### PR TITLE
Add REST API parameter type documentation

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -190,6 +190,10 @@
       <groupId>org.restlet.jse</groupId>
       <artifactId>org.restlet</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
  </dependencies>
    <profiles>
     <profile>

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/Example.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/Example.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.restlet.swagger;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+/**
+ * An example of a value, used to document POJOs.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Example {
+  /**
+   * The contents of the example, usually a string containing JSON.
+   */
+  String value();
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/pojos/Instance.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/pojos/Instance.java
@@ -15,16 +15,20 @@
  */
 package com.linkedin.pinot.controller.api.pojos;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.restlet.swagger.Example;
 import org.apache.helix.model.InstanceConfig;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.linkedin.pinot.common.utils.CommonConstants;
+
+
 /**
  * Instance POJO, used as part of the API to create instances.
  */
+@Example("{\n" + "\t\"host\": \"hostname.example.com\",\n" + "\t\"port\": \"1234\",\n" + "\t\"type\": \"server\"\n" + "}")
 public class Instance {
   private final String _host;
   private final String _port;
@@ -34,10 +38,10 @@ public class Instance {
 
   @JsonCreator
   public Instance(
-      @JsonProperty("host") String host,
-      @JsonProperty("port") String port,
-      @JsonProperty("type") String type,
-      @JsonProperty("tag") String tag) {
+      @JsonProperty(value = "host", required = true) String host,
+      @JsonProperty(value = "port", required = true) String port,
+      @JsonProperty(value = "type", required = true) String type,
+      @JsonProperty(value = "tag", required = false) String tag) {
     _host = host;
     _port = port;
     _tag = tag;


### PR DESCRIPTION
Add support to generate Swagger parameter type documentation and JSON
schemas, as well as support for examples. Add documentation for the
instance creation API.