### PR TITLE
Change log4j level to log more info to the files by default

### DIFF
--- a/pinot-tools/src/main/resources/conf/pinot-admin-log4j.properties
+++ b/pinot-tools/src/main/resources/conf/pinot-admin-log4j.properties
@@ -17,6 +17,7 @@
 log4j.rootLogger=ERROR, stdout
 log4j.logger.com.linkedin.pinot=ERROR
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Threshold=ERROR
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 
@@ -26,21 +27,24 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.additivity.com.linkedin.pinot.tools.admin = false
 
-log4j.logger.com.linkedin.pinot.controller=ERROR, controllerLog
-log4j.logger.com.linkedin.pinot.broker=ERROR, brokerLog
-log4j.logger.com.linkedin.pinot.server=ERROR, serverLog
+log4j.logger.com.linkedin.pinot.controller=INFO, controllerLog
+log4j.logger.com.linkedin.pinot.broker=INFO, brokerLog
+log4j.logger.com.linkedin.pinot.server=INFO, serverLog
 
-log4j.appender.controllerLog=org.apache.log4j.FileAppender
+log4j.appender.controllerLog=org.apache.log4j.RollingFileAppender
 log4j.appender.controllerLog.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerLog.File=pinotController.log
+log4j.appender.controllerLog.MaxFileSize=20MB
 log4j.appender.controllerLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n
 
-log4j.appender.brokerLog=org.apache.log4j.FileAppender
+log4j.appender.brokerLog=org.apache.log4j.RollingFileAppender
 log4j.appender.brokerLog.layout=org.apache.log4j.PatternLayout
 log4j.appender.brokerLog.File=pinotBroker.log
+log4j.appender.brokerLog.MaxFileSize=20MB
 log4j.appender.brokerLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n
 
-log4j.appender.serverLog=org.apache.log4j.FileAppender
+log4j.appender.serverLog=org.apache.log4j.RollingFileAppender
 log4j.appender.serverLog.layout=org.apache.log4j.PatternLayout
 log4j.appender.serverLog.File=pinotServer.log
+log4j.appender.serverLog.MaxFileSize=20MB
 log4j.appender.serverLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n

--- a/pinot-tools/src/main/resources/conf/pinot-broker-log4j.properties
+++ b/pinot-tools/src/main/resources/conf/pinot-broker-log4j.properties
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=ERROR, brokerLog
+log4j.rootLogger=INFO, brokerLog
 
-log4j.appender.brokerLog=org.apache.log4j.FileAppender
+log4j.appender.brokerLog=org.apache.log4j.RollingFileAppender
+log4j.appender.brokerLog.File=pinot-broker.log
+log4j.appender.brokerLog.MaxFileSize=20MB
 log4j.appender.brokerLog.layout=org.apache.log4j.PatternLayout
-log4j.appender.brokerLog.File=pinotBroker.log
 log4j.appender.brokerLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n

--- a/pinot-tools/src/main/resources/conf/pinot-controller-log4j.properties
+++ b/pinot-tools/src/main/resources/conf/pinot-controller-log4j.properties
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=ERROR, controllerLog
+log4j.rootLogger=INFO, controllerLog
 
-log4j.appender.controllerLog=org.apache.log4j.FileAppender
+log4j.appender.controllerLog=org.apache.log4j.RollingFileAppender
+log4j.appender.controllerLog.File=pinot-controller.log
+log4j.appender.controllerLog.MaxFileSize=20MB
 log4j.appender.controllerLog.layout=org.apache.log4j.PatternLayout
-log4j.appender.controllerLog.File=pinotController.log
 log4j.appender.controllerLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n

--- a/pinot-tools/src/main/resources/conf/pinot-server-log4j.properties
+++ b/pinot-tools/src/main/resources/conf/pinot-server-log4j.properties
@@ -14,9 +14,10 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=ERROR, serverLog
+log4j.rootLogger=INFO, serverLog
 
-log4j.appender.serverLog=org.apache.log4j.FileAppender
+log4j.appender.serverLog=org.apache.log4j.RollingFileAppender
+log4j.appender.serverLog.File=pinot-server.log
+log4j.appender.serverLog.MaxFileSize=20MB
 log4j.appender.serverLog.layout=org.apache.log4j.PatternLayout
-log4j.appender.serverLog.File=pinotServer.log
 log4j.appender.serverLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n


### PR DESCRIPTION
Fixing log4j level for pinot-admin/StartController/StartBroker/StartServer script and change FileAppender to RollingFileAppender.