### PR TITLE
PINOT-3296 Handle spaces in segment names

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -43,7 +43,10 @@ import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -143,6 +146,11 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
       @Parameter(name = "segmentName", in = "path", description = "The name of the segment to download", required = true)
       String segmentName) {
     Representation presentation;
+    try {
+      segmentName = URLDecoder.decode(segmentName, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError("UTF-8 encoding should always be supported", e);
+    }
     final File dataFile = new File(baseDataDir, StringUtil.join("/", tableName, segmentName));
     if (dataFile.exists()) {
       presentation = new FileRepresentation(dataFile, MediaType.ALL, 0);
@@ -539,7 +547,11 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   }
 
   public String constructDownloadUrl(String tableName, String segmentName) {
-    final String ret = StringUtil.join("/", vip, "segments", tableName, segmentName);
-    return ret;
+    try {
+      return StringUtil.join("/", vip, "segments", tableName, URLEncoder.encode(segmentName, "UTF-8"));
+    } catch (UnsupportedEncodingException e) {
+      // Shouldn't happen
+      throw new AssertionError("UTF-8 encoding should always be supported", e);
+    }
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -732,7 +732,9 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
               genConfig.setSchema(inputPinotSchema);
             }
 
-            genConfig.setSegmentNamePostfix(Integer.toString(segmentNumber));
+            // jfim: We add a space and a special character to do a regression test for PINOT-3296 Segments with spaces
+            // in their filename don't work properly
+            genConfig.setSegmentNamePostfix(Integer.toString(segmentNumber) + " %");
             genConfig.setEnableStarTreeIndex(createStarTreeIndex);
             genConfig.setStarTreeIndexSpec(null);
 


### PR DESCRIPTION
Add URL encoding for spaces and special characters in generated URLs,
which fixes issues when segments with special characters are uploaded.
Without this fix, segments with spaces in their name cause the retry
logic (with exponential backoff) to be triggered, blocking download of
other segments on the same host. Update integration tests to test for
this case.