### PR TITLE
Removed un-necessary recursive calls to 'createAggDocForAllNodes'.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
@@ -382,11 +382,11 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
 
       Map<Integer, StarTreeIndexNode> children = node.getChildren();
       for (StarTreeIndexNode child : children.values()) {
-        MetricBuffer childMetricBuffer = createAggDocForAllNodes(child);
         // don't use the star node value to compute aggregate for the parent
         if (child.getDimensionValue() == StarTreeIndexNode.all()) {
           continue;
         }
+        MetricBuffer childMetricBuffer = createAggDocForAllNodes(child);
         if (aggMetricBuffer == null) {
           aggMetricBuffer = new MetricBuffer(childMetricBuffer);
         } else {


### PR DESCRIPTION
The code to create aggregatedDoc for all nodes in the star tree needs to
skip its recursive calls for star nodes. Not doing is so is not only
waste of CPU resource, but also may potentially cause NPE when the only
child of a star node is star child (ie no other nodes).