### PR TITLE
Remove most log output from Travis builds

### DIFF
--- a/pinot-common/src/main/resources/log4j-nooutput.properties
+++ b/pinot-common/src/main/resources/log4j-nooutput.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=FATAL, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p %c{1} [%x] - %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,18 @@
     <argLine> -Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g </argLine>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>travis</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <argLine> -Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g -Dlog4j.configuration=log4j-nooutput.properties</argLine>
+      </properties>
+    </profile>
+  </profiles>
+
   <repositories>
     <repository>
       <id>restlet.org</id>
@@ -820,27 +832,4 @@
       </plugin>
     </plugins>
   </reporting>
-  <profiles>
-    <!--
-      Configuration for unit/integration tests section 3 of 3 (profiles) STARTS HERE.
-      Use the following profile to run Integration tests. From the command line:
-      mvn clean install -P integration-test
-      or:
-      mvn integration-test -P integration-test
-     * Note that if you do: 'mvn test -P integration-test'
-       integration tests will not run, because the test phase is before the
-       integration phase in the default maven lifecycle.
-     * Also note that unit tests will also be run when integration tests are
-       run, because the integration-test phase is always after the test phase
-       in the default Maven lifecycle.
-       See also: surefire plugin section and properties section.
-      -->
-    <profile>
-      <id>integration-test</id>
-      <properties>
-        <SKIP_INTEGRATION_TESTS>false</SKIP_INTEGRATION_TESTS>
-      </properties>
-    </profile>
-    <!-- Configuration for unit/integration tests section 3 of 3 (profiles) ENDS HERE.-->
-  </profiles>
 </project>


### PR DESCRIPTION
Travis builds are capped to 10k lines of log output. This patch adds a
new log4j configuration that is only used during Travis builds which
removes most of the output so that we can read the maven logs, which
contain the list of tests that failed, if applicable.