### PR TITLE
Support segment upload with Uri

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
@@ -26,15 +26,40 @@ import com.linkedin.pinot.common.utils.FileUploadUtils;
 public class HttpSegmentFetcher implements SegmentFetcher {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpSegmentFetcher.class);
+  private static final String MAX_RETRIES = "maxRetries";
+  private static final int DEFAULT_MAX_RETRIES = 3;
+  private int maxRetryCount = DEFAULT_MAX_RETRIES;
 
   @Override
   public void init(Map<String, String> configs) {
+    if (configs.containsKey(MAX_RETRIES)) {
+      try {
+        maxRetryCount = Integer.parseInt(configs.get(MAX_RETRIES));
+      } catch (Exception e) {
+        maxRetryCount = DEFAULT_MAX_RETRIES;
+      }
+    }
   }
 
   @Override
   public void fetchSegmentToLocal(String uri, File tempFile) throws Exception {
-    final long httpGetResponseContentLength = FileUploadUtils.getFile(uri, tempFile);
-    LOGGER.info("Downloaded file from {} to {}; Length of httpGetResponseContent: {}; Length of downloaded file: {}", uri, tempFile,
-        httpGetResponseContentLength, tempFile.length());
+    for (int retry = 1; retry <= maxRetryCount; ++retry) {
+      try {
+        final long httpGetResponseContentLength = FileUploadUtils.getFile(uri, tempFile);
+        LOGGER.info(
+            "Downloaded file from {} to {}; Length of httpGetResponseContent: {}; Length of downloaded file: {}", uri,
+            tempFile, httpGetResponseContentLength, tempFile.length());
+        return;
+      } catch (Exception e) {
+        LOGGER.error("Failed to download file from {}, retry: {}", uri, retry, e);
+        if (retry == maxRetryCount) {
+          LOGGER.error("Exceeded maximum retry count while fetching file from {} to local file: {}, aborting.", uri, tempFile, e);
+          throw e;
+        } else {
+          long backOffTimeInSec = 5 * retry;
+          Thread.sleep(backOffTimeInSec * 1000);
+        }
+      }
+    }
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
@@ -24,16 +24,21 @@ import java.io.InputStream;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpVersion;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
+import org.apache.commons.httpclient.methods.RequestEntity;
+import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.apache.commons.httpclient.methods.multipart.FilePart;
 import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
 import org.apache.commons.httpclient.methods.multipart.Part;
 import org.apache.commons.httpclient.methods.multipart.PartSource;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.entity.ContentType;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +48,16 @@ public class FileUploadUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FileUploadUtils.class);
   private static final String SEGMENTS_PATH = "segments";
+  public static final String UPLOAD_TYPE = "UPLOAD_TYPE";
+  public static final String DOWNLOAD_URI = "DOWNLOAD_URI";
+  private static final MultiThreadedHttpConnectionManager CONNECTION_MANAGER =
+      new MultiThreadedHttpConnectionManager();
+  private static final HttpClient FILE_UPLOAD_HTTP_CLIENT = new HttpClient(CONNECTION_MANAGER);
+
+  {
+    FILE_UPLOAD_HTTP_CLIENT.getParams().setParameter("http.protocol.version", HttpVersion.HTTP_1_1);
+    FILE_UPLOAD_HTTP_CLIENT.getParams().setSoTimeout(3600 * 1000); // One hour
+  }
 
   public enum SendFileMethod {
     POST {
@@ -61,12 +76,9 @@ public class FileUploadUtils {
 
   public static int sendFile(final String host, final String port, final String path, final String fileName,
       final InputStream inputStream, final long lengthInBytes, SendFileMethod httpMethod) {
-    HttpClient client = new HttpClient();
+    EntityEnclosingMethod method = null;
     try {
-
-      client.getParams().setParameter("http.protocol.version", HttpVersion.HTTP_1_1);
-      client.getParams().setSoTimeout(3600 * 1000); // One hour
-      EntityEnclosingMethod method = httpMethod.forUri("http://" + host + ":" + port + "/" + path);
+      method = httpMethod.forUri("http://" + host + ":" + port + "/" + path);
       Part[] parts = {
           new FilePart(fileName, new PartSource() {
             @Override
@@ -86,7 +98,7 @@ public class FileUploadUtils {
           })
       };
       method.setRequestEntity(new MultipartRequestEntity(parts, new HttpMethodParams()));
-      client.executeMethod(method);
+      FILE_UPLOAD_HTTP_CLIENT.executeMethod(method);
       if (method.getStatusCode() >= 400) {
         String errorString = "POST Status Code: " + method.getStatusCode() + "\n";
         if (method.getResponseHeader("Error") != null) {
@@ -96,9 +108,13 @@ public class FileUploadUtils {
       }
       return method.getStatusCode();
     } catch (Exception e) {
-      LOGGER.error("Caught exception while sending file", e);
+      LOGGER.error("Caught exception while sending file: {}", fileName, e);
       Utils.rethrowException(e);
       throw new AssertionError("Should not reach this");
+    } finally {
+      if (method != null) {
+        method.releaseConnection();
+      }
     }
   }
 
@@ -107,11 +123,69 @@ public class FileUploadUtils {
     return sendFile(host, port, SEGMENTS_PATH, fileName, inputStream, lengthInBytes, SendFileMethod.POST);
   }
 
-  public static long getFile(String url, File file) throws Exception {
+
+  public static int sendSegmentUri(final String host, final String port, final String uri) {
+    SendFileMethod httpMethod = SendFileMethod.POST;
+    EntityEnclosingMethod method = null;
     try {
-      HttpClient httpClient = new HttpClient();
-      GetMethod httpget = new GetMethod(url);
-      int responseCode = httpClient.executeMethod(httpget);
+      method = httpMethod.forUri("http://" + host + ":" + port + "/" + SEGMENTS_PATH);
+      method.setRequestHeader(UPLOAD_TYPE, FileUploadType.URI.toString());
+      method.setRequestHeader(DOWNLOAD_URI, uri);
+      FILE_UPLOAD_HTTP_CLIENT.executeMethod(method);
+      if (method.getStatusCode() >= 400) {
+        String errorString = "POST Status Code: " + method.getStatusCode() + "\n";
+        if (method.getResponseHeader("Error") != null) {
+          errorString += "ServletException: " + method.getResponseHeader("Error").getValue();
+        }
+        throw new HttpException(errorString);
+      }
+      return method.getStatusCode();
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while sending uri: {}", uri, e);
+      Utils.rethrowException(e);
+      throw new AssertionError("Should not reach this");
+    } finally {
+      if (method != null) {
+        method.releaseConnection();
+      }
+    }
+  }
+
+  public static int sendSegmentJson(final String host, final String port, final JSONObject segmentJson) {
+    PostMethod postMethod = null;
+    try {
+      RequestEntity requestEntity = new StringRequestEntity(
+          segmentJson.toString(),
+          ContentType.APPLICATION_JSON.getMimeType(),
+          ContentType.APPLICATION_JSON.getCharset().name());
+      postMethod = new PostMethod("http://" + host + ":" + port + "/" + SEGMENTS_PATH);
+      postMethod.setRequestEntity(requestEntity);
+      postMethod.setRequestHeader(UPLOAD_TYPE, FileUploadType.JSON.toString());
+      int statusCode = FILE_UPLOAD_HTTP_CLIENT.executeMethod(postMethod);
+      if (statusCode >= 400) {
+        String errorString = "POST Status Code: " + statusCode + "\n";
+        if (postMethod.getResponseHeader("Error") != null) {
+          errorString += "ServletException: " + postMethod.getResponseHeader("Error").getValue();
+        }
+        throw new HttpException(errorString);
+      }
+      return statusCode;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while sending json: {}", segmentJson.toString(), e);
+      Utils.rethrowException(e);
+      throw new AssertionError("Should not reach this");
+    } finally {
+      if (postMethod != null) {
+        postMethod.releaseConnection();
+      }
+    }
+  }
+
+  public static long getFile(String url, File file) throws Exception {
+    GetMethod httpget = null;
+    try {
+      httpget = new GetMethod(url);
+      int responseCode = FILE_UPLOAD_HTTP_CLIENT.executeMethod(httpget);
       if (responseCode >= 400) {
         long contentLength = httpget.getResponseContentLength();
         if (contentLength > 0) {
@@ -134,6 +208,32 @@ public class FileUploadUtils {
     } catch (Exception ex) {
       LOGGER.error("Caught exception", ex);
       throw ex;
+    } finally {
+      if (httpget != null) {
+        httpget.releaseConnection();
+      }
+    }
+  }
+
+  public enum FileUploadType {
+    URI,
+    JSON,
+    TAR; // Default value
+
+    public FileUploadType valueOf(Object o) {
+      if (o != null) {
+        String ostring = o.toString();
+        for (FileUploadType u: FileUploadType.values()) {
+          if (ostring.equalsIgnoreCase(u.toString())) {
+            return u;
+          }
+        }
+      }
+      return getDefaultUploadType();
+    }
+
+    public static FileUploadType getDefaultUploadType() {
+      return TAR;
     }
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/FileUploadUtilsTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/FileUploadUtilsTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.linkedin.pinot.common.utils.FileUploadUtils.FileUploadType;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+
+@Test
+public class FileUploadUtilsTest {
+
+  private static final String TEST_HOST = "localhost";
+  private static final String TEST_PORT =
+      "" + (new Random(System.currentTimeMillis()).nextInt(10000) + 10000);
+  private static final String TEST_URI = "http://testhost/segments/testSegment";
+  private static HttpServer TEST_SERVER;
+
+  @BeforeClass
+  public void setup() throws Exception {
+    TEST_SERVER = HttpServer.create(new InetSocketAddress(Integer.parseInt(TEST_PORT)), 0);
+    TEST_SERVER.createContext("/segments", new testSegmentUploadHandler());
+    TEST_SERVER.setExecutor(null); // creates a default executor
+    TEST_SERVER.start();
+  }
+
+
+  static class testSegmentUploadHandler implements HttpHandler {
+    private int calledJson = 0;
+    private int calledUri = 0;
+
+    @Override
+    public void handle(HttpExchange httpExchange) throws IOException {
+      Headers requestHeaders = httpExchange.getRequestHeaders();
+      String uploadTypeStr = requestHeaders.getFirst(FileUploadUtils.UPLOAD_TYPE);
+      FileUploadType uploadType = FileUploadType.valueOf(uploadTypeStr);
+      if (uploadType == FileUploadType.JSON) {
+        InputStream bodyStream = httpExchange.getRequestBody();
+        String requestBody = IOUtils.toString(bodyStream, "UTF-8");
+        com.alibaba.fastjson.JSONObject jsonObject =
+            com.alibaba.fastjson.JSONObject.parseObject(requestBody);
+        Assert.assertEquals(jsonObject.get(CommonConstants.Segment.Offline.DOWNLOAD_URL), TEST_URI);
+        calledJson++;
+        // System.out.println("calledJson = " + calledJson);
+      } else if (uploadType == FileUploadType.URI) {
+        String downloadUri = requestHeaders.getFirst(FileUploadUtils.DOWNLOAD_URI);
+        Assert.assertEquals(downloadUri, TEST_URI);
+        calledUri++;
+        // System.out.println("calledUri = " + calledUri);
+      } else if (uploadType == FileUploadType.TAR) {
+        // Do nothing.
+      } else {
+        // Shouldn't reach here
+        Assert.assertTrue(false);
+      }
+      String response = "OK";
+      httpExchange.sendResponseHeaders(200, response.length());
+      OutputStream os = httpExchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
+    }
+  }
+
+  @AfterClass
+  public void Shutdown() {
+    TEST_SERVER.stop(0);
+  }
+
+  @Test
+  public void testSendFileWithUri() {
+    int respCode = FileUploadUtils.sendSegmentUri(TEST_HOST, TEST_PORT, TEST_URI);
+    Assert.assertEquals(respCode, 200);
+  }
+
+  @Test
+  public void testSendFileWithJson() throws JSONException {
+    JSONObject segmentJson = new JSONObject();
+    segmentJson.put(CommonConstants.Segment.Offline.DOWNLOAD_URL, TEST_URI);
+    int respCode = FileUploadUtils.sendSegmentJson(TEST_HOST, TEST_PORT, segmentJson);
+    Assert.assertEquals(respCode, 200);
+  }
+
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/BasePinotControllerRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/BasePinotControllerRestletResource.java
@@ -1,5 +1,6 @@
 package com.linkedin.pinot.controller.api.restlet.resources;
 
+import com.alibaba.fastjson.JSONObject;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.common.utils.NetUtil;
@@ -11,6 +12,7 @@ import java.util.concurrent.Executor;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.restlet.Response;
+import org.restlet.data.MediaType;
 import org.restlet.engine.header.Header;
 import org.restlet.engine.header.HeaderConstants;
 import org.restlet.representation.StringRepresentation;
@@ -124,6 +126,14 @@ public class BasePinotControllerRestletResource extends ServerResource {
   }
 
   public static StringRepresentation exceptionToStringRepresentation(Exception e) {
-    return new StringRepresentation(e.getMessage() + "\n" + ExceptionUtils.getStackTrace(e));
+    String errorMsg = e.getMessage() + "\n" + ExceptionUtils.getStackTrace(e);
+    JSONObject errorMsgInJson = getErrorMsgInJson(errorMsg);
+    return new StringRepresentation(errorMsgInJson.toJSONString(), MediaType.APPLICATION_JSON);
+  }
+
+  protected static JSONObject getErrorMsgInJson(String errorMsg) {
+    JSONObject errorMsgJson = new JSONObject();
+    errorMsgJson.put("ERROR", errorMsgJson);
+    return errorMsgJson;
   }
 }

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/PinotHadoopJobLauncher.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/PinotHadoopJobLauncher.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.hadoop.job.SegmentCreationJob;
 import com.linkedin.pinot.hadoop.job.SegmentTarPushJob;
+import com.linkedin.pinot.hadoop.job.SegmentUriPushJob;
 
 
 public class PinotHadoopJobLauncher {
@@ -29,14 +30,18 @@ public class PinotHadoopJobLauncher {
   enum PinotHadoopJobType {
     SegmentCreation,
     SegmentTarPush,
-    SegmentCreationAndTarPush
+    SegmentUriPush,
+    SegmentCreationAndTarPush,
+    SegmentCreationAndUriPush
   }
 
   private static final String USAGE = "usage: [job_type] [job.properties]";
   private static final String SUPPORT_JOB_TYPES = "\tsupport job types: " + Arrays.toString(PinotHadoopJobType.values());
   private static final String SEGMENT_CREATION_JOB_NAME = PinotHadoopJobType.SegmentCreation.toString();
   private static final String SEGMENT_PUSH_TAR_JOB_NAME = PinotHadoopJobType.SegmentTarPush.toString();
+  private static final String SEGMENT_PUSH_URI_JOB_NAME = PinotHadoopJobType.SegmentUriPush.toString();
   private static final String SEGMENT_CREATION_AND_TAR_PUSH_JOB_NAME = PinotHadoopJobType.SegmentCreationAndTarPush.toString();
+  private static final String SEGMENT_CREATION_AND_URI_PUSH_JOB_NAME = PinotHadoopJobType.SegmentCreationAndUriPush.toString();
 
   private static void usage() {
     System.err.println(USAGE);
@@ -51,9 +56,16 @@ public class PinotHadoopJobLauncher {
       case SegmentTarPush:
         new SegmentTarPushJob(SEGMENT_PUSH_TAR_JOB_NAME, jobConf).run();
         break;
+      case SegmentUriPush:
+        new SegmentUriPushJob(SEGMENT_PUSH_URI_JOB_NAME, jobConf).run();
+        break;
       case SegmentCreationAndTarPush:
         new SegmentCreationJob(StringUtil.join(":", SEGMENT_CREATION_JOB_NAME, SEGMENT_CREATION_AND_TAR_PUSH_JOB_NAME), jobConf).run();
         new SegmentTarPushJob(StringUtil.join(":", SEGMENT_PUSH_TAR_JOB_NAME, SEGMENT_CREATION_AND_TAR_PUSH_JOB_NAME), jobConf).run();
+        break;
+      case SegmentCreationAndUriPush:
+        new SegmentCreationJob(StringUtil.join(":", SEGMENT_CREATION_JOB_NAME, SEGMENT_CREATION_AND_URI_PUSH_JOB_NAME), jobConf).run();
+        new SegmentUriPushJob(StringUtil.join(":", SEGMENT_PUSH_TAR_JOB_NAME, SEGMENT_CREATION_AND_URI_PUSH_JOB_NAME), jobConf).run();
         break;
       default:
         throw new RuntimeException("Not a valid jobType - " + jobType);

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentUriPushJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentUriPushJob.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.hadoop.job;
+
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.pinot.common.utils.FileUploadUtils;
+
+public class SegmentUriPushJob extends Configured {
+
+  private String _pushUriPrefix;
+  private String _pushUriSuffix;
+  private String _segmentPath;
+  private String[] _hosts;
+  private String _port;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentUriPushJob.class);
+
+  public SegmentUriPushJob(String name, Properties properties) {
+    super(new Configuration());
+    _pushUriPrefix = properties.getProperty("uri.prefix", "");
+    _pushUriSuffix = properties.getProperty("uri.suffix", "");
+    _segmentPath = properties.getProperty("path.to.output") + "/";
+    _hosts = properties.getProperty("push.to.hosts").split(",");
+    _port = properties.getProperty("push.to.port");
+
+  }
+
+  public void run() throws Exception {
+    Configuration conf = new Configuration();
+    FileSystem fs = FileSystem.get(conf);
+    Path path = new Path(_segmentPath);
+    FileStatus[] fileStatusArr = fs.globStatus(path);
+    for (FileStatus fileStatus : fileStatusArr) {
+      if (fileStatus.isDirectory()) {
+        pushDir(fs, fileStatus.getPath());
+      } else {
+        pushOneTarFile(fs, fileStatus.getPath());
+      }
+    }
+
+  }
+
+  public void pushDir(FileSystem fs, Path path) throws Exception {
+    LOGGER.info("******** Now uploading segments tar from dir: {}", path);
+    FileStatus[] fileStatusArr = fs.listStatus(new Path(path.toString() + "/"));
+    for (FileStatus fileStatus : fileStatusArr) {
+      if (fileStatus.isDirectory()) {
+        pushDir(fs, fileStatus.getPath());
+      } else {
+        pushOneTarFile(fs, fileStatus.getPath());
+      }
+    }
+  }
+
+  public void pushOneTarFile(FileSystem fs, Path path) throws Exception {
+    String fileName = path.getName();
+    if (!fileName.endsWith(".tar.gz")) {
+      return;
+    }
+    for (String host : _hosts) {
+      String uri = String.format("%s%s%s", _pushUriPrefix, path.toUri().getRawPath(), _pushUriSuffix);
+      LOGGER.info("******** Upoading file: {} to Host: {} and Port: {} with download uri: {} *******", fileName, host, _port, uri);
+      try {
+        int responseCode = FileUploadUtils.sendSegmentUri(host, _port, uri);
+        LOGGER.info("Response code: {}", responseCode);
+      } catch (Exception e) {
+        LOGGER.error("******** Error Upoading file: {} to Host: {} and Port: {}  *******", fileName, host, _port);
+        LOGGER.error("Caught exception during upload", e);
+        throw new RuntimeException("Got Error during send tar files to push hosts!");
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Adding a default maxRetries for HttpSegmentFetcher to 3.
Adding enum type FileUploadType to support Tar and Uri.
Tar is the default one which is currently using.
For Uri mode, instead of curling the entire segment in a POST request, we just put segment download uri in the request header and controller will fetch segment to local based on the given uri.
