### PR TITLE
Added a main method in StarTreeQueryGenerator to generate star tree queries.

### DIFF
--- a/pinot-integration-tests/src/test/resources/OnTimeStarTreeQueries.txt
+++ b/pinot-integration-tests/src/test/resources/OnTimeStarTreeQueries.txt
@@ -1,3345 +1,999 @@
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Massachusetts' AND Diverted = '0' AND DayofMonth = '27' GROUP BY Year, Cancelled, DestStateFips
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff = '1003' AND Quarter = '2' AND Carrier = 'HA' GROUP BY Diverted, Quarter, FlightDate
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Diverted = '1' AND WheelsOn = '321' AND Year = '2014' GROUP BY TailNum, TaxiIn, DivActualElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '1' AND DivAirportLandings = '0' AND Distance = '629' GROUP BY TaxiOut, DepTime, WheelsOn
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE TailNum = 'N907WN' AND ActualElapsedTime = '155' GROUP BY Distance, OriginAirportSeqID, OriginWac
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '1300-1359' AND ArrTimeBlk = '1400-1459' AND CancellationCode = 'A' GROUP BY DayOfWeek, SecurityDelay, DayofMonth
-SELECT SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '6' AND Quarter = '2' AND DivAirportLandings = '1' GROUP BY DepTimeBlk, TailNum, NASDelay
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND Cancelled = '1' AND UniqueCarrier = 'B6' GROUP BY DestStateName, ActualElapsedTime, OriginAirportID
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginState = 'AR' AND DepTimeBlk = '1200-1259' AND CancellationCode = 'B' GROUP BY Origin, ArrTimeBlk, DivActualElapsedTime
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE AirlineID = '19805' AND DestAirportSeqID = '1393003' AND Cancelled = '1' GROUP BY TailNum, DivAirportLandings, Diverted
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivArrDelay = '201' AND Flights = '1' AND UniqueCarrier = 'MQ' GROUP BY DivAirportLandings, DivDistance, TaxiIn
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1200-1259' AND DivReachedDest = '1' AND DistanceGroup = '6' GROUP BY OriginCityName, DestAirportSeqID, CancellationCode
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings = '1' AND Flights = '1' AND FlightDate = '2014-06-23' GROUP BY LateAircraftDelay, Distance, FirstDepTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DistanceGroup = '2' AND CancellationCode = 'noodles' AND DivArrDelay = '170' GROUP BY CRSElapsedTime, Month, DivDistance
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime = '1' AND Flights = '1' AND CancellationCode = 'noodles' GROUP BY LongestAddGTime, FlightDate, CarrierDelay
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND Diverted = '1' AND DestWac = '39' GROUP BY NASDelay, SecurityDelay, TailNum
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth = '2' AND DivAirportLandings = '0' AND Carrier = 'WN' GROUP BY LongestAddGTime, WeatherDelay, CRSElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE OriginCityName = 'Lansing, MI' AND DepTimeBlk = '0600-0659' AND Cancelled = '1' GROUP BY Cancelled, Flights, TaxiOut
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips = '12' GROUP BY FirstDepTime, DivDistance, CRSElapsedTime
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE Carrier = 'OO' AND OriginCityMarketID = '34006' AND DivReachedDest = '1' GROUP BY NASDelay, OriginState, WeatherDelay
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest = '0' GROUP BY CRSArrTime, Diverted, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode = 'noodles' AND ArrTimeBlk = '1300-1359' AND TaxiIn = '19' GROUP BY OriginAirportID, OriginStateFips, AirTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID = '14831' AND Month = '6' AND DayofMonth = '19' GROUP BY DepTimeBlk, DivAirportLandings, OriginCityMarketID
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND DepTime = '1853' AND Flights = '1' GROUP BY CancellationCode, Quarter, DayofMonth
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND Carrier = 'MQ' AND Month = '6' GROUP BY Diverted, OriginWac, DestState
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestState = 'OH' AND UniqueCarrier = 'MQ' AND OriginStateName = 'Texas' GROUP BY TaxiIn, ArrTimeBlk, Year
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Dest = 'BHM' AND Diverted = '0' AND DestStateFips = '1' GROUP BY OriginWac, ArrTimeBlk, WeatherDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSArrTime = '802' AND Flights = '1' AND OriginWac = '54' GROUP BY WeatherDelay, ArrTimeBlk, DestCityName
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay = '174' AND DestStateName = 'New York' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CRSArrTime = '1756' AND DestWac = '91' AND Diverted = '1' GROUP BY Distance, CarrierDelay, Month
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND OriginCityName = 'Brownsville, TX' AND Flights = '1' GROUP BY ArrTime, DivReachedDest, SecurityDelay
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID = '19690' AND Flights = '1' AND Quarter = '2' GROUP BY WheelsOff, AirTime, OriginStateFips
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DayofMonth = '4' AND DestState = 'IL' GROUP BY Carrier, CRSElapsedTime, DivArrDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '221' AND DayOfWeek = '3' AND Quarter = '2' GROUP BY Distance, OriginStateName, OriginAirportID
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE FlightDate = '2014-06-28' AND ArrTimeBlk = '2200-2259' GROUP BY DivActualElapsedTime, TaxiOut
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '1' GROUP BY OriginAirportID, DestStateFips, DestWac
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '9' AND DepTimeBlk = '1200-1259' AND OriginStateFips = '40' GROUP BY DepTime, Origin, DivDistance
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND OriginStateName = 'New York' AND WheelsOn = '1035' GROUP BY TailNum
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum = '1550' AND Month = '6' GROUP BY OriginAirportSeqID, DayofMonth, DepTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginWac = '93' GROUP BY DivReachedDest, DayOfWeek, DestState
-SELECT SUM(DepDel15) FROM myStarTable WHERE SecurityDelay = '0' AND DestAirportID = '10279' AND WheelsOff = '1356' GROUP BY Month, DivReachedDest, OriginCityMarketID
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '0' AND Year = '2014' AND FlightNum = '1402' GROUP BY OriginState, DistanceGroup, ActualElapsedTime
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DestAirportID = '14108' AND DayOfWeek = '6' GROUP BY Carrier, DestAirportSeqID, OriginCityMarketID
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND Flights = '1' AND DepTime = '1124' GROUP BY Cancelled, SecurityDelay, CarrierDelay
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND Cancelled = '0' AND UniqueCarrier = 'OO' GROUP BY OriginAirportSeqID, DestAirportSeqID, OriginStateName
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = '27' AND Carrier = 'OO' AND DivAirportLandings = '1' GROUP BY CRSArrTime, OriginCityMarketID, ArrTimeBlk
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTime = '557' AND Month = '6' AND Flights = '1' GROUP BY Quarter, OriginWac, ActualElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime = '-9999' AND DivReachedDest = '1' AND Flights = '1' GROUP BY DestState, CancellationCode, DistanceGroup
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND ArrTimeBlk = '0001-0559' AND LateAircraftDelay = '33' GROUP BY Cancelled, ArrTimeBlk, FlightNum
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DepTime = '25' AND CancellationCode = 'noodles' GROUP BY FlightDate, Year, OriginWac
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestWac = '35' AND Flights = '1' AND LateAircraftDelay = '59' GROUP BY FlightDate, OriginCityMarketID, DestAirportID
-SELECT SUM(DepDel15) FROM myStarTable WHERE Carrier = 'OO' AND DivReachedDest = '0' GROUP BY Carrier, Diverted, CRSDepTime
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DestWac = '74' AND Dest = 'IAH' AND ArrTimeBlk = '1100-1159' GROUP BY Distance, WheelsOn, OriginCityName
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '0' AND CancellationCode = 'noodles' AND CRSArrTime = '2345' GROUP BY DestCityMarketID, AirTime, FirstDepTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID = '19977' AND Quarter = '2' AND CancellationCode = 'noodles' GROUP BY Cancelled, WheelsOn, DestState
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'WN' AND TaxiIn = '38' AND WeatherDelay = '0' GROUP BY SecurityDelay, OriginCityMarketID, DivReachedDest
-SELECT SUM(DepDelay) FROM myStarTable WHERE Month = '6' AND DivAirportLandings = '0' AND NASDelay = '7' GROUP BY FirstDepTime, CRSElapsedTime, CancellationCode
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '3' AND DestAirportSeqID = '1468502' AND DivAirportLandings = '1' GROUP BY DistanceGroup, OriginCityMarketID, FlightNum
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOn = '1400' AND Flights = '1' AND OriginWac = '43' GROUP BY DivActualElapsedTime, WheelsOn, DayofMonth
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1000-1059' AND DestWac = '65' AND DistanceGroup = '6' GROUP BY DestCityMarketID, DestCityName, Distance
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND DivActualElapsedTime = '307' AND UniqueCarrier = 'MQ' GROUP BY CancellationCode, OriginAirportSeqID, WheelsOff
-SELECT SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-11' AND DivAirportLandings = '9' AND Diverted = '0' GROUP BY CRSElapsedTime, OriginCityName, FlightNum
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Quarter = '2' GROUP BY LongestAddGTime, OriginCityMarketID, WheelsOff
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND Flights = '1' AND Year = '2014' GROUP BY OriginStateFips
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginCityName = 'Indianapolis, IN' AND UniqueCarrier = 'US' AND DivAirportLandings = '1' GROUP BY FlightDate, LongestAddGTime, OriginCityName
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID = '32206' AND Diverted = '0' AND DepTimeBlk = '1700-1759' GROUP BY CRSElapsedTime, DestAirportSeqID, FlightNum
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Dest = 'CMX' AND DivReachedDest = '0' AND Quarter = '2' GROUP BY Distance, DepTimeBlk, Month
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE AirTime = '254' GROUP BY Year, OriginCityMarketID, DivAirportLandings
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestStateFips = '12' AND Year = '2014' AND DayOfWeek = '4' GROUP BY LongestAddGTime, DestAirportSeqID, Flights
-SELECT SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk = '2200-2259' AND DivAirportLandings = '9' AND Quarter = '2' GROUP BY DestCityMarketID, OriginStateFips, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DivActualElapsedTime = '438' AND OriginAirportSeqID = '1426202' GROUP BY AirTime, CarrierDelay, DestStateName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Distance = '1027' AND Month = '6' AND Quarter = '2' GROUP BY Cancelled, ActualElapsedTime, OriginAirportID
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode = 'noodles' AND ArrTime = '1500' AND OriginState = 'CT' GROUP BY TailNum, ArrTime, DestAirportID
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn = '7' AND DivReachedDest = '1' AND DistanceGroup = '11' GROUP BY Flights, AirlineID, DistanceGroup
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginWac = '43' AND SecurityDelay = '0' AND Quarter = '2' GROUP BY CancellationCode, DestState, Quarter
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestState = 'NE' AND Cancelled = '0' AND Diverted = '1' GROUP BY DestState, NASDelay, ActualElapsedTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND DivArrDelay = '193' AND DivReachedDest = '1' GROUP BY OriginStateName, FirstDepTime, CRSDepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk = '1600-1659' AND Month = '6' AND CarrierDelay = '46' GROUP BY DepTime
-SELECT SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk = '0900-0959' AND Distance = '575' AND Diverted = '0' GROUP BY FirstDepTime, OriginAirportID, DepTimeBlk
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac = '1' AND DistanceGroup = '1' AND DayOfWeek = '4' GROUP BY OriginAirportID, AirlineID, CarrierDelay
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Quarter = '2' AND FlightDate = '2014-06-03' AND TaxiOut = '28' GROUP BY Diverted, TailNum, DayOfWeek
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestState = 'WY' AND WheelsOn = '2046' AND Flights = '1' GROUP BY DepTimeBlk, ArrTimeBlk, DivActualElapsedTime
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityName = 'Colorado Springs, CO' AND DivAirportLandings = '1' AND Flights = '1' GROUP BY Carrier, Flights, DestAirportSeqID
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '3' AND ArrTimeBlk = '1300-1359' AND DestCityName = 'Dallas/Fort Worth, TX' GROUP BY DestStateName, Diverted, FlightNum
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance = '451' GROUP BY DestCityMarketID, OriginAirportID, CRSArrTime
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay = '7' AND Flights = '1' AND OriginAirportSeqID = '1457002' GROUP BY TaxiIn, DestState, DestCityMarketID
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND DayOfWeek = '4' AND DivAirportLandings = '9' GROUP BY NASDelay, DepTime, CRSDepTime
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE FlightDate = '2014-06-28' AND DivReachedDest = '-9999' AND DestStateName = 'Colorado' GROUP BY DivActualElapsedTime, ActualElapsedTime, CarrierDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND DayOfWeek = '2' AND Dest = 'GNV' GROUP BY DestCityMarketID, AirlineID, DivArrDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestWac = '34' AND Month = '6' GROUP BY FirstDepTime, TaxiOut, DestStateName
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '72' AND Year = '2014' AND FlightDate = '2014-06-09' GROUP BY DestStateFips, Origin, AirTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND DistanceGroup = '1' AND DivAirportLandings = '9' GROUP BY Diverted, TaxiIn, ActualElapsedTime
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTimeBlk = '1000-1059' AND DestState = 'SD' AND DayOfWeek = '5' GROUP BY OriginCityMarketID, DivActualElapsedTime, LongestAddGTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime = '832' GROUP BY LongestAddGTime, TaxiOut, DayofMonth
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateName = 'Florida' AND Quarter = '2' AND DivAirportLandings = '9' GROUP BY LongestAddGTime, DestStateFips, Cancelled
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '1' AND DestWac = '14' AND Year = '2014' GROUP BY DestAirportID, Dest, DestCityName
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE FlightDate = '2014-06-16' AND ActualElapsedTime = '66' AND Quarter = '2' GROUP BY DivAirportLandings, DivActualElapsedTime, DestCityMarketID
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestCityMarketID = '33342' GROUP BY TaxiIn, DayOfWeek, CRSElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay = '0' AND Month = '6' AND CRSArrTime = '1726' GROUP BY DayofMonth, DivReachedDest, DepTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND Distance = '287' AND DivReachedDest = '-9999' GROUP BY TaxiIn, DestState, DepTime
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestStateFips = '17' AND DivReachedDest = '1' AND Flights = '1' GROUP BY OriginStateFips, OriginAirportID, DivDistance
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE LateAircraftDelay = '-9999' AND DayOfWeek = '3' AND Origin = 'GRR' GROUP BY CarrierDelay, DistanceGroup, DayofMonth
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName = 'Arkansas' AND AirlineID = '20304' AND Quarter = '2' GROUP BY TaxiOut, CRSDepTime, DivReachedDest
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'A' AND Flights = '1' AND DepTimeBlk = '0001-0559' GROUP BY DivArrDelay, LateAircraftDelay, SecurityDelay
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'VX' AND CancellationCode = 'A' AND OriginAirportID = '14679' GROUP BY LongestAddGTime, WeatherDelay, Carrier
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Carrier = 'AA' AND TaxiOut = '32' AND ArrTimeBlk = '1000-1059' GROUP BY DestAirportID, Quarter, CarrierDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TaxiOut = '2' AND AirlineID = '19393' AND DestWac = '41' GROUP BY DivArrDelay, CRSDepTime, OriginAirportSeqID
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND FirstDepTime = '1936' AND Month = '6' GROUP BY Distance, Flights, DepTimeBlk
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND AirTime = '176' AND ArrTimeBlk = '1000-1059' GROUP BY DestAirportSeqID, FlightDate, LateAircraftDelay
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DestWac = '43' AND CarrierDelay = '84' AND ArrTimeBlk = '1900-1959' GROUP BY ArrTimeBlk
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = '-9999' AND Origin = 'OAJ' AND Flights = '1' GROUP BY LongestAddGTime, DivArrDelay, Distance
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-06' AND DivReachedDest = '0' AND Flights = '1' GROUP BY Dest, SecurityDelay, OriginCityName
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE FirstDepTime = '2305' AND SecurityDelay = '0' GROUP BY CRSArrTime, Flights, LateAircraftDelay
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '5' AND Cancelled = '0' AND NASDelay = '65' GROUP BY Dest, Quarter, TailNum
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '8' AND Diverted = '0' AND Dest = 'BNA' GROUP BY ArrTimeBlk, Flights, DivAirportLandings
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime = '35' GROUP BY DivReachedDest, DestState, UniqueCarrier
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND AirlineID = '20304' AND DivReachedDest = '1' GROUP BY ActualElapsedTime, DivActualElapsedTime, FirstDepTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest = '0' AND OriginState = 'IL' AND UniqueCarrier = 'AA' GROUP BY Origin, UniqueCarrier, ArrTime
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn = '20' AND DepTimeBlk = '1600-1659' AND DayOfWeek = '5' GROUP BY AirlineID, TotalAddGTime, OriginStateFips
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DivReachedDest = '1' AND OriginWac = '86' AND Month = '6' GROUP BY CarrierDelay, OriginAirportID, OriginState
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY ArrTimeBlk, DistanceGroup, DivReachedDest WHERE DayofMonth = '24' AND NASDelay = '7' AND UniqueCarrier = 'MQ'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY ArrTime, Year, Diverted WHERE WeatherDelay = '24'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY CancellationCode, FirstDepTime, Year WHERE Origin = 'LAX' AND DayofMonth = '22' AND ArrTimeBlk = '0700-0759'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Cancelled, OriginAirportID, UniqueCarrier WHERE DivReachedDest = '0' AND UniqueCarrier = 'EV' AND DepTimeBlk = '1400-1459'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Carrier, DepTimeBlk, Diverted WHERE DistanceGroup = '3' AND DepTimeBlk = '1400-1459' AND DestStateFips = '6'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Carrier, Year, LateAircraftDelay WHERE DepTimeBlk = '1800-1859' AND DayofMonth = '4' AND UniqueCarrier = 'OO'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY CRSArrTime, CancellationCode, Year WHERE LateAircraftDelay = '148' AND UniqueCarrier = 'B6' AND DayOfWeek = '3'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY CRSDepTime, Flights, DayOfWeek WHERE Carrier = 'EV' AND TaxiIn = '20' AND Cancelled = '0'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY CRSElapsedTime, UniqueCarrier, Flights WHERE OriginStateFips = '42' AND DayofMonth = '11' AND Diverted = '0'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, DestCityMarketID, Flights WHERE Carrier = 'EV' AND CancellationCode = 'B' AND Flights = '1'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, TotalAddGTime, SecurityDelay WHERE Cancelled = '0' AND DayOfWeek = '7'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DayOfWeek, DivAirportLandings, OriginStateName WHERE LateAircraftDelay = '14' AND ArrTimeBlk = '2100-2159' AND Flights = '1'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DepTimeBlk, DistanceGroup, FlightDate WHERE ArrTime = '1304'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestAirportID, Quarter, DayofMonth WHERE DestStateName = 'Montana'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestAirportSeqID, AirlineID, Flights WHERE OriginCityMarketID = '31986'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestCityName, DayOfWeek, Month WHERE Diverted = '0' AND ActualElapsedTime = '125' AND OriginStateFips = '48'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestStateFips, FirstDepTime, Flights WHERE SecurityDelay = '-9999' AND DestAirportSeqID = '1345902' AND Month = '6'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestStateFips, TaxiOut, Flights WHERE WeatherDelay = '100'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestStateFips, TotalAddGTime, Cancelled WHERE Month = '6' AND Diverted = '0' AND NASDelay = '134'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestStateName, LateAircraftDelay, Quarter WHERE DestStateName = 'Arizona' AND DayofMonth = '20' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestWac, Flights, Diverted WHERE OriginCityName = 'Dallas/Fort Worth, TX' AND SecurityDelay = '-9999' AND DistanceGroup = '5'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestWac, OriginWac, Diverted WHERE ArrTimeBlk = '1600-1659'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DivArrDelay, Diverted, Quarter WHERE CancellationCode = 'noodles' AND AirlineID = '20409'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DivArrDelay, UniqueCarrier, Month WHERE DestAirportSeqID = '1240203' AND Cancelled = '0' AND DivReachedDest = '0'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY FlightNum, Cancelled, Flights WHERE CancellationCode = 'B'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityMarketID, Cancelled, DepTimeBlk WHERE DestStateFips = '12' AND DestAirportSeqID = '1498603' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityMarketID, DepTimeBlk, Flights WHERE DayOfWeek = '1'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityMarketID, Month, DayofMonth WHERE DestStateName = 'Puerto Rico' AND DivReachedDest = '1' AND Year = '2014'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName, DestState, Diverted WHERE OriginState = 'NE' AND Flights = '1' AND DivReachedDest = '0'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName, DestStateFips, DivReachedDest WHERE DestStateName = 'Montana'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName, DivDistance, Year WHERE WheelsOn = '1658' AND DivAirportLandings = '0' AND Diverted = '0'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Quarter, OriginCityName, SecurityDelay WHERE Flights = '1' AND OriginCityMarketID = '30431' AND DepTimeBlk = '1100-1159'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Flights, Year WHERE DayOfWeek = '4' AND DestWac = '67' AND Year = '2014'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Year, Diverted WHERE Cancelled = '0' AND DestStateName = 'Illinois' AND Diverted = '0'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY TaxiIn, DivDistance, Year WHERE OriginStateName = 'Arkansas' AND DestStateName = 'Illinois' AND DivAirportLandings = '1'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOff, DivReachedDest, Year WHERE CancellationCode = 'noodles' AND DepTime = '945' AND AirlineID = '19393'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, DivAirportLandings, Quarter WHERE Year = '2014' AND Month = '6' AND OriginStateName = 'Kansas'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, DivReachedDest, Year WHERE OriginCityName = 'Nashville, TN' AND AirlineID = '20304' AND Cancelled = '0'
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, Month, SecurityDelay WHERE DestCityName = 'Sun Valley/Hailey/Ketchum, ID'
-SELECT SUM(ArrDel15) FROM myStarTable WHERE AirlineID = '19977' AND OriginAirportSeqID = '1071302' AND DayOfWeek = '2' GROUP BY Flights, CancellationCode, TaxiIn
-SELECT SUM(ArrDel15) FROM myStarTable WHERE AirlineID = '19977' GROUP BY OriginStateFips, DayOfWeek, DistanceGroup
-SELECT SUM(ArrDel15) FROM myStarTable WHERE AirTime = '130' GROUP BY ActualElapsedTime, DepTimeBlk, Month
-SELECT SUM(ArrDel15) FROM myStarTable WHERE ArrTime = '1349' AND Quarter = '2' AND DistanceGroup = '3' GROUP BY OriginCityName, DistanceGroup, Year
-SELECT SUM(ArrDel15) FROM myStarTable WHERE ArrTimeBlk = '1800-1859' AND Dest = 'ELP' AND Year = '2014' GROUP BY AirTime, DepTimeBlk, Quarter
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'A' AND Flights = '1' AND DepTimeBlk = '0001-0559' GROUP BY DivArrDelay, LateAircraftDelay, SecurityDelay
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND DestAirportSeqID = '1025702' AND DistanceGroup = '9' GROUP BY DepTime, SecurityDelay, Month
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Cancelled = '0' AND DivReachedDest = '1' AND DivArrDelay = '312' GROUP BY AirTime, Diverted, Year
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Cancelled = '0' AND Month = '6' AND Diverted = '1' GROUP BY DivDistance, DestState, Year
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Carrier = 'AA' AND Diverted = '1' AND CRSArrTime = '610' GROUP BY ActualElapsedTime, DivAirportLandings, CancellationCode
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Carrier = 'B6' AND DepTimeBlk = '1700-1759' AND TaxiIn = '10' GROUP BY WeatherDelay, DayofMonth, CancellationCode
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay = '7' AND Flights = '1' AND OriginAirportSeqID = '1457002' GROUP BY TaxiIn, DestState, DestCityMarketID
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Carrier = 'MQ' AND DayofMonth = '18' AND Quarter = '2' GROUP BY DayOfWeek, Carrier, DestStateFips
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '25' AND UniqueCarrier = 'EV' AND DestStateFips = '13' GROUP BY OriginWac, SecurityDelay, Diverted
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '2' AND ArrTimeBlk = '1800-1859' AND Diverted = '1' GROUP BY OriginAirportSeqID, Carrier, Quarter
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '2' AND Quarter = '2' AND DestCityMarketID = '32206' GROUP BY OriginStateName, WeatherDelay, Flights
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '6' AND DistanceGroup = '1' AND OriginState = 'MO' GROUP BY Origin, DivReachedDest, DistanceGroup
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '1300-1359' AND ArrTimeBlk = '1400-1459' AND CancellationCode = 'A' GROUP BY DayOfWeek, SecurityDelay, DayofMonth
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '1500-1559' AND DivReachedDest = '1' AND FlightNum = '382' GROUP BY DestCityName, Flights, DistanceGroup
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID = '1343302' GROUP BY TotalAddGTime, Year, CarrierDelay
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestStateName = 'Utah' AND Month = '6' AND WheelsOn = '1313' GROUP BY CancellationCode, CRSArrTime, Cancelled
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestState = 'OH' AND UniqueCarrier = 'MQ' AND OriginStateName = 'Texas' GROUP BY TaxiIn, ArrTimeBlk, Year
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DivDistance = '104' AND Flights = '1' AND Month = '6' GROUP BY DestStateName, DivReachedDest, Flights
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Diverted = '0' AND DayOfWeek = '4' AND DestState = 'LA' GROUP BY DestCityName, ArrTimeBlk, Flights
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Diverted = '1' AND OriginStateFips = '45' AND CancellationCode = 'noodles' GROUP BY DepTimeBlk, DestStateFips, Month
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DivReachedDest = '1' GROUP BY FlightNum, Month, Year
-SELECT SUM(ArrDel15) FROM myStarTable  WHERE DivReachedDest = '-9999' AND FlightDate = '2014-06-30' AND Flights = '1'
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND Month = '6' AND UniqueCarrier = 'DL' GROUP BY Dest, FlightDate, Month
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Month = '6' AND DayofMonth = '16' AND OriginState = 'ME' GROUP BY DestStateName, Quarter, OriginStateFips
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Month = '6' GROUP BY TaxiIn, OriginWac, Month
-SELECT SUM(ArrDel15) FROM myStarTable WHERE NASDelay = '15' AND Year = '2014' AND CarrierDelay = '40' GROUP BY Cancelled, Dest, Diverted
-SELECT SUM(ArrDel15) FROM myStarTable WHERE NASDelay = '44' GROUP BY CRSArrTime, SecurityDelay, Flights
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginState = 'KS' AND ArrTimeBlk = '1800-1859' AND DivReachedDest = '-9999' GROUP BY Carrier, OriginAirportID, Cancelled
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Maryland' AND ActualElapsedTime = '300' AND Flights = '1' GROUP BY Origin, DistanceGroup, DivReachedDest
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND AirlineID = '19805' AND WeatherDelay = '18' GROUP BY DestStateFips, WeatherDelay, Month
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND Diverted = '1' AND DestWac = '39' GROUP BY NASDelay, SecurityDelay, TailNum
-SELECT SUM(ArrDel15) FROM myStarTable WHERE SecurityDelay = '-9999' AND Flights = '1' AND Diverted = '0' GROUP BY DivActualElapsedTime, Year, Diverted
-SELECT SUM(ArrDel15) FROM myStarTable WHERE TailNum = 'N750AT' GROUP BY AirTime, ArrTimeBlk, Flights
-SELECT SUM(ArrDel15) FROM myStarTable WHERE TaxiIn = '3' AND NASDelay = '72' AND Diverted = '0' GROUP BY LateAircraftDelay, DepTimeBlk, Cancelled
-SELECT SUM(ArrDel15) FROM myStarTable WHERE TaxiOut = '30' AND Diverted = '0' AND OriginWac = '91' GROUP BY CarrierDelay, DestStateName, Flights
-SELECT SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'EV' AND Origin = 'GSO' AND DivAirportLandings = '0' GROUP BY OriginAirportSeqID, DepTimeBlk, Month
-SELECT SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'F9' GROUP BY OriginAirportID, Carrier, Flights
-SELECT SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'FL' GROUP BY ArrTime, DivReachedDest, Quarter
-SELECT SUM(ArrDel15) FROM myStarTable WHERE WheelsOff = '1030' AND OriginState = 'NY' GROUP BY CarrierDelay, DestStateFips, Quarter
-SELECT SUM(ArrDel15) FROM myStarTable WHERE WheelsOff = '1814' AND Cancelled = '0' AND UniqueCarrier = 'OO' GROUP BY OriginWac, DestState, Year
-SELECT SUM(ArrDel15) FROM myStarTable WHERE WheelsOn = '2004' AND ArrTimeBlk = '1800-1859' AND DivReachedDest = '-9999' GROUP BY CarrierDelay, Carrier, Flights
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateName, DestStateFips, Quarter WHERE Diverted = '0' AND DestAirportSeqID = '1072102' AND Year = '2014'
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestState, OriginStateName, Quarter WHERE DayOfWeek = '7' AND LateAircraftDelay = '84' AND DistanceGroup = '5'
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY OriginStateName, DistanceGroup, UniqueCarrier WHERE Cancelled = '0' AND Year = '2014' AND FlightNum = '2932'
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOn, SecurityDelay, Month WHERE Diverted = '0'
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '9' AND Flights = '1' AND TotalAddGTime = '22' GROUP BY DivActualElapsedTime, Year, Month
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE FlightNum = '4214' AND DepTimeBlk = '0700-0759' GROUP BY DestCityMarketID, DivReachedDest, Month
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND DistanceGroup = '4' AND FlightDate = '2014-06-13' GROUP BY CRSArrTime, Quarter, CancellationCode
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff = '1557' AND DestStateFips = '48' AND Diverted = '0' GROUP BY OriginAirportSeqID, ArrTimeBlk, Quarter
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightNum, Quarter, Year WHERE Month = '6' AND OriginState = 'AZ' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CarrierDelay = '88' GROUP BY CarrierDelay, DistanceGroup, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '351' AND UniqueCarrier = 'US' AND TaxiOut = '29' GROUP BY WeatherDelay, Carrier, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND CRSElapsedTime = '152' AND LateAircraftDelay = '15' GROUP BY WheelsOn, Diverted, Year
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginState = 'AZ' GROUP BY DivDistance, OriginStateFips
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DepTimeBlk = '2200-2259' AND Month = '6' GROUP BY ArrTime, Diverted, Year
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestCityName = 'Myrtle Beach, SC' GROUP BY OriginCityName, DepTimeBlk, Month
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ActualElapsedTime = '275' AND Quarter = '2' AND ArrTimeBlk = '1800-1859' GROUP BY OriginStateFips, LongestAddGTime, CancellationCode
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, NASDelay, Month WHERE DepTimeBlk = '1400-1459'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1800-1859' AND TailNum = 'N21130' AND Flights = '1' GROUP BY OriginStateName, NASDelay, Month
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DistanceGroup, FlightDate, Carrier WHERE Diverted = '0' AND OriginState = 'MI' AND DivAirportLandings = '0'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Year, Dest, Diverted WHERE DistanceGroup = '10' AND Flights = '1' AND Carrier = 'AA'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateFips, DestWac, Year WHERE DivAirportLandings = '0' AND DestState = 'IL' AND CancellationCode = 'C'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime, DayOfWeek, Quarter WHERE DepTimeBlk = '2200-2259' AND DestStateName = 'Puerto Rico'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay, DistanceGroup, Cancelled WHERE Quarter = '2' AND WheelsOff = '2254' AND Month = '6'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TaxiIn = '42' AND DivReachedDest = '1' AND Month = '6' GROUP BY FlightDate, TotalAddGTime, DivAirportLandings
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOff, CancellationCode, Month WHERE Cancelled = '0' AND DayOfWeek = '2' AND AirlineID = '21171'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE SecurityDelay = '-9999' AND Cancelled = '0' AND DistanceGroup = '5' GROUP BY TaxiOut
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND DayofMonth = '8' AND ArrTimeBlk = '0700-0759' GROUP BY OriginAirportSeqID, Diverted, CancellationCode
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Carrier, OriginAirportSeqID WHERE Carrier = 'B6' AND TotalAddGTime = '13' AND DivAirportLandings = '0'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DivActualElapsedTime = '181' GROUP BY CRSArrTime, Diverted, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportSeqID, FlightDate, Year WHERE ArrTimeBlk = '0700-0759' AND Year = '2014' AND DestStateFips = '27'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month = '6' AND Origin = 'TYR' GROUP BY TotalAddGTime, Quarter, FlightDate
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime, Year, DestState WHERE DistanceGroup = '9' AND Cancelled = '1' AND DestState = 'AZ'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest = '-9999' AND DestStateName = 'Kentucky' AND ArrTimeBlk = '2300-2359' GROUP BY DayofMonth, DestAirportSeqID, Month
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY WheelsOn, Cancelled, Diverted WHERE Carrier = 'EV'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE CarrierDelay = '31' AND DestState = 'CO' AND ArrTimeBlk = '2000-2059' GROUP BY OriginCityMarketID, ArrTimeBlk, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup = '9' GROUP BY TaxiOut, DestState, Year
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND WeatherDelay = '65' AND DestAirportID = '15919' GROUP BY OriginCityMarketID, DivReachedDest
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, DepTimeBlk, Flights WHERE Year = '2014' AND DivArrDelay = '149' AND DayOfWeek = '4'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestState, OriginWac, Month WHERE Cancelled = '0' AND Month = '6' AND DivAirportLandings = '0'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY ArrTime, Diverted, Quarter WHERE DivAirportLandings = '0' AND Cancelled = '0' AND Dest = 'ATW'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Quarter, CancellationCode, OriginCityName WHERE Flights = '1' AND DayOfWeek = '1' AND AirlineID = '19393'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '1' AND DestState = 'NM' AND Cancelled = '0' GROUP BY FirstDepTime, DepTimeBlk, Year
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestAirportSeqID = '1104103' AND DayofMonth = '7' AND Year = '2014' GROUP BY DepTime, DivReachedDest, Month
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup = '7' GROUP BY WeatherDelay, Flights, LongestAddGTime
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Month = '6' AND OriginState = 'SD' AND DayOfWeek = '4' GROUP BY WheelsOff, Cancelled, Month
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips = '8' AND DayOfWeek = '7' AND OriginState = 'MD' GROUP BY CarrierDelay, UniqueCarrier, Quarter
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DistanceGroup = '4' AND ArrTime = '1000' AND Year = '2014' GROUP BY TaxiIn, Quarter, Carrier
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND CRSArrTime = '914' AND CancellationCode = 'noodles' GROUP BY Quarter, OriginAirportID, ArrTimeBlk
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND DivReachedDest = '0' AND Origin = 'LAX' GROUP BY WheelsOn, Quarter, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DepTimeBlk, Quarter, Month WHERE FlightDate = '2014-06-12'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND Dest = 'RIC' AND DivAirportLandings = '1' GROUP BY SecurityDelay, FirstDepTime, DayOfWeek
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, DivReachedDest, Year WHERE OriginCityName = 'La Crosse, WI'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestState = 'LA' AND Carrier = 'WN' AND DistanceGroup = '5' GROUP BY Quarter, AirlineID, DivArrDelay
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk = '1400-1459' AND DistanceGroup = '4' AND OriginAirportID = '11259' GROUP BY DayOfWeek, FirstDepTime, SecurityDelay
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirTime = '160' GROUP BY DepTime, Diverted, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '2' AND Flights = '1' AND Cancelled = '0' GROUP BY CRSElapsedTime, Flights, UniqueCarrier
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '0' AND Carrier = 'B6' AND DestCityMarketID = '30299' GROUP BY AirlineID, Dest, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND OriginCityName = 'Fayetteville, AR' AND DestStateFips = '8' GROUP BY CRSArrTime, Flights, DayOfWeek
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, DivReachedDest, Cancelled WHERE FlightDate = '2014-06-17' AND DayOfWeek = '2' AND OriginState = 'VI'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivDistance WHERE DivAirportLandings = '0' AND Diverted = '0' AND DayofMonth = '5'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' AND DayOfWeek = '6' AND ArrTime = '2340' GROUP BY WeatherDelay, OriginStateFips, Year
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND Cancelled = '1' AND UniqueCarrier = 'FL' GROUP BY DistanceGroup, UniqueCarrier, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Diverted = '0' AND Carrier = 'DL' AND Cancelled = '1' GROUP BY FirstDepTime, DivAirportLandings, DayOfWeek
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayofMonth = '19' AND DestState = 'NV' AND CancellationCode = 'A' GROUP BY CRSArrTime, Cancelled, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginState = 'SC' AND Diverted = '1' AND DayOfWeek = '7' GROUP BY ActualElapsedTime, DivAirportLandings, Year
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTime, Year, DivReachedDest WHERE DestStateFips = '26' AND Flights = '1' AND WheelsOff = '634'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '2000-2059' AND DestWac = '21' GROUP BY LongestAddGTime, OriginWac, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName, Month, SecurityDelay WHERE DestCityMarketID = '31703' AND LongestAddGTime = '29' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'WN' AND TaxiIn = '38' AND WeatherDelay = '0' GROUP BY SecurityDelay, OriginCityMarketID, DivReachedDest
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSArrTime, DivAirportLandings, Cancelled WHERE Quarter = '2' AND DestWac = '85' AND OriginState = 'CT'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LateAircraftDelay, DepTimeBlk, Quarter WHERE CarrierDelay = '83' AND Month = '6' AND ArrTimeBlk = '1300-1359'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime = '266' GROUP BY SecurityDelay, DestAirportSeqID, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate = '2014-06-26' GROUP BY NASDelay, LongestAddGTime, Month
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DepTimeBlk, Month, OriginState WHERE DestCityMarketID = '30529' AND DivReachedDest = '1' AND CRSArrTime = '1340'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Diverted = '0' AND AirlineID = '20366' AND DestCityName = 'Albany, NY' GROUP BY Dest, DivAirportLandings, DayOfWeek
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY NASDelay, Month, Flights WHERE Month = '6' AND DistanceGroup = '6' AND SecurityDelay = '0'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DistanceGroup, DivAirportLandings, LateAircraftDelay WHERE Year = '2014' AND CancellationCode = 'B' AND ArrTimeBlk = '2000-2059'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' AND Month = '6' AND AirlineID = '20304' GROUP BY WheelsOn, SecurityDelay, Month
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TailNum, Month, Diverted WHERE Month = '6' AND DepTime = '634'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY TailNum, Quarter, Cancelled WHERE DepTimeBlk = '1900-1959' AND DayOfWeek = '1' AND OriginAirportID = '14107'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestStateName = 'New Jersey' AND Quarter = '2' AND CRSElapsedTime = '123' GROUP BY TailNum, Month, Flights
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier = 'HA' GROUP BY DestAirportSeqID, UniqueCarrier, Month
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, Year, DivReachedDest WHERE DivAirportLandings = '2' AND DivReachedDest = '1' AND SecurityDelay = '-9999'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTime, Flights, DivAirportLandings WHERE Flights = '1' AND LateAircraftDelay = '97' AND OriginAirportID = '11298'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND CRSArrTime = '1610' AND UniqueCarrier = 'MQ' GROUP BY WheelsOn, Diverted, Month
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, CancellationCode, UniqueCarrier WHERE OriginStateFips = '17' AND DestAirportSeqID = '1329002' AND DayOfWeek = '1'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Diverted = '1' AND DestWac = '34' AND Flights = '1' GROUP BY OriginAirportID, Diverted, DistanceGroup
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestCityMarketID, UniqueCarrier, Quarter WHERE DayOfWeek = '3' AND LongestAddGTime = '-9999' AND AirlineID = '20436'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID = '1402702' GROUP BY Flights, Year, DestCityName
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID WHERE Diverted = '1' AND DayofMonth = '1' AND TaxiIn = '51'
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTime = '1759' GROUP BY DestWac
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND DivAirportLandings = '1' AND Quarter = '2' GROUP BY Dest, SecurityDelay, Flights
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '0' AND CancellationCode = 'noodles' AND DestAirportID = '13296' GROUP BY ActualElapsedTime, Flights, UniqueCarrier
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Diverted = '1' AND WheelsOn = '321' AND Year = '2014' GROUP BY TailNum, TaxiIn, DivActualElapsedTime
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY ActualElapsedTime, DistanceGroup, Flights WHERE Quarter = '2' AND TaxiIn = '18' AND DivReachedDest = '1'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND DivAirportLandings = '0' AND DestWac = '85' GROUP BY Year
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateFips = '27' GROUP BY FlightDate, OriginStateFips, Month
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND DayofMonth = '11' AND DepTimeBlk = '1800-1859' GROUP BY DistanceGroup, OriginCityMarketID, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Diverted = '0' AND LateAircraftDelay = '74' GROUP BY OriginState, DayofMonth, DivAirportLandings
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOff = '1820' AND CRSElapsedTime = '118' AND Flights = '1' GROUP BY Distance, Quarter, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestCityName = 'Springfield, IL' AND TaxiOut = '22' AND Year = '2014' GROUP BY TotalAddGTime, DistanceGroup, Quarter
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND DayofMonth = '15' AND Year = '2014' GROUP BY OriginAirportSeqID, ArrTimeBlk, Flights
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOff, DivReachedDest, Month WHERE Cancelled = '0' AND DestCityMarketID = '31140' AND DayOfWeek = '3'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'EV' AND DepTime = '749' AND ArrTimeBlk = '1000-1059' GROUP BY DestAirportID, DivReachedDest, DayOfWeek
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportID = '13367' AND ArrTimeBlk = '1000-1059' AND Cancelled = '1' GROUP BY WeatherDelay, FirstDepTime, Quarter
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND DepTimeBlk = '1000-1059' AND DivReachedDest = '1' GROUP BY DestState, NASDelay
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier = 'US' AND Flights = '1' AND DayofMonth = '15' GROUP BY SecurityDelay, NASDelay, Month
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Distance, DivAirportLandings, Flights WHERE OriginWac = '91' AND ActualElapsedTime = '300' AND UniqueCarrier = 'DL'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, Diverted, Origin WHERE TaxiIn = '22' AND ArrTimeBlk = '1600-1659' AND Carrier = 'MQ'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips = '20' AND CancellationCode = 'noodles' AND Year = '2014' GROUP BY LateAircraftDelay, Year, DestStateName
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY AirlineID, Year, DestCityName WHERE DayOfWeek = '1' AND DestStateName = 'Massachusetts' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestState = 'SD' GROUP BY OriginStateFips, Flights, UniqueCarrier
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE FirstDepTime = '607' GROUP BY Cancelled, OriginAirportSeqID, Quarter
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, DestAirportID, DistanceGroup WHERE Quarter = '2' AND OriginStateName = 'Alaska' AND DayofMonth = '9'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY CarrierDelay, DayOfWeek, CancellationCode WHERE Year = '2014' AND Carrier = 'UA' AND AirTime = '327'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '11' GROUP BY CarrierDelay, AirlineID, Month
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY CarrierDelay, OriginStateName, Month WHERE DayofMonth = '7' AND CRSDepTime = '1319' AND OriginAirportID = '15016'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DestStateFips, DayofMonth, Year WHERE ArrTimeBlk = '1200-1259' AND DestState = 'MT' AND Month = '6'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-22' AND ArrTimeBlk = '0700-0759' GROUP BY LateAircraftDelay, DistanceGroup, Flights
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, Year, SecurityDelay WHERE ActualElapsedTime = '351' AND OriginWac = '91' AND Carrier = 'AA'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, FirstDepTime, Month WHERE Diverted = '1' AND SecurityDelay = '-9999' AND ArrTime = '849'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivActualElapsedTime = '348' AND DayofMonth = '10' AND Flights = '1' GROUP BY DestCityMarketID, DayOfWeek, Diverted
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE AirlineID = '20398' AND CancellationCode = 'C' AND OriginStateName = 'Ohio' GROUP BY DistanceGroup, TaxiIn, Cancelled
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DestAirportID = '14108' AND DayOfWeek = '6' GROUP BY Carrier, DestAirportSeqID, OriginCityMarketID
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE CancellationCode = 'noodles' AND DestAirportSeqID = '1033302' AND SecurityDelay = '-9999' GROUP BY DivAirportLandings, TaxiIn, CancellationCode
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, FirstDepTime, DivAirportLandings WHERE DestStateFips = '39' AND Flights = '1' AND OriginStateName = 'South Carolina'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, ArrTimeBlk, Month WHERE Cancelled = '1' AND Carrier = 'AA' AND Month = '6'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivDistance, Year, Quarter WHERE DistanceGroup = '5' AND DepTime = '903' AND DayOfWeek = '1'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND Diverted = '0' AND TaxiIn = '24' GROUP BY OriginCityName, DayofMonth, Month
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DayofMonth = '6' AND DepTimeBlk = '1300-1359' AND DestWac = '72' GROUP BY Origin, DayofMonth, Month
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, LongestAddGTime, DivAirportLandings WHERE DepTimeBlk = '0800-0859'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestWac, WeatherDelay, Flights WHERE CRSDepTime = '809' AND Flights = '1' AND Diverted = '0'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND Diverted = '0' AND DestAirportID = '11721' GROUP BY TotalAddGTime, NASDelay, Year
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier = 'B6' AND DistanceGroup = '4' AND Flights = '1' GROUP BY SecurityDelay, WheelsOn, Flights
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayofMonth = '5' AND DestStateName = 'Tennessee' AND AirlineID = '19790' GROUP BY ArrTime, SecurityDelay, Quarter
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' AND Month = '6' AND UniqueCarrier = 'AA' GROUP BY NASDelay, Diverted, DepTimeBlk
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayofMonth = '6' AND Cancelled = '1' AND DestWac = '82' GROUP BY CRSDepTime, Flights, CancellationCode
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1400-1459' AND OriginStateFips = '32' AND Cancelled = '1' GROUP BY CRSArrTime, DivReachedDest, Quarter
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable  WHERE DayOfWeek = '5' AND DivReachedDest = '-9999' AND Distance = '1990'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY OriginState, Flights, TotalAddGTime WHERE UniqueCarrier = 'UA' AND ArrTimeBlk = '1400-1459' AND CancellationCode = 'noodles'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' AND DistanceGroup = '7' AND Quarter = '2' GROUP BY TailNum, Cancelled, Year
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DepTimeBlk, Quarter, OriginAirportID WHERE Flights = '1' AND DestState = 'GA' AND Diverted = '1'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityName = 'Dickinson, ND' AND SecurityDelay = '-9999' AND DistanceGroup = '2' GROUP BY Year, TailNum, Diverted
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTime, CancellationCode, Quarter WHERE AirlineID = '20436' AND DayOfWeek = '3' AND OriginStateName = 'Arkansas'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateName, Month, DistanceGroup WHERE Diverted = '0' AND OriginCityMarketID = '33076' AND Year = '2014'
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime = '70' AND Month = '6' AND CancellationCode = 'C' GROUP BY TaxiOut, Month, DivReachedDest
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Carrier, OriginWac, Quarter WHERE DivArrDelay = '252' AND Year = '2014' AND DivReachedDest = '1'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FlightNum, Year, Diverted WHERE OriginWac = '85' AND DistanceGroup = '6' AND ActualElapsedTime = '188'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Origin, DepTimeBlk, Quarter WHERE ArrTimeBlk = '1100-1159' AND DepTime = '1157' AND TotalAddGTime = '-9999'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOn, Cancelled, Diverted WHERE DivAirportLandings = '1'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '1' AND DestWac = '14' AND Year = '2014' GROUP BY DestAirportID, Dest, DestCityName
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestState = 'IA' GROUP BY SecurityDelay, DestAirportSeqID
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings = '2' AND DayOfWeek = '3' AND DivReachedDest = '0' GROUP BY Carrier, DestAirportID, Month
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest = '1' AND DestCityMarketID = '34524' GROUP BY FlightDate, OriginAirportSeqID, Quarter
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime = '36' GROUP BY Month, DayOfWeek, DestState
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY CRSDepTime, Cancelled, Flights WHERE DepTime = '755' AND ArrTime = '1008' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Cancelled, ActualElapsedTime, DivReachedDest WHERE Year = '2014' AND OriginState = 'NC' AND ActualElapsedTime = '50'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestState, DivDistance, Month WHERE SecurityDelay = '-9999' AND Year = '2014' AND OriginCityMarketID = '34254'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY FlightDate, Dest, Month WHERE Cancelled = '1' AND DestState = 'HI'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND OriginAirportSeqID = '1302902' AND TaxiIn = '3' GROUP BY TaxiOut, LongestAddGTime, Flights
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginCityName = 'New Bern/Morehead/Beaufort, NC' AND Year = '2014' AND DayOfWeek = '2' GROUP BY DistanceGroup, DayOfWeek, Flights
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND TaxiOut = '88' AND DepTimeBlk = '1800-1859' GROUP BY DestAirportID, DistanceGroup, Cancelled
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, FlightDate, Month WHERE Year = '2014' AND Cancelled = '0' AND ArrTimeBlk = '2200-2259'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Flights, Quarter, DayOfWeek WHERE DestCityMarketID = '34321'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips = '12' GROUP BY DivReachedDest, DestStateName, UniqueCarrier
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TaxiIn, DepTimeBlk, CancellationCode WHERE Flights = '1' AND Month = '6' AND TailNum = 'N270WN'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DivDistance = '174' AND Diverted = '1' AND ArrTimeBlk = '1300-1359' GROUP BY CancellationCode, DestAirportID, Year
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY Cancelled, Origin, Quarter WHERE Year = '2014' AND LongestAddGTime = '85' AND AirlineID = '20398'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, DistanceGroup, Carrier WHERE OriginStateFips = '56'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY SecurityDelay, ArrTimeBlk, DestStateFips WHERE DepTimeBlk = '1000-1059' AND DayofMonth = '27' AND DestStateName = 'North Dakota'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Dest = 'SHV' GROUP BY DivReachedDest, SecurityDelay, DestCityMarketID
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY SecurityDelay, Carrier, UniqueCarrier WHERE Quarter = '2' AND ActualElapsedTime = '50' AND AirlineID = '20409'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY FlightDate, OriginCityName, Year WHERE Flights = '1' AND Year = '2014' AND ActualElapsedTime = '53'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, DivAirportLandings, SecurityDelay WHERE DestAirportSeqID = '1430702' AND DivAirportLandings = '0' AND Cancelled = '0'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, DepTimeBlk, FirstDepTime WHERE AirTime = '241' AND DivReachedDest = '-9999' AND DayOfWeek = '7'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Quarter = '2' AND FlightDate = '2014-06-03' AND TaxiOut = '28' GROUP BY Diverted, TailNum, DayOfWeek
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Quarter = '2' GROUP BY LongestAddGTime, OriginCityMarketID, WheelsOff
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '1' GROUP BY DepTimeBlk, Origin, Flights
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month = '6' AND DayofMonth = '24' AND CRSElapsedTime = '132' GROUP BY DestState, TaxiOut, Month
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime = '22' AND Year = '2014' AND Quarter = '2' GROUP BY CRSArrTime, Flights, DivReachedDest
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '0' GROUP BY CancellationCode, LongestAddGTime, DepTimeBlk
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TaxiOut = '25' AND NASDelay = '-9999' AND DivAirportLandings = '1' GROUP BY Quarter, DayofMonth, SecurityDelay
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestState = 'WI' AND Cancelled = '0' AND DepTimeBlk = '2200-2259' GROUP BY Carrier, OriginState, Cancelled
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiIn, DestStateName, Year WHERE DepTime = '1156' AND DestStateFips = '20' AND Year = '2014'
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month = '6' AND DestStateFips = '33' AND UniqueCarrier = 'EV' GROUP BY CRSArrTime, Month, Quarter
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY ArrTimeBlk, CarrierDelay, Year WHERE DivAirportLandings = '0' AND DayOfWeek = '6' AND DayofMonth = '8'
-SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Origin, DivReachedDest, DivAirportLandings WHERE Quarter = '2' AND DestAirportSeqID = '1143302' AND DayofMonth = '17'
-SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DivArrDelay = '218' AND ArrTimeBlk = '1900-1959' AND Diverted = '1' GROUP BY OriginCityMarketID, Month, DayOfWeek
-SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime = '44' AND Quarter = '2' GROUP BY OriginAirportID, FlightDate, Month
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY Distance, Cancelled, Diverted WHERE DestCityName = 'St. George, UT' AND Month = '6'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, DistanceGroup, Year WHERE OriginStateName = 'California' AND TailNum = 'N3KEAA' AND DivAirportLandings = '0'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND SecurityDelay = '0' AND DestCityMarketID = '30747' GROUP BY OriginAirportID, AirlineID, Cancelled
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND Flights = '1' AND OriginAirportID = '11884' GROUP BY DivAirportLandings, DayOfWeek, OriginState
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DestWac, DayofMonth, Cancelled WHERE LateAircraftDelay = '133'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivReachedDest, DayofMonth, FirstDepTime WHERE Quarter = '2' AND OriginWac = '86' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayOfWeek, WeatherDelay, Quarter WHERE AirTime = '282' AND DestStateFips = '32' AND DestStateName = 'Nevada'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay = '-9999' AND WheelsOff = '1749' AND DistanceGroup = '5' GROUP BY ArrTime, Cancelled, Flights
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, DayofMonth, Year WHERE DestAirportID = '10994'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND OriginState = 'RI' AND DepTimeBlk = '0700-0759' GROUP BY WheelsOn, SecurityDelay, Year
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk = '0600-0659' AND DivAirportLandings = '9' AND Cancelled = '1' GROUP BY WeatherDelay, SecurityDelay, Month
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, Flights, Year WHERE DistanceGroup = '4' AND WheelsOn = '1504' AND DayOfWeek = '1'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DestState = 'OH' AND OriginState = 'VA' GROUP BY TailNum, Month, Flights
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSDepTime, Cancelled, Diverted WHERE Quarter = '2' AND DayOfWeek = '1' AND CRSDepTime = '1238'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND DepTimeBlk = '1900-1959' AND DivAirportLandings = '9' GROUP BY DivArrDelay, DepTimeBlk, Month
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '3' AND Year = '2014' AND ArrTime = '1105' GROUP BY Cancelled, DivArrDelay, DayOfWeek
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime = '292' GROUP BY Flights, TaxiIn, DepTimeBlk
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Quarter, WheelsOff, Cancelled WHERE Diverted = '0' AND OriginAirportID = '13244' AND ArrTimeBlk = '1600-1659'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivAirportLandings, DivDistance, Carrier WHERE DayOfWeek = '1' AND WheelsOff = '1452' AND DivReachedDest = '1'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, LongestAddGTime, Month WHERE DistanceGroup = '3' AND TotalAddGTime = '20' AND DayofMonth = '8'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, Flights, DepTimeBlk WHERE DayOfWeek = '3' AND Year = '2014'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY OriginStateName, Carrier, Year WHERE Diverted = '0' AND Quarter = '2' AND OriginAirportID = '11122'
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Distance = '970' GROUP BY Flights, WheelsOff, Year
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '3' GROUP BY DivActualElapsedTime, Flights, AirlineID
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateName = 'Ohio' GROUP BY OriginAirportID, Year, Cancelled
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY Cancelled, DepTime, Year WHERE DayOfWeek = '4' AND DayofMonth = '28' AND Diverted = '0'
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY DayOfWeek, CRSElapsedTime, Flights WHERE Origin = 'PNS' AND DayofMonth = '24'
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE ActualElapsedTime = '299' AND DepTimeBlk = '0800-0859' AND AirlineID = '19977' GROUP BY OriginAirportSeqID, DivReachedDest, Quarter
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE FlightDate = '2014-06-16' AND ActualElapsedTime = '66' AND Quarter = '2' GROUP BY DivAirportLandings, DivActualElapsedTime, DestCityMarketID
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND Cancelled = '0' AND UniqueCarrier = 'OO' GROUP BY OriginAirportSeqID, DestAirportSeqID, OriginStateName
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateFips, FirstDepTime, Cancelled WHERE FlightDate = '2014-06-15' AND DepTimeBlk = '1500-1559' AND SecurityDelay = '-9999'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, NASDelay, Flights WHERE DayOfWeek = '5' AND Dest = 'STT' AND SecurityDelay = '-9999'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportSeqID = '1289605' GROUP BY TaxiIn, TaxiOut
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportSeqID = '1389101' AND Cancelled = '0' AND DivAirportLandings = '1' GROUP BY OriginAirportID, AirlineID, Diverted
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '65' AND Cancelled = '1' AND DivReachedDest = '-9999' GROUP BY OriginAirportID, DepTimeBlk, Quarter
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '0' AND Flights = '1' AND Distance = '2342' GROUP BY OriginStateFips, DivAirportLandings, SecurityDelay
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND DivArrDelay = '125' AND DayOfWeek = '7' GROUP BY OriginWac, DestState, Cancelled
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND OriginAirportSeqID = '1410702' AND DestWac = '43' GROUP BY AirTime, Quarter, DivReachedDest
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn = '44' GROUP BY OriginStateFips, Year, Diverted
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DepTime = '25' AND CancellationCode = 'noodles' GROUP BY FlightDate, Year, OriginWac
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '1' AND DestStateFips = '78' AND OriginStateName = 'North Carolina' GROUP BY TailNum, Cancelled, Quarter
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Distance, Quarter, DivAirportLandings WHERE UniqueCarrier = 'F9' AND Year = '2014' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek, Origin, Diverted WHERE ArrTimeBlk = '2200-2259' AND Quarter = '2' AND CancellationCode = 'C'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime = '2229' GROUP BY DestStateName, TaxiIn, Diverted
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '1' AND Month = '6' AND ArrTimeBlk = '1800-1859' GROUP BY Diverted, Origin, Carrier
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, UniqueCarrier, Year WHERE Year = '2014' AND DepTimeBlk = '1900-1959' AND DestStateName = 'Iowa'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE ArrTime = '2220' AND DestState = 'TX' AND Year = '2014' GROUP BY DestState, CancellationCode, DayOfWeek
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '1' AND Month = '6' AND OriginState = 'NM' GROUP BY DepTimeBlk, Dest, Year
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName = 'Alaska' AND Year = '2014' AND Carrier = 'AA' GROUP BY OriginStateName, CarrierDelay, Flights
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, ArrTimeBlk, DayOfWeek WHERE DistanceGroup = '4' AND DepTime = '838' AND AirlineID = '20436'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityMarketID, FlightDate, Year WHERE TaxiOut = '54' AND DayOfWeek = '1' AND DivReachedDest = '1'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestWac = '35' AND Flights = '1' AND LateAircraftDelay = '59' GROUP BY FlightDate, OriginCityMarketID, DestAirportID
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE AirlineID = '20366' AND ArrTimeBlk = '0900-0959' AND OriginCityMarketID = '33851' GROUP BY DestAirportID, DepTimeBlk, Flights
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Cancelled, ActualElapsedTime, Month WHERE Cancelled = '0' AND OriginState = 'TT' AND Year = '2014'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportID, Cancelled, Diverted WHERE CRSArrTime = '1108' AND UniqueCarrier = 'AS' AND TaxiIn = '6'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay, Year, AirlineID WHERE DepTimeBlk = '1000-1059' AND DistanceGroup = '2' AND FlightDate = '2014-06-18'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID WHERE CRSDepTime = '1446'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, Year, Flights WHERE DistanceGroup = '7'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityName = 'Williston, ND' AND DistanceGroup = '6' AND DepTimeBlk = '0900-0959' GROUP BY SecurityDelay, DivArrDelay, Quarter
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND Year = '2014' AND OriginAirportID = '10721' GROUP BY WheelsOff, DivAirportLandings, Quarter
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND AirlineID = '20366' GROUP BY Month, OriginState, SecurityDelay
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Cancelled = '0' AND Quarter = '2' AND DestAirportID = '13360' GROUP BY OriginStateName, Diverted, DepTimeBlk
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, Quarter, DivAirportLandings WHERE DivReachedDest = '-9999' AND DestWac = '12' AND Quarter = '2'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID = '35249' AND AirlineID = '19790' AND Cancelled = '0' GROUP BY OriginAirportSeqID, Flights, DivAirportLandings
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' GROUP BY TaxiIn, DayofMonth, Flights
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Dest, SecurityDelay WHERE ArrTimeBlk = '2000-2059' AND TaxiIn = '5' AND CarrierDelay = '21'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY SecurityDelay, DepTimeBlk, FlightDate WHERE Diverted = '1' AND OriginWac = '82' AND DestWac = '13'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestCityName, UniqueCarrier, Diverted WHERE OriginAirportID = '12519' AND DayofMonth = '21' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, DistanceGroup, Month WHERE DivReachedDest = '-9999' AND CRSArrTime = '1603' AND CancellationCode = 'noodles'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '314' AND Month = '6' AND Year = '2014' GROUP BY ActualElapsedTime, SecurityDelay, Year
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Quarter = '2' AND UniqueCarrier = 'MQ' AND OriginState = 'WI' GROUP BY CarrierDelay, DistanceGroup, DivAirportLandings
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestState = 'ID' AND DepTimeBlk = '1100-1159' AND Cancelled = '0' GROUP BY DestStateName, Month, OriginWac
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DayOfWeek, UniqueCarrier, WeatherDelay WHERE AirlineID = '19930' AND ArrTimeBlk = '2100-2159' AND SecurityDelay = '0'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DepTimeBlk, OriginCityName, Year WHERE ArrTimeBlk = '1300-1359' AND Carrier = 'B6' AND DayofMonth = '16'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '2100-2159' AND Year = '2014' AND Flights = '1' GROUP BY DivActualElapsedTime, DepTimeBlk, Flights
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Distance = '283' GROUP BY WheelsOff, Month, DivAirportLandings
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID, Cancelled, Flights WHERE Month = '6' AND CRSArrTime = '1256' AND Cancelled = '0'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND FlightDate = '2014-06-03' AND DivReachedDest = '-9999' GROUP BY FlightNum, Cancelled, Month
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Carrier = 'EV' AND DayofMonth = '7' AND DivAirportLandings = '1' GROUP BY Month, ArrTime, Quarter
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DepTime, DivAirportLandings, Diverted WHERE Quarter = '2' AND TaxiOut = '118' AND SecurityDelay = '0'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips = '38' AND Carrier = 'MQ' AND Diverted = '0' GROUP BY OriginAirportSeqID, ArrTimeBlk, Quarter
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE ArrTime = '1316' AND UniqueCarrier = 'OO' AND TaxiOut = '9' GROUP BY TotalAddGTime, OriginStateFips, Flights
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable  WHERE TaxiIn = '18'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac = '65' GROUP BY CRSElapsedTime, Flights, ArrTimeBlk
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '1' AND DestStateFips = '4' AND DepTimeBlk = '1000-1059' GROUP BY OriginStateFips, SecurityDelay, UniqueCarrier
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, Month, ArrTimeBlk WHERE UniqueCarrier = 'AS' AND Diverted = '0' AND WheelsOff = '839'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Dest, Quarter, Month WHERE Flights = '1' AND DestWac = '91' AND WeatherDelay = '66'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FirstDepTime, Diverted, DestState WHERE WheelsOff = '1313' AND DistanceGroup = '4' AND Month = '6'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '5' AND DestStateName = 'Pennsylvania' AND FlightNum = '608' GROUP BY LateAircraftDelay, DepTimeBlk, Flights
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY UniqueCarrier, LongestAddGTime, DayOfWeek WHERE DepTime = '902' AND CancellationCode = 'noodles' AND UniqueCarrier = 'OO'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CRSDepTime = '1813' GROUP BY DivArrDelay, SecurityDelay, CancellationCode
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, Year, Quarter WHERE DistanceGroup = '3' AND UniqueCarrier = 'B6' AND WheelsOff = '1656'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND Distance = '373' AND DepTimeBlk = '1300-1359' GROUP BY Carrier, DivAirportLandings, Flights
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY FlightDate, OriginWac, CancellationCode WHERE DivAirportLandings = '1' AND DivActualElapsedTime = '290' AND UniqueCarrier = 'DL'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID, Month, Origin WHERE DepTimeBlk = '1800-1859' AND Flights = '1' AND Distance = '1162'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY OriginWac, DistanceGroup, Cancelled WHERE ActualElapsedTime = '186' AND Dest = 'OKC' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND Flights = '1' AND Dest = 'IND' GROUP BY WheelsOn, Month, Diverted
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginWac, DivAirportLandings, FlightDate WHERE Diverted = '0' AND ActualElapsedTime = '315' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityName = 'San Jose, CA' AND TailNum = 'N558AS' AND Quarter = '2' GROUP BY DayOfWeek, TaxiOut, CancellationCode
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '37' GROUP BY DivAirportLandings, OriginAirportSeqID, DayOfWeek
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY ArrTimeBlk, AirlineID, Month WHERE SecurityDelay = '-9999' AND DayofMonth = '18' AND OriginStateName = 'Iowa'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, Flights, DivReachedDest WHERE OriginStateName = 'North Dakota' AND DistanceGroup = '6' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirlineID, Flights, LongestAddGTime WHERE OriginAirportSeqID = '1104103' AND Quarter = '2' AND DayofMonth = '9'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND Year = '2014' AND DistanceGroup = '9' GROUP BY DayofMonth, DayOfWeek, Year
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateName = 'Mississippi' AND CarrierDelay = '8' AND Flights = '1' GROUP BY ArrTime, Diverted, Cancelled
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier = 'WN' GROUP BY TaxiOut, OriginStateFips, Flights
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FlightDate, SecurityDelay, OriginStateFips WHERE Month = '6' AND DivReachedDest = '-9999' AND Flights = '1'
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DestWac = '71' AND ArrTimeBlk = '0800-0859' GROUP BY DestAirportSeqID, Quarter, DivAirportLandings
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID = '1411302' GROUP BY UniqueCarrier, DepTimeBlk, DistanceGroup
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY AirTime, SecurityDelay, Cancelled WHERE TotalAddGTime = '29' AND DestWac = '43' AND DayOfWeek = '7'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY AirTime, SecurityDelay, Diverted WHERE CancellationCode = 'noodles' AND Quarter = '2' AND FirstDepTime = '1540'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY ArrTime, Flights, Cancelled WHERE FlightNum = '1456' AND Quarter = '2' AND TotalAddGTime = '-9999'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, Distance, Month WHERE OriginCityName = 'Portland, OR' AND WheelsOn = '1456' AND Year = '2014'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Cancelled, CRSDepTime, CancellationCode WHERE OriginAirportSeqID = '1127802' AND DivReachedDest = '-9999' AND AirTime = '139'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Carrier, DestStateFips, Month WHERE ArrTimeBlk = '2000-2059' AND DivReachedDest = '1' AND DistanceGroup = '4'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Carrier, OriginStateFips, Flights WHERE Distance = '145'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY CRSElapsedTime, DayOfWeek, Year WHERE Year = '2014' AND Month = '6' AND DayofMonth = '27'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DayofMonth, DestCityName, Year WHERE DestWac = '83'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DayofMonth, DestStateFips, Year WHERE ArrTime = '1945' AND Carrier = 'AA' AND Month = '6'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DayofMonth, OriginWac, Quarter WHERE OriginStateFips = '16' AND DayOfWeek = '5' AND Quarter = '2'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DepTimeBlk, DestStateFips, Quarter WHERE DestWac = '81' AND DivAirportLandings = '1' AND Quarter = '2'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, TaxiOut, Month WHERE Month = '6' AND TaxiIn = '58' AND Year = '2014'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestStateName, DivDistance, Month WHERE DestAirportSeqID = '1105703' AND LateAircraftDelay = '16' AND DistanceGroup = '2'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DistanceGroup, DestStateName, DivAirportLandings WHERE OriginCityName = 'Bethel, AK'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivAirportLandings, DistanceGroup, Month WHERE DivReachedDest = '1' AND AirlineID = '20355' AND FlightDate = '2014-06-17'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY FirstDepTime, WeatherDelay, Year WHERE CancellationCode = 'C' AND OriginState = 'CA' AND CRSElapsedTime = '87'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY FlightNum, Diverted, Quarter WHERE Quarter = '2' AND FlightNum = '5659'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY LateAircraftDelay, DepTimeBlk, Diverted WHERE Flights = '1' AND Year = '2014' AND Quarter = '2'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, WeatherDelay, Diverted WHERE ActualElapsedTime = '88' AND UniqueCarrier = 'DL' AND DayofMonth = '18'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Month, Flights, OriginCityMarketID WHERE Flights = '1' AND TailNum = 'N963SW' AND TaxiOut = '13'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID, FlightDate, Month WHERE DestState = 'FL' AND ArrTimeBlk = '0700-0759' AND Flights = '1'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportSeqID, FlightDate, Year WHERE DestStateName = 'Tennessee' AND Diverted = '0' AND TaxiOut = '46'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityName, DistanceGroup, Month WHERE DestCityName = 'Knoxville, TN' AND Diverted = '0' AND WeatherDelay = '-9999'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginState, Diverted, SecurityDelay WHERE Flights = '1' AND Diverted = '1' AND Quarter = '2'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginStateFips WHERE DestStateName = 'Indiana' AND Year = '2014' AND DayOfWeek = '7'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginStateName, ArrTimeBlk, Month WHERE Year = '2014' AND FlightDate = '2014-06-14' AND Diverted = '0'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY SecurityDelay, WheelsOn, Quarter WHERE AirlineID = '19805' AND NASDelay = '33' AND DistanceGroup = '4'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY TaxiIn, DayofMonth, Diverted WHERE Year = '2014' AND Diverted = '0' AND UniqueCarrier = 'VX'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY TaxiIn, UniqueCarrier, Month WHERE ArrTime = '26' AND DivAirportLandings = '0' AND DistanceGroup = '7'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY UniqueCarrier, AirTime WHERE DayOfWeek = '7' AND CRSElapsedTime = '361' AND Carrier = 'US'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY UniqueCarrier, DivArrDelay, Month WHERE OriginAirportSeqID = '1471102'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOff, SecurityDelay, Month WHERE DayofMonth = '5' AND Cancelled = '1'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOn, Flights, CancellationCode WHERE OriginState = 'ME' AND DestState = 'NY' AND DivReachedDest = '0'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Year, OriginStateFips, OriginState WHERE CRSElapsedTime = '120' AND OriginStateFips = '19' AND Carrier = 'OO'
-SELECT SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk = '0800-0859' AND CRSDepTime = '115' AND FlightDate = '2014-06-07' GROUP BY Month, DayOfWeek, DivAirportLandings
-SELECT SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk = '0900-0959' AND Distance = '575' AND Diverted = '0' GROUP BY FirstDepTime, OriginAirportID, DepTimeBlk
-SELECT SUM(ArrDelay) FROM myStarTable WHERE CancellationCode = 'B' GROUP BY ArrTimeBlk
-SELECT SUM(ArrDelay) FROM myStarTable WHERE CancellationCode = 'noodles' AND DivArrDelay = '164' GROUP BY DivAirportLandings, FirstDepTime, Carrier
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '0' AND WheelsOff = '826' AND Flights = '1' GROUP BY DivArrDelay, Year, UniqueCarrier
-SELECT SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime = '1850' AND DestStateName = 'New York' AND OriginStateFips = '17' GROUP BY DepTimeBlk, ArrTimeBlk, DayOfWeek
-SELECT SUM(ArrDelay) FROM myStarTable WHERE CRSDepTime = '1157' GROUP BY DistanceGroup, TotalAddGTime, Cancelled
-SELECT SUM(ArrDelay) FROM myStarTable WHERE CRSDepTime = '2210' GROUP BY UniqueCarrier, Quarter, OriginWac
-SELECT SUM(ArrDelay) FROM myStarTable WHERE CRSElapsedTime = '105' AND DayOfWeek = '5' AND Cancelled = '1' GROUP BY SecurityDelay, OriginStateName
-SELECT SUM(ArrDelay) FROM myStarTable WHERE CRSElapsedTime = '97' AND OriginStateFips = '38' GROUP BY AirlineID, DestCityName, Cancelled
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DayofMonth = '19' AND Dest = 'IND' AND UniqueCarrier = 'EV' GROUP BY DayOfWeek, DivArrDelay, Month
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '2' AND WheelsOff = '723' AND Flights = '1' GROUP BY Dest, DistanceGroup, DivReachedDest
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk = '1800-1859' AND Cancelled = '0' AND DestStateFips = '53' GROUP BY CancellationCode, DestCityMarketID, Cancelled
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk = '2200-2259' AND Carrier = 'US' AND DayofMonth = '12' GROUP BY WeatherDelay, OriginStateFips, Cancelled
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DestAirportSeqID = '1163805' AND Year = '2014' AND Month = '6' GROUP BY DayofMonth, OriginState, SecurityDelay
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DestStateFips = '47' AND Month = '6' AND FlightDate = '2014-06-15' GROUP BY DivAirportLandings, Diverted, DestWac
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DestStateName = 'Indiana' GROUP BY Carrier, CRSElapsedTime, Flights
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DestWac = '74' AND Dest = 'IAH' AND ArrTimeBlk = '1100-1159' GROUP BY Distance, WheelsOn, OriginCityName
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings = '0' AND DayOfWeek = '1' AND UniqueCarrier = 'HA' GROUP BY Diverted, Carrier, UniqueCarrier
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings = '9' AND UniqueCarrier = 'WN' AND ArrTimeBlk = '1700-1759' GROUP BY DivArrDelay, Flights, UniqueCarrier
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DivArrDelay = '256' AND Quarter = '2' AND DivAirportLandings = '1' GROUP BY Flights, WheelsOn, Year
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Diverted = '0' AND OriginCityName = 'Asheville, NC' AND AirlineID = '20366' GROUP BY Quarter, OriginStateFips, Year
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Diverted = '1' AND TaxiIn = '20' AND ArrTime = '30' 
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '1' AND UniqueCarrier = 'OO' AND DayOfWeek = '4' GROUP BY OriginState, Carrier, DivReachedDest
-SELECT SUM(ArrDelay) FROM myStarTable WHERE FlightDate = '2014-06-16' GROUP BY Dest, DepTimeBlk, Quarter
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND DestWac = '92' AND CancellationCode = 'noodles' GROUP BY Origin, DivAirportLandings, DivReachedDest
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND Distance = '909' AND DivReachedDest = '0' GROUP BY Dest, AirlineID, Quarter
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND DivReachedDest = '-9999' AND TotalAddGTime = '44' GROUP BY DayOfWeek, LongestAddGTime, DepTimeBlk
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND LateAircraftDelay = '111' AND ArrTimeBlk = '1600-1659' GROUP BY FlightDate, DestStateFips, Diverted
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' GROUP BY Distance, Flights, Cancelled
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND DivReachedDest = '-9999' AND DayofMonth = '17' GROUP BY DestAirportSeqID, AirlineID, Flights
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND OriginCityName = 'Brownsville, TX' AND Flights = '1' GROUP BY ArrTime, DivReachedDest, SecurityDelay
-SELECT SUM(ArrDelay) FROM myStarTable WHERE NASDelay = '17' GROUP BY LongestAddGTime, OriginState, Cancelled
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips = '12' AND DestCityName = 'Raleigh/Durham, NC' AND Flights = '1' GROUP BY DistanceGroup, DestState, Quarter
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginState = 'MD' AND Carrier = 'DL' AND Diverted = '0' GROUP BY TaxiOut, DivReachedDest, CancellationCode
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginWac = '43' AND SecurityDelay = '0' AND Quarter = '2' GROUP BY CancellationCode, DestState, Quarter
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginWac = '5' GROUP BY AirTime, Year
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND Diverted = '0' AND AirlineID = '20304' GROUP BY DistanceGroup, ActualElapsedTime, Year
-SELECT SUM(ArrDelay) FROM myStarTable WHERE WeatherDelay = '3' AND Month = '6' AND DivAirportLandings = '0' GROUP BY Flights, OriginCityMarketID, DistanceGroup
-SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOff = '1812' AND DistanceGroup = '8' GROUP BY Month, WeatherDelay, DivDistance
-SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOn = '1046' AND AirlineID = '20304' AND DivReachedDest = '-9999' GROUP BY TaxiOut, DestState, Year
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Year = '2014' AND DayOfWeek = '4' AND WheelsOff = '657' GROUP BY DestAirportID, DivAirportLandings, Flights
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, DivReachedDest, Cancelled WHERE DayOfWeek = '5' AND OriginStateFips = '8' AND DivAirportLandings = '1'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirTime, DivAirportLandings, Month WHERE Month = '6' AND OriginStateName = 'Michigan' AND TaxiIn = '61'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, Diverted, AirlineID WHERE Cancelled = '0' AND LongestAddGTime = '68' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CancellationCode WHERE DistanceGroup = '3' AND DayofMonth = '25' AND CRSElapsedTime = '117'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Carrier, Quarter, OriginCityMarketID WHERE NASDelay = '40' AND ArrTimeBlk = '2100-2159' AND Month = '6'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayOfWeek, FlightDate, CancellationCode WHERE TailNum = 'N889AS' AND DayOfWeek = '4' AND Month = '6'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, DepTimeBlk, Month WHERE WheelsOn = '2243' AND Quarter = '2' AND DayofMonth = '4'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityName, AirlineID, Diverted WHERE ArrTimeBlk = '2100-2159' AND DivReachedDest = '-9999' AND AirTime = '239'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityName, CancellationCode, Cancelled WHERE NASDelay = '53' AND Flights = '1' AND OriginStateFips = '8'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityName, Quarter, DepTimeBlk WHERE DepTime = '1632' AND OriginWac = '33' AND AirlineID = '19805'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Dest, DivAirportLandings, SecurityDelay WHERE LateAircraftDelay = '25'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateFips, TaxiOut, Quarter WHERE CancellationCode = 'B' AND Quarter = '2' AND DestStateName = 'Missouri'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestState, TaxiOut, Quarter WHERE ActualElapsedTime = '203' AND Diverted = '0' AND DestStateName = 'Florida'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DistanceGroup, UniqueCarrier, DayOfWeek WHERE CRSDepTime = '1528'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, DepTimeBlk, Month WHERE DivReachedDest = '1' AND ArrTimeBlk = '2100-2159' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, Month, UniqueCarrier WHERE UniqueCarrier = 'HA' AND ArrTime = '1648' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivDistance, DivAirportLandings, AirlineID WHERE Cancelled = '0' AND OriginStateFips = '12' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightDate WHERE Flights = '1' AND OriginAirportID = '13232' AND ActualElapsedTime = '165'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightNum, Quarter, Cancelled WHERE Diverted = '1' AND Flights = '1' AND OriginCityMarketID = '32129'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightNum, Year, Quarter WHERE OriginAirportID = '12323' AND Flights = '1' AND Diverted = '1'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Flights, DivReachedDest, SecurityDelay WHERE AirlineID = '20437' AND Year = '2014' AND TaxiOut = '34'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, OriginStateName, Quarter WHERE DestCityName = 'Sacramento, CA' AND Year = '2014' AND Cancelled = '1'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY NASDelay, Diverted, Month WHERE DivReachedDest = '-9999' AND WheelsOn = '1756' AND DayOfWeek = '2'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, Quarter, ArrTimeBlk WHERE DestCityMarketID = '30615'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, Flights, AirlineID WHERE DayOfWeek = '3' AND DestStateName = 'New York' AND DayofMonth = '21'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Origin, DivReachedDest, Quarter WHERE Year = '2014' AND OriginStateName = 'Iowa' AND FlightDate = '2014-06-02'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Origin, Year, CancellationCode WHERE OriginWac = '44' AND FlightDate = '2014-06-17' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, AirTime, DivReachedDest WHERE WheelsOn = '924' AND CancellationCode = 'noodles'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, DepTime, Year WHERE OriginAirportSeqID = '1129202' AND DestState = 'CT' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, DestAirportID, Diverted WHERE CRSArrTime = '1630' AND DestAirportSeqID = '1029904' AND DivAirportLandings = '0'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiIn, NASDelay, Year WHERE CancellationCode = 'C' AND DepTimeBlk = '1300-1359' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, Dest, Flights WHERE FlightNum = '624' AND DistanceGroup = '6' AND OriginWac = '81'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, Flights, Diverted WHERE Diverted = '1' AND Flights = '1' AND WheelsOff = '2213'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Year, OriginStateName, OriginState WHERE ArrTimeBlk = '1300-1359' AND CRSElapsedTime = '345' AND AirlineID = '21171'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime = '148' GROUP BY OriginWac, TaxiOut, Flights
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID = '20304' AND DistanceGroup = '3' AND DivAirportLandings = '2' GROUP BY DayOfWeek, Flights, Dest
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID = '20398' AND FlightDate = '2014-06-25' AND OriginWac = '61' GROUP BY TotalAddGTime, WeatherDelay, Year
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTimeBlk = '1000-1059' AND Cancelled = '1' AND Quarter = '2' GROUP BY DestStateFips, DistanceGroup, DivAirportLandings
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' 
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND Carrier = 'WN' AND OriginState = 'OH' GROUP BY OriginStateName, Cancelled, Diverted
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled = '1' AND Year = '2014' AND Carrier = 'VX' GROUP BY OriginWac, DivReachedDest, DayofMonth
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'FL' AND DestWac = '43' AND Month = '6' GROUP BY OriginAirportSeqID, Diverted, UniqueCarrier
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'UA' AND Year = '2014' AND TaxiIn = '9' GROUP BY Month, DayOfWeek, TaxiIn
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSDepTime = '1250' AND Dest = 'MKE' AND Diverted = '0' GROUP BY DayOfWeek, OriginStateFips, Quarter
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DayofMonth = '17' AND ArrTime = '2002' AND AirlineID = '19805' GROUP BY DestStateFips, WeatherDelay, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '1' AND Year = '2014' AND WheelsOn = '634' GROUP BY OriginAirportID, DayofMonth, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '0700-0759' AND DestWac = '11' AND Quarter = '2' 
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportID = '10732' GROUP BY Quarter, CancellationCode, OriginState
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportID = '12953' GROUP BY OriginCityName, Carrier, Diverted
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportSeqID = '1251902' AND DivReachedDest = '-9999' AND DistanceGroup = '1' GROUP BY AirlineID, OriginAirportSeqID, Flights
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityMarketID = '32012' GROUP BY DivReachedDest, DivDistance, Diverted
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips = '36' GROUP BY Dest, DepTimeBlk, Year
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName = 'Massachusetts' AND CancellationCode = 'noodles' AND TaxiOut = '50' GROUP BY OriginWac, DivAirportLandings, ArrTimeBlk
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestState = 'VA' AND Year = '2014' AND ArrTime = '1644' GROUP BY DestAirportSeqID, DivReachedDest, DistanceGroup
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '3' AND ArrTimeBlk = '1500-1559' AND Carrier = 'AA' GROUP BY ActualElapsedTime, CancellationCode, DivReachedDest
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '4' GROUP BY Year, FlightDate, DivReachedDest
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '5' AND OriginState = 'VA' AND DepTimeBlk = '0700-0759' GROUP BY TaxiOut, DestStateName, Year
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '7' AND DivAirportLandings = '1' AND Quarter = '2' GROUP BY Cancelled, Quarter, DayOfWeek
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '0' AND SecurityDelay = '0' AND DestAirportSeqID = '1336003' GROUP BY OriginStateFips, TotalAddGTime, Flights
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '1' AND LongestAddGTime = '11' AND DivReachedDest = '0' GROUP BY DepTime, DayOfWeek, Flights
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '0' AND DivReachedDest = '-9999' AND Year = '2014' GROUP BY TaxiIn, OriginState, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '1' GROUP BY ArrTimeBlk, DestState, CancellationCode
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest = '0' GROUP BY CRSArrTime, Diverted, DivAirportLandings
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest = '-9999' AND Carrier = 'AS' AND LateAircraftDelay = '10' 
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest = '-9999' AND Year = '2014' AND CarrierDelay = '127' GROUP BY DivAirportLandings, Diverted, WeatherDelay
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate = '2014-06-20' AND Month = '6' AND Carrier = 'MQ' GROUP BY DivArrDelay, Cancelled, DayOfWeek
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate = '2014-06-25' AND DepTimeBlk = '0900-0959' AND Month = '6' GROUP BY DestCityName, DistanceGroup, DivReachedDest
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND CRSElapsedTime = '104' AND DivReachedDest = '-9999' GROUP BY OriginState, DestStateFips, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND OriginAirportID = '12945' GROUP BY OriginCityMarketID, DayOfWeek, Diverted
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '23' GROUP BY AirlineID, Origin, Diverted
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '-9999' AND DivReachedDest = '1' AND DistanceGroup = '10' GROUP BY Origin, DayOfWeek, DivReachedDest
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '-9999' AND OriginStateFips = '17' AND AirlineID = '20409' GROUP BY DistanceGroup, OriginAirportSeqID, Cancelled
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID = '1127802' AND ArrTimeBlk = '1900-1959' AND DayofMonth = '24' GROUP BY FlightDate, LongestAddGTime, DivAirportLandings
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Origin = 'FNT' GROUP BY WheelsOn, CancellationCode, Quarter
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginState = 'CT' AND DayOfWeek = '1' AND Diverted = '1' GROUP BY OriginStateName, NASDelay, Quarter
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips = '27' AND Quarter = '2' AND CancellationCode = 'B' GROUP BY OriginAirportSeqID, CancellationCode, Quarter
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateName = 'Colorado' AND DayOfWeek = '5' AND DivArrDelay = '200' GROUP BY DistanceGroup, AirlineID, Cancelled
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateName = 'Connecticut' GROUP BY AirlineID, ActualElapsedTime, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac = '23' AND DayofMonth = '1' AND DistanceGroup = '8' 
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND TaxiOut = '66' AND DayOfWeek = '4' GROUP BY LateAircraftDelay, FlightDate, Year
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay = '-9999' AND OriginState = 'NJ' AND DepTimeBlk = '1600-1659' GROUP BY FirstDepTime, OriginWac, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TailNum = 'N526UA' GROUP BY WheelsOff, Quarter, CancellationCode
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut = '32' GROUP BY DivDistance, Diverted, DepTimeBlk
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE UniqueCarrier = 'VX' AND Month = '6' AND Flights = '1' GROUP BY DivAirportLandings, NASDelay, Year
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND CRSDepTime = '1434' AND Month = '6' GROUP BY Origin, DayofMonth, Quarter
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND NASDelay = '46' AND AirlineID = '19393' GROUP BY CarrierDelay, DayofMonth, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY CarrierDelay, DestWac, Year WHERE Carrier = 'AA' AND DayofMonth = '20' AND DistanceGroup = '7'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY CarrierDelay, DistanceGroup, Cancelled WHERE AirlineID = '20304' AND Year = '2014' AND ArrTime = '1107'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateFips, Year, DivDistance WHERE Cancelled = '0' AND UniqueCarrier = 'WN' AND OriginAirportID = '13931'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestCityMarketID = '31624' AND Diverted = '0' AND DayOfWeek = '1' GROUP BY AirTime, CancellationCode, Flights
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Year = '2014' AND OriginWac = '85' AND Cancelled = '0' GROUP BY DayOfWeek, DestStateFips, Flights
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY FlightDate, CarrierDelay, Year WHERE WheelsOn = '1213' AND Quarter = '2' AND UniqueCarrier = 'OO'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState, OriginStateFips, Diverted WHERE TotalAddGTime = '57' AND SecurityDelay = '-9999' AND UniqueCarrier = 'MQ'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Diverted, TaxiOut, Cancelled WHERE Year = '2014' AND Cancelled = '0' AND OriginState = 'VI'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY AirlineID, Quarter, DayofMonth WHERE CRSDepTime = '1846'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY WeatherDelay, DestStateName, Flights WHERE DestAirportSeqID = '1091802'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY UniqueCarrier, FirstDepTime WHERE OriginStateName = 'Pennsylvania'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Origin = 'ORD' GROUP BY DestAirportSeqID, SecurityDelay, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Dest, DivReachedDest, DayOfWeek WHERE AirlineID = '20398' AND DestStateName = 'Alabama' AND ArrTimeBlk = '1800-1859'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TailNum, Month, Diverted WHERE DayofMonth = '9'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY CRSDepTime, CancellationCode, Cancelled WHERE OriginStateName = 'New Jersey' AND Year = '2014' AND FlightDate = '2014-06-08'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, DivAirportLandings, Year WHERE DistanceGroup = '5' AND Flights = '1' AND DivActualElapsedTime = '458'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTime = '2005' AND OriginWac = '63' AND DayOfWeek = '3' GROUP BY DestCityName, DivReachedDest, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND SecurityDelay = '0' AND Dest = 'PHX' GROUP BY DestStateName, FirstDepTime, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE FlightNum = '637' AND CRSElapsedTime = '332' AND Diverted = '0' GROUP BY FlightNum, Month, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn = '1011' GROUP BY DestCityMarketID, DayOfWeek, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Month = '6' AND OriginState = 'KS' AND Diverted = '0' GROUP BY CRSElapsedTime, DistanceGroup, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '1' AND Year = '2014' AND Distance = '991' GROUP BY Cancelled, OriginAirportID, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Cancelled, CancellationCode, DivActualElapsedTime WHERE OriginStateName = 'Kentucky' AND Year = '2014' AND Cancelled = '0'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND OriginState = 'SD' AND Quarter = '2' GROUP BY DayofMonth, DestStateFips, SecurityDelay
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, DestCityName, Flights WHERE Month = '6' AND Quarter = '2' AND CRSArrTime = '2125'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1700-1759' AND UniqueCarrier = 'UA' AND ActualElapsedTime = '147' GROUP BY Diverted, TaxiIn, FlightDate
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE FirstDepTime = '1604' AND Flights = '1' AND Month = '6' GROUP BY TaxiOut, DayOfWeek, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DestWac, SecurityDelay, ArrTimeBlk WHERE Flights = '1' AND Quarter = '2' AND OriginState = 'KY'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DayofMonth = '7' AND DepTime = '1959' AND SecurityDelay = '-9999' GROUP BY OriginCityName, ArrTimeBlk, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable  WHERE AirlineID = '19930' AND Diverted = '1' AND DayofMonth = '12'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY WeatherDelay, CancellationCode, DivAirportLandings WHERE DayofMonth = '17' AND DivAirportLandings = '2' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DestCityName, Flights, Quarter WHERE TotalAddGTime = '17' AND Diverted = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DivArrDelay = '124' AND UniqueCarrier = 'AA' AND Year = '2014' GROUP BY DayofMonth, TotalAddGTime, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, DivAirportLandings, DivReachedDest WHERE DayofMonth = '13' AND ActualElapsedTime = '333' AND LongestAddGTime = '-9999'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, LongestAddGTime, Flights WHERE FirstDepTime = '-9999' AND DistanceGroup = '3' AND ArrTimeBlk = '0900-0959'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTime = '1107' AND Flights = '1' AND AirlineID = '20437' GROUP BY Diverted, WeatherDelay, DivAirportLandings
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY CarrierDelay, DayOfWeek, Flights WHERE DayOfWeek = '5' AND DepTimeBlk = '1700-1759' AND CarrierDelay = '53'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestStateName, DayofMonth, Diverted WHERE Month = '6' AND DepTimeBlk = '1800-1859' AND DayOfWeek = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE OriginWac = '41' AND CRSElapsedTime = '142' AND DayOfWeek = '5' GROUP BY ActualElapsedTime, Diverted, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightNum, Month, Flights WHERE DestStateFips = '16' AND Cancelled = '1' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateName, WeatherDelay, Year WHERE Cancelled = '0' AND FlightDate = '2014-06-08' AND WheelsOff = '2212'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY WeatherDelay, OriginState, Quarter WHERE FlightDate = '2014-06-04' AND DepTime = '846' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DayofMonth = '1' AND OriginCityMarketID = '34952' AND SecurityDelay = '-9999' GROUP BY Diverted, ActualElapsedTime, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateName, DestState, Cancelled WHERE Month = '6' AND CRSArrTime = '1349' AND Diverted = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DepTime, DivReachedDest, Cancelled WHERE DivAirportLandings = '1' AND OriginStateName = 'Arizona' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Quarter = '2' AND CancellationCode = 'B' AND OriginAirportID = '11292' GROUP BY DestCityName, UniqueCarrier, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiIn, ArrTimeBlk, SecurityDelay WHERE DistanceGroup = '4' AND DivReachedDest = '-9999' AND DestCityName = 'Chicago, IL'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginStateFips, DivAirportLandings, Quarter WHERE Year = '2014' AND Month = '6' AND Distance = '2239'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1800-1859' AND NASDelay = '0' AND Origin = 'HNL' GROUP BY OriginStateName, DivAirportLandings, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestState = 'SD' AND AirTime = '73' GROUP BY DestWac, DivDistance, Flights
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivDistance, FirstDepTime, Flights WHERE Quarter = '2' AND Diverted = '0' AND Origin = 'BHM'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DayofMonth, OriginAirportID, Month WHERE DestWac = '1' AND Month = '6'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DepTime, Month, Flights WHERE TaxiOut = '52' AND SecurityDelay = '0' AND OriginStateFips = '6'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestAirportSeqID, Quarter, Flights WHERE TaxiIn = '63' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, SecurityDelay, Cancelled WHERE Carrier = 'OO' AND Diverted = '0' AND DestStateName = 'Idaho'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Origin, ArrTimeBlk, Quarter WHERE Flights = '1' AND ArrTimeBlk = '0700-0759' AND DestCityMarketID = '31205'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityName, DayofMonth, Year WHERE WheelsOff = '1716' AND Diverted = '0' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '-9999' AND DistanceGroup = '7' AND OriginCityName = 'Baltimore, MD' GROUP BY DayOfWeek, OriginAirportID, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND WheelsOn = '1302' AND SecurityDelay = '-9999' GROUP BY OriginCityName, Year, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, Origin, Month WHERE OriginCityName = 'Boston, MA' AND DestState = 'VA' AND CancellationCode = 'A'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-30' AND Dest = 'DFW' AND Carrier = 'EV' GROUP BY CancellationCode, Diverted, AirTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY LongestAddGTime, WeatherDelay, Month WHERE OriginWac = '81' AND DestWac = '86' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ArrTime, Year, DivReachedDest WHERE Flights = '1' AND Year = '2014' AND NASDelay = '17'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY LateAircraftDelay, CancellationCode, Quarter WHERE Cancelled = '0' AND Quarter = '2' AND Dest = 'SPS'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateFips, Year, DepTimeBlk WHERE Flights = '1' AND SecurityDelay = '5' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime, WeatherDelay, Quarter WHERE Diverted = '0' AND Quarter = '2' AND Dest = 'LFT'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DivAirportLandings, SecurityDelay, TaxiOut WHERE Month = '6' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Year, OriginCityMarketID, DayOfWeek WHERE DestStateFips = '48' AND Flights = '1' AND UniqueCarrier = 'UA'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE AirlineID = '20366' GROUP BY FlightDate, CarrierDelay, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID = '14831' AND Month = '6' AND DayofMonth = '19' GROUP BY DepTimeBlk, DivAirportLandings, OriginCityMarketID
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Month, DestWac, DivReachedDest WHERE DivAirportLandings = '1' AND DepTimeBlk = '0600-0659' AND OriginWac = '62'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND OriginStateName = 'New York' AND DivReachedDest = '0' GROUP BY OriginStateName, OriginState, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE AirTime = '243' AND Quarter = '2' AND DestStateFips = '53' GROUP BY OriginCityMarketID, Flights, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND Cancelled = '1' AND UniqueCarrier = 'B6' GROUP BY DestStateName, ActualElapsedTime, OriginAirportID
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY SecurityDelay, Distance, Flights WHERE Cancelled = '0' AND OriginStateName = 'Arkansas' AND WheelsOn = '951'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY WheelsOff, DivAirportLandings, Diverted WHERE DestAirportID = '15295' AND DayofMonth = '28' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, DivReachedDest, Quarter WHERE OriginStateName = 'Georgia'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY Cancelled, DivAirportLandings, OriginState WHERE UniqueCarrier = 'WN' AND CarrierDelay = '-9999' AND DepTime = '2028'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY AirlineID, Year, Origin WHERE Carrier = 'EV' AND Diverted = '0' AND WheelsOff = '945'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Washington' GROUP BY CRSElapsedTime, UniqueCarrier, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestStateName, DistanceGroup, UniqueCarrier WHERE Flights = '1' AND FlightNum = '1887' AND DivAirportLandings = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY OriginWac, OriginState, Year WHERE CRSArrTime = '1320' AND Flights = '1' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE AirlineID = '19790' AND TaxiIn = '49' AND ArrTimeBlk = '1000-1059' GROUP BY Year, CarrierDelay, TotalAddGTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID, Diverted, TaxiIn WHERE Quarter = '2' AND Cancelled = '0' AND FlightNum = '2642'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityMarketID, UniqueCarrier, Flights WHERE DivActualElapsedTime = '350' AND OriginCityName = 'San Francisco, CA' AND Cancelled = '0'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND TotalAddGTime = '52' AND OriginWac = '22' GROUP BY Distance, DivAirportLandings, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY Dest, UniqueCarrier, Flights WHERE Cancelled = '0' AND DistanceGroup = '4' AND DayOfWeek = '7'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayOfWeek, AirlineID, Diverted WHERE DivAirportLandings = '0' AND Distance = '1050' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'Hawaii' AND Quarter = '2' AND CRSDepTime = '2019' GROUP BY Cancelled, OriginState, DayofMonth
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY ArrTimeBlk, LongestAddGTime, DivReachedDest WHERE SecurityDelay = '-9999'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirTime = '-9999' AND DivArrDelay = '107' AND DayOfWeek = '4' GROUP BY OriginAirportID, Carrier, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '1' AND DestAirportSeqID = '1177502' AND DivReachedDest = '-9999' GROUP BY UniqueCarrier, DestState, DayOfWeek
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState = 'PR' AND CancellationCode = 'noodles' AND CRSElapsedTime = '169' GROUP BY Year, DepTime, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '3' AND Dest = 'CRP' AND CRSArrTime = '1347' GROUP BY DistanceGroup, DayOfWeek, OriginStateName
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY FirstDepTime, DivReachedDest, Carrier WHERE ActualElapsedTime = '139' AND Flights = '1' AND DepTime = '1145'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE TaxiIn = '27' AND DayOfWeek = '3' AND Diverted = '1' GROUP BY OriginAirportID, CancellationCode, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Dest = 'AVL' AND ArrTimeBlk = '1300-1359' AND Month = '6' GROUP BY Origin, SecurityDelay, Flights
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirlineID = '19790' AND CancellationCode = 'noodles' AND TaxiOut = '20' GROUP BY DivActualElapsedTime, Diverted, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut = '95' AND Cancelled = '0' AND DivAirportLandings = '1' GROUP BY FirstDepTime, DestStateName, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac = '2' AND Carrier = 'UA' AND DayofMonth = '15' GROUP BY SecurityDelay, DayOfWeek, OriginStateName
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable  WHERE Quarter = '2' AND OriginWac = '81' AND DestWac = '91'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn = '45' GROUP BY Diverted, Carrier, TaxiIn
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month = '6' AND TaxiIn = '21' AND DestAirportSeqID = '1104202' GROUP BY Dest, Flights, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestAirportID = '10529' AND OriginStateName = 'North Carolina' AND CancellationCode = 'C' GROUP BY DivDistance, OriginStateFips, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, DistanceGroup, DivReachedDest WHERE WheelsOff = '1952' AND Quarter = '2' AND DayOfWeek = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateFips, DayOfWeek, DepTimeBlk WHERE Year = '2014' AND DivReachedDest = '1' AND LongestAddGTime = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestState = 'VA' AND LateAircraftDelay = '94' AND OriginWac = '13' GROUP BY OriginWac, DestStateFips, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND DistanceGroup = '7' AND DestState = 'DE' GROUP BY DestAirportID, Quarter, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable  WHERE AirlineID = '20355' AND Diverted = '0' AND ActualElapsedTime = '330'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Dest = 'MHT' AND Year = '2014' AND Month = '6' GROUP BY OriginStateFips, OriginStateName, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn = '7' AND DivReachedDest = '1' AND DistanceGroup = '11' GROUP BY Flights, AirlineID, DistanceGroup
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY TotalAddGTime WHERE DayOfWeek = '3' AND Flights = '1' AND WeatherDelay = '68'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Month, CarrierDelay, SecurityDelay WHERE OriginAirportID = '11612' AND DayofMonth = '5' AND AirlineID = '20366'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '3' AND LongestAddGTime = '52' AND OriginWac = '22' GROUP BY DestAirportID, Diverted, DistanceGroup
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '6' 
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID = '32547' GROUP BY LongestAddGTime, SecurityDelay, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, Month, DayOfWeek WHERE Cancelled = '0' AND ArrTimeBlk = '1500-1559' AND OriginStateName = 'Maryland'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE AirTime = '69' AND OriginAirportID = '12003' AND Year = '2014' GROUP BY LateAircraftDelay, DistanceGroup, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DivAirportLandings, AirTime, Quarter WHERE Flights = '1' AND ArrTimeBlk = '2000-2059' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE CRSArrTime = '945' AND SecurityDelay = '-9999' AND DestStateName = 'North Carolina' GROUP BY Year, FlightDate, Flights
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut = '45' AND DistanceGroup = '7' AND UniqueCarrier = 'US' GROUP BY CRSDepTime, DivReachedDest, Flights
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Nebraska' GROUP BY OriginCityName, Month, DayofMonth
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID = '1457604' AND Flights = '1' AND Cancelled = '1' GROUP BY DivArrDelay, Month, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, CarrierDelay, DivReachedDest WHERE Year = '2014' AND Cancelled = '0' AND WheelsOn = '305'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '0' AND SecurityDelay = '-9999' AND OriginWac = '13' GROUP BY DivArrDelay, Month, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings = '1' AND DivReachedDest = '1' AND DestCityName = 'West Yellowstone, MT' GROUP BY OriginStateName, Quarter, TaxiIn
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn = '1101' AND Flights = '1' AND Year = '2014' GROUP BY LateAircraftDelay, Flights, DepTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '2' AND TaxiOut = '45' AND Quarter = '2' GROUP BY DepTime, CancellationCode, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, Distance, Cancelled WHERE Quarter = '2' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND DestWac = '64' AND DayOfWeek = '5' GROUP BY AirlineID, OriginStateName, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY TailNum, Flights, Cancelled WHERE Flights = '1' AND Diverted = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Carrier, DivAirportLandings, SecurityDelay WHERE DivActualElapsedTime = '295' AND Flights = '1' AND OriginState = 'MN'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND DepTimeBlk = '1900-1959' AND OriginWac = '92' GROUP BY FirstDepTime, Quarter, DivDistance
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DestStateName = 'Nevada' AND OriginAirportSeqID = '1477101' AND CancellationCode = 'A' GROUP BY OriginCityMarketID, ArrTimeBlk, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, OriginAirportSeqID, Year WHERE Year = '2014' AND OriginAirportSeqID = '1471102' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirTime, Month, Quarter WHERE Year = '2014' AND WeatherDelay = '82' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay = '0' AND Cancelled = '0' AND DistanceGroup = '11' GROUP BY ArrTime, Flights, DivAirportLandings
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DistanceGroup = '4' AND DestCityMarketID = '30194' AND Carrier = 'AA' GROUP BY DepTimeBlk, DestState, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Origin = 'ILM' AND DivReachedDest = '1' AND Quarter = '2' GROUP BY AirTime, DivReachedDest, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY FlightDate, NASDelay, Quarter WHERE DestCityName = 'Idaho Falls, ID' AND DivAirportLandings = '0' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID, Year, FlightDate WHERE ActualElapsedTime = '70' AND Flights = '1' AND ArrTimeBlk = '1800-1859'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY UniqueCarrier, DestCityName, Cancelled WHERE DepTimeBlk = '1900-1959' AND AirlineID = '20436' AND DayofMonth = '24'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY FlightNum, Month, Flights WHERE DivAirportLandings = '0' AND AirlineID = '20409' AND DestWac = '15'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND LongestAddGTime = '30' AND DivReachedDest = '1' GROUP BY CRSDepTime, Flights, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TailNum, Quarter, Year WHERE Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, Carrier WHERE Year = '2014' AND Dest = 'FLL' AND WeatherDelay = '3'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTime = '413' GROUP BY OriginAirportSeqID, DivReachedDest, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DestWac = '73' AND CRSElapsedTime = '81' AND Cancelled = '0' GROUP BY OriginWac, OriginStateName, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestStateFips, FlightDate, Month WHERE TaxiIn = '6' AND DestCityMarketID = '34653' AND FlightNum = '2264'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' GROUP BY DestAirportSeqID, Quarter, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND DayOfWeek = '4' AND DivAirportLandings = '9' GROUP BY NASDelay, DepTime, CRSDepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Cancelled, Origin, DivReachedDest WHERE WheelsOn = '1736' AND Flights = '1' AND AirlineID = '20398'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestStateName, CarrierDelay, Quarter WHERE DivArrDelay = '266' AND OriginStateName = 'Puerto Rico' AND CancellationCode = 'noodles'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DistanceGroup, Dest, Month WHERE Quarter = '2' AND DistanceGroup = '1' AND DayofMonth = '20'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Diverted, AirlineID, DestState WHERE Month = '6' AND WheelsOff = '16' AND DayofMonth = '27'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FlightNum, Diverted, Flights WHERE DepTimeBlk = '1100-1159' AND OriginState = 'MI' AND DivAirportLandings = '9'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WeatherDelay, Month, DestState WHERE UniqueCarrier = 'DL' AND WheelsOn = '248' AND DayOfWeek = '4'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1000-1059' AND DestWac = '65' AND DistanceGroup = '6' GROUP BY DestCityMarketID, DestCityName, Distance
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings = '9' AND UniqueCarrier = 'OO' AND DestCityName = 'Cody, WY' GROUP BY DestAirportSeqID, DayOfWeek, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Diverted = '0' AND DestStateName = 'New Hampshire' AND Year = '2014' GROUP BY FlightDate, CancellationCode, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay = '0' AND Carrier = 'UA' AND Dest = 'SAN' GROUP BY CRSElapsedTime, DivReachedDest, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, SecurityDelay, Cancelled WHERE Diverted = '0' AND DayOfWeek = '3' AND OriginStateName = 'Kentucky'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, OriginStateFips, Diverted WHERE DistanceGroup = '4' AND OriginCityMarketID = '31650' AND DivReachedDest = '0'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportID, DivAirportLandings, Quarter WHERE OriginCityMarketID = '30977' AND Carrier = 'WN' AND DayofMonth = '14'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, DayofMonth, Year WHERE DestStateName = 'Nebraska' AND Quarter = '2' AND Month = '6'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Diverted, DestCityMarketID, Month WHERE DestCityMarketID = '32523'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay = '33' GROUP BY Month, CRSArrTime, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, ArrTimeBlk, Month WHERE Year = '2014' AND LongestAddGTime = '43' AND AirlineID = '20366'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND DistanceGroup = '8' AND DivActualElapsedTime = '411' GROUP BY LongestAddGTime, Month, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOff = '1318' AND SecurityDelay = '-9999' AND Month = '6' GROUP BY DestStateName, CancellationCode, Carrier
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY FlightDate, CancellationCode, DepTimeBlk WHERE Quarter = '2' AND DayOfWeek = '7' AND CRSArrTime = '1053'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn = '2247' AND DayOfWeek = '3' AND Quarter = '2' GROUP BY DestAirportID, DepTimeBlk, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY CRSDepTime, Flights, DivAirportLandings WHERE OriginState = 'NV' AND DistanceGroup = '5' AND DepTimeBlk = '1400-1459'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY Month, WeatherDelay, Carrier WHERE DayofMonth = '4' AND Flights = '1' AND DestStateName = 'Missouri'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY TaxiOut, Cancelled, AirlineID WHERE ArrTimeBlk = '2000-2059' AND FlightDate = '2014-06-01' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, DivArrDelay, Cancelled WHERE CRSDepTime = '938'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'UA' AND Diverted = '1' AND Month = '6' GROUP BY NASDelay, DestState, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiOut = '11' AND DestState = 'NJ' AND LateAircraftDelay = '23' GROUP BY DivArrDelay, DivAirportLandings, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DivReachedDest, OriginStateName WHERE DistanceGroup = '2' AND DivAirportLandings = '1' AND DivArrDelay = '172'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth = '19' AND ArrTimeBlk = '0600-0659' AND Flights = '1' GROUP BY OriginWac
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestWac = '23' AND Cancelled = '0' AND DayOfWeek = '2' 
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, DistanceGroup, Month WHERE Quarter = '2' AND DayOfWeek = '6' AND Dest = 'TUL'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, CancellationCode, Diverted WHERE Carrier = 'OO' AND Cancelled = '0' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, DayOfWeek, Cancelled WHERE Cancelled = '0' AND DestStateName = 'Maryland'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, DepTimeBlk, DivAirportLandings WHERE TotalAddGTime = '-9999' AND Dest = 'SUN' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY WeatherDelay, FirstDepTime, Month WHERE AirlineID = '20436' AND DivReachedDest = '1' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginAirportID, Flights, CancellationCode WHERE DayOfWeek = '5' AND Quarter = '2' AND CRSArrTime = '1511'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE SecurityDelay = '-9999' AND DayOfWeek = '4' AND OriginAirportID = '13577' GROUP BY AirlineID, LateAircraftDelay, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'UA' AND Quarter = '2' AND ActualElapsedTime = '163' GROUP BY OriginStateFips, UniqueCarrier, DayOfWeek
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Diverted, DivDistance WHERE OriginAirportID = '10408'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE WeatherDelay = '61' GROUP BY TaxiIn, DivReachedDest, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Quarter, DestWac, OriginWac WHERE DestStateFips = '18' AND Cancelled = '0' AND TaxiOut = '46'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup = '1' AND Carrier = 'WN' AND DayofMonth = '29' GROUP BY DivActualElapsedTime, Diverted, DivAirportLandings
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirTime, ArrTimeBlk, Month WHERE Year = '2014' AND OriginAirportSeqID = '1115003' AND DivAirportLandings = '0'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY OriginState, DistanceGroup, UniqueCarrier WHERE Month = '6' AND DayofMonth = '16' AND DestState = 'MD'
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DepTime, SecurityDelay, Flights WHERE Flights = '1' AND WheelsOn = '1344' AND SecurityDelay = '-9999'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Diverted, OriginStateFips, DistanceGroup WHERE LateAircraftDelay = '225' AND Flights = '1' AND OriginStateFips = '15'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DepTime = '1042' GROUP BY DepTime, DivAirportLandings, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE LateAircraftDelay = '168' GROUP BY OriginCityMarketID, Diverted, Carrier
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE WheelsOn = '1853' AND Year = '2014' AND UniqueCarrier = 'B6' GROUP BY OriginCityMarketID, Flights, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '0' AND DivReachedDest = '1' AND DestStateFips = '28' GROUP BY DestCityName, ArrTimeBlk, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest = '-9999' AND Year = '2014' AND DistanceGroup = '9' GROUP BY ArrTimeBlk, DestCityName, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Cancelled = '0' AND DayOfWeek = '4' AND Flights = '1' GROUP BY Year, OriginStateFips, OriginState
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '1' AND Diverted = '0' AND DestAirportSeqID = '1538003' GROUP BY Cancelled, AirTime, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, Month, Quarter WHERE CarrierDelay = '24' AND Flights = '1' AND DestAirportID = '14570'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID = '31603' AND CancellationCode = 'B' AND Cancelled = '1' GROUP BY OriginAirportSeqID, Quarter, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE OriginWac = '67' GROUP BY DepTimeBlk, Cancelled, FirstDepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Cancelled = '0' AND UniqueCarrier = 'FL' AND Origin = 'MSP' GROUP BY DestState, FirstDepTime, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE FirstDepTime = '1417' GROUP BY DayofMonth, OriginStateName, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportSeqID, FlightDate, Year WHERE Quarter = '2' AND DivDistance = '30' AND DayOfWeek = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings = '1' GROUP BY DestWac, Cancelled, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY AirTime, DayOfWeek, Cancelled WHERE Cancelled = '0' AND TaxiIn = '111' AND Month = '6'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Origin, SecurityDelay, Cancelled WHERE DestStateFips = '56' AND Quarter = '2' AND DivReachedDest = '0'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateName, NASDelay, Quarter WHERE ArrTime = '441' AND UniqueCarrier = 'B6' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk, OriginCityName, Year WHERE OriginCityMarketID = '33029' AND TaxiIn = '7' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND Year = '2014' AND DivReachedDest = '1' GROUP BY NASDelay, DepTimeBlk, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSArrTime = '802' AND Flights = '1' AND OriginWac = '54' GROUP BY WeatherDelay, ArrTimeBlk, DestCityName
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID = '11278' AND ArrTimeBlk = '0600-0659' AND DayOfWeek = '5' GROUP BY OriginAirportSeqID, SecurityDelay, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityMarketID, SecurityDelay, DivReachedDest WHERE CancellationCode = 'noodles' AND Diverted = '0' AND CRSDepTime = '1403'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginState, LongestAddGTime, Month WHERE Diverted = '0' AND OriginCityMarketID = '34689' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Flights, Dest, Cancelled WHERE CancellationCode = 'C' AND DayOfWeek = '5'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'B6' AND NASDelay = '104' AND Year = '2014' GROUP BY DistanceGroup, TotalAddGTime, Carrier
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND WheelsOff = '1649' AND OriginStateName = 'Missouri' GROUP BY DivReachedDest, WeatherDelay, ArrTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY CRSArrTime, Year, Flights WHERE DestWac = '88'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LateAircraftDelay = '-9999' AND OriginCityMarketID = '34108' AND SecurityDelay = '-9999' GROUP BY DayOfWeek, OriginAirportID, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, DayOfWeek, Year WHERE LongestAddGTime = '35'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LongestAddGTime, OriginState, DivReachedDest WHERE DivActualElapsedTime = '391' AND UniqueCarrier = 'US' AND DivAirportLandings = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = '382' AND Carrier = 'MQ' AND Flights = '1' GROUP BY NASDelay, DistanceGroup, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk, OriginCityName, Year WHERE TotalAddGTime = '-9999' AND Month = '6' AND AirTime = '204'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Dest = 'GEG' AND Cancelled = '1' AND DistanceGroup = '4' GROUP BY DepTime, Year, DivAirportLandings
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = '557' GROUP BY DivArrDelay, DistanceGroup, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityName, DepTimeBlk, Month WHERE Month = '6' AND DestStateFips = '17' AND FlightNum = '5419'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestState, DestStateName, Month WHERE ActualElapsedTime = '231' AND TaxiIn = '15' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac = '21' AND Flights = '1' AND CarrierDelay = '34' GROUP BY DepTime, DivAirportLandings, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateFips, DestStateFips, Month WHERE UniqueCarrier = 'B6'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND WheelsOff = '2354' AND Quarter = '2' GROUP BY Diverted, DivDistance, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DivActualElapsedTime, DayOfWeek, Diverted WHERE Year = '2014' AND SecurityDelay = '-9999' AND TailNum = 'N3FDAA'
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode = 'A' AND AirlineID = '19690' AND Quarter = '2' GROUP BY Cancelled, AirlineID, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY CancellationCode, Diverted, DayofMonth WHERE OriginState = 'OK' AND WheelsOff = '1049' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY CarrierDelay WHERE Flights = '1' AND Year = '2014' AND ArrTime = '202'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk = '1600-1659' AND Month = '6' AND CarrierDelay = '46' GROUP BY DepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND FlightDate = '2014-06-02' AND TaxiOut = '9' GROUP BY OriginAirportSeqID, Carrier, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Quarter = '2' AND Cancelled = '0' AND OriginAirportID = '11953' GROUP BY Distance, SecurityDelay, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay = '-9999' AND FlightDate = '2014-06-14' AND Diverted = '0' GROUP BY OriginCityName, AirlineID, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay = '-9999' AND TailNum = 'N558UA' AND AirlineID = '19977' GROUP BY Origin, Month, UniqueCarrier
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE TaxiIn = '7' AND LateAircraftDelay = '63' AND DayOfWeek = '5' GROUP BY OriginCityName, FlightDate, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, UniqueCarrier, Flights WHERE DayOfWeek = '6' AND DistanceGroup = '4' AND DivReachedDest = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Distance, CancellationCode, Quarter WHERE OriginWac = '84' AND DivAirportLandings = '9' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DayofMonth = '28' AND OriginState = 'IL' AND Cancelled = '0' GROUP BY NASDelay, OriginStateFips, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay = '96' GROUP BY DivArrDelay, DivReachedDest, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = '75' GROUP BY Year, OriginState, DivAirportLandings
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay = '18' GROUP BY OriginWac, AirlineID, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '0' AND DestWac = '34' AND DestState = 'GA' GROUP BY OriginState, DayofMonth, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND AirTime = '144' AND SecurityDelay = '0' GROUP BY FlightDate, DistanceGroup, ArrTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, Month, CancellationCode WHERE DepTimeBlk = '0900-0959' AND Quarter = '2' AND AirlineID = '19790'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestState = 'LA' AND OriginStateFips = '8' AND Diverted = '0' GROUP BY AirTime, Flights, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest = '-9999' AND LateAircraftDelay = '-9999' AND FlightNum = '5503' GROUP BY DestState, DivAirportLandings, DepTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime, OriginStateFips, Quarter WHERE ArrTimeBlk = '2300-2359' AND Distance = '1514' AND Year = '2014'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE WheelsOff = '1833' AND AirTime = '144' AND Year = '2014' GROUP BY DestAirportSeqID, DepTimeBlk, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivAirportLandings, DepTimeBlk, AirlineID WHERE OriginStateFips = '27' AND DestStateName = 'Alaska' AND Month = '6'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime = '832' GROUP BY LongestAddGTime, TaxiOut, DayofMonth
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestAirportID, DayOfWeek, Flights WHERE Flights = '1' AND DestStateFips = '32' AND LateAircraftDelay = '84'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled = '0' AND DistanceGroup = '6' AND ActualElapsedTime = '281' GROUP BY ArrTimeBlk, FirstDepTime, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSArrTime, SecurityDelay, Month WHERE CRSElapsedTime = '369' AND Cancelled = '0' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY TailNum, Quarter, Year WHERE DayofMonth = '28' AND UniqueCarrier = 'DL' AND DestStateFips = '15'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DestState, FirstDepTime, Cancelled WHERE FlightDate = '2014-06-23' AND Month = '6' AND AirlineID = '20366'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND DestAirportSeqID = '1334205' AND DepTime = '1314' GROUP BY Diverted, CarrierDelay, DepTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '3' AND Dest = 'PVD' AND Diverted = '0' GROUP BY OriginAirportID, Cancelled, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, Year, OriginStateName WHERE AirlineID = '20409' AND CRSArrTime = '1903' AND DayOfWeek = '7'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivDistance, DepTimeBlk, Flights WHERE ArrTimeBlk = '1500-1559'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY SecurityDelay, DepTimeBlk, Diverted WHERE CancellationCode = 'noodles' AND DestCityMarketID = '30255' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay = '0' AND OriginAirportID = '15024' AND AirlineID = '20409' GROUP BY AirTime, DayOfWeek, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY LongestAddGTime, DestStateName WHERE Month = '6'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE WheelsOn = '2115' AND ActualElapsedTime = '81' AND AirlineID = '19393' GROUP BY DivReachedDest, Distance, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = '345' AND ArrTimeBlk = '1200-1259' AND Diverted = '1' GROUP BY CRSElapsedTime, DepTimeBlk, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DivActualElapsedTime = '446' GROUP BY LongestAddGTime, DestStateName, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND OriginStateName = 'New York' AND WheelsOn = '1035' GROUP BY TailNum
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Carrier, Flights, Cancelled WHERE Cancelled = '0' AND WheelsOn = '1835' AND OriginStateName = 'Tennessee'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestWac = '34' AND Month = '6' GROUP BY FirstDepTime, TaxiOut, DestStateName
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY DivDistance, DistanceGroup, Diverted WHERE DepTimeBlk = '1400-1459' AND ActualElapsedTime = '236' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff = '48' AND DayofMonth = '29' GROUP BY TaxiOut, DestWac, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '0' AND Quarter = '2' AND OriginStateName = 'California' GROUP BY Month, DistanceGroup, TaxiOut
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND Cancelled = '1' AND Quarter = '2' GROUP BY OriginState, Quarter, FirstDepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND DivReachedDest = '-9999' AND OriginStateFips = '49' GROUP BY Cancelled, CancellationCode, DepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1000-1059' AND CarrierDelay = '16' AND Month = '6' GROUP BY Origin, CancellationCode, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityName, Month, DayOfWeek WHERE Distance = '933'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY LongestAddGTime, DivAirportLandings, Year WHERE Diverted = '0' AND Quarter = '2' AND CRSElapsedTime = '342'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay = '10' AND Quarter = '2' AND DayOfWeek = '2' GROUP BY Month, ActualElapsedTime, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY NASDelay, OriginState, Year WHERE WheelsOn = '605' AND DayOfWeek = '1' AND AirlineID = '20409'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DepTime, Cancelled, Quarter WHERE CRSDepTime = '2208' AND DivAirportLandings = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Distance, Flights, DivReachedDest WHERE DestWac = '33' AND Month = '6' AND OriginWac = '4'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CancellationCode, TaxiOut, Month WHERE DayofMonth = '29' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND DepTime = '1853' AND Flights = '1' GROUP BY CancellationCode, Quarter, DayofMonth
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Carrier = 'AA' AND TaxiOut = '32' AND ArrTimeBlk = '1000-1059' GROUP BY DestAirportID, Quarter, CarrierDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DestStateName = 'Colorado' AND Flights = '1' AND ActualElapsedTime = '252' GROUP BY DivActualElapsedTime, CancellationCode, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DivReachedDest = '-9999' GROUP BY FlightNum, Month, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND Flights = '1' AND OriginState = 'ME' GROUP BY UniqueCarrier, ArrTimeBlk, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateFips, OriginStateFips, Diverted WHERE DestWac = '61' AND Quarter = '2' AND OriginStateName = 'Nevada'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY SecurityDelay, OriginAirportID, Cancelled WHERE CancellationCode = 'A' AND Flights = '1' AND Cancelled = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND OriginStateName = 'New Jersey' AND TaxiOut = '35' GROUP BY DivArrDelay, Carrier, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DestState, TotalAddGTime, Diverted WHERE DivAirportLandings = '1' AND DayofMonth = '18' AND DivArrDelay = '343'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DestState = 'NV' AND DistanceGroup = '5' AND FlightDate = '2014-06-14' GROUP BY Distance, Quarter, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityMarketID = '34100' GROUP BY FlightDate, DivDistance, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, DivAirportLandings, Flights WHERE Cancelled = '0' AND DestState = 'NJ' AND OriginAirportSeqID = '1099402'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginWac = '86' AND Quarter = '2' AND DayOfWeek = '5' GROUP BY FirstDepTime, ArrTimeBlk, SecurityDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '0' AND CRSDepTime = '1240' AND Quarter = '2' GROUP BY DivDistance, OriginStateName, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE TailNum = 'N197JB' AND Diverted = '1' AND Month = '6' 
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Cancelled, DivDistance, Year WHERE DestCityMarketID = '34457' AND DayofMonth = '15' AND Quarter = '2'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DayOfWeek, TaxiIn, Cancelled WHERE DestCityMarketID = '30693' AND Flights = '1' AND WheelsOff = '1824'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivArrDelay, CancellationCode, Flights WHERE Quarter = '2' AND Year = '2014' AND Diverted = '0'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FlightNum, Month, Flights WHERE Origin = 'ORD' AND ArrTimeBlk = '0800-0859' AND DestAirportID = '11823'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime = '2030' GROUP BY Carrier, DestStateName, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Year, WeatherDelay, OriginWac WHERE Quarter = '2' AND AirTime = '320' AND OriginWac = '21'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips = '30' GROUP BY CancellationCode, Month, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, Year, SecurityDelay WHERE Flights = '1' AND CRSDepTime = '942'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '9' GROUP BY DayOfWeek, WheelsOn, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND OriginAirportID = '13964' AND Cancelled = '1' GROUP BY DistanceGroup
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE TaxiOut = '78' AND Year = '2014' AND Flights = '1' GROUP BY DestStateFips, DestStateName, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '2' AND Origin = 'VPS' AND Flights = '1' GROUP BY DepTime, DayOfWeek, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TailNum, Quarter, Flights WHERE Cancelled = '0'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '0' AND CancellationCode = 'noodles' AND Diverted = '1' GROUP BY CRSElapsedTime, CancellationCode, SecurityDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestStateName = 'Idaho' GROUP BY Diverted, LongestAddGTime, CancellationCode
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Year, Diverted, Flights WHERE DivAirportLandings = '0' AND FlightDate = '2014-06-22' AND CRSElapsedTime = '59'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1700-1759' AND DestCityName = 'Portland, OR' AND Flights = '1' 
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, DepTimeBlk, Quarter WHERE CRSElapsedTime = '249' AND DayofMonth = '18' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginState = 'IN' AND DestState = 'IL' AND DayofMonth = '19' GROUP BY CRSDepTime, Diverted, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = '2' AND OriginAirportID = '11003' AND Cancelled = '0' GROUP BY OriginCityName, Cancelled, Carrier
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE TotalAddGTime = '-9999' AND ActualElapsedTime = '370' GROUP BY DestCityName, DepTimeBlk, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DepTime = '1924' AND Flights = '1' AND Year = '2014' GROUP BY DestCityName, DivAirportLandings, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Maryland' AND DistanceGroup = '3' GROUP BY FirstDepTime, Year, TaxiOut
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '3' AND DestAirportID = '12197' AND Diverted = '1' GROUP BY Month, WheelsOn, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY Quarter, LongestAddGTime, OriginWac WHERE SecurityDelay = '0' AND DepTimeBlk = '0700-0759' AND Flights = '1'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '-9999' AND DestStateName = 'Pennsylvania' AND AirTime = '250' GROUP BY TailNum, Diverted, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestWac, TotalAddGTime, Diverted WHERE Origin = 'DTW' AND Quarter = '2' AND DayofMonth = '27'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DestStateFips = '34' AND Year = '2014' AND WheelsOff = '1808' GROUP BY DestAirportID, ArrTimeBlk, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Origin = 'LNK' AND Year = '2014' AND Month = '6' GROUP BY OriginStateName, CarrierDelay, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Year, ArrTime, Flights WHERE Diverted = '1' AND Flights = '1' AND DestStateName = 'Arkansas'
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY Distance, Month, Cancelled WHERE Cancelled = '0' AND ArrTimeBlk = '2100-2159' AND Carrier = 'EV'
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY FirstDepTime, DepTimeBlk, Diverted WHERE CancellationCode = 'A' AND DayofMonth = '29' AND OriginState = 'IL'
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY FlightDate, LateAircraftDelay, Flights WHERE Flights = '1' AND CancellationCode = 'noodles' AND WeatherDelay = '33'
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY Month, DestStateFips, LateAircraftDelay WHERE ArrTimeBlk = '1500-1559' AND Quarter = '2' AND DestState = 'UT'
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '15' GROUP BY CRSArrTime, DivAirportLandings, Cancelled
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '6' AND DivReachedDest = '-9999' AND AirlineID = '19805' GROUP BY OriginWac, DivDistance, Month
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DepTime = '2347' GROUP BY UniqueCarrier, OriginAirportID, Month
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Dest = 'IND' AND Cancelled = '0' AND DivAirportLandings = '0' GROUP BY DepTime, Cancelled, Month
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND Cancelled = '1' AND CRSDepTime = '1645' GROUP BY DestCityMarketID, Flights, AirlineID
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CarrierDelay = '7' AND DepTime = '1834' AND DivAirportLandings = '0' GROUP BY OriginAirportSeqID, ArrTimeBlk, Month
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE NASDelay = '117' GROUP BY LongestAddGTime, OriginStateName, Flights
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Year, DivReachedDest, AirlineID WHERE DestCityName = 'Twin Falls, ID' AND DayOfWeek = '2' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestCityName = 'Lincoln, NE' GROUP BY DestStateFips, Carrier, Flights
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, AirlineID, Year WHERE DivReachedDest = '1' AND DestAirportID = '14100' AND TaxiOut = '8'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND DayofMonth = '5' AND UniqueCarrier = 'OO' GROUP BY UniqueCarrier, DestAirportSeqID, Quarter
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime, CancellationCode, Quarter WHERE Cancelled = '0' AND CRSDepTime = '1127'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek = '1' AND ArrTimeBlk = '0700-0759' AND ArrTime = '653' GROUP BY FlightDate, UniqueCarrier, SecurityDelay
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayofMonth, FirstDepTime, Month WHERE Flights = '1' AND DivAirportLandings = '0' AND Carrier = 'US'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, Month, WeatherDelay WHERE TaxiOut = '24' AND DivArrDelay = '141'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName = 'Vermont' GROUP BY Quarter, TotalAddGTime, OriginStateName
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName = 'Minnesota' AND DayOfWeek = '7' AND Carrier = 'AA' GROUP BY NASDelay, FlightDate, Flights
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE NASDelay = '16' GROUP BY LongestAddGTime, OriginStateFips, Diverted
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '9' AND DepTimeBlk = '1200-1259' AND OriginStateFips = '40' GROUP BY DepTime, Origin, DivDistance
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TailNum = 'N641SW' AND Diverted = '0' AND DayOfWeek = '5' GROUP BY DivDistance, Carrier, Cancelled
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND TaxiOut = '58' AND DivReachedDest = '-9999' GROUP BY Flights, DestAirportSeqID, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Origin = 'GTF' GROUP BY Flights, DestCityName, FlightDate
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND CarrierDelay = '6' AND DestCityName = 'Dallas, TX' GROUP BY FirstDepTime, OriginState, Flights
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '1' AND DistanceGroup = '5' AND DestWac = '93' GROUP BY Month, AirTime, DayOfWeek
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, OriginStateName, Diverted WHERE CancellationCode = 'noodles' AND DayofMonth = '10' AND DestStateFips = '53'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '5' AND Cancelled = '0' AND NASDelay = '65' GROUP BY Dest, Quarter, TailNum
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, DepTimeBlk, Month WHERE DepTimeBlk = '2000-2059' AND DivReachedDest = '1'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode = 'noodles' AND ArrTimeBlk = '1300-1359' AND TaxiIn = '19' GROUP BY OriginAirportID, OriginStateFips, AirTime
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn = '2129' AND OriginWac = '2' AND DivReachedDest = '-9999' GROUP BY OriginCityMarketID, UniqueCarrier, Month
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY OriginStateName, Month, DepTimeBlk WHERE DepTime = '1823' AND DivReachedDest = '-9999' AND Diverted = '0'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY SecurityDelay, FirstDepTime, Quarter WHERE Flights = '1' AND Origin = 'RDM' AND Diverted = '0'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn = '1624' AND DayOfWeek = '5' AND Diverted = '0' GROUP BY Cancelled, DepTime, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Month, Year, OriginStateFips WHERE DepTimeBlk = '0600-0659' AND DestCityMarketID = '31714' AND Flights = '1'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '1' AND TaxiOut = '47' AND UniqueCarrier = 'UA' GROUP BY OriginState, DayOfWeek, Flights
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Cancelled = '1' AND Quarter = '2' AND DestStateName = 'Georgia' GROUP BY Flights, Diverted, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSDepTime = '1400' AND DivAirportLandings = '1' AND Carrier = 'FL' GROUP BY Month, CarrierDelay, DistanceGroup
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Distance = '1912' AND DivReachedDest = '-9999' AND DepTimeBlk = '1500-1559' GROUP BY DestStateName, Month, CarrierDelay
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled = '1' AND SecurityDelay = '-9999' AND FirstDepTime = '1627' GROUP BY WheelsOff, Quarter, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightDate, Cancelled, Month WHERE Quarter = '2'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TailNum, Cancelled, Quarter WHERE DistanceGroup = '9' AND ArrTimeBlk = '1000-1059' AND TaxiOut = '25'
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '2' AND CancellationCode = 'noodles' AND AirTime = '250' GROUP BY DestCityMarketID, UniqueCarrier, Diverted
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' AND FlightDate = '2014-06-05' AND OriginAirportSeqID = '1454302' GROUP BY DivDistance, DestStateName, Quarter
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY Quarter, CRSDepTime, Month WHERE CRSElapsedTime = '224' AND Cancelled = '0' AND Flights = '1'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, OriginAirportID, Month WHERE DayOfWeek = '6' AND AirlineID = '20436' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Diverted, AirlineID, CarrierDelay WHERE ArrTimeBlk = '2100-2159' AND DayofMonth = '30' AND DistanceGroup = '7'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, CancellationCode, Cancelled WHERE FlightDate = '2014-06-09' AND OriginStateName = 'Oklahoma' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND ArrTimeBlk = '1100-1159' AND OriginCityName = 'Montgomery, AL' GROUP BY Quarter, DestCityMarketID, UniqueCarrier
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '1' AND DivActualElapsedTime = '533' AND OriginCityName = 'Charlotte, NC' GROUP BY CarrierDelay, OriginWac, Flights
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND ActualElapsedTime = '46' AND OriginState = 'AZ' GROUP BY LongestAddGTime
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn = '20' AND DepTimeBlk = '1600-1659' AND DayOfWeek = '5' GROUP BY AirlineID, TotalAddGTime, OriginStateFips
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff = '1718' AND Year = '2014' AND OriginStateName = 'Wisconsin' GROUP BY DestStateName
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND Flights = '1' AND DepTime = '1124' GROUP BY Cancelled, SecurityDelay, CarrierDelay
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek = '1' AND DestStateName = 'Iowa' AND Flights = '1' GROUP BY Quarter, CarrierDelay, Cancelled
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk = '1200-1259' AND AirlineID = '19393' AND DestAirportSeqID = '1172102' GROUP BY CRSElapsedTime, DivAirportLandings, Cancelled
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, Year, DistanceGroup WHERE Quarter = '2' AND DivActualElapsedTime = '229' AND DayOfWeek = '5'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay, Cancelled, SecurityDelay WHERE DayofMonth = '9' AND Year = '2014' AND CancellationCode = 'noodles'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivActualElapsedTime = '428' AND Diverted = '1' AND OriginCityName = 'Chicago, IL' GROUP BY Month, CancellationCode, TaxiIn
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginStateName = 'South Carolina' AND Flights = '1' AND DivReachedDest = '0' GROUP BY DestAirportID, DayofMonth, Month
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ArrTime, Cancelled, Flights WHERE CRSElapsedTime = '134' AND UniqueCarrier = 'AA' AND SecurityDelay = '-9999'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayOfWeek, AirlineID, SecurityDelay WHERE OriginState = 'CA' AND DepTimeBlk = '1000-1059' AND DivActualElapsedTime = '281'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiOut, FlightDate, Diverted WHERE Quarter = '2' AND Year = '2014' AND ArrTimeBlk = '1000-1059'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID = '1115003' GROUP BY FlightDate, OriginState, Year
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, Quarter, UniqueCarrier WHERE OriginStateName = 'Tennessee' AND DepTimeBlk = '1400-1459' AND UniqueCarrier = 'US'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '84' GROUP BY DayofMonth, TaxiOut, Cancelled
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime = '923' AND Diverted = '0' AND DistanceGroup = '5' GROUP BY CRSElapsedTime, Carrier, Quarter
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE UniqueCarrier = 'US' AND AirTime = '198' AND DayofMonth = '20' GROUP BY DivArrDelay, Carrier, Month
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE ArrTime = '2235' AND TaxiOut = '31' AND Cancelled = '0' GROUP BY Origin, DivReachedDest, Year
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DepTime = '1854' GROUP BY Year, CarrierDelay, CancellationCode
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportID, AirlineID, Cancelled WHERE SecurityDelay = '0'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips = '42' AND WheelsOff = '1358' AND AirlineID = '20355' GROUP BY DayOfWeek, CancellationCode
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TailNum, Quarter, Year WHERE WeatherDelay = '61'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay = '0' GROUP BY CRSArrTime, Flights, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY CarrierDelay, FlightDate, Year WHERE Carrier = 'DL' AND ArrTime = '2309' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, DistanceGroup, Flights WHERE Dest = 'PDX' AND CancellationCode = 'A' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginAirportSeqID = '1502403' GROUP BY FlightNum, Diverted, Flights
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime, UniqueCarrier, Month WHERE OriginStateFips = '16' AND Year = '2014' AND CancellationCode = 'A'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestCityName, ArrTimeBlk, Quarter WHERE AirTime = '311' AND Quarter = '2' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips = '17' AND DepTime = '1229' AND Cancelled = '0' GROUP BY Origin, Cancelled, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportSeqID, DistanceGroup, Month WHERE DepTimeBlk = '1500-1559' AND DistanceGroup = '11' AND AirTime = '371'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '41' GROUP BY DepTimeBlk, DivDistance, Diverted
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY TailNum, Year, Quarter WHERE DivReachedDest = '0' AND DayOfWeek = '1' AND Flights = '1'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState = 'AL' AND Quarter = '2' AND DayOfWeek = '5' GROUP BY Flights, DivDistance, DestStateFips
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY UniqueCarrier, FirstDepTime, SecurityDelay WHERE Cancelled = '0' AND CRSArrTime = '1603' AND DestAirportSeqID = '1449202'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY AirlineID, SecurityDelay, Quarter WHERE ArrTimeBlk = '2100-2159' AND Cancelled = '0' AND OriginAirportSeqID = '1457002'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac = '34' AND FlightDate = '2014-06-11' AND Month = '6' GROUP BY OriginState, DestState, Flights
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE UniqueCarrier = 'DL' AND OriginCityName = 'Fort Myers, FL' AND Flights = '1' GROUP BY CarrierDelay, OriginState, Month
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY CancellationCode WHERE Quarter = '2' AND DayofMonth = '24' AND Flights = '1'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '1' AND Cancelled = '0' AND ActualElapsedTime = '323' GROUP BY Diverted, Distance, Month
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestStateFips = '38' AND ArrTimeBlk = '0800-0859' AND DivAirportLandings = '0' GROUP BY LongestAddGTime, Quarter, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE SecurityDelay = '-9999' AND Cancelled = '1' AND DestAirportSeqID = '1015502' GROUP BY DayofMonth, DepTimeBlk, Month
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '1400-1459' AND CRSDepTime = '1008' AND Cancelled = '0' GROUP BY DivReachedDest, Origin, DistanceGroup
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DestAirportSeqID = '1169703' AND Quarter = '2' GROUP BY DestWac, CancellationCode, DayofMonth
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginState, Cancelled, SecurityDelay WHERE ArrTimeBlk = '1100-1159' AND Quarter = '2' AND DayofMonth = '8'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY NASDelay, FirstDepTime, Year WHERE Cancelled = '0'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayofMonth, DivReachedDest, DayOfWeek WHERE DistanceGroup = '7' AND DestState = 'NY'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND DistanceGroup = '6' AND OriginStateFips = '34' GROUP BY DestStateFips, DepTimeBlk, SecurityDelay
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn = '4' AND DepTimeBlk = '1500-1559' AND DestAirportSeqID = '1056103' GROUP BY DestAirportSeqID, DayofMonth, Flights
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CRSElapsedTime = '210' GROUP BY CRSElapsedTime, Cancelled, CancellationCode
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivArrDelay = '201' AND Flights = '1' AND UniqueCarrier = 'MQ' GROUP BY DivAirportLandings, DivDistance, TaxiIn
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode = 'A' AND OriginStateName = 'California' AND DistanceGroup = '1' GROUP BY LateAircraftDelay, DestStateName, Flights
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState = 'AL' GROUP BY Diverted, DestStateFips, DestState
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiIn, Year, ArrTimeBlk WHERE FlightNum = '2967'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, ArrTimeBlk, Year WHERE Cancelled = '0' AND OriginAirportID = '11259' AND WheelsOn = '2016'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WeatherDelay, OriginState, Flights WHERE ArrTimeBlk = '1000-1059' AND OriginWac = '86' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, Flights, Diverted WHERE WheelsOn = '407' AND Month = '6'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable  WHERE Year = '2014' AND DivAirportLandings = '0' AND Cancelled = '0'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '1' GROUP BY OriginStateFips, DivDistance, Quarter
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '7' AND AirTime = '219' AND DepTimeBlk = '2300-2359' GROUP BY DepTime, Flights, DayOfWeek
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayofMonth = '6' AND AirTime = '116' AND Quarter = '2' GROUP BY Quarter, DepTimeBlk, OriginCityMarketID
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, DivAirportLandings, Month WHERE Quarter = '2' AND DestCityName = 'Miami, FL' AND OriginState = 'VI'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Cancelled, AirTime, CancellationCode WHERE Quarter = '2' AND FlightDate = '2014-06-08' AND OriginStateFips = '2'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY TaxiOut, Month, Flights WHERE ActualElapsedTime = '223' AND DayofMonth = '10' AND Flights = '1'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE AirlineID = '20366' AND Year = '2014' AND Carrier = 'EV' GROUP BY CRSDepTime, Flights, CancellationCode
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestState = 'NV' AND OriginStateName = 'Michigan' AND DayOfWeek = '5' GROUP BY OriginCityMarketID, Diverted, Carrier
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY WheelsOff, DayOfWeek, Quarter WHERE Month = '6' AND OriginStateFips = '17' AND FlightDate = '2014-06-09'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DestStateName, TaxiIn, Month WHERE Cancelled = '0' AND Month = '6' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay = '-9999' AND OriginState = 'TX' AND DivAirportLandings = '2' GROUP BY DivActualElapsedTime, Diverted, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND Month = '6' AND Diverted = '1' GROUP BY AirTime, Flights, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND TaxiOut = '12' AND Distance = '761' GROUP BY WheelsOn, DivReachedDest, Diverted
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityMarketID = '30721' AND LongestAddGTime = '13' AND DestAirportSeqID = '1289203' GROUP BY OriginStateName, AirlineID, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY LongestAddGTime, Diverted, Cancelled WHERE Year = '2014' AND OriginStateName = 'Oregon' AND SecurityDelay = '0'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings = '1' AND AirlineID = '20398' AND SecurityDelay = '-9999' GROUP BY OriginStateFips, DivDistance, Year
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'FL' GROUP BY CarrierDelay, Quarter, DayofMonth
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CRSArrTime = '1756' AND DestWac = '91' AND Diverted = '1' GROUP BY Distance, CarrierDelay, Month
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier = 'F9' AND UniqueCarrier = 'F9' AND DestWac = '61' GROUP BY DestCityMarketID, UniqueCarrier, Diverted
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND Flights = '1' AND FlightNum = '4586' GROUP BY ActualElapsedTime, CancellationCode, SecurityDelay
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier = 'AS' AND Quarter = '2' AND TotalAddGTime = '13' GROUP BY DestStateFips, DayOfWeek, Month
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE NASDelay = '41' GROUP BY DivArrDelay, Flights, UniqueCarrier
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Distance, DayOfWeek, Month WHERE DayofMonth = '25' AND OriginStateFips = '31' AND DepTimeBlk = '0600-0659'
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'South Dakota' AND Year = '2014' AND Diverted = '1' GROUP BY DivArrDelay, UniqueCarrier, Year
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOff = '1343' AND OriginAirportID = '12889' AND Flights = '1' GROUP BY OriginCityMarketID, DayOfWeek, Diverted
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayofMonth WHERE CRSArrTime = '2131' AND AirlineID = '20366' AND DestAirportID = '11042'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestStateFips, Quarter, Year WHERE Diverted = '0' AND NASDelay = '4' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, ArrTimeBlk, Quarter WHERE DepTimeBlk = '0900-0959' AND DestAirportSeqID = '1457002'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivReachedDest, FirstDepTime, Diverted WHERE DestState = 'IL' AND Diverted = '1' AND CRSArrTime = '1135'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState, OriginStateFips, Quarter WHERE TaxiIn = '6' AND OriginStateFips = '54' AND DepTimeBlk = '1700-1759'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, FirstDepTime, Cancelled WHERE CancellationCode = 'noodles' AND Origin = 'MRY' AND Month = '6'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '0' AND AirlineID = '19930' AND OriginState = 'MO' GROUP BY DepTimeBlk, TaxiOut, Flights
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE FirstDepTime = '2305' AND SecurityDelay = '0' GROUP BY CRSArrTime, Flights, LateAircraftDelay
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY ArrTimeBlk, DivReachedDest, OriginStateName WHERE DayOfWeek = '4' AND Month = '6' AND OriginCityMarketID = '31123'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, DestStateName, Quarter WHERE WheelsOn = '1949'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, Cancelled, Year WHERE DivAirportLandings = '0' AND Quarter = '2' AND OriginCityMarketID = '34321'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND OriginWac = '22' AND Flights = '1' GROUP BY Distance, CancellationCode, Flights
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut, Year, LongestAddGTime WHERE AirlineID = '20304' AND Quarter = '2' AND WheelsOff = '539'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE AirlineID = '20398' AND DayOfWeek = '4' AND OriginStateFips = '51' GROUP BY Flights, OriginState, Carrier
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, SecurityDelay, Cancelled WHERE OriginWac = '71' AND ArrTimeBlk = '1000-1059' AND ArrTime = '1046'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '9' AND Year = '2014' AND FlightNum = '3642' GROUP BY Flights, OriginStateName, DistanceGroup
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' AND DivAirportLandings = '9' AND OriginCityMarketID = '31057' GROUP BY DestWac, DepTimeBlk, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE WheelsOn = '321' AND Month = '6' AND Year = '2014' GROUP BY WheelsOn
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime, TaxiIn, Quarter WHERE OriginState = 'ID' AND Year = '2014' AND Diverted = '1'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityName = 'Montgomery, AL' GROUP BY DivReachedDest, NASDelay, UniqueCarrier
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID = '11042' AND Diverted = '1' AND TaxiIn = '32' GROUP BY LateAircraftDelay, FlightDate, Flights
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CRSDepTime, DivAirportLandings, Year WHERE Dest = 'BWI' AND DayOfWeek = '2' AND WheelsOff = '1012'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-20' AND DestWac = '51' AND Month = '6' GROUP BY TailNum, Year, Quarter
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY CancellationCode, UniqueCarrier, DestStateFips WHERE DestStateName = 'Washington' AND Cancelled = '0' AND UniqueCarrier = 'OO'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '0' AND UniqueCarrier = 'EV' AND AirTime = '77' GROUP BY DistanceGroup, DestAirportID, Quarter
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DestStateFips, LongestAddGTime, Diverted WHERE CancellationCode = 'C' AND DestWac = '54' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY DestStateName, Flights, CancellationCode WHERE Quarter = '2' AND OriginAirportSeqID = '1161802' AND CarrierDelay = '53'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY AirlineID, DayofMonth, Quarter WHERE Diverted = '0' AND OriginWac = '85' AND Carrier = 'B6'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = '40' AND DayofMonth = '19' AND Month = '6' GROUP BY DestStateFips, DivAirportLandings, Diverted
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, CancellationCode, DayOfWeek WHERE Carrier = 'US' AND AirlineID = '20355' AND CarrierDelay = '48'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE TailNum = 'N226WN' AND SecurityDelay = '-9999' AND AirTime = '75' GROUP BY DepTimeBlk, Origin, Quarter
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateName = 'Massachusetts' GROUP BY LongestAddGTime, UniqueCarrier, Year
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND Diverted = '0' AND DestStateName = 'Kansas' GROUP BY TaxiOut, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND Cancelled = '1' AND FlightDate = '2014-06-01' GROUP BY DestWac, WeatherDelay, Cancelled
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE AirlineID = '20398' AND FlightDate = '2014-06-09' AND Flights = '1' GROUP BY NASDelay, SecurityDelay, DistanceGroup
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginWac = '63' AND CRSElapsedTime = '235' AND Year = '2014' GROUP BY OriginStateFips, SecurityDelay, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND DayofMonth = '29' AND ArrTimeBlk = '1700-1759' GROUP BY FlightDate, DivDistance, Flights
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND DestStateName = 'New Mexico' AND FlightDate = '2014-06-18' GROUP BY TotalAddGTime, LateAircraftDelay, Month
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY OriginWac, NASDelay, Flights WHERE DayOfWeek = '3' AND CancellationCode = 'C' AND DestWac = '43'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY ArrTime, Month, SecurityDelay WHERE OriginCityName = 'Cody, WY'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DistanceGroup, ArrTimeBlk, DayofMonth WHERE Flights = '1' AND DestState = 'GA' AND TailNum = 'N3732J'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightNum WHERE DayofMonth = '5' AND DistanceGroup = '4' AND OriginCityName = 'Juneau, AK'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY Diverted, DivArrDelay, SecurityDelay WHERE FlightDate = '2014-06-20' AND Year = '2014' AND DestStateFips = '40'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Month, DepTime, SecurityDelay WHERE OriginAirportSeqID = '1449202' AND DestState = 'CO' AND Diverted = '0'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Quarter, DivReachedDest, DepTimeBlk WHERE OriginAirportID = '10728'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirlineID, OriginAirportID, Month WHERE SecurityDelay = '14'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '35' GROUP BY FlightNum, Flights, Quarter
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Carrier = 'FL' AND Year = '2014' AND DayofMonth = '24' GROUP BY OriginState, Month, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TaxiIn, Diverted, UniqueCarrier WHERE Quarter = '2' AND AirTime = '340' AND Diverted = '0'
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DivReachedDest = '1' AND OriginWac = '86' AND Month = '6' GROUP BY CarrierDelay, OriginAirportID, OriginState
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'MQ' AND DestCityName = 'El Paso, TX' AND CancellationCode = 'noodles' GROUP BY DestStateName, DistanceGroup, Year
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Diverted = '1' GROUP BY TotalAddGTime, Quarter, CarrierDelay
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY Cancelled, DistanceGroup, LongestAddGTime WHERE OriginCityMarketID = '30135' AND CancellationCode = 'noodles' AND Month = '6'
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivReachedDest, CarrierDelay, CancellationCode WHERE Year = '2014' AND WheelsOff = '1250' AND DayOfWeek = '1'
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk = '0600-0659' AND CancellationCode = 'C' AND DivAirportLandings = '0' GROUP BY DivReachedDest, DistanceGroup, DestState
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-10' AND DepTimeBlk = '1500-1559' AND Month = '6' GROUP BY DistanceGroup, DivArrDelay, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Quarter = '2' AND DestStateFips = '17' AND Cancelled = '1' GROUP BY DestState, FirstDepTime, Month
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE WheelsOff = '750' AND Flights = '1' AND DistanceGroup = '7' GROUP BY LateAircraftDelay, Carrier, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND CRSArrTime = '1009' GROUP BY OriginAirportSeqID, DistanceGroup, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime WHERE DivAirportLandings = '0' AND Cancelled = '0' AND AirlineID = '19393'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, NASDelay, Quarter WHERE DayofMonth = '2' AND Flights = '1' AND OriginStateName = 'Puerto Rico'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime, CancellationCode, Quarter WHERE DestAirportSeqID = '1535602'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'VX' AND CancellationCode = 'A' AND OriginAirportID = '14679' GROUP BY LongestAddGTime, WeatherDelay, Carrier
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayOfWeek, DayofMonth, ArrTimeBlk WHERE ArrTimeBlk = '1800-1859' AND NASDelay = '25' AND DayofMonth = '23'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Year, TaxiOut, DayofMonth WHERE Flights = '1' AND LateAircraftDelay = '53' AND OriginStateFips = '12'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND OriginStateFips = '49' AND DepTime = '2004' GROUP BY OriginState, TotalAddGTime, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName = 'Iowa' AND DepTimeBlk = '1700-1759' AND Cancelled = '1' GROUP BY WeatherDelay, Diverted, OriginWac
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance = '451' GROUP BY DestCityMarketID, OriginAirportID, CRSArrTime
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE FirstDepTime = '730' GROUP BY Year, CRSArrTime, SecurityDelay
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND AirlineID = '21171' AND FlightDate = '2014-06-24' GROUP BY DestCityName, ArrTimeBlk, Flights
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestCityMarketID = '33342' GROUP BY TaxiIn, DayOfWeek, CRSElapsedTime
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DivReachedDest = '1' AND CRSArrTime = '1020' AND OriginStateFips = '55' GROUP BY ArrTime, Flights, DayOfWeek
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, FlightDate, Flights WHERE DestStateFips = '72' AND Diverted = '0' AND CRSElapsedTime = '256'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CancellationCode, TaxiOut, SecurityDelay WHERE OriginAirportSeqID = '1379603'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, TotalAddGTime, Quarter WHERE TaxiOut = '59' AND SecurityDelay = '0' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND DestCityMarketID = '33076' AND Diverted = '1' GROUP BY LateAircraftDelay, DivReachedDest, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY TailNum, Quarter, Year WHERE OriginWac = '38'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY DepTimeBlk, WeatherDelay, DivAirportLandings WHERE Flights = '1' AND Cancelled = '1' AND AirlineID = '20398'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY OriginStateFips, Carrier, DivReachedDest WHERE DestState = 'ME'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '1800-1859' AND OriginCityName = 'Dayton, OH' AND Month = '6' GROUP BY CRSArrTime, Flights, Year
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Diverted, CRSArrTime, Cancelled WHERE AirlineID = '19690' AND Month = '6' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime = '131' AND DestAirportID = '14869' AND Month = '6' GROUP BY TaxiIn, Carrier, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE TotalAddGTime = '121' GROUP BY UniqueCarrier, OriginStateName
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestCityName = 'Sitka, AK' GROUP BY DistanceGroup, Cancelled, DestAirportID
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '1' AND DestWac = '33' AND DivReachedDest = '1' GROUP BY Distance, Cancelled, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID = '20437' GROUP BY SecurityDelay, DistanceGroup, Year
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' AND Carrier = 'US' AND Quarter = '2' GROUP BY TaxiIn, DivAirportLandings, UniqueCarrier
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestStateName = 'South Carolina' GROUP BY DestStateName, TotalAddGTime, Month
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TotalAddGTime = '52' GROUP BY OriginAirportID, DayOfWeek, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime, Flights, TaxiOut WHERE DepTime = '1029' AND OriginAirportID = '14771' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginAirportID = '14307' GROUP BY DivActualElapsedTime, DivAirportLandings, Month
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE TailNum = 'N959DN' GROUP BY TaxiOut, Diverted, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirlineID, OriginCityMarketID, Flights WHERE AirlineID = '20436' AND Diverted = '0' AND OriginWac = '31'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted, ArrTime, Flights WHERE OriginState = 'OR' AND ArrTimeBlk = '0800-0859' AND DayofMonth = '11'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY FlightDate, DestStateFips, CancellationCode WHERE DestStateName = 'Tennessee'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivDistance = '405' AND ArrTimeBlk = '1400-1459' GROUP BY ActualElapsedTime, Diverted, Month
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay = '75' GROUP BY DestStateFips, DivDistance, Quarter
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY WheelsOff, Diverted, DivAirportLandings WHERE OriginWac = '65' AND Quarter = '2' AND FlightDate = '2014-06-13'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE FlightNum = '4602' AND DayOfWeek = '2' AND Quarter = '2' GROUP BY DestAirportSeqID, Quarter, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay = '0' AND CancellationCode = 'noodles' AND DestState = 'KS' GROUP BY DestCityMarketID, CancellationCode, Quarter
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOn, Diverted, Quarter WHERE DayofMonth = '21' AND Year = '2014' AND Distance = '271'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginState, OriginStateFips, Cancelled WHERE TaxiOut = '3' AND SecurityDelay = '-9999' AND Month = '6'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' GROUP BY DivDistance, DayofMonth, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateFips, TaxiIn, Year WHERE DestStateName = 'Nebraska' AND DivArrDelay = '177' AND DayOfWeek = '6'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY SecurityDelay, DivDistance, Month WHERE DistanceGroup = '6'
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings = '9' AND CancellationCode = 'A' AND DistanceGroup = '7' GROUP BY DestAirportID, Quarter, DistanceGroup
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTime = '616' AND OriginStateName = 'Missouri' AND SecurityDelay = '-9999' GROUP BY ActualElapsedTime, UniqueCarrier, Month
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Distance = '903' AND DayOfWeek = '5' AND CRSElapsedTime = '151' GROUP BY OriginAirportID, AirlineID, Month
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Carrier, LateAircraftDelay, Quarter WHERE OriginStateFips = '15'
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime, OriginStateName, CancellationCode WHERE WeatherDelay = '22' AND DayOfWeek = '2' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE CRSElapsedTime = '299' AND Cancelled = '0' AND Month = '6' GROUP BY CRSElapsedTime, CancellationCode, Year
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestCityName = 'Philadelphia, PA' AND DivReachedDest = '0' AND Cancelled = '0' GROUP BY TailNum, Month, Diverted
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup = '1' GROUP BY DestCityMarketID, CancellationCode, Year
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND DestState = 'WI' AND Year = '2014' GROUP BY Diverted, TaxiOut, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay = '0' AND CRSArrTime = '1600' AND OriginState = 'WA' GROUP BY Distance, Flights, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, FirstDepTime, Diverted WHERE CancellationCode = 'noodles' AND DayofMonth = '13' AND TailNum = 'N854MQ'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayofMonth, FirstDepTime, DivAirportLandings WHERE CancellationCode = 'A' AND Cancelled = '1' AND Carrier = 'VX'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName, DivReachedDest, CancellationCode WHERE DepTimeBlk = '2000-2059' AND Month = '6' AND TaxiOut = '6'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName, Year, Quarter WHERE Carrier = 'DL' AND DivArrDelay = '90' AND DivReachedDest = '1'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightDate, OriginState, CancellationCode WHERE DivReachedDest = '-9999' AND DayofMonth = '24' AND OriginCityName = 'Orlando, FL'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE AirTime = '230' GROUP BY DestWac, DivReachedDest, Month
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DivActualElapsedTime = '241' AND DistanceGroup = '4' GROUP BY DestCityName, Diverted, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Cancelled = '0' AND DepTimeBlk = '1600-1659' AND ArrTime = '2227' GROUP BY DayofMonth, Cancelled, Month
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND CRSElapsedTime = '216' AND Month = '6' GROUP BY DivActualElapsedTime, DivAirportLandings, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND OriginState = 'AR' AND DestStateFips = '8' GROUP BY TailNum, Cancelled, Quarter
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WeatherDelay, TotalAddGTime, Month WHERE DivAirportLandings = '0' AND Flights = '1' AND DepTimeBlk = '1200-1259'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, Year, TaxiIn WHERE DayofMonth = '11' AND LateAircraftDelay = '5' AND Diverted = '0'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestWac = '63' AND DepTimeBlk = '1600-1659' AND Flights = '1' GROUP BY OriginStateFips, FlightDate, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '-9999' AND Cancelled = '0' AND DestState = 'WA' GROUP BY AirlineID, DepTimeBlk, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityName, DistanceGroup, Quarter WHERE Carrier = 'AS' AND FlightDate = '2014-06-04' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Cancelled, DestStateName, Month WHERE LateAircraftDelay = '22' AND OriginWac = '53' AND Diverted = '0'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivArrDelay, AirlineID, Quarter WHERE DestState = 'NJ' AND DistanceGroup = '9' AND CancellationCode = 'B'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestStateName, AirlineID, Cancelled WHERE CarrierDelay = '69'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DepTimeBlk, SecurityDelay, OriginStateName WHERE DivAirportLandings = '0' AND Flights = '1' AND DestAirportID = '11995'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-23' AND TaxiIn = '22' AND Year = '2014' GROUP BY TotalAddGTime, LongestAddGTime, Flights
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY LateAircraftDelay, Cancelled, DistanceGroup WHERE DestStateFips = '24' AND DepTimeBlk = '2300-2359' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND DayOfWeek = '1' AND DepTime = '1121' GROUP BY ActualElapsedTime, Flights, AirlineID
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Cancelled = '0' AND CRSElapsedTime = '116' AND OriginState = 'OR' GROUP BY TailNum, Year, Flights
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY OriginState, Year WHERE DestCityMarketID = '34524' AND DepTimeBlk = '1300-1359'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips = '36' AND Carrier = 'HA' AND Diverted = '0' GROUP BY TailNum, Diverted, Quarter
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND Flights = '1' AND CancellationCode = 'C' GROUP BY OriginAirportID, Month, SecurityDelay
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk = '1700-1759' AND DayOfWeek = '7' AND DepTimeBlk = '1800-1859' GROUP BY ArrTime, DivAirportLandings, Flights
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime = '6' AND DivAirportLandings = '0' AND Flights = '1' GROUP BY FlightNum, Year, Flights
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE CRSArrTime = '2020' GROUP BY LongestAddGTime, Quarter, UniqueCarrier
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable  WHERE TailNum = 'N23139' AND Month = '6' AND DivReachedDest = '1'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE LateAircraftDelay = '71' GROUP BY DepTime, DivAirportLandings, Year
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn = '7' AND DayofMonth = '7' AND OriginCityName = 'Seattle, WA' GROUP BY DivActualElapsedTime, DistanceGroup, Quarter
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginWac, DayofMonth, Quarter WHERE LateAircraftDelay = '15' AND Carrier = 'AS' AND DepTimeBlk = '1000-1059'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DepTime = '1342' AND CancellationCode = 'B' GROUP BY DestAirportID, ArrTimeBlk, Quarter
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff = '1244' GROUP BY OriginCityMarketID, DayOfWeek, Year
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'California' AND Flights = '1' AND ArrTimeBlk = '0800-0859' GROUP BY WeatherDelay, Month, TotalAddGTime
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY Origin, DayofMonth, Year WHERE Cancelled = '0' AND DistanceGroup = '9' AND OriginAirportID = '14869'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY TailNum, Cancelled, Year WHERE ArrTimeBlk = '2100-2159' AND SecurityDelay = '-9999' AND TaxiIn = '15'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTime = '2256' GROUP BY WheelsOff, Flights, Diverted
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac = '38' AND WheelsOn = '1904' AND DivAirportLandings = '1' GROUP BY TailNum, Quarter, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND DivDistance = '108' AND CancellationCode = 'noodles' GROUP BY AirTime, Year, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'WN' AND OriginCityMarketID = '34492' AND Year = '2014' GROUP BY DestCityName, Cancelled, DayOfWeek
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginAirportID, Diverted, Quarter WHERE DayOfWeek = '4' AND OriginCityMarketID = '30980' AND Flights = '1'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Month = '6' AND CancellationCode = 'noodles' GROUP BY DepTimeBlk, AirlineID, SecurityDelay
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DestStateFips, DepTimeBlk, DivAirportLandings WHERE DivAirportLandings = '0'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportID, DayOfWeek, Month WHERE OriginAirportID = '10627'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '28' AND Year = '2014' GROUP BY OriginCityName, DistanceGroup, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY AirTime, CancellationCode, Diverted WHERE Distance = '89' AND DepTimeBlk = '1900-1959' AND Cancelled = '0'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Carrier, DestStateName, DayOfWeek WHERE OriginState = 'GA' AND DivReachedDest = '-9999' AND FlightDate = '2014-06-18'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Carrier = 'EV' AND Diverted = '0' AND OriginState = 'AR' GROUP BY WeatherDelay, NASDelay, Month
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSElapsedTime, ArrTimeBlk, Month WHERE DivAirportLandings = '0' AND DepTime = '701' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateName, DestStateFips, Quarter WHERE CancellationCode = 'B' AND OriginState = 'WI' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY CancellationCode, OriginCityName, DayOfWeek WHERE AirTime = '141' AND Dest = 'SJC' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY DepTime, DivReachedDest, Year WHERE FlightDate = '2014-06-13' AND Year = '2014' AND DivReachedDest = '-9999'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY Quarter, CRSElapsedTime, DivAirportLandings WHERE OriginState = 'VT' AND Month = '6' AND Year = '2014'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName, DivReachedDest, Year WHERE UniqueCarrier = 'EV' AND DivReachedDest = '-9999' AND DestStateName = 'West Virginia'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek = '5' AND ArrTimeBlk = '0700-0759' AND OriginCityName = 'Omaha, NE' GROUP BY DestStateName, Carrier, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, Diverted, Year WHERE Flights = '1' AND AirTime = '376'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DistanceGroup = '7' AND Quarter = '2' AND UniqueCarrier = 'F9' GROUP BY LateAircraftDelay, SecurityDelay, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightNum, Quarter, Diverted WHERE ArrTime = '109' AND Diverted = '0' AND DestWac = '43'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut = '62' GROUP BY WeatherDelay, TaxiIn, Year
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY CRSArrTime, Cancelled, CancellationCode WHERE DivActualElapsedTime = '248' AND Flights = '1' AND UniqueCarrier = 'MQ'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestState = 'NM' AND Diverted = '1' GROUP BY OriginCityMarketID, DistanceGroup, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityName = 'Colorado Springs, CO' AND DivAirportLandings = '1' AND Flights = '1' GROUP BY Carrier, Flights, DestAirportSeqID
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, Cancelled, Month WHERE TaxiIn = '3' AND Flights = '1' AND CRSElapsedTime = '382'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CarrierDelay, LongestAddGTime, Month WHERE AirlineID = '20355' AND CRSElapsedTime = '64' AND DayofMonth = '15'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode = 'C' GROUP BY Year, NASDelay
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate = '2014-06-06' GROUP BY Quarter, AirlineID, DistanceGroup
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ActualElapsedTime = '287' GROUP BY Dest, AirlineID, Month
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CarrierDelay, DivReachedDest, AirlineID WHERE CRSElapsedTime = '323' AND DistanceGroup = '9' AND DayOfWeek = '3'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportSeqID, Carrier, Quarter WHERE Flights = '1' AND SecurityDelay = '0' AND DestAirportID = '14487'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Diverted, FirstDepTime, CancellationCode WHERE Carrier = 'US' AND Cancelled = '1' AND Quarter = '2'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND Month = '6' AND NASDelay = '191' GROUP BY DepTime, Cancelled, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginState, CancellationCode, Flights WHERE DivArrDelay = '76' AND Year = '2014' AND Month = '6'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, DistanceGroup, Month WHERE DayofMonth = '24' AND Quarter = '2' AND DestCityMarketID = '30928'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY AirlineID, TaxiIn, Month WHERE FlightDate = '2014-06-14' AND DistanceGroup = '5' AND Cancelled = '0'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ArrTime, Diverted, Year WHERE DistanceGroup = '11' AND AirlineID = '20409' AND DivAirportLandings = '0'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ArrTime, SecurityDelay, Flights WHERE CRSElapsedTime = '138' AND Year = '2014' AND UniqueCarrier = 'AS'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Cancelled, FirstDepTime, ArrTimeBlk WHERE DestStateName = 'Texas' AND AirlineID = '19805' AND AirTime = '121'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CarrierDelay, TotalAddGTime, Quarter WHERE DestCityMarketID = '34524' AND FlightDate = '2014-06-28'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSArrTime, Diverted, Quarter WHERE DayOfWeek = '2' AND Month = '6' AND OriginWac = '71'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSDepTime, SecurityDelay, Year WHERE DestStateName = 'Texas' AND DayofMonth = '26'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayofMonth, OriginCityMarketID, Quarter WHERE DestAirportSeqID = '1410702' AND DepTimeBlk = '1500-1559' AND Diverted = '1'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, Quarter, FlightDate WHERE AirlineID = '20366' AND NASDelay = '80' AND DayOfWeek = '2'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestCityMarketID, FlightDate, Quarter WHERE DivReachedDest = '0' AND DistanceGroup = '9' AND TotalAddGTime = '46'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestCityName, Year, Flights WHERE Origin = 'FCA'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateFips, DestWac, DivReachedDest WHERE DivActualElapsedTime = '200'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateFips, LongestAddGTime, CancellationCode WHERE TaxiOut = '32' AND CancellationCode = 'noodles' AND DayOfWeek = '5'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestWac, LongestAddGTime, Diverted WHERE Year = '2014' AND Quarter = '2' AND CRSElapsedTime = '234'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Distance, CancellationCode, Year WHERE DepTimeBlk = '1800-1859' AND DestAirportID = '13871' AND UniqueCarrier = 'US'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivReachedDest, DivArrDelay, DivAirportLandings WHERE ArrTime = '1202' AND Diverted = '0' AND AirlineID = '20366'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime, DestStateName, Diverted WHERE TailNum = 'N799SW' AND Year = '2014' AND OriginAirportSeqID = '1039705'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightDate, DivReachedDest, CancellationCode WHERE OriginWac = '35'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightNum, Cancelled, Flights WHERE Quarter = '2' AND ArrTimeBlk = '1500-1559' AND CarrierDelay = '6'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightNum, Month, Flights WHERE FlightDate = '2014-06-08' AND UniqueCarrier = 'OO' AND OriginState = 'MT'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY LateAircraftDelay, Cancelled, DistanceGroup WHERE OriginStateFips = '30' AND Diverted = '0' AND DepTime = '705'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY LongestAddGTime, DepTimeBlk, DistanceGroup WHERE CRSElapsedTime = '334' AND Flights = '1' AND Diverted = '1'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY NASDelay, TaxiIn, Flights WHERE FirstDepTime = '1045'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, FlightDate, Flights WHERE Carrier = 'AA' AND DivActualElapsedTime = '440' AND OriginStateFips = '6'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, Quarter, ArrTimeBlk WHERE Cancelled = '1' AND DayOfWeek = '6' AND ArrTimeBlk = '1100-1159'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, Quarter, ArrTimeBlk WHERE SecurityDelay = '-9999' AND DivAirportLandings = '1' AND OriginStateFips = '42'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, ArrTimeBlk, Flights WHERE TotalAddGTime = '42'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, DepTimeBlk, Cancelled WHERE AirTime = '307' AND Year = '2014' AND DestStateName = 'New York'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, DepTimeBlk, DivReachedDest WHERE CRSElapsedTime = '163' AND SecurityDelay = '-9999' AND WheelsOff = '2006'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginWac, CarrierDelay, Quarter WHERE DivAirportLandings = '0' AND OriginStateName = 'Illinois' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginWac, SecurityDelay, Quarter WHERE WheelsOn = '2154' AND AirlineID = '20437' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TaxiOut, DivReachedDest, DayofMonth WHERE DestWac = '88' AND Diverted = '0' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WeatherDelay, FirstDepTime, Year WHERE DestState = 'LA' AND DivAirportLandings = '1' AND TaxiOut = '15'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WheelsOff, Cancelled, DivAirportLandings WHERE OriginAirportSeqID = '1302902' AND DivReachedDest = '-9999' AND DayofMonth = '10'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Year, Quarter, DestStateName WHERE DivDistance = '17' AND Year = '2014' AND Cancelled = '0'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ActualElapsedTime = '74' AND OriginWac = '43' AND DestStateFips = '42' GROUP BY NASDelay, FirstDepTime, Quarter
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID = '20437' AND Cancelled = '0' AND NASDelay = '69' GROUP BY OriginCityName, CancellationCode, Month
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '1600-1659' GROUP BY DestState, SecurityDelay, Quarter
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '2000-2059' AND TaxiOut = '24' AND DayOfWeek = '7' GROUP BY DivAirportLandings, DestStateFips, CancellationCode
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled = '0' AND NASDelay = '0' AND DestCityName = 'Newport News/Williamsburg, VA' GROUP BY DestAirportID, DistanceGroup, Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay = '51' AND DistanceGroup = '2' AND Flights = '1' GROUP BY UniqueCarrier, Origin, Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime = '830' AND DistanceGroup = '1' AND AirlineID = '19805' GROUP BY DestCityName, AirlineID, Quarter
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime = '221' AND Carrier = 'AS' AND Quarter = '2' GROUP BY DepTime, Year, Cancelled
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek = '1' AND Diverted = '0' AND DestAirportID = '10299' GROUP BY TotalAddGTime, DivDistance, Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek = '7' AND TaxiOut = '-9999' AND Diverted = '0' GROUP BY DistanceGroup, ArrTimeBlk, DepTimeBlk
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTime = '536' GROUP BY CarrierDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1200-1259' AND DivReachedDest = '1' AND DistanceGroup = '6' GROUP BY OriginCityName, DestAirportSeqID, CancellationCode
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '2300-2359' AND DayOfWeek = '5' AND Month = '6' GROUP BY TaxiOut, OriginWac, Month
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportSeqID = '1295103' AND Year = '2014' AND DistanceGroup = '4' GROUP BY WheelsOn, Cancelled, Flights
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Dest = 'BTR' AND Cancelled = '0' AND Diverted = '0' GROUP BY UniqueCarrier, ActualElapsedTime, Flights
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Dest = 'CMX' AND DivReachedDest = '0' AND Quarter = '2' GROUP BY Distance, DepTimeBlk, Month
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateFips = '4' AND DayofMonth = '21' AND DepTimeBlk = '0800-0859' GROUP BY DepTimeBlk, OriginCityName, Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateName = 'Alabama' GROUP BY DivReachedDest, WheelsOff, Diverted
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestState = 'WY' AND WheelsOn = '2046' AND Flights = '1' GROUP BY DepTimeBlk, ArrTimeBlk, DivActualElapsedTime
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DistanceGroup = '1' AND DestAirportSeqID = '1026802' AND CancellationCode = 'noodles' GROUP BY OriginAirportSeqID, UniqueCarrier, Month
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = '263' GROUP BY OriginStateFips, CarrierDelay, Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '0' AND CancellationCode = 'noodles' AND CRSArrTime = '2345' GROUP BY DestCityMarketID, AirTime, FirstDepTime
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '1' AND Origin = 'MDT' 
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivDistance = '277' AND Flights = '1' AND Quarter = '2' GROUP BY ArrTimeBlk, Month, DestStateName
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '0' AND OriginStateFips = '34' AND WheelsOff = '2229' GROUP BY DepTime, Flights, SecurityDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '1' AND Quarter = '2' AND DivArrDelay = '193' GROUP BY DestWac, DayOfWeek, UniqueCarrier
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '1' AND UniqueCarrier = 'MQ' AND FlightDate = '2014-06-07' GROUP BY CarrierDelay, DistanceGroup, Flights
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest = '0' AND Year = '2014' AND TotalAddGTime = '20' GROUP BY FlightDate, Year, DestAirportSeqID
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightNum = '1567' GROUP BY OriginState, Month, Carrier
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightNum = '5220' GROUP BY LateAircraftDelay, DivReachedDest, Quarter
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND ActualElapsedTime = '336' AND Carrier = 'WN' GROUP BY OriginAirportSeqID, ArrTimeBlk, Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND Cancelled = '0' AND DivActualElapsedTime = '203' GROUP BY ArrTime, Year, DivReachedDest
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND WheelsOff = '1010' AND Month = '6' GROUP BY TaxiOut, TotalAddGTime, Month
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE LateAircraftDelay = '37' GROUP BY LongestAddGTime, Diverted, WeatherDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE LateAircraftDelay = '-9999' AND DayOfWeek = '3' AND Origin = 'GRR' GROUP BY CarrierDelay, DistanceGroup, DayofMonth
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month = '6' AND ArrTimeBlk = '1400-1459' AND TaxiIn = '14' GROUP BY OriginWac, LongestAddGTime, Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month = '6' AND Year = '2014' AND OriginCityName = 'Ponce, PR' GROUP BY FlightDate, DestCityName, Quarter
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityMarketID = '32884' GROUP BY OriginStateFips, CancellationCode, Carrier
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Origin = 'COU' GROUP BY NASDelay, DestState, Flights
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Origin = 'SGU' GROUP BY Quarter, OriginCityName, Flights
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName = 'Georgia' AND ArrTime = '20' AND DivReachedDest = '-9999' GROUP BY ActualElapsedTime, DayOfWeek, Cancelled
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn = '26' AND Quarter = '2' AND DepTimeBlk = '0600-0659' GROUP BY TotalAddGTime, Cancelled, SecurityDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiOut = '60' AND Diverted = '0' AND Carrier = 'EV' GROUP BY Dest, DayofMonth, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY LateAircraftDelay, DistanceGroup, DivAirportLandings WHERE Origin = 'SBA' AND DayofMonth = '4' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportID, Flights, Month WHERE WheelsOn = '628' AND DayOfWeek = '7' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiIn, CancellationCode, Diverted WHERE Quarter = '2' AND ArrTimeBlk = '0900-0959' AND DestStateName = 'Pennsylvania'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime = '315' GROUP BY DistanceGroup, OriginCityName, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginWac = '93' GROUP BY DivReachedDest, DayOfWeek, DestState
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND Carrier = 'AA' AND CancellationCode = 'B' GROUP BY CRSElapsedTime, Flights, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Diverted, ActualElapsedTime, Flights WHERE TotalAddGTime = '121'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOff, SecurityDelay, Quarter WHERE AirlineID = '19805' AND Diverted = '1' AND DistanceGroup = '3'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityName, Year, Diverted WHERE Year = '2014' AND Flights = '1' AND Month = '6'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightNum, Month, Flights WHERE Month = '6' AND CancellationCode = 'noodles' AND DestCityName = 'Appleton, WI'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DivActualElapsedTime, Month, DivReachedDest WHERE CarrierDelay = '0' AND LateAircraftDelay = '85' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Diverted = '0' AND OriginStateFips = '37' AND NASDelay = '117' GROUP BY DivActualElapsedTime, Flights, CancellationCode
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek, Month, DestCityMarketID WHERE DepTimeBlk = '1000-1059' AND AirlineID = '19805' AND ActualElapsedTime = '357'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Cancelled = '0' AND OriginAirportSeqID = '1232303' GROUP BY Year, TaxiOut, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted, CarrierDelay, Carrier WHERE DayOfWeek = '2' AND Diverted = '0' AND UniqueCarrier = 'EV'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup = '11' AND CancellationCode = 'noodles' AND WheelsOff = '848' GROUP BY DestCityMarketID, DepTimeBlk, Month
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '1' AND DestAirportID = '12323' AND OriginWac = '36' GROUP BY UniqueCarrier, DestCityMarketID, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName = 'Arkansas' AND AirlineID = '20304' AND Quarter = '2' GROUP BY TaxiOut, CRSDepTime, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Origin, SecurityDelay, Month WHERE DepTimeBlk = '1200-1259' AND CRSElapsedTime = '155' AND Cancelled = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightNum = '2511' GROUP BY UniqueCarrier, TotalAddGTime, Carrier
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CarrierDelay = '12' AND LateAircraftDelay = '84' AND Flights = '1' GROUP BY TotalAddGTime, FirstDepTime, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CarrierDelay, DestState, Quarter WHERE WheelsOff = '1608' AND Quarter = '2' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityName = 'Cedar Rapids/Iowa City, IA' AND Cancelled = '0' AND CancellationCode = 'noodles' GROUP BY DestAirportID, ArrTimeBlk, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay WHERE Cancelled = '0' AND DestState = 'IN' AND DayofMonth = '18'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DivActualElapsedTime = '398' AND OriginState = 'OH' GROUP BY ArrTime, Year, DayOfWeek
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips = '12' GROUP BY FirstDepTime, DivDistance, CRSElapsedTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND Diverted = '1' AND SecurityDelay = '-9999' GROUP BY UniqueCarrier, DestCityName, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestStateFips, TaxiIn, Quarter WHERE NASDelay = '55' AND ArrTimeBlk = '1400-1459' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DivArrDelay, SecurityDelay, DivReachedDest WHERE OriginStateFips = '51' AND TaxiOut = '15' AND ArrTimeBlk = '0600-0659'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DayofMonth = '20' AND OriginAirportSeqID = '1199603' GROUP BY OriginWac, DestWac, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier = 'OO' AND DivAirportLandings = '0' AND DestStateFips = '47' GROUP BY CancellationCode, OriginCityMarketID, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DestWac, AirlineID, Cancelled WHERE DepTimeBlk = '0600-0659' AND Diverted = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Month, SecurityDelay, DestState WHERE DistanceGroup = '1' AND CancellationCode = 'noodles' AND TaxiIn = '29'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, DivReachedDest, Quarter WHERE DepTime = '1055' AND Month = '6' AND FlightDate = '2014-06-26'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = '367' GROUP BY TaxiIn, Flights, LongestAddGTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, Quarter, NASDelay WHERE DayOfWeek = '1' AND Year = '2014' AND CRSArrTime = '1926'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayofMonth = '21' AND Quarter = '2' AND DestState = 'LA' GROUP BY DestAirportSeqID, Cancelled, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginAirportID = '10599' AND SecurityDelay = '-9999' AND Quarter = '2' GROUP BY TotalAddGTime, SecurityDelay, AirlineID
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY TaxiOut, UniqueCarrier, Cancelled WHERE DestStateName = 'Virginia' AND FlightDate = '2014-06-04' AND SecurityDelay = '0'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Year = '2014' AND Month = '6' AND OriginStateName = 'Delaware' GROUP BY Origin, Quarter, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportID, DepTimeBlk, Year WHERE Quarter = '2' AND Flights = '1' AND DayOfWeek = '7'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Carrier, Quarter, Dest WHERE DistanceGroup = '8' AND DestAirportSeqID = '1245102'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateName = 'Rhode Island' GROUP BY TaxiOut, TotalAddGTime, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE TotalAddGTime = '66' 
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Carrier = 'AA' AND ArrTimeBlk = '1800-1859' AND DestCityMarketID = '30615' GROUP BY DestCityName, DayOfWeek, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk = '1400-1459' AND OriginCityName = 'Bismarck/Mandan, ND' GROUP BY DestStateName, SecurityDelay, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityName, UniqueCarrier, Flights WHERE DivAirportLandings = '1' AND DepTimeBlk = '1800-1859' AND Month = '6'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY Month, ActualElapsedTime, DivAirportLandings WHERE Cancelled = '0' AND WheelsOff = '554' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY OriginWac, CarrierDelay, Month WHERE Month = '6' AND OriginWac = '36' AND NASDelay = '30'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DayofMonth = '1' AND Diverted = '1' AND OriginCityName = 'Deadhorse, AK' GROUP BY DestCityMarketID, DayofMonth, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID = '1468303' AND DestStateFips = '42' AND Year = '2014' GROUP BY DestState, DivDistance, Month
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE TaxiIn = '8' AND UniqueCarrier = 'VX' AND Flights = '1' GROUP BY Year, DivActualElapsedTime, AirlineID
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTime, Diverted, DivReachedDest WHERE DestCityName = 'Devils Lake, ND'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'FL' AND DivReachedDest = '0' GROUP BY TaxiOut, DestStateFips, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '1' AND OriginCityMarketID = '34006' GROUP BY ArrTimeBlk, CarrierDelay, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOn = '1400' AND Flights = '1' AND OriginWac = '43' GROUP BY DivActualElapsedTime, WheelsOn, DayofMonth
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSArrTime = '1428' AND DayofMonth = '23' AND Diverted = '1' GROUP BY CRSElapsedTime, DepTimeBlk, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE TailNum = 'N907WN' AND ActualElapsedTime = '155' GROUP BY Distance, OriginAirportSeqID, OriginWac
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'AA' AND DayofMonth = '19' AND DestStateName = 'Minnesota' GROUP BY Month, DistanceGroup, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivAirportLandings, ActualElapsedTime, Quarter WHERE AirTime = '244' AND Quarter = '2' AND Month = '6'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTime = '1428' GROUP BY Quarter, WeatherDelay, DivDistance
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DivDistance, DestState, Year WHERE Quarter = '2' AND DepTimeBlk = '1700-1759' AND Cancelled = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityMarketID, Month, DayOfWeek WHERE DistanceGroup = '5'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut = '95' AND DestState = 'MD' AND Year = '2014' GROUP BY DestStateName, OriginWac, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE AirTime = '26' AND Year = '2014' AND TaxiIn = '16' GROUP BY Quarter, Dest, UniqueCarrier
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginWac = '82' GROUP BY DayofMonth, Dest, Month
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime, Year, DayOfWeek WHERE Year = '2014' AND ArrTimeBlk = '2100-2159' AND Quarter = '2'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND Month = '6' AND UniqueCarrier = 'VX' GROUP BY DayofMonth, UniqueCarrier, DayOfWeek
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, CRSArrTime, Year WHERE DestCityName = 'Shreveport, LA' AND Quarter = '2' AND DistanceGroup = '3'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND OriginWac = '44' AND Quarter = '2' GROUP BY DestAirportSeqID, FlightDate, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY Month, DivReachedDest, DestStateName WHERE DivReachedDest = '-9999' AND Diverted = '0' AND Distance = '744'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY WeatherDelay, DivReachedDest, DivAirportLandings WHERE Flights = '1' AND DestAirportSeqID = '1295402'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Year, FlightNum, Diverted WHERE Flights = '1' AND CancellationCode = 'B' AND DepTime = '1952'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginCityMarketID = '30434' AND Year = '2014' AND Flights = '1' GROUP BY OriginStateName, DivDistance, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TaxiIn = '13' AND Year = '2014' AND DayofMonth = '5' GROUP BY DivReachedDest, DestAirportID, DayOfWeek
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND Distance = '114' AND CancellationCode = 'noodles' GROUP BY AirlineID, Month, ActualElapsedTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '0' AND DivDistance = '762' AND Year = '2014' GROUP BY LateAircraftDelay, Year, DayofMonth
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateFips, FirstDepTime, Year WHERE OriginWac = '63' AND DestCityMarketID = '32467' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportSeqID = '1078102' AND CancellationCode = 'A' GROUP BY CRSDepTime, Month, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CancellationCode = 'B' AND Dest = 'MSP' GROUP BY SecurityDelay, DivReachedDest, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime = '243' AND Carrier = 'DL' AND DepTimeBlk = '2000-2059' GROUP BY TaxiOut, OriginState, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY AirlineID, DivAirportLandings, DestStateFips WHERE OriginAirportSeqID = '1072102' AND DepTimeBlk = '1000-1059' AND DistanceGroup = '7'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Flights, DestAirportSeqID, Year WHERE OriginAirportID = '11109' AND DestAirportID = '14747' AND ActualElapsedTime = '-9999'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = '9' AND Month = '6' AND OriginStateFips = '39' GROUP BY Month, Distance, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn = '2057' GROUP BY Carrier, CarrierDelay, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Month = '6' GROUP BY ActualElapsedTime, AirlineID, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable  WHERE Flights = '1' AND Carrier = 'DL' AND DayOfWeek = '4'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY CarrierDelay, Year, UniqueCarrier WHERE AirlineID = '19393' AND DepTime = '1509'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, Cancelled, DivReachedDest WHERE OriginAirportSeqID = '1477101' AND DepTimeBlk = '2000-2059' AND WeatherDelay = '0'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportID, DepTimeBlk, Flights WHERE LongestAddGTime = '57'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY TaxiIn, CancellationCode, Diverted WHERE Quarter = '2' AND Flights = '1' AND FirstDepTime = '1419'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND TaxiOut = '77' AND Carrier = 'US' GROUP BY CancellationCode, OriginAirportID, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTime = '1206' GROUP BY FlightDate, DestAirportSeqID, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Flights, DestCityName, Month WHERE ArrTime = '1941'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE NASDelay = '23' AND CRSElapsedTime = '155' AND DivReachedDest = '-9999' GROUP BY WeatherDelay, OriginState, Month
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '4' AND FlightDate = '2014-06-05' AND DepTime = '1749' GROUP BY DivArrDelay, DivReachedDest, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY Cancelled, FlightDate, DayofMonth WHERE DayofMonth = '5' AND OriginState = 'MS' AND ArrTimeBlk = '1700-1759'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest = '-9999' AND DestStateFips = '55' AND DepTime = '1553' GROUP BY CarrierDelay, TotalAddGTime, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND DivAirportLandings = '1' AND DepTime = '806' GROUP BY NASDelay, DivAirportLandings, CancellationCode
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '1900-1959' AND DivAirportLandings = '1' AND OriginStateFips = '30' GROUP BY TailNum, Cancelled, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY NASDelay, Year WHERE DivReachedDest = '1' AND Quarter = '2' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, NASDelay, Flights WHERE DayofMonth = '15' AND Cancelled = '1' AND DistanceGroup = '11'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTime, DivAirportLandings, Year WHERE CancellationCode = 'noodles' AND UniqueCarrier = 'US' AND ActualElapsedTime = '283'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TotalAddGTime, Year, DestStateName WHERE Flights = '1' AND TotalAddGTime = '57' AND DepTimeBlk = '1700-1759'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityMarketID = '31834' 
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND CarrierDelay = '38' AND DestWac = '85' GROUP BY DepTimeBlk, DestCityName, Month
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Dest = 'SAV' GROUP BY LateAircraftDelay, Year, DayofMonth
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DivArrDelay WHERE DistanceGroup = '5' AND DestState = 'WY'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTimeBlk = '1700-1759' GROUP BY Dest, Cancelled, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Month, DistanceGroup, OriginStateFips WHERE DayofMonth = '24' AND DayOfWeek = '5' AND DivAirportLandings = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestWac = '66' AND Month = '6' AND DayOfWeek = '7' GROUP BY FirstDepTime, Flights, Carrier
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Diverted = '0' AND DestAirportID = '10728' AND DayOfWeek = '2' GROUP BY DestState, DestStateFips, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime, TaxiIn, Year WHERE CRSArrTime = '915' AND DivAirportLandings = '0' AND OriginCityName = 'Dallas/Fort Worth, TX'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '91' GROUP BY TotalAddGTime, OriginState, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestStateFips = '44' AND Diverted = '1' AND Flights = '1' GROUP BY DayofMonth, OriginAirportSeqID, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '-9999' AND DayOfWeek = '2' AND DestCityName = 'Salt Lake City, UT' GROUP BY DivActualElapsedTime, Cancelled, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE LateAircraftDelay = '168' GROUP BY LongestAddGTime, DivDistance, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE WheelsOff = '1518' GROUP BY ArrTimeBlk, CancellationCode, OriginStateName
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Carrier = 'B6' AND ActualElapsedTime = '135' AND OriginStateName = 'Florida' GROUP BY OriginAirportID, DayofMonth, Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY LongestAddGTime, OriginState, DivAirportLandings WHERE FlightNum = '3260'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DivReachedDest = '-9999' AND DayOfWeek = '1' GROUP BY DivDistance, Month, DestState
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityMarketID, DistanceGroup WHERE Month = '6' AND TaxiOut = '26' AND OriginStateName = 'Colorado'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DayofMonth = '9' AND CancellationCode = 'A' AND Carrier = 'OO' GROUP BY DivDistance, UniqueCarrier, DivAirportLandings
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime, DivReachedDest, Diverted WHERE Flights = '1' AND ActualElapsedTime = '79'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY CancellationCode, DestStateName, TotalAddGTime WHERE Month = '6' AND CRSArrTime = '2129' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Distance, Diverted, CancellationCode WHERE WeatherDelay = '10' AND Month = '6' AND CancellationCode = 'noodles'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityMarketID, Year, SecurityDelay WHERE DistanceGroup = '5'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay = '0' AND DivAirportLandings = '0' AND FlightNum = '1203' GROUP BY SecurityDelay, DestStateFips, AirlineID
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Diverted = '0' AND DayofMonth = '6' AND Distance = '624' GROUP BY TailNum, Year, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginCityMarketID = '33038' GROUP BY DivReachedDest, DestAirportSeqID, Month
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime, Quarter, Flights WHERE Year = '2014' AND DayOfWeek = '5' AND DivArrDelay = '293'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Distance, Flights, CancellationCode WHERE CancellationCode = 'B' AND OriginState = 'CA' AND DepTimeBlk = '1300-1359'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime WHERE Quarter = '2' AND Origin = 'GPT'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest = '1' AND Year = '2014' AND DestCityMarketID = '31973' GROUP BY DayofMonth, DestWac, CancellationCode
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk = '1700-1759' AND DivDistance = '-9999' AND CRSElapsedTime = '136' GROUP BY TailNum, Flights, Month
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DestState = 'CT' AND Quarter = '2' AND Year = '2014' GROUP BY Diverted, Origin, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY ActualElapsedTime, ArrTimeBlk, Month WHERE ActualElapsedTime = '62' AND FlightDate = '2014-06-30' AND DayOfWeek = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DivArrDelay, Month, Diverted WHERE Month = '6' AND Flights = '1' AND DestCityMarketID = '31295'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE WheelsOn = '2243' AND TaxiOut = '24' AND Flights = '1' GROUP BY DestCityMarketID, DivAirportLandings
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-16' AND Origin = 'PVD' AND Quarter = '2' GROUP BY DivArrDelay, UniqueCarrier, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND DestStateFips = '26' GROUP BY FlightNum, Month, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiOut, AirlineID, DivAirportLandings WHERE DepTimeBlk = '1200-1259' AND DestCityMarketID = '30476' AND DivReachedDest = '-9999'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WeatherDelay, DestWac, Month WHERE DepTimeBlk = '2300-2359' AND Diverted = '0' AND DestState = 'IN'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TotalAddGTime, WeatherDelay, Year WHERE DepTimeBlk = '2200-2259'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityMarketID = '30154' GROUP BY Month, DivAirportLandings, Distance
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, CancellationCode, SecurityDelay WHERE ArrTimeBlk = '2000-2059' AND DestStateFips = '8' AND WheelsOff = '2050'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Carrier = 'HA' AND Year = '2014' AND CarrierDelay = '10' GROUP BY CarrierDelay, OriginWac, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestStateName = 'Michigan' AND Cancelled = '1' AND Year = '2014' GROUP BY Year, DayofMonth, Carrier
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID = '31905' GROUP BY DestStateName, WeatherDelay, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY FirstDepTime, DayOfWeek, DivAirportLandings WHERE Flights = '1' AND Carrier = 'DL' AND OriginCityMarketID = '30194'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Quarter, DivDistance, DepTimeBlk WHERE AirTime = '179' AND Month = '6' AND Diverted = '0'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '72' AND Year = '2014' AND FlightDate = '2014-06-09' GROUP BY DestStateFips, Origin, AirTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE TaxiOut = '138' GROUP BY SecurityDelay, CRSElapsedTime, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, OriginStateName, Diverted WHERE Flights = '1' AND Diverted = '1' AND DestStateFips = '54'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY OriginWac, DivDistance, Year WHERE Cancelled = '0' AND Year = '2014' AND Dest = 'ELP'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier = 'MQ' AND OriginAirportID = '13061' GROUP BY Carrier, DivActualElapsedTime, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportSeqID, DistanceGroup, Year WHERE DivAirportLandings = '0' AND TaxiIn = '10' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY LateAircraftDelay, DestState, Flights WHERE CRSArrTime = '1333' AND DistanceGroup = '6' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginCityName = 'Cleveland, OH' AND DestStateFips = '55' AND DayOfWeek = '4' GROUP BY DestWac, TaxiIn, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY CarrierDelay, DayOfWeek, Year WHERE Month = '6' AND ArrTime = '1144' AND DivReachedDest = '-9999'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY CRSDepTime, CancellationCode, Cancelled WHERE Diverted = '0' AND DayOfWeek = '5' AND DestCityMarketID = '30255'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY ArrTime, Year, DivAirportLandings WHERE Carrier = 'UA' AND TaxiOut = '23' AND DayofMonth = '5'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE FirstDepTime = '1121' GROUP BY DivReachedDest, OriginStateName, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirlineID = '21171' GROUP BY Cancelled, WheelsOn, Month
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTime, Diverted, Month WHERE DayOfWeek = '3' AND Flights = '1' AND TailNum = 'N127DL'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DestAirportSeqID, DistanceGroup, Month WHERE DivReachedDest = '-9999' AND FlightDate = '2014-06-20' AND DestAirportID = '13377'
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Diverted = '0' AND AirlineID = '20355' AND CRSElapsedTime = '149' GROUP BY LongestAddGTime, AirlineID, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY ActualElapsedTime, SecurityDelay, Diverted WHERE FirstDepTime = '1457'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID, DivDistance, DivReachedDest WHERE Quarter = '2' AND OriginStateFips = '12' AND ArrTimeBlk = '0900-0959'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY TaxiOut, DestStateName, Year WHERE DayofMonth = '7' AND Diverted = '1' AND CRSArrTime = '1520'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY TotalAddGTime, FlightDate, Flights WHERE OriginStateName = 'Kansas' AND CancellationCode = 'noodles' AND WheelsOn = '1549'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE AirlineID = '19805' AND OriginWac = '91' AND FlightNum = '180' GROUP BY NASDelay, Cancelled, AirlineID
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DayofMonth = '21' GROUP BY DestCityName, DivReachedDest, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestStateFips = '45' AND Flights = '1' AND Month = '6' GROUP BY Month, DestStateName, DestStateFips
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '1' AND DistanceGroup = '11' AND DayOfWeek = '2' GROUP BY DestAirportID, Diverted, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID = '13795' AND Year = '2014' AND DivReachedDest = '-9999' GROUP BY Year, TotalAddGTime, DayofMonth
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay = '3' AND Quarter = '2' GROUP BY CRSArrTime, SecurityDelay, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '3' AND DestAirportSeqID = '1468502' AND DivAirportLandings = '1' GROUP BY DistanceGroup, OriginCityMarketID, FlightNum
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DepTime, Year, SecurityDelay WHERE Month = '6' AND CRSElapsedTime = '200' AND OriginWac = '13'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '430' GROUP BY DivAirportLandings, NASDelay, Month
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Diverted, Flights WHERE CRSArrTime = '1541' AND DayOfWeek = '5' AND Cancelled = '0'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, Flights, DivAirportLandings WHERE CancellationCode = 'noodles' AND DepTimeBlk = '1100-1159' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Origin = 'DFW' AND WheelsOn = '1439' AND SecurityDelay = '0' GROUP BY DestAirportID, DivReachedDest, Month
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay = '109' GROUP BY ActualElapsedTime, Flights, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY LateAircraftDelay, DestWac, Month WHERE SecurityDelay = '5'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY UniqueCarrier, DivActualElapsedTime, Year WHERE DestStateFips = '29' AND DivAirportLandings = '2' AND Cancelled = '0'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay = '15' GROUP BY WeatherDelay, DayOfWeek, DivAirportLandings
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState = 'MN' AND Diverted = '1' AND DestWac = '62' GROUP BY DayOfWeek, CarrierDelay, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Distance = '200' AND DepTime = '2050' AND Flights = '1' GROUP BY TaxiIn, DayofMonth, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND Flights = '1' AND ArrTimeBlk = '0600-0659' GROUP BY WheelsOn, Flights, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = '321' GROUP BY DistanceGroup, Quarter, UniqueCarrier
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DepTimeBlk, SecurityDelay WHERE DestAirportID = '10990' AND DayofMonth = '27' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestStateFips = '42' AND DistanceGroup = '5' AND Carrier = 'US' GROUP BY ActualElapsedTime, Diverted, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '4' GROUP BY Cancelled, DistanceGroup, OriginAirportSeqID
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY NASDelay, Quarter WHERE DistanceGroup = '1' AND Year = '2014' AND DivArrDelay = '233'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND Carrier = 'DL' AND ActualElapsedTime = '134' GROUP BY OriginAirportID, Carrier, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportSeqID = '1457002' GROUP BY DivActualElapsedTime, Cancelled, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff = '1003' AND Quarter = '2' AND Carrier = 'HA' GROUP BY Diverted, Quarter, FlightDate
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier = 'AS' AND DestWac = '93' AND CRSElapsedTime = '335' GROUP BY DestAirportSeqID, ArrTimeBlk, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, DivArrDelay, Month WHERE CRSDepTime = '900' AND CancellationCode = 'noodles' AND DivAirportLandings = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND Month = '6' AND ArrTimeBlk = '0600-0659' GROUP BY OriginAirportID, Month, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Distance = '1027' AND Month = '6' AND Quarter = '2' GROUP BY Cancelled, ActualElapsedTime, OriginAirportID
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '0001-0559' AND FlightDate = '2014-06-25' GROUP BY ArrTimeBlk, Origin, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DivDistance = '-9999' AND OriginCityMarketID = '35096' GROUP BY WeatherDelay, Cancelled, CancellationCode
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DestWac, FlightDate, CancellationCode WHERE Year = '2014' AND DestAirportID = '11986' AND FlightDate = '2014-06-02'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '-9999' AND DestAirportSeqID = '1163002' AND DepTimeBlk = '1000-1059' GROUP BY WheelsOn, Diverted, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTime, SecurityDelay, Flights WHERE OriginState = 'TX' AND CancellationCode = 'C' AND DestAirportID = '11057'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DistanceGroup, DivAirportLandings, SecurityDelay WHERE Year = '2014' AND WheelsOff = '920' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND DestWac = '45' AND OriginStateFips = '12' GROUP BY DayOfWeek, SecurityDelay, DistanceGroup
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND SecurityDelay = '0' AND Distance = '328' GROUP BY AirlineID, DestWac, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY CarrierDelay, DestStateName, Year WHERE DestStateFips = '12' AND DepTime = '1249' AND Quarter = '2'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Carrier, OriginCityName, Month WHERE UniqueCarrier = 'DL' AND DestStateName = 'Georgia' AND Origin = 'MHT'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Diverted, CancellationCode, ArrTimeBlk WHERE NASDelay = '104' AND Quarter = '2'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Flights, ActualElapsedTime, Carrier WHERE TaxiIn = '26' AND OriginAirportSeqID = '1014002' AND CancellationCode = 'noodles'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY LongestAddGTime, NASDelay, Month WHERE DestAirportID = '14747' AND DivAirportLandings = '1' AND Month = '6'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE NASDelay = '37' AND Flights = '1' AND Carrier = 'MQ' GROUP BY OriginStateName, Flights, DistanceGroup
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND AirTime = '84' AND WheelsOff = '1023' GROUP BY ArrTimeBlk, Dest, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, Year, DistanceGroup WHERE Diverted = '1' AND DepTime = '735' AND Quarter = '2'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, Diverted, NASDelay WHERE DestWac = '93' AND DivReachedDest = '-9999' AND Carrier = 'F9'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' AND DayOfWeek = '5' AND FlightNum = '5531' GROUP BY LongestAddGTime, LateAircraftDelay, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState = 'NE' AND SecurityDelay = '0' AND LateAircraftDelay = '16' GROUP BY FlightDate, OriginState, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DepTimeBlk = '1400-1459' AND Cancelled = '0' GROUP BY OriginAirportID, Cancelled, UniqueCarrier
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime = '-9999' AND Diverted = '0' AND DestAirportSeqID = '1477101' GROUP BY Quarter, TaxiOut, DestState
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DistanceGroup = '2' AND CancellationCode = 'noodles' AND DivArrDelay = '170' GROUP BY CRSElapsedTime, Month, DivDistance
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DepTimeBlk, DestStateFips, SecurityDelay WHERE DepTimeBlk = '1300-1359' AND Carrier = 'MQ' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY CarrierDelay, Quarter, FlightDate WHERE CancellationCode = 'B' AND TotalAddGTime = '43' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '1' AND CancellationCode = 'C' AND Year = '2014' GROUP BY TotalAddGTime, Year, ArrTimeBlk
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY FlightNum, Month, Cancelled WHERE DepTime = '1344' AND AirlineID = '21171' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY FlightNum, Month, Flights WHERE Flights = '1' AND AirlineID = '19805'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOff, Cancelled, CancellationCode WHERE ArrTime = '1910' AND DestState = 'ND' AND Quarter = '2'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE CRSElapsedTime = '340' AND FlightDate = '2014-06-10' GROUP BY UniqueCarrier, WeatherDelay, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE CancellationCode = 'noodles' AND DivAirportLandings = '1' AND OriginStateFips = '2' GROUP BY WheelsOff, SecurityDelay, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND DestAirportID = '11308' AND Flights = '1' GROUP BY OriginAirportID, Diverted, DistanceGroup
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Cancelled, Month WHERE DestState = 'UT' AND TaxiOut = '19' AND DayOfWeek = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CRSElapsedTime, DivReachedDest, Diverted WHERE Cancelled = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayofMonth, DistanceGroup, Month WHERE CRSDepTime = '1121' AND Diverted = '0' AND OriginStateFips = '12'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings = '0' AND CRSElapsedTime = '247' AND DepTimeBlk = '1100-1159' GROUP BY Carrier, NASDelay, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY Month, LateAircraftDelay, Quarter WHERE CRSElapsedTime = '160' AND ArrTimeBlk = '0001-0559' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityMarketID, DivAirportLandings, Year WHERE Month = '6' AND OriginStateFips = '48' AND Dest = 'CMH'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY AirlineID, OriginCityName, Diverted WHERE DivAirportLandings = '9' AND Flights = '1' AND DistanceGroup = '11'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime, Cancelled, Diverted WHERE TaxiOut = '16' AND DayOfWeek = '2' AND DayofMonth = '12'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayofMonth = '22' AND CRSElapsedTime = '89' AND DepTimeBlk = '1400-1459' 
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE CancellationCode = 'B' AND ArrTimeBlk = '2100-2159' AND DestWac = '82' GROUP BY FirstDepTime, DivDistance, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY CancellationCode, CRSElapsedTime, Diverted WHERE DestState = 'MD'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY CRSDepTime, DivAirportLandings, Flights WHERE DestStateName = 'Washington'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DayofMonth = '7' AND DepTime = '2050' AND DistanceGroup = '4' GROUP BY DivActualElapsedTime, ArrTimeBlk, Month
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY TailNum, Cancelled, Year WHERE Flights = '1' AND OriginStateFips = '26' AND Carrier = 'AA'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '1' AND DestStateFips = '8' AND CRSArrTime = '1512' GROUP BY DestAirportSeqID, FlightDate, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY Month, OriginAirportSeqID, DayOfWeek WHERE Diverted = '1' AND DivReachedDest = '1' AND DistanceGroup = '3'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateFips, OriginStateName, Quarter WHERE UniqueCarrier = 'DL' AND ArrTimeBlk = '1800-1859' AND DestStateFips = '4'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Dest = 'MSN' GROUP BY WheelsOff, Month, DayOfWeek
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, TaxiIn, Year WHERE Diverted = '1' AND OriginCityMarketID = '34819' AND DepTimeBlk = '0900-0959'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, Diverted, DistanceGroup WHERE Year = '2014' AND Cancelled = '1' AND TotalAddGTime = '6'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY Origin, Diverted, DivAirportLandings WHERE DepTime = '1314'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestCityName = 'Abilene, TX' AND Cancelled = '0' AND UniqueCarrier = 'MQ' GROUP BY NASDelay, SecurityDelay, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY AirlineID, WeatherDelay, Quarter WHERE DivAirportLandings = '2'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, Month, CancellationCode WHERE DivReachedDest = '0' AND DayOfWeek = '2' AND OriginStateFips = '48'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DivDistance, AirlineID, DivReachedDest WHERE Origin = 'ORD' AND CRSArrTime = '1455'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY Diverted, DestAirportSeqID, DivAirportLandings WHERE AirlineID = '20304' AND Cancelled = '0' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable  WHERE TaxiOut = '30' AND AirlineID = '20366' AND Origin = 'AGS'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, Quarter, TaxiIn WHERE DayOfWeek = '3' AND OriginCityName = 'Elko, NV' AND Cancelled = '0'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY OriginWac, Carrier, DivAirportLandings WHERE Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiIn, Carrier, SecurityDelay WHERE NASDelay = '7' AND DivReachedDest = '-9999' AND LateAircraftDelay = '60'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DepTime = '633' AND Year = '2014' AND Flights = '1' GROUP BY DistanceGroup, TaxiOut, Cancelled
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateName, LongestAddGTime, CancellationCode WHERE OriginCityMarketID = '31537' AND Cancelled = '0' AND DivReachedDest = '-9999'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '0' AND DayOfWeek = '3' GROUP BY DivReachedDest, CRSElapsedTime, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND ActualElapsedTime = '257' AND Diverted = '0' GROUP BY OriginState, WeatherDelay, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips = '37' AND Quarter = '2' AND DestState = 'NC' GROUP BY CRSArrTime, Year, CancellationCode
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivAirportLandings, OriginState, DistanceGroup WHERE Month = '6' AND DayOfWeek = '3' AND DestState = 'HI'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY WheelsOff, SecurityDelay, Flights WHERE DivDistance = '-9999' AND Diverted = '1' AND FirstDepTime = '-9999'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, DepTimeBlk, Flights WHERE CRSArrTime = '2248' AND AirlineID = '20398' AND DayOfWeek = '6'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY LateAircraftDelay, UniqueCarrier, Flights WHERE OriginWac = '81' AND ArrTime = '1101'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Diverted, TotalAddGTime, TaxiIn WHERE DayOfWeek = '7' AND Flights = '1' AND CRSDepTime = '2121'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DivActualElapsedTime = '438' AND OriginAirportSeqID = '1426202' GROUP BY AirTime, CarrierDelay, DestStateName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = '-9999' AND Origin = 'OAJ' AND Flights = '1' GROUP BY LongestAddGTime, DivArrDelay, Distance
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CRSElapsedTime, Quarter, AirlineID WHERE ArrTimeBlk = '1300-1359' AND Month = '6' AND Diverted = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName = 'Maryland' AND Month = '6' AND SecurityDelay = '0' GROUP BY Month, DepTimeBlk, OriginStateName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE OriginStateName = 'Georgia' AND CRSElapsedTime = '134' AND UniqueCarrier = 'UA' GROUP BY DepTimeBlk, CarrierDelay, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Month, DestStateName, Year WHERE TotalAddGTime = '53' AND DivReachedDest = '-9999' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND OriginCityMarketID = '31066' AND TailNum = 'N935DN' GROUP BY UniqueCarrier, AirlineID, DayofMonth
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, Diverted, Flights WHERE DivAirportLandings = '0' AND OriginCityName = 'San Francisco, CA' AND DayofMonth = '5'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FirstDepTime, DivDistance, Quarter WHERE DestStateName = 'Pennsylvania' AND WheelsOff = '2114' AND Flights = '1'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Diverted = '0' AND DestStateName = 'California' AND NASDelay = '41' GROUP BY FirstDepTime, OriginWac, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND CancellationCode = 'noodles' AND OriginCityMarketID = '31921' GROUP BY CancellationCode, DestStateName, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateName = 'Louisiana' AND Diverted = '1' AND DayOfWeek = '6' GROUP BY DayofMonth, OriginAirportSeqID, Year
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportID, Diverted, DivReachedDest WHERE OriginCityName = 'Great Falls, MT'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestStateFips = '50' AND Diverted = '0' AND DayOfWeek = '3' GROUP BY TotalAddGTime, OriginStateFips, Month
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirlineID = '19805' AND Flights = '1' AND Diverted = '0' GROUP BY DestState, DivReachedDest, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' GROUP BY OriginAirportID, AirlineID, Flights
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk = '0700-0759' AND AirlineID = '19805' AND DistanceGroup = '4' GROUP BY Origin, DayOfWeek, CancellationCode
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, DayofMonth, SecurityDelay WHERE Month = '6' AND DistanceGroup = '2' AND AirTime = '46'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk = '0700-0759' AND OriginCityName = 'Reno, NV' AND Cancelled = '0' GROUP BY Carrier, CancellationCode, AirlineID
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY AirTime, Year, DayOfWeek WHERE DestAirportID = '15008'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivReachedDest, Carrier, TaxiOut WHERE OriginStateFips = '56'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY FirstDepTime, OriginStateName, Year WHERE Quarter = '2' AND Cancelled = '0' AND WheelsOff = '725'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, AirlineID, Year WHERE NASDelay = '96' AND Year = '2014' AND AirlineID = '20366'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND Cancelled = '0' AND AirTime = '380' GROUP BY DestCityName, DayofMonth, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY NASDelay, OriginStateFips, Flights WHERE TaxiOut = '69' AND DistanceGroup = '1' AND Year = '2014'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Oregon' AND Diverted = '1' AND Year = '2014' GROUP BY ArrTimeBlk, SecurityDelay, AirlineID
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Year = '2014' AND DistanceGroup = '7' AND OriginAirportID = '10620' GROUP BY DestStateFips, OriginStateFips, Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID = '1449202' AND Cancelled = '1' AND UniqueCarrier = 'US' GROUP BY DepTime, CancellationCode, Diverted
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, Carrier, Month WHERE DayofMonth = '8' AND FlightNum = '2185' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY AirlineID, DistanceGroup, CancellationCode WHERE DepTimeBlk = '2200-2259' AND TailNum = 'N566SW' AND DivReachedDest = '-9999'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY AirlineID, OriginCityMarketID, Month WHERE Month = '6' AND TotalAddGTime = '21' AND DivAirportLandings = '1'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY AirTime, AirlineID, Quarter WHERE OriginAirportID = '14794' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ArrTimeBlk, LateAircraftDelay, Month WHERE UniqueCarrier = 'WN' AND AirlineID = '19393' AND DepTime = '647'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CancellationCode, CRSArrTime, Year WHERE DestCityMarketID = '32457' AND DayofMonth = '11' AND AirlineID = '19790'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CancellationCode, DistanceGroup, TaxiOut WHERE UniqueCarrier = 'MQ' AND Diverted = '0' AND WheelsOff = '1938'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSElapsedTime, SecurityDelay, Month WHERE ArrTimeBlk = '2300-2359'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek, AirlineID, Year WHERE Diverted = '1' AND DepTime = '904' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek, FlightDate, DistanceGroup WHERE Year = '2014' AND Quarter = '2' AND DestStateName = 'North Dakota'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek, TaxiIn WHERE DestState = 'SC' AND Diverted = '1' AND CRSElapsedTime = '83'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DepTimeBlk, Diverted, DivDistance WHERE CancellationCode = 'C' AND DivReachedDest = '-9999' AND DestWac = '12'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DepTime WHERE FlightNum = '625' AND OriginStateFips = '51' AND DivReachedDest = '1'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, Diverted, DayOfWeek WHERE OriginStateName = 'Massachusetts' AND DivReachedDest = '0' AND DestStateFips = '12'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, UniqueCarrier, Cancelled WHERE DistanceGroup = '9' AND ActualElapsedTime = '387' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, UniqueCarrier, Cancelled WHERE OriginWac = '92' AND CancellationCode = 'C' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityMarketID, DayOfWeek, DivReachedDest WHERE OriginStateFips = '37' AND Year = '2014' AND WheelsOn = '1958'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, DayofMonth, Year WHERE TaxiOut = '44' AND Flights = '1' AND DestStateFips = '2'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestWac, DivDistance, Year WHERE Flights = '1' AND ArrTimeBlk = '0900-0959' AND Month = '6'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DistanceGroup, DayOfWeek, Cancelled WHERE Month = '6' AND OriginAirportID = '11041' AND Quarter = '2'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DistanceGroup, FirstDepTime, Month WHERE DistanceGroup = '3' AND Quarter = '2' AND DivAirportLandings = '2'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivAirportLandings, Month, LongestAddGTime WHERE DayofMonth = '30' AND Carrier = 'EV' AND DestAirportSeqID = '1027903'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LateAircraftDelay, DepTimeBlk, Month WHERE TaxiOut = '2' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LateAircraftDelay, FlightDate, Flights WHERE Diverted = '1' AND OriginWac = '15' AND UniqueCarrier = 'WN'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LongestAddGTime, DepTimeBlk, DivReachedDest WHERE CRSArrTime = '1823'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LongestAddGTime, DestWac, Year WHERE Diverted = '0' AND OriginStateFips = '18' AND DestWac = '85'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LongestAddGTime, Month, Year WHERE LongestAddGTime = '23'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WeatherDelay, TaxiOut, Month WHERE DivAirportLandings = '0' AND DayOfWeek = '3' AND OriginState = 'MT'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOff, Diverted, CancellationCode WHERE Quarter = '2' AND DepTimeBlk = '1700-1759' AND TaxiIn = '22'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOff, SecurityDelay, Flights WHERE Month = '6' AND Diverted = '1' AND DayOfWeek = '3'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE AirlineID = '19393' AND Cancelled = '1' AND Flights = '1' GROUP BY UniqueCarrier, WeatherDelay, CancellationCode
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime = '43' AND Carrier = 'DL' AND Flights = '1' GROUP BY OriginAirportSeqID, Diverted, AirlineID
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '0700-0759' AND Diverted = '0' AND OriginCityMarketID = '35401' GROUP BY Flights, DistanceGroup, UniqueCarrier
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode = 'noodles' AND ArrTime = '1500' AND OriginState = 'CT' GROUP BY TailNum, ArrTime, DestAirportID
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier = 'OO' AND Year = '2014' AND LateAircraftDelay = '16' GROUP BY Carrier, TotalAddGTime, Month
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime = '943' AND Flights = '1' AND TaxiOut = '6' 
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime = '198' AND Year = '2014' AND ArrTimeBlk = '0900-0959' GROUP BY DayofMonth, CancellationCode, Month
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime = '241' GROUP BY DepTime, DivReachedDest, Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime = '350' GROUP BY Distance, DivAirportLandings, Quarter
-SELECT SUM(DepartureDelayGroups) FROM myStarTable  WHERE DayOfWeek = '3'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek = '4' AND DivAirportLandings = '2' AND OriginStateName = 'Florida' GROUP BY OriginState, Quarter, Diverted
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek = '6' AND ArrTime = '2116' AND DestCityMarketID = '32575' GROUP BY DistanceGroup, DestAirportID, Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek = '7' AND Cancelled = '1' AND ArrTimeBlk = '1500-1559' GROUP BY DestState, OriginStateName, Month
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1400-1459' AND Carrier = 'AA' AND ActualElapsedTime = '140' GROUP BY OriginCityMarketID, DivAirportLandings, Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '2000-2059' AND DestAirportSeqID = '1349503' AND Diverted = '0' GROUP BY DivActualElapsedTime, AirlineID, Flights
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID = '1169703' AND CRSElapsedTime = '171' AND Year = '2014' GROUP BY OriginCityMarketID, DivReachedDest, Month
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID = '1227802' GROUP BY DivAirportLandings, CRSDepTime, Month
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Dest = 'HNL' AND TaxiOut = '16' AND Flights = '1' GROUP BY CRSElapsedTime, DepTimeBlk, Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestState = 'FL' AND Year = '2014' AND ArrTime = '527' GROUP BY DestCityMarketID, Cancelled, Carrier
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'New Mexico' AND CRSElapsedTime = '65' AND DayofMonth = '10' GROUP BY OriginState, OriginWac, Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable  WHERE DestWac = '33' AND CRSElapsedTime = '279' AND DivReachedDest = '-9999'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest = '-9999' AND DepTime = '2130' AND Flights = '1' GROUP BY CRSElapsedTime, Flights, Month
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest = '-9999' AND SecurityDelay = '0' AND DestCityName = 'Arcata/Eureka, CA' GROUP BY UniqueCarrier, Diverted, AirlineID
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-01' AND Month = '6' AND OriginStateName = 'Arizona' GROUP BY DestCityMarketID, UniqueCarrier, Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-24' AND AirTime = '299' AND Cancelled = '0' GROUP BY ActualElapsedTime, Cancelled, SecurityDelay
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND Diverted = '0' AND ArrTimeBlk = '1200-1259' GROUP BY TailNum, Diverted, Quarter
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND OriginAirportID = '11337' AND Cancelled = '1' GROUP BY DestStateFips, DayOfWeek, DivAirportLandings
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND TaxiIn = '5' AND DivAirportLandings = '1' GROUP BY TotalAddGTime, DayOfWeek, DayofMonth
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND TaxiOut = '13' AND AirlineID = '20304' GROUP BY Flights, FlightDate, WeatherDelay
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND WheelsOff = '2101' AND AirlineID = '19977' GROUP BY WeatherDelay, Diverted, FlightDate
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime = '1' AND Flights = '1' AND CancellationCode = 'noodles' GROUP BY LongestAddGTime, FlightDate, CarrierDelay
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND FlightDate = '2014-06-03' AND OriginStateFips = '12' GROUP BY AirlineID, DestState, DivAirportLandings
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND FlightDate = '2014-06-12' AND WheelsOn = '53' GROUP BY OriginWac, DestStateFips, Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName = 'California' AND DepTimeBlk = '0600-0659' AND Year = '2014' GROUP BY SecurityDelay, LongestAddGTime, AirlineID
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = '2' AND DivAirportLandings = '1' AND TaxiIn = '2' GROUP BY DestAirportID, Year, Diverted
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay = '-9999' AND DestCityMarketID = '30781' AND DayofMonth = '27' GROUP BY Quarter, DistanceGroup
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TailNum = 'N812DN' AND OriginCityMarketID = '32457' AND SecurityDelay = '0' GROUP BY OriginAirportSeqID, Flights, FlightDate
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut = '15' AND OriginStateName = 'Massachusetts' AND Year = '2014' GROUP BY FlightDate, DestStateName, SecurityDelay
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE UniqueCarrier = 'UA' AND Quarter = '2' AND DivAirportLandings = '9' GROUP BY OriginStateFips, Diverted
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff = '1608' GROUP BY DivArrDelay, DivReachedDest, CancellationCode
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn = '1400' AND TaxiOut = '22' AND Origin = 'LGA' GROUP BY Month, TotalAddGTime, Carrier
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND SecurityDelay = '0' AND LateAircraftDelay = '8' GROUP BY DepTime, DayOfWeek, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestAirportID, DayofMonth, Flights WHERE DayofMonth = '4' AND DestStateFips = '32' AND Distance = '1590'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestWac, OriginStateFips, DivReachedDest WHERE Origin = 'SEA' AND DepTimeBlk = '0700-0759' AND DayOfWeek = '1'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DistanceGroup, OriginStateFips, Quarter WHERE Year = '2014' AND CRSArrTime = '2336' AND DayofMonth = '9'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Diverted = '1' AND CancellationCode = 'noodles' AND DestAirportSeqID = '1244805' GROUP BY DestAirportSeqID, Flights, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE DestAirportSeqID = '1473003' AND Year = '2014' AND OriginState = 'CO' GROUP BY Year, OriginStateName, DestStateName
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE UniqueCarrier = 'FL' AND LateAircraftDelay = '16' AND Cancelled = '0' GROUP BY TotalAddGTime, DivReachedDest, DestStateName
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '0700-0759' AND SecurityDelay = '-9999' AND OriginStateFips = '26' GROUP BY AirTime, Flights, CancellationCode
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityMarketID = '30372' AND Diverted = '0' AND Month = '6' GROUP BY DivDistance, Quarter, DayOfWeek
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE NASDelay = '5' GROUP BY Diverted, DestAirportID, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSDepTime, DayOfWeek, Quarter WHERE DayOfWeek = '7' AND DestWac = '43' AND ArrTime = '1447'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY SecurityDelay, DepTimeBlk, DestState WHERE SecurityDelay = '0' AND DestState = 'AZ' AND Cancelled = '0'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY Distance, SecurityDelay, Flights WHERE DestStateName = 'Massachusetts' AND Diverted = '0' AND TotalAddGTime = '113'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Quarter, ArrTimeBlk, NASDelay WHERE DivReachedDest = '0'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime, DayOfWeek, Year WHERE OriginStateName = 'Maine' AND UniqueCarrier = 'US'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND UniqueCarrier = 'EV' AND CRSElapsedTime = '63' GROUP BY DayofMonth, UniqueCarrier, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay = '0' GROUP BY ArrTimeBlk, OriginAirportID, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE UniqueCarrier = 'EV' AND DistanceGroup = '3' AND AirTime = '102' 
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CancellationCode = 'C' AND Diverted = '0' AND DivAirportLandings = '9' GROUP BY TailNum, Cancelled, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, CancellationCode, DivReachedDest WHERE WheelsOff = '2301' AND Year = '2014' AND Cancelled = '1'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE CancellationCode = 'B' AND Quarter = '2' AND AirlineID = '19393' GROUP BY CRSElapsedTime, DayOfWeek, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, SecurityDelay, Quarter WHERE ActualElapsedTime = '89' AND Diverted = '0' AND DestWac = '82'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Origin = 'MTJ' GROUP BY Flights, DestWac, NASDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, Flights, CancellationCode WHERE Year = '2014' AND CarrierDelay = '15' AND OriginStateFips = '41'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, Year, SecurityDelay WHERE Diverted = '0' AND DestAirportSeqID = '1013603' AND DepTimeBlk = '1000-1059'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Month, Distance, DivAirportLandings WHERE Origin = 'GCC'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut, DayOfWeek, Quarter WHERE FirstDepTime = '-9999' AND SecurityDelay = '14' AND Month = '6'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND TaxiIn = '24' AND OriginStateFips = '8' GROUP BY ArrTime, DivReachedDest, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime = '17' AND OriginCityName = 'Chicago, IL' AND DistanceGroup = '1' GROUP BY CRSElapsedTime, CancellationCode, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND WheelsOff = '1155' AND DivAirportLandings = '0' GROUP BY DayofMonth, NASDelay, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND Cancelled = '1' AND CRSDepTime = '833' GROUP BY DivAirportLandings, ArrTime, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND NASDelay = '34' AND Carrier = 'OO' GROUP BY DistanceGroup, DestAirportID, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND ActualElapsedTime = '132' AND Carrier = 'MQ' GROUP BY OriginAirportID, ArrTimeBlk, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, DayofMonth, Flights WHERE TaxiOut = '8' AND Diverted = '0' AND DepTimeBlk = '0700-0759'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek = '4' AND DestWac = '52' AND Carrier = 'MQ' GROUP BY TailNum, Quarter, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, Quarter, LongestAddGTime WHERE Origin = 'BUR' AND AirTime = '63' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DayofMonth = '21' AND DestAirportSeqID = '1129202' AND UniqueCarrier = 'EV' GROUP BY DestState, OriginStateName, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings = '1' AND OriginWac = '37' AND ArrTimeBlk = '1200-1259' GROUP BY Quarter, WheelsOn, DivAirportLandings
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips = '56' AND DivReachedDest = '-9999' AND SecurityDelay = '0' GROUP BY Dest, DivAirportLandings, SecurityDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Carrier, Quarter, LongestAddGTime WHERE CRSElapsedTime = '339' AND Carrier = 'AS' AND Cancelled = '0'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, DivReachedDest, Year WHERE Year = '2014' AND DivAirportLandings = '0' AND SecurityDelay = '0'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, Flights, CancellationCode WHERE LateAircraftDelay = '28' AND OriginState = 'WI' AND ArrTimeBlk = '2100-2159'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Month, Year, FlightNum WHERE ActualElapsedTime = '116' AND OriginStateFips = '49' AND Cancelled = '0'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID = '20366' GROUP BY Origin, ArrTimeBlk, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CarrierDelay = '241' GROUP BY OriginAirportID, SecurityDelay, CancellationCode
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '10' AND OriginStateName = 'California' AND Diverted = '0' GROUP BY OriginAirportSeqID, FlightDate, Flights
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' AND NASDelay = '101' AND Year = '2014' GROUP BY AirlineID
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn = '10' AND DepTimeBlk = '1400-1459' AND UniqueCarrier = 'F9' GROUP BY DestAirportSeqID, DivReachedDest, DayOfWeek
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND CancellationCode = 'B' AND ArrTimeBlk = '0001-0559' GROUP BY OriginAirportID, UniqueCarrier, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY Dest, Quarter, Cancelled WHERE OriginStateFips = '13' AND DistanceGroup = '3' AND ArrTimeBlk = '2000-2059'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DivDistance, DayOfWeek, Year WHERE DivReachedDest = '-9999' AND Month = '6' AND DestState = 'TX'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportID WHERE Quarter = '2'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSElapsedTime, UniqueCarrier, Flights WHERE TotalAddGTime = '18'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, DivReachedDest, DistanceGroup WHERE AirlineID = '20355' AND Origin = 'MSY' AND UniqueCarrier = 'US'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest = '0' AND OriginState = 'IL' AND UniqueCarrier = 'AA' GROUP BY Origin, UniqueCarrier, ArrTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WheelsOff, CancellationCode, Month WHERE OriginWac = '63' AND DestStateName = 'Massachusetts'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateName = 'Florida' AND Quarter = '2' AND DivAirportLandings = '9' GROUP BY LongestAddGTime, DestStateFips, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DepTime = '1655' AND DayofMonth = '12' GROUP BY DestState, Quarter, NASDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ActualElapsedTime = '83' AND DayOfWeek = '4' AND UniqueCarrier = 'UA' GROUP BY TotalAddGTime, DivDistance, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '0' GROUP BY TaxiIn, Carrier, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginCityName = 'Klamath Falls, OR' GROUP BY CancellationCode, DestStateName, DivAirportLandings
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '2' AND DestState = 'OK' AND Flights = '1' GROUP BY OriginStateName, DepTimeBlk, DivAirportLandings
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND DivArrDelay = '193' AND DivReachedDest = '1' GROUP BY OriginStateName, FirstDepTime, CRSDepTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY OriginWac, UniqueCarrier, Year WHERE CRSElapsedTime = '390' AND Year = '2014' AND Cancelled = '0'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Flights, CRSDepTime, DivAirportLandings WHERE DivReachedDest = '0' AND DestState = 'ND' AND DistanceGroup = '2'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WeatherDelay, OriginWac, Flights WHERE CRSElapsedTime = '70' AND Cancelled = '0' AND DepTimeBlk = '1500-1559'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE Carrier = 'OO' AND Dest = 'APN' AND Month = '6' GROUP BY UniqueCarrier, Month, NASDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '5' AND CancellationCode = 'noodles' AND Year = '2014' GROUP BY Diverted, AirTime, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, DivReachedDest, ArrTimeBlk WHERE TaxiIn = '32' AND Flights = '1' AND ArrTimeBlk = '2200-2259'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Year, DestAirportSeqID, AirlineID WHERE Diverted = '0' AND Cancelled = '0' AND TaxiOut = '23'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-21' AND Diverted = '0' AND OriginState = 'NV' GROUP BY CRSDepTime, Diverted, Flights
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, DayofMonth, Flights WHERE DestStateName = 'Illinois' AND OriginCityName = 'Norfolk, VA' AND DayofMonth = '15'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY WeatherDelay, UniqueCarrier, Quarter WHERE Year = '2014' AND FlightDate = '2014-06-20' AND OriginStateFips = '20'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Year = '2014' AND TotalAddGTime = '46' GROUP BY Carrier, DestAirportSeqID, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Dest = 'DTW' AND CancellationCode = 'A' AND UniqueCarrier = 'EV' GROUP BY DestState, DayofMonth, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE ArrTimeBlk = '0600-0659' AND CancellationCode = 'C' AND Month = '6' GROUP BY Dest, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '5' AND Month = '6' AND LongestAddGTime = '21' GROUP BY ArrTime, Diverted, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Flights, WheelsOn, Diverted WHERE CancellationCode = 'noodles' AND ArrTime = '1457' AND DivReachedDest = '1'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '2200-2259' AND Quarter = '2' AND FlightDate = '2014-06-20' GROUP BY OriginStateName, DestState, Flights
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, Month, AirlineID WHERE LongestAddGTime = '6' AND CRSElapsedTime = '262'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY OriginStateName, DepTimeBlk, CancellationCode WHERE DivReachedDest = '-9999' AND OriginStateName = 'Nebraska' AND Month = '6'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DepTime = '535' AND Flights = '1' AND DestState = 'NC' GROUP BY ArrTime, Flights, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth = '25' AND DestCityMarketID = '30257' AND DivReachedDest = '-9999' GROUP BY OriginCityMarketID, DayofMonth, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportID WHERE NASDelay = '32' AND Flights = '1' AND ArrTimeBlk = '0800-0859'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, CancellationCode, DayofMonth WHERE DivAirportLandings = '1' AND Month = '6' AND CRSElapsedTime = '398'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DivReachedDest = '1' AND DivAirportLandings = '1' GROUP BY TaxiIn, Cancelled, DestState
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportID = '10693' AND DayofMonth = '12' AND Month = '6' GROUP BY DayOfWeek, TotalAddGTime, CancellationCode
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID = '19977' AND Quarter = '2' AND CancellationCode = 'noodles' GROUP BY Cancelled, WheelsOn, DestState
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestWac = '16' GROUP BY OriginWac, DestStateName, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay, Cancelled, Diverted WHERE ActualElapsedTime = '122'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirlineID, Flights, OriginAirportID WHERE Diverted = '0' AND OriginStateName = 'Nevada' AND DayOfWeek = '7'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE FlightNum = '1379' AND Cancelled = '0' AND Diverted = '1' GROUP BY DepTimeBlk, DestStateName, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '2300-2359' AND Flights = '1' AND DestState = 'AK' GROUP BY DestCityName, Cancelled, UniqueCarrier
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY CarrierDelay, DepTimeBlk, DivReachedDest WHERE Year = '2014' AND TaxiIn = '15' AND OriginStateFips = '55'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest = '1' AND Quarter = '2' AND Flights = '1' GROUP BY CRSDepTime, CancellationCode, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportID, DayOfWeek, Cancelled WHERE DivActualElapsedTime = '338' AND DivDistance = '0' AND DistanceGroup = '5'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, SecurityDelay, Month WHERE DayOfWeek = '7' AND SecurityDelay = '0' AND AirTime = '108'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DayofMonth, OriginCityMarketID, Flights WHERE ActualElapsedTime = '236' AND Month = '6' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn = '2119' GROUP BY OriginWac, DivAirportLandings, SecurityDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND DestAirportSeqID = '1226603' AND AirlineID = '20355' GROUP BY DestAirportID, DivReachedDest, DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSArrTime = '1252' GROUP BY TotalAddGTime, DivDistance, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayofMonth, Quarter, TotalAddGTime WHERE DepTime = '858' AND Cancelled = '0' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CancellationCode = 'A' AND Carrier = 'AS' AND Diverted = '0' GROUP BY DestState, FirstDepTime, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY ArrTimeBlk, DestAirportSeqID, Year WHERE Flights = '1' AND Diverted = '0' AND OriginCityName = 'Scranton/Wilkes-Barre, PA'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND OriginWac = '85' AND DestCityName = 'Buffalo, NY' 
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Kentucky' AND DayofMonth = '6' AND DayOfWeek = '4' GROUP BY CRSDepTime, CancellationCode, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND DestStateFips = '1' AND DayOfWeek = '3' GROUP BY Flights, DivReachedDest, DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TaxiIn, Quarter, TotalAddGTime WHERE DivArrDelay = '303'
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateName = 'Alaska' AND CarrierDelay = '27' AND Year = '2014' GROUP BY Dest, ArrTimeBlk, Flights
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Cancelled, OriginCityName, DivReachedDest WHERE Cancelled = '0' AND TaxiIn = '35' AND OriginWac = '43'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DepTimeBlk, OriginAirportID, Month WHERE DestWac = '1' AND DivReachedDest = '1' AND Carrier = 'DL'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestState, OriginState, Quarter WHERE DivAirportLandings = '1' AND AirlineID = '19805' AND Month = '6'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Month, DestStateFips, DistanceGroup WHERE SecurityDelay = '0' AND Flights = '1' AND CRSDepTime = '742'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateFips, CarrierDelay WHERE DestStateFips = '36' AND Month = '6' AND ArrTimeBlk = '1700-1759'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, OriginState, Month WHERE Month = '6' AND DivAirportLandings = '1' AND Origin = 'EWR'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '1800-1859' AND Diverted = '1' AND DayofMonth = '3' GROUP BY WeatherDelay, DayofMonth, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest = '1' AND Quarter = '2' AND DestState = 'MD' GROUP BY FirstDepTime, UniqueCarrier, DayOfWeek
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityName = 'Deadhorse, AK' GROUP BY DepTimeBlk, Carrier, ArrTimeBlk
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, DistanceGroup, DivAirportLandings WHERE Quarter = '2' AND DestState = 'MO' AND CancellationCode = 'C'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, AirlineID, Month WHERE CancellationCode = 'noodles' AND DestState = 'HI' AND ArrTimeBlk = '0700-0759'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Cancelled, AirlineID, DayOfWeek WHERE Year = '2014' AND DestWac = '88' AND DivAirportLandings = '9'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime = '138' AND DestStateFips = '13' AND DepTimeBlk = '1100-1159' GROUP BY ArrTimeBlk, WeatherDelay, SecurityDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID = '30529' GROUP BY DivReachedDest, DistanceGroup, Carrier
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DestWac, LateAircraftDelay, Quarter WHERE AirlineID = '20398' AND DivAirportLandings = '0' AND TotalAddGTime = '67'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest = '0' AND DayofMonth = '18' AND OriginWac = '92' GROUP BY DestWac, DivReachedDest, DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE OriginWac = '52' AND UniqueCarrier = 'DL' AND TaxiIn = '14' GROUP BY FlightNum, Cancelled, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE AirlineID = '19930' GROUP BY DepTimeBlk, DivArrDelay, Flights
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DepTime, Month, Flights WHERE Month = '6' AND WheelsOn = '537' AND Quarter = '2'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE UniqueCarrier = 'B6' AND ArrTimeBlk = '1700-1759' AND Month = '6' GROUP BY WeatherDelay, DivAirportLandings, DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestAirportID, FlightDate, Month WHERE Diverted = '1' AND DestAirportID = '11057' AND DayofMonth = '15'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Dest = 'DAL' AND Month = '6' GROUP BY OriginStateFips, DayOfWeek, DepTimeBlk
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DivArrDelay, SecurityDelay, Quarter WHERE FirstDepTime = '1431'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DistanceGroup, OriginState, CancellationCode WHERE DayOfWeek = '2' AND DayofMonth = '11' AND DestState = 'AR'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CarrierDelay, DepTimeBlk, Diverted WHERE FirstDepTime = '1527'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '4' AND FlightDate = '2014-06-11' AND DestStateName = 'Washington' GROUP BY DivActualElapsedTime, Cancelled, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND WeatherDelay = '8' AND DepTimeBlk = '0600-0659' GROUP BY DestState, DestStateName, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND DestAirportSeqID = '1055102' AND DayofMonth = '2' GROUP BY TailNum, Quarter, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE NASDelay = '-9999' AND DestState = 'WA' AND CRSElapsedTime = '232' GROUP BY WeatherDelay, FlightDate, Year
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY CRSDepTime, Cancelled, Diverted WHERE FlightNum = '1805' AND Quarter = '2' AND OriginStateFips = '37'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND DivReachedDest = '1' AND AirlineID = '20436' GROUP BY DayOfWeek, FlightDate, AirlineID
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY CarrierDelay, OriginStateFips, Year WHERE ArrTimeBlk = '1900-1959' AND Dest = 'ONT' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk, DistanceGroup, Year WHERE DivReachedDest = '-9999'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime, SecurityDelay, Flights WHERE DistanceGroup = '2' AND Flights = '1' AND DestWac = '43'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID = '33105' AND Quarter = '2' AND Carrier = 'OO' 
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivAirportLandings, Origin, Year WHERE DivReachedDest = '-9999' AND DestStateName = 'Puerto Rico' AND CancellationCode = 'noodles'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND Quarter = '2' AND CRSDepTime = '639' GROUP BY LongestAddGTime, DestStateFips, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, TaxiIn, Year WHERE DistanceGroup = '1' AND DivArrDelay = '305' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DepTimeBlk, DestWac, DayOfWeek WHERE NASDelay = '53' AND DayofMonth = '25' AND Cancelled = '0'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE NASDelay = '57' AND Diverted = '0' AND CancellationCode = 'noodles' GROUP BY FirstDepTime, DivAirportLandings, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DivReachedDest = '1' AND Origin = 'MFR' AND Diverted = '1' GROUP BY WheelsOn, Month, Flights
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName, DistanceGroup, DivReachedDest WHERE Cancelled = '1' AND DestState = 'OK' AND DayOfWeek = '3'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DayOfWeek, DestAirportSeqID, CancellationCode WHERE DestAirportID = '13476'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '0' AND DivReachedDest = '-9999' AND DayofMonth = '28' GROUP BY FirstDepTime, DayofMonth, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Cancelled, OriginState, FlightDate WHERE CRSArrTime = '2027' AND Flights = '1' AND DistanceGroup = '11'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DivActualElapsedTime = '355' GROUP BY OriginWac, DivAirportLandings, Carrier
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY OriginCityName, AirlineID, Year WHERE DestStateFips = '50' AND Month = '6' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, ArrTimeBlk WHERE AirlineID = '20409' AND CRSArrTime = '1839'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DestCityName, Carrier WHERE Flights = '1' AND DistanceGroup = '5' AND OriginStateFips = '17'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY UniqueCarrier, DayofMonth, DivReachedDest WHERE Cancelled = '0' AND OriginState = 'FL' AND Quarter = '2'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY Year, OriginState, Cancelled WHERE TaxiIn = '48'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime = '96' AND DayOfWeek = '1' AND DepTimeBlk = '0700-0759' GROUP BY TaxiOut, AirlineID, DivReachedDest
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE AirTime = '106' AND DayofMonth = '30' AND Month = '6' GROUP BY DestAirportSeqID, DivReachedDest, SecurityDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' GROUP BY OriginAirportSeqID, DepTimeBlk, Flights
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND DivActualElapsedTime = '539' AND OriginWac = '21' GROUP BY Dest, SecurityDelay, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay = '56' GROUP BY TaxiIn, Quarter, OriginStateFips
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DestStateFips = '8' AND DivAirportLandings = '2' AND Flights = '1' GROUP BY CRSElapsedTime, Year, Carrier
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND DistanceGroup = '1' AND DivAirportLandings = '9' GROUP BY Diverted, TaxiIn, ActualElapsedTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestCityMarketID, FlightDate, Month WHERE AirlineID = '19790' AND AirTime = '81' AND DestStateName = 'New York'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY SecurityDelay, DistanceGroup, DepTimeBlk WHERE DayOfWeek = '1' AND Diverted = '1' AND OriginStateName = 'South Dakota'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '7' AND Flights = '1' AND Cancelled = '1' GROUP BY WheelsOff, Month, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND WeatherDelay = '75' AND Year = '2014' GROUP BY Cancelled, FlightDate, Carrier
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DivArrDelay = '336' GROUP BY FlightDate, DivDistance, Month
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE TaxiIn = '46' GROUP BY Dest, DivAirportLandings, DivReachedDest
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY AirTime, AirlineID, Year WHERE DistanceGroup = '11' AND OriginState = 'CA' AND DepTimeBlk = '0800-0859'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime = '334' GROUP BY DestAirportSeqID, DivAirportLandings, DayOfWeek
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY OriginWac, DayofMonth, Month WHERE UniqueCarrier = 'EV' AND DestWac = '22' AND DivActualElapsedTime = '214'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, Carrier, Diverted WHERE TaxiIn = '41' AND DestState = 'NJ'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, Diverted, DayOfWeek WHERE Cancelled = '0' AND DestStateFips = '9' AND ArrTime = '106'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityMarketID, DivReachedDest, DistanceGroup WHERE DestStateFips = '34' AND Year = '2014' AND CRSElapsedTime = '218'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, WeatherDelay, Month WHERE TaxiOut = '40'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, Quarter, DivReachedDest WHERE OriginStateName = 'South Dakota' AND TaxiOut = '17' AND Quarter = '2'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay = '137' GROUP BY TotalAddGTime, Diverted, DivReachedDest
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestWac = '38' AND CarrierDelay = '13' AND Cancelled = '0' GROUP BY WeatherDelay, DivReachedDest, AirlineID
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DivAirportLandings, Distance, Month WHERE Flights = '1' AND ActualElapsedTime = '125' AND WheelsOff = '1705'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestAirportSeqID, DivAirportLandings, Quarter WHERE Cancelled = '0' AND TaxiOut = '39' AND DestStateName = 'Montana'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ActualElapsedTime = '152' AND SecurityDelay = '-9999' AND DestStateName = 'Indiana' GROUP BY CRSDepTime, Year, DivAirportLandings
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, DivReachedDest, CancellationCode WHERE DestStateFips = '49' AND OriginStateFips = '17' AND DayofMonth = '5'
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '5' AND CarrierDelay = '1' AND Flights = '1' GROUP BY Cancelled, DestAirportID, Year
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Year, Diverted WHERE DistanceGroup = '10' AND DayofMonth = '19' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY CarrierDelay, DepTimeBlk, Quarter WHERE FirstDepTime = '954' AND Year = '2014' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY TailNum, Month, Quarter WHERE Flights = '1' AND DivArrDelay = '179' AND DestAirportID = '11278'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE AirTime = '29' AND Quarter = '2' AND FlightDate = '2014-06-21' GROUP BY Year, TotalAddGTime, DestStateFips
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE CancellationCode = 'noodles' AND OriginStateName = 'Alabama' AND TaxiIn = '4' GROUP BY TotalAddGTime, UniqueCarrier, CancellationCode
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginState = 'IA' AND UniqueCarrier = 'WN' AND Month = '6' GROUP BY WheelsOff, Diverted, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TaxiOut = '2' AND AirlineID = '19393' AND DestWac = '41' GROUP BY DivArrDelay, CRSDepTime, OriginAirportSeqID
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier = 'US' GROUP BY DepTime, DivReachedDest, Flights
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, SecurityDelay, Year WHERE DivActualElapsedTime = '627' AND DayOfWeek = '2' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY WheelsOff, DivReachedDest, Flights WHERE Diverted = '0' AND AirTime = '47' AND Quarter = '2'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DayofMonth = '28' AND DestStateFips = '47' AND SecurityDelay = '-9999' GROUP BY NASDelay, Flights, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '43' AND TaxiOut = '50' AND Month = '6' GROUP BY LateAircraftDelay, Month, DestWac
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '1' AND Quarter = '2' AND Cancelled = '0' GROUP BY DistanceGroup, TotalAddGTime, DivAirportLandings
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND AirlineID = '20304' AND DivReachedDest = '1' GROUP BY ActualElapsedTime, DivActualElapsedTime, FirstDepTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DestState = 'CO' AND DivAirportLandings = '9' GROUP BY TaxiIn, UniqueCarrier, CancellationCode
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND OriginStateFips = '34' AND ActualElapsedTime = '184' GROUP BY OriginCityName, Flights, DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime = '-9999' AND DestWac = '81' AND Month = '6' GROUP BY TaxiOut, Quarter, FlightDate
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOff = '1232' AND DestCityMarketID = '34986' AND CancellationCode = 'noodles' GROUP BY DestStateName, Month, DayofMonth
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY CRSDepTime, DayOfWeek, Year WHERE DayofMonth = '2' AND DayOfWeek = '6' AND SecurityDelay = '0'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TailNum, Year, Cancelled WHERE CRSArrTime = '1605' AND Cancelled = '1' AND Month = '6'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND DayOfWeek = '2' AND Dest = 'GNV' GROUP BY DestCityMarketID, AirlineID, DivArrDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Carrier, OriginStateName, Month WHERE AirTime = '108' AND DayOfWeek = '5' AND DivAirportLandings = '0'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DestStateFips, Cancelled, OriginStateFips WHERE Quarter = '2' AND DestStateFips = '72' AND DepTimeBlk = '1300-1359'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY Cancelled, Diverted, WheelsOn WHERE DayofMonth = '17' AND DepTimeBlk = '1400-1459' AND CancellationCode = 'C'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ArrTime = '510' GROUP BY OriginCityName, DistanceGroup, Quarter
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Year = '2014' AND Origin = 'BZN' AND DivReachedDest = '1' GROUP BY DepTimeBlk, OriginStateFips, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Year = '2014' AND UniqueCarrier = 'HA' AND AirTime = '18' GROUP BY OriginState, OriginStateFips, Year
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips = '19' AND DivAirportLandings = '0' AND LateAircraftDelay = '27' GROUP BY OriginStateFips, Quarter, TotalAddGTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE FlightNum = '484' GROUP BY TaxiIn, Quarter, UniqueCarrier
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportSeqID, Month, CancellationCode WHERE DestStateName = 'Michigan' AND DayOfWeek = '6' AND AirlineID = '19805'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY ArrTime, Quarter, SecurityDelay WHERE WeatherDelay = '7' AND OriginCityMarketID = '33195' AND TotalAddGTime = '-9999'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DestStateName, FlightDate, Cancelled WHERE Flights = '1' AND DayofMonth = '22' AND OriginStateFips = '44'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate = '2014-06-04' AND CRSArrTime = '2300' AND Diverted = '0' GROUP BY Carrier, WeatherDelay, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY SecurityDelay, OriginState, DistanceGroup WHERE AirlineID = '20398' AND OriginCityName = 'Cincinnati, OH' AND SecurityDelay = '-9999'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY WheelsOff, DivAirportLandings, Cancelled WHERE DayOfWeek = '4'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY Month, DepTimeBlk, DestStateFips WHERE DivAirportLandings = '0' AND FlightDate = '2014-06-03' AND CarrierDelay = '2'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY CRSArrTime, DivAirportLandings, Diverted WHERE Quarter = '2' AND DepTimeBlk = '1800-1859' AND Cancelled = '0'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY SecurityDelay, WheelsOn, Quarter WHERE AirlineID = '19930' AND OriginState = 'MI' AND DivReachedDest = '-9999'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Carrier = 'MQ' AND Flights = '1' AND WheelsOn = '1014' GROUP BY WeatherDelay, OriginStateFips, Cancelled
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY FlightDate, OriginStateFips, Diverted WHERE Year = '2014' AND TaxiIn = '33' AND DestWac = '23'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DestAirportID, DivReachedDest, Month WHERE TaxiIn = '14' AND DivReachedDest = '1' AND Year = '2014'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CRSDepTime, Cancelled, Flights WHERE Cancelled = '0' AND DivReachedDest = '1' AND WheelsOff = '1400'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND DivActualElapsedTime = '200' AND Quarter = '2' GROUP BY WheelsOff, DayOfWeek, Month
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE OriginWac = '64' AND AirlineID = '19930' AND Month = '6' GROUP BY DistanceGroup, DayofMonth, Carrier
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateName, TaxiOut, Flights WHERE WheelsOn = '1500' AND Year = '2014' AND Month = '6'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateFips, UniqueCarrier, Quarter WHERE DepTimeBlk = '1700-1759' AND CRSArrTime = '2144' AND DestCityName = 'Phoenix, AZ'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivAirportLandings, WeatherDelay, Year WHERE Flights = '1' AND DistanceGroup = '2' AND Quarter = '2'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '221' AND DayOfWeek = '3' AND Quarter = '2' GROUP BY Distance, OriginStateName, OriginAirportID
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DivArrDelay, SecurityDelay, DivReachedDest WHERE OriginState = 'WI' AND Diverted = '1' AND DivArrDelay = '178'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY WeatherDelay, DestWac, Diverted WHERE OriginCityName = 'Juneau, AK'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY CRSArrTime, DivReachedDest, Flights WHERE AirTime = '356'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay = '6' AND Year = '2014' AND Cancelled = '0' GROUP BY NASDelay, DestState, Flights
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk = '1900-1959' GROUP BY DivArrDelay, DivAirportLandings, CancellationCode
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DepTime, Month, DayOfWeek WHERE Origin = 'RNO' AND DayOfWeek = '1' AND LongestAddGTime = '-9999'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest = '-9999' AND Quarter = '2' AND WeatherDelay = '202' GROUP BY LateAircraftDelay, Cancelled, CancellationCode
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime, OriginWac, Quarter WHERE Flights = '1' AND OriginWac = '2' AND WheelsOn = '1752'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityName, CancellationCode, Year WHERE TaxiIn = '19' AND Year = '2014' AND FlightDate = '2014-06-30'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND FlightDate = '2014-06-25' AND ArrTimeBlk = '2300-2359' GROUP BY Distance, CancellationCode, Flights
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE OriginStateName = 'Indiana' AND DestWac = '34' AND Month = '6' GROUP BY DepTimeBlk, OriginStateFips, Month
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, Flights, DistanceGroup WHERE DayOfWeek = '6' AND Cancelled = '0' AND LongestAddGTime = '27'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSDepTime = '1051' AND TaxiOut = '16' AND DivAirportLandings = '0' GROUP BY TaxiOut, DayOfWeek, DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth = '2' AND DivAirportLandings = '0' AND Carrier = 'WN' GROUP BY LongestAddGTime, WeatherDelay, CRSElapsedTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup = '4' AND DestStateName = 'Utah' AND Cancelled = '0' GROUP BY WheelsOn, Diverted, Month
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DayofMonth, OriginWac, DivReachedDest WHERE SecurityDelay = '0' AND ArrTimeBlk = '1500-1559' AND OriginState = 'OR'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE TaxiOut = '21' AND Cancelled = '0' AND OriginState = 'MD' GROUP BY OriginCityName, DayofMonth, Year
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, OriginStateFips, DayofMonth WHERE Origin = 'GCC'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DistanceGroup = '2' AND ArrTime = '921' AND Quarter = '2' GROUP BY DestStateName, TaxiOut, Month
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightDate, OriginAirportID, Year WHERE DepTimeBlk = '0800-0859' AND CarrierDelay = '49' AND Flights = '1'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateName, TaxiOut, Quarter WHERE ArrTime = '1542' AND Year = '2014' AND Carrier = 'DL'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY Year, DestState, OriginStateFips WHERE Flights = '1' AND ActualElapsedTime = '71' AND DestStateName = 'Texas'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivAirportLandings, DivReachedDest, Cancelled WHERE SecurityDelay = '33'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightNum, Cancelled, Flights WHERE CRSArrTime = '715' AND Flights = '1' AND OriginWac = '13'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Diverted = '0' AND DayofMonth = '17' AND CRSElapsedTime = '340' GROUP BY CRSElapsedTime, DivReachedDest, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DivReachedDest = '1' GROUP BY CRSArrTime, Year, SecurityDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk = '2300-2359' GROUP BY Cancelled, Origin, DivAirportLandings
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings = '0' GROUP BY LongestAddGTime, CarrierDelay, Year
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightDate, NASDelay, Diverted WHERE DestWac = '86' AND DepTimeBlk = '1700-1759' AND Quarter = '2'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityName, CancellationCode, DayOfWeek WHERE Year = '2014' AND DivArrDelay = '174' AND DayofMonth = '5'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Month = '6' AND OriginAirportSeqID = '1086803' AND DestState = 'TX' GROUP BY OriginCityName, Month, Year
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '-9999' AND Quarter = '2' AND DestWac = '64' GROUP BY DivActualElapsedTime, DepTimeBlk, Month
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DepTimeBlk, OriginStateFips, SecurityDelay WHERE FlightDate = '2014-06-24'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginStateName, TotalAddGTime, Diverted WHERE TaxiOut = '153' AND Flights = '1' AND Cancelled = '0'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '9' AND DestCityMarketID = '31067' AND Flights = '1' GROUP BY OriginCityMarketID, Year, DayofMonth
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND ArrTimeBlk = '0800-0859' AND FlightDate = '2014-06-15' GROUP BY OriginCityMarketID, Month, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Quarter, Diverted WHERE OriginStateFips = '51' AND OriginStateName = 'Virginia' AND DestStateFips = '45'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'UA' AND Diverted = '0' AND DayOfWeek = '3' GROUP BY CRSElapsedTime, AirlineID, Flights
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY ActualElapsedTime, DepTimeBlk, Quarter WHERE WheelsOn = '214'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY ActualElapsedTime, Diverted, CancellationCode WHERE Diverted = '1' AND DayofMonth = '25' AND Distance = '677'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY AirlineID, DestWac, DayOfWeek WHERE DivAirportLandings = '0' AND DestAirportID = '13342' AND OriginStateName = 'Michigan'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY AirlineID, FirstDepTime, Cancelled WHERE UniqueCarrier = 'EV' AND DayOfWeek = '1' AND OriginCityName = 'Lansing, MI'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY ArrTime, DivReachedDest, Flights WHERE SecurityDelay = '-9999' AND AirlineID = '20366' AND Cancelled = '1'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY CancellationCode, FlightDate, ArrTimeBlk WHERE OriginStateFips = '47'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY CRSDepTime, Month, DayOfWeek WHERE WeatherDelay = '0' AND Cancelled = '0' AND DestAirportID = '13422'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DayofMonth, FlightDate, Cancelled WHERE OriginWac = '41' AND Cancelled = '0' AND UniqueCarrier = 'AA'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, Cancelled, DestCityMarketID WHERE CarrierDelay = '85' AND DayofMonth = '1' AND Month = '6'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, OriginAirportID, CancellationCode WHERE Diverted = '1' AND CRSElapsedTime = '82' AND DayOfWeek = '1'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DepTimeBlk, AirTime, Year WHERE Dest = 'JAC' AND Flights = '1' AND DistanceGroup = '1'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DepTime, DivAirportLandings, Month WHERE DayofMonth = '3' AND OriginStateName = 'Florida' AND DestAirportID = '12478'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DepTime, Quarter, SecurityDelay WHERE Year = '2014' AND AirlineID = '20366' AND OriginStateName = 'Connecticut'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Dest, AirlineID, Month WHERE DivDistance = '67'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestAirportID, Carrier, Cancelled WHERE Distance = '926' AND Quarter = '2'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Dest, DepTimeBlk, Quarter WHERE Diverted = '0'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestStateFips, WeatherDelay, Month WHERE Year = '2014' AND CancellationCode = 'B' AND OriginStateName = 'West Virginia'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestStateName, DivDistance, Year WHERE DivAirportLandings = '1' AND Year = '2014' AND DestWac = '4'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestState, NASDelay, Flights WHERE DistanceGroup = '2' AND DepTimeBlk = '1700-1759' AND CancellationCode = 'C'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestWac, DepTimeBlk, DivAirportLandings WHERE Cancelled = '0' AND Carrier = 'EV' AND FlightDate = '2014-06-01'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestWac, WeatherDelay, Month WHERE TaxiIn = '54' AND Year = '2014' AND Cancelled = '0'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Distance, DivReachedDest, Cancelled WHERE ArrTimeBlk = '2000-2059' AND TaxiIn = '32' AND DivReachedDest = '-9999'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DistanceGroup, OriginState, AirlineID WHERE AirTime = '275'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Diverted, WeatherDelay, Year WHERE DayofMonth = '6' AND DistanceGroup = '6' AND CRSDepTime = '550'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DivReachedDest, Flights, TaxiIn WHERE DepTimeBlk = '1400-1459' AND CRSArrTime = '1440' AND TaxiIn = '7'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Flights, OriginState, DepTimeBlk WHERE ActualElapsedTime = '272' AND DistanceGroup = '6' AND DivReachedDest = '-9999'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Flights, TaxiIn, OriginStateName WHERE TaxiOut = '39' AND DestStateFips = '5' AND Flights = '1'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY LateAircraftDelay, TotalAddGTime, Month WHERE DayOfWeek = '3' AND WheelsOn = '650' AND ActualElapsedTime = '56'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY LongestAddGTime, ArrTimeBlk, Month WHERE Quarter = '2' AND DivAirportLandings = '1' AND DestState = 'IN'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY NASDelay, UniqueCarrier, Quarter WHERE DayOfWeek = '4' AND DestState = 'NY' AND Flights = '1'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportID, Cancelled, Diverted WHERE TailNum = 'N192JB'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportSeqID WHERE Diverted = '1' AND TailNum = 'N508AY'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginCityName, Diverted, SecurityDelay WHERE DepTime = '1445'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Origin, Diverted, Month WHERE Flights = '1' AND DivAirportLandings = '0' AND Month = '6'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginState, Carrier, Flights WHERE Month = '6' AND Year = '2014' AND FirstDepTime = '1313'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginState, DayOfWeek, AirlineID WHERE CarrierDelay = '34' AND Flights = '1' AND UniqueCarrier = 'DL'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginStateFips, CarrierDelay, Year WHERE UniqueCarrier = 'MQ' AND Month = '6' AND DayOfWeek = '7'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginStateFips, TotalAddGTime, DivAirportLandings WHERE LateAircraftDelay = '37' AND DestState = 'OK' AND SecurityDelay = '0'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginStateName, FirstDepTime, Flights WHERE Year = '2014' AND TaxiIn = '2' AND WheelsOff = '646'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginState, OriginWac WHERE AirlineID = '20436' AND DayofMonth = '23' AND CRSArrTime = '2230'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginWac, DayofMonth, SecurityDelay WHERE Quarter = '2' AND OriginWac = '63' AND FlightDate = '2014-06-10'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginWac, Year, DivAirportLandings WHERE Diverted = '0' AND Quarter = '2' AND DepTimeBlk = '1600-1659'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY SecurityDelay, DestState, FlightDate WHERE DivAirportLandings = '1'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY SecurityDelay, DivAirportLandings, Origin WHERE Year = '2014' AND DivReachedDest = '1' AND OriginCityName = 'Des Moines, IA'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY TaxiIn, DistanceGroup, Month WHERE DivReachedDest = '-9999' AND DepTimeBlk = '1200-1259' AND CRSElapsedTime = '83'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY UniqueCarrier, DivDistance, Year WHERE OriginWac = '23'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY WeatherDelay, Diverted, ArrTimeBlk WHERE Flights = '1' AND DayOfWeek = '4' AND OriginAirportSeqID = '1062702'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY WheelsOff, DayOfWeek, Quarter WHERE DivActualElapsedTime = '517' AND Month = '6' AND OriginStateName = 'Georgia'
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Year, DepTime, CancellationCode WHERE DivAirportLandings = '1' AND Diverted = '1' AND Dest = 'MSY'
-SELECT SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime = '385' AND Quarter = '2' AND Year = '2014' GROUP BY DivDistance, DestStateFips, Quarter
-SELECT SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime = '96' AND DivAirportLandings = '0' AND DestAirportSeqID = '1473003' GROUP BY DestStateName, OriginStateName, Diverted
-SELECT SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk = '2200-2259' AND DivAirportLandings = '9' AND Quarter = '2' GROUP BY DestCityMarketID, OriginStateFips, Quarter
-SELECT SUM(DepDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND WheelsOff = '1335' AND DistanceGroup = '6' GROUP BY CancellationCode, DayOfWeek, DestCityName
-SELECT SUM(DepDel15) FROM myStarTable WHERE Cancelled = '0' AND DestWac = '88' AND Month = '6' GROUP BY OriginAirportSeqID, Month, UniqueCarrier
-SELECT SUM(DepDel15) FROM myStarTable WHERE Cancelled = '0' AND UniqueCarrier = 'UA' AND LongestAddGTime = '17' GROUP BY DepTime, Year, Month
-SELECT SUM(DepDel15) FROM myStarTable WHERE Cancelled = '1' GROUP BY TaxiIn, Quarter, DayofMonth
-SELECT SUM(DepDel15) FROM myStarTable WHERE Carrier = 'MQ' AND DayOfWeek = '7' AND OriginCityName = 'Cleveland, OH' GROUP BY DestAirportID, DayofMonth, Flights
-SELECT SUM(DepDel15) FROM myStarTable WHERE Carrier = 'MQ' AND Year = '2014' AND CarrierDelay = '36' GROUP BY Month, Quarter, DivReachedDest
-SELECT SUM(DepDel15) FROM myStarTable WHERE Carrier = 'OO' AND DivReachedDest = '0' GROUP BY Carrier, Diverted, CRSDepTime
-SELECT SUM(DepDel15) FROM myStarTable WHERE CRSArrTime = '1449' GROUP BY DestCityMarketID, ArrTimeBlk, Quarter
-SELECT SUM(DepDel15) FROM myStarTable WHERE CRSDepTime = '1530' AND DivAirportLandings = '0' AND ActualElapsedTime = '84' GROUP BY DestAirportSeqID, UniqueCarrier, Diverted
-SELECT SUM(DepDel15) FROM myStarTable WHERE DayofMonth = '27' AND CarrierDelay = '69' AND Cancelled = '0' GROUP BY Carrier, ArrTimeBlk, Quarter
-SELECT SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '6' AND Quarter = '2' AND DivAirportLandings = '1' GROUP BY DepTimeBlk, TailNum, NASDelay
-SELECT SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '6' GROUP BY UniqueCarrier, CancellationCode, DestState
-SELECT SUM(DepDel15) FROM myStarTable WHERE DestCityName = 'Las Vegas, NV' AND Month = '6' AND Cancelled = '0' GROUP BY FlightDate, DestAirportID, Month
-SELECT SUM(DepDel15) FROM myStarTable WHERE DestCityName = 'Santa Barbara, CA' GROUP BY TaxiOut, DayofMonth, DivReachedDest
-SELECT SUM(DepDel15) FROM myStarTable WHERE DestStateFips = '36' AND WeatherDelay = '17' AND Flights = '1' GROUP BY DestStateFips, WeatherDelay, Month
-SELECT SUM(DepDel15) FROM myStarTable WHERE DestState = 'GA' AND Month = '6' AND Carrier = 'F9' GROUP BY TailNum, Cancelled, Month
-SELECT SUM(DepDel15) FROM myStarTable WHERE Distance = '1620' AND Month = '6' AND DepTimeBlk = '1000-1059' GROUP BY TotalAddGTime, DivReachedDest, OriginState
-SELECT SUM(DepDel15) FROM myStarTable WHERE DistanceGroup = '6' AND AirlineID = '20366' AND DayOfWeek = '3' GROUP BY ActualElapsedTime, DistanceGroup, Cancelled
-SELECT SUM(DepDel15) FROM myStarTable  WHERE DivAirportLandings = '0' AND CancellationCode = 'noodles' AND DivReachedDest = '-9999'
-SELECT SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '0' AND WheelsOn = '756' AND Month = '6' GROUP BY Cancelled, WeatherDelay, ArrTimeBlk
-SELECT SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '1' AND ArrTimeBlk = '2000-2059' AND DestWac = '64' GROUP BY SecurityDelay, CancellationCode, NASDelay
-SELECT SUM(DepDel15) FROM myStarTable WHERE DivDistance = '451' GROUP BY TaxiIn, ArrTimeBlk, Flights
-SELECT SUM(DepDel15) FROM myStarTable WHERE Diverted = '0' AND ArrTimeBlk = '1100-1159' AND OriginStateFips = '51' GROUP BY DepTimeBlk, Quarter, OriginAirportSeqID
-SELECT SUM(DepDel15) FROM myStarTable WHERE Diverted = '0' AND Origin = 'PIT' AND AirlineID = '20398' GROUP BY ArrTime, DivReachedDest, Flights
-SELECT SUM(DepDel15) FROM myStarTable WHERE DivReachedDest = '-9999' AND UniqueCarrier = 'EV' AND DistanceGroup = '6' GROUP BY DestAirportSeqID, Flights, ArrTimeBlk
-SELECT SUM(DepDel15) FROM myStarTable  WHERE FlightDate = '2014-06-08' AND OriginWac = '93' AND Year = '2014'
-SELECT SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-11' AND DivAirportLandings = '9' AND Diverted = '0' GROUP BY CRSElapsedTime, OriginCityName, FlightNum
-SELECT SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-13' AND Quarter = '2' AND OriginCityName = 'Pittsburgh, PA' GROUP BY Distance, SecurityDelay, Quarter
-SELECT SUM(DepDel15) FROM myStarTable WHERE FlightNum = '4265' AND Flights = '1' AND SecurityDelay = '0' GROUP BY CancellationCode, ActualElapsedTime, Year
-SELECT SUM(DepDel15) FROM myStarTable WHERE LateAircraftDelay = '49' AND Carrier = 'AS' GROUP BY Origin, Quarter, DayofMonth
-SELECT SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND CRSArrTime = '349' AND Year = '2014' GROUP BY Diverted, AirTime, CancellationCode
-SELECT SUM(DepDel15) FROM myStarTable WHERE NASDelay = '22' AND FlightDate = '2014-06-19' AND Quarter = '2' GROUP BY SecurityDelay, ArrTimeBlk, LongestAddGTime
-SELECT SUM(DepDel15) FROM myStarTable WHERE OriginAirportID = '16218' AND Diverted = '0' AND DepTimeBlk = '0800-0859' GROUP BY WeatherDelay, Diverted, CancellationCode
-SELECT SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID = '30257' GROUP BY CRSArrTime, Quarter, DivReachedDest
-SELECT SUM(DepDel15) FROM myStarTable WHERE OriginStateName = 'Ohio' AND Cancelled = '0' AND CancellationCode = 'noodles' GROUP BY WheelsOff, Flights, DivAirportLandings
-SELECT SUM(DepDel15) FROM myStarTable WHERE OriginWac = '74' AND DepTimeBlk = '1800-1859' AND TaxiOut = '5' GROUP BY Flights, Origin, Quarter
-SELECT SUM(DepDel15) FROM myStarTable WHERE Quarter = '2' AND ArrTimeBlk = '1500-1559' AND DestAirportID = '14685' GROUP BY TailNum, Flights, Diverted
-SELECT SUM(DepDel15) FROM myStarTable WHERE Quarter = '2' AND SecurityDelay = '-9999' GROUP BY OriginCityMarketID, DivReachedDest, Flights
-SELECT SUM(DepDel15) FROM myStarTable WHERE Quarter = '2' AND Year = '2014' AND OriginStateName = 'Colorado' GROUP BY DayofMonth, Flights, OriginWac
-SELECT SUM(DepDel15) FROM myStarTable WHERE SecurityDelay = '0' AND DestAirportID = '10279' AND WheelsOff = '1356' GROUP BY Month, DivReachedDest, OriginCityMarketID
-SELECT SUM(DepDel15) FROM myStarTable WHERE TailNum = 'N710UW' AND DayOfWeek = '4' AND ArrTimeBlk = '0600-0659' GROUP BY Diverted, Dest, Flights
-SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiOut = '12' AND WheelsOn = '2016' AND Diverted = '0' GROUP BY OriginStateName, Month, DivReachedDest
-SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiOut = '16' AND ArrTimeBlk = '2300-2359' AND Month = '6' GROUP BY ActualElapsedTime, Carrier, Flights
-SELECT SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier = 'EV' GROUP BY OriginWac, Year, CarrierDelay
-SELECT SUM(DepDel15) FROM myStarTable WHERE WheelsOn = '2155' AND Diverted = '1' AND DestAirportID = '11292' GROUP BY LongestAddGTime, OriginState, CancellationCode
-SELECT SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND DivReachedDest = '-9999' AND DestStateFips = '47' GROUP BY FirstDepTime, AirlineID, CancellationCode
-SELECT SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND OriginWac = '92' AND WheelsOff = '1213' GROUP BY OriginState, DepTimeBlk, Year
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY Diverted, CRSDepTime, DivAirportLandings WHERE DivAirportLandings = '1' AND Carrier = 'AS' AND FlightDate = '2014-06-02'
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY DivReachedDest, DepTimeBlk, CancellationCode WHERE FlightDate = '2014-06-01' AND Diverted = '0' AND TaxiOut = '32'
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, Year, Cancelled WHERE CancellationCode = 'noodles' AND DayofMonth = '7' AND OriginAirportSeqID = '1106603'
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE CRSElapsedTime = '201' AND Year = '2014' AND Flights = '1' GROUP BY Diverted, DestCityName, Quarter
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Diverted = '1' AND ArrTimeBlk = '1700-1759' GROUP BY TotalAddGTime, SecurityDelay, Carrier
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WeatherDelay WHERE ArrTime = '1000' AND Carrier = 'FL' AND Year = '2014'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '1' AND Flights = '1' AND DepTime = '1641' GROUP BY DistanceGroup, OriginStateName, Cancelled
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Flights, Month, Carrier WHERE Month = '6' AND UniqueCarrier = 'OO' AND DestCityMarketID = '31775'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DivAirportLandings, TaxiOut, AirlineID WHERE FlightDate = '2014-06-04' AND Carrier = 'AS' AND Diverted = '0'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DivActualElapsedTime, ArrTimeBlk, Quarter WHERE OriginCityMarketID = '31067' AND Diverted = '1' AND DayofMonth = '2'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '0' AND DayOfWeek = '2' AND DestCityMarketID = '30647' GROUP BY Quarter, UniqueCarrier, DayOfWeek
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestStateFips, OriginState, DivReachedDest WHERE DivAirportLandings = '9' AND WeatherDelay = '-9999' AND DestStateName = 'Missouri'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '2' AND OriginWac = '34' AND DayOfWeek = '1' GROUP BY TaxiIn, FirstDepTime, Quarter
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '-9999' AND DestAirportID = '12953' AND WheelsOn = '1537' GROUP BY AirlineID, OriginAirportID, Diverted
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivDistance, OriginStateName, Year WHERE DestCityMarketID = '31454'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Dest, DepTimeBlk, Month WHERE Month = '6' AND SecurityDelay = '33' AND Flights = '1'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk, OriginStateFips, Quarter WHERE CRSArrTime = '1504' AND DistanceGroup = '6' AND CancellationCode = 'noodles'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'VX' GROUP BY NASDelay, DestStateName, Flights
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '-9999' GROUP BY DivActualElapsedTime, DayOfWeek, DivReachedDest
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TaxiOut, DestState, Quarter WHERE AirlineID = '20409' AND CRSArrTime = '922' AND Quarter = '2'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND WheelsOn = '1708' AND DayofMonth = '27' GROUP BY ArrTime, Diverted, Flights
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Cancelled = '0' AND DestAirportID = '12945' AND DivReachedDest = '1' GROUP BY ActualElapsedTime, DepTimeBlk, Quarter
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Flights, Origin, Cancelled WHERE DistanceGroup = '5' AND DivReachedDest = '-9999' AND CancellationCode = 'A'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ArrTime = '2154' AND Month = '6' AND Flights = '1' GROUP BY OriginStateName, OriginState, Year
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityName = 'Minneapolis, MN' AND WheelsOn = '1745' AND Flights = '1' GROUP BY Quarter, CancellationCode, DestStateName
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginWac = '74' AND DayOfWeek = '5' AND Diverted = '1' GROUP BY ActualElapsedTime, DayOfWeek, Diverted
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DistanceGroup, CarrierDelay, Flights WHERE Flights = '1' AND DestWac = '67' AND Diverted = '0'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE CRSDepTime = '1025' AND Cancelled = '0' AND OriginWac = '45' GROUP BY ArrTime, DivReachedDest, Flights
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DayofMonth = '8' AND WeatherDelay = '61' AND Cancelled = '0' GROUP BY OriginCityMarketID, SecurityDelay, DivReachedDest
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Dest = 'GEG' AND AirlineID = '19790' AND Diverted = '0' GROUP BY DestStateName, LongestAddGTime, Diverted
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, DayOfWeek, Quarter WHERE OriginWac = '22' AND DestAirportID = '12945' AND Year = '2014'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips = '42' GROUP BY OriginState, ArrTimeBlk, DayOfWeek
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginStateName, Diverted, TaxiIn WHERE DepTimeBlk = '2100-2159' AND Quarter = '2' AND Year = '2014'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE CancellationCode = 'noodles' AND DestWac = '91' AND OriginWac = '91' GROUP BY Quarter, FlightDate, TaxiIn
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime = '67' AND Flights = '1' GROUP BY CRSElapsedTime, CancellationCode, Month
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND ActualElapsedTime = '99' AND OriginStateName = 'Arkansas' GROUP BY Carrier, DestCityName, Year
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE LateAircraftDelay = '362' GROUP BY DestAirportID, AirlineID, Month
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime = '402' AND Flights = '1' AND DayOfWeek = '4' GROUP BY Dest, SecurityDelay, DivAirportLandings
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips = '47' AND Flights = '1' AND AirlineID = '20436' GROUP BY Diverted, OriginWac, DestStateFips
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE UniqueCarrier = 'OO' AND CancellationCode = 'A' AND DayofMonth = '7' 
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' AND DestCityMarketID = '34922' AND Year = '2014' GROUP BY CancellationCode, DestCityName, Diverted
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, AirlineID, Year WHERE Cancelled = '1' AND OriginAirportSeqID = '1126702' AND CancellationCode = 'B'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityMarketID = '30466' AND Quarter = '2' AND ArrTimeBlk = '1200-1259' GROUP BY OriginAirportSeqID, Diverted, DistanceGroup
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE TotalAddGTime = '52' GROUP BY Diverted, SecurityDelay, FirstDepTime
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '0' AND TailNum = 'N902DA' GROUP BY OriginAirportSeqID, DayOfWeek, Cancelled
-SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk = '1500-1559' AND DivReachedDest = '1' AND OriginState = 'VT' GROUP BY DestAirportID, Diverted, CancellationCode
-SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '3' AND DestCityMarketID = '30431' AND Quarter = '2' GROUP BY Month, LongestAddGTime, WeatherDelay
-SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DivActualElapsedTime = '209' AND TaxiIn = '8' GROUP BY CRSArrTime, Quarter, DivReachedDest
-SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginWac = '88' AND DayOfWeek = '6' AND Flights = '1' GROUP BY LongestAddGTime, Flights, DayOfWeek
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, Flights, Year WHERE DayOfWeek = '2' AND FlightNum = '4797' AND Cancelled = '0'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut, TaxiIn, Quarter WHERE TaxiOut = '56' AND Quarter = '2' AND Cancelled = '0'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, DivReachedDest, CancellationCode WHERE DestCityMarketID = '30647' AND ArrTimeBlk = '2300-2359' AND Month = '6'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Dest = 'BHM' AND Diverted = '0' AND DestStateFips = '1' GROUP BY OriginWac, ArrTimeBlk, WeatherDelay
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestState = 'CT' AND Diverted = '0' AND OriginState = 'PA' GROUP BY OriginAirportID, SecurityDelay, Month
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DayofMonth = '7' AND Quarter = '2' AND OriginWac = '45' GROUP BY DistanceGroup, Year, Carrier
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier = 'AA' AND OriginState = 'CT' AND Cancelled = '1' GROUP BY DivDistance, Year
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY AirlineID, SecurityDelay, TaxiIn WHERE CRSArrTime = '2138'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateFips, NASDelay, Quarter WHERE Carrier = 'EV' AND Quarter = '2'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY NASDelay, FirstDepTime, Flights WHERE LateAircraftDelay = '4' AND DepTimeBlk = '1000-1059' AND DivAirportLandings = '0'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID, Cancelled, Flights WHERE ArrTime = '1524' AND Diverted = '1'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DepTime, CancellationCode, Diverted WHERE DayOfWeek = '6' AND ActualElapsedTime = '56' AND Year = '2014'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOff, SecurityDelay, Year WHERE OriginAirportSeqID = '1501603' AND Quarter = '2' AND Flights = '1'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk = '1600-1659' AND OriginCityName = 'Lexington, KY' AND Year = '2014' GROUP BY DivArrDelay, Month, DivAirportLandings
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Year, DivArrDelay, Flights WHERE Carrier = 'MQ' AND OriginWac = '64' AND CancellationCode = 'noodles'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DistanceGroup, AirTime, Year WHERE DayOfWeek = '7' AND DestAirportSeqID = '1100303' AND OriginStateFips = '8'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState, OriginWac, DivReachedDest WHERE OriginStateName = 'Virginia'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '7' AND Diverted = '0' AND TotalAddGTime = '23' GROUP BY OriginWac, Quarter, ArrTimeBlk
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'Nebraska' AND ArrTimeBlk = '1600-1659' AND AirTime = '65' GROUP BY Month, FlightDate, DestStateName
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestStateFips, DivAirportLandings, FlightDate WHERE DayofMonth = '9' AND ArrTimeBlk = '1700-1759' AND DestState = 'GA'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '1' AND CRSElapsedTime = '285' AND Year = '2014' GROUP BY SecurityDelay, FlightDate, DistanceGroup
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE ArrTimeBlk = '1000-1059' AND Quarter = '2' AND UniqueCarrier = 'F9' GROUP BY WheelsOn, SecurityDelay, Quarter
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DestStateFips, FirstDepTime, Flights WHERE DestWac = '16' AND UniqueCarrier = 'B6'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE FlightDate = '2014-06-14' AND Flights = '1' AND OriginState = 'HI' GROUP BY FirstDepTime, OriginStateFips
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTimeBlk = '1800-1859' AND Year = '2014' AND TaxiIn = '29' GROUP BY Quarter, AirTime, DivAirportLandings
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName, SecurityDelay, DayofMonth WHERE DayOfWeek = '3' AND Distance = '945' AND Diverted = '1'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DestStateName = 'Puerto Rico' AND CancellationCode = 'noodles' GROUP BY Distance, SecurityDelay, Flights
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, DestStateName, DayofMonth WHERE OriginCityMarketID = '31834' AND Cancelled = '1' AND DayofMonth = '3'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY NASDelay, DivReachedDest WHERE LongestAddGTime = '121'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut = '33' AND Flights = '1' AND DestState = 'OR' GROUP BY CarrierDelay, Carrier, Cancelled
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND OriginAirportID = '10279' AND CancellationCode = 'B' GROUP BY DayOfWeek, Distance, Quarter
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestStateName = 'Indiana' AND OriginState = 'AZ' AND Month = '6' GROUP BY UniqueCarrier, OriginStateName, Flights
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Flights, Origin, DivReachedDest WHERE WheelsOn = '2136' AND SecurityDelay = '-9999' AND DivAirportLandings = '0'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestWac, CancellationCode, DayofMonth WHERE ArrTime = '1938' AND OriginAirportID = '12173' AND DivReachedDest = '-9999'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE TotalAddGTime = '52' GROUP BY DestCityMarketID, DayofMonth, Quarter
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DestState, NASDelay, Flights WHERE OriginAirportSeqID = '1153703' AND Quarter = '2' AND Diverted = '1'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Diverted = '0' GROUP BY DepTime, CancellationCode, Diverted
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Origin, Month, FlightDate WHERE Cancelled = '1' AND Year = '2014' AND FirstDepTime = '2004'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE ArrTime = '856' AND Month = '6' AND DivAirportLandings = '0' GROUP BY DivActualElapsedTime, Diverted, SecurityDelay
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings = '2' AND DestStateName = 'Texas' AND DepTimeBlk = '1200-1259' GROUP BY Cancelled, DestState, Carrier
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportID = '11066' AND Diverted = '0' AND CarrierDelay = '73' GROUP BY DivDistance, Flights, Cancelled
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier = 'MQ' AND Month = '6' AND FirstDepTime = '616' GROUP BY AirlineID, DestAirportSeqID, Year
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted = '0' GROUP BY TotalAddGTime, TaxiIn, Year
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName = 'Arizona' GROUP BY DestAirportSeqID, DivAirportLandings, Quarter
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY LateAircraftDelay, Carrier, Diverted WHERE FlightNum = '1902'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateName, DestState, Diverted WHERE DestState = 'CA' AND AirlineID = '19977' AND ArrTime = '1948'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DepTime, DivAirportLandings, Quarter WHERE DayofMonth = '26'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND OriginAirportID = '12448' AND UniqueCarrier = 'MQ' GROUP BY WheelsOff, Quarter, DivReachedDest
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '43' AND Cancelled = '0' AND OriginState = 'IL' GROUP BY DayofMonth, DestState, Year
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND Cancelled = '0' AND DivReachedDest = '0' GROUP BY Dest, DivReachedDest, Cancelled
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Dest, Flights, Year WHERE Quarter = '2' AND TotalAddGTime = '24' AND DestState = 'CA'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime = '1659' AND FlightDate = '2014-06-02' GROUP BY TaxiIn, OriginStateFips, Quarter
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips = '36' AND UniqueCarrier = 'AA' AND DistanceGroup = '3' GROUP BY CRSDepTime, Month, CancellationCode
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay = '10' AND Carrier = 'UA' AND UniqueCarrier = 'UA' GROUP BY OriginState, DestState, Flights
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND Year = '2014' AND DestStateName = 'New York' GROUP BY ArrTime, Quarter, Cancelled
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, CancellationCode, Quarter WHERE Diverted = '1' AND DestWac = '72' AND UniqueCarrier = 'US'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '1' AND DestWac = '88' AND DayofMonth = '18' GROUP BY DivDistance, OriginWac, Year
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestAirportID, SecurityDelay, Diverted WHERE AirTime = '336' AND Flights = '1' AND DayofMonth = '2'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier = 'EV' AND DepTimeBlk = '0600-0659' AND SecurityDelay = '-9999' GROUP BY DepTimeBlk, DivArrDelay, Month
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE UniqueCarrier = 'OO' AND FlightDate = '2014-06-10' AND Flights = '1' GROUP BY CRSArrTime, DivAirportLandings, Diverted
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE WheelsOff = '2014' AND DistanceGroup = '6' AND DivReachedDest = '1' GROUP BY Year, DivReachedDest, DivArrDelay
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayOfWeek, Quarter, DestAirportSeqID WHERE DivReachedDest = '-9999' AND NASDelay = '35' AND Dest = 'BQN'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime, LateAircraftDelay, Flights WHERE WheelsOn = '749' AND DestWac = '63' AND OriginAirportSeqID = '1449202'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY AirTime, DivAirportLandings, DivReachedDest WHERE Year = '2014' AND DestAirportID = '11884' AND ArrTimeBlk = '1500-1559'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestState = 'VA' AND DepTimeBlk = '1900-1959' AND Cancelled = '0' GROUP BY DivReachedDest, DepTime, Diverted
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips = '47' AND ArrTimeBlk = '1700-1759' AND TaxiIn = '4' GROUP BY DepTimeBlk, CarrierDelay, Year
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, Month, Flights WHERE OriginWac = '23' AND WheelsOff = '1614' AND Diverted = '0'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE FirstDepTime = '2001' AND Year = '2014' GROUP BY DepTime, DivReachedDest, Year
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND ArrTimeBlk = '0001-0559' AND LateAircraftDelay = '33' GROUP BY Cancelled, ArrTimeBlk, FlightNum
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivReachedDest, DestCityMarketID, Quarter WHERE OriginStateFips = '46'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY AirTime, DayOfWeek, Quarter WHERE Quarter = '2' AND OriginAirportID = '12951' AND CancellationCode = 'A'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE AirlineID = '19805' AND DestAirportSeqID = '1393003' AND Cancelled = '1' GROUP BY TailNum, DivAirportLandings, Diverted
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY SecurityDelay, ArrTime, Year WHERE FlightNum = '617' AND DistanceGroup = '1' AND Flights = '1'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, DivAirportLandings, Month WHERE DayOfWeek = '3' AND DivAirportLandings = '9' AND DestStateName = 'Michigan'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Cancelled, Quarter, OriginState WHERE DestStateName = 'Illinois' AND Year = '2014' AND ArrTimeBlk = '1600-1659'
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE FlightDate = '2014-06-29' GROUP BY TaxiOut, SecurityDelay, UniqueCarrier
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestState = 'ND' AND Carrier = 'EV' AND Month = '6' GROUP BY NASDelay, Flights, CancellationCode
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut = '11' AND DayofMonth = '12' AND DivReachedDest = '0' GROUP BY Carrier, FlightDate, SecurityDelay
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DistanceGroup, FlightDate, Cancelled WHERE Month = '6' AND DepTimeBlk = '1500-1559' AND FlightDate = '2014-06-11'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY NASDelay, Month, UniqueCarrier WHERE DivReachedDest = '1' AND Cancelled = '0' AND DestStateFips = '18'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '1' AND DestWac = '23' AND Cancelled = '0' GROUP BY DivDistance, FirstDepTime, Flights
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest = '-9999' AND TaxiIn = '9' AND CRSElapsedTime = '61' GROUP BY TailNum, Flights, Diverted
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Month, Quarter WHERE DistanceGroup = '11'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '6' AND Flights = '1' AND Distance = '1084' GROUP BY DestStateFips, UniqueCarrier, Diverted
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Cancelled, Carrier, Flights WHERE DayOfWeek = '6' AND OriginWac = '38' AND WheelsOff = '632'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '1' AND Month = '6' AND OriginStateName = 'West Virginia' GROUP BY Dest, UniqueCarrier, Month
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay = '-9999' AND DivReachedDest = '0' GROUP BY LateAircraftDelay, Carrier, Month
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY UniqueCarrier, DivActualElapsedTime, Quarter WHERE DayOfWeek = '1' AND DestAirportSeqID = '1289203' AND DayofMonth = '2'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestWac, LongestAddGTime, DivReachedDest WHERE CancellationCode = 'noodles' AND Dest = 'HNL' AND WeatherDelay = '4'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND OriginState = 'TX' AND DivAirportLandings = '9' GROUP BY DivReachedDest, Cancelled, TaxiOut
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportSeqID, FlightDate, Month WHERE TaxiIn = '17' AND Year = '2014' AND UniqueCarrier = 'UA'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TaxiIn, DayOfWeek, Month WHERE DestCityMarketID = '35356'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable  WHERE OriginStateName = 'Oklahoma' AND Year = '2014'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '0800-0859' AND Cancelled = '0' AND ArrTimeBlk = '1300-1359' GROUP BY DayofMonth, OriginAirportSeqID, Year
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE AirTime = '36' AND Quarter = '2' AND OriginCityName = 'Fargo, ND' GROUP BY DivDistance, DestStateFips, Flights
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportSeqID, Carrier, Flights WHERE AirlineID = '20409' AND DestStateName = 'New York' AND DistanceGroup = '3'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginState = 'MD' AND DayOfWeek = '4' AND DayofMonth = '26' GROUP BY DivArrDelay, DivReachedDest, Year
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings = '0' AND OriginStateFips = '21' AND WeatherDelay = '3' GROUP BY DayOfWeek, AirlineID, ArrTimeBlk
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE AirTime = '254' GROUP BY Year, OriginCityMarketID, DivAirportLandings
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DivReachedDest = '-9999' GROUP BY DestCityMarketID, DayOfWeek, Diverted
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, Month, CancellationCode WHERE Year = '2014' AND CRSDepTime = '858' AND Flights = '1'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips = '20' GROUP BY CarrierDelay, ArrTimeBlk, Month
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY Year, ArrTimeBlk, OriginCityName WHERE OriginAirportID = '12892' AND TotalAddGTime = '17' AND DestStateName = 'Louisiana'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime, FirstDepTime, Diverted WHERE AirTime = '86' AND CancellationCode = 'noodles' AND CarrierDelay = '7'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DivDistance = '577' GROUP BY DivArrDelay, Quarter, Carrier
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, Carrier, Month WHERE Flights = '1' AND WheelsOn = '2008' AND DestState = 'IN'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DepTime, Cancelled, Quarter WHERE OriginCityMarketID = '31041' AND DestState = 'CA' AND DivReachedDest = '-9999'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayofMonth = '28' AND Origin = 'MCI' AND Flights = '1' GROUP BY DestAirportID, FlightDate
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips = '48' AND Cancelled = '0' AND ActualElapsedTime = '289' GROUP BY CRSElapsedTime, AirlineID, Quarter
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '1' AND Distance = '737' GROUP BY AirTime, Cancelled, CancellationCode
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginStateFips = '42' AND UniqueCarrier = 'AS' AND Flights = '1' GROUP BY ArrTime, Cancelled, Year
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateName WHERE LongestAddGTime = '67'
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable  WHERE SecurityDelay = '14' AND DivAirportLandings = '0' AND DayOfWeek = '1'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ArrTime, Flights, CancellationCode WHERE DestWac = '33'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestWac, Diverted, WeatherDelay WHERE OriginCityName = 'Milwaukee, WI' AND DestAirportID = '11298' AND Carrier = 'MQ'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateFips, Quarter, ArrTimeBlk WHERE Quarter = '2' AND FlightDate = '2014-06-27' AND ArrTime = '1554'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '1800-1859' GROUP BY LongestAddGTime, DestState, DivAirportLandings
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState = 'TN' AND DistanceGroup = '3' AND TaxiOut = '39' GROUP BY DistanceGroup, LateAircraftDelay, DivReachedDest
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac = '31' GROUP BY WeatherDelay, SecurityDelay, Carrier
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND Year = '2014' AND TaxiIn = '7' GROUP BY ArrTimeBlk, DivReachedDest, DivAirportLandings
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginStateName = 'Oregon' AND WheelsOn = '1414' AND Diverted = '0' GROUP BY DestWac, TotalAddGTime, Cancelled
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk = '1900-1959' AND DivAirportLandings = '1' AND TaxiIn = '33' GROUP BY DivDistance, ArrTimeBlk, CancellationCode
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityMarketID = '35323' GROUP BY OriginAirportSeqID, Diverted, Flights
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips = '23' GROUP BY Month, LongestAddGTime, OriginStateName
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DivDistance, Month, TotalAddGTime WHERE ArrTimeBlk = '1300-1359' AND DayofMonth = '4' AND TaxiIn = '14'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOff, DivReachedDest, Quarter WHERE DivActualElapsedTime = '498' AND DestWac = '4' AND Cancelled = '0'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE AirTime = '284' GROUP BY TailNum, Diverted, Quarter
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestState = 'AR' AND DivReachedDest = '-9999' AND WheelsOn = '1707' 
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff = '802' AND CancellationCode = 'noodles' AND OriginWac = '87' GROUP BY Quarter, LongestAddGTime, UniqueCarrier
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay = '174' AND DestStateName = 'New York' AND Year = '2014'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'California' GROUP BY DistanceGroup, OriginStateName, Quarter
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WeatherDelay, TaxiIn, Quarter WHERE DivReachedDest = '0' AND OriginState = 'WA' AND DestStateFips = '56'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay = '138' GROUP BY ArrTimeBlk, OriginAirportSeqID, Year
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier = 'AS' AND CancellationCode = 'noodles' AND DestState = 'MD' GROUP BY DivActualElapsedTime, CancellationCode, Quarter
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Idaho' AND DivAirportLandings = '1' AND DayofMonth = '29' GROUP BY OriginCityName, AirlineID, Cancelled
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND FlightNum = '236' AND DistanceGroup = '4' GROUP BY LateAircraftDelay, DestState, Flights
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND Cancelled = '1' AND DayOfWeek = '5' GROUP BY CarrierDelay, DivReachedDest, Year
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, DistanceGroup, Month WHERE WheelsOn = '747' AND Year = '2014' AND DivAirportLandings = '0'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '5' AND DestState = 'MN' AND Carrier = 'WN' GROUP BY Month, OriginStateName, CancellationCode
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestState, DivReachedDest, DestStateFips WHERE Dest = 'ONT' AND DayOfWeek = '6' AND AirlineID = '20304'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Cancelled = '1' AND DayOfWeek = '6' GROUP BY Origin, DayOfWeek, DivReachedDest
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirTime, Year, Diverted WHERE DayOfWeek = '5' AND DepTimeBlk = '0900-0959' AND Month = '6'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, DestWac, SecurityDelay WHERE WeatherDelay = '0' AND AirlineID = '19690' AND TaxiIn = '13'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY DestState, CancellationCode, ArrTimeBlk WHERE DivAirportLandings = '2' AND Flights = '1' AND TaxiIn = '4'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityName, AirlineID, Year WHERE CancellationCode = 'noodles' AND Cancelled = '0' AND DestStateName = 'Pennsylvania'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips = '1' AND ArrTimeBlk = '1500-1559' AND AirlineID = '19393' GROUP BY FlightNum, Month, Cancelled
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime = '35' AND DivReachedDest = '-9999' AND Quarter = '2' GROUP BY ArrTimeBlk, DivActualElapsedTime, Flights
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateFips, OriginStateName, Diverted WHERE TotalAddGTime = '17' AND Year = '2014' AND Carrier = 'MQ'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, FlightDate, Flights WHERE Flights = '1' AND DayofMonth = '14' AND Origin = 'BFL'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, ArrTimeBlk, Year WHERE DestStateName = 'Illinois' AND OriginStateFips = '72' AND Carrier = 'UA'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestWac = '61' AND DayofMonth = '9' AND DayOfWeek = '3' GROUP BY CancellationCode, DivActualElapsedTime, Year
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = '27' AND Carrier = 'OO' AND DivAirportLandings = '1' GROUP BY CRSArrTime, OriginCityMarketID, ArrTimeBlk
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn = '1508' AND Diverted = '0' AND UniqueCarrier = 'DL' GROUP BY SecurityDelay, Year, DayofMonth
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '10' AND Month = '6' AND DivReachedDest = '1' GROUP BY DestStateFips, AirlineID, Month
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights = '1' AND CRSDepTime = '808' AND FlightDate = '2014-06-11' GROUP BY CRSArrTime, Diverted, Month
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Origin = 'RSW' AND DestState = 'TX' AND FlightDate = '2014-06-12' GROUP BY Dest, DivAirportLandings, Quarter
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND DivActualElapsedTime = '307' AND UniqueCarrier = 'MQ' GROUP BY CancellationCode, OriginAirportSeqID, WheelsOff
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'EV' AND DivReachedDest = '-9999' AND Quarter = '2' GROUP BY NASDelay, LongestAddGTime, Flights
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND Quarter = '2' AND CRSElapsedTime = '70' GROUP BY OriginAirportSeqID, Quarter, DayofMonth
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DepTime, CancellationCode, Diverted WHERE DivReachedDest = '0' AND WeatherDelay = '-9999' AND DestCityName = 'Miami, FL'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WeatherDelay, DestWac, Quarter WHERE OriginAirportID = '10785' AND Year = '2014' AND Quarter = '2'
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum = '1550' AND Month = '6' GROUP BY OriginAirportSeqID, DayofMonth, DepTime
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY DestWac, TaxiIn, Flights WHERE CancellationCode = 'noodles' AND ArrTimeBlk = '1100-1159' AND DepTimeBlk = '0600-0659'
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND Month = '6' AND FlightDate = '2014-06-26' GROUP BY OriginAirportID, ArrTimeBlk, Quarter
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Origin = 'CID' AND AirTime = '72' AND Year = '2014' GROUP BY AirTime, DistanceGroup, Month
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DivActualElapsedTime = '438' GROUP BY NASDelay, FlightDate, Year
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '-9999' AND NASDelay = '117' AND Month = '6' GROUP BY Cancelled, SecurityDelay, CRSElapsedTime
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TailNum = 'N623MQ' GROUP BY CRSElapsedTime, DistanceGroup, Year
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND Flights = '1' AND Year = '2014' GROUP BY OriginStateFips
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TaxiOut, WeatherDelay, Month WHERE Diverted = '1' AND AirlineID = '20436' AND DestState = 'TX'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestCityName, Flights, Carrier WHERE TaxiIn = '8' AND FlightDate = '2014-06-26' AND SecurityDelay = '0'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Month, DivAirportLandings WHERE DepTimeBlk = '0001-0559' AND Diverted = '1' AND DestStateFips = '48'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE LateAircraftDelay = '116' GROUP BY DivActualElapsedTime, SecurityDelay, Year
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE OriginWac = '41' AND TaxiOut = '74' AND UniqueCarrier = 'UA' GROUP BY LongestAddGTime, DistanceGroup, SecurityDelay
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, OriginAirportSeqID, Month WHERE DayofMonth = '30' AND DepTimeBlk = '0600-0659' AND Diverted = '0'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivAirportLandings, Flights, OriginWac WHERE NASDelay = '-9999' AND Diverted = '1' AND DivArrDelay = '210'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Diverted = '0' AND ArrTime = '631' AND Cancelled = '0' GROUP BY ArrTime, SecurityDelay, Quarter
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate = '2014-06-11' AND DistanceGroup = '7' AND ArrTimeBlk = '0600-0659' GROUP BY TotalAddGTime, DistanceGroup, Diverted
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE UniqueCarrier = 'WN' AND DivReachedDest = '0' AND ArrTimeBlk = '1800-1859' 
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '0' AND ArrTime = '749' AND Flights = '1' GROUP BY Origin, DayofMonth, Flights
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE ActualElapsedTime = '239' GROUP BY SecurityDelay, DestStateName, DayOfWeek
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE CRSDepTime = '1429' AND Flights = '1' AND DivReachedDest = '1' GROUP BY Month, FirstDepTime, CancellationCode
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE FlightDate = '2014-06-28' AND DivReachedDest = '-9999' AND DestStateName = 'Colorado' GROUP BY DivActualElapsedTime, ActualElapsedTime, CarrierDelay
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Flights, AirlineID, LateAircraftDelay WHERE DestState = 'OK' AND Flights = '1' AND DepTimeBlk = '1100-1159'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay = '129' GROUP BY DivActualElapsedTime, Diverted, DivReachedDest
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WheelsOn, Year, DivReachedDest WHERE Dest = 'PWM'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND Cancelled = '1' AND FlightDate = '2014-06-15' GROUP BY DivActualElapsedTime, DistanceGroup, Flights
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips = '49' AND CRSArrTime = '904' AND DistanceGroup = '2' GROUP BY ArrTimeBlk, DivAirportLandings, Quarter
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND CRSArrTime = '27' AND Quarter = '2' GROUP BY TotalAddGTime, CancellationCode, DayofMonth
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE TaxiIn = '7' AND DivReachedDest = '-9999' AND FlightDate = '2014-06-17' GROUP BY DestCityMarketID, DayOfWeek, CancellationCode
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityName, FlightDate, Quarter WHERE Quarter = '2' AND AirlineID = '19790' AND CRSDepTime = '819'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DivAirportLandings, Origin, Year WHERE CRSDepTime = '520' AND Cancelled = '0'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivReachedDest, OriginStateFips, OriginState WHERE DestState = 'MD' AND Year = '2014' AND ActualElapsedTime = '83'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LateAircraftDelay, DestState, Flights WHERE Diverted = '1' AND DivDistance = '0' AND Dest = 'DEN'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayofMonth, SecurityDelay, Month WHERE OriginWac = '34' AND Quarter = '2' AND FlightDate = '2014-06-26'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips = '13' AND DayofMonth = '5' AND DestStateFips = '72' GROUP BY DepTime, Diverted, Month
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DepTime = '1649' AND ArrTimeBlk = '1800-1859' AND DistanceGroup = '4' GROUP BY Month, TaxiIn
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiIn, TotalAddGTime, Quarter WHERE NASDelay = '41' AND DepTimeBlk = '1600-1659' AND AirlineID = '20355'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, Month WHERE LateAircraftDelay = '167' AND OriginState = 'CA' AND Diverted = '0'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityName = 'Trenton, NJ' GROUP BY WheelsOn, DayOfWeek, Quarter
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivReachedDest, DestWac, DestStateName WHERE Flights = '1' AND Quarter = '2' AND DepTimeBlk = '1100-1159'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TaxiIn = '3' AND UniqueCarrier = 'FL' GROUP BY DestAirportID, Flights, Month
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, DivReachedDest, Diverted WHERE FlightNum = '786'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOn, DivReachedDest, Year WHERE Dest = 'MIA' AND DivReachedDest = '-9999' AND Flights = '1'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, DepTimeBlk, Month WHERE Year = '2014' AND DivReachedDest = '-9999' AND CRSDepTime = '1659'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY LateAircraftDelay, FlightDate, Quarter WHERE Flights = '1' AND DayofMonth = '17' AND Diverted = '0'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '6' AND WheelsOff = '1448' AND CancellationCode = 'noodles' GROUP BY SecurityDelay, DepTime, Year
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, Year, TaxiOut WHERE DistanceGroup = '1' AND ArrTimeBlk = '1400-1459' AND SecurityDelay = '0'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE ArrTime = '857' AND CancellationCode = 'noodles' AND Diverted = '1' GROUP BY DistanceGroup, TotalAddGTime, CancellationCode
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DepTime, Flights, DayOfWeek WHERE DayofMonth = '1' AND ArrTimeBlk = '0900-0959' AND Carrier = 'EV'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '1' AND AirlineID = '19977' GROUP BY CRSArrTime, Quarter, DayOfWeek
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = '2' AND WheelsOn = '557' AND Cancelled = '0' GROUP BY Diverted, CancellationCode, WeatherDelay
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay = '142' AND Flights = '1' AND Cancelled = '0' GROUP BY DepTime, DivAirportLandings, Month
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, AirlineID, Diverted WHERE DivArrDelay = '315' AND DivAirportLandings = '1' AND Quarter = '2'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND OriginStateFips = '37' AND ArrTime = '729' GROUP BY DivActualElapsedTime, Carrier, Quarter
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek, DestStateFips, Quarter WHERE DestStateFips = '24' AND Quarter = '2' AND OriginStateName = 'New York'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, FlightDate, Flights WHERE Year = '2014' AND DayofMonth = '4' AND OriginWac = '5'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled = '1' AND DestState = 'ME' AND DayOfWeek = '3' GROUP BY SecurityDelay, Diverted, OriginCityName
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '0' AND NASDelay = '91' AND TaxiIn = '7' GROUP BY DestState, DestStateName, Quarter
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY ArrTimeBlk, CarrierDelay, Diverted WHERE CRSArrTime = '2302' AND Carrier = 'EV' AND DivReachedDest = '0'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode = 'A' AND OriginStateFips = '13' AND Diverted = '0' GROUP BY DistanceGroup, AirlineID, SecurityDelay
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivReachedDest, CarrierDelay, Carrier WHERE Year = '2014' AND WheelsOn = '2301' AND DayOfWeek = '6'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TotalAddGTime = '66' GROUP BY DayofMonth, DestCityName, Year
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '2000-2059' 
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DistanceGroup, OriginAirportSeqID, Year WHERE ArrTimeBlk = '1800-1859' AND Year = '2014' AND Month = '6'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateName, Cancelled, Quarter WHERE NASDelay = '46' AND UniqueCarrier = 'US' AND Month = '6'
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestCityName = 'Wichita, KS' GROUP BY TaxiOut, FirstDepTime, Flights
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings = '1' AND Flights = '1' AND FlightDate = '2014-06-23' GROUP BY LateAircraftDelay, Distance, FirstDepTime
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY FirstDepTime, DivDistance, Month WHERE DayOfWeek = '3' AND DestAirportID = '11540' AND CancellationCode = 'noodles'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY AirTime, CancellationCode, Flights WHERE FlightDate = '2014-06-03' AND Month = '6' AND UniqueCarrier = 'AS'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY ArrTimeBlk, OriginAirportID, Year WHERE ActualElapsedTime = '131' AND Diverted = '0' AND DestWac = '37'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY ArrTimeBlk, OriginWac, DivReachedDest WHERE Carrier = 'OO' AND Quarter = '2' AND DestAirportSeqID = '1489302'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY ArrTime, DayOfWeek, Quarter WHERE Cancelled = '0' AND Flights = '1' AND SecurityDelay = '0'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY CancellationCode, Origin, DivAirportLandings WHERE Quarter = '2'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY CRSDepTime, SecurityDelay, Year WHERE Month = '6' AND DepTimeBlk = '0900-0959' AND OriginStateFips = '55'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY CRSElapsedTime, Quarter WHERE Year = '2014' AND Cancelled = '1' AND DayofMonth = '4'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DayofMonth, DistanceGroup, DivAirportLandings WHERE OriginStateFips = '31' AND Cancelled = '0' AND LateAircraftDelay = '2'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DepTimeBlk, OriginAirportID, Quarter WHERE FlightNum = '4637' AND DivAirportLandings = '1' AND DayOfWeek = '3'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestCityMarketID, DepTimeBlk, Year WHERE FlightDate = '2014-06-15'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestCityMarketID, Quarter, Cancelled WHERE ActualElapsedTime = '81' AND OriginState = 'MA' AND AirlineID = '19393'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Dest, DayofMonth, Year WHERE DepTimeBlk = '0700-0759' AND OriginAirportID = '14492' AND DayOfWeek = '4'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Dest, DivReachedDest, DayOfWeek WHERE Year = '2014' AND TailNum = 'N57857' AND ArrTimeBlk = '0001-0559'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestStateFips, FirstDepTime, Flights WHERE CRSElapsedTime = '340' AND SecurityDelay = '0' AND TaxiIn = '14'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestStateFips, TaxiOut, Year WHERE UniqueCarrier = 'VX' AND CRSElapsedTime = '155' AND ArrTimeBlk = '1700-1759'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestStateName, OriginStateFips, DivReachedDest WHERE DayofMonth = '6' AND WheelsOff = '626' AND Year = '2014'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestWac, LongestAddGTime, DivAirportLandings WHERE DivActualElapsedTime = '285' AND Dest = 'MIA' AND Year = '2014'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Distance, Cancelled, Flights WHERE OriginAirportSeqID = '1025702' AND Diverted = '1' AND DivReachedDest = '1'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Distance, Diverted, DivReachedDest WHERE Flights = '1' AND Carrier = 'US' AND DivAirportLandings = '2'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Diverted, ArrTimeBlk, DivDistance WHERE Distance = '1149' AND Year = '2014' AND CancellationCode = 'noodles'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Diverted, OriginCityMarketID, DivAirportLandings WHERE Distance = '1123'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DivReachedDest, Carrier, DivDistance WHERE Year = '2014' AND FirstDepTime = '558' AND Quarter = '2'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY FlightNum, Flights, Quarter WHERE ArrTimeBlk = '2300-2359'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportID, Diverted, Quarter WHERE DepTime = '1650' AND Quarter = '2' AND Cancelled = '0'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, Diverted, Cancelled WHERE CancellationCode = 'A' AND Cancelled = '1' AND Quarter = '2'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, Flights, DepTimeBlk WHERE Year = '2014' AND OriginStateFips = '1' AND CarrierDelay = '3'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, Flights, DistanceGroup WHERE Flights = '1' AND DivDistance = '258' AND Year = '2014'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginCityName, DistanceGroup, Flights WHERE DayOfWeek = '1' AND Cancelled = '0' AND DestAirportSeqID = '1221702'
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginStateFips, FlightDate, Month WHERE CancellationCode = 'noodles' AND Carrier = 'DL' AND CRSElapsedTime = '55'
-SELECT SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk = '1000-1059' AND Diverted = '0' AND OriginState = 'UT' GROUP BY Carrier, DestStateFips, Quarter
-SELECT SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk = '1100-1159' AND CRSDepTime = '1016' AND Origin = 'SAV' GROUP BY OriginCityName, Diverted, DistanceGroup
-SELECT SUM(DepDelay) FROM myStarTable WHERE CancellationCode = 'noodles' AND OriginState = 'FL' AND TaxiOut = '38' GROUP BY TaxiIn, Flights, OriginWac
-SELECT SUM(DepDelay) FROM myStarTable WHERE Cancelled = '0' AND OriginStateFips = '40' AND CRSArrTime = '1344' GROUP BY DestWac, SecurityDelay, UniqueCarrier
-SELECT SUM(DepDelay) FROM myStarTable WHERE Cancelled = '1' AND Carrier = 'OO' AND TaxiOut = '36' GROUP BY TailNum, Year, Quarter
-SELECT SUM(DepDelay) FROM myStarTable WHERE CarrierDelay = '31' AND TaxiOut = '25' AND Quarter = '2' GROUP BY CRSElapsedTime, UniqueCarrier, Flights
-SELECT SUM(DepDelay) FROM myStarTable WHERE CRSDepTime = '1818' AND SecurityDelay = '-9999' AND DivReachedDest = '-9999' GROUP BY OriginAirportID, SecurityDelay, Flights
-SELECT SUM(DepDelay) FROM myStarTable WHERE DayofMonth = '18' AND DestStateFips = '20' AND ArrTimeBlk = '1400-1459' GROUP BY OriginAirportSeqID, CancellationCode, Flights
-SELECT SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '1' AND TaxiIn = '47' AND DivReachedDest = '-9999' GROUP BY Diverted, OriginCityName, Month
-SELECT SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '2' AND DayofMonth = '2' AND NASDelay = '67' GROUP BY Flights, Dest, Carrier
-SELECT SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '4' AND ArrTime = '1445' AND UniqueCarrier = 'WN' GROUP BY DestCityMarketID, Year, Diverted
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTime = '557' AND Month = '6' AND Flights = '1' GROUP BY Quarter, OriginWac, ActualElapsedTime
-SELECT SUM(DepDelay) FROM myStarTable  WHERE DepTimeBlk = '0001-0559' AND ArrTimeBlk = '0800-0859' AND CancellationCode = 'A'
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk = '0700-0759' AND OriginState = 'TX' AND Cancelled = '0' GROUP BY UniqueCarrier, CancellationCode, CarrierDelay
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk = '1300-1359' AND DivAirportLandings = '1' AND OriginWac = '85' GROUP BY SecurityDelay, DepTimeBlk, UniqueCarrier
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk = '1400-1459' AND Year = '2014' AND WheelsOff = '1433' GROUP BY Quarter, ArrTime, DayOfWeek
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk = '2200-2259' AND FlightDate = '2014-06-13' AND Carrier = 'OO' GROUP BY CRSElapsedTime, DivReachedDest, CancellationCode
-SELECT SUM(DepDelay) FROM myStarTable WHERE Dest = 'OME' AND Quarter = '2' AND Month = '6' GROUP BY DestAirportID, Month, DivAirportLandings
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestStateFips = '17' AND DivReachedDest = '1' AND Flights = '1' GROUP BY OriginStateFips, OriginAirportID, DivDistance
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestStateName = 'Colorado' GROUP BY TaxiIn, SecurityDelay, DivReachedDest
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestWac = '14' AND Flights = '1' AND OriginCityMarketID = '31703' GROUP BY OriginStateName, DepTimeBlk, Cancelled
-SELECT SUM(DepDelay) FROM myStarTable WHERE Distance = '264' AND Year = '2014' AND ArrTimeBlk = '2200-2259' GROUP BY TotalAddGTime, DayOfWeek, FlightDate
-SELECT SUM(DepDelay) FROM myStarTable WHERE DistanceGroup = '6' AND SecurityDelay = '0' AND OriginStateName = 'Michigan' GROUP BY Dest, Diverted, DistanceGroup
-SELECT SUM(DepDelay) FROM myStarTable WHERE DivAirportLandings = '0' AND DivReachedDest = '-9999' AND OriginAirportID = '13158' GROUP BY TotalAddGTime, DayofMonth, Year
-SELECT SUM(DepDelay) FROM myStarTable WHERE Diverted = '1' AND AirlineID = '19393' AND DivReachedDest = '0' GROUP BY Quarter, DepTimeBlk, LateAircraftDelay
-SELECT SUM(DepDelay) FROM myStarTable WHERE DivReachedDest = '1' GROUP BY Flights, DivActualElapsedTime, Month
-SELECT SUM(DepDelay) FROM myStarTable WHERE FlightNum = '3052' GROUP BY OriginWac, OriginState, DivReachedDest
-SELECT SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND FlightNum = '353' AND DayOfWeek = '1' GROUP BY DestWac, DayOfWeek, Cancelled
-SELECT SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND OriginStateName = 'Missouri' AND ActualElapsedTime = '186' GROUP BY OriginCityMarketID, AirlineID, Diverted
-SELECT SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND Year = '2014' AND ArrTime = '630' GROUP BY TaxiOut, DestStateFips, Flights
-SELECT SUM(DepDelay) FROM myStarTable WHERE Month = '6' AND ArrTimeBlk = '2000-2059' AND DestWac = '34' GROUP BY DivDistance, OriginStateFips, Year
-SELECT SUM(DepDelay) FROM myStarTable WHERE Month = '6' AND DivAirportLandings = '0' AND NASDelay = '7' GROUP BY FirstDepTime, CRSElapsedTime, CancellationCode
-SELECT SUM(DepDelay) FROM myStarTable WHERE Month = '6' AND Flights = '1' AND CarrierDelay = '263' GROUP BY ActualElapsedTime, DivReachedDest, Flights
-SELECT SUM(DepDelay) FROM myStarTable WHERE NASDelay = '32' GROUP BY Distance, Diverted, DivAirportLandings
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginCityName = 'Baltimore, MD' GROUP BY TaxiOut, LongestAddGTime, Flights
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginState = 'CO' AND DivDistance = '997' AND Cancelled = '0' GROUP BY Distance, Month, DayOfWeek
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginStateName = 'Nevada' AND Flights = '1' AND Diverted = '0' GROUP BY WheelsOff, Flights, Month
-SELECT SUM(DepDelay) FROM myStarTable WHERE TailNum = 'N766SW' AND Diverted = '0' AND OriginStateFips = '8' GROUP BY CRSElapsedTime, DepTimeBlk, Month
-SELECT SUM(DepDelay) FROM myStarTable WHERE TaxiOut = '27' AND DistanceGroup = '2' AND AirlineID = '19393' GROUP BY DestCityName, DivReachedDest, Month
-SELECT SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier = 'AA' AND Quarter = '2' AND OriginCityMarketID = '30928' GROUP BY LongestAddGTime, DestStateFips, Year
-SELECT SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier = 'EV' AND WheelsOff = '1550' AND AirlineID = '20366' GROUP BY Origin, CancellationCode, DivReachedDest
-SELECT SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND DestAirportID = '10849' AND DepTimeBlk = '1900-1959' GROUP BY DivReachedDest, OriginAirportSeqID, Year
-SELECT SUM(DepDelay) FROM myStarTable WHERE Year = '2014' AND TaxiIn = '25' AND CRSDepTime = '1844' GROUP BY DestWac, Quarter, DivDistance
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirlineID, Diverted, DayOfWeek WHERE Flights = '1' AND FlightDate = '2014-06-22' AND DivReachedDest = '-9999'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, Diverted, CancellationCode WHERE OriginStateFips = '44'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY CancellationCode, CarrierDelay, UniqueCarrier WHERE Carrier = 'F9' AND DestAirportID = '14689' AND DivAirportLandings = '0'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY CancellationCode, CRSElapsedTime, Year WHERE DistanceGroup = '5' AND TaxiOut = '33' AND Cancelled = '1'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Cancelled, CarrierDelay, UniqueCarrier WHERE DayofMonth = '29'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, DivAirportLandings, Diverted WHERE DestState = 'SD' AND CancellationCode = 'C' AND DivAirportLandings = '9'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, ArrTimeBlk, Year WHERE TaxiOut = '76'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayOfWeek, Flights, Cancelled WHERE DivActualElapsedTime = '226'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DepTime, DayOfWeek, Flights WHERE Diverted = '1' AND WheelsOff = '1214'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, DivDistance, Quarter WHERE Year = '2014' AND AirTime = '71' AND DestAirportID = '14122'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, LateAircraftDelay, Flights WHERE DayOfWeek = '4' AND CancellationCode = 'C' AND Year = '2014'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestState, OriginState, Month WHERE DayOfWeek = '3'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestWac, DepTimeBlk, DivReachedDest WHERE Quarter = '2' AND AirlineID = '21171' AND TaxiIn = '19'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestWac, Quarter, OriginStateFips WHERE Year = '2014' AND DayofMonth = '30' AND OriginCityMarketID = '34492'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestWac, UniqueCarrier, Cancelled WHERE Origin = 'DCA' AND DestAirportID = '12478' AND DepTimeBlk = '1800-1859'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DistanceGroup, Carrier, DestStateName WHERE DistanceGroup = '11' AND CRSDepTime = '1625' AND OriginCityMarketID = '33830'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, ArrTimeBlk, Quarter WHERE DayOfWeek = '5' AND Cancelled = '0' AND CRSArrTime = '937'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, Quarter, DepTimeBlk WHERE Cancelled = '0' AND Dest = 'SMF' AND TaxiIn = '7'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted, AirTime, DivReachedDest WHERE OriginAirportID = '13487' AND DepTimeBlk = '2100-2159' AND DayofMonth = '23'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted, SecurityDelay, DivReachedDest WHERE Year = '2014' AND TotalAddGTime = '43'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, OriginWac, Year WHERE TaxiOut = '54' AND OriginCityMarketID = '33044' AND Flights = '1'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, DestState, Cancelled WHERE DestStateName = 'Florida' AND OriginAirportID = '10874' AND Month = '6'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightDate, LateAircraftDelay, Year WHERE DestAirportID = '10874' AND Diverted = '0' AND DayofMonth = '21'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightDate, OriginStateName, SecurityDelay WHERE DistanceGroup = '1'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY FlightDate, UniqueCarrier, Month WHERE TaxiOut = '71' AND Month = '6' AND DayOfWeek = '3'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Flights, CarrierDelay, DayOfWeek WHERE Quarter = '2' AND OriginStateFips = '54' AND ArrTimeBlk = '1800-1859'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Flights, CRSArrTime, DivReachedDest WHERE OriginStateName = 'New York' AND DepTimeBlk = '1300-1359' AND TaxiOut = '9'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, OriginWac, DivReachedDest WHERE ArrTimeBlk = '0800-0859' AND OriginAirportID = '14254' AND DivReachedDest = '-9999'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, Year, DayofMonth WHERE DestCityName = 'West Palm Beach/Palm Beach, FL' AND Carrier = 'F9' AND Year = '2014'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, Year, WeatherDelay WHERE OriginAirportSeqID = '1059904' AND DepTimeBlk = '1200-1259' AND DayOfWeek = '6'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, DivReachedDest, CancellationCode WHERE DestAirportSeqID = '1489302' AND FlightDate = '2014-06-17' AND Year = '2014'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, CancellationCode, Year WHERE CancellationCode = 'noodles' AND SecurityDelay = '14' AND Quarter = '2'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, TotalAddGTime, DivAirportLandings WHERE DestWac = '4' AND Cancelled = '1' AND Flights = '1'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateName, DestWac, Year WHERE Year = '2014'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateName, FirstDepTime, Year WHERE Quarter = '2' AND DivActualElapsedTime = '218' AND Year = '2014'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, WeatherDelay, DayofMonth WHERE Year = '2014' AND DivReachedDest = '-9999' AND DestAirportSeqID = '1079204'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, LongestAddGTime, Carrier WHERE TaxiOut = '22' AND Cancelled = '0' AND DestStateName = 'Rhode Island'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY TaxiIn, DestWac, Quarter WHERE TaxiIn = '65' AND UniqueCarrier = 'EV' AND Cancelled = '0'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY WeatherDelay, Cancelled, DestWac WHERE Month = '6' AND Cancelled = '0' AND ActualElapsedTime = '351'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY WeatherDelay, DayofMonth, DivAirportLandings WHERE UniqueCarrier = 'AA' AND AirlineID = '19805' AND CancellationCode = 'A'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY WeatherDelay, OriginStateFips, Year WHERE ArrTime = '702' AND Year = '2014' AND DivReachedDest = '-9999'
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE ActualElapsedTime = '214' AND DestWac = '87' AND DivAirportLandings = '0' GROUP BY ArrTimeBlk, DestCityMarketID, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE AirlineID = '19930' GROUP BY DivReachedDest, Distance, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE AirlineID = '20409' AND FlightDate = '2014-06-04' AND Quarter = '2' GROUP BY FlightDate, ArrTimeBlk, Diverted
-SELECT SUM(DepDelayMinutes) FROM myStarTable  WHERE CancellationCode = 'noodles' AND DivArrDelay = '210'
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier = 'VX' GROUP BY FlightNum, Diverted, Month
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CRSArrTime = '1245' GROUP BY DivReachedDest, DestAirportID
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '236' GROUP BY TaxiOut, Year, DestWac
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DayofMonth = '20' AND AirTime = '62' AND Quarter = '2' GROUP BY Flights, ArrTime, CancellationCode
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek = '7' AND WheelsOn = '1212' GROUP BY Carrier, FlightDate, AirlineID
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '1300-1359' AND DayOfWeek = '6' AND DayofMonth = '4' GROUP BY DestStateFips, Carrier, DistanceGroup
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '1400-1459' AND DayOfWeek = '3' AND DayofMonth = '1' GROUP BY AirlineID, TaxiOut, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID = '11982' AND Cancelled = '1' AND CancellationCode = 'A' GROUP BY AirlineID, OriginCityMarketID, Cancelled
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Dest = 'BUR' AND DepTimeBlk = '0600-0659' AND CancellationCode = 'noodles' GROUP BY FlightDate, CarrierDelay, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityMarketID = '34986' AND TaxiOut = '39' AND Cancelled = '0' GROUP BY DestCityMarketID, UniqueCarrier, Flights
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityName = 'Valparaiso, FL' AND DayOfWeek = '4' AND Diverted = '1' GROUP BY LateAircraftDelay, DayOfWeek, Cancelled
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips = '23' AND DayOfWeek = '4' AND DestStateName = 'Maine' GROUP BY ArrTime, Diverted, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Distance = '1491' GROUP BY LongestAddGTime, WeatherDelay, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup = '2' AND DayOfWeek = '6' AND DestWac = '51' GROUP BY Dest, Flights, SecurityDelay
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '0' AND CRSElapsedTime = '43' AND AirlineID = '19930' GROUP BY Cancelled, TotalAddGTime, DayofMonth
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '1' AND OriginWac = '66' AND ArrTimeBlk = '0800-0859' GROUP BY Origin, CancellationCode, DayOfWeek
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '2' AND CancellationCode = 'noodles' AND Month = '6' GROUP BY CRSDepTime, Year, CancellationCode
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivArrDelay = '190' AND ArrTimeBlk = '2300-2359' AND Quarter = '2' GROUP BY SecurityDelay, DivReachedDest, DestAirportID
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivDistance = '220' GROUP BY Dest, Year, SecurityDelay
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted = '1' AND DivArrDelay = '205' AND DayofMonth = '29' GROUP BY WeatherDelay, DestStateName, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE FirstDepTime = '925' GROUP BY DepTimeBlk, OriginStateName, Diverted
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE FlightDate = '2014-06-28' GROUP BY DivActualElapsedTime, CancellationCode, DivAirportLandings
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum = '1438' GROUP BY OriginStateFips, TaxiIn, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND DivActualElapsedTime = '233' AND OriginWac = '37' GROUP BY FlightDate, TotalAddGTime, Flights
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Flights = '1' AND OriginAirportSeqID = '1111102' AND Quarter = '2' GROUP BY AirTime, DistanceGroup, Cancelled
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '17' AND OriginCityName = 'San Francisco, CA' AND Flights = '1' GROUP BY DestStateFips, DistanceGroup, Carrier
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE LongestAddGTime = '21' AND DistanceGroup = '5' GROUP BY OriginState, UniqueCarrier, Flights
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND Cancelled = '0' AND Year = '2014' GROUP BY Quarter, CRSElapsedTime, Diverted
-SELECT SUM(DepDelayMinutes) FROM myStarTable  WHERE Month = '6' AND DestWac = '88' AND Quarter = '2'
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND DivReachedDest = '0' AND Flights = '1' GROUP BY OriginAirportSeqID, Cancelled, DivReachedDest
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND Flights = '1' AND OriginStateFips = '46' GROUP BY FirstDepTime, Month, OriginState
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName = 'Denver, CO' AND Month = '6' AND CRSElapsedTime = '148' GROUP BY Flights, ActualElapsedTime, DayOfWeek
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin = 'PHL' GROUP BY Cancelled, WheelsOff, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips = '15' AND FlightDate = '2014-06-19' AND Year = '2014' GROUP BY DayofMonth, Flights, DivReachedDest
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips = '78' GROUP BY TaxiIn, FlightDate, Diverted
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND AirTime = '176' AND ArrTimeBlk = '1000-1059' GROUP BY DestAirportSeqID, FlightDate, LateAircraftDelay
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND DepTimeBlk = '1300-1359' AND Carrier = 'HA' GROUP BY DivArrDelay, Flights, Carrier
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND Year = '2014' AND OriginStateFips = '51' GROUP BY OriginStateName, DestStateFips, Cancelled
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay = '-9999' AND Cancelled = '0' AND ArrTime = '1025' GROUP BY DepTime, Quarter, DivAirportLandings
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE TailNum = 'N178DN' GROUP BY CRSElapsedTime, Diverted, CancellationCode
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE TailNum = 'N751SK' GROUP BY DivArrDelay, DepTimeBlk, Month
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiOut = '105' AND Flights = '1' AND UniqueCarrier = 'UA' GROUP BY DivActualElapsedTime, Month, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime = '21' AND DayOfWeek = '5' AND CancellationCode = 'noodles' GROUP BY CarrierDelay, TotalAddGTime, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WeatherDelay = '20' GROUP BY DestAirportSeqID, DivAirportLandings, CancellationCode
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOff = '1315' AND DistanceGroup = '4' AND Year = '2014' GROUP BY OriginCityName, DepTimeBlk, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOff = '1930' AND DayofMonth = '11' AND ArrTimeBlk = '2100-2159' GROUP BY OriginCityName, DivAirportLandings, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn = '136' GROUP BY NASDelay, Flights, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn = '2400' AND UniqueCarrier = 'AA' AND SecurityDelay = '0' GROUP BY WeatherDelay, OriginWac, Flights
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND ArrTimeBlk = '1400-1459' AND FlightDate = '2014-06-09' GROUP BY TaxiIn, NASDelay, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DestAirportID, AirlineID, Diverted WHERE AirTime = '135' AND Carrier = 'AS' AND DepTimeBlk = '2100-2159'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DivArrDelay, Quarter, DepTimeBlk WHERE DayofMonth = '17' AND NASDelay = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY Month, DivReachedDest, WheelsOff WHERE ArrTime = '2302' AND DivAirportLandings = '1' AND DistanceGroup = '9'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TotalAddGTime, UniqueCarrier, Quarter WHERE NASDelay = '31' AND Cancelled = '0' AND DayOfWeek = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Dest = 'LAX' AND Flights = '1' AND WheelsOff = '915' GROUP BY OriginStateName, AirlineID, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginState = 'MI' AND Carrier = 'OO' AND Month = '6' GROUP BY DepTime, Cancelled, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND UniqueCarrier = 'US' AND FlightDate = '2014-06-04' GROUP BY ArrTimeBlk, DestState, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestWac, DepTimeBlk, Flights WHERE Diverted = '0' AND DestStateFips = '51' AND OriginAirportID = '10785'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY SecurityDelay, TaxiOut, Cancelled WHERE Cancelled = '0' AND DayofMonth = '24' AND AirlineID = '19977'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTime, CancellationCode, Quarter WHERE LateAircraftDelay = '40' AND DestWac = '81' AND Cancelled = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND CRSDepTime = '1608' AND Cancelled = '0' GROUP BY DestCityName, Cancelled, CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '5' AND DivDistance = '762' AND Diverted = '1' GROUP BY AirTime, UniqueCarrier
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestCityName = 'Lihue, HI' AND Cancelled = '0' AND Flights = '1' GROUP BY OriginCityMarketID, DayofMonth, Month
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, DepTimeBlk, Month WHERE DestState = 'MD'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CancellationCode, Cancelled, TotalAddGTime WHERE AirTime = '105' AND DepTimeBlk = '2100-2159' AND Diverted = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID = '1169703' AND Year = '2014' AND DistanceGroup = '7' GROUP BY OriginAirportID, DivAirportLandings, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Dest, SecurityDelay, Quarter WHERE TaxiOut = '14' AND CRSArrTime = '843' AND Diverted = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime = '49' AND Diverted = '0' AND ArrTimeBlk = '0700-0759' GROUP BY DivDistance, OriginStateFips, Month
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek = '3' AND Diverted = '0' AND DestCityName = 'Branson, MO' GROUP BY DivReachedDest, DestAirportSeqID, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '1' AND DayofMonth = '26' AND OriginStateName = 'California' GROUP BY Month, OriginState, DestStateName
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY FlightNum, Month, Year WHERE WeatherDelay = '60' AND Month = '6' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, DayofMonth, Flights WHERE OriginCityName = 'Dallas, TX' AND CRSArrTime = '1330' AND DivAirportLandings = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Carrier = 'F9' AND Cancelled = '0' AND FlightDate = '2014-06-30' GROUP BY AirlineID, TaxiOut, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportSeqID = '1197302' GROUP BY Diverted, FlightNum, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TailNum = 'N929DL' GROUP BY OriginCityMarketID, Quarter, DepTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Year, FlightDate, Month WHERE DepTime = '1829' AND DivReachedDest = '-9999' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '3' AND DestCityName = 'Jackson, WY' AND Month = '6' GROUP BY DestAirportID, DistanceGroup, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Diverted = '0' AND DivAirportLandings = '9' AND DayOfWeek = '4' GROUP BY TailNum, Quarter, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Carrier = 'WN' GROUP BY OriginState, OriginWac, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, CancellationCode, DayOfWeek WHERE NASDelay = '88'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '4' AND OriginAirportID = '15304' AND CancellationCode = 'noodles' GROUP BY Flights, FlightDate, CarrierDelay
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND Flights = '1' AND DayOfWeek = '4' GROUP BY Flights, ArrTime, CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID = '20437' AND DayofMonth = '12' AND DestState = 'MD' GROUP BY DepTimeBlk, SecurityDelay, OriginState
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips = '9' AND UniqueCarrier = 'US' AND Month = '6' GROUP BY Distance, SecurityDelay, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1400-1459' AND OriginCityName = 'Los Angeles, CA' AND DayofMonth = '25' GROUP BY ArrTime, Diverted, Month
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND LongestAddGTime = '6' AND Year = '2014' GROUP BY ActualElapsedTime, Diverted, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginAirportID = '11278' GROUP BY AirlineID, FlightDate, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Origin, Month, Carrier WHERE Quarter = '2' AND DivAirportLandings = '1' AND DayofMonth = '5'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = '0' AND Flights = '1' GROUP BY Diverted, DayofMonth, UniqueCarrier
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSArrTime, Quarter, Diverted WHERE DayOfWeek = '7' AND ArrTimeBlk = '1000-1059' AND DestStateName = 'North Carolina'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DistanceGroup = '9' AND TaxiIn = '10' AND DayofMonth = '23' GROUP BY DestStateName, ArrTimeBlk, DivAirportLandings
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DivArrDelay = '116' AND Cancelled = '0' AND DayOfWeek = '4' GROUP BY Dest, CancellationCode, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID = '33495' AND DepTimeBlk = '1600-1659' AND Quarter = '2' GROUP BY WheelsOn, Year, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE OriginState = 'MN' AND DestStateName = 'Texas' AND LateAircraftDelay = '0' GROUP BY AirTime, DivReachedDest, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime = '-9999' AND SecurityDelay = '5' AND DivReachedDest = '-9999' GROUP BY CarrierDelay, Year, DivAirportLandings
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted = '1' AND Distance = '1080' AND DayOfWeek = '5' GROUP BY TaxiOut, DivAirportLandings, DepTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivReachedDest, DivArrDelay, Cancelled WHERE Quarter = '2' AND FlightNum = '1372' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FirstDepTime, Flights, DivDistance WHERE Year = '2014' AND DayOfWeek = '5' AND CRSArrTime = '1404'
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime = '140' AND Diverted = '0' AND OriginState = 'RI' GROUP BY DistanceGroup, Diverted, AirlineID
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime, SecurityDelay, Flights WHERE Quarter = '2' AND CRSDepTime = '2151' AND DistanceGroup = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityMarketID, AirlineID, Cancelled WHERE FlightNum = '1585' AND CancellationCode = 'noodles' AND DayOfWeek = '5'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY LateAircraftDelay, ArrTimeBlk, Flights WHERE DivReachedDest = '1' AND OriginState = 'AZ' AND DestAirportSeqID = '1289203'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Carrier = 'FL' AND Quarter = '2' AND Year = '2014' GROUP BY DestWac, ArrTimeBlk, CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTime WHERE DivReachedDest = '-9999' AND WeatherDelay = '72' AND DayOfWeek = '4'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CarrierDelay, Diverted, DistanceGroup WHERE Dest = 'DAL' AND Year = '2014' AND Cancelled = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, Diverted, Year WHERE DivAirportLandings = '9' AND Origin = 'SAT' AND Cancelled = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, Flights, ArrTimeBlk WHERE DayOfWeek = '1' AND CRSDepTime = '753' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightNum, Year, Flights WHERE DivReachedDest = '-9999' AND ArrTime = '2307' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, DayOfWeek, CancellationCode WHERE DestAirportID = '12217' AND DayOfWeek = '3'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips = '6' AND CancellationCode = 'C' AND Cancelled = '1' GROUP BY ActualElapsedTime, DivReachedDest, DivAirportLandings
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DayOfWeek, ArrTimeBlk, SecurityDelay WHERE DayofMonth = '6' AND CRSElapsedTime = '71' AND Cancelled = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY Month, OriginStateFips, CarrierDelay WHERE TaxiOut = '136' AND DayOfWeek = '1' AND CancellationCode = 'noodles'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'US' AND FlightDate = '2014-06-18' AND ArrTimeBlk = '1200-1259' GROUP BY TailNum, Cancelled, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY UniqueCarrier, DestAirportID, Flights WHERE Flights = '1' AND Diverted = '1' AND TailNum = 'N37471'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Year, CRSArrTime, Quarter WHERE Year = '2014' AND WheelsOn = '1750' AND DivReachedDest = '-9999'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityMarketID = '34945' GROUP BY FirstDepTime, NASDelay, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE TaxiOut = '19' GROUP BY FlightNum, Quarter, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestWac = '44' AND DayOfWeek = '1' AND UniqueCarrier = 'US' GROUP BY OriginState, Diverted, DayofMonth
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID = '1161802' AND DayOfWeek = '5' AND Flights = '1' GROUP BY DestCityMarketID, Diverted, AirlineID
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DistanceGroup = '1' GROUP BY DivArrDelay, Carrier, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY SecurityDelay, ActualElapsedTime, Year WHERE CRSElapsedTime = '366' AND Year = '2014' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportID, Carrier, Quarter WHERE Quarter = '2' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Year = '2014' AND OriginStateFips = '53' AND CancellationCode = 'A' GROUP BY Distance, Cancelled, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest = '0' AND DestAirportSeqID = '1432103' AND Diverted = '1' GROUP BY DayofMonth, DestStateFips, Month
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '4' AND OriginState = 'CO' AND DivReachedDest = '-9999' GROUP BY SecurityDelay, OriginStateName, ArrTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DepTimeBlk, DivActualElapsedTime, Quarter WHERE Year = '2014' AND TailNum = 'N929AT' AND ArrTimeBlk = '1600-1659'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY Carrier, DayOfWeek, DistanceGroup WHERE OriginStateFips = '49' AND Quarter = '2' AND DivReachedDest = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestState = 'AK' GROUP BY TailNum, Cancelled, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, Quarter, Month WHERE Flights = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, SecurityDelay, Month WHERE TaxiOut = '6' AND DestAirportID = '12264' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID = '1177801' GROUP BY DayofMonth, TotalAddGTime, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights = '1' AND Quarter = '2' AND DestAirportSeqID = '1039705' GROUP BY OriginCityName, Cancelled, CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND FlightNum = '3938' AND DestStateName = 'Missouri' GROUP BY CRSDepTime, DivAirportLandings, Month
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTime = '1335' GROUP BY ArrTime, Cancelled, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY Cancelled, CRSArrTime, Year WHERE DestAirportSeqID = '1126702' AND Diverted = '0' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DestState, DayOfWeek, Carrier WHERE DistanceGroup = '4' AND DestStateFips = '32'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable  WHERE DivAirportLandings = '2' AND Cancelled = '0' AND DestStateName = 'Virginia'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportSeqID, DivReachedDest, Year WHERE Month = '6' AND OriginStateName = 'South Dakota' AND Cancelled = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CancellationCode = 'B' AND Carrier = 'OO' AND FlightDate = '2014-06-19' GROUP BY OriginStateFips, DivAirportLandings, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY Diverted, DestStateName, DistanceGroup WHERE OriginStateFips = '4' AND DayofMonth = '4' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTime = '928' GROUP BY LateAircraftDelay, UniqueCarrier, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY TotalAddGTime, DivDistance, Year WHERE DestState = 'CO' AND UniqueCarrier = 'FL' AND DivAirportLandings = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestWac, OriginStateFips, Cancelled WHERE OriginStateName = 'Tennessee' AND CarrierDelay = '112' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY DayOfWeek, Distance, Quarter WHERE Month = '6' AND DivAirportLandings = '1' AND DepTimeBlk = '1400-1459'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE TaxiOut = '7' AND AirlineID = '19393' AND ArrTimeBlk = '1800-1859' GROUP BY OriginAirportID, CancellationCode, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND DistanceGroup = '11' AND DayOfWeek = '3' GROUP BY WheelsOn, DivAirportLandings
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime = '197' AND DayOfWeek = '3' AND DayofMonth = '30' GROUP BY DestStateFips, Flights, FlightDate
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE UniqueCarrier = 'WN' AND DayOfWeek = '3' AND Origin = 'LGA' GROUP BY CRSArrTime, Flights, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportID, UniqueCarrier, Diverted WHERE Diverted = '1' AND OriginState = 'CT' AND DestStateFips = '51'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND LateAircraftDelay = '93' GROUP BY DayofMonth, ArrTimeBlk, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE TaxiIn = '2' AND Month = '6' AND Flights = '1' GROUP BY WheelsOff, Year, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND Distance = '287' AND DivReachedDest = '-9999' GROUP BY TaxiIn, DestState, DepTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE FlightDate = '2014-06-28' AND ArrTimeBlk = '2200-2259' GROUP BY DivActualElapsedTime, TaxiOut
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Origin = 'ILG' AND Flights = '1' AND Year = '2014' GROUP BY TailNum, Year, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginAirportID, DivReachedDest WHERE CancellationCode = 'B' AND Carrier = 'B6' AND Cancelled = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID = '20304' AND Cancelled = '0' AND ArrTimeBlk = '1200-1259' GROUP BY FlightNum, Year, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime = '-9999' AND DivReachedDest = '1' AND Flights = '1' GROUP BY DestState, CancellationCode, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, Year, DepTimeBlk WHERE DayofMonth = '25' AND Diverted = '0' AND OriginAirportSeqID = '1289605'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY TailNum, Flights, Month WHERE UniqueCarrier = 'WN' AND ArrTime = '49' AND Quarter = '2'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, AirlineID, Quarter WHERE Origin = 'LGB' AND FlightDate = '2014-06-18' AND Diverted = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiIn, ArrTimeBlk, CancellationCode WHERE Carrier = 'VX' AND AirTime = '177' AND Cancelled = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginState = 'AR' AND DepTimeBlk = '1200-1259' AND CancellationCode = 'B' GROUP BY Origin, ArrTimeBlk, DivActualElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginAirportID = '13204' AND DepTime = '1922' AND Year = '2014' GROUP BY ArrTime, Diverted, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState, OriginStateName, Diverted WHERE DivReachedDest = '0' AND Distance = '351' AND Carrier = 'EV'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY ArrTime, Month, Quarter WHERE DepTime = '1637' AND ArrTimeBlk = '1700-1759' AND CancellationCode = 'A'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime = '101' AND Diverted = '0' GROUP BY OriginWac, DepTimeBlk, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Distance = '391' AND DayOfWeek = '4' AND DivReachedDest = '1' GROUP BY CRSArrTime, SecurityDelay, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Carrier, SecurityDelay, TotalAddGTime WHERE NASDelay = '47'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityName = 'Seattle, WA' GROUP BY Carrier, CancellationCode, FlightDate
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginState = 'NC' AND Flights = '1' AND DestState = 'NV' GROUP BY TaxiIn, DivDistance, Month
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ArrTimeBlk, TaxiOut, Diverted WHERE Month = '6' AND CRSElapsedTime = '176' AND Diverted = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, Month, ArrTimeBlk WHERE Year = '2014' AND DepTime = '1832' AND SecurityDelay = '-9999'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestWac = '43' AND DayOfWeek = '3' AND OriginCityName = 'Madison, WI' GROUP BY CarrierDelay, Flights, DepTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay = '0' AND Flights = '1' AND ActualElapsedTime = '50' GROUP BY CRSArrTime, DivReachedDest, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk = '2100-2159' AND DepTimeBlk = '1900-1959' AND DivReachedDest = '1' 
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginState, Cancelled, DivAirportLandings WHERE DivDistance = '283'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay = '0' AND Month = '6' AND CRSArrTime = '1726' GROUP BY DayofMonth, DivReachedDest, DepTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'EV' AND DestAirportSeqID = '1481402' AND Diverted = '1' GROUP BY Quarter, Diverted, WheelsOn
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND OriginCityName = 'San Jose, CA' AND DivReachedDest = '-9999' GROUP BY OriginStateFips, FlightDate, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DestWac = '86' GROUP BY CRSElapsedTime, Quarter, DepTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND DivReachedDest = '-9999' AND LateAircraftDelay = '172' GROUP BY TaxiIn, DestStateFips, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestWac, CarrierDelay, Flights WHERE Year = '2014' AND DivReachedDest = '1' AND DepTimeBlk = '1900-1959'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY SecurityDelay, DestState, DepTimeBlk WHERE DestWac = '53' AND DepTimeBlk = '1600-1659' AND AirlineID = '20366'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID = '12892' AND Quarter = '2' AND DayOfWeek = '2' GROUP BY CancellationCode, AirTime, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DepTimeBlk, OriginAirportSeqID, Month WHERE Cancelled = '0' AND DestWac = '82'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityName, Diverted, Quarter WHERE DistanceGroup = '6' AND AirlineID = '20409' AND SecurityDelay = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TaxiOut, Year, AirlineID WHERE SecurityDelay = '-9999' AND Carrier = 'WN' AND DayOfWeek = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Massachusetts' AND Diverted = '0' AND DayofMonth = '27' GROUP BY Year, Cancelled, DestStateFips
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY ArrTime, DivAirportLandings, Month WHERE Quarter = '2' AND Month = '6' AND OriginCityName = 'Williston, ND'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Flights = '1' AND ArrTime = '2042' AND UniqueCarrier = 'HA' GROUP BY TaxiOut, DestWac, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOn, Month, Quarter WHERE DestAirportSeqID = '1220603' AND Quarter = '2' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' AND ArrTime = '1705' AND Year = '2014' GROUP BY Quarter, WheelsOn, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE FirstDepTime = '1440' GROUP BY CarrierDelay, Quarter, DayofMonth
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'Pennsylvania' AND DayOfWeek = '6' AND AirlineID = '21171' GROUP BY DestCityMarketID, Carrier, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Diverted = '0' AND DestStateFips = '33' AND CarrierDelay = '144' GROUP BY DivActualElapsedTime, Year, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier = 'EV' AND DistanceGroup = '6' AND Month = '6' GROUP BY OriginAirportSeqID, Year, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivReachedDest, DestState, DepTimeBlk WHERE DistanceGroup = '4' AND DivArrDelay = '168'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '2' AND TaxiOut = '13' AND DepTimeBlk = '0001-0559' GROUP BY DepTime, DivAirportLandings, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-06' AND DivReachedDest = '0' AND Flights = '1' GROUP BY Dest, SecurityDelay, OriginCityName
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Month = '6' AND WheelsOn = '1843' GROUP BY AirlineID, TaxiOut, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND Flights = '1' AND CRSElapsedTime = '360' GROUP BY DayofMonth
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '12' AND CRSElapsedTime = '166' AND ActualElapsedTime = '235' GROUP BY DepTimeBlk, DestCityName, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND FlightDate = '2014-06-22' AND DestState = 'CT' GROUP BY DestCityName, UniqueCarrier, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID = '12156' AND DivReachedDest = '-9999' AND Year = '2014' GROUP BY CancellationCode, Origin, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DestStateName, DayofMonth, Flights WHERE OriginAirportSeqID = '1405702' AND Diverted = '1' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Quarter = '2' AND DepTime = '1732' AND OriginCityMarketID = '30194' GROUP BY TaxiIn, Flights, DestStateName
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Year, DestAirportID, CancellationCode WHERE OriginStateFips = '37'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk = '2200-2259' AND Flights = '1' AND FlightNum = '2146' GROUP BY TailNum, Quarter, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportID, UniqueCarrier, Flights WHERE AirlineID = '19790' AND Diverted = '1' AND WheelsOn = '1923'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE FirstDepTime = '1619' GROUP BY TaxiOut, CancellationCode, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY FlightNum, Year, Cancelled WHERE CRSElapsedTime = '83' AND SecurityDelay = '-9999' AND Quarter = '2'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportSeqID, UniqueCarrier, Month WHERE DivReachedDest = '-9999'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DistanceGroup, DestCityMarketID, Diverted WHERE OriginWac = '85' AND Diverted = '1' AND AirlineID = '19977'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, ArrTimeBlk, Month WHERE AirlineID = '20355' AND Flights = '1' AND OriginState = 'PR'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '1' AND OriginStateFips = '21' AND Flights = '1' GROUP BY WheelsOn, Month, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut, DivAirportLandings, Quarter WHERE OriginCityMarketID = '33024' AND Quarter = '2' AND DivAirportLandings = '0'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Distance = '758' GROUP BY OriginAirportSeqID, UniqueCarrier, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportSeqID, DayofMonth, Month WHERE DepTimeBlk = '1200-1259' AND Dest = 'GSO' AND Flights = '1'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime, Diverted, CancellationCode WHERE WeatherDelay = '2' AND Year = '2014' AND UniqueCarrier = 'DL'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY TailNum, Quarter, Cancelled WHERE SecurityDelay = '0' AND WeatherDelay = '6' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayofMonth = '21' AND UniqueCarrier = 'OO' AND Year = '2014' GROUP BY DepTimeBlk, Diverted, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND UniqueCarrier = 'WN' AND OriginCityName = 'Oklahoma City, OK' GROUP BY DepTimeBlk, Quarter, DivActualElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DepTime = '2211' GROUP BY NASDelay, SecurityDelay, CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSDepTime = '1704' AND DestState = 'CA' AND Flights = '1' GROUP BY LongestAddGTime, AirlineID, Carrier
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ArrTimeBlk, TaxiIn, Flights WHERE WheelsOff = '857' AND DestWac = '45'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND Month = '6' AND OriginAirportSeqID = '1105703' GROUP BY CRSArrTime, SecurityDelay, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOn = '646' GROUP BY CRSDepTime, CancellationCode, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY Carrier, WeatherDelay, SecurityDelay WHERE Quarter = '2' AND DestStateFips = '17' AND CancellationCode = 'C'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DivAirportLandings = '0' AND LateAircraftDelay = '343' AND Month = '6' GROUP BY LongestAddGTime, OriginState, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND TaxiIn = '21' AND Carrier = 'UA' GROUP BY DivDistance, DivAirportLandings, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY CRSElapsedTime, AirlineID, Year WHERE OriginStateFips = '41' AND DayofMonth = '3' AND Carrier = 'DL'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings = '2' AND Origin = 'MGM' AND Flights = '1' GROUP BY OriginStateFips, DivReachedDest, ArrTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, TotalAddGTime, DivReachedDest WHERE Cancelled = '0' AND WheelsOff = '1727' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '1' AND UniqueCarrier = 'EV' AND OriginStateFips = '28' 
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DestAirportSeqID WHERE Diverted = '0' AND WheelsOff = '1521' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateName, LongestAddGTime, Flights WHERE Quarter = '2' AND DivActualElapsedTime = '249' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY AirlineID, DayOfWeek, ArrTimeBlk WHERE TaxiIn = '14' AND AirlineID = '19790' AND DayofMonth = '2'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, TotalAddGTime, Month WHERE DivReachedDest = '1' AND OriginCityName = 'Fort Smith, AR' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY Month, OriginStateFips, DayofMonth WHERE DivArrDelay = '130' AND OriginStateName = 'Missouri'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, Cancelled, Flights WHERE Quarter = '2' AND DepTimeBlk = '1700-1759' AND DayofMonth = '3'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateFips, ArrTimeBlk, Quarter WHERE DivReachedDest = '-9999' AND TaxiIn = '10' AND OriginAirportSeqID = '1484304'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DepTime, DivAirportLandings, Quarter WHERE Month = '6' AND DayOfWeek = '6' AND DestStateFips = '31'
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DepTime = '1254' AND Flights = '1' AND SecurityDelay = '0' GROUP BY CancellationCode, AirlineID, OriginStateName
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivArrDelay, DepTimeBlk, Month WHERE Year = '2014' AND OriginStateFips = '15' AND DivAirportLandings = '9'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Flights, Month, ArrTime WHERE NASDelay = '25' AND OriginStateName = 'Arizona'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Year, DivArrDelay, Cancelled WHERE Quarter = '2' AND Cancelled = '0' AND Carrier = 'OO'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTime = '1303' GROUP BY DepTime, Quarter, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'Colorado' AND TaxiIn = '25' AND Year = '2014' GROUP BY Distance, Month, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = '2' AND DestStateFips = '25' AND DistanceGroup = '8' GROUP BY WeatherDelay, DepTimeBlk, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Year = '2014' AND CRSArrTime = '1211' GROUP BY DestState, DayOfWeek, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year = '2014' AND DepTimeBlk = '1300-1359' AND DestAirportSeqID = '1320402' GROUP BY CancellationCode, AirTime, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName = 'Arizona' AND Cancelled = '0' AND Flights = '1' GROUP BY AirTime, ArrTimeBlk, Month
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateFips, UniqueCarrier, DivAirportLandings WHERE SecurityDelay = '0' AND OriginWac = '93' AND DayOfWeek = '3'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOff, DivReachedDest, Year WHERE AirTime = '298' AND TaxiIn = '5' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DivDistance, OriginStateName, Month WHERE LongestAddGTime = '19' AND ArrTimeBlk = '1400-1459'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek = '2' AND UniqueCarrier = 'B6' AND DayofMonth = '21' GROUP BY DestStateFips, Cancelled, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND DivArrDelay = '130' AND DepTimeBlk = '1400-1459' GROUP BY DivReachedDest, Diverted, FlightDate
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestStateFips = '24' AND Month = '6' AND FlightDate = '2014-06-27' GROUP BY OriginAirportSeqID, Cancelled, AirlineID
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DestCityMarketID, DayOfWeek, Month WHERE DivReachedDest = '0' AND AirlineID = '19790' AND Year = '2014'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Cancelled, DestAirportID, Month WHERE ActualElapsedTime = '161' AND CarrierDelay = '18' AND DistanceGroup = '4'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND WheelsOn = '1246' AND Flights = '1' GROUP BY TailNum, Quarter, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY TailNum, Quarter, Flights WHERE DayofMonth = '16' AND OriginAirportID = '14905' AND SecurityDelay = '-9999'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestCityName, AirlineID, Month WHERE CRSElapsedTime = '159' AND Cancelled = '0' AND WheelsOn = '1314'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginCityName = 'Bakersfield, CA' GROUP BY DestCityName, DivReachedDest, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, DayOfWeek, Year WHERE Flights = '1'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '1' GROUP BY OriginAirportID, DestStateFips, DestWac
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateFips, FirstDepTime, Month WHERE Quarter = '2' AND DepTimeBlk = '2000-2059' AND DestStateName = 'Michigan'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay = '45' GROUP BY LateAircraftDelay, UniqueCarrier, Month
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Diverted = '0' AND DestWac = '1' AND DistanceGroup = '5' GROUP BY CRSElapsedTime, CancellationCode, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY SecurityDelay, Distance, Year WHERE AirlineID = '20437' AND Quarter = '2' AND OriginState = 'FL'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestCityMarketID = '31977' AND DivReachedDest = '-9999' AND DepTime = '1619' GROUP BY TailNum, Quarter, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityMarketID, UniqueCarrier, Flights WHERE DayOfWeek = '6' AND DivReachedDest = '-9999' AND Origin = 'FAI'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk = '1500-1559' AND OriginStateFips = '29' AND CancellationCode = 'B' GROUP BY Distance, Quarter, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '1' AND DivAirportLandings = '0' AND Distance = '629' GROUP BY TaxiOut, DepTime, WheelsOn
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Quarter = '2' AND OriginStateName = 'Washington' AND CRSElapsedTime = '281' GROUP BY DestCityMarketID, Month, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TotalAddGTime = '22' AND DayOfWeek = '3' AND Year = '2014' GROUP BY DivReachedDest, OriginState, DestStateName
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, Flights, CancellationCode WHERE AirlineID = '19790' AND ArrTimeBlk = '2000-2059' AND OriginStateName = 'Virginia'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, FirstDepTime, Flights WHERE DepTimeBlk = '1600-1659' AND DayOfWeek = '2' AND OriginCityMarketID = '32134'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '1' AND FlightDate = '2014-06-15' AND DivReachedDest = '0' GROUP BY SecurityDelay, WheelsOn, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk = '1300-1359' AND DivActualElapsedTime = '439' AND Flights = '1' GROUP BY FlightDate, Dest, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Month, CancellationCode, DepTimeBlk WHERE WheelsOn = '2120' AND Origin = 'BOI' AND UniqueCarrier = 'OO'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND Cancelled = '0' GROUP BY TaxiOut, DestState, Month
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND CancellationCode = 'B' AND Dest = 'LRD' GROUP BY DistanceGroup, DivDistance, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest = '1' AND TailNum = 'N146PQ' AND DivAirportLandings = '1' GROUP BY DestWac, DestState, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' GROUP BY WeatherDelay, Year, NASDelay
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginStateFips = '48' AND DivReachedDest = '-9999' AND DepTime = '1629' GROUP BY CancellationCode, OriginState, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateName, DestWac WHERE Cancelled = '0' AND DestState = 'MI' AND DepTimeBlk = '0600-0659'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, DayOfWeek, Flights WHERE DestAirportSeqID = '1489302' AND Cancelled = '0' AND WheelsOn = '1204'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY ArrTimeBlk, ActualElapsedTime, Year WHERE DivAirportLandings = '1' AND Quarter = '2' AND WheelsOn = '1820'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CRSArrTime, Quarter, DayOfWeek WHERE Diverted = '0' AND DayofMonth = '23' AND OriginStateName = 'Colorado'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DivArrDelay, AirlineID, Year WHERE Cancelled = '1' AND DestAirportID = '10781' AND DivAirportLandings = '0'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY TaxiOut, DivAirportLandings, DayOfWeek WHERE DivAirportLandings = '0' AND CancellationCode = 'B' AND CRSElapsedTime = '71'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID = '12264' GROUP BY DistanceGroup, DayofMonth, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND DivActualElapsedTime = '483' AND DepTimeBlk = '1000-1059' GROUP BY DestStateFips, Cancelled, ArrTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Month = '6' AND Year = '2014' AND OriginAirportID = '11140' GROUP BY FirstDepTime, Diverted, OriginState
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityMarketID, Diverted, Month WHERE Cancelled = '0' AND FlightNum = '374' AND Quarter = '2'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY Dest, UniqueCarrier, Diverted WHERE ArrTimeBlk = '2000-2059' AND CancellationCode = 'B' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' GROUP BY FirstDepTime, OriginStateFips, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY AirTime, DayOfWeek, Month WHERE CancellationCode = 'noodles' AND FlightNum = '3441' AND DayOfWeek = '7'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY Distance, Year, CancellationCode WHERE Flights = '1' AND Carrier = 'WN' AND FlightDate = '2014-06-27'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, OriginState, Year WHERE Distance = '728' AND WeatherDelay = '0' AND Month = '6'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DestState = 'AL' AND DivAirportLandings = '0' AND CarrierDelay = '1' GROUP BY LateAircraftDelay, ArrTimeBlk, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Distance = '1174' GROUP BY Flights, AirlineID, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND AirTime = '301' AND Flights = '1' GROUP BY Dest
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY ArrTimeBlk, OriginState, Quarter WHERE ArrTimeBlk = '1000-1059' AND UniqueCarrier = 'B6' AND DivReachedDest = '1'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY FirstDepTime, Carrier, Month WHERE Quarter = '2' AND DivAirportLandings = '2' AND DistanceGroup = '6'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityMarketID = '31921' AND Year = '2014' AND AirlineID = '20366' GROUP BY CarrierDelay, ArrTimeBlk, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOff, DivReachedDest, Year WHERE DayOfWeek = '4' AND TaxiIn = '31' AND Quarter = '2'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff = '720' GROUP BY FlightDate, AirlineID, Quarter
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Diverted = '0' AND OriginCityName = 'Minneapolis, MN' GROUP BY AirlineID, DayofMonth, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '1500-1559' AND LongestAddGTime = '19' AND Year = '2014' GROUP BY OriginCityMarketID, AirlineID, Year
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, Month, CancellationCode WHERE DivReachedDest = '0' AND TotalAddGTime = '20' AND Cancelled = '0'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestWac = '4' AND Quarter = '2' AND Carrier = 'US' GROUP BY DivArrDelay
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac = '61' AND Diverted = '0' AND CancellationCode = 'A' GROUP BY ArrTimeBlk, TaxiIn, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Diverted, OriginAirportSeqID, Month WHERE CancellationCode = 'noodles' AND DivReachedDest = '0' AND FirstDepTime = '1808'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE UniqueCarrier = 'EV' AND OriginAirportID = '10434' AND DestState = 'IL' GROUP BY ArrTime, DayOfWeek, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '8' AND ActualElapsedTime = '233' AND DayOfWeek = '6' GROUP BY ActualElapsedTime, DayOfWeek, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk, Month, TotalAddGTime WHERE Cancelled = '0'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime = '937' GROUP BY CarrierDelay, OriginStateFips, Quarter
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '2' AND WheelsOff = '713' AND DestStateName = 'Alaska' GROUP BY TailNum, Year, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '0' AND Year = '2014' AND FlightNum = '1402' GROUP BY OriginState, DistanceGroup, ActualElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, Flights, Year WHERE DayofMonth = '25' AND DivAirportLandings = '0' AND TailNum = 'N929FR'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips = '34' AND DestStateName = 'Virginia' AND DayofMonth = '16' GROUP BY OriginStateName, ArrTimeBlk, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportID = '11049' GROUP BY OriginStateFips, CancellationCode, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DistanceGroup, OriginAirportSeqID, Diverted WHERE DivArrDelay = '133' AND ArrTimeBlk = '1400-1459' AND Flights = '1'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DestState = 'IN' AND FlightDate = '2014-06-08' AND DivReachedDest = '-9999' GROUP BY Dest, CancellationCode, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY Distance, Month, Flights WHERE DestStateName = 'Tennessee' AND Cancelled = '1' AND Diverted = '0'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOn, Month, DivAirportLandings WHERE AirlineID = '20304' AND DepTimeBlk = '0800-0859' AND Dest = 'MFR'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'noodles' AND Carrier = 'MQ' AND Month = '6' GROUP BY Diverted, OriginWac, DestState
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime = '13' 
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '5' AND Year = '2014' AND Cancelled = '1' GROUP BY WeatherDelay, DivReachedDest, ArrTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportSeqID, DivReachedDest, Diverted WHERE Diverted = '0' AND ArrTimeBlk = '1000-1059' AND Carrier = 'AA'
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE TailNum = 'N569SW' GROUP BY FirstDepTime, DayofMonth, DivAirportLandings
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY FlightNum, Cancelled, Month WHERE Quarter = '2' AND UniqueCarrier = 'VX' AND OriginStateFips = '48'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY SecurityDelay, OriginWac, DivReachedDest WHERE DestState = 'TX' AND TotalAddGTime = '16'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayOfWeek = '3' AND FirstDepTime = '1733' GROUP BY DayOfWeek, DayofMonth, LongestAddGTime
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CRSArrTime, Year, Month WHERE CancellationCode = 'B' AND Cancelled = '1' AND DestCityName = 'Nashville, TN'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, AirlineID, Quarter WHERE ActualElapsedTime = '70' AND OriginStateName = 'Kansas'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, DayOfWeek, Month WHERE TotalAddGTime = '66'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE TaxiIn = '8' AND Cancelled = '0' AND OriginStateFips = '25' GROUP BY TotalAddGTime, DivReachedDest, DestStateName
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID = '1319801' AND Dest = 'BNA' AND Month = '6' GROUP BY LateAircraftDelay, LongestAddGTime, Quarter
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Month, Dest, Quarter WHERE OriginState = 'TX' AND Month = '6' AND DestAirportID = '11980'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginCityName, Year, SecurityDelay WHERE FlightDate = '2014-06-27' AND DestAirportID = '10821' AND Cancelled = '0'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY OriginCityName, DayofMonth, Year WHERE Flights = '1' AND WeatherDelay = '-9999' AND Carrier = 'WN'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Year = '2014' AND DayofMonth = '1' AND DepTimeBlk = '1500-1559' GROUP BY OriginCityMarketID, Cancelled, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, DivAirportLandings, DivReachedDest WHERE AirTime = '233'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '2' AND SecurityDelay = '0' AND UniqueCarrier = 'WN' GROUP BY DestAirportSeqID, Cancelled, SecurityDelay
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY UniqueCarrier, CRSElapsedTime, Year WHERE Carrier = 'EV' AND CarrierDelay = '12' AND ArrTimeBlk = '1100-1159'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginState = 'TX' AND Year = '2014' AND FlightDate = '2014-06-23' GROUP BY Distance, DayOfWeek, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay = '40' GROUP BY SecurityDelay, Carrier, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '5' AND OriginState = 'NV' AND Diverted = '1' GROUP BY CRSDepTime, Flights, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE LateAircraftDelay = '13' AND Cancelled = '0' AND DivReachedDest = '-9999' GROUP BY FirstDepTime, DayofMonth, CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Cancelled, Quarter, CRSDepTime WHERE OriginState = 'OR' AND Quarter = '2' AND DayOfWeek = '2'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE OriginStateName = 'Florida' AND UniqueCarrier = 'EV' AND DayOfWeek = '5' GROUP BY OriginCityMarketID
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestStateName, Diverted, Flights WHERE WheelsOn = '1950' AND DayofMonth = '9' AND Diverted = '0'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime = '35' GROUP BY DivReachedDest, DestState, UniqueCarrier
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY AirTime, SecurityDelay, Quarter WHERE DivArrDelay = '294' AND OriginWac = '91' AND Diverted = '1'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE OriginCityName = 'Lansing, MI' AND DepTimeBlk = '0600-0659' AND Cancelled = '1' GROUP BY Cancelled, Flights, TaxiOut
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings = '1' AND CRSDepTime = '1829' AND Month = '6' GROUP BY DepTime, DivReachedDest, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE SecurityDelay = '0' AND Quarter = '2' AND DestStateName = 'Wyoming' GROUP BY DivAirportLandings, CarrierDelay, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek = '3' AND DepTimeBlk = '1000-1059' AND DivAirportLandings = '2' GROUP BY OriginAirportID, DepTimeBlk, Year
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Cancelled = '0' AND DestStateName = 'Massachusetts' AND Flights = '1' GROUP BY Carrier, DestStateFips, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DestStateName, DivAirportLandings, Year WHERE Carrier = 'US' AND Year = '2014' AND TaxiIn = '40'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginCityName, DepTimeBlk, Flights WHERE DestState = 'KS' AND Year = '2014' AND OriginWac = '85'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WheelsOff, Year, Flights WHERE Cancelled = '0' AND ArrTimeBlk = '1100-1159' AND OriginStateFips = '30'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND Origin = 'CRP' AND SecurityDelay = '0' GROUP BY WheelsOff, Year, CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Origin, DivReachedDest, Quarter WHERE DestStateName = 'Texas' AND ActualElapsedTime = '274' AND AirlineID = '20409'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND Month = '6' AND OriginCityName = 'Champaign/Urbana, IL' GROUP BY DivDistance, Cancelled, Carrier
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime = '21' AND TaxiOut = '25' GROUP BY CRSElapsedTime, Cancelled, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac = '42' AND DayOfWeek = '6' AND DepTimeBlk = '1600-1659' GROUP BY AirTime, DayOfWeek, Year
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityName, Month, Year WHERE CRSArrTime = '1032' AND Diverted = '0' AND DestWac = '34'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY OriginWac, TaxiIn, Flights WHERE DayofMonth = '17' AND DivAirportLandings = '9' AND DayOfWeek = '3'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY LongestAddGTime, DayofMonth, DayOfWeek WHERE DestStateFips = '33' AND SecurityDelay = '-9999' AND Diverted = '1'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips = '12' AND TotalAddGTime = '22' AND Flights = '1' GROUP BY DayofMonth, AirlineID, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TotalAddGTime = '18' GROUP BY Origin, UniqueCarrier, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year = '2014' AND Diverted = '1' AND Dest = 'FOE' GROUP BY DivActualElapsedTime, DayOfWeek, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginCityName, Carrier, Quarter WHERE CRSArrTime = '1346' AND AirlineID = '20437' AND Diverted = '0'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND Month = '6' AND TailNum = 'N616QX' GROUP BY Quarter, UniqueCarrier, CarrierDelay
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' AND OriginCityMarketID = '31003' AND Flights = '1' GROUP BY WeatherDelay, DestState, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE FirstDepTime = '1013' AND Quarter = '2' AND Month = '6' GROUP BY Distance, DivReachedDest, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '22' AND Quarter = '2' AND OriginAirportSeqID = '1169502' GROUP BY NASDelay, OriginStateName, Year
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'B' AND DayOfWeek = '7' AND Flights = '1' GROUP BY DivDistance, SecurityDelay, Carrier
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, SecurityDelay, Month WHERE OriginStateFips = '5' AND ActualElapsedTime = '153' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = '26' AND Diverted = '0' AND OriginAirportSeqID = '1474703' GROUP BY DayofMonth, OriginWac, Year
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier = 'WN' AND OriginWac = '93' AND DepTimeBlk = '1600-1659' GROUP BY OriginWac, WeatherDelay, Cancelled
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '1' AND Flights = '1' AND ArrTimeBlk = '0700-0759' GROUP BY Origin, SecurityDelay, DivReachedDest
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, OriginCityMarketID, Diverted WHERE DayOfWeek = '3'
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime = '64' GROUP BY Cancelled, AirlineID, DestCityName
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE CRSArrTime = '658' GROUP BY FirstDepTime, Flights, DivDistance
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Distance, Quarter, DayOfWeek WHERE TaxiIn = '16' AND DistanceGroup = '9' AND DivReachedDest = '-9999'
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WeatherDelay, DestStateFips, Flights WHERE DayofMonth = '22' AND Year = '2014' AND DistanceGroup = '10'
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestState = 'NE' AND Cancelled = '0' AND Diverted = '1' GROUP BY DestState, NASDelay, ActualElapsedTime
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY ArrTime, SecurityDelay, Year WHERE DepTime = '1225' AND DestStateFips = '21' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID = '19690' AND Flights = '1' AND Quarter = '2' GROUP BY WheelsOff, AirTime, OriginStateFips
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac = '2' AND Quarter = '2' AND Month = '6' GROUP BY OriginStateFips, Carrier, Flights
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut, OriginWac, Quarter WHERE DestCityMarketID = '32575' AND AirlineID = '19977' AND ActualElapsedTime = '144'
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode = 'noodles' GROUP BY OriginStateName, AirlineID, DivAirportLandings
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime = '1' GROUP BY DestCityMarketID, Cancelled, Year
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter = '2' GROUP BY DestAirportID, ArrTimeBlk, Flights
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime = '111' GROUP BY DivArrDelay, Carrier, Flights
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY NASDelay, OriginStateName, Quarter WHERE Year = '2014' AND LongestAddGTime = '28' AND DestAirportID = '12953'
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime = '1242' GROUP BY Origin, DivAirportLandings, DivReachedDest
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSArrTime = '640' AND Flights = '1' AND OriginWac = '35' GROUP BY OriginCityName, Month, DepTimeBlk
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DayofMonth = '4' AND DestState = 'IL' GROUP BY Carrier, CRSElapsedTime, DivArrDelay
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup = '8' AND Diverted = '0' AND Dest = 'BNA' GROUP BY ArrTimeBlk, Flights, DivAirportLandings
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND Distance = '298' AND DayofMonth = '19' GROUP BY ArrTime, DayOfWeek, Flights
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '5' AND ArrTimeBlk = '1600-1659' AND DayofMonth = '23' GROUP BY OriginStateName, DestStateName, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY CRSDepTime, DayOfWeek, Year WHERE FirstDepTime = '958'
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivReachedDest, DistanceGroup, FirstDepTime WHERE Carrier = 'US' AND Origin = 'PVD' AND DivAirportLandings = '0'
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOn, Diverted, Year WHERE Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Dest = 'OKC' GROUP BY OriginCityName, DayOfWeek, Month
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DestWac = '38' AND ArrTimeBlk = '1900-1959' GROUP BY DestWac, OriginStateName, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '10' AND DivArrDelay = '248' AND Cancelled = '0' GROUP BY DestCityName, DivAirportLandings, Flights
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = '1' AND DayofMonth = '12' AND AirlineID = '20304' GROUP BY TailNum, Cancelled, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CarrierDelay, Cancelled, DivReachedDest WHERE OriginStateName = 'California' AND ArrTimeBlk = '1300-1359' AND DivAirportLandings = '9'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, DestStateFips, Month WHERE DayOfWeek = '7' AND FlightNum = '3242' AND UniqueCarrier = 'MQ'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginWac, TaxiIn, Diverted WHERE UniqueCarrier = 'VX' AND Flights = '1' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, DistanceGroup, WeatherDelay WHERE TaxiIn = '15' AND DestWac = '81' AND DepTimeBlk = '0600-0659'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, Carrier, UniqueCarrier WHERE NASDelay = '9'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivReachedDest, OriginStateName, UniqueCarrier WHERE DivReachedDest = '-9999' AND DayOfWeek = '3' AND AirlineID = '20437'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirTime = '217' AND Flights = '1' AND DestState = 'PA' GROUP BY DayOfWeek, Diverted, CarrierDelay
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestStateFips, OriginWac, Year WHERE LateAircraftDelay = '72' AND CancellationCode = 'noodles' AND DestState = 'MN'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY WheelsOn, Month, Year WHERE DestStateName = 'Florida' AND CRSArrTime = '2236' AND DistanceGroup = '9'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Cancelled = '0' AND Flights = '1' AND DivAirportLandings = '0' GROUP BY DestAirportSeqID, Month, SecurityDelay
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Carrier = 'WN' AND DayOfWeek = '1' GROUP BY TailNum, Cancelled, Year
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-04' AND Diverted = '1' AND Year = '2014' GROUP BY OriginCityMarketID, Year, Carrier
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Flights, OriginAirportID, Quarter WHERE DivDistance = '156' AND DivAirportLandings = '1' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '0800-0859' AND ArrTimeBlk = '0800-0859' AND Cancelled = '1' GROUP BY OriginAirportID, Month, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Quarter, DistanceGroup, OriginAirportID WHERE ArrTimeBlk = '2300-2359' AND SecurityDelay = '-9999' AND AirlineID = '20304'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac = '1' AND DistanceGroup = '1' AND DayOfWeek = '4' GROUP BY OriginAirportID, AirlineID, CarrierDelay
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime, OriginStateName, Quarter WHERE DayOfWeek = '3' AND CancellationCode = 'C' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Month = '6' AND Flights = '1' AND LongestAddGTime = '44' GROUP BY TaxiIn, OriginState, Diverted
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = '3' AND ArrTimeBlk = '1300-1359' AND DestCityName = 'Dallas/Fort Worth, TX' GROUP BY DestStateName, Diverted, FlightNum
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Distance = '1121' GROUP BY DayofMonth, FlightDate, Month
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Dest = 'SFO' AND ArrTimeBlk = '1600-1659' AND OriginWac = '74' GROUP BY CarrierDelay, Quarter, CancellationCode
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginCityName = 'College Station/Bryan, TX' AND DivReachedDest = '1' AND Cancelled = '0' GROUP BY Carrier, TaxiIn
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '0700-0759' AND AirTime = '279' AND Year = '2014' GROUP BY OriginStateFips, CarrierDelay, Year
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginStateFips, FlightDate, Cancelled WHERE DayOfWeek = '3' AND UniqueCarrier = 'VX' AND Month = '6'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY OriginWac, Carrier, Cancelled WHERE ArrTimeBlk = '2100-2159'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightNum, Year, Quarter WHERE DestStateFips = '8' AND DayOfWeek = '1' AND OriginCityMarketID = '34100'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportSeqID, DayOfWeek, Month WHERE Year = '2014' AND TaxiOut = '72' AND Cancelled = '0'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest = '1' AND OriginCityName = 'St. Cloud, MN' AND Cancelled = '0' GROUP BY WheelsOn, DivReachedDest, Cancelled
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState = 'NJ' GROUP BY CarrierDelay, DistanceGroup, Year
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup = '2' AND Year = '2014' AND DestStateName = 'South Carolina' GROUP BY DepTime, DivReachedDest, Cancelled
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivReachedDest, Quarter, CRSArrTime WHERE FirstDepTime = '1627'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year = '2014' AND Quarter = '2' AND OriginState = 'SD' GROUP BY TailNum, Diverted, Month
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month = '6' AND DayOfWeek = '5' AND Flights = '1' GROUP BY CRSElapsedTime, Cancelled, CancellationCode
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, AirlineID, Flights WHERE DestState = 'TX' AND DivAirportLandings = '9'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk = '1700-1759' AND Diverted = '1' AND DayOfWeek = '2' GROUP BY FlightDate, OriginStateName, SecurityDelay
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings = '0' AND Quarter = '2' AND OriginAirportID = '11973' GROUP BY Diverted, WheelsOn, Month
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DayOfWeek, TotalAddGTime, ArrTimeBlk WHERE Quarter = '2' AND NASDelay = '9' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, UniqueCarrier, Diverted WHERE FlightDate = '2014-06-22' AND DepTimeBlk = '1100-1159' AND ArrTimeBlk = '1300-1359'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac = '2' AND AirlineID = '19977' AND WheelsOff = '2030' GROUP BY FlightDate, Quarter, OriginStateFips
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, Diverted, DivAirportLandings WHERE Year = '2014' AND FlightDate = '2014-06-08' AND Dest = 'PDX'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '6' AND Cancelled = '0' AND ArrTimeBlk = '1500-1559' GROUP BY CRSDepTime, CancellationCode, Month
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, DayOfWeek, Flights WHERE DivReachedDest = '1' AND DestWac = '74' AND OriginWac = '82'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivAirportLandings, Month, SecurityDelay WHERE DivAirportLandings = '0' AND CRSArrTime = '2014' AND Carrier = 'B6'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Year, WeatherDelay, DivAirportLandings WHERE CancellationCode = 'noodles' AND AirlineID = '20409' AND WheelsOff = '1755'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier = 'OO' AND CRSElapsedTime = '195' AND DivAirportLandings = '0' GROUP BY DestStateFips, OriginState, Cancelled
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Month = '6' AND ArrTimeBlk = '1100-1159' AND CRSElapsedTime = '340' GROUP BY TailNum, Cancelled, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable  WHERE Flights = '1' AND Year = '2014' AND Dest = 'DLH'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY Origin, DayofMonth, Flights WHERE Dest = 'OMA' AND OriginStateName = 'Missouri' AND DepTimeBlk = '1800-1859'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek = '4' AND Year = '2014' AND CRSElapsedTime = '294' GROUP BY AirTime, Carrier, Month
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter = '2' AND FirstDepTime = '1936' AND Month = '6' GROUP BY Distance, Flights, DepTimeBlk
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY OriginStateFips, OriginState, DivReachedDest WHERE OriginCityMarketID = '30581' AND DayofMonth = '6' AND TotalAddGTime = '-9999'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY NASDelay, Carrier, Quarter WHERE Flights = '1' AND OriginCityName = 'Moab, UT' AND DivReachedDest = '-9999'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivDistance, AirlineID, Month WHERE DestStateFips = '2' AND DivReachedDest = '0'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth = '17' AND DestAirportSeqID = '1467903' AND UniqueCarrier = 'US' GROUP BY AirTime, DivReachedDest, DayOfWeek
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate = '2014-06-25' AND CancellationCode = 'C' AND Year = '2014' GROUP BY DestState, FirstDepTime, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CancellationCode, Flights, DivActualElapsedTime WHERE TailNum = 'N555NW' AND Flights = '1' AND SecurityDelay = '0'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND DestCityName = 'St. Cloud, MN' AND OriginState = 'IL' GROUP BY WheelsOff, Year, DivReachedDest
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE TaxiIn = '19' GROUP BY DestCityMarketID, Cancelled, Flights
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '1' AND CarrierDelay = '-9999' AND CRSElapsedTime = '155' GROUP BY DivAirportLandings, DestState, SecurityDelay
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY TaxiIn, FirstDepTime, Year WHERE Year = '2014' AND CarrierDelay = '143' AND DayOfWeek = '4'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, LongestAddGTime, Diverted WHERE DistanceGroup = '3' AND TaxiIn = '6' AND CRSArrTime = '1912'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY TailNum, Flights, Cancelled WHERE Carrier = 'MQ' AND DestState = 'OH' AND SecurityDelay = '-9999'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestAirportID, CancellationCode, Year WHERE Cancelled = '1' AND UniqueCarrier = 'AA' AND DistanceGroup = '9'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState, DivAirportLandings, SecurityDelay WHERE OriginStateName = 'Oregon' AND ArrTimeBlk = '0800-0859' AND CancellationCode = 'noodles'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month = '6' AND WheelsOff = '1523' AND Year = '2014' GROUP BY DivDistance, Cancelled, Month
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY ArrTime, Cancelled, Quarter WHERE Distance = '466' AND AirTime = '68' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND AirTime = '255' AND CRSElapsedTime = '289' GROUP BY DayOfWeek, OriginCityName, Cancelled
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivAirportLandings, Origin, Flights WHERE OriginCityName = 'Hartford, CT' AND DayOfWeek = '2' AND DistanceGroup = '4'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Year = '2014' AND DayOfWeek = '5' AND ActualElapsedTime = '49' GROUP BY DestState, OriginStateName, Cancelled
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE Carrier = 'OO' GROUP BY DivAirportLandings, DayOfWeek, DestStateName
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY Origin, DistanceGroup, Month WHERE AirlineID = '19393' AND ArrTime = '1820' AND DepTimeBlk = '1400-1459'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk = '0700-0759' AND UniqueCarrier = 'DL' AND DestState = 'MN' GROUP BY WheelsOff, Cancelled, Quarter
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year = '2014' AND DestAirportSeqID = '1161706' AND CancellationCode = 'noodles' GROUP BY DivAirportLandings, DepTimeBlk, WeatherDelay
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup = '3' AND Flights = '1' AND AirlineID = '20437' GROUP BY Quarter, ArrTime, CancellationCode
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY FirstDepTime, LongestAddGTime, Quarter WHERE CancellationCode = 'noodles' AND LongestAddGTime = '18' AND CRSElapsedTime = '175'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DestWac = '43' AND CarrierDelay = '84' AND ArrTimeBlk = '1900-1959' GROUP BY ArrTimeBlk
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportSeqID, AirlineID, Flights WHERE AirlineID = '20355' AND SecurityDelay = '0' AND Year = '2014'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName = 'Iowa' AND Flights = '1' GROUP BY AirTime, UniqueCarrier, Year
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState, Month, Flights WHERE DestAirportID = '11097' AND ArrTimeBlk = '2000-2059' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DayofMonth, OriginWac, Year WHERE OriginAirportID = '13367' AND Month = '6' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TaxiOut = '24' AND DivReachedDest = '0' AND DayofMonth = '3' GROUP BY AirlineID, TaxiIn, DayOfWeek
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac = '22' GROUP BY CRSDepTime, DayOfWeek, Flights
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted = '0' AND FirstDepTime = '925' GROUP BY Year, Diverted, TailNum
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Quarter = '2' AND Diverted = '0' AND OriginState = 'MT' GROUP BY DivArrDelay, UniqueCarrier, Month
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivArrDelay, CancellationCode, DivAirportLandings WHERE OriginWac = '14' AND DayOfWeek = '1' AND ArrTimeBlk = '0700-0759'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips = '49' AND UniqueCarrier = 'AS' AND Carrier = 'AS' GROUP BY Flights, OriginCityName, SecurityDelay
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime, DayOfWeek, Month WHERE UniqueCarrier = 'OO' AND ArrTime = '2052' AND Cancelled = '0'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Quarter, ArrTimeBlk, TaxiOut WHERE TailNum = 'N562SW' AND Diverted = '1'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, Flights, DestStateName WHERE WheelsOn = '1612' AND UniqueCarrier = 'US' AND DivAirportLandings = '0'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestStateName = 'Virginia' AND DivReachedDest = '0' AND OriginWac = '43' GROUP BY DestCityMarketID, Diverted, SecurityDelay
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE FlightDate = '2014-06-25' AND Cancelled = '1' AND DestStateName = 'Iowa' GROUP BY WheelsOff, Year, CancellationCode
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE TaxiOut = '35' AND DepTimeBlk = '1000-1059' AND DivAirportLandings = '0' GROUP BY Distance, DivAirportLandings, Flights
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '5' AND TaxiIn = '15' AND OriginCityMarketID = '34783' GROUP BY WeatherDelay, UniqueCarrier, DivAirportLandings
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, DayofMonth, Quarter WHERE DivActualElapsedTime = '420' AND Flights = '1' AND OriginStateName = 'Alabama'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY AirTime, AirlineID, Month WHERE Flights = '1' AND OriginAirportSeqID = '1348702' AND Dest = 'OKC'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '5' AND DestWac = '64' AND OriginStateName = 'Massachusetts' GROUP BY TailNum, Month, Year
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE AirTime = '258' AND Year = '2014' AND DepTimeBlk = '0700-0759' GROUP BY Flights, Dest, DepTimeBlk
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Flights, OriginAirportSeqID, Cancelled WHERE OriginCityMarketID = '30136' AND Flights = '1' AND DivAirportLandings = '1'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportID, DayOfWeek, Diverted WHERE OriginStateFips = '32' AND DestStateFips = '13' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DayOfWeek = '2' AND Flights = '1' AND Quarter = '2' GROUP BY DayOfWeek, CRSDepTime, Flights
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE WheelsOff = '1023' AND Cancelled = '0' AND Carrier = 'EV' GROUP BY Origin, Month, AirlineID
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Month = '6' AND WeatherDelay = '17' GROUP BY Diverted, TotalAddGTime, OriginStateFips
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Distance = '383' GROUP BY OriginStateName, OriginState
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Cancelled, DestWac, DayofMonth WHERE AirlineID = '20366' AND Cancelled = '0' AND CRSArrTime = '737'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayofMonth, Cancelled, DepTimeBlk WHERE DepTimeBlk = '1500-1559' AND Year = '2014' AND DestWac = '39'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Distance, SecurityDelay, Month WHERE Cancelled = '0' AND Flights = '1' AND CRSDepTime = '1343'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY UniqueCarrier, DestWac, Diverted WHERE DepTimeBlk = '1300-1359' AND OriginStateName = 'Kentucky' AND DivReachedDest = '1'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTime = '1800' GROUP BY DivActualElapsedTime, SecurityDelay, Quarter
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Diverted = '0' GROUP BY ArrTimeBlk, DestAirportID, Month
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest = '1' AND Year = '2014' GROUP BY Diverted, DestAirportID, AirlineID
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = '2' AND ArrTimeBlk = '1100-1159' AND OriginStateFips = '1' GROUP BY TotalAddGTime, FlightDate, Cancelled
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup = '6' AND Year = '2014' AND Diverted = '0' GROUP BY OriginAirportID, Cancelled, CancellationCode
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CancellationCode = 'A' GROUP BY DestAirportID, DivAirportLandings, Diverted
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY AirTime, CancellationCode, SecurityDelay WHERE Year = '2014' AND DayofMonth = '17' AND CarrierDelay = '12'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Dest = 'BHM' AND Year = '2014' AND Quarter = '2' GROUP BY OriginCityMarketID, DayofMonth, Flights
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, ArrTimeBlk, Year WHERE Diverted = '1' AND Distance = '1635' AND ArrTimeBlk = '1400-1459'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DayofMonth = '11' AND Carrier = 'B6' AND Flights = '1' GROUP BY Cancelled, CRSElapsedTime, DayOfWeek
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginState = 'CO' AND DestStateFips = '53' AND DayofMonth = '11' GROUP BY Cancelled, DepTimeBlk, CancellationCode
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTimeBlk = '1000-1059' AND DestState = 'SD' AND DayOfWeek = '5' GROUP BY OriginCityMarketID, DivActualElapsedTime, LongestAddGTime
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE ArrTime = '1552' AND Carrier = 'WN' AND DistanceGroup = '1' GROUP BY Cancelled, ArrTimeBlk, Flights
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Year = '2014' AND DayofMonth = '3' AND CancellationCode = 'B' GROUP BY AirTime, DivAirportLandings, DivReachedDest
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter = '2' AND DestWac = '64' AND OriginStateName = 'Oklahoma' GROUP BY OriginAirportID, Carrier, Quarter
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID, Diverted, OriginStateName WHERE DivReachedDest = '0' AND WheelsOff = '2250'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest = '0' GROUP BY OriginCityMarketID, DivReachedDest, Diverted
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime = '1057' AND DayOfWeek = '5' AND Carrier = 'MQ' GROUP BY DestWac, DayofMonth, Diverted
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE Year = '2014' AND Carrier = 'EV' AND DepTime = '1154' GROUP BY TaxiOut, Carrier, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TailNum, Quarter, Year WHERE DayOfWeek = '6' AND FlightDate = '2014-06-14' AND DivReachedDest = '0'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestState = 'TX' AND Cancelled = '0' AND FlightNum = '686' GROUP BY ActualElapsedTime, CancellationCode, Year
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE SecurityDelay = '0' AND FlightDate = '2014-06-29' AND DestStateName = 'Washington' GROUP BY ArrTime, CancellationCode, Month
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier = 'WN' AND Quarter = '2' AND AirTime = '142' GROUP BY SecurityDelay, ActualElapsedTime, DivAirportLandings
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk = '1000-1059' AND DivAirportLandings = '0' AND AirlineID = '19690' GROUP BY CancellationCode
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightNum, Diverted, Flights WHERE DayOfWeek = '2' AND WheelsOn = '1329'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier = 'HA' AND WheelsOff = '1206' AND Quarter = '2' GROUP BY DestCityName, Flights, DayOfWeek
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DestAirportSeqID, AirlineID, Diverted WHERE DestWac = '21' AND DayOfWeek = '5' AND OriginStateFips = '41'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityName = 'Valparaiso, FL' GROUP BY DestAirportSeqID, Diverted, Month
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted, CRSArrTime, CancellationCode WHERE Carrier = 'WN' AND DistanceGroup = '7' AND ArrTime = '1611'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Diverted = '1' GROUP BY DestStateName, Flights, DayofMonth
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivDistance = '485' AND OriginState = 'CO' AND FlightDate = '2014-06-25' GROUP BY DayOfWeek, DivArrDelay, Quarter
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk = '1800-1859' AND SecurityDelay = '-9999' AND DestState = 'MD' GROUP BY DestStateFips, DayofMonth, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DistanceGroup = '9' GROUP BY DestStateName, DayOfWeek, DivAirportLandings
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE SecurityDelay = '-9999' AND AirTime = '209' AND Flights = '1' GROUP BY FlightDate
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND Year = '2014' AND DestStateName = 'Arizona' GROUP BY OriginWac, TotalAddGTime, Quarter
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY CRSArrTime, Flights, DivAirportLandings WHERE Flights = '1' AND AirlineID = '19930' AND DestState = 'CA'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Distance, Cancelled, Month WHERE Cancelled = '0' AND Month = '6' AND OriginCityMarketID = '30431'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE ActualElapsedTime = '252' AND DestState = 'VA' AND ArrTimeBlk = '2100-2159' GROUP BY DestAirportSeqID, Month, ArrTimeBlk
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Year = '2014' GROUP BY Dest, DayOfWeek, DivReachedDest
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, Diverted, DivReachedDest WHERE AirlineID = '19977' AND DivReachedDest = '-9999' AND OriginState = 'MA'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND Quarter = '2' AND Dest = 'SBA' GROUP BY ActualElapsedTime, Flights, Month
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Cancelled = '0' AND DivReachedDest = '0' AND AirlineID = '20409' GROUP BY Month, DestAirportSeqID, FlightDate
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '2000-2059' AND Carrier = 'VX' AND Flights = '1' GROUP BY ArrTimeBlk, Year, OriginCityMarketID
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND DestCityMarketID = '34100' AND ArrTimeBlk = '1700-1759' GROUP BY Dest, DayOfWeek, CancellationCode
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY Year, TotalAddGTime, OriginState WHERE Flights = '1' AND DepTimeBlk = '1200-1259' AND CancellationCode = 'A'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '1800-1859' AND OriginStateFips = '36' AND Cancelled = '0' GROUP BY NASDelay, Year, ArrTimeBlk
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, DistanceGroup, Year WHERE SecurityDelay = '-9999' AND Month = '6' AND OriginState = 'SC'
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DestCityName, UniqueCarrier, Month WHERE OriginStateFips = '13'
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivActualElapsedTime, DayOfWeek, Month WHERE SecurityDelay = '0' AND WheelsOff = '1849' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY LateAircraftDelay, DestState, Year WHERE DestAirportID = '14321' AND Flights = '1' AND DayofMonth = '13'
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Carrier = 'DL' AND DayofMonth = '19' AND TaxiOut = '72' GROUP BY OriginAirportSeqID, Month, AirlineID
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE TailNum = 'N923DN' AND DestState = 'VA' AND Cancelled = '0' GROUP BY DestAirportSeqID, Cancelled, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginCityName = 'Indianapolis, IN' AND UniqueCarrier = 'US' AND DivAirportLandings = '1' GROUP BY FlightDate, LongestAddGTime, OriginCityName
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Year = '2014' AND DayofMonth = '21' AND CRSArrTime = '2301' GROUP BY DivReachedDest, AirlineID, NASDelay
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Carrier, CRSElapsedTime, Month WHERE Flights = '1' AND TaxiOut = '9' AND DivAirportLandings = '1'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, CarrierDelay, Flights WHERE CRSDepTime = '1746'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Quarter = '2' AND SecurityDelay = '-9999' AND Month = '6' GROUP BY OriginWac, UniqueCarrier
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, LateAircraftDelay, TotalAddGTime WHERE AirlineID = '20355' AND DestStateFips = '15' AND DayOfWeek = '6'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayofMonth, ArrTimeBlk, DivAirportLandings WHERE OriginAirportID = '10785' AND DayofMonth = '21' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY OriginState, Year, DivDistance WHERE ArrTime = '648'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, NASDelay, DivAirportLandings WHERE CancellationCode = 'noodles' AND OriginCityMarketID = '34288' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiOut = '17' AND DestAirportSeqID = '1125903' AND DepTimeBlk = '0600-0659' GROUP BY FirstDepTime, DivAirportLandings, Month
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSElapsedTime, Diverted, Cancelled WHERE Month = '6' AND OriginWac = '64' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID = '32206' AND Diverted = '0' AND DepTimeBlk = '1700-1759' GROUP BY CRSElapsedTime, DestAirportSeqID, FlightNum
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime = '23' AND Flights = '1' AND OriginStateName = 'Florida' GROUP BY DivDistance, OriginState, Month
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime = '1938' GROUP BY WheelsOff, Cancelled, Month
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, Cancelled, Month WHERE Month = '6' AND SecurityDelay = '0' AND LateAircraftDelay = '44'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE NASDelay = '38' AND CancellationCode = 'noodles' AND ArrTime = '1558' GROUP BY DepTime, Month, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestAirportSeqID = '1161802' AND AirlineID = '20366' AND Quarter = '2' GROUP BY UniqueCarrier
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode = 'A' GROUP BY ArrTime, Cancelled, Diverted
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Month, CRSDepTime, Cancelled WHERE DestStateName = 'Indiana' AND Quarter = '2' AND Month = '6'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Month, DestWac, Year WHERE TaxiOut = '14' AND Cancelled = '1' AND OriginCityName = 'Rapid City, SD'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY UniqueCarrier, CRSElapsedTime, Year WHERE Carrier = 'OO' AND DayOfWeek = '1' AND WheelsOn = '823'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Dest = 'TVC' GROUP BY Origin, SecurityDelay, DivAirportLandings
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DivReachedDest, TaxiIn, Flights WHERE UniqueCarrier = 'AS' AND Dest = 'SCC'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY ActualElapsedTime, Year, UniqueCarrier WHERE CRSArrTime = '1110' AND DestStateName = 'Colorado' AND Year = '2014'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FlightDate, OriginStateFips, DivReachedDest WHERE DestAirportID = '11648' AND Flights = '1' AND Cancelled = '1'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName = 'Portland, OR' AND AirlineID = '19690' AND Cancelled = '0' GROUP BY DepTime, Diverted, Cancelled
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DepTime, Month, Diverted WHERE DepTimeBlk = '1200-1259' AND OriginWac = '13' AND Year = '2014'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '1100-1159' AND DistanceGroup = '11' AND OriginWac = '22' GROUP BY Month, LongestAddGTime, DestStateFips
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode = 'C' AND Year = '2014' AND DivAirportLandings = '9' GROUP BY UniqueCarrier, DestCityName, Flights
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, CancellationCode, FirstDepTime WHERE DayOfWeek = '1' AND ArrTime = '1948' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Month = '6' AND DestCityName = 'Honolulu, HI' AND DistanceGroup = '10' GROUP BY AirlineID, OriginCityMarketID, Month
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DistanceGroup = '5' AND Quarter = '2' AND Carrier = 'WN' GROUP BY OriginCityName, CancellationCode, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Dest, DayofMonth, Flights WHERE NASDelay = '20' AND AirlineID = '20355' AND DestState = 'AZ'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginWac, DestStateFips, DivReachedDest WHERE CancellationCode = 'noodles' AND DivReachedDest = '-9999' AND DestCityName = 'Columbus, GA'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime = '740' AND Year = '2014' AND AirlineID = '20366' GROUP BY DestCityName, Year, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Origin, Month, SecurityDelay WHERE FlightDate = '2014-06-26' AND OriginStateFips = '47' AND DistanceGroup = '4'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND LongestAddGTime = '1' AND Year = '2014' GROUP BY CarrierDelay, OriginState, Quarter
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayofMonth = '21' AND OriginState = 'TX' AND DepTimeBlk = '1300-1359' 
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Flights = '1' AND CarrierDelay = '91' AND Diverted = '0' GROUP BY ActualElapsedTime, Cancelled, Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayofMonth, Year, DestWac WHERE Cancelled = '0' AND NASDelay = '3' AND Distance = '1236'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE CarrierDelay = '59' GROUP BY DestCityMarketID, DepTimeBlk, Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiOut, TotalAddGTime, Quarter WHERE Month = '6' AND DivDistance = '441' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, Flights, UniqueCarrier WHERE CancellationCode = 'noodles' AND DayofMonth = '4' AND DivArrDelay = '259'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestState = 'FL' GROUP BY DepTimeBlk, Diverted, Carrier
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityMarketID, Year, AirlineID WHERE AirTime = '311' AND ArrTimeBlk = '2200-2259' AND DistanceGroup = '9'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Quarter, DayOfWeek, CRSArrTime WHERE DayofMonth = '30' AND DestCityName = 'Williston, ND' AND DivAirportLandings = '1'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateFips = '35' AND FlightDate = '2014-06-23' AND ArrTimeBlk = '2300-2359' GROUP BY OriginCityMarketID, Cancelled, DistanceGroup
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, SecurityDelay, DivReachedDest WHERE WheelsOn = '2104' AND Carrier = 'FL' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, Month, AirlineID WHERE DivReachedDest = '-9999' AND DepTimeBlk = '1000-1059' AND Quarter = '2'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Distance = '2715' AND Year = '2014' AND Cancelled = '0' GROUP BY ActualElapsedTime, Carrier, Flights
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE NASDelay = '21' AND TaxiIn = '13' GROUP BY DestStateFips, LongestAddGTime, Flights
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY CRSElapsedTime, Cancelled, Diverted WHERE AirTime = '31' AND DestStateName = 'Nevada' AND ArrTimeBlk = '0001-0559'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Cancelled = '0' AND TailNum = 'N622AW' AND DepTimeBlk = '0800-0859' GROUP BY ActualElapsedTime, Cancelled, Quarter
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestStateFips = '12' AND Year = '2014' AND DayOfWeek = '4' GROUP BY LongestAddGTime, DestAirportSeqID, Flights
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DistanceGroup, OriginStateFips, AirlineID WHERE DivAirportLandings = '9' AND DestWac = '85' AND OriginWac = '91'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY WheelsOn, DayOfWeek, Year WHERE DestState = 'KS' AND Flights = '1' AND Year = '2014'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportSeqID, Diverted, Month WHERE Flights = '1' AND AirlineID = '20409' AND Cancelled = '0'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek = '6' GROUP BY UniqueCarrier, DestCityMarketID, Diverted
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY SecurityDelay, AirTime, DivReachedDest WHERE OriginCityName = 'Brainerd, MN' AND Year = '2014' AND Flights = '1'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE CancellationCode = 'B' AND DestWac = '54' AND DayOfWeek = '6' GROUP BY AirTime, UniqueCarrier, Flights
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY ActualElapsedTime, DivAirportLandings WHERE DestWac = '41' AND OriginWac = '34' AND ArrTimeBlk = '1500-1559'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Diverted, DestState, DistanceGroup WHERE DayOfWeek = '3' AND DepTime = '1415' AND AirlineID = '20398'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights = '1' AND DivAirportLandings = '9' AND OriginState = 'NY' GROUP BY WheelsOn, Diverted, DivReachedDest
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month = '6' AND TailNum = 'N455WN' AND Quarter = '2' GROUP BY DestAirportID, FlightDate, Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestAirportSeqID, Cancelled, Diverted WHERE Cancelled = '0' AND DestCityMarketID = '35048'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights = '1' AND Month = '6' AND Dest = 'RAP' GROUP BY DestAirportSeqID, Carrier, Quarter
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Flights = '1' AND DestCityMarketID = '32323' AND AirlineID = '19790' GROUP BY DestStateName, OriginState, Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, Diverted, DivReachedDest WHERE Month = '6' AND Quarter = '2' AND FlightDate = '2014-06-11'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE Quarter = '2' AND TaxiIn = '2' AND ArrTimeBlk = '1000-1059' GROUP BY AirlineID, DestAirportSeqID, Month
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE Carrier = 'OO' AND OriginCityMarketID = '34006' AND DivReachedDest = '1' GROUP BY NASDelay, OriginState, WeatherDelay
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk = '2300-2359' AND OriginAirportSeqID = '1161802' AND DestWac = '43' GROUP BY DestAirportID, DayOfWeek, Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DestWac = '91' AND DayOfWeek = '5' AND OriginCityName = 'Carlsbad, CA' GROUP BY TailNum, Diverted
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CRSDepTime = '1931' AND DivAirportLandings = '0' AND Cancelled = '1' GROUP BY OriginCityMarketID, FlightDate, Month
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk = '1500-1559' AND DestWac = '1' AND AirTime = '42' GROUP BY DayOfWeek, Diverted, OriginStateFips
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek = '3' AND Year = '2014' AND FlightNum = '747' GROUP BY Distance, Cancelled, Month
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivActualElapsedTime = '320' AND OriginAirportSeqID = '1288903' AND Year = '2014' GROUP BY OriginStateName, DivDistance, Month
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestAirportSeqID, UniqueCarrier, Diverted
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestWac, Carrier, DayOfWeek
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, Carrier, Flights
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID, DivReachedDest, Diverted
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID, Year, Flights
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginWac, OriginStateName
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DepTime, Cancelled, Diverted
-SELECT SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayofMonth, Dest, Quarter
-SELECT SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityName, ArrTimeBlk, Quarter
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, DayofMonth, Year
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Cancelled, Distance, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DivActualElapsedTime
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, CancellationCode, Flights
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DistanceGroup, WeatherDelay, DivReachedDest
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Diverted, DestAirportSeqID, Carrier
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TotalAddGTime, Month, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Carrier, DestWac, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, CancellationCode, Month
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, Carrier, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY LateAircraftDelay, TotalAddGTime, Year
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DepTimeBlk, DestWac, Year
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Distance, Quarter, DivAirportLandings
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivAirportLandings, DayofMonth, DepTimeBlk
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivArrDelay, Diverted, DivReachedDest
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Quarter, Month
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, FirstDepTime, Year
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginWac, NASDelay, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, Month, CancellationCode
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk, WeatherDelay, Diverted
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, DestState, Cancelled
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, TotalAddGTime, DivAirportLandings
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, Diverted, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, DepTimeBlk, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, UniqueCarrier, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, DayofMonth
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportID, DayOfWeek, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk, OriginCityName, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, FlightDate, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY CancellationCode, DivActualElapsedTime, DivReachedDest
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivAirportLandings, Origin, Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOff, DivAirportLandings, Quarter
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, AirlineID, Month
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY ActualElapsedTime, CancellationCode, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY TaxiOut, LongestAddGTime, Month
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DivActualElapsedTime, Flights, DayOfWeek
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, WheelsOff, Year
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportSeqID, Month, Cancelled
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, DistanceGroup, Flights
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime, DepTimeBlk, Year
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Quarter, ArrTime, DivAirportLandings
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Distance, Diverted, CancellationCode
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CarrierDelay, OriginState, Month
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestAirportSeqID, DivReachedDest, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, Origin, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, Cancelled, DivAirportLandings
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestState, Quarter, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY AirlineID, Cancelled, OriginAirportSeqID
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY WeatherDelay, DivAirportLandings, ArrTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestWac, DivDistance, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Year, DestState, CarrierDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DivReachedDest, Dest, Cancelled
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY CRSElapsedTime, Diverted, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CancellationCode, CRSDepTime, Year
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Cancelled, TailNum, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, FirstDepTime, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirTime, DayOfWeek, Diverted
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayofMonth, OriginStateName, DivAirportLandings
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, Flights, LateAircraftDelay
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, UniqueCarrier, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestStateFips, AirlineID, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiIn, FirstDepTime, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSDepTime, DivReachedDest, Year
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, Year, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY NASDelay, DayofMonth, Year
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportSeqID, CancellationCode, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSArrTime, DivAirportLandings, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivAirportLandings, DivActualElapsedTime, Quarter
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginState, DivDistance, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY OriginState, TaxiOut, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, OriginWac, Quarter
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginWac, CarrierDelay, Flights
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Carrier, LongestAddGTime, Diverted
-SELECT SUM(DepDelay) FROM myStarTable 
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY FirstDepTime, CancellationCode, DayOfWeek
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Diverted, Flights
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, WeatherDelay, Year
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginState, Month, WeatherDelay
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Cancelled, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginStateFips, OriginWac, DivReachedDest
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivDistance, OriginStateName, Month
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, DivReachedDest, Year
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Dest, AirlineID, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DepTime, Month, Year
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelay) FROM myStarTable GROUP BY Quarter, DestCityMarketID, SecurityDelay
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CarrierDelay, DivAirportLandings, UniqueCarrier
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Month, LongestAddGTime, Flights
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Carrier
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Carrier, TaxiOut, Quarter
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, SecurityDelay, Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestAirportID, CancellationCode, DivReachedDest
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityName, Month, ArrTimeBlk
-SELECT SUM(DepDelay), SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportID, DistanceGroup, Flights
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DayOfWeek, DestStateName, Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDelay) FROM myStarTable 
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY CRSDepTime, DayOfWeek, Month
-SELECT SUM(DepDelay), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, SecurityDelay, Year
-SELECT SUM(DepDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Quarter, DivActualElapsedTime, Flights
-SELECT SUM(DepDelay), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, DivDistance, Year
-SELECT SUM(DepDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestWac, DivDistance, Flights
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestState, UniqueCarrier, Cancelled
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Diverted, NASDelay, Month
-SELECT SUM(DepDelayMinutes) FROM myStarTable 
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, CancellationCode, Diverted
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, NASDelay, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, OriginAirportSeqID, Cancelled
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Flights, Month
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Month, Dest, Quarter
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY NASDelay, DestStateFips, Year
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityName, DistanceGroup, Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY AirTime, Quarter, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName, SecurityDelay, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, DivAirportLandings, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Distance, Flights, Diverted
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginState, DivDistance, Flights
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestState, Year, TaxiIn
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, Diverted, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOff, SecurityDelay, Year
-SELECT SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DivAirportLandings, LateAircraftDelay, Year
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Month, OriginState, DepTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CancellationCode, DestCityName, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayofMonth, CarrierDelay, Diverted
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, ArrTimeBlk, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime, Year, DestStateFips
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, DistanceGroup, Cancelled
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY CRSElapsedTime, Diverted, Flights
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Dest, AirlineID, Month
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY OriginCityMarketID, Flights, DivAirportLandings
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, AirlineID, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID, Flights, Year
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn, SecurityDelay, Quarter
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY LongestAddGTime, Year, Flights
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY AirlineID, DestWac, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Quarter, AirlineID, UniqueCarrier
-SELECT SUM(DepDelay), SUM(DepDelay) FROM myStarTable GROUP BY TaxiIn, Month, DivReachedDest
-SELECT SUM(DepDelay), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY SecurityDelay
-SELECT SUM(DepDelay), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityMarketID, ArrTimeBlk, Month
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable 
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirTime, DivAirportLandings, DivReachedDest
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime IN (104, 366, 522, 284, 422) AND Origin BETWEEN 'LEX' AND 'MSP' GROUP BY OriginStateName
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, ArrTimeBlk
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSArrTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE TaxiIn > 101 AND FlightNum BETWEEN 1774 AND 3982 GROUP BY OriginCityName, DistanceGroup
+SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiIn > 2 GROUP BY Year, WheelsOff
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTimeBlk <> '2200-2259' AND WheelsOn IN (1047, 959, 552) AND OriginStateFips IN (24, 75, 9, 34, 32) GROUP BY Year, FlightNum
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk = '1900-1959' AND OriginWac IN (91, 41, 44) AND TaxiIn <= 78 GROUP BY WheelsOn
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTime BETWEEN 508 AND 1531 AND DayOfWeek IN (3) AND DivDistance BETWEEN 302 AND 760 GROUP BY Carrier
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE FirstDepTime IN (1842, 1346) AND TaxiIn <> 117 GROUP BY ArrTime, DepTimeBlk
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestWac BETWEEN 21 AND 23
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn BETWEEN 522 AND 1839 AND ArrTime <= 2138
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityName <= 'Louisville, KY' AND OriginStateName IN ('Michigan', 'Louisiana', 'Pennsylvania') GROUP BY Origin
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DepTime <> 1859 AND OriginAirportID BETWEEN 10431 AND 12094 AND CRSArrTime IN (2051, 2308, 2344, 1844, 1440)
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Cancelled
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TotalAddGTime IN (97, 149)
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest IN (0) AND CRSArrTime BETWEEN 1105 AND 2108 GROUP BY DestAirportSeqID, DayofMonth
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Quarter, AirlineID
+SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginState = 'NC' GROUP BY SecurityDelay
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime BETWEEN 51 AND 54 GROUP BY TotalAddGTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestState BETWEEN 'AR' AND 'WY' GROUP BY DivDistance
+SELECT SUM(DepDel15) FROM myStarTable WHERE Month BETWEEN 4 AND 10 GROUP BY DestStateName, CRSArrTime
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 9 AND DestStateName BETWEEN 'Louisiana' AND 'North Dakota' AND Flights IN (1) GROUP BY Month
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSElapsedTime >= 350 AND DestCityMarketID > 30779 AND CancellationCode IN ('A', 'C', 'noodles')
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime BETWEEN 146 AND 332 AND DestWac IN (1, 36, 67, 41) GROUP BY Origin, Distance
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay BETWEEN 19 AND 119 AND DestAirportSeqID IN (1114003, 1087402, 1244805, 1200702, 1219702) GROUP BY OriginAirportID, DivDistance
+SELECT SUM(ArrDelay) FROM myStarTable WHERE WeatherDelay BETWEEN 36 AND 103 AND DestStateFips < 47 AND CRSDepTime >= 1823 GROUP BY CancellationCode, Month
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID IN (1541103, 1161802, 1537602, 1479402, 1014602) GROUP BY DestCityMarketID, TailNum
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginStateName BETWEEN 'Arizona' AND 'Louisiana'
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (-2147483648, 3, 6, 5) AND ActualElapsedTime > 480
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn IN (1433, 2151, 2218, 50) AND DivArrDelay BETWEEN 247 AND 681
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = 1
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips BETWEEN 22 AND 42 AND DepTime < 527 AND DestAirportSeqID < 1226402 GROUP BY OriginState, AirTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestStateFips BETWEEN 40 AND 48 AND WheelsOn IN (621, 1955, 1135, 1221, 1025) GROUP BY Year, TaxiOut
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestCityMarketID
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay, NASDelay
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTimeBlk IN ('1700-1759', '1200-1259') GROUP BY DestAirportID, Origin
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginAirportID IN (12197, 13230, 13931) AND DivAirportLandings BETWEEN 0 AND 1 AND DivReachedDest >= 1
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime BETWEEN 10 AND 1517 AND WheelsOn BETWEEN 1031 AND 1919 GROUP BY FlightNum
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Origin > 'IMT' AND DestCityMarketID < 34960 GROUP BY WheelsOff
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE CRSArrTime = 1120
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TaxiIn BETWEEN 11 AND 20
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY AirTime, OriginStateFips
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings <= 9 GROUP BY AirTime, DestStateName
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest >= 0 GROUP BY Cancelled
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime IN (150, 125, 89) AND AirTime <= 424 GROUP BY DivActualElapsedTime, ArrTimeBlk
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier IN ('FL', 'DL', 'F9') GROUP BY Quarter
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState < 'UT' AND Quarter BETWEEN -2147483648 AND 3
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirlineID >= 19790 AND WheelsOff = 909 GROUP BY LateAircraftDelay
+SELECT SUM(ArrDel15) FROM myStarTable WHERE WheelsOn BETWEEN 544 AND 1303
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID IN (19790) AND ArrTimeBlk IN ('1600-1659', '0600-0659', '2000-2059')
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestCityMarketID, Dest
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 347 AND 2043
+SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginStateName IN ('Rhode Island', 'Delaware', 'Idaho') GROUP BY CRSArrTime, DestAirportID
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Origin IN ('MSP', 'IMT', 'FLL', 'JAX', 'BKG') GROUP BY DistanceGroup, Flights
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 21 AND 1211 GROUP BY DivActualElapsedTime, DistanceGroup
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportID
+SELECT SUM(DepDelay) FROM myStarTable WHERE FlightDate <= '2014-06-13'
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights >= -2147483648 GROUP BY LateAircraftDelay
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID BETWEEN 32320 AND 33485
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DistanceGroup, DivReachedDest
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE CRSDepTime <= 10
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightDate
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup IN (7, 2, 5, 11) AND DepTime IN (1714, 1112, 1212, 741, 555)
+SELECT SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime >= 2204 GROUP BY TaxiOut
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginStateFips <> 28 GROUP BY ArrTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1098002 AND 1114003
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips IN (37, 24, 48, 33, 32) AND DepTime <> 511 AND Diverted = 1 GROUP BY DivReachedDest, CRSArrTime
+SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DepTime BETWEEN 649 AND 956 AND DestCityMarketID <> 33485 GROUP BY CarrierDelay, ArrTimeBlk
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month >= 10 AND DestCityMarketID IN (33342) AND OriginWac BETWEEN 5 AND 31
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirTime = 15 AND DivReachedDest <= 1 AND DayOfWeek IN (7, 6, 2)
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE SecurityDelay IN (4) GROUP BY Origin, TailNum
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiOut, Dest
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WeatherDelay IN (152, 13, 14) GROUP BY DayOfWeek
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestWac IN (37) GROUP BY UniqueCarrier
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay IN (24, 6, 10, 14) GROUP BY OriginStateName
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek BETWEEN -2147483648 AND 1
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID BETWEEN 30930 AND 31823 AND TotalAddGTime BETWEEN 20 AND 145 AND DivAirportLandings IN (2) GROUP BY Cancelled, Quarter
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips BETWEEN 13 AND 40 AND DayofMonth < 10 AND DepTimeBlk IN ('1800-1859', '1700-1759', '2200-2259', '1200-1259', '0700-0759') GROUP BY TaxiOut, WheelsOn
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CarrierDelay = 207 GROUP BY DistanceGroup
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 31641 AND 33264
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings >= 1 GROUP BY OriginAirportSeqID
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TailNum < 'N889AS'
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, WheelsOn
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Origin <= 'TUS' AND OriginCityName > 'Waterloo, IA' AND Quarter BETWEEN -2147483648 AND 2 GROUP BY Cancelled, DestState
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Month > 6 GROUP BY Year
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY CarrierDelay
+SELECT SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (0, -2147483648, 1, -9999) GROUP BY Dest
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Origin < 'CWA' GROUP BY DestState, Quarter
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode BETWEEN 'ALL' AND 'noodles' GROUP BY UniqueCarrier, OriginWac
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState = 'NC' GROUP BY UniqueCarrier
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayofMonth
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Month IN (4, 10, 5, 11, 7) AND DepTime <= 506
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff IN (1527) GROUP BY DestCityMarketID, OriginCityMarketID
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE UniqueCarrier IN ('US', 'UA', 'OO', 'FL', 'MQ') GROUP BY DestStateName
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Distance BETWEEN 516 AND 1107 AND ActualElapsedTime < 103 AND DayOfWeek <> -2147483648 GROUP BY TaxiOut
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivDistance IN (85, 209) GROUP BY Dest
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportSeqID >= 1537002 GROUP BY Carrier
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TotalAddGTime BETWEEN 78 AND 104 AND DivArrDelay <= 85 AND FlightDate <> '2014-09-16'
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE CRSArrTime >= 745 AND OriginAirportID IN (15607, 10135, 16218)
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID IN (1350202, 1201602)
+SELECT SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay > 169 AND DivReachedDest BETWEEN -2147483648 AND -9999 GROUP BY ArrTimeBlk
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime IN (47, 300, 493, 31, 398) GROUP BY TotalAddGTime, LongestAddGTime
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityName IN ('Sacramento, CA', 'Wilmington, DE', 'Orlando, FL', 'Billings, MT', 'Hattiesburg/Laurel, MS') GROUP BY Distance, DistanceGroup
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1014003 AND 1558202 GROUP BY DestAirportID, DistanceGroup
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup IN (7, 1) AND CRSElapsedTime IN (447, 665, 642, 99, 356)
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY CRSElapsedTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE NASDelay BETWEEN 57 AND 131 AND FlightDate <= '2014-02-27'
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, WheelsOff
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = 3 AND Year IN (-2147483648, 2014)
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DestAirportID, DestWac
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn BETWEEN 346 AND 2203 GROUP BY Dest, DayofMonth
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestState BETWEEN 'AK' AND 'TT' GROUP BY DepTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips BETWEEN 15 AND 29 AND DayOfWeek IN (2, 1, 6, 5, 7) GROUP BY DestAirportID
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestCityMarketID = 33728 AND Carrier <> 'AA'
+SELECT SUM(DepDelay) FROM myStarTable WHERE CancellationCode >= 'noodles' AND DivDistance = 60 GROUP BY Cancelled
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TotalAddGTime
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE FlightNum IN (5364, 388, 4554, 3058, 206) AND OriginWac IN (38, 41, 14, 15) GROUP BY DestState, DestCityName
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE FirstDepTime BETWEEN 831 AND 900
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DepTime < 1104 AND SecurityDelay IN (7, 9, 19) GROUP BY TaxiOut
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, SecurityDelay
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivReachedDest, CRSArrTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityMarketID <= 33459
+SELECT SUM(DepDelay) FROM myStarTable WHERE Carrier IN ('WN', 'AS', 'B6', 'MQ', 'F9') AND WeatherDelay > 140 GROUP BY DestState, CancellationCode
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN 1403 AND 1514 GROUP BY WeatherDelay, UniqueCarrier
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestStateFips > 6 AND TaxiIn BETWEEN 15 AND 18 GROUP BY OriginCityMarketID
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 1 AND 9 AND DestAirportSeqID <> 1129803 GROUP BY DivDistance, OriginWac
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Carrier < 'MQ' AND DivReachedDest IN (1, -9999, 0) AND SecurityDelay BETWEEN 4 AND 4 GROUP BY OriginStateFips
+SELECT SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY Quarter
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, CRSDepTime
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DistanceGroup
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime < 173 AND DepTimeBlk < '1200-1259' AND FlightNum < 2091 GROUP BY DestCityMarketID
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Cancelled IN (1) AND Diverted BETWEEN -2147483648 AND 0 AND LongestAddGTime > 11
+SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOff IN (140, 44, 2353) AND DestCityMarketID < 34842 AND DepTimeBlk <= '1000-1059' GROUP BY CRSDepTime, CancellationCode
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE NASDelay BETWEEN 149 AND 153 AND Cancelled BETWEEN 0 AND 1
+SELECT SUM(DepDelay) FROM myStarTable WHERE DivArrDelay BETWEEN 50 AND 230 GROUP BY DestStateFips
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CancellationCode IN ('C', 'A', 'noodles', 'B') AND AirlineID < 20437 AND Dest IN ('ERI', 'GSO', 'JNU', 'SGF') GROUP BY DepTimeBlk
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestState BETWEEN 'MS' AND 'SC' GROUP BY DivDistance, OriginAirportSeqID
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestCityName BETWEEN 'Augusta, GA' AND 'New Bern/Morehead/Beaufort, NC' AND ArrTime IN (1336, 13, 1157) GROUP BY OriginStateName
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac <> 63 AND DivAirportLandings = 9 AND DayofMonth BETWEEN 10 AND 12 GROUP BY WheelsOff
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Cancelled IN (0) AND DistanceGroup IN (8, 5, 11, 10)
+SELECT SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk < '1300-1359' AND DestStateFips >= 15 GROUP BY DepTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate IN ('2014-12-07', '2014-06-22') GROUP BY OriginState, CancellationCode
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY SecurityDelay, Origin
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState BETWEEN 'AL' AND 'MO' GROUP BY TaxiIn
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY FirstDepTime, ArrTimeBlk
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (6, 3, 4, 7) GROUP BY DivArrDelay, DayofMonth
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FirstDepTime >= 1343
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY WeatherDelay
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Diverted
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState BETWEEN 'WI' AND 'WY' AND DayofMonth BETWEEN 23 AND 31 AND DivReachedDest BETWEEN -9999 AND -9999 GROUP BY TaxiOut
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightNum BETWEEN 501 AND 811 AND DestStateName BETWEEN 'Alabama' AND 'Maryland' AND DestWac BETWEEN 2 AND 54 GROUP BY FlightDate, AirTime
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID IN (33304, 35249, 32211, 30136) AND NASDelay >= 303 AND DivArrDelay < 1053 GROUP BY DepTimeBlk
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE TaxiOut IN (71, 122, 40, -9999) AND DivAirportLandings >= 0 AND Year BETWEEN -2147483648 AND 2014
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CancellationCode < 'noodles' GROUP BY FlightNum
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginWac IN (51) GROUP BY UniqueCarrier, DestState
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup = 3 AND TaxiIn BETWEEN 25 AND 99 GROUP BY OriginStateName
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay IN (201, 83) AND Carrier BETWEEN 'EV' AND 'FL' AND OriginStateFips IN (21, 38, 34, 19, 50) GROUP BY CRSDepTime, DestStateName
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DayofMonth IN (1, 25, 13, 30, 17) AND DivArrDelay BETWEEN 39 AND 199 GROUP BY CRSArrTime, FlightNum
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut BETWEEN 68 AND 127 AND ArrTimeBlk BETWEEN '1600-1659' AND '1800-1859' GROUP BY ArrTimeBlk
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier > 'FL' GROUP BY LongestAddGTime, CancellationCode
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID IN (33342, 31136) GROUP BY CRSArrTime, UniqueCarrier
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY OriginStateName, Flights
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter IN (1, 2)
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek < 2 AND Origin BETWEEN 'JAN' AND 'PIT'
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName < 'Maryland'
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn BETWEEN 1430 AND 2003
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips IN (56, 39) AND DestAirportID IN (12954, 13577, 11315, 11066) GROUP BY OriginCityName, DayOfWeek
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE ActualElapsedTime BETWEEN 80 AND 92 AND TaxiIn IN (1, 162, 54, 107) GROUP BY DivDistance, LateAircraftDelay
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips > 27 AND CRSDepTime BETWEEN 752 AND 1530 GROUP BY LateAircraftDelay
+SELECT SUM(DepDelay) FROM myStarTable WHERE CRSElapsedTime IN (186, 240, 485, 152) GROUP BY Month, DestCityName
+SELECT SUM(DepDelay) FROM myStarTable WHERE NASDelay <= 65 AND DepTime >= 907 GROUP BY OriginAirportSeqID
+SELECT SUM(ArrDelay) FROM myStarTable WHERE FlightDate IN ('2014-06-04') AND DivAirportLandings < 9 GROUP BY OriginStateName, OriginWac
+SELECT SUM(DepDelay) FROM myStarTable WHERE DistanceGroup = 10 AND DestStateFips BETWEEN 4 AND 72 GROUP BY UniqueCarrier, Year
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 4623 AND 7364 GROUP BY DayOfWeek, TotalAddGTime
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Diverted IN (-2147483648, 1, 0) AND SecurityDelay <= 22 AND FlightNum BETWEEN 3574 AND 3812 GROUP BY AirTime, FlightDate
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE FlightDate <= '2014-02-02' AND LongestAddGTime BETWEEN 8 AND 148 AND OriginCityName < 'Raleigh/Durham, NC' GROUP BY TaxiIn
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 37 AND 92
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID BETWEEN 20398 AND 20409 AND DayofMonth IN (16, 3, 7, 11, 12) AND OriginStateName <= 'Nebraska'
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1073103 AND 1275803 AND AirlineID > 20436 GROUP BY DepTimeBlk
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn > 17 AND ActualElapsedTime IN (101) AND DestWac <> 63 GROUP BY ArrTimeBlk
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime BETWEEN 40 AND 943 AND OriginAirportID < 13198
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 33044 AND 33214 GROUP BY LateAircraftDelay, Flights
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn IN (2327, 138, 2035, 246, 646) AND Distance <= 1061 GROUP BY Origin, UniqueCarrier
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month BETWEEN -2147483648 AND 1 GROUP BY DayofMonth
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('1300-1359', '1900-1959', '2100-2159', '1100-1159', '1200-1259') GROUP BY DayOfWeek, DepTimeBlk
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn >= 2034 AND FlightDate >= '2014-01-10' GROUP BY OriginWac, DestStateFips
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, ArrTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, DistanceGroup
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 37 AND 61
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DepTimeBlk, DestAirportSeqID
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CRSElapsedTime < 243 AND NASDelay BETWEEN 2 AND 115 AND DepTime IN (600, 2324, 553, 634, 2319) GROUP BY DestStateName, CancellationCode
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayofMonth
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE CarrierDelay IN (276) GROUP BY NASDelay, FlightDate
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut BETWEEN 72 AND 102 GROUP BY NASDelay
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Year
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState BETWEEN 'CO' AND 'RI' AND LongestAddGTime BETWEEN 52 AND 101 GROUP BY WeatherDelay, OriginCityName
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = 1
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay IN (42, 16) GROUP BY FlightNum
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut IN (54, 153, 59, 15) AND OriginAirportID >= 10257 AND DepTime >= 309 GROUP BY DestAirportID, Month
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY Dest, Year
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime BETWEEN 366 AND 437 AND CRSDepTime BETWEEN 548 AND 1915 GROUP BY Month
+SELECT SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay <> 15 AND WheelsOff IN (718, 1109, 829, 1022, 1318) AND FlightNum IN (4124, 1387, 809, 3990) GROUP BY AirTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '1200-1259' AND '1800-1859' GROUP BY DestStateName, CarrierDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState IN ('PA', 'PR', 'AK', 'UT') GROUP BY DestAirportID, OriginAirportID
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth BETWEEN 11 AND 16 AND Distance IN (137) AND WeatherDelay <> 82 GROUP BY DivAirportLandings, DestState
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE FirstDepTime <> 1940 AND Quarter > 3
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Carrier <> 'F9' AND TaxiIn <> 53 GROUP BY DestWac, DayofMonth
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestWac <> 43 AND OriginWac > 66
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WheelsOff, DivActualElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID IN (15607, 11193, 11109, 10561, 13184)
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime BETWEEN 22 AND 90 GROUP BY DistanceGroup
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut = 8 GROUP BY DayOfWeek, SecurityDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestCityName = 'Medford, OR' AND TailNum <= 'N292WN' GROUP BY DestStateName, DivDistance
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay IN (22, 4, -9999, 14) AND WheelsOn IN (1846) GROUP BY DestAirportID, Distance
+SELECT SUM(DepDelay) FROM myStarTable WHERE FlightDate BETWEEN '2014-08-22' AND '2014-09-17' AND OriginStateFips IN (10, 18) GROUP BY FirstDepTime, DistanceGroup
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE WheelsOn BETWEEN 431 AND 2229 AND OriginStateName BETWEEN 'Arizona' AND 'Utah' AND DivActualElapsedTime IN (382, 1321, 445, 446) GROUP BY OriginCityMarketID
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Origin <> 'RNO' AND WheelsOff IN (205, 111) GROUP BY Origin, OriginCityName
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, SecurityDelay
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek BETWEEN 3 AND 6 AND Diverted IN (1, 0, -2147483648) AND CarrierDelay BETWEEN 58 AND 252 GROUP BY OriginAirportSeqID, OriginStateFips
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE WeatherDelay >= 50 AND OriginCityName BETWEEN 'Champaign/Urbana, IL' AND 'Springfield, MO' AND TaxiOut BETWEEN 73 AND 131 GROUP BY OriginStateName
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LateAircraftDelay BETWEEN 58 AND 68 GROUP BY OriginStateFips, DivArrDelay
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk <> '1400-1459' GROUP BY Distance, LateAircraftDelay
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DestAirportSeqID
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac BETWEEN 5 AND 88 AND FirstDepTime BETWEEN 942 AND 1545
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Distance <> 2504 AND CRSElapsedTime IN (262, 615, 397) GROUP BY Year
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier >= 'EV' GROUP BY CRSElapsedTime
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Month <= 9 AND TotalAddGTime BETWEEN 66 AND 121
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID BETWEEN 14843 AND 15096 AND WeatherDelay BETWEEN 39 AND 132 GROUP BY WheelsOff
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TailNum, Distance
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips < 38 AND DivArrDelay = 173 AND CRSArrTime BETWEEN 147 AND 1318
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName BETWEEN 'Jackson, WY' AND 'Mosinee, WI' AND DistanceGroup > 2 AND TotalAddGTime IN (5, 74, 45) GROUP BY TaxiIn, UniqueCarrier
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Dest BETWEEN 'CMX' AND 'MGM' AND NASDelay IN (60, 8, 13) GROUP BY Year, TotalAddGTime
+SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID IN (30559, 35991)
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY CRSArrTime, Carrier
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DayofMonth BETWEEN 3 AND 27 AND Year IN (-2147483648, 2014) GROUP BY FlightDate, TaxiIn
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk < '1200-1259'
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime < 248 GROUP BY Distance, TotalAddGTime
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginStateFips BETWEEN -2147483648 AND 34 AND Diverted <= 0 GROUP BY DestCityName
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled = 0 GROUP BY TotalAddGTime
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Carrier, ArrTime
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings BETWEEN -2147483648 AND 9
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Cancelled IN (1, -2147483648, 0) AND CancellationCode IN ('B', 'noodles', 'C', 'ALL') GROUP BY DestCityName
+SELECT SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings BETWEEN 9 AND 9
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek BETWEEN 5 AND 7 AND TaxiOut IN (98, 115, 72, 62) AND Month BETWEEN -2147483648 AND 12
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime IN (101, 14, 47) GROUP BY Diverted
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE ActualElapsedTime BETWEEN 248 AND 318 GROUP BY OriginAirportSeqID
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginStateName = 'Iowa' AND UniqueCarrier = 'F9' AND DestStateFips < 18
+SELECT SUM(ArrDelay) FROM myStarTable WHERE AirlineID >= 19977 AND CarrierDelay <> 240
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID IN (12441) GROUP BY CRSElapsedTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, DistanceGroup
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DivArrDelay
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE Flights >= -2147483648 AND AirlineID BETWEEN 20366 AND 20398 AND FirstDepTime >= 1959 GROUP BY CRSElapsedTime, DepTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityName BETWEEN 'New Bern/Morehead/Beaufort, NC' AND 'Sitka, AK' AND DivDistance <> 0 AND DestAirportID IN (14588, 11097) GROUP BY TotalAddGTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Waterloo, IA', 'Elmira/Corning, NY', 'New York, NY', 'Manchester, NH', 'Scranton/Wilkes-Barre, PA') GROUP BY CancellationCode, WeatherDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID BETWEEN -2147483648 AND 19393 AND Month BETWEEN -2147483648 AND 3 GROUP BY WheelsOn, ActualElapsedTime
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityName >= 'Hilo, HI' AND OriginAirportID BETWEEN 10849 AND 11648 AND DestStateFips > 37 GROUP BY CancellationCode, ArrTimeBlk
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID BETWEEN 31097 AND 32129 AND Flights BETWEEN -2147483648 AND 1 AND AirTime BETWEEN 256 AND 395
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestAirportID >= 12339 AND Cancelled >= 1
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 1 AND DestAirportID <= 10620
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CancellationCode
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE Origin >= 'OAK' AND TaxiIn IN (52, 12) AND CRSArrTime > 2313 GROUP BY TailNum
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut IN (64, 39, 104, 59, 78) GROUP BY OriginCityName
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID >= 31447 AND DestCityName <= 'Helena, MT' AND ArrTimeBlk >= '1600-1659' GROUP BY TaxiIn
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE FirstDepTime <> 1024 AND OriginAirportSeqID IN (1529502) AND CRSDepTime <> 809 GROUP BY Year, WheelsOff
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityName IN ('Waco, TX', 'Cincinnati, OH', 'Abilene, TX') GROUP BY FlightNum, OriginStateName
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY WheelsOn, Year
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay IN (440, 1508, 96, 158) AND FlightNum < 4195 GROUP BY OriginCityName, DestCityMarketID
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DivArrDelay IN (489, 257, 44) AND LateAircraftDelay <> 337 GROUP BY WeatherDelay
+SELECT SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay BETWEEN -9999 AND 33 AND Origin <> 'BIL' GROUP BY OriginAirportSeqID, DivReachedDest
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE ActualElapsedTime BETWEEN 132 AND 349
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestState, FlightDate
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY WheelsOn, UniqueCarrier
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Carrier BETWEEN 'UA' AND 'VX' AND Origin <= 'PHF'
+SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiOut BETWEEN 74 AND 74 GROUP BY Carrier, OriginAirportSeqID
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest IN (-9999) AND DayOfWeek BETWEEN 5 AND 6 GROUP BY TaxiIn
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestStateName, Year
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay IN (110) GROUP BY Dest
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE CRSElapsedTime BETWEEN 51 AND 341 AND DayOfWeek IN (6, 3, -2147483648, 4) GROUP BY DistanceGroup, DepTimeBlk
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay <= 0 GROUP BY OriginStateName
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Quarter BETWEEN -2147483648 AND 2
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportID IN (11697) AND Origin BETWEEN 'DVL' AND 'LNK' GROUP BY OriginAirportSeqID, LongestAddGTime
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DistanceGroup
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE FirstDepTime < 1633 AND Month BETWEEN 7 AND 7 GROUP BY Month
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month BETWEEN 1 AND 6 AND NASDelay BETWEEN 65 AND 70 AND DestStateName BETWEEN 'Kentucky' AND 'Louisiana'
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightDate
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY AirlineID, OriginAirportSeqID
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayOfWeek
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights IN (-2147483648, 1) GROUP BY CancellationCode
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode IN ('noodles', 'C', 'A')
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightNum <> 7434 AND AirlineID < 20398
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier IN ('EV', 'OO', 'ALL', 'F9') AND AirTime IN (341, 37) AND FlightDate <> '2014-08-14' GROUP BY WeatherDelay, DivActualElapsedTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay <= 24 GROUP BY TaxiOut, DestState
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID IN (1082103) AND ActualElapsedTime <= 273 GROUP BY OriginCityMarketID, LateAircraftDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE TotalAddGTime IN (105, 84, 128, 29)
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Aguadilla, PR', 'Sun Valley/Hailey/Ketchum, ID', 'Guam, TT', 'Panama City, FL', 'Lexington, KY') AND NASDelay BETWEEN 21 AND 72 GROUP BY DestState
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID BETWEEN 11823 AND 13476 AND Distance > 102 GROUP BY DivAirportLandings
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE LongestAddGTime IN (87, 36, 17) AND DivReachedDest BETWEEN -2147483648 AND 1
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY ArrTimeBlk, DepTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Carrier BETWEEN 'B6' AND 'HA' AND DepTime <= 1007 AND DepTimeBlk IN ('1100-1159', '1300-1359', '1200-1259', '1900-1959', '1700-1759') GROUP BY DivActualElapsedTime
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup > 7 GROUP BY WheelsOff
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek IN (3, -2147483648, 2, 5) AND ArrTimeBlk <> '1700-1759' AND DestAirportSeqID IN (1106702) GROUP BY TailNum
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted IN (1, -2147483648, 0) GROUP BY TaxiOut
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSDepTime BETWEEN 2047 AND 2250 AND CRSElapsedTime BETWEEN 203 AND 660 GROUP BY DestCityName, OriginWac
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, Month
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CancellationCode, Month
+SELECT SUM(DepDelay) FROM myStarTable WHERE Origin IN ('GSO') GROUP BY DestState, OriginWac
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime >= 1731 AND Diverted >= 0
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay < 14 GROUP BY ArrTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Distance BETWEEN 305 AND 826
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY OriginStateName
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DestAirportID IN (15411) GROUP BY Distance, ArrTimeBlk
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState IN ('IL') AND OriginAirportSeqID <= 1104203 GROUP BY CarrierDelay, OriginCityName
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID < 13127 GROUP BY ArrTimeBlk, TaxiOut
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, FlightDate
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOn IN (118, 459, 1718, 2003) AND DestState BETWEEN 'AL' AND 'WI' AND DestCityName = 'Pittsburgh, PA'
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay BETWEEN 6 AND 8 GROUP BY DivArrDelay, TaxiIn
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY Distance
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTime IN (904) AND Cancelled <> 1 GROUP BY DayofMonth
+SELECT SUM(DepDelay) FROM myStarTable WHERE CarrierDelay BETWEEN 14 AND 19 AND TaxiIn BETWEEN 39 AND 51 GROUP BY WheelsOff, OriginCityName
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestState >= 'ND' AND DestStateName IN ('Rhode Island', 'Kansas', 'North Carolina') GROUP BY UniqueCarrier
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, FirstDepTime
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac IN (2, 42)
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivDistance < 157 AND Origin IN ('AUS') GROUP BY TaxiIn, DepTime
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTime IN (1016, 2124, 1243, 548, 1247) AND Diverted IN (0, 1, -2147483648) AND DestCityName > 'Manchester, NH'
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year BETWEEN -2147483648 AND 2014 AND DayofMonth BETWEEN 10 AND 28
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TailNum = 'N945UW'
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DepTime >= 1159 AND DivDistance BETWEEN 696 AND 2994 GROUP BY DivArrDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateName BETWEEN 'South Carolina' AND 'Wyoming' GROUP BY DivReachedDest
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek BETWEEN 3 AND 7 AND OriginStateFips BETWEEN 12 AND 33 AND WheelsOn > 2112
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, DivDistance
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Flights IN (1, -2147483648) AND DivDistance BETWEEN 376 AND 390 GROUP BY DivAirportLandings, WheelsOn
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirTime
+SELECT SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay > 298 AND Quarter >= 2 GROUP BY AirlineID
+SELECT SUM(DepDelay) FROM myStarTable WHERE DepTime < 731 GROUP BY OriginCityMarketID
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier > 'UA' AND OriginCityName BETWEEN 'Pittsburgh, PA' AND 'Texarkana, AR' GROUP BY DestStateName, DivAirportLandings
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime > 2202 AND DestCityMarketID BETWEEN 31867 AND 31995
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID IN (11013, 10208, 10874) GROUP BY ActualElapsedTime, Month
+SELECT SUM(DepDel15) FROM myStarTable WHERE DivDistance IN (227, 967, 255, 773, 3784) GROUP BY Quarter
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips BETWEEN 26 AND 53 AND CancellationCode BETWEEN 'B' AND 'noodles' GROUP BY DestCityMarketID
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips IN (53, 72, 16, 32) AND OriginWac IN (62, 54) GROUP BY DestAirportID, OriginState
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime IN (131, 128, 24, 44, 63) GROUP BY OriginCityName
+SELECT SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime IN (128, 78) AND TailNum BETWEEN 'N12924' AND 'N928DN' AND TotalAddGTime > 74 GROUP BY CRSDepTime
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest BETWEEN -9999 AND 1 GROUP BY ActualElapsedTime, ArrTimeBlk
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Origin BETWEEN 'BKG' AND 'GRB'
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginState
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 11140 AND 11624 AND DayOfWeek IN (-2147483648, 7, 5) AND DestStateName < 'Illinois' GROUP BY OriginStateFips
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup < 5 AND ActualElapsedTime > 81
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime BETWEEN 404 AND 425 AND DestWac > 14 AND TaxiOut BETWEEN 4 AND 16 GROUP BY OriginState, DestCityName
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime IN (150, 272, 40, 172, 394) GROUP BY DistanceGroup, DestCityMarketID
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN -2147483648 AND 1957 AND OriginStateName BETWEEN 'Georgia' AND 'Massachusetts'
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1068502, 1058102, 1025702, 1226402) AND DestState BETWEEN 'IN' AND 'NM' AND OriginAirportID IN (15412, 12953, 10561, 10926, 12264) GROUP BY DestAirportSeqID
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID <> 1419304 AND FlightNum BETWEEN 2519 AND 6273 AND DestAirportID IN (14908, 11624) GROUP BY ActualElapsedTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Distance <= 1294 AND OriginAirportID BETWEEN 10170 AND 10408 GROUP BY CarrierDelay
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier <> 'MQ' AND Quarter >= 3 GROUP BY DayofMonth
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateName > 'Montana' AND FlightDate BETWEEN '2014-07-24' AND '2014-08-15' AND DivActualElapsedTime BETWEEN 225 AND 884 GROUP BY Origin, Carrier
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE WeatherDelay <= 25 GROUP BY Dest
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, Month
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginWac BETWEEN 5 AND 21 AND Distance BETWEEN 475 AND 611 AND DestStateFips BETWEEN 30 AND 55 GROUP BY DivDistance
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime = 50 AND Origin BETWEEN 'ADQ' AND 'LCH' GROUP BY DestStateName, DepTime
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayofMonth
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, Flights
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest <> -2147483648 AND UniqueCarrier <= 'UA' AND DestState IN ('WA', 'NY', 'OK', 'NH', 'NM')
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityMarketID > 33377 AND CRSDepTime <> 1755 GROUP BY SecurityDelay, DistanceGroup
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DayofMonth BETWEEN 1 AND 17 AND OriginWac < 38 GROUP BY DestStateName
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE LongestAddGTime BETWEEN 109 AND 122 GROUP BY DepTime
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID < 30141 GROUP BY TailNum, Diverted
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier >= 'HA' AND DestStateName = 'Virginia' AND AirTime IN (543, 185, 20) GROUP BY DayofMonth
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Carrier BETWEEN 'HA' AND 'WN' AND DivActualElapsedTime IN (413, 951) GROUP BY DepTimeBlk, DepTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName IN ('Georgia', 'South Dakota') AND SecurityDelay <= 41 AND OriginWac BETWEEN 2 AND 34 GROUP BY OriginAirportSeqID
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID BETWEEN 33214 AND 33495 GROUP BY TotalAddGTime
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTime IN (839) AND TaxiIn BETWEEN -9999 AND 12 GROUP BY WheelsOff
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Dest BETWEEN 'FAY' AND 'GCK'
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, DivReachedDest
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DepTime BETWEEN 1638 AND 1645 GROUP BY DivActualElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Origin BETWEEN 'MGM' AND 'SRQ' AND UniqueCarrier <= 'DL' AND CRSArrTime BETWEEN 1912 AND 2355 GROUP BY DistanceGroup
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime < 2208 GROUP BY OriginAirportSeqID, TailNum
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiIn <= 109 AND CancellationCode > 'C'
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DivArrDelay <= 64 AND Carrier IN ('WN', 'DL') GROUP BY DivReachedDest
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime IN (321, 320, 120) AND DestStateFips IN (37, 5, 75) GROUP BY OriginStateFips
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance BETWEEN 109 AND 283
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayofMonth
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DayofMonth BETWEEN 14 AND 31 AND WeatherDelay IN (135, 194, 95, 27)
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestStateFips < 19 GROUP BY DivReachedDest, FlightNum
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DepTimeBlk
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest BETWEEN 0 AND 1
+SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOff > 1210
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips BETWEEN 46 AND 54 GROUP BY WheelsOff
+SELECT SUM(DepDelay) FROM myStarTable WHERE Dest > 'ADK'
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportID IN (11076, 10361, 10299, 13851) AND OriginStateFips <> 28 GROUP BY DepTime, TailNum
+SELECT SUM(DepDel15) FROM myStarTable WHERE CarrierDelay BETWEEN 83 AND 262 GROUP BY UniqueCarrier
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiIn BETWEEN 27 AND 34 AND Cancelled BETWEEN 0 AND 1 GROUP BY Carrier, CRSDepTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier IN ('B6') GROUP BY ArrTime, DestAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityName < 'Bellingham, WA' AND ArrTimeBlk BETWEEN '1500-1559' AND '1700-1759' GROUP BY DistanceGroup, DayofMonth
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance BETWEEN 307 AND 488 GROUP BY DestAirportID, Month
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateName
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY FlightNum
+SELECT SUM(DepDelay) FROM myStarTable WHERE Diverted >= 1 AND TotalAddGTime BETWEEN 60 AND 90 GROUP BY TaxiIn, Origin
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 11002 AND 13830 GROUP BY DepTimeBlk, Year
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff <> 2220 GROUP BY LongestAddGTime, DayOfWeek
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Origin BETWEEN 'GTR' AND 'VEL' GROUP BY DestAirportID
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips IN (20, 27, 29, 44) GROUP BY WheelsOff, OriginCityMarketID
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest >= -9999 AND CRSDepTime > 2001 GROUP BY OriginState
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime <= 1125 AND DestState IN ('NE', 'WV') GROUP BY WheelsOn
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Carrier IN ('WN', 'DL', 'OO', 'EV', 'MQ') AND Cancelled BETWEEN -2147483648 AND 1 AND CRSElapsedTime = 358 GROUP BY UniqueCarrier, TaxiIn
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestCityName <> 'Great Falls, MT' AND OriginAirportID <= 13873 GROUP BY TaxiIn
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY FirstDepTime, TaxiOut
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime IN (444, 121) GROUP BY Carrier
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 4473 AND 6055 AND WeatherDelay BETWEEN 105 AND 179 AND Distance <= 629 GROUP BY OriginAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime IN (514)
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TotalAddGTime
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE LongestAddGTime BETWEEN 74 AND 193
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE WheelsOn BETWEEN 709 AND 957 GROUP BY DayOfWeek
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TailNum
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CRSElapsedTime BETWEEN 208 AND 447 GROUP BY NASDelay
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 14 AND 92 AND WheelsOff IN (1243) GROUP BY DivAirportLandings
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID <= 34588 AND DepTime BETWEEN 1028 AND 2018 GROUP BY ArrTimeBlk, CRSArrTime
+SELECT SUM(DepDelay) FROM myStarTable WHERE TaxiIn IN (101, 127, 31, 95)
+SELECT SUM(DepDelay) FROM myStarTable WHERE WeatherDelay IN (405, 33, 44, 11)
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID IN (30397, 31703, 32016)
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Origin >= 'VPS' AND DestAirportID BETWEEN 10713 AND 12896 AND ArrTime >= 534
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Year, OriginAirportSeqID
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier <> 'AS' GROUP BY DivReachedDest, TaxiIn
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier BETWEEN 'HA' AND 'WN' AND DestStateName IN ('Georgia', 'Maine', 'Missouri', 'Idaho')
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY Cancelled, LongestAddGTime
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportSeqID, TailNum
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOff >= 1134 AND Diverted BETWEEN -2147483648 AND 0 AND LongestAddGTime BETWEEN 37 AND 45 GROUP BY LateAircraftDelay, DayOfWeek
+SELECT SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportID
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirTime BETWEEN 14 AND 127 AND DestAirportSeqID IN (1013603, 1251102) GROUP BY Month
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DestStateFips
+SELECT SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY WeatherDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE AirTime BETWEEN 201 AND 348 AND UniqueCarrier BETWEEN 'AA' AND 'B6' GROUP BY OriginAirportID
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = 366 GROUP BY OriginCityMarketID, TaxiIn
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (-9999, 0) GROUP BY DivReachedDest, Diverted
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName IN ('Virginia', 'Alabama', 'Maryland') AND DivArrDelay BETWEEN 247 AND 312
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestStateName >= 'Delaware' AND TaxiOut <= 22 AND DivAirportLandings BETWEEN 2 AND 2
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DivDistance = 105
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek BETWEEN 5 AND 5 AND Cancelled > 0 AND CancellationCode >= 'ALL' GROUP BY DestStateFips, CRSDepTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DistanceGroup, AirTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE TaxiOut <= 134 AND CRSElapsedTime BETWEEN 164 AND 231 AND UniqueCarrier BETWEEN 'ALL' AND 'F9' GROUP BY SecurityDelay
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE NASDelay <= 327 AND FlightDate BETWEEN '2014-03-09' AND '2014-10-17' GROUP BY CRSArrTime, Origin
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE AirTime = 270 GROUP BY DistanceGroup
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState IN ('AZ', 'OK', 'NM', 'IA', 'WI') AND DestStateName BETWEEN 'Maryland' AND 'Montana' GROUP BY ArrTime, DivDistance
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Dest >= 'OAJ' GROUP BY LongestAddGTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE CRSElapsedTime <> 168 AND ActualElapsedTime BETWEEN 196 AND 208 AND OriginStateFips IN (78, 56, 42, 72, 35) GROUP BY OriginState
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportID BETWEEN 10372 AND 11697
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY TailNum, TaxiIn
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSArrTime IN (508) GROUP BY DepTimeBlk
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOn, CRSArrTime
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DepTime, DestStateFips
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Month BETWEEN -2147483648 AND 7 AND OriginAirportSeqID BETWEEN 1199603 AND 1477101 AND OriginCityMarketID < 32884
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff <= 2106 AND LongestAddGTime IN (6, 53, 121)
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay BETWEEN 50 AND 101 AND TailNum > 'N907DL' AND DepTimeBlk < '1200-1259' GROUP BY OriginCityMarketID
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName BETWEEN 'Colorado' AND 'Hawaii' GROUP BY Distance, DestWac
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1289102 AND 1295402 AND DestCityMarketID BETWEEN 30257 AND 33184 AND LongestAddGTime BETWEEN 14 AND 66
+SELECT SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'Hawaii' AND OriginAirportSeqID <> 1320402 AND FlightNum >= 898
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TaxiIn <> 22 AND UniqueCarrier = 'AA'
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '0600-0659' AND '2100-2159' AND OriginCityMarketID IN (33127, 34653) AND DayofMonth BETWEEN 18 AND 18
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivArrDelay, DestWac
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate BETWEEN '2014-02-25' AND '2014-08-30' AND SecurityDelay BETWEEN 9 AND 42 GROUP BY DestAirportID, WheelsOn
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier BETWEEN 'AS' AND 'US' GROUP BY Quarter
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate > '2014-08-23' AND CancellationCode IN ('A', 'C', 'noodles', 'ALL') AND DivDistance BETWEEN 896 AND 2398 GROUP BY NASDelay
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips BETWEEN 15 AND 39 GROUP BY Quarter
+SELECT SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk BETWEEN '1100-1159' AND '2200-2259' GROUP BY TaxiOut
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn <> 338 GROUP BY Flights
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE CarrierDelay BETWEEN 42 AND 208
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode IN ('ALL', 'B', 'noodles', 'C')
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Distance BETWEEN 451 AND 461 GROUP BY DestCityMarketID, OriginWac
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Distance, TotalAddGTime
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime IN (37, 8, 27, 60, 126)
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestState IN ('OR', 'CA', 'AL', 'MA', 'FL')
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (0, -2147483648) GROUP BY DestStateName, CRSDepTime
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 11637 AND 14685 AND CRSElapsedTime >= 344
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestWac IN (3, 51, 52, 87) GROUP BY CRSArrTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn BETWEEN -9999 AND 80 AND SecurityDelay BETWEEN -9999 AND 4 AND Month <> 5 GROUP BY OriginAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier > 'DL' AND CRSArrTime IN (427, 2333, 2215, 1856, 1752) AND DestState BETWEEN 'KY' AND 'VI'
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginWac, DivArrDelay
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime IN (42) AND DestState <= 'MA'
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginState IN ('OR') GROUP BY Cancelled, TaxiIn
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, DivDistance
+SELECT SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier IN ('OO', 'WN', 'MQ', 'EV') GROUP BY LongestAddGTime
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE UniqueCarrier IN ('OO', 'MQ', 'ALL') GROUP BY OriginState
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 31997 AND 33970 AND CRSDepTime <> 2302 AND Cancelled BETWEEN 0 AND 1
+SELECT SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk IN ('0800-0859') AND LongestAddGTime BETWEEN 45 AND 93 AND DestAirportSeqID BETWEEN 1298202 AND 1469802 GROUP BY DivArrDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TailNum
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE OriginWac <> 36 AND DestWac <= 23 AND OriginState BETWEEN 'MO' AND 'TN'
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month BETWEEN 7 AND 10 AND TaxiIn <> 82 AND ActualElapsedTime <= 370 GROUP BY TailNum, DestStateName
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime <= 552 AND OriginStateFips IN (53, 38) GROUP BY OriginAirportID, Carrier
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('State College, PA', 'Meridian, MS', 'Bakersfield, CA', 'Santa Maria, CA', 'Scranton/Wilkes-Barre, PA') AND CRSArrTime BETWEEN 27 AND 724
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay IN (103, 34, 20, 123, 125) GROUP BY DivReachedDest, DivArrDelay
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1219102) AND Quarter BETWEEN -2147483648 AND 1 AND DestState BETWEEN 'MD' AND 'OR'
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Dest BETWEEN 'ISN' AND 'TLH' AND NASDelay BETWEEN 129 AND 213 AND OriginStateFips BETWEEN 25 AND 78 GROUP BY NASDelay
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE TailNum <> 'N783AA' AND LateAircraftDelay BETWEEN -9999 AND 147 AND OriginAirportSeqID BETWEEN 1232002 AND 1477101
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportID, CRSElapsedTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'Hawaii' AND 'Rhode Island' AND Diverted BETWEEN -2147483648 AND 0
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn BETWEEN 15 AND 69 GROUP BY DepTime, OriginState
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, DestStateName
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Origin, CRSArrTime
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 22 AND 71 AND FlightDate <> '2014-02-26' GROUP BY AirTime, Dest
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay BETWEEN 76 AND 424 AND TailNum <= 'N198DN' AND DestCityName BETWEEN 'Fairbanks, AK' AND 'St. George, UT' GROUP BY FirstDepTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup BETWEEN 5 AND 6 GROUP BY ArrTimeBlk
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Month, NASDelay
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityMarketID, FlightDate
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut, OriginCityName
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime > 441 AND ArrTimeBlk BETWEEN '0900-0959' AND '1400-1459'
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Carrier < 'EV'
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '1900-1959' AND 'ALL' AND ArrTimeBlk BETWEEN '1500-1559' AND '2000-2059' GROUP BY DayofMonth
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, LongestAddGTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivActualElapsedTime <= 1317 AND DivReachedDest IN (1, 0, -9999, -2147483648)
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityName IN ('Medford, OR', 'Lihue, HI', 'Phoenix, AZ', 'Gulfport/Biloxi, MS', 'Wrangell, AK') AND CarrierDelay BETWEEN 0 AND 89 GROUP BY Quarter
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance IN (1521, 868, 84, 29) GROUP BY AirlineID, DepTimeBlk
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay = 27 AND OriginAirportID >= 14828 AND DistanceGroup < 10 GROUP BY Quarter
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY FlightDate, CRSDepTime
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE NASDelay < 174 AND Dest IN ('HOU', 'SGF') AND TailNum BETWEEN 'N527MQ' AND 'N567AA' GROUP BY Flights, DayOfWeek
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime IN (3) GROUP BY FirstDepTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Dest
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID
+SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivActualElapsedTime, NASDelay
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DestAirportSeqID = 1129202
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TotalAddGTime IN (83, -2147483648, 29) AND Carrier BETWEEN 'AS' AND 'FL' GROUP BY DivDistance, FlightNum
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightDate BETWEEN '2014-03-14' AND '2014-12-21' AND Quarter IN (3) AND DivDistance BETWEEN 604 AND 1166 GROUP BY LateAircraftDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier BETWEEN 'AA' AND 'EV' AND WheelsOn > 1712 GROUP BY Diverted
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID IN (15919, 11641, 13388)
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings IN (2) GROUP BY UniqueCarrier, TailNum
+SELECT SUM(DepDel15) FROM myStarTable WHERE DepTime <= 556 GROUP BY DayofMonth
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState IN ('RI', 'ALL', 'SC', 'UT') AND Year BETWEEN -2147483648 AND 2014
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTime < 700 AND OriginAirportSeqID >= 1474703 AND DestState BETWEEN 'CT' AND 'CT' GROUP BY CarrierDelay, DestCityName
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay BETWEEN 8 AND 41 AND OriginState <= 'SC' GROUP BY FirstDepTime
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE OriginCityName >= 'San Angelo, TX'
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName BETWEEN 'Baltimore, MD' AND 'St. Louis, MO'
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CarrierDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled <= 1 GROUP BY LateAircraftDelay, DepTime
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CRSDepTime IN (1037, 1730, 519, 833) AND OriginStateFips > 26 GROUP BY DestWac
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivDistance BETWEEN 93 AND 460
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk BETWEEN '0600-0659' AND '2000-2059' AND FlightDate IN ('2014-01-31', '2014-09-02') GROUP BY DestStateName, SecurityDelay
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk BETWEEN '0001-0559' AND '1300-1359' AND UniqueCarrier = 'UA' AND CRSDepTime <> 1422 GROUP BY Diverted, OriginStateName
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate IN ('2014-08-14', '2014-07-31', '2014-09-24', '2014-10-08') AND CRSArrTime >= 1025 AND CarrierDelay BETWEEN 19 AND 321
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime BETWEEN 51 AND 86 AND Year BETWEEN -2147483648 AND 2014 GROUP BY TailNum, FlightDate
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Diverted
+SELECT SUM(ArrDel15) FROM myStarTable WHERE FlightDate >= '2014-10-08'
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Distance
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivActualElapsedTime BETWEEN 273 AND 1527 GROUP BY DestAirportID, WheelsOff
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE UniqueCarrier BETWEEN 'B6' AND 'DL' AND CarrierDelay BETWEEN 67 AND 121 GROUP BY TaxiIn
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportID <= 12339 AND Quarter BETWEEN -2147483648 AND 1 AND ActualElapsedTime IN (365, 266, 617, 379, 39) GROUP BY DestAirportID, CRSElapsedTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (5, -2147483648) GROUP BY WheelsOff, Carrier
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month BETWEEN 3 AND 8 AND OriginCityName BETWEEN 'Birmingham, AL' AND 'Eau Claire, WI' AND DistanceGroup BETWEEN 5 AND 10 GROUP BY NASDelay
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk BETWEEN '2200-2259' AND 'ALL' GROUP BY CRSDepTime, TaxiIn
+SELECT SUM(ArrDelay) FROM myStarTable WHERE FlightDate BETWEEN '2014-05-19' AND '2014-06-25' GROUP BY OriginStateFips
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Carrier >= 'ALL' GROUP BY AirlineID, OriginCityName
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestStateFips BETWEEN 4 AND 55 AND CarrierDelay BETWEEN 102 AND 102 GROUP BY OriginAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY TaxiOut, Month
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Distance IN (683, 742, 157, 274) AND DestStateName IN ('North Dakota', 'California', 'New York', 'Illinois', 'Louisiana')
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled < 1 AND TaxiIn = 10 AND AirTime IN (481, 145, 343, 80) GROUP BY Origin
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE CarrierDelay IN (51, 455, 186, 175, 82) AND DestStateName BETWEEN 'Delaware' AND 'Wyoming' AND OriginStateName <= 'Michigan'
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivDistance
+SELECT SUM(DepDelay) FROM myStarTable WHERE Cancelled IN (0, -2147483648, 1) AND ArrTime IN (739) GROUP BY OriginWac, SecurityDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ActualElapsedTime >= 373 AND WheelsOff BETWEEN 145 AND 1957 GROUP BY DivDistance
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE OriginWac IN (63, 11, 74, 45, 16) GROUP BY Origin, WheelsOn
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Distance IN (490, 1158, 2267)
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, Diverted
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, DivReachedDest
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips IN (36, 13) AND ActualElapsedTime BETWEEN 110 AND 617 AND CRSElapsedTime BETWEEN 565 AND 575 GROUP BY OriginStateName, FlightDate
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY TailNum
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE AirTime IN (269) GROUP BY DestAirportID, AirlineID
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE NASDelay BETWEEN 123 AND 288
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('2100-2159', '2300-2359')
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DivActualElapsedTime BETWEEN 317 AND 609 GROUP BY DestAirportID
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled IN (1, 0, -2147483648) GROUP BY OriginState
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled BETWEEN -2147483648 AND 1 GROUP BY DestStateName, CancellationCode
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime IN (109, 56, 41, 100) AND CRSDepTime <> 1913 GROUP BY Cancelled, DepTimeBlk
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY FlightNum
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTime, NASDelay
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime = 40 AND WeatherDelay <> 228 GROUP BY DistanceGroup
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, Month
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay <= 205 AND Diverted <> -2147483648 AND CarrierDelay > 39
+SELECT SUM(ArrDel15) FROM myStarTable WHERE LongestAddGTime IN (4, 53) AND DepTimeBlk BETWEEN '0600-0659' AND 'ALL' GROUP BY OriginCityName
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime IN (643, 629) GROUP BY OriginStateName, DepTimeBlk
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1158702, 1110902, 1200302) GROUP BY OriginAirportSeqID, TaxiIn
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CarrierDelay, DivArrDelay
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Month BETWEEN 7 AND 9 AND ArrTimeBlk IN ('2000-2059', '1000-1059') GROUP BY Origin
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime >= 281
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID BETWEEN 10397 AND 11726 GROUP BY OriginStateName, Flights
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY DestWac, WeatherDelay
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID IN (20409, 20436, 19790) AND DistanceGroup > 8
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Quarter BETWEEN -2147483648 AND 4 AND CarrierDelay IN (187, 228, 25, 238, 137) AND WheelsOn BETWEEN 731 AND 1619 GROUP BY DestStateName, NASDelay
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier BETWEEN 'VX' AND 'WN' GROUP BY DivArrDelay
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID BETWEEN 30146 AND 30436 AND FlightNum BETWEEN 897 AND 1388 AND Cancelled BETWEEN -2147483648 AND 0 GROUP BY NASDelay
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE WheelsOn IN (457, 1243, 1355)
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Carrier >= 'OO' GROUP BY DivArrDelay
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID IN (1524903, 1288903) AND UniqueCarrier < 'OO' AND DepTime BETWEEN 1232 AND 1727
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime BETWEEN 13 AND 85 GROUP BY FlightNum, DayOfWeek
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginState = 'MT' GROUP BY AirlineID, DivReachedDest
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportID > 10980 AND FlightDate IN ('2014-06-18', '2014-01-29', '2014-08-27', '2014-10-25', '2014-08-21') GROUP BY DestStateFips, TailNum
+SELECT SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay > 9 AND FlightNum > 106 GROUP BY OriginCityMarketID, DestAirportID
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime > 135 AND TaxiOut < 130 GROUP BY LongestAddGTime, OriginCityName
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, CRSElapsedTime
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE NASDelay BETWEEN 162 AND 378
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestWac BETWEEN 41 AND 65 AND CarrierDelay >= 36 GROUP BY Year, ArrTimeBlk
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE FlightDate < '2014-01-05' AND OriginAirportID <> 14193 GROUP BY Year
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY DayofMonth, FlightNum
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest BETWEEN 0 AND 1 GROUP BY Flights
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestState, Flights
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay >= 33 AND CRSDepTime BETWEEN 1928 AND 2345 AND Year BETWEEN 2014 AND 2014 GROUP BY Cancelled
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND TailNum BETWEEN 'N571UW' AND 'N8638A' AND ArrTime IN (1432) GROUP BY DivAirportLandings, Flights
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY UniqueCarrier
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime BETWEEN -9999 AND 90
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay BETWEEN 20 AND 935
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay BETWEEN 1 AND 24
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ArrTimeBlk, DistanceGroup
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Quarter IN (3, 4, 2) AND LateAircraftDelay <> 121 AND WheelsOn IN (2153, 718, 655, 1638) GROUP BY FirstDepTime
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime IN (1008) AND Carrier BETWEEN 'AA' AND 'AS'
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestStateFips BETWEEN 5 AND 38 AND TotalAddGTime > 3
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest BETWEEN 1 AND 1 AND OriginCityMarketID = 33127 GROUP BY DestWac
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Year
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTime IN (1615, 1208, 2006, 450) GROUP BY FirstDepTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Carrier BETWEEN 'HA' AND 'US' GROUP BY LateAircraftDelay
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter IN (3, 4, -2147483648, 1, 2)
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1098002 AND 1490503 GROUP BY CRSDepTime, OriginCityMarketID
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut IN (38, 83, 27) GROUP BY DivActualElapsedTime, DepTimeBlk
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayofMonth BETWEEN 4 AND 22 AND DivDistance > 600 GROUP BY TotalAddGTime, DestCityName
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth < 4 AND TailNum < 'N759GS'
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate IN ('2014-10-17', '2014-04-17', '2014-02-09', '2014-04-13') AND ActualElapsedTime <= 668
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiOut BETWEEN 48 AND 55
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Quarter > 3 GROUP BY UniqueCarrier
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY LateAircraftDelay, DestState
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportSeqID IN (1412202, 1234302) GROUP BY DestCityName
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips BETWEEN 34 AND 55 AND WheelsOn IN (1116, 1942, 2100, 1608) AND TailNum <> 'N614QX'
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY Origin
+SELECT SUM(DepDelay) FROM myStarTable WHERE CarrierDelay IN (37, 255) AND Quarter IN (3, 1, 2, -2147483648, 4) AND DivActualElapsedTime <> 1308 GROUP BY FlightNum, Cancelled
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1100303 AND 1161706 AND Quarter BETWEEN 4 AND 4
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn < 248 AND DestStateName = 'Wisconsin' GROUP BY CRSDepTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips IN (41, 46) GROUP BY Quarter
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TaxiOut, Year
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 1845 AND 1853 AND UniqueCarrier IN ('B6', 'F9', 'FL', 'AA') AND Carrier IN ('FL') GROUP BY ActualElapsedTime, DayofMonth
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay <= 50
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestStateFips IN (18) GROUP BY TaxiIn, DistanceGroup
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestState IN ('GA', 'MO', 'VI', 'PA') AND DestCityName BETWEEN 'Eau Claire, WI' AND 'Waterloo, IA' AND DepTimeBlk IN ('1100-1159', '1800-1859', '2000-2059')
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter BETWEEN 2 AND 3 AND WheelsOn IN (1607, 506) AND Origin < 'CAK' GROUP BY Quarter, FlightDate
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTimeBlk > '0700-0759' GROUP BY DestState, DepTimeBlk
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportID BETWEEN 10620 AND 11648 GROUP BY WheelsOn
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayofMonth <> 30
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityMarketID BETWEEN 30599 AND 33785 AND Distance BETWEEN 309 AND 628 GROUP BY DivAirportLandings
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE AirTime < 312
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY Year
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE FirstDepTime = 1954 AND UniqueCarrier BETWEEN 'AS' AND 'WN' GROUP BY Carrier, DivReachedDest
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityMarketID IN (32600) AND Cancelled IN (-2147483648, 1, 0) AND OriginAirportSeqID < 1164102 GROUP BY DayofMonth, ArrTimeBlk
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay <> 370 AND DestCityMarketID IN (31617, 32129, 31401, 32211, 32323) GROUP BY OriginState
+SELECT SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings IN (0, 9) GROUP BY Carrier, WheelsOn
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut IN (133, 86) AND ArrTimeBlk <= '1400-1459'
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, OriginState
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Diverted IN (0) GROUP BY Quarter
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY FirstDepTime, Distance
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportID IN (13931)
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE WeatherDelay <= 92 AND DestStateFips <> 24
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month < 9 GROUP BY DistanceGroup, DivArrDelay
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID BETWEEN 10926 AND 14893
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirTime BETWEEN 277 AND 380 AND WheelsOff BETWEEN 653 AND 1502
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ActualElapsedTime <= 122 GROUP BY UniqueCarrier
+SELECT SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk BETWEEN '1500-1559' AND '1500-1559'
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut, DivArrDelay
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TaxiIn, DestState
+SELECT SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay BETWEEN 87 AND 143 GROUP BY OriginState, Cancelled
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Cancelled
+SELECT SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CarrierDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay = 129
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE WheelsOff < 2354 AND DayofMonth BETWEEN 11 AND 23 GROUP BY DivDistance, Dest
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TotalAddGTime BETWEEN 45 AND 149 GROUP BY DestState
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter IN (-2147483648, 3, 2, 1) AND DestStateFips BETWEEN 10 AND 15 AND LateAircraftDelay IN (30) GROUP BY DestAirportSeqID, WheelsOn
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Origin < 'MOB' AND DepTime IN (31) GROUP BY LateAircraftDelay, DestCityName
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityMarketID BETWEEN 31953 AND 33502 AND DayofMonth BETWEEN 7 AND 12 GROUP BY DivArrDelay, TailNum
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Month IN (1, 2, 4) AND Quarter BETWEEN -2147483648 AND 1 GROUP BY NASDelay, OriginAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 10551 AND 11423 AND CarrierDelay <> 455 GROUP BY DestStateName
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID > 31066
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk IN ('2000-2059', '1000-1059') AND Carrier IN ('MQ', 'UA', 'FL', 'OO', 'DL') AND DayofMonth BETWEEN 1 AND 8 GROUP BY WeatherDelay, OriginWac
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiIn
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled IN (-2147483648, 1, 0) GROUP BY AirTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE SecurityDelay > 6 AND DayOfWeek BETWEEN -2147483648 AND 2 AND DestStateFips >= 23 GROUP BY Dest, Diverted
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityMarketID BETWEEN 31867 AND 34113 AND DestWac <> 22 GROUP BY FlightDate, FlightNum
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivDistance IN (170, 733, 173, 54) GROUP BY WheelsOff
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay BETWEEN 138 AND 184 GROUP BY OriginCityName, OriginState
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay BETWEEN 3 AND 50
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportID, Diverted
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Quarter IN (2, 3, 4) AND FlightDate BETWEEN '2014-04-09' AND '2014-06-05' AND Diverted IN (0, -2147483648) GROUP BY DepTime
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE NASDelay BETWEEN 85 AND 119 AND DestState IN ('VI', 'MS', 'TN', 'PR') GROUP BY TailNum, FirstDepTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay IN (193) AND ArrTime >= 143
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter IN (2) AND ActualElapsedTime <= 137
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Diverted IN (1) AND DivDistance >= 849 AND DestStateFips IN (54, 42, 29, 15, 18) GROUP BY SecurityDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Diverted, DestCityName
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportSeqID IN (1111102, 1199603, 1104103, 1133703, 1345902) AND CRSDepTime BETWEEN 1324 AND 1842
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivArrDelay, DistanceGroup
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY LateAircraftDelay, LongestAddGTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportID IN (14006, 14633, 12448) AND OriginStateName IN ('U.S. Virgin Islands', 'Indiana', 'Iowa', 'Florida', 'New Jersey') AND DestCityMarketID BETWEEN 30990 AND 33105 GROUP BY DepTime, OriginAirportID
+SELECT SUM(ArrDelay) FROM myStarTable WHERE AirlineID IN (19930, 21171, 20398, 20436, 19977) AND CRSDepTime BETWEEN 848 AND 949 GROUP BY TotalAddGTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk BETWEEN '0900-0959' AND '1600-1659' AND Quarter IN (4, 2)
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY SecurityDelay, Quarter
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiOut BETWEEN 102 AND 105 AND OriginStateName < 'Idaho'
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 30140 AND 31049 AND OriginAirportID BETWEEN 10268 AND 14262 GROUP BY DestState
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate IN ('2014-04-04', '2014-12-27', '2014-01-03') AND DivAirportLandings IN (0, 1, 2, -2147483648)
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Cancelled IN (1, 0, -2147483648) AND LateAircraftDelay IN (179, 217) GROUP BY OriginCityMarketID
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest <= -9999 AND ArrTimeBlk IN ('1900-1959') AND CRSDepTime < 1050 GROUP BY WheelsOff
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest <= 0 GROUP BY DestAirportID, CRSElapsedTime
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Diverted BETWEEN 0 AND 1 AND DestWac IN (3, 5, 66, 39) AND DivArrDelay BETWEEN 118 AND 402 GROUP BY CarrierDelay
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'California' AND 'Montana' AND Dest >= 'SMF' AND Quarter IN (1, 2, 3, 4) GROUP BY FlightNum, AirlineID
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CarrierDelay
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestAirportID < 11823 AND Diverted BETWEEN -2147483648 AND 0 AND DayOfWeek > -2147483648 GROUP BY DayOfWeek
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginStateName >= 'Massachusetts' AND DivArrDelay IN (331, 213)
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY CRSElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName IN ('Oregon', 'Alabama') AND OriginCityMarketID > 34150 GROUP BY WheelsOff
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1412202, 1013603, 1393102)
+SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginCityName BETWEEN 'Bloomington/Normal, IL' AND 'Omaha, NE' AND Quarter <> 3 AND WheelsOff BETWEEN 28 AND 1036
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirTime < 401 AND ActualElapsedTime BETWEEN 202 AND 388 AND DepTimeBlk IN ('0600-0659', '1400-1459') GROUP BY DestAirportID
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '2000-2059' AND '2300-2359' GROUP BY CRSElapsedTime, TaxiIn
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings IN (9, 2, -2147483648) AND OriginAirportSeqID BETWEEN 1084903 AND 1560702 AND CancellationCode IN ('noodles', 'ALL', 'B', 'C', 'A') GROUP BY DestStateFips
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY ArrTimeBlk
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Flights IN (1, -2147483648)
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY WeatherDelay
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier <= 'B6' AND DestWac <> 14 AND DayofMonth IN (2, 18, 25) GROUP BY CRSArrTime, ArrTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE CancellationCode BETWEEN 'noodles' AND 'noodles' AND Flights IN (1, -2147483648) GROUP BY DestWac, DayOfWeek
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportSeqID
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Carrier <> 'AA' AND Diverted >= -2147483648
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn >= 2009 AND Carrier BETWEEN 'AA' AND 'MQ'
+SELECT SUM(ArrDel15) FROM myStarTable WHERE CRSElapsedTime BETWEEN 211 AND 339 AND AirlineID IN (20409, 20355, 19393, 19977, 19930) AND DestWac IN (1, 34, 38, 54) GROUP BY Quarter
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY Year, Distance
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Year
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay IN (95)
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DestWac, DivReachedDest
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff < 1943 GROUP BY CRSDepTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginWac IN (2, 38) AND FlightNum BETWEEN 4617 AND 7376 AND Quarter BETWEEN -2147483648 AND 3 GROUP BY DestWac
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName BETWEEN 'Arizona' AND 'Mississippi' AND LongestAddGTime BETWEEN 66 AND 70 AND Diverted BETWEEN 0 AND 0 GROUP BY TaxiOut
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn <= 39
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (4, -2147483648) AND DestCityMarketID IN (35991, 32575, 35041, 32888)
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode > 'C' AND WheelsOff BETWEEN 1745 AND 2148 AND DestAirportSeqID IN (1133602, 1066602, 1529502, 1188402) GROUP BY DayOfWeek
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DayofMonth > 18 AND NASDelay >= 44 GROUP BY DestCityName, NASDelay
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Distance IN (1727, 252, 873) GROUP BY WheelsOff, CRSDepTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID >= 11977 GROUP BY ArrTimeBlk
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY Carrier, OriginStateName
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = 1 GROUP BY OriginStateFips
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('2300-2359', '2200-2259') AND CRSElapsedTime <> 393 GROUP BY CarrierDelay
+SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE WheelsOn BETWEEN 1317 AND 1547 AND DistanceGroup >= 5 GROUP BY DayOfWeek
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestState
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, DayOfWeek
+SELECT SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirTime, Distance
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSDepTime BETWEEN 555 AND 717 AND ActualElapsedTime = 232 AND DestWac BETWEEN 38 AND 87 GROUP BY TailNum, FirstDepTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND DepTime IN (453, 103)
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginState IN ('AZ', 'LA', 'HI', 'CA', 'DE')
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime IN (173, 290, 339, 251, 450) AND DistanceGroup BETWEEN 4 AND 11 GROUP BY DestStateName
+SELECT SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime IN (490, 267, 538) AND CancellationCode BETWEEN 'ALL' AND 'noodles' AND SecurityDelay IN (33, -9999, 14, 15)
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE TaxiOut IN (9, 138, 60, 93) GROUP BY OriginAirportID
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Pago Pago, TT', 'Spokane, WA', 'Santa Fe, NM')
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TailNum
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY TotalAddGTime, UniqueCarrier
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime IN (102) AND ArrTimeBlk IN ('0001-0559', '1000-1059', '1600-1659', '0700-0759', '1100-1159') AND Flights IN (1, -2147483648)
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate BETWEEN '2014-07-08' AND '2014-09-14' AND LateAircraftDelay IN (259, 15) AND DivAirportLandings IN (-2147483648, 9, 2, 0) GROUP BY ArrTimeBlk
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestStateFips IN (21, 45, 32) AND OriginAirportSeqID <= 1348602 GROUP BY WeatherDelay
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (-2147483648, 0, -9999) AND OriginWac >= -2147483648 GROUP BY OriginWac
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Flights
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CRSArrTime <> 1037 AND Dest IN ('SIT')
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'Alabama' AND 'Nevada'
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE Month IN (6, 11, 8, 4, 9) AND DestCityMarketID IN (33388)
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayofMonth = 28 AND OriginAirportSeqID > 1127802 GROUP BY FlightDate
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Quarter BETWEEN 2 AND 3 AND Origin BETWEEN 'ALL' AND 'GCK' GROUP BY Cancelled, NASDelay
+SELECT SUM(DepDel15) FROM myStarTable WHERE Origin IN ('GPT', 'MDW', 'PDX') GROUP BY TotalAddGTime, ActualElapsedTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Carrier
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestCityName, WeatherDelay
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DayofMonth <= 17 AND ArrTime IN (1405, 2211, 1952) AND OriginWac IN (3, 5, 65, 85) GROUP BY OriginState, TotalAddGTime
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay < 101 AND TaxiOut IN (27) GROUP BY Flights, Carrier
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year <> -2147483648 AND CRSDepTime BETWEEN 109 AND 1406
+SELECT SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivArrDelay BETWEEN 125 AND 191 AND DestAirportSeqID >= 1299204 AND DayofMonth < 10 GROUP BY OriginCityMarketID
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime <> 112 GROUP BY UniqueCarrier
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier IN ('FL', 'F9') GROUP BY DivAirportLandings
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOn >= 1400
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, DestCityName
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TailNum BETWEEN 'N453UA' AND 'N615SW' AND OriginStateName BETWEEN 'Nebraska' AND 'Tennessee' GROUP BY AirTime, FlightNum
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, OriginAirportID
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay <> 48
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Origin IN ('DCA', 'IAD') AND TaxiOut = 45 GROUP BY AirlineID
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportID
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest > -2147483648 AND CancellationCode IN ('noodles', 'ALL', 'A') GROUP BY FlightDate
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSArrTime >= 1725 AND CarrierDelay BETWEEN 17 AND 1139 AND Quarter BETWEEN 3 AND 4
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay BETWEEN 6 AND 200 AND OriginState <> 'UT'
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips IN (31, 55, 33, 32) AND LateAircraftDelay BETWEEN 81 AND 157
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN 1236 AND 2359 GROUP BY ArrTime, UniqueCarrier
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime BETWEEN 1016 AND 2319 AND NASDelay >= 203 AND DestCityName <> 'ALL'
+SELECT SUM(DepDelay) FROM myStarTable WHERE DayofMonth <= 2 AND DestStateName IN ('Washington', 'Kansas', 'Michigan', 'Connecticut', 'Maine') AND FlightDate >= '2014-11-27' GROUP BY Month, DestCityMarketID
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Origin > 'TUL' GROUP BY Carrier
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginWac IN (61, 22) AND LateAircraftDelay IN (25, 112)
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginCityMarketID IN (31714)
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter >= 1 GROUP BY Month
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestState
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TailNum BETWEEN 'N636JB' AND 'N682DA' AND FlightNum < 1797 GROUP BY Diverted, DistanceGroup
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE NASDelay <= 287 AND FlightNum IN (2434, 2307, 5668) GROUP BY DivActualElapsedTime, Diverted
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DepTime BETWEEN 904 AND 1639 AND DestState >= 'DE' GROUP BY Month
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights IN (1, -2147483648) AND DivArrDelay BETWEEN 138 AND 231 AND OriginAirportSeqID IN (1099002, 1537002)
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestAirportID <> 13029 AND Quarter IN (1, 3, -2147483648, 2) GROUP BY Dest, DestStateFips
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TailNum IN ('N495CA', 'N603MQ', 'N1607B', 'N446UA', 'N794AS') AND AirlineID BETWEEN 19690 AND 19805 AND Month BETWEEN 9 AND 12 GROUP BY WeatherDelay
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings IN (0) GROUP BY OriginCityMarketID
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, DestWac
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY WheelsOn, AirlineID
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE TaxiOut <> 118
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestStateFips BETWEEN 15 AND 28 AND SecurityDelay IN (18) GROUP BY Month, ActualElapsedTime
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime > 1544 AND DestWac BETWEEN 41 AND 81 AND DistanceGroup >= 11 GROUP BY DestCityName
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay IN (67) GROUP BY FlightDate, OriginState
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID < 31136 AND OriginWac IN (54, 52) AND DestAirportID IN (10154, 14520, 11433, 11041) GROUP BY DivArrDelay, DepTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestState IN ('OR') GROUP BY TaxiOut
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier IN ('OO', 'VX', 'AA', 'MQ', 'UA') AND WheelsOff BETWEEN 829 AND 1122 AND DestAirportSeqID IN (1411302, 1468502, 1119302, 1402702, 1345902)
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips > 54 GROUP BY TotalAddGTime
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac < 34 AND Dest <= 'GUC' AND DestCityMarketID BETWEEN 30070 AND 30361
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY TotalAddGTime
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE OriginAirportSeqID <= 1302402 AND Month <= 12
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE NASDelay BETWEEN 19 AND 152
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk IN ('2100-2159', '0700-0759', '1100-1159', '1400-1459') AND DestStateName > 'New Hampshire'
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CancellationCode, OriginStateName
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted, DestStateName
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted IN (-2147483648, 0, 1)
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestWac
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE AirTime <> 520 AND Distance IN (1521, 1488, 410) GROUP BY WheelsOff, DepTimeBlk
+SELECT SUM(ArrDel15) FROM myStarTable WHERE WheelsOff IN (1000, 1611, 854, 1712) GROUP BY ActualElapsedTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateName <= 'Florida' AND AirTime BETWEEN 190 AND 297 GROUP BY AirlineID
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Lihue, HI', 'Bend/Redmond, OR', 'Grand Forks, ND')
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Carrier BETWEEN 'B6' AND 'FL'
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Distance BETWEEN 260 AND 846 AND OriginStateFips BETWEEN 20 AND 55 GROUP BY TailNum, UniqueCarrier
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOff <= 1717 AND DistanceGroup IN (3, 9, -2147483648, 5, 10) AND OriginWac BETWEEN 64 AND 72 GROUP BY DestCityMarketID
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivArrDelay IN (527) AND OriginStateName BETWEEN 'Missouri' AND 'Puerto Rico' GROUP BY CRSArrTime, DivActualElapsedTime
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND OriginWac > 84
+SELECT SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestAirportSeqID IN (1217301, 1056103, 1324402, 1599102, 1558202) AND Year IN (-2147483648, 2014) GROUP BY DestWac
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestWac IN (2, 42) GROUP BY SecurityDelay
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime < 161 AND DestStateFips IN (56, 6, 24, 46) GROUP BY DestCityName, DistanceGroup
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth <= 10 GROUP BY CarrierDelay, OriginCityMarketID
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('0001-0559', '2300-2359', '2000-2059', '1100-1159', '1000-1059') AND WheelsOff <> 47
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivReachedDest
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND DestStateFips = 38
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CRSElapsedTime BETWEEN 227 AND 520 AND Carrier BETWEEN 'AS' AND 'DL' AND UniqueCarrier IN ('B6', 'AA', 'FL', 'UA', 'WN')
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID IN (1036102) AND UniqueCarrier BETWEEN 'B6' AND 'UA' AND ActualElapsedTime BETWEEN 78 AND 273
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn > 27 GROUP BY Month, CancellationCode
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestAirportID < 12982 GROUP BY DepTimeBlk
+SELECT SUM(ArrDelay) FROM myStarTable WHERE ArrTime BETWEEN 708 AND 1233 AND LateAircraftDelay >= 21 GROUP BY TaxiOut, DepTime
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportSeqID IN (1294503, 1410902) AND DepTime BETWEEN 24 AND 1422 GROUP BY TaxiOut
+SELECT SUM(DepDelay) FROM myStarTable WHERE Year BETWEEN 2014 AND 2014 AND CRSArrTime IN (2124, 2313) AND Carrier BETWEEN 'F9' AND 'F9'
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DestAirportID BETWEEN 10140 AND 12448 GROUP BY OriginStateFips
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE AirlineID BETWEEN 19690 AND 19805 GROUP BY OriginState
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 9
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, DepTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSElapsedTime, AirTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Carrier, OriginAirportID
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay IN (189, 43, 133, 101)
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportID BETWEEN 13198 AND 15376 AND FlightNum IN (6196, 6055, 5934, 730, 2012) GROUP BY SecurityDelay, OriginWac
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup BETWEEN 10 AND 10 AND DepTime IN (1315, 1616, 1325, 835) AND OriginAirportSeqID BETWEEN 1188402 AND 1289203
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled <> 1 AND LongestAddGTime BETWEEN 29 AND 54 AND DivArrDelay <= 80 GROUP BY ArrTimeBlk
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter <> 2 AND LateAircraftDelay BETWEEN 86 AND 141 AND DepTimeBlk BETWEEN '1300-1359' AND '1800-1859' GROUP BY ActualElapsedTime, FirstDepTime
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE FirstDepTime <= 553 GROUP BY LateAircraftDelay, OriginStateFips
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityName >= 'Oklahoma City, OK' AND CancellationCode IN ('C') AND FlightDate BETWEEN '2014-09-13' AND '2014-11-10' GROUP BY DepTime
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Carrier
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestWac, CRSElapsedTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime IN (71, 85, 126, 113) AND DestAirportSeqID BETWEEN 1302402 AND 1558202
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginStateFips BETWEEN 4 AND 78 AND DepTimeBlk BETWEEN '0600-0659' AND 'ALL'
+SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginWac <= 73 GROUP BY DestAirportID, DayOfWeek
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE FlightDate BETWEEN '2014-03-10' AND '2014-08-31' GROUP BY WheelsOff
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay IN (1, 33, 19) GROUP BY OriginStateName, ArrTimeBlk
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay IN (19) AND TailNum IN ('N378SW', 'N908DA') GROUP BY OriginStateFips
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year BETWEEN -2147483648 AND 2014 GROUP BY NASDelay, Diverted
+SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Distance BETWEEN 335 AND 721 AND DestState >= 'AK' GROUP BY TaxiIn
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek IN (5, 1) AND UniqueCarrier IN ('AS') AND TailNum >= 'N646UA'
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FirstDepTime
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginWac IN (1, 5, 41, 72, 16)
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightDate >= '2014-02-17' AND OriginCityName >= 'Fargo, ND'
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter IN (3) AND OriginStateName IN ('Nebraska', 'Hawaii', 'Illinois')
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime BETWEEN 48 AND 90 AND FlightDate > '2014-02-03' AND DivActualElapsedTime <> 652 GROUP BY CRSArrTime, OriginWac
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TotalAddGTime IN (67, 101, 17) AND Quarter IN (1, 4, 2, 3, -2147483648) AND CRSDepTime BETWEEN 205 AND 1001
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY TotalAddGTime, Flights
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance <> 395 AND OriginAirportSeqID IN (1468303) AND WeatherDelay IN (-9999, 109, 111, 51, 98) GROUP BY Carrier
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier IN ('DL', 'UA', 'F9', 'FL', 'VX') AND DestAirportID BETWEEN 10268 AND 14685
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID BETWEEN 19977 AND 20366 AND Cancelled BETWEEN 0 AND 1 AND FlightDate > '2014-09-06' GROUP BY OriginCityMarketID
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime > 600 AND DestAirportID = 11292
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestAirportID <= 15356 AND FlightNum < 6296 GROUP BY OriginState, FlightNum
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DepTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Year BETWEEN 2014 AND 2014 AND NASDelay BETWEEN 8 AND 146 GROUP BY DivAirportLandings
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Origin IN ('HOU', 'PVD')
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DestWac BETWEEN 37 AND 43

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/StarTreeQueryGenerator.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/StarTreeQueryGenerator.java
@@ -16,6 +16,14 @@
 package com.linkedin.pinot.tools.query.comparison;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.segment.index.loader.Loaders;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -289,5 +297,49 @@ public class StarTreeQueryGenerator {
    */
   public String nextQuery() {
     return buildQuery(generateAggregations(), generatePredicates(), generateGroupBys());
+  }
+
+  /**
+   * Given star tree segments directory and number of queries, generate star tree queries.
+   * Usage: StarTreeQueryGenerator starTreeSegmentsDirectory numQueries
+   *
+   * @param args arguments.
+   */
+  public static void main(String[] args)
+      throws Exception {
+    if (args.length != 2) {
+      System.err.println("Usage: StarTreeQueryGenerator starTreeSegmentsDirectory numQueries");
+      return;
+    }
+
+    // Get segment metadata for the first segment to get table name and verify query is fit for star tree.
+    File segmentsDir = new File(args[0]);
+    Preconditions.checkState(segmentsDir.exists());
+    Preconditions.checkState(segmentsDir.isDirectory());
+    File[] segments = segmentsDir.listFiles();
+    Preconditions.checkNotNull(segments);
+    File segment = segments[0];
+    IndexSegment indexSegment = Loaders.IndexSegment.load(segment, ReadMode.heap);
+    SegmentMetadata segmentMetadata = indexSegment.getSegmentMetadata();
+    String tableName = segmentMetadata.getTableName();
+
+    // Set up star tree query generator.
+    int numQueries = Integer.parseInt(args[1]);
+    SegmentInfoProvider infoProvider = new SegmentInfoProvider(args[0]);
+    StarTreeQueryGenerator generator =
+        new StarTreeQueryGenerator(tableName, infoProvider.getSingleValueDimensionColumns(),
+            infoProvider.getMetricColumns(), infoProvider.getSingleValueDimensionValuesMap());
+    Pql2Compiler compiler = new Pql2Compiler();
+
+    for (int i = 0; i < numQueries; i++) {
+      String query = generator.nextQuery();
+      System.out.println(query);
+
+      // Verify that query is fit for star tree.
+      BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+      Preconditions.checkState(
+          RequestUtils.isFitForStarTreeIndex(segmentMetadata, RequestUtils.generateFilterQueryTree(brokerRequest),
+              brokerRequest));
+    }
   }
 }


### PR DESCRIPTION
1. Given star tree segments directory and number of queries, StarTreeQueryGenerator
can generate queries that are fit for star tree.
2. Update the StarTreeClusterIntegrationTest hardcoded query set with all supported
type of queries. (Add non-equality comparison, IN predicate and BETWEEN predicate)