### PR TITLE
Added storage quota configuration to table configuration

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/OfflineTableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/OfflineTableConfig.java
@@ -30,8 +30,8 @@ public class OfflineTableConfig extends AbstractTableConfig {
 
   protected OfflineTableConfig(String tableName, String tableType,
       SegmentsValidationAndRetentionConfig validationConfig, TenantConfig tenantConfig,
-      TableCustomConfig customConfigs, IndexingConfig indexConfig) {
-    super(tableName, tableType, validationConfig, tenantConfig, customConfigs);
+      TableCustomConfig customConfigs, IndexingConfig indexConfig, QuotaConfig quotaConfig) {
+    super(tableName, tableType, validationConfig, tenantConfig, customConfigs, quotaConfig);
     this.indexConfig = indexConfig;
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/QuotaConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/QuotaConfig.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.config;
+
+import com.linkedin.pinot.common.utils.DataSize;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration.ConfigurationRuntimeException;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class representing table quota configuration
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuotaConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(QuotaConfig.class);
+
+  private String storage;
+
+  static final String STORAGE_FIELD_NAME = "storage";
+  static final String QUOTA_SECTION_NAME = "quota";
+
+  public @Nullable String getStorage() {
+    return storage;
+  }
+
+  public void setStorage(@Nullable String storage) {
+    this.storage = storage;
+  }
+
+  /**
+   * Get the storage quota configured value in bytes
+   * @return configured size in bytes or -1 if the value is missing or
+   *    unparseable
+   */
+  public long storageSizeBytes() {
+    return DataSize.toBytes(this.storage);
+  }
+
+  public JSONObject toJson() {
+    JSONObject quotaObject = new JSONObject();
+    try {
+      quotaObject.put(STORAGE_FIELD_NAME, storage);
+    } catch (JSONException e) {
+      LOGGER.error("Failed to convert to json", e);
+    }
+    return quotaObject;
+  }
+
+  public String toString() {
+    return toJson().toString();
+
+  }
+
+  public void validate() {
+    if (storage != null && DataSize.toBytes(storage) < 0) {
+      LOGGER.error("Failed to convert storage quota config: {} to bytes", storage);
+      throw new ConfigurationRuntimeException("Failed to convert storage quota config: "
+       + storage + " to bytes");
+    }
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/RealtimeTableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/RealtimeTableConfig.java
@@ -30,8 +30,8 @@ public class RealtimeTableConfig extends AbstractTableConfig {
 
   protected RealtimeTableConfig(String tableName, String tableType,
       SegmentsValidationAndRetentionConfig validationConfig, TenantConfig tenantConfig,
-      TableCustomConfig customConfigs, IndexingConfig indexConfig) {
-    super(tableName, tableType, validationConfig, tenantConfig, customConfigs);
+      TableCustomConfig customConfigs, IndexingConfig indexConfig, QuotaConfig quotaConfig) {
+    super(tableName, tableType, validationConfig, tenantConfig, customConfigs, quotaConfig);
     this.indexConfig = indexConfig;
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataSize.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataSize.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +51,11 @@ public class DataSize {
    * @param val string to parse
    * @return returns -1 in case of invalid value
    */
-  public static long toBytes(String val) {
+  public static long toBytes(@Nullable String val) {
+    if (val == null) {
+      return -1;
+    }
+
     Matcher matcher = STORAGE_VAL_PATTERN.matcher(val);
     if (! matcher.matches()) {
       return -1;

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.pinot.common.config;
+
+import java.io.IOException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class QuotaConfigTest {
+
+  @Test
+  public void testQuotaConfig()
+      throws IOException {
+    {
+      String quotaConfigStr = "{\"storage\" : \"100g\"}";
+      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+
+      Assert.assertEquals(quotaConfig.getStorage(), "100g");
+      Assert.assertEquals(quotaConfig.storageSizeBytes(), 100 * 1024 * 1024 * 1024L);
+    }
+    {
+      String quotaConfigStr = "{}";
+      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      Assert.assertNull(quotaConfig.getStorage());
+      Assert.assertEquals(quotaConfig.storageSizeBytes(), -1);
+    }
+  }
+
+  @Test
+  public void testBadQuotaConfig ()
+      throws IOException {
+    {
+      String quotaConfigStr = "{\"storage\" : \"124GB3GB\"}";
+      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+      Assert.assertNotNull(quotaConfig.getStorage());
+      Assert.assertEquals(quotaConfig.storageSizeBytes(), -1);
+    }
+  }
+
+}


### PR DESCRIPTION
Support an optional 'quota' section in table configuration.
Example configuration: "quota" : { "storage" : "100M" }. The supported
storage units are K,M,T,P or plain numeric value for bytes. 100M = 1024 * 1024 bytes.
This follows same convention as unix tools like du, ls.

Testing: UT