### PR TITLE
Change timestamp format for realtime segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/SegmentNameBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/SegmentNameBuilder.java
@@ -47,7 +47,7 @@ public class SegmentNameBuilder {
       // old style name
       //  return StringUtils.join(
       //      Lists.newArrayList(tableName, instanceName, groupId, partitionName, sequenceNumber), "__");
-      
+
       // shorter name: {groupId}__{partitionRange}__{sequenceNumber}
       // groupId contains the realtime table name, amongst other things
       // see com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder#getGroupIdFromRealtimeDataTable for details on the groupId
@@ -63,9 +63,9 @@ public class SegmentNameBuilder {
 
     public static String buildLowLevelConsumerSegmentName(String tableName, String partitionId, String sequenceNumber,
         long millisSinceEpoch) {
-      // ISO8601 date: 2016-01-20T123456.789Z
+      // ISO8601 date: 20160120T1234Z
       DateTime dateTime = new DateTime(millisSinceEpoch, DateTimeZone.UTC);
-      String date = dateTime.toString("yyyy-MM-DD'T'HHmmss.SSS'Z'");
+      String date = dateTime.toString("yyyyMMdd'T'HHmm'Z'");
 
       // New realtime consumer v2 name: {tableName}__{partitionId}__{sequenceNumber}__{date}
       if (isValidSegmentComponent(tableName) && isValidSegmentComponent(partitionId) &&

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/SegmentNameBuilderTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/SegmentNameBuilderTest.java
@@ -33,7 +33,7 @@ public class SegmentNameBuilderTest {
     String v2Name = SegmentNameBuilder.Realtime.buildLowLevelConsumerSegmentName("myTable_REALTIME", "0", "1", 1465508537069L);
 
     assertEquals(shortV1Name, "myTable_REALTIME_1234567_0__ALL__1234567");
-    assertEquals(v2Name, "myTable_REALTIME__0__1__2016-06-161T214217.069Z");
+    assertEquals(v2Name, "myTable_REALTIME__0__1__20160609T2142Z");
 
     // Check v1/v2 format detection
     assertEquals(isRealtimeV1Name(oldV1Name), true);


### PR DESCRIPTION
Change the timestamp format for realtime segments to be more compact.
Fix the timestamp format to use days of month instead of days of year.