### PR TITLE
Add support for documenting HTTP responses through Swagger

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/Response.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/Response.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.restlet.swagger;
+
+/**
+ * A response for an API call.
+ */
+public @interface Response {
+  /**
+   * The HTTP Status Code that can be returned by this API call or the String "default" for the default response object.
+   *
+   * @return A numeric HTTP status code or the string "default"
+   */
+  String statusCode();
+
+  /**
+   * A description of the response.
+   *
+   * @return A textual description of the response.
+   */
+  String description();
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/Responses.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/Responses.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.restlet.swagger;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+/**
+ * Documents the responses that can be returned by an API call.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Responses {
+  Response[] value();
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/SwaggerResource.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/SwaggerResource.java
@@ -152,6 +152,20 @@ public class SwaggerResource extends ServerResource {
           operation.put(Tags.class.getSimpleName().toLowerCase(), ((Tags) annotationInstance).value());
         }
 
+        annotationInstance = method.getAnnotation(Responses.class);
+        if (annotationInstance != null) {
+          Responses responsesAnnotation = (Responses) annotationInstance;
+          JSONObject responses = new JSONObject();
+
+          for (Response responseAnnotation : responsesAnnotation.value()) {
+            JSONObject response = new JSONObject();
+            response.put("description", responseAnnotation.description());
+            responses.put(responseAnnotation.statusCode(), response);
+          }
+
+          operation.put(Responses.class.getSimpleName().toLowerCase(), responses);
+        }
+
         operation.put("operationId", method.getName());
 
         ArrayList<JSONObject> parameters = new ArrayList<JSONObject>();


### PR DESCRIPTION
This patch adds annotations to document the API HTTP status codes that can be
returned through API calls. See
http://swagger.io/specification/#responsesObject