### PR TITLE
Adding support for min max range query

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/AggregationFunctionRegistry.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/AggregationFunctionRegistry.java
@@ -28,6 +28,8 @@ import com.linkedin.pinot.core.query.aggregation.function.MaxAggregationFunction
 import com.linkedin.pinot.core.query.aggregation.function.MaxAggregationNoDictionaryFunction;
 import com.linkedin.pinot.core.query.aggregation.function.MinAggregationFunction;
 import com.linkedin.pinot.core.query.aggregation.function.MinAggregationNoDictionaryFunction;
+import com.linkedin.pinot.core.query.aggregation.function.MinMaxRangeAggregationFunction;
+import com.linkedin.pinot.core.query.aggregation.function.MinMaxRangeAggregationNoDictionaryFunction;
 import com.linkedin.pinot.core.query.aggregation.function.SumAggregationFunction;
 import com.linkedin.pinot.core.query.aggregation.function.SumAggregationNoDictionaryFunction;
 import com.linkedin.pinot.core.query.aggregation.function.DistinctCountHLLAggregationFunction;
@@ -55,6 +57,7 @@ public class AggregationFunctionRegistry {
     keyToFunctionWithDictionary.put("min", MinAggregationFunction.class);
     keyToFunctionWithDictionary.put("sum", SumAggregationFunction.class);
     keyToFunctionWithDictionary.put("avg", AvgAggregationFunction.class);
+    keyToFunctionWithDictionary.put("minmaxrange", MinMaxRangeAggregationFunction.class);
     keyToFunctionWithDictionary.put("distinctcount", DistinctCountAggregationFunction.class);
     keyToFunctionWithDictionary.put("distinctcounthll", DistinctCountHLLAggregationFunction.class);
     // quantiles
@@ -73,6 +76,7 @@ public class AggregationFunctionRegistry {
     keyToFunctionWithoutDictionary.put("min", MinAggregationNoDictionaryFunction.class);
     keyToFunctionWithoutDictionary.put("sum", SumAggregationNoDictionaryFunction.class);
     keyToFunctionWithoutDictionary.put("avg", AvgAggregationNoDictionaryFunction.class);
+    keyToFunctionWithoutDictionary.put("minmaxrange", MinMaxRangeAggregationNoDictionaryFunction.class);
     keyToFunctionWithoutDictionary.put("distinctcount", DistinctCountAggregationNoDictionaryFunction.class);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.aggregation.function;
+
+import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.List;
+import java.util.Locale;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.common.request.AggregationInfo;
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockDocIdIterator;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+import com.linkedin.pinot.core.common.Constants;
+import com.linkedin.pinot.core.query.aggregation.AggregationFunction;
+import com.linkedin.pinot.core.query.aggregation.CombineLevel;
+import com.linkedin.pinot.core.query.aggregation.function.MinMaxRangeAggregationFunction.MinMaxRangePair;
+import com.linkedin.pinot.core.query.utils.Pair;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+
+/**
+ * This function will take a column and do min/max and compute diff on that.
+ */
+public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMaxRangePair, Double> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MinMaxRangeAggregationFunction.class);
+  private static final double DEFAULT_MIN_MAX_RANGE_VALUE = -1;
+
+  private String _minMaxRangeByColumn;
+
+  public MinMaxRangeAggregationFunction() {
+
+  }
+
+  @Override
+  public void init(AggregationInfo aggregationInfo) {
+    _minMaxRangeByColumn = aggregationInfo.getAggregationParams().get("column");
+
+  }
+
+  @Override
+  public MinMaxRangePair aggregate(Block docIdSetBlock, Block[] block) {
+    double min = Double.POSITIVE_INFINITY;
+    double max = Double.NEGATIVE_INFINITY;
+    int docId = 0;
+    Dictionary dictionaryReader = block[0].getMetadata().getDictionary();
+    BlockDocIdIterator docIdIterator = docIdSetBlock.getBlockDocIdSet().iterator();
+    BlockSingleValIterator blockValIterator =
+        (BlockSingleValIterator) block[0].getBlockValueSet().iterator();
+
+    while ((docId = docIdIterator.next()) != Constants.EOF) {
+      if (blockValIterator.skipTo(docId)) {
+        int dictionaryIndex = blockValIterator.nextIntVal();
+        if (dictionaryIndex != Dictionary.NULL_VALUE_INDEX) {
+          min = Math.min(min, dictionaryReader.getDoubleValue(dictionaryIndex));
+          max = Math.max(max, dictionaryReader.getDoubleValue(dictionaryIndex));
+        }
+      }
+    }
+    return new MinMaxRangePair(min, max);
+  }
+
+  @Override
+  public MinMaxRangePair aggregate(MinMaxRangePair mergedResult, int docId, Block[] block) {
+    BlockSingleValIterator blockValIterator =
+        (BlockSingleValIterator) block[0].getBlockValueSet().iterator();
+    if (blockValIterator.skipTo(docId)) {
+      int dictId = blockValIterator.nextIntVal();
+      if (dictId != Dictionary.NULL_VALUE_INDEX) {
+        double currentValue = block[0].getMetadata().getDictionary().getDoubleValue(dictId);
+        if (mergedResult == null) {
+          return new MinMaxRangePair(currentValue, currentValue);
+        }
+        return new MinMaxRangePair(Math.min(mergedResult.getFirst(), currentValue),
+            Math.max(mergedResult.getSecond(), currentValue));
+      }
+    }
+    return mergedResult;
+  }
+
+  @Override
+  public List<MinMaxRangePair> combine(List<MinMaxRangePair> aggregationResultList, CombineLevel combineLevel) {
+    double combinedMinResult = Double.POSITIVE_INFINITY;
+    double combinedMaxResult = Double.NEGATIVE_INFINITY;
+    for (MinMaxRangePair aggregationResult : aggregationResultList) {
+      combinedMinResult = Math.min(combinedMinResult, aggregationResult.getFirst());
+      combinedMaxResult = Math.max(combinedMaxResult, aggregationResult.getSecond());
+    }
+    aggregationResultList.clear();
+    aggregationResultList.add(new MinMaxRangePair(combinedMinResult, combinedMaxResult));
+    return aggregationResultList;
+  }
+
+  @Override
+  public MinMaxRangePair combineTwoValues(MinMaxRangePair aggregationResult0, MinMaxRangePair aggregationResult1) {
+    if (aggregationResult0 == null) {
+      return aggregationResult1;
+    }
+    if (aggregationResult1 == null) {
+      return aggregationResult0;
+    }
+    return new MinMaxRangePair(Math.min(aggregationResult0.getFirst(), aggregationResult1.getFirst()),
+        Math.max(aggregationResult0.getSecond(), aggregationResult1.getSecond()));
+  }
+
+  @Override
+  public Double reduce(List<MinMaxRangePair> combinedResult) {
+    if (combinedResult.isEmpty()) {
+      return DEFAULT_MIN_MAX_RANGE_VALUE;
+    }
+
+    double reducedMinResult = Double.POSITIVE_INFINITY;
+    double reducedMaxResult = Double.NEGATIVE_INFINITY;
+    for (MinMaxRangePair combineResult : combinedResult) {
+      reducedMinResult = Math.min(reducedMinResult, combineResult.getFirst());
+      reducedMaxResult = Math.max(reducedMaxResult, combineResult.getSecond());
+    }
+    if (reducedMinResult != Double.POSITIVE_INFINITY
+        && reducedMaxResult != Double.NEGATIVE_INFINITY) {
+      return reducedMaxResult - reducedMinResult;
+    } else {
+      return DEFAULT_MIN_MAX_RANGE_VALUE;
+    }
+  }
+
+  @Override
+  public JSONObject render(Double finalAggregationResult) {
+    try {
+      if ((finalAggregationResult == null) || (Double.isNaN(finalAggregationResult))) {
+        return new JSONObject().put("value", DEFAULT_MIN_MAX_RANGE_VALUE);
+      }
+      return new JSONObject().put("value",
+          String.format(Locale.US, "%1.5f", finalAggregationResult));
+    } catch (JSONException e) {
+      LOGGER.error("Caught exception while rendering to JSON", e);
+      Utils.rethrowException(e);
+      throw new AssertionError("Should not reach this");
+    }
+  }
+
+  @Override
+  public DataType aggregateResultDataType() {
+    return DataType.OBJECT;
+  }
+
+  @Override
+  public String getFunctionName() {
+    return "minMaxRange_" + _minMaxRangeByColumn;
+  }
+
+  public class MinMaxRangePair extends Pair<Double, Double>
+      implements Comparable<MinMaxRangePair>, Serializable {
+    public MinMaxRangePair(Double first, Double second) {
+      super(first, second);
+    }
+
+    @Override
+    public int compareTo(MinMaxRangePair o) {
+      double diff = getSecond() - getFirst() - o.getSecond() + o.getFirst();
+      if (diff > 0) {
+        return 1;
+      } else if (diff < 0) {
+        return -1;
+      }
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return new DecimalFormat("####################.##########",
+          DecimalFormatSymbols.getInstance(Locale.US)).format((getSecond() - getFirst()));
+    }
+  }
+
+  public MinMaxRangePair getMinMaxRangePair(double first, double second) {
+    return new MinMaxRangePair(first, second);
+  }
+
+  @Override
+  public Serializable getDefaultValue() {
+    return new MinMaxRangePair(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationNoDictionaryFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationNoDictionaryFunction.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.aggregation.function;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockDocIdIterator;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+import com.linkedin.pinot.core.common.Constants;
+
+/**
+ * This function will take a column and do sum on that.
+ */
+public class MinMaxRangeAggregationNoDictionaryFunction extends MinMaxRangeAggregationFunction {
+
+  @Override
+  public MinMaxRangePair aggregate(Block docIdSetBlock, Block[] block) {
+    double min = Double.POSITIVE_INFINITY;
+    double max = Double.NEGATIVE_INFINITY;
+    int docId = 0;
+    BlockDocIdIterator docIdIterator = docIdSetBlock.getBlockDocIdSet().iterator();
+    BlockSingleValIterator blockValIterator = (BlockSingleValIterator) block[0].getBlockValueSet().iterator();
+
+    while ((docId = docIdIterator.next()) != Constants.EOF) {
+      if (blockValIterator.skipTo(docId)) {
+        double nextDoubleVal = blockValIterator.nextDoubleVal();
+        min = Math.min(min, nextDoubleVal);
+        max = Math.max(max, nextDoubleVal);
+      }
+    }
+    return new MinMaxRangePair(min, max);
+  }
+
+  @Override
+  public MinMaxRangePair aggregate(MinMaxRangePair mergedResult, int docId, Block[] block) {
+    BlockSingleValIterator blockValIterator = (BlockSingleValIterator) block[0].getBlockValueSet().iterator();
+    if (blockValIterator.skipTo(docId)) {
+      double nextDoubleVal = blockValIterator.nextDoubleVal();
+      if (mergedResult == null) {
+        return new MinMaxRangePair(nextDoubleVal, nextDoubleVal);
+      }
+      return new MinMaxRangePair(
+          Math.min(mergedResult.getFirst(), nextDoubleVal),
+          Math.max(mergedResult.getSecond(), nextDoubleVal));
+    }
+    return mergedResult;
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByOperatorTest.java
@@ -93,7 +93,7 @@ public class AggregationGroupByOperatorTest {
 
   public static AggregationInfo _paramsInfo;
   public static List<AggregationInfo> _aggregationInfos;
-  public static int _numAggregations = 6;
+  public static int _numAggregations = 7;
 
   public Map<String, ColumnMetadata> _medataMap;
   public static GroupBy _groupBy;
@@ -483,8 +483,10 @@ public class AggregationGroupByOperatorTest {
         .toString());
     Assert.assertEquals("avg_met_impressionCount", brokerResponse.getAggregationResults().get(4).getString("function")
         .toString());
+    Assert.assertEquals("minMaxRange_met_impressionCount", brokerResponse.getAggregationResults().get(5).getString("function")
+        .toString());
     Assert.assertEquals("distinctCount_column12",
-        brokerResponse.getAggregationResults().get(5).getString("function").toString());
+        brokerResponse.getAggregationResults().get(6).getString("function").toString());
   }
 
   private void assertEmptyBrokerResponse(BrokerResponseJSON brokerResponse) throws JSONException {
@@ -507,6 +509,7 @@ public class AggregationGroupByOperatorTest {
     aggregationResultList.add(getMaxResult());
     aggregationResultList.add(getMinResult());
     aggregationResultList.add(getAvgResult());
+    aggregationResultList.add(getMinMaxRangeResult());
     aggregationResultList.add(getDistinctCountResult());
     return aggregationResultList;
   }
@@ -518,6 +521,7 @@ public class AggregationGroupByOperatorTest {
     groupResults.add(getMaxGroupResult());
     groupResults.add(getMinGroupResult());
     groupResults.add(getAvgGroupResult());
+    groupResults.add(getMinMaxRangeGroupResult());
     groupResults.add(getDistinctCountGroupResult());
     return groupResults;
   }
@@ -562,6 +566,14 @@ public class AggregationGroupByOperatorTest {
     return new String[] { "[\"U\",\"yhq\"]", "[\"U\",\"mNh\"]", "[\"U\",\"Vj\"]", "[\"U\",\"OYMU\"]", "[\"U\",\"zZe\"]", "[\"U\",\"jb\"]", "[\"D\",\"aN\"]", "[\"U\",\"bVnY\"]", "[\"U\",\"iV\"]", "[\"i\",\"LjAS\"]", "[\"D\",\"xDLG\"]", "[\"U\",\"EXYv\"]", "[\"D\",\"iV\"]", "[\"D\",\"Gac\"]", "[\"D\",\"QMl\"]" };
   }
 
+  private static double[] getMinMaxRangeResult() {
+    return new double[] { 8023137590212612100.00000, 8023137590212612100.00000, 8023137590212612100.00000, 8023137590212612100.00000, 8023137590212612100.00000, 8023137590212612100.00000, 8023137590212612100.00000, 8023137590212612100.00000, 7589238585770968100.00000, 7589238585770968100.00000, 7589238585770968100.00000, 4934060917342722000.00000, 4934060917342722000.00000, 4934060917342722000.00000, 4934060917342722000.00000 };
+  }
+
+  private static String[] getMinMaxRangeGroupResult() {
+    return new String[] { "[\"i\",\"yhq\"]", "[\"i\",\"VsKz\"]", "[\"i\",\"mNh\"]", "[\"D\",\"Gac\"]", "[\"D\",\"CqC\"]", "[\"U\",\"\"]", "[\"D\",\"\"]", "[\"i\",\"jb\"]", "[\"i\",\"QMl\"]", "[\"D\",\"bVnY\"]", "[\"i\",\"\"]", "[\"i\",\"Pcb\"]", "[\"i\",\"EXYv\"]", "[\"i\",\"CqC\"]", "[\"i\",\"zZe\"]" };
+  }
+
   private static double[] getDistinctCountResult() {
     return new double[] { 128, 109, 100, 99, 84, 81, 77, 76, 75, 74, 71, 67, 67, 62, 57 };
   }
@@ -578,6 +590,7 @@ public class AggregationGroupByOperatorTest {
     aggregationsInfo.add(getMaxAggregationInfo());
     aggregationsInfo.add(getMinAggregationInfo());
     aggregationsInfo.add(getAvgAggregationInfo());
+    aggregationsInfo.add(getMinMaxRangeAggregationInfo());
     aggregationsInfo.add(getDistinctCountAggregationInfo("column12"));
     brokerRequest.setAggregationsInfo(aggregationsInfo);
     brokerRequest.setGroupBy(getGroupBy());
@@ -591,6 +604,7 @@ public class AggregationGroupByOperatorTest {
     aggregationsInfo.add(getMaxAggregationInfo());
     aggregationsInfo.add(getMinAggregationInfo());
     aggregationsInfo.add(getAvgAggregationInfo());
+    aggregationsInfo.add(getMinMaxRangeAggregationInfo());
     aggregationsInfo.add(getDistinctCountAggregationInfo("column12"));
     return aggregationsInfo;
   }
@@ -653,6 +667,16 @@ public class AggregationGroupByOperatorTest {
     return aggregationInfo;
   }
 
+  private static AggregationInfo getMinMaxRangeAggregationInfo() {
+    final String type = "minMaxRange";
+    final Map<String, String> params = new HashMap<String, String>();
+    params.put("column", "met_impressionCount");
+    final AggregationInfo aggregationInfo = new AggregationInfo();
+    aggregationInfo.setAggregationType(type);
+    aggregationInfo.setAggregationParams(params);
+    return aggregationInfo;
+  }
+
   private static AggregationInfo getDistinctCountAggregationInfo(String dim) {
     final String type = "distinctCount";
     final Map<String, String> params = new HashMap<String, String>();
@@ -682,6 +706,7 @@ public class AggregationGroupByOperatorTest {
     aggregationsInfo.add(getMaxAggregationInfo());
     aggregationsInfo.add(getMinAggregationInfo());
     aggregationsInfo.add(getAvgAggregationInfo());
+    aggregationsInfo.add(getMinMaxRangeAggregationInfo());
     aggregationsInfo.add(getDistinctCountAggregationInfo("column12"));
     brokerRequest.setAggregationsInfo(aggregationsInfo);
     brokerRequest.setGroupBy(getGroupBy());
@@ -722,6 +747,7 @@ public class AggregationGroupByOperatorTest {
     aggregationsInfo.add(getMaxAggregationInfo());
     aggregationsInfo.add(getMinAggregationInfo());
     aggregationsInfo.add(getAvgAggregationInfo());
+    aggregationsInfo.add(getMinMaxRangeAggregationInfo());
     aggregationsInfo.add(getDistinctCountAggregationInfo("column12"));
     brokerRequest.setAggregationsInfo(aggregationsInfo);
     brokerRequest.setGroupBy(getGroupBy());

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/AggregationFuncFactory.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/AggregationFuncFactory.java
@@ -21,6 +21,7 @@ public class AggregationFuncFactory {
   private static final String MAX = "MAX";
   private static final String SUM = "SUM";
   private static final String AVG = "AVG";
+  private static final String MINMAXRANGE = "MINMAXRANGE";
   private static final String DISTINCT_COUNT = "DISTINCTCOUNT";
 
   public static AggregationFunc getAggregationFunc(ResultTable rows, String column, String functionName) {
@@ -39,6 +40,9 @@ public class AggregationFuncFactory {
 
       case AVG:
         return new AvgFunction(rows, column);
+
+      case MINMAXRANGE:
+        return new MinMaxRangeFunction(rows, column);
 
       case DISTINCT_COUNT:
         return new DistinctCountFunction(rows, column);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/MinMaxRangeFunction.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/scan/query/MinMaxRangeFunction.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.tools.scan.query;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import com.linkedin.pinot.core.query.utils.Pair;
+
+public class MinMaxRangeFunction extends AggregationFunc {
+  private static final String _name = "minmaxrange";
+
+  MinMaxRangeFunction(ResultTable rows, String column) {
+    super(rows, column);
+  }
+
+  @Override
+  public ResultTable run() {
+    Double max = Double.NEGATIVE_INFINITY;
+    Double min = Double.POSITIVE_INFINITY;
+
+    for (ResultTable.Row row : _rows) {
+      max = Math.max(max, new Double(row.get(_column, _name).toString()));
+      min = Math.min(min, new Double(row.get(_column, _name).toString()));
+    }
+
+    ResultTable resultTable = new ResultTable(new ArrayList<Pair>(), 1);
+    resultTable.add(0, max - min);
+
+    return resultTable;
+  }
+}


### PR DESCRIPTION
Range is defined as max(column) - min(column) for the selected docs.
Similar to max/min function, internally use double value, so this function only support for numeric column.