### PR TITLE
Use ideal state to compute segment assignment

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
@@ -24,6 +24,7 @@ import java.util.PriorityQueue;
 
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +37,6 @@ import com.linkedin.pinot.common.utils.Pairs.Number2ObjectPair;
 
 /**
  * Assigns a segment to the instance that has least number of segments.
- *
- *
  */
 public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(BalanceNumSegmentAssignmentStrategy.class);
@@ -58,23 +57,29 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
     List<String> selectedInstances = new ArrayList<String>();
     Map<String, Integer> currentNumSegmentsPerInstanceMap = new HashMap<String, Integer>();
     List<String> allTaggedInstances = helixAdmin.getInstancesInClusterWithTag(helixClusterName, serverTenantName);
+
     for (String instance : allTaggedInstances) {
       currentNumSegmentsPerInstanceMap.put(instance, 0);
     }
-    ExternalView externalView = helixAdmin.getResourceExternalView(helixClusterName, tableName);
-    if (externalView != null) {
-      for (String partitionName : externalView.getPartitionSet()) {
-        Map<String, String> instanceToStateMap = externalView.getStateMap(partitionName);
-        for (String instanceName : instanceToStateMap.keySet()) {
-          if (currentNumSegmentsPerInstanceMap.containsKey(instanceName)) {
-            currentNumSegmentsPerInstanceMap.put(instanceName, currentNumSegmentsPerInstanceMap.get(instanceName) + 1);
-          } else {
-            currentNumSegmentsPerInstanceMap.put(instanceName, 1);
+
+    // Count number of segments assigned to each instance
+    IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, tableName);
+    if (idealState != null) {
+      for (String partitionName : idealState.getPartitionSet()) {
+        Map<String, String> instanceToStateMap =  idealState.getInstanceStateMap(partitionName);
+        if (instanceToStateMap != null) {
+          for (String instanceName : instanceToStateMap.keySet()) {
+            if (currentNumSegmentsPerInstanceMap.containsKey(instanceName)) {
+              currentNumSegmentsPerInstanceMap.put(instanceName, currentNumSegmentsPerInstanceMap.get(instanceName) + 1);
+            } else {
+              currentNumSegmentsPerInstanceMap.put(instanceName, 1);
+            }
           }
         }
       }
-
     }
+
+    // Select up to numReplicas instances with the fewest segments assigned
     PriorityQueue<Number2ObjectPair<String>> priorityQueue =
         new PriorityQueue<Number2ObjectPair<String>>(numReplicas, Pairs.getDescendingnumber2ObjectPairComparator());
     for (String key : currentNumSegmentsPerInstanceMap.keySet()) {
@@ -87,6 +92,7 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
     while (!priorityQueue.isEmpty()) {
       selectedInstances.add(priorityQueue.poll().getB());
     }
+
     LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : "
         + segmentMetadata.getTableName() + ", selected instances: " + Arrays.toString(selectedInstances.toArray()));
     return selectedInstances;

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategyIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategyIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.linkedin.pinot.controller.helix.core.sharding;
+
+import com.linkedin.pinot.common.request.helper.ControllerRequestBuilder;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
+import com.linkedin.pinot.integration.tests.UploadRefreshDeleteIntegrationTest;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.model.IdealState;
+import org.json.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Integration test for the balance num segment assignment strategy
+ */
+public class BalanceNumSegmentAssignmentStrategyIntegrationTest extends UploadRefreshDeleteIntegrationTest {
+
+  private ZKHelixAdmin _helixAdmin;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    // Start zk and controller
+    startZk();
+    startController();
+
+    // Start one server and one broker instance
+    startServer();
+    startBroker();
+
+    // Create one table with a replication factor of three
+    JSONObject request = ControllerRequestBuilder.buildCreateOfflineTableJSON("mytable", null, null, "DaysSinceEpoch",
+        "DAYS", "DAYS", "300", 3, "BalanceNumSegmentAssignmentStrategy", Collections.<String>emptyList(), "MMAP");
+    sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(), request.toString());
+
+    // Create eight dummy server instances
+    for(int i = 0; i < 8; ++i) {
+      JSONObject serverInstance = new JSONObject();
+      serverInstance.put("host", "1.2.3.4");
+      serverInstance.put("port", Integer.toString(1234 + i));
+      serverInstance.put("tag", "DefaultTenant_OFFLINE");
+      serverInstance.put("type", "server");
+      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceCreate(),
+          serverInstance.toString());
+    }
+
+    // Create Helix connection
+    _helixAdmin = new ZKHelixAdmin(ZkStarter.DEFAULT_ZK_STR);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    // Close the Helix connection
+    _helixAdmin.close();
+
+    // Stop everything
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+  }
+
+  @Test
+  public void testSegmentAssignmentStrategy() throws Exception {
+    // Upload nine segments
+    for(int i = 0; i < 9; ++i) {
+      generateAndUploadRandomSegment("mytable_" + i, 10);
+    }
+
+    // Count the number of segments per instance
+    IdealState idealState = _helixAdmin.getResourceIdealState(getHelixClusterName(), "mytable_OFFLINE");
+    Map<String, Integer> segmentsPerInstance = new HashMap<String, Integer>();
+
+    for (String partitionName : idealState.getPartitionSet()) {
+      for (String instanceName : idealState.getInstanceSet(partitionName)) {
+        if (!segmentsPerInstance.containsKey(instanceName)) {
+          segmentsPerInstance.put(instanceName, 1);
+        } else {
+          segmentsPerInstance.put(instanceName, segmentsPerInstance.get(instanceName) + 1);
+        }
+      }
+    }
+
+    // Check that each instance has exactly three segments assigned
+    for (String instanceName : segmentsPerInstance.keySet()) {
+      int segmentCountForInstance = segmentsPerInstance.get(instanceName);
+      assertEquals(segmentCountForInstance, 3,
+          "Instance " + instanceName + " did not have the expected number of segments assigned");
+    }
+  }
+
+  @Test
+  public void testRefresh() {
+    // Ignore this inherited test
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -87,7 +87,7 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     ensureDirectoryExistsAndIsEmpty(_tarsDir);
   }
 
-  private void generateAndUploadRandomSegment(String segmentName, int rowCount) throws Exception {
+  protected void generateAndUploadRandomSegment(String segmentName, int rowCount) throws Exception {
     ThreadLocalRandom random = ThreadLocalRandom.current();
     Schema schema = new Schema.Parser().parse(
         new File(TestUtils.getFileFromResourceUrl(getClass().getClassLoader().getResource("dummy.avsc"))));


### PR DESCRIPTION
Before this patch, we used the external view to compute segment
assignment. If a server if offline, it does not appear in external
view. As such, an offline server will be considered empty when
assigning segments and will be assigned all new segments until it
comes back online.

This patch fixes this behavior by using the ideal state instead of the
external view for segment assignment.