### PR TITLE
Fix for overflowing cells in Tabular View

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -12,8 +12,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import jersey.repackaged.com.google.common.collect.Lists;
-
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheLoader.InvalidCacheLoadException;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.api.CollectionSchema;
 import com.linkedin.thirdeye.api.TimeGranularity;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -4,12 +4,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import jersey.repackaged.com.google.common.collect.Lists;
 
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -193,12 +196,12 @@ public class Utils {
 
   public static List<MetricFunction> computeMetricFunctionsFromExpressions(
       List<MetricExpression> metricExpressions) {
-    List<MetricFunction> metricFunctions = new ArrayList<>();
+    Set<MetricFunction> metricFunctions = new HashSet<>();
 
     for (MetricExpression expression : metricExpressions) {
       metricFunctions.addAll(expression.computeMetricFunctions());
     }
-    return metricFunctions;
+    return Lists.newArrayList(metricFunctions);
   }
 
   public static TimeGranularity getAggregationTimeGranularity(String aggTimeGranularity) {


### PR DESCRIPTION
In the case when the tabular view has a ratio metric (say a/b) and another metric which is part of the ratio (say a), the metric a is generating twice the number of cells