### PR TITLE
Change instance status API, fix instance listing

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
@@ -25,6 +25,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
   CONTROLLER_INTERNAL_ERROR("InternalError", true),
   CONTROLLER_INSTANCE_GET_ERROR("InstanceGetError", true),
+  CONTROLLER_INSTANCE_POST_ERROR("InstancePostError", true),
   CONTROLLER_SEGMENT_GET_ERROR("SegmentGetError", true),
   CONTROLLER_SEGMENT_DELETE_ERROR("SegmentDeleteError", true),
   CONTROLLER_SEGMENT_UPLOAD_ERROR("SegmentUploadError", true),

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -55,12 +55,8 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "instances/");
   }
 
-  public String forInstanceDisable(String instanceName) {
-    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "instances", instanceName, "?state=disable");
-  }
-
-  public String forInstanceEnable(String instanceName) {
-    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "instances", instanceName, "?state=enable");
+  public String forInstanceState(String instanceName) {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "instances", instanceName, "state");
   }
 
   public String forInstanceBulkCreate() {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -100,7 +100,7 @@ public class ControllerInstanceToggleTest extends ControllerTest {
           _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
       Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
       Assert.assertEquals(instanceSet.size(), i--);
-      sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceDisable(instanceName));
+      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "disable");
       Thread.sleep(2000);
       resourceExternalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
       instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
@@ -115,7 +115,7 @@ public class ControllerInstanceToggleTest extends ControllerTest {
           _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
       Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
       Assert.assertEquals(instanceSet.size(), i++);
-      sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceEnable(instanceName));
+      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "ENABLE");
       Thread.sleep(2000);
       resourceExternalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
       instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
@@ -130,7 +130,7 @@ public class ControllerInstanceToggleTest extends ControllerTest {
           _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
       Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
       Assert.assertEquals(instanceSet.size(), i--);
-      sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceDisable(instanceName));
+      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "Disable");
       Thread.sleep(2000);
       resourceExternalView =
           _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
@@ -146,7 +146,7 @@ public class ControllerInstanceToggleTest extends ControllerTest {
           _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
       Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
       Assert.assertEquals(instanceSet.size(), i++);
-      sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceEnable(instanceName));
+      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "Enable");
       Thread.sleep(2000);
       resourceExternalView =
           _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);


### PR DESCRIPTION
Change the instance status REST API to use POST instead of GET query parameters
to be more restful, document the HTTP status codes of the various
instance-related REST API calls. Fixed the /instances API call that would
always fail unless an ignored status query parameter was passed.

This PR is based off #157