### PR TITLE
Let Travis only run tests on JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
   - PINOT_MODULE="pinot-perf"
 
 jdk:
-  - openjdk7
   - oraclejdk7
+  - openjdk7
   - oraclejdk8
 
 install:

--- a/.travis_test.sh
+++ b/.travis_test.sh
@@ -22,5 +22,11 @@ if [ $? -ne 0 ]; then
   exit 0
 fi
 
+# Only run tests for JDK 8
+if [ $TRAVIS_JDK_VERSION != 'oraclejdk7' ]; then
+  echo 'Skip tests for version other than oraclejdk7.'
+  exit 0
+fi
+
 cd $PINOT_MODULE
 mvn test -P travis


### PR DESCRIPTION
We will test installation on oraclejdk7, openjdk7 and oraclejdk8,
but only run tests on oraclejdk8 to accelerate Travis-ci.