### PR TITLE
Fixing of kafka consumer clean shutdown

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -299,7 +299,11 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
   @Override
   public void handleChildChange(String parentPath, List<String> currentChilds)
       throws Exception {
-    processPropertyStoreChange(parentPath);
+    for (String table: currentChilds) {
+      if (table.endsWith("_REALTIME")) {
+        processPropertyStoreChange(parentPath + "/" + table);
+      }
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/AbstractTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/AbstractTableDataManager.java
@@ -200,7 +200,7 @@ public abstract  class AbstractTableDataManager implements TableDataManager {
     _serverMetrics.addMeteredTableValue(_tableName, ServerMeter.DELETED_SEGMENT_COUNT, 1L);
     _serverMetrics.addValueToTableGauge(_tableName, ServerGauge.DOCUMENT_COUNT,
         -segmentDataManager.getSegment().getSegmentMetadata().getTotalRawDocs());
-    segmentDataManager.getSegment().destroy();
+    segmentDataManager.destroy();
     LOGGER.info("Segment {} for table {} has been closed", segmentName, _tableName);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/OfflineSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/OfflineSegmentDataManager.java
@@ -46,4 +46,9 @@ public class OfflineSegmentDataManager extends SegmentDataManager {
   public String toString() {
     return "SegmentDataManager { " + _indexSegment.getSegmentName() + " } ";
   }
+
+  @Override
+  public void destroy() {
+    _indexSegment.destroy();
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/SegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/SegmentDataManager.java
@@ -41,4 +41,6 @@ public abstract class SegmentDataManager {
   public abstract IndexSegment getSegment();
 
   public abstract String getSegmentName();
+  
+  public abstract void destroy();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -53,6 +53,9 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
   @Override
   protected void doShutdown() {
     _segmentAsyncExecutorService.shutdown();
+    for (SegmentDataManager segmentDataManager :_segmentsMap.values() ) {
+      segmentDataManager.destroy();
+    }
   }
 
   protected void doInit() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -393,6 +393,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
 
   @Override
   public void destroy() {
+    LOGGER.info("Trying to close RealtimeSegmentImpl : {}", this.getSegmentName());
     for (DataFileReader dfReader : columnIndexReaderWriterMap.values()) {
       try {
         dfReader.close();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
@@ -40,7 +40,13 @@ public class KafkaHighLevelStreamProviderConfig implements StreamProviderConfig 
     /*defaultProps.put("zookeeper.connect", zookeeper);
     defaultProps.put("group.id", groupId);*/
     defaultProps.put("zookeeper.session.timeout.ms", "30000");
-    defaultProps.put("zookeeper.sync.time.ms", "200");
+    defaultProps.put("zookeeper.connection.timeout.ms", "10000");
+    defaultProps.put("zookeeper.sync.time.ms", "2000");
+
+    // Rebalance retries will take up to 1 mins to fail.
+    defaultProps.put("rebalance.max.retries", "30");
+    defaultProps.put("rebalance.backoff.ms", "2000");
+    
     defaultProps.put("auto.commit.enable", "false");
     defaultProps.put("auto.offset.reset", "largest");
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/IndexSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/IndexSegmentImpl.java
@@ -114,8 +114,8 @@ public class IndexSegmentImpl implements IndexSegment {
 
   @Override
   public void destroy() {
+    LOGGER.info("Trying to destroy segment : {}", this.getSegmentName());
     for (String column : indexContainerMap.keySet()) {
-
       try {
         indexContainerMap.get(column).getDictionary().close();
       } catch (Exception e) {


### PR DESCRIPTION
Current way of shutting down kafka consumer is not clean. So if we bounce the machine very quickly, the old kafka consumer client session id is still in zookeeper, which will cause consumer rebalance error. Current kafka consumer setting will fail in about 10 secs, which is smaller than zk session timeout, which means realtime segment won't start indexing because of bouncing too fast.

The fix here is to clean shutdown kafka consumer for realtime indexing segment during machine bouncing and  realtime table deletion.

Also extend the kafka consumer rebalance timeout(1 min) longer than zookeeper session timeout. So consumer won't fail due to consumer unclean shutdown and back within 30 secs.
