### PR TITLE
Change V1/V2 references to high/low level

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/SegmentNameBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/SegmentNameBuilder.java
@@ -78,9 +78,9 @@ public class SegmentNameBuilder {
     }
 
     public static String extractTableName(String segmentId) {
-      if (isOldV1StyleName(segmentId) || isRealtimeV2Name(segmentId)) {
+      if (isLongHighLevelSegmentName(segmentId) || isLowLevelRealtimeSegmentName(segmentId)) {
         return segmentId.split("__")[0];
-      } else if (isShortV1StyleName(segmentId)) {
+      } else if (isShortHighLevelSegmentName(segmentId)) {
         // Table name is the first part of the Kafka consumer group id
         String groupId = extractGroupIdName(segmentId);
         return groupId.substring(0, groupId.indexOf(REALTIME_SUFFIX) + REALTIME_SUFFIX_LENGTH);
@@ -90,11 +90,11 @@ public class SegmentNameBuilder {
     }
 
     public static String extractGroupIdName(String segmentId) {
-      if (isOldV1StyleName(segmentId)) {
+      if (isLongHighLevelSegmentName(segmentId)) {
         return segmentId.split("__")[2];
-      } else if (isShortV1StyleName(segmentId)) {
+      } else if (isShortHighLevelSegmentName(segmentId)) {
         return segmentId.split("__")[0];
-      } else if (isRealtimeV2Name(segmentId)){
+      } else if (isLowLevelRealtimeSegmentName(segmentId)){
         throw new RuntimeException("Realtime v2 segments don't have a consumer group id");
       } else {
         throw new RuntimeException("Unable to parse segment name " + segmentId);
@@ -102,11 +102,11 @@ public class SegmentNameBuilder {
     }
 
     public static String extractPartitionRange(String segmentId) {
-      if (isOldV1StyleName(segmentId)) {
+      if (isLongHighLevelSegmentName(segmentId)) {
         return segmentId.split("__")[3];
-      } else if (isShortV1StyleName(segmentId)) {
+      } else if (isShortHighLevelSegmentName(segmentId)) {
         return segmentId.split("__")[1];
-      } else if (isRealtimeV2Name(segmentId)){
+      } else if (isLowLevelRealtimeSegmentName(segmentId)){
         return segmentId.split("__")[2];
       } else {
         throw new RuntimeException("Unable to parse segment name " + segmentId);
@@ -114,11 +114,11 @@ public class SegmentNameBuilder {
     }
 
     public static String extractSequenceNumber(String segmentId) {
-      if (isOldV1StyleName(segmentId)) {
+      if (isLongHighLevelSegmentName(segmentId)) {
         return segmentId.split("__")[4];
-      } else if (isShortV1StyleName(segmentId)) {
+      } else if (isShortHighLevelSegmentName(segmentId)) {
         return segmentId.split("__")[2];
-      } else if (isRealtimeV2Name(segmentId)){
+      } else if (isLowLevelRealtimeSegmentName(segmentId)){
         return segmentId.split("__")[2];
       } else {
         throw new RuntimeException("Unable to parse segment name " + segmentId);
@@ -126,7 +126,7 @@ public class SegmentNameBuilder {
 
     }
 
-    public static boolean isRealtimeV1Name(String segmentId) {
+    public static boolean isHighLevelRealtimeSegmentName(String segmentId) {
       int namePartCount = segmentId.split("__").length;
       // Realtime v1 segment names have either:
       // - Five parts (old style name: tableName, instanceName, groupId, partitionName, sequenceNumber)
@@ -134,17 +134,17 @@ public class SegmentNameBuilder {
       return namePartCount == 5 || namePartCount == 3;
     }
 
-    public static boolean isRealtimeV2Name(String segmentId) {
+    public static boolean isLowLevelRealtimeSegmentName(String segmentId) {
       int namePartCount = segmentId.split("__").length;
       // Realtime v2 segment names have four parts (tableName, partitionId, sequenceNumber, date)
       return namePartCount == 4;
     }
 
-    private static boolean isOldV1StyleName(String segmentId) {
+    private static boolean isLongHighLevelSegmentName(String segmentId) {
       return segmentId.split("__").length == 5;
     }
 
-    private static boolean isShortV1StyleName(String segmentId) {
+    private static boolean isShortHighLevelSegmentName(String segmentId) {
       return segmentId.split("__").length == 3;
     }
 

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/SegmentNameBuilderTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/SegmentNameBuilderTest.java
@@ -30,24 +30,24 @@ public class SegmentNameBuilderTest {
   public void testSegmentNameBuilder() {
     String oldV1Name = "myTable_REALTIME__Server_1.2.3.4_1234__myTable_REALTIME_1234567_0__0__23456789";
     String shortV1Name = SegmentNameBuilder.Realtime.buildHighLevelConsumerSegmentName("myTable_REALTIME_1234567_0", "ALL", "1234567");
-    String v2Name = SegmentNameBuilder.Realtime.buildLowLevelConsumerSegmentName("myTable_REALTIME", "0", "1", 1465508537069L);
+    String v2Name = SegmentNameBuilder.Realtime.buildLowLevelConsumerSegmentName("myTable", "0", "1", 1465508537069L);
 
     assertEquals(shortV1Name, "myTable_REALTIME_1234567_0__ALL__1234567");
-    assertEquals(v2Name, "myTable_REALTIME__0__1__20160609T2142Z");
+    assertEquals(v2Name, "myTable__0__1__20160609T2142Z");
 
-    // Check v1/v2 format detection
-    assertEquals(isRealtimeV1Name(oldV1Name), true);
-    assertEquals(isRealtimeV1Name(shortV1Name), true);
-    assertEquals(isRealtimeV1Name(v2Name), false);
+    // Check high level consumer/low level consumer format detection
+    assertEquals(isHighLevelRealtimeSegmentName(oldV1Name), true);
+    assertEquals(isHighLevelRealtimeSegmentName(shortV1Name), true);
+    assertEquals(isHighLevelRealtimeSegmentName(v2Name), false);
 
-    assertEquals(isRealtimeV2Name(oldV1Name), false);
-    assertEquals(isRealtimeV2Name(shortV1Name), false);
-    assertEquals(isRealtimeV2Name(v2Name), true);
+    assertEquals(isLowLevelRealtimeSegmentName(oldV1Name), false);
+    assertEquals(isLowLevelRealtimeSegmentName(shortV1Name), false);
+    assertEquals(isLowLevelRealtimeSegmentName(v2Name), true);
 
     // Check table name
     assertEquals(extractTableName(oldV1Name), "myTable_REALTIME");
     assertEquals(extractTableName(shortV1Name), "myTable_REALTIME");
-    assertEquals(extractTableName(v2Name), "myTable_REALTIME");
+    assertEquals(extractTableName(v2Name), "myTable");
 
     // Check partition range
     assertEquals(extractPartitionRange(oldV1Name), "0");


### PR DESCRIPTION
Rename methods that contain references to V1 and V2 to mention the high
level and low level consumers, to make the code more readable.