### PR TITLE
Add a summary for /data/timeseries endpoint

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -545,9 +545,13 @@ public class DashboardResource {
           valueArray.put(metricTimeSeries.getValue());
         }
       }
+      JSONObject summaryMap = new JSONObject();
+      summaryMap.put("currentStart", start);
+      summaryMap.put("currentEnd", end);
       JSONObject jsonResponseObject = new JSONObject();
       jsonResponseObject.put("timeSeriesData", timeseriesMap);
       jsonResponseObject.put("keys", new JSONArray(keys));
+      jsonResponseObject.put("summary", summaryMap);
       jsonResponse = jsonResponseObject.toString();
     } catch (Exception e) {
       throw e;


### PR DESCRIPTION
Pull request for ThirdEye Jira 832.

The summary provides the current start (i.e., "currentStart") and end (i.e., "currentEnd") of the returned time series.

An example of the new time series:
  {"summary":{"currentStart":1467212400000,"currentEnd":1467298800000}, (... old fields)}