### PR TITLE
Use "Exception" instead of "exception" for data table metadata key

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -46,6 +46,9 @@ import com.linkedin.pinot.common.utils.DataTableBuilder.DataSchema;
  * Read only Datatable. Use DataTableBuilder to build the data table
  */
 public class DataTable {
+
+  public static final String EXCEPTION_METADATA_KEY = "Exception";
+
   private static final Charset UTF8 = Charset.forName("UTF-8");
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DataTable.class);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -87,7 +87,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
 
       if (instanceResponse.getDataSchema() == null && instanceResponse.getMetadata() != null) {
         for (String key : instanceResponse.getMetadata().keySet()) {
-          if (key.startsWith("Exception")) {
+          if (key.startsWith(DataTable.EXCEPTION_METADATA_KEY)) {
             QueryProcessingException processingException = new QueryProcessingException();
             processingException.setErrorCode(Integer.parseInt(key.substring(9)));
             processingException.setMessage(instanceResponse.getMetadata().get(key));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/DefaultReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/DefaultReduceService.java
@@ -127,7 +127,7 @@ public class DefaultReduceService implements ReduceService<BrokerResponseJSON> {
 
       if (instanceResponse.getDataSchema() == null && instanceResponse.getMetadata() != null) {
         for (String key : instanceResponse.getMetadata().keySet()) {
-          if (key.startsWith("Exception")) {
+          if (key.startsWith(DataTable.EXCEPTION_METADATA_KEY)) {
             ProcessingException processingException = new ProcessingException();
             processingException.setErrorCode(Integer.parseInt(key.substring(9)));
             processingException.setMessage(instanceResponse.getMetadata().get(key));

--- a/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestHandler.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestHandler.java
@@ -385,7 +385,7 @@ public class BrokerRequestHandler {
             DataTable r2 = new DataTable(b2);
             if (errors != null && errors.containsKey(e.getKey())) {
               Throwable throwable = errors.get(e.getKey());
-              r2.getMetadata().put("exception", new RequestProcessingException(throwable).toString());
+              r2.getMetadata().put(DataTable.EXCEPTION_METADATA_KEY, new RequestProcessingException(throwable).toString());
               _brokerMetrics.addMeteredQueryValue(request, BrokerMeter.REQUEST_FETCH_EXCEPTIONS, 1);
             }
             instanceResponseMap.put(e.getKey(), r2);


### PR DESCRIPTION
Pinot use "Exception" and "exception" as data table metadata key inconsistently. Should always use same.