### PR TITLE
Keep build errors during Travis build

### DIFF
--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -28,4 +28,4 @@ if [ $? -ne 0 ]; then
   exit 0
 fi
 
-mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly=true > /dev/null
+mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly=true | egrep '(ERROR|SUCCESS|FAILURE|SKIPPED)'


### PR DESCRIPTION
During Travis builds, build errors were silently swallowed. This patch
keeps relevant logs during build, so that we can diagnose compilation
errors.