### PR TITLE
Refactoring MSelectionOnlyOperator to remove redundant iterator initialization.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
@@ -33,6 +33,7 @@ import com.linkedin.pinot.core.common.BlockId;
 import com.linkedin.pinot.core.common.Constants;
 import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.query.selection.SelectionFetcher;
 import com.linkedin.pinot.core.query.selection.SelectionOperatorUtils;
 
 
@@ -79,15 +80,15 @@ public class MSelectionOnlyOperator extends BaseOperator {
     long numDocsScanned = 0;
     ProjectionBlock projectionBlock = null;
     while ((projectionBlock = (ProjectionBlock) _projectionOperator.nextBlock()) != null) {
-      int j = 0;
       for (int i = 0; i < _dataSchema.size(); ++i) {
-        _blocks[j++] = projectionBlock.getBlock(_dataSchema.getColumnName(i));
+        _blocks[i] = projectionBlock.getBlock(_dataSchema.getColumnName(i));
       }
+      SelectionFetcher selectionFetcher = new SelectionFetcher(_blocks, _dataSchema);
       BlockDocIdIterator blockDocIdIterator = projectionBlock.getDocIdSetBlock().getBlockDocIdSet().iterator();
       int docId;
       while ((docId = blockDocIdIterator.next()) != Constants.EOF && _rowEvents.size() < _limitDocs) {
         numDocsScanned++;
-        _rowEvents.add(SelectionOperatorUtils.collectRowFromBlockValSets(docId, _blocks, _dataSchema));
+        _rowEvents.add(selectionFetcher.getRow(docId));
       }
       if (_rowEvents.size() == _limitDocs) {
         break;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionFetcher.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.common.utils.DataTableBuilder.DataSchema;
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.operator.blocks.MultiValueBlock;
+import com.linkedin.pinot.core.operator.blocks.SortedSingleValueBlock;
+import com.linkedin.pinot.core.operator.blocks.UnSortedSingleValueBlock;
+import com.linkedin.pinot.core.query.selection.iterator.DoubleArraySelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.DoubleSelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.FloatArraySelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.FloatSelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.IntArraySelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.IntSelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.LongArraySelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.LongSelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.SelectionColumnIterator;
+import com.linkedin.pinot.core.query.selection.iterator.SelectionSingleValueColumnWithDictIterator;
+import com.linkedin.pinot.core.query.selection.iterator.StringArraySelectionColumnIterator;
+import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeMultiValueBlock;
+import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeSingleValueBlock;
+import com.linkedin.pinot.core.realtime.impl.dictionary.DoubleMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.FloatMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.IntMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.LongMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.StringMutableDictionary;
+import com.linkedin.pinot.core.segment.index.readers.DoubleDictionary;
+import com.linkedin.pinot.core.segment.index.readers.FloatDictionary;
+import com.linkedin.pinot.core.segment.index.readers.IntDictionary;
+import com.linkedin.pinot.core.segment.index.readers.LongDictionary;
+import com.linkedin.pinot.core.segment.index.readers.StringDictionary;
+
+/**
+ * Selection fetcher is used for querying rows from given blocks and schema.
+ * SelectionFetcher will initialize iterators on each data column and provide
+ * the ability to return a Serializable array as a row for a given docId.
+ *
+ */
+public class SelectionFetcher {
+  private final int length;
+  private final SelectionColumnIterator[] selectionColumnIterators;
+
+  public SelectionFetcher(Block[] blocks, DataSchema dataSchema) {
+    this.length = blocks.length;
+    selectionColumnIterators = new SelectionColumnIterator[blocks.length];
+    for (int i = 0; i < dataSchema.size(); ++i) {
+      if (blocks[i] instanceof RealtimeSingleValueBlock && blocks[i].getMetadata().hasDictionary()) {
+        switch (dataSchema.getColumnType(i)) {
+          case INT:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Integer, IntMutableDictionary>(blocks[i]);
+            break;
+          case FLOAT:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Float, FloatMutableDictionary>(blocks[i]);
+            break;
+          case LONG:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Long, LongMutableDictionary>(blocks[i]);
+            break;
+          case DOUBLE:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Double, DoubleMutableDictionary>(blocks[i]);
+            break;
+          case STRING:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<String, StringMutableDictionary>(blocks[i]);
+            break;
+          default:
+            break;
+        }
+      } else if ((blocks[i] instanceof UnSortedSingleValueBlock || blocks[i] instanceof SortedSingleValueBlock) && blocks[i].getMetadata().hasDictionary()) {
+        switch (dataSchema.getColumnType(i)) {
+          case INT:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Integer, IntDictionary>(blocks[i]);
+            break;
+          case FLOAT:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Float, FloatDictionary>(blocks[i]);
+            break;
+          case LONG:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Long, LongDictionary>(blocks[i]);
+            break;
+          case DOUBLE:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Double, DoubleDictionary>(blocks[i]);
+            break;
+          case STRING:
+            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<String, StringDictionary>(blocks[i]);
+            break;
+          default:
+            break;
+        }
+      } else if (blocks[i] instanceof RealtimeMultiValueBlock || blocks[i] instanceof MultiValueBlock) {
+        switch (dataSchema.getColumnType(i)) {
+          case INT_ARRAY:
+            selectionColumnIterators[i] = new IntArraySelectionColumnIterator(blocks[i]);
+            break;
+          case FLOAT_ARRAY:
+            selectionColumnIterators[i] = new FloatArraySelectionColumnIterator(blocks[i]);
+            break;
+          case LONG_ARRAY:
+            selectionColumnIterators[i] = new LongArraySelectionColumnIterator(blocks[i]);
+            break;
+          case DOUBLE_ARRAY:
+            selectionColumnIterators[i] = new DoubleArraySelectionColumnIterator(blocks[i]);
+            break;
+          case STRING_ARRAY:
+            selectionColumnIterators[i] = new StringArraySelectionColumnIterator(blocks[i]);
+            break;
+          default:
+            break;
+        }
+      } else if (!blocks[i].getMetadata().hasDictionary()) {
+        switch (dataSchema.getColumnType(i)) {
+          case INT:
+            selectionColumnIterators[i] = new IntSelectionColumnIterator(blocks[i]);
+            break;
+          case FLOAT:
+            selectionColumnIterators[i] = new FloatSelectionColumnIterator(blocks[i]);
+            break;
+          case LONG:
+            selectionColumnIterators[i] = new LongSelectionColumnIterator(blocks[i]);
+            break;
+          case DOUBLE:
+            selectionColumnIterators[i] = new DoubleSelectionColumnIterator(blocks[i]);
+            break;
+          default:
+            break;
+        }
+      } else {
+        throw new UnsupportedOperationException("Failed to get SelectionColumnIterator on Block - " + blocks[i] + " with index - " + i);
+      }
+    }
+  }
+
+  public Serializable[] getRow(int docId) {
+    final Serializable[] row = new Serializable[length];
+    for (int i = 0; i < length; ++i) {
+      row[i] = selectionColumnIterators[i].getValue(docId);
+    }
+    return row;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -207,6 +207,7 @@ public class SelectionOperatorUtils {
     return new DataSchema(columns.toArray(new String[0]), dataTypes);
   }
 
+  @Deprecated
   public static Serializable[] collectRowFromBlockValSets(int docId, Block[] blocks, DataSchema dataSchema) {
 
     final Serializable[] row = new Serializable[dataSchema.size()];

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/DoubleArraySelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/DoubleArraySelectionColumnIterator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+
+/**
+ * Iterator on double array column selection query.
+ *
+ */
+public class DoubleArraySelectionColumnIterator extends SelectionMultiValueColumnIterator {
+
+  public DoubleArraySelectionColumnIterator(Block block) {
+    super(block);
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    int dictSize = bvIter.nextIntVal(dictIds);
+    double[] rawIntRow = new double[dictSize];
+    for (int dictIdx = 0; dictIdx < dictSize; ++dictIdx) {
+      rawIntRow[dictIdx] = (Double) (dict.get(dictIds[dictIdx]));
+    }
+    return rawIntRow;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/DoubleSelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/DoubleSelectionColumnIterator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+
+/**
+ * Iterator on double no dictionary column selection query.
+ *
+ */
+public class DoubleSelectionColumnIterator implements SelectionColumnIterator {
+  protected BlockSingleValIterator bvIter;
+
+  public DoubleSelectionColumnIterator(Block block) {
+    bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    return bvIter.nextDoubleVal();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/FloatArraySelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/FloatArraySelectionColumnIterator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+
+/**
+ * Iterator on float array column selection query.
+ *
+ */
+public class FloatArraySelectionColumnIterator extends SelectionMultiValueColumnIterator {
+
+  public FloatArraySelectionColumnIterator(Block block) {
+    super(block);
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    int dictSize = bvIter.nextIntVal(dictIds);
+    float[] rawIntRow = new float[dictSize];
+    for (int dictIdx = 0; dictIdx < dictSize; ++dictIdx) {
+      rawIntRow[dictIdx] = (Float) (dict.get(dictIds[dictIdx]));
+    }
+    return rawIntRow;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/FloatSelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/FloatSelectionColumnIterator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+
+/**
+ * Iterator on float no dictionary column selection query.
+ *
+ */
+public class FloatSelectionColumnIterator implements SelectionColumnIterator {
+  protected BlockSingleValIterator bvIter;
+
+  public FloatSelectionColumnIterator(Block block) {
+    bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    return bvIter.nextFloatVal();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/IntArraySelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/IntArraySelectionColumnIterator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+
+/**
+ * Iterator on int array column selection query.
+ *
+ */
+public class IntArraySelectionColumnIterator extends SelectionMultiValueColumnIterator {
+
+  public IntArraySelectionColumnIterator(Block block) {
+    super(block);
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    int dictSize = bvIter.nextIntVal(dictIds);
+    int[] rawIntRow = new int[dictSize];
+    for (int dictIdx = 0; dictIdx < dictSize; ++dictIdx) {
+      rawIntRow[dictIdx] = (Integer) (dict.get(dictIds[dictIdx]));
+    }
+    return rawIntRow;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/IntSelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/IntSelectionColumnIterator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+
+/**
+ * Iterator on int no dictionary column selection query.
+ *
+ */
+public class IntSelectionColumnIterator implements SelectionColumnIterator {
+  protected BlockSingleValIterator bvIter;
+
+  public IntSelectionColumnIterator(Block block) {
+    bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    return bvIter.nextIntVal();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/LongArraySelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/LongArraySelectionColumnIterator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+
+/**
+ * Iterator on long array column selection query.
+ *
+ */
+public class LongArraySelectionColumnIterator extends SelectionMultiValueColumnIterator {
+
+  public LongArraySelectionColumnIterator(Block block) {
+    super(block);
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    int dictSize = bvIter.nextIntVal(dictIds);
+    long[] rawIntRow = new long[dictSize];
+    for (int dictIdx = 0; dictIdx < dictSize; ++dictIdx) {
+      rawIntRow[dictIdx] = (Long) (dict.get(dictIds[dictIdx]));
+    }
+    return rawIntRow;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/LongSelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/LongSelectionColumnIterator.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+
+/**
+ * Iterator on long no dictionary column selection query.
+ *
+ */
+public class LongSelectionColumnIterator implements SelectionColumnIterator {
+  protected BlockSingleValIterator bvIter;
+
+  public LongSelectionColumnIterator(Block block) {
+    bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    return bvIter.nextLongVal();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionColumnIterator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+/**
+ * Column iterator interface for selection query on a column.
+ *
+ */
+public interface SelectionColumnIterator {
+
+  Serializable getValue(int docId);
+
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionMultiValueColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionMultiValueColumnIterator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockMultiValIterator;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+
+/**
+ * Iterator on multi-value column selection query.
+ * 
+ */
+public abstract class SelectionMultiValueColumnIterator implements SelectionColumnIterator {
+  protected BlockMultiValIterator bvIter;
+  protected Dictionary dict;
+  protected int[] dictIds;
+
+  public SelectionMultiValueColumnIterator(Block block) {
+    bvIter = (BlockMultiValIterator) block.getBlockValueSet().iterator();
+    dict = block.getMetadata().getDictionary();
+    dictIds = new int[block.getMetadata().getMaxNumberOfMultiValues()];
+  }
+
+  @Override
+  public abstract Serializable getValue(int docId);
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionSingleValueColumnWithDictIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionSingleValueColumnWithDictIterator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+
+/**
+ * Iterator on single-value column with dictionary for selection query.
+ *
+ */
+public class SelectionSingleValueColumnWithDictIterator<T extends Serializable, DICT extends Dictionary> implements SelectionColumnIterator {
+  protected BlockSingleValIterator bvIter;
+  protected DICT dict;
+
+  @SuppressWarnings("unchecked")
+  public SelectionSingleValueColumnWithDictIterator(Block block) {
+    bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
+    dict = (DICT) block.getMetadata().getDictionary();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    return (T) ((DICT) dict).get(bvIter.nextIntVal());
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/StringArraySelectionColumnIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/StringArraySelectionColumnIterator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.selection.iterator;
+
+import java.io.Serializable;
+
+import com.linkedin.pinot.core.common.Block;
+
+/**
+ * Iterator on string array column selection query.
+ *
+ */
+public class StringArraySelectionColumnIterator extends SelectionMultiValueColumnIterator {
+
+  public StringArraySelectionColumnIterator(Block block) {
+    super(block);
+  }
+
+  @Override
+  public Serializable getValue(int docId) {
+    bvIter.skipTo(docId);
+    int dictSize = bvIter.nextIntVal(dictIds);
+    String[] rawIntRow = new String[dictSize];
+    for (int dictIdx = 0; dictIdx < dictSize; ++dictIdx) {
+      rawIntRow[dictIdx] = (String) (dict.get(dictIds[dictIdx]));
+    }
+    return rawIntRow;
+  }
+}


### PR DESCRIPTION
Refactoring MSelectionOnlyOperator to use SelectionFetcher for removing
redundant work during row collection.
SelectionFetcher is used for querying rows from given blocks and schema.
By giving blocks and schema, SelectionFetcher will underlying initialize
different iterators based on block and column type and provide the
ability to collect a Serializable array as a row for any given docId.