### PR TITLE
Lower memory usage of MmapUtils

### DIFF
--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/MmapUtilsTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/MmapUtilsTest.java
@@ -1,0 +1,11 @@
+package com.linkedin.pinot.common.utils;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * FIXME Document me!
+ */
+public class MmapUtilsTest {
+
+}

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/MmapUtilsTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/MmapUtilsTest.java
@@ -1,11 +1,51 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.linkedin.pinot.common.utils;
+
+import java.io.File;
+import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 
 /**
- * FIXME Document me!
+ * Tests for MmapUtils.
  */
 public class MmapUtilsTest {
+  @Test
+  public void testAllocationContext() {
+    // No file
+    assertEquals(new MmapUtils.AllocationContext("potato", MmapUtils.AllocationType.MMAP).getContext(), "potato");
+    assertEquals(new MmapUtils.AllocationContext(null, "potato", MmapUtils.AllocationType.MMAP).getContext(), "potato");
 
+    // With various paths
+    assertEquals(
+        new MmapUtils.AllocationContext(new File("a"), "potato", MmapUtils.AllocationType.MMAP).getContext(),
+        "a (potato)");
+    assertEquals(
+        new MmapUtils.AllocationContext(new File("/a"), "potato", MmapUtils.AllocationType.MMAP).getContext(),
+        "/a (potato)");
+    assertEquals(
+        new MmapUtils.AllocationContext(new File("/a/b"), "potato", MmapUtils.AllocationType.MMAP).getContext(),
+        "/a/b (potato)");
+    assertEquals(
+        new MmapUtils.AllocationContext(new File("/a/b/c"), "potato", MmapUtils.AllocationType.MMAP).getContext(),
+        "/a/b/c (potato)");
+    assertEquals(
+        new MmapUtils.AllocationContext(new File("/a/b/c/d"), "potato", MmapUtils.AllocationType.MMAP).getContext(),
+        "/a/b/c/d (potato)");
+  }
 }


### PR DESCRIPTION
Lower the on-heap memory usage of MmapUtils by reusing duplicated file
path components. Most of the paths that are stored contain many
duplicated paths, as they are of the form
storageDirectory/segmentName/column.ext. This patch allows reusing the
same String instances for storageDirectory, segmentName and column.ext.