### PR TITLE
Fixing sometimes realtime table doesn't index after table creation

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -299,7 +299,11 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
   @Override
   public void handleChildChange(String parentPath, List<String> currentChilds)
       throws Exception {
-    processPropertyStoreChange(parentPath);
+    for (String table: currentChilds) {
+      if (table.endsWith("_REALTIME")) {
+        processPropertyStoreChange(parentPath + "/" + table);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
When I create a new cluster and only add one realtime table, sometimes this table doesn't consume data.
The reason is controller only get children change for path /PROPERTYSTORE/CONFIGS/TABLE as we add a new table, but this only get new segments assigned to instances in idealStates.

The fix is
1. Create necessary PropertyStore path during cluster initialization.
2. Process each realtime table for children change triggered for  path /PROPERTYSTORE/CONFIGS/TABLE
