### PR TITLE
Handle exceptional cases in realtime consumption

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -179,8 +179,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           try {
             row = kafkaStreamProvider.next();
 
-            row = extractor.transform(row);
             if (row != null) {
+              row = extractor.transform(row);
               notFull = realtimeSegment.index(row);
               exceptionSleepMillis = 50L;
             }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelConsumerStreamProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelConsumerStreamProvider.java
@@ -99,6 +99,7 @@ public class KafkaHighLevelConsumerStreamProvider implements StreamProvider {
         INSTANCE_LOGGER.warn("Caught exception while consuming events", e);
         serverMetrics.addMeteredTableValue(tableAndStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
         serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
+        throw e;
       }
     }
     return null;


### PR DESCRIPTION
Avoid NPEs when transforming rows and properly bubble exceptions up on
exceptional code paths as to trigger exponential backoff.