### PR TITLE
Added controller API to provide table sizes

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/SegmentSizeInfo.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/SegmentSizeInfo.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.restlet.resources;
+
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SegmentSizeInfo {
+  public String segmentName;
+  public long diskSizeInBytes = -1;
+
+  public SegmentSizeInfo() {
+
+  }
+
+  public SegmentSizeInfo(String segmentName, long sizeBytes) {
+    this.segmentName = segmentName;
+    this.diskSizeInBytes = sizeBytes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SegmentSizeInfo)) {
+      return false;
+    }
+
+    SegmentSizeInfo that = (SegmentSizeInfo) o;
+
+    if (diskSizeInBytes != that.diskSizeInBytes) {
+      return false;
+    }
+    return segmentName != null ? segmentName.equals(that.segmentName) : that.segmentName == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = segmentName != null ? segmentName.hashCode() : 0;
+    result = 31 * result + (int) (diskSizeInBytes ^ (diskSizeInBytes >>> 32));
+    return result;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/TableSizeInfo.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/resources/TableSizeInfo.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.restlet.resources;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TableSizeInfo {
+  public String tableName;
+  public long diskSizeInBytes = -1;
+  public List<SegmentSizeInfo> segments = new ArrayList<>();
+
+  public TableSizeInfo() {
+
+  }
+
+  public TableSizeInfo(String tableName, long sizeInBytes) {
+    this.tableName = tableName;
+    this.diskSizeInBytes = sizeInBytes;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -136,6 +136,7 @@ public class CommonConstants {
       public static final String INSTANCE_NAME = "instance.name";
       public static final String GROUP_ID_SUFFIX = "kafka.hlc.groupId";
       public static final String PARTITION_SUFFIX = "kafka.hlc.partition";
+      public static final String ADMIN_PORT_KEY = "adminPort";
     }
 
     public static enum TableType {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/http/MultiGetRequestTest.java
@@ -124,8 +124,9 @@ public class MultiGetRequestTest {
     int errors = 0;
     int timeouts = 0;
     for (int i = 0; i < urls.size(); i++) {
+      GetMethod getMethod = null;
       try {
-        GetMethod getMethod = completionService.take().get();
+         getMethod = completionService.take().get();
         if (getMethod.getStatusCode() >= 300) {
           ++errors;
           Assert.assertEquals(getMethod.getResponseBodyAsString(), ERROR_MSG);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -24,11 +24,6 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 
 import com.linkedin.pinot.common.utils.StringUtil;
 
-
-/**
- * Sep 26, 2014
- */
-
 public class ControllerConf extends PropertiesConfiguration {
   private static final String CONTROLLER_VIP_HOST = "controller.vip.host";
   private static final String CONTROLLER_VIP_PROTOCOL = "controller.vip.protocol";
@@ -43,10 +38,13 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String RETENTION_MANAGER_FREQUENCY_IN_SECONDS = "controller.retention.frequencyInSeconds";
   private static final String VALIDATION_MANAGER_FREQUENCY_IN_SECONDS = "controller.validation.frequencyInSeconds";
   private static final String STATUS_CHECKER_FREQUENCY_IN_SECONDS = "controller.statuschecker.frequencyInSeconds";
+  private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
+
   private static final int DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
   private static final int DEFAULT_VALIDATION_CONTROLLER_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
   private static final int DEFAULT_STATUS_CONTROLLER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
   private static final long DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS = 120_000L; // 2 minutes
+  private static final int DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = 30;
 
   public ControllerConf(File file) throws ConfigurationException {
     super(file);
@@ -199,5 +197,16 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public void setTenantIsolationEnabled(boolean isSingleTenant) {
     setProperty(CLUSTER_TENANT_ISOLATION_ENABLE, isSingleTenant);
+  }
+
+  public void setServerAdminRequestTimeoutSeconds(int timeoutSeconds) {
+    setProperty(SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS, timeoutSeconds);
+  }
+
+  public int getServerAdminRequestTimeoutSeconds() {
+    if (containsKey(SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS)) {
+      getInt(SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS);
+    }
+    return DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerRestApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerRestApplication.java
@@ -21,6 +21,7 @@ import com.linkedin.pinot.controller.api.restlet.resources.BasePinotControllerRe
 import com.linkedin.pinot.controller.api.restlet.resources.PinotVersionRestletResource;
 import com.linkedin.pinot.common.restlet.swagger.SwaggerResource;
 
+import com.linkedin.pinot.controller.api.restlet.resources.TableSize;
 import org.restlet.Context;
 import org.restlet.Request;
 import org.restlet.Response;
@@ -92,6 +93,7 @@ public class ControllerRestApplication extends PinotRestletApplication {
     attachRoutesForClass(router, PinotTableInstances.class);
     attachRoutesForClass(router, PinotTableSchema.class);
     attachRoutesForClass(router, PinotSegmentRestletResource.class);
+    attachRoutesForClass(router, TableSize.class);
 
     // PUT
     attachRoutesForClass(router, PinotTableSegmentConfigs.class);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/pojos/Instance.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/pojos/Instance.java
@@ -15,21 +15,16 @@
  */
 package com.linkedin.pinot.controller.api.pojos;
 
-import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import org.apache.helix.model.InstanceConfig;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.StringUtil;
-
-
 /**
  * Instance POJO, used as part of the API to create instances.
  */
-
 public class Instance {
   private final String _host;
   private final String _port;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PqlQueryResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PqlQueryResource.java
@@ -40,11 +40,6 @@ import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.pql.parsers.Pql2Compiler;
 
-
-/**
- * Dec 8, 2014
- */
-
 public class PqlQueryResource extends BasePinotControllerRestletResource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PqlQueryResource.class);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/ServerTableSizeReader.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.api.restlet.resources;
+
+import com.google.common.collect.BiMap;
+import com.linkedin.pinot.common.http.MultiGetRequest;
+import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
+import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.Executor;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Get the size information details from the server. Only the servers returning success are returned by the method
+ * For servers returning errors (http error or otherwise), no entry is created in the return map
+ */
+public class ServerTableSizeReader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableSizeReader.class);
+
+  private final Executor executor;
+  private final HttpConnectionManager connectionManager;
+
+  public ServerTableSizeReader(Executor executor, HttpConnectionManager connectionManager) {
+    this.executor = executor;
+    this.connectionManager = connectionManager;
+  }
+
+  public Map<String, List<SegmentSizeInfo>> getSizeDetailsFromServers(BiMap<String, String> serverEndPoints,
+      String table, int timeoutMsec) {
+
+    List<String> serverUrls = new ArrayList<>(serverEndPoints.size());
+    BiMap<String, String> endpointsToServers = serverEndPoints.inverse();
+    for (String endpoint : endpointsToServers.keySet()) {
+      String tableSizeUri = "http://" + endpoint + "/table/" + table + "/size";
+      serverUrls.add(tableSizeUri);
+    }
+
+    MultiGetRequest mget = new MultiGetRequest(executor, connectionManager);
+    CompletionService<GetMethod> completionService = mget.execute(serverUrls, timeoutMsec);
+
+    Map<String, List<SegmentSizeInfo>> serverSegmentSizes = new HashMap<>(serverEndPoints.size());
+
+    for (int i = 0; i < serverUrls.size(); i++) {
+      try {
+        GetMethod getMethod = completionService.take().get();
+        URI uri = getMethod.getURI();
+        String instance = endpointsToServers.get(uri.getHost() + ":" + uri.getPort());
+        if (getMethod.getStatusCode() >= 300) {
+          LOGGER.error("Server: {} returned error: {}", instance, getMethod.getStatusCode());
+          continue;
+        }
+        TableSizeInfo tableSizeInfo = new ObjectMapper().readValue(getMethod.getResponseBodyAsString(), TableSizeInfo.class);
+        serverSegmentSizes.put(instance, tableSizeInfo.segments);
+      } catch (Exception e) {
+        // ignore for all errors..we let callers manage failures
+      }
+    }
+    return serverSegmentSizes;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableSize.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableSize.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.api.restlet.resources;
+
+import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
+import com.linkedin.pinot.common.restlet.swagger.Parameter;
+import com.linkedin.pinot.common.restlet.swagger.Paths;
+import com.linkedin.pinot.common.restlet.swagger.Summary;
+import com.linkedin.pinot.common.restlet.swagger.Tags;
+import java.io.IOException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.restlet.data.MediaType;
+import org.restlet.data.Status;
+import org.restlet.representation.Representation;
+import org.restlet.representation.StringRepresentation;
+import org.restlet.resource.Get;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TableSize extends BasePinotControllerRestletResource {
+  private static Logger LOGGER = LoggerFactory.getLogger(TableSize.class);
+
+  @Get
+  @Override
+  public Representation get() {
+    final String tableName = (String) getRequest().getAttributes().get("tableName");
+    final String detailedVal = (String) getRequest().getAttributes().get("detailed");
+    final boolean detailed = ! "false".equalsIgnoreCase(detailedVal);
+
+    if (tableName == null) {
+      setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
+      StringRepresentation resp = new StringRepresentation("{\"error\" : \"Table name is required\"}");
+      resp.setMediaType(MediaType.APPLICATION_JSON);
+      return resp;
+    }
+    return getTableSizes(tableName, detailed);
+  }
+
+  @HttpVerb("get")
+  @Summary("Get table storage size across all replicas")
+  @Tags({"table"})
+  @Paths({"/tables/{tableName}/size"})
+  private Representation getTableSizes(
+      @Parameter(name="tableName", in = "path", description = "Table name")
+      String tableName,
+      @Parameter(name="detailed", in="query",
+      description = "true=Provide detailed size information; false=Only aggregated size",
+      required = false)
+      boolean detailed) {
+    TableSizeReader tableSizeReader = new TableSizeReader(executor, connectionManager, _pinotHelixResourceManager);
+
+
+    TableSizeReader.TableSizeDetails tableSizeDetails = null;
+    try {
+      tableSizeDetails = tableSizeReader.getTableSizeDetails(tableName,
+          _controllerConf.getServerAdminRequestTimeoutSeconds());
+    } catch (Throwable t) {
+      LOGGER.error("Failed to read table size for: {}", tableName, t);
+      return responseRepresentation(Status.SERVER_ERROR_INTERNAL,
+          "{\"error\" : \"Error reading size information for "
+          + tableName + "\"}");
+    }
+
+    if (tableSizeDetails == null) {
+      return responseRepresentation(Status.CLIENT_ERROR_NOT_FOUND,
+          "{\"error\" : \"Table " + tableName + " does not exist\" }");
+    }
+
+    try {
+      return responseRepresentation(Status.SUCCESS_OK,
+          new ObjectMapper().writeValueAsString(tableSizeDetails));
+    } catch (IOException e) {
+      LOGGER.error("Failed to convert table size to json for table: {}", tableName, e);
+      return responseRepresentation(Status.SERVER_ERROR_INTERNAL,
+          "{\"error\" : \"Error formatting table size\"}");
+    }
+  }
+
+  private StringRepresentation responseRepresentation(Status status, String jsonMsg) {
+    setStatus(status);
+    StringRepresentation repr = new StringRepresentation(jsonMsg);
+    repr.setMediaType(MediaType.APPLICATION_JSON);
+    return repr;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableSizeReader.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.api.restlet.resources;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Reads table sizes from servers
+ */
+public class TableSizeReader {
+  private static Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
+  private Executor executor;
+  private HttpConnectionManager connectionManager;
+  private PinotHelixResourceManager helixResourceManager;
+
+  public TableSizeReader(Executor executor, HttpConnectionManager connectionManager,
+      PinotHelixResourceManager helixResourceManager) {
+    this.executor = executor;
+    this.connectionManager = connectionManager;
+    this.helixResourceManager = helixResourceManager;
+  }
+
+  /**
+   * Get the table size.
+   * This one polls all servers in parallel for segment sizes. In the response,
+   * reported size indicates actual sizes collected from servers. For errors,
+   * we use the size of largest segment as an estimate.
+   * Returns null if the table is not found.
+   * @param tableName
+   * @param timeoutMsec
+   * @return
+   */
+  public @Nullable TableSizeDetails getTableSizeDetails(@Nonnull String tableName,
+      @Nonnegative int timeoutMsec) {
+    Preconditions.checkNotNull(tableName, "Table name should not be null");
+    Preconditions.checkArgument(timeoutMsec > 0, "Timeout value must be greater than 0");
+
+    boolean hasRealtimeTable = false;
+    boolean hasOfflineTable = false;
+    CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+
+    if (tableType != null) {
+      hasRealtimeTable = tableType == CommonConstants.Helix.TableType.REALTIME;
+      hasOfflineTable = tableType == CommonConstants.Helix.TableType.OFFLINE;
+    } else {
+      hasRealtimeTable = helixResourceManager.hasRealtimeTable(tableName);
+      hasOfflineTable = helixResourceManager.hasOfflineTable(tableName);
+    }
+
+    if (!hasOfflineTable && !hasRealtimeTable) {
+      return null;
+    }
+
+    TableSizeDetails tableSizeDetails = new TableSizeDetails(tableName);
+
+    if (hasRealtimeTable) {
+      String realtimeTableName = new TableNameBuilder(CommonConstants.Helix.TableType.REALTIME).forTable(tableName);
+      tableSizeDetails.realtimeSegments = getTableSubtypeSize(realtimeTableName, timeoutMsec);
+      tableSizeDetails.reportedSizeInBytes += tableSizeDetails.realtimeSegments.reportedSizeInBytes;
+      tableSizeDetails.estimatedSizeInBytes += tableSizeDetails.realtimeSegments.estimatedSizeInBytes;
+    }
+    if (hasOfflineTable) {
+      String offlineTableName = new TableNameBuilder(CommonConstants.Helix.TableType.OFFLINE).forTable(tableName);
+      tableSizeDetails.offlineSegments = getTableSubtypeSize(offlineTableName, timeoutMsec);
+      tableSizeDetails.reportedSizeInBytes += tableSizeDetails.offlineSegments.reportedSizeInBytes;
+      tableSizeDetails.estimatedSizeInBytes += tableSizeDetails.offlineSegments.estimatedSizeInBytes;
+    }
+    return tableSizeDetails;
+  }
+
+  //
+  // Reported size below indicates the sizes actually reported by servers on successful responses.
+  // Estimated sizes indicates the size estimated size with approximated calculations for errored servers
+  //
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public class TableSizeDetails {
+    public String tableName;
+    public long reportedSizeInBytes = 0;
+    // estimated size if servers are down
+    public long estimatedSizeInBytes = 0;
+    public @Nullable TableSubTypeSizeDetails offlineSegments;
+    public @Nullable TableSubTypeSizeDetails realtimeSegments;
+
+    public TableSizeDetails(String tableName) {
+      this.tableName = tableName;
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public class TableSubTypeSizeDetails {
+    public long reportedSizeInBytes = 0;
+    public long estimatedSizeInBytes = 0;
+    public Map<String, SegmentSizeDetails> segments = new HashMap<>();
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public class SegmentSizeDetails {
+    public long reportedSizeInBytes = 0;
+    public long estimatedSizeInBytes = 0;
+    public Map<String, SegmentSizeInfo> serverInfo = new HashMap<>();
+  }
+
+  public TableSubTypeSizeDetails getTableSubtypeSize(String tableNameWithType, int timeoutMsec) {
+    // for convenient usage within this function
+    final String table = tableNameWithType;
+
+    // get list of servers
+    Map<String, List<String>> serverSegmentsMap =
+        helixResourceManager.getInstanceToSegmentsInATableMap(table);
+    ServerTableSizeReader serverTableSizeReader = new ServerTableSizeReader(executor, connectionManager);
+    BiMap<String, String> endpoints = helixResourceManager.getDataInstanceAdminEndpoints(serverSegmentsMap.keySet());
+    Map<String, List<SegmentSizeInfo>> serverSizeInfo =
+        serverTableSizeReader.getSizeDetailsFromServers(endpoints, table, timeoutMsec);
+
+    populateErroredServerSizes(serverSizeInfo, serverSegmentsMap);
+
+    TableSubTypeSizeDetails subTypeSizeDetails = new TableSubTypeSizeDetails();
+
+    Map<String, SegmentSizeDetails> segmentMap = subTypeSizeDetails.segments;
+    // convert from server ->SegmentSizes to segment -> (SegmentSizeDetails: server -> segmentSizes)
+    for (Map.Entry<String, List<SegmentSizeInfo>> serverSegments : serverSizeInfo.entrySet()) {
+      String server = serverSegments.getKey();
+      List<SegmentSizeInfo> segments = serverSegments.getValue();
+      for (SegmentSizeInfo segment : segments) {
+        SegmentSizeDetails sizeDetails = segmentMap.get(segment.segmentName);
+        if (sizeDetails == null) {
+          sizeDetails = new SegmentSizeDetails();
+          segmentMap.put(segment.segmentName, sizeDetails);
+        }
+        sizeDetails.serverInfo.put(server, segment);
+      }
+    }
+
+    // iterate through the map of segments and calculate the reported and estimated sizes
+    // for each segment. For servers that reported error, we use the max size of the same segment
+    // reported by another server. If no server reported size for a segment, we use the size
+    // of the largest segment reported by any server for the table.
+    // At all times, reportedSize indicates actual size that is reported by servers. For errored
+    // segments are not reflected in that count. Estimated size is what we estimate in case of
+    // errors, as described above.
+    // estimatedSize >= reportedSize. If no server reported error, estimatedSize == reportedSize
+    long tableLevelMax = -1;
+    for (Map.Entry<String, SegmentSizeDetails> segmentEntry : segmentMap.entrySet()) {
+      SegmentSizeDetails segmentSizes = segmentEntry.getValue();
+      // track segment level max size
+      long segmentLevelMax = -1;
+      int errors = 0;
+      // iterate over all servers that reported size for this segment
+      for (Map.Entry<String, SegmentSizeInfo> serverInfo : segmentSizes.serverInfo.entrySet()) {
+        SegmentSizeInfo ss = serverInfo.getValue();
+        if (ss.diskSizeInBytes != -1) {
+          segmentSizes.reportedSizeInBytes += ss.diskSizeInBytes;
+          segmentLevelMax = Math.max(segmentLevelMax, ss.diskSizeInBytes);
+        } else {
+          ++errors;
+        }
+      }
+      // after iterating over all servers update summary reported and estimated size of the segment
+      if (errors != segmentSizes.serverInfo.size()) {
+        // atleast one server reported size for this segment
+        segmentSizes.estimatedSizeInBytes = segmentSizes.reportedSizeInBytes + errors * segmentLevelMax;
+        tableLevelMax = Math.max(tableLevelMax, segmentLevelMax);
+        subTypeSizeDetails.reportedSizeInBytes += segmentSizes.reportedSizeInBytes;
+        subTypeSizeDetails.estimatedSizeInBytes += segmentSizes.estimatedSizeInBytes;
+      } else {
+        segmentSizes.reportedSizeInBytes = -1;
+        segmentSizes.estimatedSizeInBytes = -1;
+      }
+    }
+    if (tableLevelMax == -1) {
+      // no server reported size
+      subTypeSizeDetails.reportedSizeInBytes = -1;
+      subTypeSizeDetails.estimatedSizeInBytes = -1;
+    } else {
+      // For segments with no reported sizes, use max table-level segment size as an estimate
+      for (Map.Entry<String, SegmentSizeDetails> segmentSizeDetailsEntry : segmentMap.entrySet()) {
+        SegmentSizeDetails sizeDetails = segmentSizeDetailsEntry.getValue();
+        if (sizeDetails.reportedSizeInBytes != -1) {
+          continue;
+        }
+        sizeDetails.estimatedSizeInBytes += sizeDetails.serverInfo.size() * tableLevelMax;
+        subTypeSizeDetails.estimatedSizeInBytes += sizeDetails.estimatedSizeInBytes;
+      }
+    }
+
+    return subTypeSizeDetails;
+  }
+
+  // for servers that reported error, populate segment size with -1
+  private void populateErroredServerSizes(Map<String, List<SegmentSizeInfo>> serverSizeInfo,
+      Map<String, List<String>> serverSegmentsMap) {
+    ImmutableSet<String> erroredServers = null;
+    try {
+      erroredServers = Sets.difference(
+          serverSegmentsMap.keySet(),
+          serverSizeInfo.keySet()).immutableCopy();
+    } catch (Exception e) {
+      LOGGER.error("Failed to get set difference: ", e);
+    }
+    for (String server : erroredServers) {
+      List<String> serverSegments = serverSegmentsMap.get(server);
+      Preconditions.checkNotNull(serverSegments);
+      List<SegmentSizeInfo> serverSegmentSizes = new ArrayList<>(serverSegments.size());
+      serverSizeInfo.put(server, serverSegmentSizes);
+      for (String segment : serverSegments) {
+        // this populates segment size info with size -1
+        serverSegmentSizes.add(new SegmentSizeInfo(segment, -1));
+      }
+    }
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
@@ -15,35 +15,35 @@
  */
 package com.linkedin.pinot.controller.helix;
 
-import static com.linkedin.pinot.common.utils.CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE;
-import static com.linkedin.pinot.common.utils.CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE;
-
+import com.google.common.collect.Lists;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.Tenant;
+import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
+import com.linkedin.pinot.common.utils.TenantRole;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.google.common.collect.Lists;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.config.Tenant;
-import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
-import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
-import com.linkedin.pinot.common.utils.TenantRole;
+import static com.linkedin.pinot.common.utils.CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE;
+import static com.linkedin.pinot.common.utils.CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE;
 
-
-/**
- * Sep 29, 2014
- */
 
 public class ControllerRequestBuilderUtil {
 
-  public static JSONObject buildInstanceCreateRequestJSON(String host, String port, String tag) throws JSONException {
+  public static JSONObject buildInstanceCreateRequestJSON(String host, String port, String tag)
+      throws JSONException {
     final JSONObject ret = new JSONObject();
     ret.put("host", host);
     ret.put("port", port);
@@ -51,7 +51,8 @@ public class ControllerRequestBuilderUtil {
     return ret;
   }
 
-  public static JSONArray buildBulkInstanceCreateRequestJSON(int start, int end) throws JSONException {
+  public static JSONArray buildBulkInstanceCreateRequestJSON(int start, int end)
+      throws JSONException {
     final JSONArray ret = new JSONArray();
     for (int i = start; i <= end; i++) {
       final JSONObject ins = new JSONObject();
@@ -65,20 +66,22 @@ public class ControllerRequestBuilderUtil {
   }
 
   public static void addFakeBrokerInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances) throws Exception {
+      int numInstances)
+      throws Exception {
     addFakeBrokerInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, false);
   }
 
   public static void addFakeBrokerInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances, boolean isSingleTenant) throws Exception {
+      int numInstances, boolean isSingleTenant)
+      throws Exception {
     for (int i = 0; i < numInstances; ++i) {
       final String brokerId = "Broker_localhost_" + i;
       final HelixManager helixZkManager =
           HelixManagerFactory.getZKHelixManager(helixClusterName, brokerId, InstanceType.PARTICIPANT, zkServer);
       final StateMachineEngine stateMachineEngine = helixZkManager.getStateMachineEngine();
       final StateModelFactory<?> stateModelFactory = new EmptyBrokerOnlineOfflineStateModelFactory();
-      stateMachineEngine.registerStateModelFactory(EmptyBrokerOnlineOfflineStateModelFactory.getStateModelDef(),
-          stateModelFactory);
+      stateMachineEngine
+          .registerStateModelFactory(EmptyBrokerOnlineOfflineStateModelFactory.getStateModelDef(), stateModelFactory);
       helixZkManager.connect();
       if (isSingleTenant) {
         helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, brokerId,
@@ -91,12 +94,21 @@ public class ControllerRequestBuilderUtil {
   }
 
   public static void addFakeDataInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances) throws Exception {
-    addFakeDataInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, false);
+      int numInstances)
+      throws Exception {
+    addFakeDataInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, false, 8097);
   }
 
   public static void addFakeDataInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances, boolean isSingleTenant) throws Exception {
+      int numInstances, boolean isSingleTenant)
+      throws Exception {
+    addFakeDataInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, isSingleTenant, 8097);
+  }
+
+  public static void addFakeDataInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
+      int numInstances, boolean isSingleTenant, int adminPort)
+      throws Exception {
+
     for (int i = 0; i < numInstances; ++i) {
       final String instanceId = "Server_localhost_" + i;
 
@@ -104,8 +116,8 @@ public class ControllerRequestBuilderUtil {
           HelixManagerFactory.getZKHelixManager(helixClusterName, instanceId, InstanceType.PARTICIPANT, zkServer);
       final StateMachineEngine stateMachineEngine = helixZkManager.getStateMachineEngine();
       final StateModelFactory<?> stateModelFactory = new EmptySegmentOnlineOfflineStateModelFactory();
-      stateMachineEngine.registerStateModelFactory(EmptySegmentOnlineOfflineStateModelFactory.getStateModelDef(),
-          stateModelFactory);
+      stateMachineEngine
+          .registerStateModelFactory(EmptySegmentOnlineOfflineStateModelFactory.getStateModelDef(), stateModelFactory);
       helixZkManager.connect();
       if (isSingleTenant) {
         helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId,
@@ -115,6 +127,12 @@ public class ControllerRequestBuilderUtil {
       } else {
         helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId, UNTAGGED_SERVER_INSTANCE);
       }
+      HelixConfigScope scope =
+          new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.PARTICIPANT, helixClusterName)
+              .forParticipant(instanceId).build();
+      Map<String, String> props = new HashMap<>();
+      props.put(CommonConstants.Helix.Instance.ADMIN_PORT_KEY, String.valueOf(adminPort + i));
+      helixZkManager.getClusterManagmentTool().setConfig(scope, props);
     }
   }
 
@@ -126,30 +144,33 @@ public class ControllerRequestBuilderUtil {
   }
 
   public static JSONObject buildServerTenantCreateRequestJSON(String tenantName, int numberOfInstances,
-      int offlineInstances, int realtimeInstances) throws JSONException {
+      int offlineInstances, int realtimeInstances)
+      throws JSONException {
     Tenant tenant = new TenantBuilder(tenantName).setRole(TenantRole.SERVER).setTotalInstances(numberOfInstances)
         .setOfflineInstances(offlineInstances).setRealtimeInstances(realtimeInstances).build();
     return tenant.toJSON();
   }
 
   public static JSONObject buildCreateOfflineTableJSON(String tableName, String serverTenant, String brokerTenant,
-      int numReplicas) throws JSONException {
+      int numReplicas)
+      throws JSONException {
     return buildCreateOfflineTableJSON(tableName, serverTenant, brokerTenant, "timeColumnName", "timeType", "DAYS",
         "700", numReplicas, "BalanceNumSegmentAssignmentStrategy");
   }
 
   public static JSONObject buildCreateOfflineTableJSON(String tableName, String serverTenant, String brokerTenant,
       String timeColumnName, String timeType, String retentionTimeUnit, String retentionTimeValue, int numReplicas,
-      String segmentAssignmentStrategy) throws JSONException {
+      String segmentAssignmentStrategy)
+      throws JSONException {
     return buildCreateOfflineTableJSON(tableName, serverTenant, brokerTenant, timeColumnName, timeType,
         retentionTimeUnit, retentionTimeValue, numReplicas, segmentAssignmentStrategy,
         Lists.newArrayList("coulmn1", "column2"));
-
   }
 
   public static JSONObject buildCreateOfflineTableJSON(String tableName, String serverTenant, String brokerTenant,
       String timeColumnName, String timeType, String retentionTimeUnit, String retentionTimeValue, int numReplicas,
-      String segmentAssignmentStrategy, List<String> invertedIndexColumnList) throws JSONException {
+      String segmentAssignmentStrategy, List<String> invertedIndexColumnList)
+      throws JSONException {
     JSONObject creationRequest = new JSONObject();
     creationRequest.put("tableName", tableName);
 
@@ -166,7 +187,7 @@ public class ControllerRequestBuilderUtil {
     creationRequest.put("segmentsConfig", segmentsConfig);
     JSONObject tableIndexConfig = new JSONObject();
     JSONArray invertedIndexColumns = new JSONArray();
-    for(String columnToIndex:invertedIndexColumnList){
+    for (String columnToIndex : invertedIndexColumnList) {
       invertedIndexColumns.put(columnToIndex);
     }
     tableIndexConfig.put("invertedIndexColumns", invertedIndexColumns);
@@ -183,15 +204,13 @@ public class ControllerRequestBuilderUtil {
     creationRequest.put("tenants", tenants);
     creationRequest.put("tableType", "OFFLINE");
     JSONObject metadata = new JSONObject();
-    JSONObject customConfigs = new JSONObject();
-    customConfigs.put("d2Name", "xlntBetaPinot");
-    metadata.put("customConfigs", customConfigs);
     creationRequest.put("metadata", metadata);
     return creationRequest;
   }
 
   public static JSONObject buildCreateOfflineTableJSON(String tableName, String serverTenant, String brokerTenant,
-      int numReplicas, String segmentAssignmentStrategy) throws JSONException {
+      int numReplicas, String segmentAssignmentStrategy)
+      throws JSONException {
     return buildCreateOfflineTableJSON(tableName, serverTenant, brokerTenant, "timeColumnName", "daysSinceEpoch",
         "DAYS", "700", numReplicas, segmentAssignmentStrategy);
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/ServerTableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/ServerTableSizeReaderTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.api.restlet.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
+import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class ServerTableSizeReaderTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableSizeReader.class);
+
+  private final ExecutorService executor = Executors.newFixedThreadPool(3);
+  private final HttpConnectionManager httpConnectionManager = new MultiThreadedHttpConnectionManager();
+  private final int serverPortStart = 10000;
+  private final String URI_PATH = "/table/";
+  private final List<HttpServer> servers = new ArrayList<>();
+  final int timeoutMsec = 5000;
+  final String tableName = "myTable";
+  final int serverCount = 6;
+  private final List<String> serverList = new ArrayList<>();
+  private final List<String> endpointList = new ArrayList<>();
+  private List<Integer> server1Segments;
+  private List<Integer> server2Segments;
+  private TableSizeInfo tableInfo1;
+  private TableSizeInfo tableInfo3;
+  private TableSizeInfo tableInfo2;
+
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    for (int i = 0; i < serverCount; i++) {
+      serverList.add("server_" + i);
+      endpointList.add("localhost:" + (serverPortStart + i));
+    }
+
+    server1Segments = Arrays.asList(1, 3, 5);
+    server2Segments = Arrays.asList(2, 3);
+
+    tableInfo1 = createTableSizeInfo(tableName, server1Segments);
+    tableInfo2 = createTableSizeInfo(tableName, server2Segments);
+    tableInfo3 = createTableSizeInfo(tableName, new ArrayList<Integer>());
+    servers.add(startServer(serverPortStart, createHandler(200, tableInfo1, 0)));
+    servers.add(startServer(serverPortStart + 1, createHandler(200, tableInfo2, 0)));
+    servers.add(startServer(serverPortStart + 3, createHandler(500, null, 0)));
+    servers.add(startServer(serverPortStart + 4, createHandler(200, null, timeoutMsec * 20)));
+    servers.add(startServer(serverPortStart + 5, createHandler(200, tableInfo3, 0)));
+  }
+
+  @AfterClass
+  public void tearDown() {
+    for (HttpServer server : servers) {
+      if (server != null) {
+        server.stop(0);
+      }
+    }
+  }
+
+  private TableSizeInfo createTableSizeInfo(String tableName, List<Integer> segmentIndexes) {
+    TableSizeInfo tableSizeInfo = new TableSizeInfo();
+    tableSizeInfo.tableName = tableName;
+    tableSizeInfo.diskSizeInBytes = 0;
+    for (int segmentIndex : segmentIndexes) {
+      long size = segmentIndexToSize(segmentIndex);
+      tableSizeInfo.diskSizeInBytes += size;
+      SegmentSizeInfo s = new SegmentSizeInfo("seg" + segmentIndex, size);
+      tableSizeInfo.segments.add(s);
+    }
+    return tableSizeInfo;
+  }
+
+  private long segmentIndexToSize(int index) {
+    return 100 + index * 100;
+  }
+
+  private HttpHandler createHandler(final int status, final TableSizeInfo tableSize, final int sleepTimeMs) {
+    return new HttpHandler() {
+      @Override
+      public void handle(HttpExchange httpExchange)
+          throws IOException {
+        if (sleepTimeMs > 0) {
+          try {
+            Thread.sleep(sleepTimeMs);
+          } catch (InterruptedException e) {
+            LOGGER.info("Handler interrupted during sleep");
+          }
+        }
+        String json = new ObjectMapper().writeValueAsString(tableSize);
+        httpExchange.sendResponseHeaders(status, json.length());
+        OutputStream responseBody = httpExchange.getResponseBody();
+        responseBody.write(json.getBytes());
+        responseBody.close();
+      }
+    };
+  }
+
+  private HttpServer startServer(int port, HttpHandler handler)
+      throws IOException {
+    final HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+    server.createContext(URI_PATH, handler);
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        server.start();
+      }
+    }).start();
+    return server;
+  }
+
+  @Test
+  public void testServerSizeReader() {
+    ServerTableSizeReader reader = new ServerTableSizeReader(executor, httpConnectionManager);
+    BiMap<String, String> endpoints = HashBiMap.create();
+    for (int i = 0; i < 2; i++) {
+      endpoints.put(serverList.get(i), endpointList.get(i));
+    }
+    endpoints.put(serverList.get(5), endpointList.get(5));
+    Map<String, List<SegmentSizeInfo>> serverSizes = reader.getSizeDetailsFromServers(endpoints, "foo", timeoutMsec);
+    Assert.assertEquals(serverSizes.size(), 3);
+    Assert.assertTrue(serverSizes.containsKey(serverList.get(0)));
+    Assert.assertTrue(serverSizes.containsKey(serverList.get(1)));
+    Assert.assertTrue(serverSizes.containsKey(serverList.get(5)));
+
+    Assert.assertEquals(serverSizes.get(serverList.get(0)), tableInfo1.segments);
+    Assert.assertEquals(serverSizes.get(serverList.get(1)), tableInfo2.segments);
+    Assert.assertEquals(serverSizes.get(serverList.get(5)), tableInfo3.segments);
+  }
+
+  @Test
+  public void testServerSizesErrors() {
+    ServerTableSizeReader reader = new ServerTableSizeReader(executor, httpConnectionManager);
+    BiMap<String, String> endpoints = HashBiMap.create();
+    for (int i = 0; i < serverCount; i++) {
+      endpoints.put(serverList.get(i), endpointList.get(i));
+    }
+    Map<String, List<SegmentSizeInfo>> serverSizes = reader.getSizeDetailsFromServers(endpoints, "foo", timeoutMsec);
+    Assert.assertEquals(serverSizes.size(), 3);
+    Assert.assertTrue(serverSizes.containsKey(serverList.get(0)));
+    Assert.assertTrue(serverSizes.containsKey(serverList.get(1)));
+    Assert.assertTrue(serverSizes.containsKey(serverList.get(5)));
+    // error and timing out servers are not part of responses
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/TableSizeReaderTest.java
@@ -1,0 +1,346 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.api.restlet.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
+import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class TableSizeReaderTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReaderTest.class);
+  private final Executor executor = Executors.newFixedThreadPool(1);
+  private final HttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+
+  private PinotHelixResourceManager helix;
+  private Map<String, FakeSizeServer> serverMap = new HashMap<>();
+  private final int serverPortStart = 20000;
+  private final String URI_PATH = "/table/";
+  private final int timeoutMsec = 10000;
+
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    helix = mock(PinotHelixResourceManager.class);
+    when(helix.hasOfflineTable(anyString())).thenAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocationOnMock)
+          throws Throwable {
+        String table = (String) invocationOnMock.getArguments()[0];
+        return table.indexOf("offline") >= 0;
+      }
+    });
+
+    when(helix.hasRealtimeTable(anyString())).thenAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocationOnMock)
+          throws Throwable {
+        String table = (String) invocationOnMock.getArguments()[0];
+        return table.indexOf("realtime") >= 0;
+      }
+    });
+
+    int counter = 0;
+    // server0
+    FakeSizeServer s = new FakeSizeServer(Arrays.asList("s1","s2", "s3"), serverPortStart + counter);
+    s.start(URI_PATH, createHandler(200, s.sizes, 0));
+    serverMap.put(serverName(counter), s);
+    ++counter;
+
+    // server1
+    s = new FakeSizeServer(Arrays.asList("s2","s5"), serverPortStart + counter);
+    s.start(URI_PATH, createHandler(200, s.sizes, 0));
+    serverMap.put(serverName(counter), s);
+    ++counter;
+
+    // server2
+    s = new FakeSizeServer(Arrays.asList("s3", "s6"), serverPortStart + counter);
+    s.start(URI_PATH, createHandler(404, s.sizes, 0));
+    serverMap.put(serverName(counter), s);
+    ++counter;
+
+    // server3
+    s = new FakeSizeServer(Arrays.asList("r1", "r2"), serverPortStart + counter);
+    s.start(URI_PATH, createHandler(200, s.sizes, 0));
+    serverMap.put(serverName(counter), s);
+    ++counter;
+
+    // server4
+    s = new FakeSizeServer(Arrays.asList("r2"), serverPortStart + counter);
+    s.start(URI_PATH, createHandler(200, s.sizes, 0));
+    serverMap.put(serverName(counter), s);
+    ++counter;
+
+    // server5 ... timing out server
+    s = new FakeSizeServer(Arrays.asList("s3","s5"), serverPortStart + counter);
+    s.start(URI_PATH, createHandler(200, s.sizes, timeoutMsec * 100));
+    serverMap.put(serverName(counter), s);
+    ++counter;
+  }
+
+  @AfterClass
+  public void tearDown() {
+    for (Map.Entry<String, FakeSizeServer> fakeServerEntry : serverMap.entrySet()) {
+      fakeServerEntry.getValue().httpServer.stop(0);
+    }
+  }
+
+  private HttpHandler createHandler(final int status,
+      final List<SegmentSizeInfo> segmentSizes, final int sleepTimeMs) {
+    return new HttpHandler() {
+      @Override
+      public void handle(HttpExchange httpExchange)
+          throws IOException {
+        if (sleepTimeMs > 0) {
+          try {
+            Thread.sleep(sleepTimeMs);
+          } catch (InterruptedException e) {
+            LOGGER.info("Handler interrupted during sleep");
+          }
+        }
+
+        TableSizeInfo tableInfo = new TableSizeInfo("myTable", 0);
+        tableInfo.segments = segmentSizes;
+        for (SegmentSizeInfo segmentSize : segmentSizes) {
+          tableInfo.diskSizeInBytes += segmentSize.diskSizeInBytes;
+        }
+
+        String json = new ObjectMapper().writeValueAsString(tableInfo);
+        httpExchange.sendResponseHeaders(status, json.length());
+        OutputStream responseBody = httpExchange.getResponseBody();
+        responseBody.write(json.getBytes());
+        responseBody.close();
+      }
+    };
+  }
+
+  private String serverName(int index) {
+    return "server" + index;
+  }
+
+  private static class FakeSizeServer {
+    List<String> segments;
+    String endpoint;
+    int port;
+    List<SegmentSizeInfo> sizes = new ArrayList<>();
+    HttpServer httpServer;
+
+    FakeSizeServer(List<String> segments, int port) {
+      this.segments = segments;
+      this.endpoint = "localhost:" + port;
+      this.port = port;
+      populateSizes(segments);
+    }
+
+    void populateSizes(List<String> segments) {
+      for (String segment : segments) {
+        SegmentSizeInfo sizeInfo =
+            new SegmentSizeInfo(segment, getSegmentSize(segment));
+        sizes.add(sizeInfo);
+      }
+    }
+
+    static long getSegmentSize(String segment) {
+      int index = Integer.parseInt(segment.substring(1));
+      return 100 + index * 10;
+    }
+
+    private void  start(String path, HttpHandler handler)
+        throws IOException {
+      httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+      httpServer.createContext(path, handler);
+      new Thread(new Runnable() {
+        @Override
+        public void run() {
+          httpServer.start();
+        }
+      }).start();
+    }
+  }
+
+  private Map<String, List<String>> subsetOfServerSegments(String...servers) {
+    Map<String, List<String>> subset = new HashMap<>();
+    for (String server : servers) {
+      subset.put(server, serverMap.get(server).segments);
+    }
+    return subset;
+  }
+
+  private BiMap<String, String> serverEndpoints(String...servers) {
+    BiMap<String, String> endpoints = HashBiMap.create(servers.length);
+    for (String server : servers) {
+      endpoints.put(server, serverMap.get(server).endpoint);
+    }
+    return endpoints;
+  }
+
+  @Test
+  public void testNoSuchTable() {
+    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
+    Assert.assertNull(reader.getTableSizeDetails("mytable", 1000));
+  }
+
+  private TableSizeReader.TableSizeDetails testRunner(final String[] servers, String table) {
+    when(helix.getInstanceToSegmentsInATableMap(anyString()))
+        .thenAnswer(new Answer<Object>() {
+          @Override
+          public Object answer(InvocationOnMock invocationOnMock)
+              throws Throwable {
+            return subsetOfServerSegments(servers);
+          }
+        });
+
+    when(helix.getDataInstanceAdminEndpoints(anySet()))
+        .thenAnswer(new Answer<Object>() {
+          @Override
+          public Object answer(InvocationOnMock invocationOnMock)
+              throws Throwable {
+            return serverEndpoints(servers);
+          }
+        });
+
+    TableSizeReader reader = new TableSizeReader(executor, connectionManager, helix);
+    return reader.getTableSizeDetails(table, 1000);
+  }
+
+  private Map<String, List<String>> segmentToServers(final String...servers) {
+    Map<String,List<String>> segmentServers = new HashMap<>();
+    for (String server : servers) {
+      List<String> segments = serverMap.get(server).segments;
+      for (String segment : segments) {
+        List<String> segServers = segmentServers.get(segment);
+        if (segServers == null) {
+          segServers = new ArrayList<String>();
+          segmentServers.put(segment, segServers);
+        }
+        segServers.add(server);
+      }
+    }
+    return segmentServers;
+  }
+
+  private void validateTableSubTypeSize(String[] servers,
+      TableSizeReader.TableSubTypeSizeDetails tableSize) {
+    Map<String, List<String>> segmentServers = segmentToServers(servers);
+    long reportedSize = 0;
+    long estimatedSize = 0;
+    long maxSegmentSize = 0;
+    boolean hasErrors = false;
+    for (Map.Entry<String, List<String>> segmentEntry : segmentServers.entrySet()) {
+      final String segmentName = segmentEntry.getKey();
+      final TableSizeReader.SegmentSizeDetails segmentDetails = tableSize.segments.get(segmentName);
+      if (segmentDetails.reportedSizeInBytes != -1) {
+        reportedSize += segmentDetails.reportedSizeInBytes;
+      }
+      if (segmentDetails.estimatedSizeInBytes != -1) {
+        estimatedSize += segmentDetails.estimatedSizeInBytes;
+      }
+
+      Assert.assertNotNull(segmentDetails);
+      final List<String> expectedServers = segmentEntry.getValue();
+      final long expectedSegmentSize = FakeSizeServer.getSegmentSize(segmentName);
+      int numResponses = expectedServers.size();
+      for (String expectedServer : expectedServers) {
+        Assert.assertTrue(segmentDetails.serverInfo.containsKey(expectedServer));
+        if (expectedServer.equals("server2") || expectedServer.equals("server5")) {
+          hasErrors = true;
+          --numResponses;
+        }
+      }
+      if (numResponses != 0) {
+        Assert.assertEquals(segmentDetails.reportedSizeInBytes, numResponses * expectedSegmentSize);
+        Assert.assertEquals(segmentDetails.estimatedSizeInBytes,
+            expectedServers.size() * expectedSegmentSize);
+      } else {
+        Assert.assertEquals(segmentDetails.reportedSizeInBytes, -1);
+        Assert.assertTrue(segmentDetails.estimatedSizeInBytes > 0);
+      }
+    }
+    Assert.assertEquals(tableSize.reportedSizeInBytes, reportedSize);
+    Assert.assertEquals(tableSize.estimatedSizeInBytes, estimatedSize);
+    if (hasErrors) {
+      Assert.assertTrue(tableSize.reportedSizeInBytes != tableSize.estimatedSizeInBytes);
+    }
+  }
+
+  @Test
+  public void testGetTableSubTypeSizeAllSuccess() {
+    final String[] servers = { "server0", "server1"};
+    TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, "offline");
+    TableSizeReader.TableSubTypeSizeDetails offlineSizes = tableSizeDetails.offlineSegments;
+    Assert.assertNotNull(offlineSizes);
+    Assert.assertEquals(offlineSizes.segments.size(), 4);
+    Assert.assertEquals(offlineSizes.reportedSizeInBytes, offlineSizes.estimatedSizeInBytes);
+    validateTableSubTypeSize(servers, offlineSizes);
+    Assert.assertNull(tableSizeDetails.realtimeSegments);
+    Assert.assertEquals(tableSizeDetails.reportedSizeInBytes, offlineSizes.reportedSizeInBytes);
+    Assert.assertEquals(tableSizeDetails.estimatedSizeInBytes, offlineSizes.estimatedSizeInBytes);
+  }
+
+  @Test
+  public void testGetTableSubTypeSizesWithErrors() {
+    final String[] servers = { "server0", "server1", "server2", "server5"};
+    TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, "offline");
+    TableSizeReader.TableSubTypeSizeDetails offlineSizes = tableSizeDetails.offlineSegments;
+    Assert.assertEquals(offlineSizes.segments.size(), 5);
+    Assert.assertTrue(offlineSizes.reportedSizeInBytes != offlineSizes.estimatedSizeInBytes);
+    validateTableSubTypeSize(servers, offlineSizes);
+    Assert.assertNull(tableSizeDetails.realtimeSegments);
+  }
+
+  @Test
+  public void getTableSizeDetailsRealtimeOnly() {
+    final String[] servers = { "server3", "server4"};
+    TableSizeReader.TableSizeDetails tableSizeDetails = testRunner(servers, "realtime");
+    Assert.assertNull(tableSizeDetails.offlineSegments);
+    TableSizeReader.TableSubTypeSizeDetails realtimeSegments = tableSizeDetails.realtimeSegments;
+    Assert.assertEquals(realtimeSegments.segments.size(), 2);
+    Assert.assertTrue(realtimeSegments.reportedSizeInBytes == realtimeSegments.estimatedSizeInBytes);
+    validateTableSubTypeSize(servers, realtimeSegments);
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.helix.core;
+
+import com.google.common.collect.BiMap;
+import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
+import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
+import com.linkedin.pinot.controller.helix.starter.HelixConfig;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class PinotHelixResourceManagerTest {
+  ZkStarter.ZookeeperInstance zkServer;
+  private PinotHelixResourceManager pinotHelixResourceManager;
+  private final static String ZK_SERVER = ZkStarter.DEFAULT_ZK_STR;
+  private final static String HELIX_CLUSTER_NAME = "PinotHelixResourceManagerTest";
+  private HelixManager helixZkManager;
+  private HelixAdmin helixAdmin;
+  private final int adminPortStart = 10000;
+  private final int numInstances = 3;
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    zkServer = ZkStarter.startLocalZkServer();
+    final String instanceId = "localhost_helixController";
+    pinotHelixResourceManager =
+        new PinotHelixResourceManager(ZK_SERVER, HELIX_CLUSTER_NAME, instanceId, null, 10000L, true);
+    pinotHelixResourceManager.start();
+
+    final String helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(ZK_SERVER);
+    helixZkManager = HelixSetupUtils.setup(HELIX_CLUSTER_NAME, helixZkURL, instanceId);
+    helixAdmin = helixZkManager.getClusterManagmentTool();
+    ControllerRequestBuilderUtil.addFakeBrokerInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME,ZK_SERVER, numInstances);
+    ControllerRequestBuilderUtil.addFakeDataInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME, ZK_SERVER, numInstances, true, adminPortStart);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    pinotHelixResourceManager.stop();
+    ZkStarter.stopLocalZkServer(zkServer);
+  }
+
+  @Test
+  public void testGetInstanceEndpoints()
+      throws InterruptedException {
+    Set<String> servers = pinotHelixResourceManager.getAllInstancesForServerTenant(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME);
+    BiMap<String, String> endpoints = pinotHelixResourceManager.getDataInstanceAdminEndpoints(servers);
+    for (Map.Entry<String, String> endpointEntry : endpoints.entrySet()) {
+      System.out.println(endpointEntry.getKey() + " -- " + endpointEntry.getValue());
+    }
+
+    for (int i = 0; i < numInstances; i++) {
+      Assert.assertTrue(endpoints.inverse().containsKey("localhost:" + String.valueOf(adminPortStart + i)));
+    }
+  }
+
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/restlet/TableSizeResource.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/restlet/TableSizeResource.java
@@ -17,6 +17,8 @@
 package com.linkedin.pinot.server.api.restlet;
 
 import com.google.common.collect.ImmutableList;
+import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
+import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
 import com.linkedin.pinot.common.restlet.swagger.Description;
 import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
 import com.linkedin.pinot.common.restlet.swagger.Parameter;
@@ -28,8 +30,6 @@ import com.linkedin.pinot.core.data.manager.offline.TableDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.server.starter.ServerInstance;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.ws.rs.Produces;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.restlet.data.Status;
@@ -93,9 +93,7 @@ public class TableSizeResource extends ServerResource {
       IndexSegment segment = segmentDataManager.getSegment();
       long segmentSizeBytes = segment.getDiskSizeBytes();
       if (detailed) {
-        SegmentSizeInfo segmentSizeInfo = new SegmentSizeInfo();
-        segmentSizeInfo.segmentName = segment.getSegmentName();
-        segmentSizeInfo.diskSizeInBytes = segmentSizeBytes;
+        SegmentSizeInfo segmentSizeInfo = new SegmentSizeInfo(segment.getSegmentName(), segmentSizeBytes);
         tableSizeInfo.segments.add(segmentSizeInfo);
       }
       tableSizeInfo.diskSizeInBytes += segmentSizeBytes;
@@ -114,17 +112,5 @@ public class TableSizeResource extends ServerResource {
       setStatus(Status.SERVER_ERROR_INTERNAL);
       return new StringRepresentation("{\"message\": \"Failed to convert data to json\"}");
     }
-  }
-
-  // we may want to pull this outside for an API of its own
-  public static class SegmentSizeInfo {
-    public String segmentName;
-    public long diskSizeInBytes;
-  }
-
-  public static class TableSizeInfo {
-    public String tableName;
-    public long diskSizeInBytes;
-    public List<SegmentSizeInfo> segments = new ArrayList<>();
   }
 }

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/api/restlet/TableSizeResourceTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/api/restlet/TableSizeResourceTest.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.server.api.restlet;
 
+import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
@@ -134,8 +135,8 @@ public class TableSizeResourceTest {
       Response response = client.handle(request);
       Assert.assertEquals(response.getStatus(),Status.SUCCESS_OK);
       String body = response.getEntity().getText();
-      TableSizeResource.TableSizeInfo tableSizeInfo =
-          new ObjectMapper().readValue(body, TableSizeResource.TableSizeInfo.class);
+      TableSizeInfo tableSizeInfo =
+          new ObjectMapper().readValue(body, TableSizeInfo.class);
       Assert.assertEquals("testTable", tableSizeInfo.tableName);
       Assert.assertEquals(1, tableSizeInfo.segments.size());
       Assert.assertEquals(indexSegment.getSegmentName(), tableSizeInfo.segments.get(0).segmentName);


### PR DESCRIPTION
Controller API provides reported and estimated table
size in bytes at uri /tables/tableName/size. The segments
sizes are read from the server. If a server fails, we estimate
the size for segments on that server to based on the max size
reported from other servers. Actual sizes reported from servers
are reported separately from estimated sizes.

Testing: UT + manual