### PR TITLE
Disable integration tests that overlap

### DIFF
--- a/.travis_test.sh
+++ b/.travis_test.sh
@@ -23,4 +23,4 @@ if [ $? -ne 0 ]; then
 fi
 
 cd $PINOT_MODULE
-mvn test
+mvn test -P travis

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -64,6 +64,29 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>travis</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <!-- jfim: Those two tests are covered by the HybridClusterIntegrationTest -->
+                <exclude>**/OfflineClusterIntegrationTest.java</exclude>
+                <exclude>**/RealtimeClusterIntegrationTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
   <dependencies>
     <dependency>
       <groupId>com.linkedin.pinot</groupId>

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -937,7 +937,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     }
   }
 
-  @Test
+  @Test(enabled = false)  // jfim: This is disabled because testGeneratedQueriesWithMultivalues covers the same thing
   public void testGeneratedQueries() throws Exception {
     int generatedQueryCount = getGeneratedQueryCount();
 

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -384,7 +384,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
-  @Test
+  @Test(enabled = false)  // jfim: This is disabled because testGeneratedQueriesWithMultivalues covers the same thing
   public void testGeneratedQueries() throws Exception {
     super.testGeneratedQueries();
   }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -37,8 +37,7 @@ import com.linkedin.pinot.common.utils.FileUploadUtils;
 import com.linkedin.pinot.util.TestUtils;
 
 /**
- * Integration test that converts avro data for 12 segments and runs queries against it.
- *
+ * Integration test that converts Avro data for 12 segments and runs queries against it.
  */
 public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(OfflineClusterIntegrationTest.class);
@@ -140,7 +139,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
-  @Test
+  @Test(enabled = false)  // jfim: This is disabled because the multivalue one covers the same thing
   public void testGeneratedQueries() throws Exception {
     super.testGeneratedQueries();
   }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -117,7 +117,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
-  @Test
+  @Test(enabled = false)  // jfim: This is disabled because the multivalue one covers the same thing
   public void testGeneratedQueries() throws Exception {
     super.testGeneratedQueries();
   }


### PR DESCRIPTION
Some integration tests overlap, so they've been disabled in order to speed up
the CI builds. The offline and realtime integration tests are covered by the
hybrid integration test, so they've been disabled. The testGeneratedQueries
test has also been disabled, as it is covered by the
testGeneratedQueriesWithMultivalues test. This should save 10-15 minutes per CI
build.