### PR TITLE
[PINOT-3176]: Enhance StarTreeIndexOperator to support all predicate types.

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -339,4 +339,28 @@ public class StarTreeClusterIntegrationTest extends ClusterTest {
     query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay > 0 AND ArrDelay > 0 AND OriginStateName = 'Massachusetts'\n";
     testOneQuery(query, false);
   }
+
+  /**
+   * Tests queries with non-equality predicates
+   */
+  @Test
+  public void testNonEqualityPredicates() {
+    String query;
+
+    // 'Range' query
+    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay between 0 and 10000\n";
+    testOneQuery(query, false);
+
+    // 'IN' query
+    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin IN ('JFK', 'LAX', 'DCW')\n";
+    testOneQuery(query, false);
+
+    // 'NOT IN' Query
+    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin NOT IN ('JFK', 'LAX', 'DCW')\n";
+    testOneQuery(query, false);
+
+    // 'NOT EQ' Query
+    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin <> 'JFK'\n";
+    testOneQuery(query, false);
+  }
 }


### PR DESCRIPTION
Currently, the StarTreeIndexOperator only supports the equality
predicate. This change is an enhancement to support all other predicate
types (eg RANGE, IN, etc). Added test to cover the non equality
predicate operators.