### PR TITLE
StarTree: Address conflict between split-order and skip-materialization config specs.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
@@ -204,30 +204,6 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     LOG.debug("metricNames:{}", metricNames);
   }
 
-  /**
-   * Validate the split order by removing any dimensions that may be part of the skip
-   * materialization list.
-   * @param dimensionsSplitOrder
-   * @param skipMaterializationForDimensions
-   * @return
-   */
-  private List<String> sanitizeSplitOrder(List<String> dimensionsSplitOrder,
-      Set<String> skipMaterializationForDimensions) {
-    List<String> validatedSplitOrder = new ArrayList<String>();
-    for (String dimension : dimensionsSplitOrder) {
-      if (skipMaterializationForDimensions == null
-          || !skipMaterializationForDimensions.contains(dimension)) {
-        LOG.info("Adding dimension {} to split order", dimension);
-        validatedSplitOrder.add(dimension);
-      } else {
-        LOG.info(
-            "Dimension {} cannot be part of 'dimensionSplitOrder' and 'skipMaterializationForDimensions', removing it from split order",
-            dimension);
-      }
-    }
-    return validatedSplitOrder;
-  }
-
   private Object getAllStarValue(FieldSpec spec) throws Exception {
     switch (spec.getDataType()) {
     case STRING:
@@ -330,14 +306,19 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
     if (skipMaterializationForDimensions == null || skipMaterializationForDimensions.isEmpty()) {
       skipMaterializationForDimensions = computeDefaultDimensionsToSkipMaterialization();
     }
+
+    // For default split order, give preference to skipMaterializationForDimensions.
+    // For user-defined split order, give preference to split-order.
     if (dimensionsSplitOrder == null || dimensionsSplitOrder.isEmpty()) {
       dimensionsSplitOrder = computeDefaultSplitOrder();
+      dimensionsSplitOrder.removeAll(skipMaterializationForDimensions);
+    } else {
+      skipMaterializationForDimensions.removeAll(dimensionsSplitOrder);
     }
 
-    // Remove any dimensions from split order that would be not be materialized.
-    dimensionsSplitOrder = sanitizeSplitOrder(dimensionsSplitOrder, skipMaterializationForDimensions);
+    LOG.debug("Split order: {}", dimensionsSplitOrder);
+    LOG.debug("Skip Materilazitaion For Dimensions: {}", skipMaterializationForDimensions);
 
-    LOG.debug("Split order:{}", dimensionsSplitOrder);
     long start = System.currentTimeMillis();
     dataBuffer.flush();
     // Sort the data based on default sort order (split order + remaining dimensions)


### PR DESCRIPTION
The split-order and skip-materialization are mutually values, ie a
dimension cannot be specified in both.
In the current code, if skip-materialization is not defined, we compute
a default value for it. And in case a split-order was explicitly
defined, but skip-materialization was not, we still give preference to
the default skip-materialization value, and remove the dimensions
appearing in both lists from split-order. This is not correct.

With this PR, we give prefernce to split-order if it was explicitly
defined by the user.

Testing: All star-tree tests + manual testing.