### PR TITLE
Fix spacing in license

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ShowClusterInfoCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ShowClusterInfoCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This fixes the below maven build error.

```
INFO] --- license-maven-plugin:2.8:check (default) @ pinot-tools ---
[INFO] Checking licenses...
[WARNING] Missing header in: /mnt/jenkins/workspace/pinot-publish/pinot/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ShowClusterInfoCommand.java
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] pinot .............................................. SUCCESS [  1.402 s]
[INFO] pinot-common ....................................... SUCCESS [ 13.538 s]
[INFO] pinot-transport .................................... SUCCESS [  5.189 s]
[INFO] pinot-core ......................................... SUCCESS [ 15.316 s]
[INFO] pinot-server ....................................... SUCCESS [  2.081 s]
[INFO] pinot-controller ................................... SUCCESS [ 17.629 s]
[INFO] pinot-broker ....................................... SUCCESS [  3.106 s]
[INFO] pinot-api .......................................... SUCCESS [  1.830 s]
[INFO] pinot-hadoop ....................................... SUCCESS [02:09 min]
[INFO] pinot-tools ........................................ FAILURE [  6.386 s]
[INFO] pinot-perf ......................................... SKIPPED
[INFO] pinot-integration-tests ............................ SKIPPED
[INFO] pinot-distribution ................................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:15 min
[INFO] Finished at: 2015-09-03T04:51:32+00:00
[INFO] Final Memory: 259M/1297M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:2.8:check (default) on project pinot-tools: Some files do not have the expected license header -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] 
```