### PR TITLE
Refactoring of view handlers, to support parsing of single query instead of one per time bucket.

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/BaseThirdEyeResponse.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/BaseThirdEyeResponse.java
@@ -36,6 +36,12 @@ public abstract class BaseThirdEyeResponse implements ThirdEyeResponse {
   }
 
   @Override
+  public abstract int getNumRows();
+
+  @Override
+  public abstract ThirdEyeResponseRow getRow(int rowId);
+
+  @Override
   public abstract int getNumRowsFor(MetricFunction metricFunction);
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeResponse.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeResponse.java
@@ -12,6 +12,10 @@ public interface ThirdEyeResponse {
 
   List<MetricFunction> getMetricFunctions();
 
+  int getNumRows();
+  
+  ThirdEyeResponseRow getRow(int rowId);
+  
   int getNumRowsFor(MetricFunction metricFunction);
 
   // TODO make new API methods to make it clearer how to retrieve metric values vs dimension values,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeResponseRow.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeResponseRow.java
@@ -1,0 +1,30 @@
+package com.linkedin.thirdeye.client;
+
+import java.util.List;
+
+public class ThirdEyeResponseRow {
+
+  int timeBucketId;
+  List<String> dimensions;
+  List<Double> metrics;
+
+  public ThirdEyeResponseRow(int timeBucketId, List<String> dimensions, List<Double> metrics) {
+    super();
+    this.timeBucketId = timeBucketId;
+    this.dimensions = dimensions;
+    this.metrics = metrics;
+  }
+
+  public List<String> getDimensions() {
+    return dimensions;
+  }
+
+  public List<Double> getMetrics() {
+    return metrics;
+  }
+  
+  public int getTimeBucketId() {
+    return timeBucketId;
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeComparisonHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeComparisonHandler.java
@@ -148,9 +148,4 @@ public class TimeOnTimeComparisonHandler {
     return queryCache.getClient();
   }
 
-  public static void main(String[] args) {
-    long x = (long) (1 << 48 - 1);
-    System.out.println(x);
-    System.out.println(Double.parseDouble("" + x));
-  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
@@ -1,250 +1,445 @@
 package com.linkedin.thirdeye.client.comparison;
 
-import static com.linkedin.thirdeye.client.comparison.TimeOnTimeConstants.ALL_BASELINE;
-import static com.linkedin.thirdeye.client.comparison.TimeOnTimeConstants.ALL_CURRENT;
-import static com.linkedin.thirdeye.client.comparison.TimeOnTimeConstants.BASELINE_VALUE;
-import static com.linkedin.thirdeye.client.comparison.TimeOnTimeConstants.CURRENT_VALUE;
-import static com.linkedin.thirdeye.client.comparison.TimeOnTimeConstants.DIMENSION_BASELINE;
-import static com.linkedin.thirdeye.client.comparison.TimeOnTimeConstants.DIMENSION_CURRENT;
-
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.TreeMap;
+import java.util.Set;
 
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Range;
+import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.client.MetricFunction;
+import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.client.ThirdEyeRequest;
+import com.linkedin.thirdeye.client.ThirdEyeRequest.ThirdEyeRequestBuilder;
 import com.linkedin.thirdeye.client.ThirdEyeResponse;
+import com.linkedin.thirdeye.client.ThirdEyeResponseRow;
 import com.linkedin.thirdeye.client.comparison.Row.Builder;
+import com.linkedin.thirdeye.client.comparison.Row.Metric;
+import com.linkedin.thirdeye.dashboard.configs.CollectionConfig;
 
 public class TimeOnTimeResponseParser {
 
-  private static final double MIN_CONTRIBUTION_PERCENT = 0.0001;
+  private ThirdEyeResponse baselineResponse;
+  private ThirdEyeResponse currentResponse;
+  private List<Range<DateTime>> baselineRanges;
+  private List<Range<DateTime>> currentRanges;
+  private TimeGranularity aggTimeGranularity;
+  private List<String> groupByDimensions;
 
-  public static Map<MetricFunction, Map<String, Map<String, Map<String, Double>>>> processGroupByDimensionResponse(
-      Map<ThirdEyeRequest, ThirdEyeResponse> queryResultMap) {
-    Map<MetricFunction, Map<String, Map<String, Map<String, Double>>>> metricGroupByDimensionData =
-        new HashMap<>();
+  private CollectionConfig collectionConfig = null;
+  private static ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeOnTimeResponseParser.class);
 
-    for (Entry<ThirdEyeRequest, ThirdEyeResponse> entry : queryResultMap.entrySet()) {
-      ThirdEyeRequest thirdEyeRequest = entry.getKey();
-      ThirdEyeResponse thirdEyeResponse = entry.getValue();
-      String requestReference = thirdEyeRequest.getRequestReference();
-      if (requestReference.startsWith(DIMENSION_BASELINE)) {
-        parseMetricGroupByDimensionResponse(metricGroupByDimensionData, thirdEyeRequest,
-            thirdEyeResponse, BASELINE_VALUE);
-      }
-      if (requestReference.startsWith(DIMENSION_CURRENT)) {
-        parseMetricGroupByDimensionResponse(metricGroupByDimensionData, thirdEyeRequest,
-            thirdEyeResponse, CURRENT_VALUE);
-      }
+
+  private static String TIME_DIMENSION_JOINER_ESCAPED = "\\|";
+  private static String TIME_DIMENSION_JOINER = "|";
+  private double metricThreshold = CollectionConfig.DEFAULT_THRESHOLD;
+  private static String OTHER = "OTHER";
+
+  public TimeOnTimeResponseParser(ThirdEyeResponse baselineResponse,
+      ThirdEyeResponse currentResponse, List<Range<DateTime>> baselineRanges,
+      List<Range<DateTime>> currentRanges, TimeGranularity timeGranularity,
+      List<String> groupByDimensions) {
+    this.baselineResponse = baselineResponse;
+    this.currentResponse = currentResponse;
+    this.baselineRanges = baselineRanges;
+    this.currentRanges = currentRanges;
+    this.aggTimeGranularity = timeGranularity;
+    this.groupByDimensions = groupByDimensions;
+
+    String collection = baselineResponse.getRequest().getCollection();
+    try {
+      collectionConfig = CACHE_REGISTRY_INSTANCE.getCollectionConfigCache().get(collection);
+    } catch (Exception e) {
+      LOGGER.debug("No collection configs for collection {}", collection);
     }
-    return metricGroupByDimensionData;
-  }
 
-  public static Map<MetricFunction, Map<String, Double>> processAggregateResponse(
-      Map<ThirdEyeRequest, ThirdEyeResponse> queryResultMap) {
-    // Map<metricFunction,Map<(baseline|current), Double>>>
-    Map<MetricFunction, Map<String, Double>> metricOnlyData = new HashMap<>();
-
-    for (Entry<ThirdEyeRequest, ThirdEyeResponse> entry : queryResultMap.entrySet()) {
-      ThirdEyeRequest thirdEyeRequest = entry.getKey();
-      ThirdEyeResponse thirdEyeResponse = entry.getValue();
-      String requestReference = thirdEyeRequest.getRequestReference();
-      if (ALL_BASELINE.equals(requestReference)) {
-        parseMetricOnlyResponse(metricOnlyData, thirdEyeResponse, BASELINE_VALUE);
-      }
-      if (ALL_CURRENT.equals(requestReference)) {
-        parseMetricOnlyResponse(metricOnlyData, thirdEyeResponse, CURRENT_VALUE);
-      }
-    }
-    return metricOnlyData;
-  }
-
-  public static void parseMetricOnlyResponse(Map<MetricFunction, Map<String, Double>> aggregateData,
-      ThirdEyeResponse thirdEyeResponse, String baselineOrCurrent) {
-    List<MetricFunction> metricFunctions = thirdEyeResponse.getMetricFunctions();
-    for (MetricFunction metricFunction : metricFunctions) {
-      Map<String, String> row = thirdEyeResponse.getRow(metricFunction, 0);
-      // TODO THIS DEPENDS STRICTLY ON THE ORDER OF THE KEYS RETURNED?
-      String baselineValue = row.values().iterator().next();
-      if (!aggregateData.containsKey(metricFunction)) {
-        aggregateData.put(metricFunction, new HashMap<String, Double>());
-      }
-      aggregateData.get(metricFunction).put(baselineOrCurrent, Double.parseDouble(baselineValue));
+    if (collectionConfig != null) {
+      metricThreshold = collectionConfig.getMetricThreshold();
     }
   }
 
-  public static void parseMetricGroupByDimensionResponse(
-      Map<MetricFunction, Map<String, Map<String, Map<String, Double>>>> dimensionData,
-      ThirdEyeRequest thirdEyeRequest, ThirdEyeResponse thirdEyeResponse,
-      String BASELINE_OR_CURRENT) {
-    List<MetricFunction> metricFunctions = thirdEyeResponse.getMetricFunctions();
-    for (MetricFunction metricFunction : metricFunctions) {
-      Map<String, Map<String, Map<String, Double>>> dimensionNameMap =
-          dimensionData.get(metricFunction);
-      if (dimensionNameMap == null) {
-        dimensionNameMap = new TreeMap<>();
-        dimensionData.put(metricFunction, dimensionNameMap);
-      }
-      // we only group by at most 1 dimension
-      String dimensionName = thirdEyeRequest.getGroupBy().get(0);
-      Map<String, Map<String, Double>> dimensionValueMap = dimensionNameMap.get(dimensionName);
-      if (dimensionValueMap == null) {
-        dimensionValueMap = new TreeMap<>();
-        dimensionData.get(metricFunction).put(dimensionName, dimensionValueMap);
-      }
-      // one row for each group by
-      int rows = thirdEyeResponse.getNumRowsFor(metricFunction);
-      for (int i = 0; i < rows; i++) {
-        Map<String, String> row = thirdEyeResponse.getRow(metricFunction, i);
-        String dimensionValue = row.get(dimensionName);
-        if (!dimensionValueMap.containsKey(dimensionValue)) {
-          Map<String, Double> value = new TreeMap<>();
-          dimensionValueMap.put(dimensionValue, value);
-          dimensionValueMap.get(dimensionValue).put(BASELINE_VALUE, 0d);
-          dimensionValueMap.get(dimensionValue).put(CURRENT_VALUE, 0d);
-        }
-        Double metricValue = Double.parseDouble(row.get(metricFunction.toString()));
-        dimensionValueMap.get(dimensionValue).put(BASELINE_OR_CURRENT, metricValue);
-      }
+  List<Row> parseResponse() {
+    if (baselineResponse == null || currentResponse == null) {
+      return Collections.emptyList();
     }
-  }
-
-  public static Row parseAggregationOnlyResponse(TimeOnTimeComparisonRequest comparisonRequest,
-      Map<ThirdEyeRequest, ThirdEyeResponse> queryResultMap) {
-    Map<MetricFunction, Map<String, Double>> metricOnlyData =
-        TimeOnTimeResponseParser.processAggregateResponse(queryResultMap);
-
-    Row.Builder rowBuilder = new Row.Builder();
-    rowBuilder.setBaselineStart(comparisonRequest.getBaselineStart());
-    rowBuilder.setBaselineEnd(comparisonRequest.getBaselineEnd());
-
-    rowBuilder.setCurrentStart(comparisonRequest.getCurrentStart());
-    rowBuilder.setCurrentEnd(comparisonRequest.getCurrentEnd());
-
-    for (Entry<MetricFunction, Map<String, Double>> entry : metricOnlyData.entrySet()) {
-      MetricFunction key = entry.getKey();
-      Map<String, Double> valueMap = entry.getValue();
-      rowBuilder.addMetric(key.getMetricName(), valueMap.get(BASELINE_VALUE),
-          valueMap.get(CURRENT_VALUE));
+    boolean hasGroupByDimensions = false;
+    if (groupByDimensions != null && groupByDimensions.size() > 0) {
+      hasGroupByDimensions = true;
     }
-    return rowBuilder.build();
-  }
-
-  public static List<Row> parseGroupByDimensionResponse(
-      TimeOnTimeComparisonRequest comparisonRequest,
-      Map<ThirdEyeRequest, ThirdEyeResponse> queryResultMap) {
-    Map<MetricFunction, Map<String, Double>> metricOnlyData =
-        TimeOnTimeResponseParser.processAggregateResponse(queryResultMap);
-    // we retrieve only top 25 group by values for each dimension, so we compute the sum of
-    // retrieved
-    // values, in the end we add a explicit "OTHER" group in each dimension
-    Map<MetricFunction, Map<String, Map<String, Double>>> metricSumFromGroupByResponse =
-        new HashMap<>();
-    // Map<MetricFunction,Map<dimensionName,Map<dimensionValue,Map<(baseline|current), Double>>>>
-    Map<MetricFunction, Map<String, Map<String, Map<String, Double>>>> metricGroupByDimensionData =
-        TimeOnTimeResponseParser.processGroupByDimensionResponse(queryResultMap);
-    // we need a build for each dimensionName, dimensionValue combination
-    Map<String, Map<String, Row.Builder>> rowBuildersMap = new LinkedHashMap<>();
-    for (Entry<MetricFunction, Map<String, Map<String, Map<String, Double>>>> metricEntry : metricGroupByDimensionData
-        .entrySet()) {
-      MetricFunction metricFunction = metricEntry.getKey();
-      Map<String, Map<String, Map<String, Double>>> dimensionDataMap = metricEntry.getValue();
-      for (String dimensionName : dimensionDataMap.keySet()) {
-        Map<String, Map<String, Double>> map = dimensionDataMap.get(dimensionName);
-        for (String dimensionValue : map.keySet()) {
-          Map<String, Double> metricValueMap = map.get(dimensionValue);
-          // check if the dimension meets the MIN_CONTRIBUTION_PERCENT, if not this will get added
-          // to the OTHER category
-          double totalBaselineValue = metricOnlyData.get(metricFunction).get(BASELINE_VALUE);
-          double totalCurrentValue = metricOnlyData.get(metricFunction).get(BASELINE_VALUE);
-          Double baselineValue = metricValueMap.get(BASELINE_VALUE);
-          Double currentValue = metricValueMap.get(CURRENT_VALUE);
-          boolean meetsMinContributionThreshold =
-              (baselineValue > (totalBaselineValue * MIN_CONTRIBUTION_PERCENT))
-                  || (currentValue > totalCurrentValue * MIN_CONTRIBUTION_PERCENT);
-          if (!meetsMinContributionThreshold) {
-            continue;
-          }
-          Row.Builder rowBuilder = getRowBuilder(rowBuildersMap, dimensionName, dimensionValue);
-          rowBuilder.addMetric(metricFunction.getMetricName(), baselineValue, currentValue);
-          // compute for each dimension
-          if (!metricSumFromGroupByResponse.containsKey(metricFunction)) {
-            Map<String, Map<String, Double>> value = new HashMap<>();
-            metricSumFromGroupByResponse.put(metricFunction, value);
-          }
-          if (!metricSumFromGroupByResponse.get(metricFunction).containsKey(dimensionName)) {
-            Map<String, Double> value = new HashMap<>();
-            value.put(BASELINE_VALUE, 0d);
-            value.put(CURRENT_VALUE, 0d);
-            metricSumFromGroupByResponse.get(metricFunction).put(dimensionName, value);
-          }
-          Map<String, Double> metricSum =
-              metricSumFromGroupByResponse.get(metricFunction).get(dimensionName);
-          metricSum.put(BASELINE_VALUE, metricSum.get(BASELINE_VALUE) + baselineValue);
-          metricSum.put(CURRENT_VALUE, metricSum.get(CURRENT_VALUE) + currentValue);
-        }
-      }
+    boolean hasGroupByTime = false;
+    if (aggTimeGranularity != null) {
+      hasGroupByTime = true;
     }
 
-    for (MetricFunction metricFunction : metricSumFromGroupByResponse.keySet()) {
-      Map<String, Map<String, Double>> map = metricSumFromGroupByResponse.get(metricFunction);
-      for (String dimensionName : map.keySet()) {
-        Map<String, Double> valueMap = map.get(dimensionName);
+    Map<String, ThirdEyeResponseRow> baselineResponseMap;
+    Map<String, ThirdEyeResponseRow> currentResponseMap;
+    List<MetricFunction> metricFunctions = baselineResponse.getMetricFunctions();
+    int numMetrics = metricFunctions.size();
 
-        double baselineValue =
-            metricOnlyData.get(metricFunction).get(BASELINE_VALUE) - valueMap.get(BASELINE_VALUE);
-        double currentValue =
-            metricOnlyData.get(metricFunction).get(CURRENT_VALUE) - valueMap.get(CURRENT_VALUE);
-        double totalBaselineValue = metricOnlyData.get(metricFunction).get(BASELINE_VALUE);
-        double totalCurrentValue = metricOnlyData.get(metricFunction).get(BASELINE_VALUE);
-        boolean meetsMinContributionThreshold =
-            (baselineValue > (totalBaselineValue * MIN_CONTRIBUTION_PERCENT))
-                || (currentValue > totalCurrentValue * MIN_CONTRIBUTION_PERCENT);
-
-        // don't add OTHER group if top 25 covered all possible dimensions or if it does not meet
-        // minimum threshold
-        if (meetsMinContributionThreshold) {
-          Builder rowBuilder = getRowBuilder(rowBuildersMap, dimensionName, "other");
-          rowBuilder.addMetric(metricFunction.getMetricName(), baselineValue, currentValue);
-        }
-      }
-    }
     List<Row> rows = new ArrayList<>();
-    for (Map<String, Builder> dimensionValueMap : rowBuildersMap.values()) {
-      for (Row.Builder builder : dimensionValueMap.values()) {
-        builder.setBaselineStart(comparisonRequest.getBaselineStart());
-        builder.setBaselineEnd(comparisonRequest.getBaselineEnd());
+    if (hasGroupByTime) {
 
-        builder.setCurrentStart(comparisonRequest.getCurrentStart());
-        builder.setCurrentEnd(comparisonRequest.getCurrentEnd());
+      int numTimeBuckets = baselineRanges.size();
 
-        Row row = builder.build();
-        rows.add(row);
+      if (hasGroupByDimensions) {
+        // group by time and dimension  //contributor
+        baselineResponseMap = createResponseMapByTimeAndDimension(baselineResponse);
+        currentResponseMap = createResponseMapByTimeAndDimension(currentResponse);
+
+        Map<Integer, List<Double>> baselineMetricSums = getMetricSumsByTime(baselineResponse);
+        Map<Integer, List<Double>> currentMetricSums = getMetricSumsByTime(currentResponse);
+
+        Set<String> timeDimensionValues = new HashSet<>();
+        timeDimensionValues.addAll(baselineResponseMap.keySet());
+        timeDimensionValues.addAll(currentResponseMap.keySet());
+        Set<String> dimensionValues = new HashSet<>();
+        for (String timeDimensionValue : timeDimensionValues) {
+          String[] tokens = timeDimensionValue.split(TIME_DIMENSION_JOINER_ESCAPED);
+          String dimensionValue = tokens.length < 2 ? "" : tokens[1];
+          dimensionValues.add(dimensionValue);
+        }
+
+        String dimensionName = baselineResponse.getGroupKeyColumns().get(1);
+
+        // other row
+        List<Row.Builder> otherBuilders = new ArrayList<>();
+        List<double[]> otherBaselineMetrics = new ArrayList<>();
+        List<double[]> otherCurrentMetrics = new ArrayList<>();
+        List<Row> otherRows = new ArrayList<>();
+        boolean includeOther = false;
+        for (int timeBucketId = 0; timeBucketId < numTimeBuckets; timeBucketId++) {
+          Range<DateTime> baselineTimeRange = baselineRanges.get(timeBucketId);
+          Range<DateTime> currentTimeRange = currentRanges.get(timeBucketId);
+
+          Row.Builder builder = new Row.Builder();
+          builder.setBaselineStart(baselineTimeRange.lowerEndpoint());
+          builder.setBaselineEnd(baselineTimeRange.upperEndpoint());
+          builder.setCurrentStart(currentTimeRange.lowerEndpoint());
+          builder.setCurrentEnd(currentTimeRange.upperEndpoint());
+          builder.setDimensionName(dimensionName);
+          builder.setDimensionValue(OTHER);
+          otherBuilders.add(builder);
+          double[] otherBaseline = new double[numMetrics];
+          Arrays.fill(otherBaseline, 0);
+          double[] otherCurrent = new double[numMetrics];
+          Arrays.fill(otherCurrent, 0);
+          otherBaselineMetrics.add(otherBaseline);
+          otherCurrentMetrics.add(otherCurrent);
+        }
+
+        for (String dimensionValue : dimensionValues) {
+          List<Row> thresholdRows = new ArrayList<>();
+          for (int timeBucketId = 0; timeBucketId < numTimeBuckets; timeBucketId++) {
+            Range<DateTime> baselineTimeRange = baselineRanges.get(timeBucketId);
+            Range<DateTime> currentTimeRange = currentRanges.get(timeBucketId);
+
+            //compute the time|dimension key
+            String baselineTimeDimensionValue = timeBucketId + TIME_DIMENSION_JOINER + dimensionValue;
+            String currentTimeDimensionValue = timeBucketId + TIME_DIMENSION_JOINER + dimensionValue;
+
+            ThirdEyeResponseRow baselineRow = baselineResponseMap.get(baselineTimeDimensionValue);
+            ThirdEyeResponseRow currentRow = currentResponseMap.get(currentTimeDimensionValue);
+
+            Row.Builder builder = new Row.Builder();
+            builder.setBaselineStart(baselineTimeRange.lowerEndpoint());
+            builder.setBaselineEnd(baselineTimeRange.upperEndpoint());
+            builder.setCurrentStart(currentTimeRange.lowerEndpoint());
+            builder.setCurrentEnd(currentTimeRange.upperEndpoint());
+            builder.setDimensionName(dimensionName);
+            builder.setDimensionValue(dimensionValue);
+            addMetric(baselineRow, currentRow, builder);
+
+            Row row = builder.build();
+            thresholdRows.add(row);
+          }
+          boolean passedThreshold = false;
+
+          for (int timeBucketId = 0; timeBucketId < numTimeBuckets; timeBucketId++) {
+            if (checkMetricSums(thresholdRows.get(timeBucketId), baselineMetricSums.get(timeBucketId), currentMetricSums.get(timeBucketId))) {
+              passedThreshold = true;
+              break;
+            }
+          }
+
+          if (passedThreshold) { // if any of the cells of a contributor row passes threshold, add all those cells
+            rows.addAll(thresholdRows);
+          } else { // else that row of cells goes into OTHER
+            otherRows.addAll(thresholdRows);
+            includeOther = true;
+            for (int timeBucketId = 0; timeBucketId < numTimeBuckets; timeBucketId++) {
+              Row row = thresholdRows.get(timeBucketId);
+              List<Metric> metrics = row.getMetrics();
+              for (int i = 0; i < metrics.size(); i++) {
+                Metric metricToAdd = metrics.get(i);
+                otherBaselineMetrics.get(timeBucketId)[i] += metricToAdd.getBaselineValue();
+                otherCurrentMetrics.get(timeBucketId)[i] += metricToAdd.getCurrentValue();
+              }
+            }
+          }
+        }
+
+        // include OTHER row
+        if (includeOther) {
+          for (int timeBucketId = 0; timeBucketId < numTimeBuckets; timeBucketId++) {
+            Builder otherBuilder = otherBuilders.get(timeBucketId);
+            double[] otherBaseline = otherBaselineMetrics.get(timeBucketId);
+            double[] otherCurrent = otherCurrentMetrics.get(timeBucketId);
+            for (int i = 0; i < numMetrics; i++) {
+              otherBuilder.addMetric(metricFunctions.get(i).getMetricName(), otherBaseline[i], otherCurrent[i]);
+            }
+            rows.add(otherBuilder.build());
+          }
+        }
+      } else {
+        // group by time only //tabular
+        baselineResponseMap = createResponseMapByTime(baselineResponse);
+        currentResponseMap = createResponseMapByTime(currentResponse);
+
+        for (int timeBucketId = 0; timeBucketId < numTimeBuckets; timeBucketId++) {
+          Range<DateTime> baselineTimeRange = baselineRanges.get(timeBucketId);
+          ThirdEyeResponseRow baselineRow =
+              baselineResponseMap.get(String.valueOf(timeBucketId));
+
+          Range<DateTime> currentTimeRange = currentRanges.get(timeBucketId);
+          ThirdEyeResponseRow currentRow = currentResponseMap.get(String.valueOf(timeBucketId));
+
+          Row.Builder builder = new Row.Builder();
+          builder.setBaselineStart(baselineTimeRange.lowerEndpoint());
+          builder.setBaselineEnd(baselineTimeRange.upperEndpoint());
+          builder.setCurrentStart(currentTimeRange.lowerEndpoint());
+          builder.setCurrentEnd(currentTimeRange.upperEndpoint());
+
+          addMetric(baselineRow, currentRow, builder);
+          Row row = builder.build();
+          rows.add(row);
+        }
+      }
+    } else {
+      // no break down by time
+      if (hasGroupByDimensions) {
+        // group by dimensions only //heatmap
+        baselineResponseMap = createResponseMapByDimension(baselineResponse);
+        currentResponseMap = createResponseMapByDimension(currentResponse);
+
+        String dimensionName = baselineResponse.getGroupKeyColumns().get(0);
+
+        Set<String> dimensionValues = new HashSet<>();
+        dimensionValues.addAll(baselineResponseMap.keySet());
+        dimensionValues.addAll(currentResponseMap.keySet());
+
+
+        for (String dimensionValue : dimensionValues) {
+          Row.Builder builder = new Row.Builder();
+          builder.setBaselineStart(baselineRanges.get(0).lowerEndpoint());
+          builder.setBaselineEnd(baselineRanges.get(0).upperEndpoint());
+          builder.setCurrentStart(currentRanges.get(0).lowerEndpoint());
+          builder.setCurrentEnd(currentRanges.get(0).upperEndpoint());
+
+          builder.setDimensionName(dimensionName);
+          builder.setDimensionValue(dimensionValue);
+
+          ThirdEyeResponseRow baselineRow = baselineResponseMap.get(dimensionValue);
+          ThirdEyeResponseRow currentRow = currentResponseMap.get(dimensionValue);
+
+          addMetric(baselineRow, currentRow, builder);
+
+          Row row = builder.build();
+          rows.add(row);
+        }
+
+        double[] baselineMetricSums = getMetricSums(baselineResponse);
+        double[] currentMetricSums = getMetricSums(currentResponse);
+        rows = getRowsWithThresholdFiltering(rows, dimensionName, metricFunctions, baselineMetricSums, currentMetricSums);
+
+      } else {
+        // no group by
       }
     }
+
     return rows;
   }
 
-  private static Builder getRowBuilder(Map<String, Map<String, Builder>> rowBuildersMap,
-      String dimensionName, String dimensionValue) {
-    Map<String, Builder> map = rowBuildersMap.get(dimensionName);
-    if (map == null) {
-      map = new LinkedHashMap<>();
-      rowBuildersMap.put(dimensionName, map);
+  private List<Row> getRowsWithThresholdFiltering(List<Row> rows, String dimensionName,
+      List<MetricFunction> metricFunctions, double[] baselineMetricSums, double[] currentMetricSums) {
+
+    int numMetrics = currentResponse.getMetricFunctions().size();
+
+    // Collect rows which pass threshold
+    List<Row> thresholdPassedRows = new ArrayList<>();
+
+    // Construct OTHER row
+    Row.Builder otherBuilder = new Row.Builder();
+    otherBuilder.setBaselineStart(baselineRanges.get(0).lowerEndpoint());
+    otherBuilder.setBaselineEnd(baselineRanges.get(0).upperEndpoint());
+    otherBuilder.setCurrentStart(currentRanges.get(0).lowerEndpoint());
+    otherBuilder.setCurrentEnd(currentRanges.get(0).upperEndpoint());
+    otherBuilder.setDimensionName(dimensionName);
+    otherBuilder.setDimensionValue(OTHER);
+    double[] otherBaseline = new double[numMetrics];
+    Arrays.fill(otherBaseline, 0);
+    double[] otherCurrent = new double[numMetrics];
+    Arrays.fill(otherCurrent, 0);
+    boolean includeOther = false;
+
+    for (Row row : rows) {
+      boolean passedThreshold = false;
+      List<Metric> metrics = row.getMetrics();
+      for (int i = 0; i < numMetrics; i ++) {
+        double baselineValue = metrics.get(i).getBaselineValue();
+        double currentValue = metrics.get(i).getCurrentValue();
+        if ((baselineValue >= baselineMetricSums[i] * metricThreshold) ||
+            (currentValue >= currentMetricSums[i] * metricThreshold)) {
+          passedThreshold = true;
+          break;
+        }
+      }
+
+      if (passedThreshold) {  // if any metric passes threshold, include it
+        thresholdPassedRows.add(row);
+      } else { // else add it to OTHER
+        includeOther = true;
+        for (int i = 0; i < numMetrics; i ++) {
+          Metric metric = metrics.get(i);
+          otherBaseline[i] += metric.getBaselineValue();
+          otherCurrent[i] += metric.getCurrentValue();
+        }
+      }
     }
-    Builder builder = map.get(dimensionValue);
-    if (builder == null) {
-      builder = new Row.Builder();
-      builder.setDimensionName(dimensionName);
-      builder.setDimensionValue(dimensionValue);
-      map.put(dimensionValue, builder);
+    if (includeOther) {
+      for (int i = 0; i < numMetrics; i ++) {
+        otherBuilder.addMetric(metricFunctions.get(i).getMetricName(), otherBaseline[i], otherCurrent[i]);
+      }
+      thresholdPassedRows.add(otherBuilder.build());
     }
-    return builder;
+
+    return thresholdPassedRows;
+  }
+
+  private static Map<String, ThirdEyeResponseRow> createResponseMapByTimeAndDimension(
+      ThirdEyeResponse thirdEyeResponse) {
+    Map<String, ThirdEyeResponseRow> responseMap;
+    responseMap = new HashMap<>();
+    int numRows = thirdEyeResponse.getNumRows();
+    for (int i = 0; i < numRows; i++) {
+      ThirdEyeResponseRow thirdEyeResponseRow = thirdEyeResponse.getRow(i);
+      responseMap.put(
+          thirdEyeResponseRow.getTimeBucketId() + "|" + thirdEyeResponseRow.getDimensions().get(0),
+          thirdEyeResponseRow);
+    }
+    return responseMap;
+  }
+
+  private static Map<String, ThirdEyeResponseRow> createResponseMapByTime(
+      ThirdEyeResponse thirdEyeResponse) {
+    Map<String, ThirdEyeResponseRow> responseMap;
+    responseMap = new HashMap<>();
+    int numRows = thirdEyeResponse.getNumRows();
+    for (int i = 0; i < numRows; i++) {
+      ThirdEyeResponseRow thirdEyeResponseRow = thirdEyeResponse.getRow(i);
+      responseMap.put(String.valueOf(thirdEyeResponseRow.getTimeBucketId()), thirdEyeResponseRow);
+    }
+    return responseMap;
+  }
+
+  private static Map<String, ThirdEyeResponseRow> createResponseMapByDimension(
+      ThirdEyeResponse thirdEyeResponse) {
+    Map<String, ThirdEyeResponseRow> responseMap;
+    responseMap = new HashMap<>();
+    int numRows = thirdEyeResponse.getNumRows();
+    for (int i = 0; i < numRows; i++) {
+      ThirdEyeResponseRow thirdEyeResponseRow = thirdEyeResponse.getRow(i);
+      responseMap.put(thirdEyeResponseRow.getDimensions().get(0), thirdEyeResponseRow);
+    }
+    return responseMap;
+  }
+
+  private void addMetric(ThirdEyeResponseRow baselineRow, ThirdEyeResponseRow currentRow, Builder builder) {
+
+    List<MetricFunction> metricFunctions = baselineResponse.getMetricFunctions();
+
+    for (int i = 0; i < metricFunctions.size(); i++) {
+      MetricFunction metricFunction = metricFunctions.get(i);
+      double baselineValue = 0;
+      if (baselineRow != null) {
+        baselineValue = baselineRow.getMetrics().get(i);
+      }
+      double currentValue = 0;
+      if (currentRow != null) {
+        currentValue = currentRow.getMetrics().get(i);
+      }
+      builder.addMetric(metricFunction.getMetricName(), baselineValue, currentValue);
+    }
+  }
+
+  private double[] getMetricSums(ThirdEyeResponse response) {
+
+    ThirdEyeRequest request = response.getRequest();
+    double[] metricSums = new double[request.getMetricNames().size()];
+    ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
+    requestBuilder.setCollection(request.getCollection());
+    requestBuilder.setStartTimeInclusive(request.getStartTimeInclusive());
+    requestBuilder.setEndTimeExclusive(request.getEndTimeExclusive());
+    requestBuilder.setFilterSet(request.getFilterSet());
+    requestBuilder.setMetricFunctions(request.getMetricFunctions());
+    ThirdEyeRequest metricSumsRequest = requestBuilder.build("metricSums");
+    ThirdEyeResponse metricSumsResponse = null;
+    try {
+      metricSumsResponse = CACHE_REGISTRY_INSTANCE.getQueryCache().getClient().execute(metricSumsRequest);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception when executing metric sums request", e);
+    }
+    List<Double> metrics = metricSumsResponse.getRow(0).getMetrics();
+    for (int i = 0; i < metrics.size(); i++) {
+      metricSums[i] = metrics.get(i);
+    }
+    return metricSums;
+  }
+
+  private Map<Integer, List<Double>> getMetricSumsByTime(ThirdEyeResponse response) {
+
+    ThirdEyeRequest request = response.getRequest();
+    Map<Integer, List<Double>> metricSums = new HashMap<>();
+    ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
+    requestBuilder.setCollection(request.getCollection());
+    requestBuilder.setStartTimeInclusive(request.getStartTimeInclusive());
+    requestBuilder.setEndTimeExclusive(request.getEndTimeExclusive());
+    requestBuilder.setFilterSet(request.getFilterSet());
+    requestBuilder.setGroupByTimeGranularity(request.getGroupByTimeGranularity());
+    requestBuilder.setMetricFunctions(request.getMetricFunctions());
+    ThirdEyeRequest metricSumsRequest = requestBuilder.build("metricSums");
+    ThirdEyeResponse metricSumsResponse = null;
+    try {
+      metricSumsResponse = CACHE_REGISTRY_INSTANCE.getQueryCache().getClient().execute(metricSumsRequest);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception when executing metric sums request", e);
+    }
+
+    for (int i = 0; i < metricSumsResponse.getNumRows(); i++) {
+      ThirdEyeResponseRow row = metricSumsResponse.getRow(i);
+      metricSums.put(row.getTimeBucketId(), row.getMetrics());
+    }
+    return metricSums;
+  }
+
+  private boolean checkMetricSums(Row row, List<Double> baselineMetricSums, List<Double> currentMetricSums) {
+    List<Metric> metrics = row.getMetrics();
+    for (int i = 0; i < metrics.size(); i ++) {
+      Metric metric = metrics.get(i);
+      if (metric.getBaselineValue() >= metricThreshold * baselineMetricSums.get(i) ||
+          metric.getCurrentValue() >= metricThreshold * currentMetricSums.get(i)) {
+        return true;
+      }
+    }
+    return false;
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -56,7 +56,7 @@ public class PqlUtils {
     String groupByClause = getDimensionGroupByClause(groupBy, timeGranularity, dataTimeSpec);
     if (StringUtils.isNotBlank(groupByClause)) {
       sb.append(" ").append(groupByClause);
-      int bucketCount = DEFAULT_TOP;
+      int bucketCount = Integer.MAX_VALUE;
       sb.append(" TOP ").append(bucketCount);
 
     }
@@ -94,7 +94,7 @@ public class PqlUtils {
     } else {
       SimpleDateFormat sdf = new SimpleDateFormat(timeFieldSpec.getFormat());
       String startDateTime = sdf.format(new Date(start.getMillis()));
-      String endDateTime = sdf.format(new Date(start.getMillis()));
+      String endDateTime = sdf.format(new Date(end.getMillis()));
       if (startDateTime.equals(endDateTime)) {
         return String.format(" %s = '%s'", timeField, startDateTime);
       } else {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
@@ -107,7 +107,8 @@ public class TimeSeriesHandler {
     return new TimeSeriesResponse(metricExpressions, groupByDimensions, rows);
   }
 
-  private TimeSeriesRow convertToTimeSeriesRow(ThirdEyeRequest thirdeyeRequest, ThirdEyeResponseRow thirdeyeResponseRow, List<Range<DateTime>> timeRanges) {
+  private TimeSeriesRow convertToTimeSeriesRow(ThirdEyeRequest thirdeyeRequest, ThirdEyeResponseRow thirdeyeResponseRow,
+      List<Range<DateTime>> timeRanges) {
     Builder builder = new TimeSeriesRow.Builder();
     Range<DateTime> range = timeRanges.get(thirdeyeResponseRow.getTimeBucketId());
     builder.setStart(range.lowerEndpoint());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/CollectionConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/CollectionConfig.java
@@ -6,8 +6,13 @@ import java.util.Map;
 import com.linkedin.thirdeye.client.MetricExpression;
 
 public class CollectionConfig extends AbstractConfig {
+
+  public static double DEFAULT_THRESHOLD = 0.01;
+
   String collectionName;
   String collectionAlias;
+
+  double metricThreshold = DEFAULT_THRESHOLD;
 
   boolean isActive = true;
   boolean enableCount = false; // Default __COUNT metric
@@ -36,6 +41,14 @@ public class CollectionConfig extends AbstractConfig {
 
   public void setCollectionAlias(String collectionAlias) {
     this.collectionAlias = collectionAlias;
+  }
+
+  public double getMetricThreshold() {
+    return metricThreshold;
+  }
+
+  public void setMetricThreshold(double metricThreshold) {
+    this.metricThreshold = metricThreshold;
   }
 
   public boolean isActive() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/contributor/ContributionCell.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/contributor/ContributionCell.java
@@ -90,7 +90,7 @@ public class ContributionCell {
         "cumulativePercentageChange", "cumulativeContributionDifference"//
     };
 
-    decimalFormat = new DecimalFormat("0.#");
+    decimalFormat = new DecimalFormat("0.##");
   }
 
   public String[] toArray() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/contributor/ContributorViewHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/contributor/ContributorViewHandler.java
@@ -21,6 +21,7 @@ import com.linkedin.thirdeye.client.cache.QueryCache;
 import com.linkedin.thirdeye.client.comparison.Row;
 import com.linkedin.thirdeye.client.comparison.Row.Metric;
 import com.linkedin.thirdeye.client.comparison.TimeOnTimeComparisonHandler;
+import com.linkedin.thirdeye.client.comparison.TimeOnTimeComparisonHandler;
 import com.linkedin.thirdeye.client.comparison.TimeOnTimeComparisonRequest;
 import com.linkedin.thirdeye.client.comparison.TimeOnTimeComparisonResponse;
 import com.linkedin.thirdeye.dashboard.Utils;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/heatmap/HeatMapCell.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/heatmap/HeatMapCell.java
@@ -93,7 +93,7 @@ public class HeatMapCell {
         "contributionToOverallColor", "contributionToOverallSize",//
         "cellSizeExpression"
     };
-    decimalFormat = new DecimalFormat("0.#");
+    decimalFormat = new DecimalFormat("0.##");
   }
 
   public String[] toArray() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/tabular/TabularViewHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/tabular/TabularViewHandler.java
@@ -9,39 +9,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 import org.joda.time.DateTime;
 
 import com.google.common.collect.Multimap;
-import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.client.MetricExpression;
-import com.linkedin.thirdeye.client.MetricFunction;
 import com.linkedin.thirdeye.client.cache.QueryCache;
 import com.linkedin.thirdeye.client.comparison.Row;
 import com.linkedin.thirdeye.client.comparison.Row.Metric;
 import com.linkedin.thirdeye.client.comparison.TimeOnTimeComparisonHandler;
 import com.linkedin.thirdeye.client.comparison.TimeOnTimeComparisonRequest;
 import com.linkedin.thirdeye.client.comparison.TimeOnTimeComparisonResponse;
-import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.dashboard.resources.ViewRequestParams;
 import com.linkedin.thirdeye.dashboard.views.GenericResponse;
+import com.linkedin.thirdeye.dashboard.views.GenericResponse.ResponseSchema;
 import com.linkedin.thirdeye.dashboard.views.TimeBucket;
 import com.linkedin.thirdeye.dashboard.views.ViewHandler;
 import com.linkedin.thirdeye.dashboard.views.ViewRequest;
-import com.linkedin.thirdeye.dashboard.views.GenericResponse.ResponseSchema;
 import com.linkedin.thirdeye.dashboard.views.heatmap.HeatMapCell;
 
 public class TabularViewHandler implements ViewHandler<TabularViewRequest, TabularViewResponse> {
-
-  private final Comparator<DateTime> dateTimeComparator = new Comparator<DateTime>() {
-    public int compare(DateTime dateTime1, DateTime dateTime2) {
-      long millisSinceEpoch1 = dateTime1.getMillis();
-      long millisSinceEpoch2 = dateTime2.getMillis();
-      return (millisSinceEpoch1 < millisSinceEpoch2) ? -1
-          : (millisSinceEpoch1 == millisSinceEpoch2) ? 0 : 1;
-    }
-  };
 
   private final Comparator<Row> rowComparator = new Comparator<Row>() {
     public int compare(Row row1, Row row2) {
@@ -71,8 +58,6 @@ public class TabularViewHandler implements ViewHandler<TabularViewRequest, Tabul
     Multimap<String, String> filters = request.getFilters();
 
     List<MetricExpression> metricExpressions = request.getMetricExpressions();
-    List<MetricFunction> metricFunctions =
-        Utils.computeMetricFunctionsFromExpressions(metricExpressions);
     comparisonRequest.setCollectionName(collection);
     comparisonRequest.setBaselineStart(baselineStart);
     comparisonRequest.setBaselineEnd(baselineEnd);


### PR DESCRIPTION
Refactored view handlers to trigger just 1 query instead of multiple as per time buckets. The response is now parsed accordingly to extract data for each time bucket.
Added OTHER category for rows which fall below a certain configurable threshold.
Tested to check that tabular, contributors, heatmap and timeseries work correctly. 
The changes in dashboard response time for sample dataset 1 were as follows:
Tabular: from 4.71s to 277ms
Contributors: from 8.83s to 439ms, 9.59s to 1.2s
Heatmap: from 1.8s to 2.2s
Timeseries: from 2.39s to 228ms
For sample dataset 2:
Tabular: from 20s to 855ms
Heatmap: 6.20 to 13s
Contributors: 38s to 1.78s
Timeseries: 10s to 538ms