### PR TITLE
Upgrade swagger-ui to 2.1.4

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerRestApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerRestApplication.java
@@ -143,7 +143,7 @@ public class ControllerRestApplication extends PinotRestletApplication {
     webdir.setIndexName("index.html");
     router.attach("/query", webdir);
 
-    final Directory swaggerUiDir = new Directory(getContext(), getClass().getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.1.8-M1").toString());
+    final Directory swaggerUiDir = new Directory(getContext(), getClass().getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.1.4").toString());
     swaggerUiDir.setDeeplyAccessible(true);
     router.attach("/swagger-ui", swaggerUiDir);
 

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/restlet/PinotAdminEndpointApplication.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/restlet/PinotAdminEndpointApplication.java
@@ -35,7 +35,7 @@ public class PinotAdminEndpointApplication extends PinotRestletApplication {
     // Attach Swagger stuff
     router.attach("/api", SwaggerResource.class);
 
-    final Directory swaggerUiDir = new Directory(getContext(), getClass().getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.1.8-M1").toString());
+    final Directory swaggerUiDir = new Directory(getContext(), getClass().getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/2.1.4").toString());
     swaggerUiDir.setDeeplyAccessible(true);
     router.attach("/swagger-ui", swaggerUiDir);
 

--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
       <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>swagger-ui</artifactId>
-        <version>2.1.8-M1</version>
+        <version>2.1.4</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
This adds support to display a curl command that is equivalent to a
request entered through the web UI. Interestingly enough, 2.1.4 is a
higher version number than 2.1.8-M1.