### PR TITLE
fix bug: missing one row each time realtime segment flush

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -259,7 +259,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     docIdSearchableOffset = docId;
     numDocsIndexed += 1;
     numSuccessIndexed += 1;
-    return true;
+    return (numDocsIndexed < capacity);
   }
 
   @Override


### PR DESCRIPTION
Each time after a realtime segment flush to offline, the new realtime segment will miss one row.