### PR TITLE
Optimize for doc level function in group key generator

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
@@ -170,16 +170,14 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
    */
   @Override
   public int generateKeyForDocId(int docId) {
+    long rawKey = 0;
+
     for (int i = 0; i < _groupByColumns.length; i++) {
-      if (_isSingleValueGroupByColumn[i]) {
-        _singleValIterators[i].skipTo(docId);
-        _reusableGroupByValuesArray[i] = _singleValIterators[i].nextIntVal();
-      } else {
-        throw new RuntimeException("GroupBy on multi-valued columns not supported.");
-      }
+      BlockSingleValIterator singleValIterator = _singleValIterators[i];
+      singleValIterator.skipTo(docId);
+      rawKey = rawKey * _cardinalities[i] + singleValIterator.nextIntVal();
     }
 
-    long rawKey = generateRawKey(_reusableGroupByValuesArray, _cardinalities);
     return updateRawKeyToGroupKeyMapping(rawKey);
   }
 


### PR DESCRIPTION
Remove the error checking in generateKeyForDocId().
Optimize for single group-by column.
The overall performance gain for certain use case is up to 20%.