### PR TITLE
Fixed caching issue by adding hashcode and equals method to PinotQuery Created multiple connections to Pinot backend upfront and pick one based on thread id. This was needed because pinotconnection is not thread safe

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
@@ -427,7 +427,6 @@ public class TimeOnTimeResponseParser {
 
     for (int i = 0; i < metrics.size(); i ++) {
       Metric metric = metrics.get(i);
-      System.out.println(i + " " + metric.getBaselineValue() + " " + metric.getCurrentValue());
       double baselineSum = 0;
       if (baselineMetricSums != null) {
         baselineSum = baselineMetricSums.get(i);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotQuery.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotQuery.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.client.pinot;
 
+import com.google.common.base.Objects;
+
 public class PinotQuery {
 
   private String pql;
@@ -26,4 +28,14 @@ public class PinotQuery {
     this.tableName = tableName;
   }
 
+  @Override
+  public int hashCode() {
+    return pql.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    PinotQuery that = (PinotQuery) obj;
+    return this.pql.equals(that.pql);
+  }
 }


### PR DESCRIPTION
Created multiple connections to Pinot backend upfront and pick one based on thread id. This was needed because pinotconnection is not thread safe