### PR TITLE
Segment Status Checker: Handle case when partition online in idealstate is not present in the external view

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -130,7 +130,6 @@ public class SegmentStatusChecker {
     try {
       _executorService.awaitTermination(SegmentCheckerDefaultIntervalSeconds, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
-      e.printStackTrace();
     }
     _executorService = null;
   }
@@ -172,6 +171,12 @@ public class SegmentStatusChecker {
           }
         }
         if (nIdeal == 0) {
+          // No online segments in ideal state
+          continue;
+        }
+        if (externalView.getStateMap(partitionName) == null) {
+          // No replicas for this segment
+          nReplicasExternal = 0;
           continue;
         }
         for (Map.Entry<String, String> serverAndState : externalView.getStateMap(partitionName).entrySet()) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -102,6 +102,7 @@ public class SegmentStatusCheckerTest {
         ControllerGauge.NUMBER_OF_REPLICAS), 1);
     segmentStatusChecker.stop();
   }
+
   @Test
   public void nonLeaderTest() throws Exception {
     final String tableName = "myTable";
@@ -131,6 +132,58 @@ public class SegmentStatusCheckerTest {
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
         ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
+        ControllerGauge.NUMBER_OF_REPLICAS), 0);
+    segmentStatusChecker.stop();
+  }
+
+  @Test
+  public void missingEVPartitionTest() throws Exception {
+    final String tableName = "myTable";
+    List<String> allTableNames = new ArrayList<String>();
+    allTableNames.add(tableName);
+    IdealState idealState = new IdealState(tableName);
+    idealState.setPartitionState("myTable_0", "pinot1", "ONLINE");
+    idealState.setPartitionState("myTable_0", "pinot2", "ONLINE");
+    idealState.setPartitionState("myTable_0", "pinot3", "ONLINE");
+    idealState.setPartitionState("myTable_1", "pinot1", "ONLINE");
+    idealState.setPartitionState("myTable_1", "pinot2", "ONLINE");
+    idealState.setPartitionState("myTable_1", "pinot3", "ONLINE");
+    idealState.setPartitionState("myTable_2", "pinot3", "OFFLINE");
+    idealState.setPartitionState("myTable_3", "pinot3", "ONLINE");
+    idealState.setReplicas("2");
+    idealState.setRebalanceMode(IdealState.RebalanceMode.CUSTOMIZED);
+
+    ExternalView externalView = new ExternalView(tableName);
+    externalView.setState("myTable_0","pinot1","ONLINE");
+    externalView.setState("myTable_0","pinot2","ONLINE");
+    externalView.setState("myTable_1","pinot1","ERROR");
+    externalView.setState("myTable_1","pinot2","ONLINE");
+
+    HelixAdmin helixAdmin;
+    {
+      helixAdmin = mock(HelixAdmin.class);
+      when(helixAdmin.getResourceIdealState("StatusChecker","myTable")).thenReturn(idealState);
+      when(helixAdmin.getResourceExternalView("StatusChecker","myTable")).thenReturn(externalView);
+    }
+    {
+      helixResourceManager = mock(PinotHelixResourceManager.class);
+      when(helixResourceManager.isLeader()).thenReturn(true);
+      when(helixResourceManager.getAllPinotTableNames()).thenReturn(allTableNames);
+      when(helixResourceManager.getHelixClusterName()).thenReturn("StatusChecker");
+      when(helixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
+    }
+    {
+      config = mock(ControllerConf.class);
+      when(config.getStatusControllerFrequencyInSeconds()).thenReturn(300);
+    }
+    metricsRegistry = new MetricsRegistry();
+    controllerMetrics = new ControllerMetrics(metricsRegistry);
+    segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config);
+    segmentStatusChecker.setMetricsRegistry(controllerMetrics);
+    segmentStatusChecker.runSegmentMetrics();
+    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
+        ControllerGauge.SEGMENTS_IN_ERROR_STATE), 1);
+    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.NUMBER_OF_REPLICAS), 0);
     segmentStatusChecker.stop();
   }


### PR DESCRIPTION
Modified Segment Status checker to mark the number of replicas in external
view as 0 for segments having online replicas in ideal state but no presence
at all in the external view. Added test to check this condition.