### PR TITLE
Adding 10 secs delay for broker to shutdown.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -255,7 +255,7 @@ public class HelixBrokerStarter {
     return pinotHelixBrokerStarter;
   }
 
-  protected void shutdown() {
+  public void shutdown() {
     LOGGER.info("Shutting down");
 
     if (_helixManager != null) {


### PR DESCRIPTION
Mostly for both health check and externalView to be in offline status.
I've observed many cases when I'm bouncing broker, the client side with see a short period that query response is empty.
I tried to setup both haproxy pinging health check and also register an externalView listener. Since we are stopping too fast, either of this approach will treat this broker is still alive, but actually getting empty results.

The clean way here is to set idealstates of this broker to offline meanwhile still serving queries. Then wait for externalView's reflection to offline then shutdown broker.

Also a configurable fixed timeout is necessary if I'm using haproxy to do health check.