### PR TITLE
In SegmentInfoProvider, added time column as a single-value dimension

### DIFF
--- a/pinot-integration-tests/src/test/resources/OnTimeStarTreeQueries.txt
+++ b/pinot-integration-tests/src/test/resources/OnTimeStarTreeQueries.txt
@@ -1,999 +1,1000 @@
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime IN (104, 366, 522, 284, 422) AND Origin BETWEEN 'LEX' AND 'MSP' GROUP BY OriginStateName
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, ArrTimeBlk
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSArrTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE TaxiIn > 101 AND FlightNum BETWEEN 1774 AND 3982 GROUP BY OriginCityName, DistanceGroup
-SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiIn > 2 GROUP BY Year, WheelsOff
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTimeBlk <> '2200-2259' AND WheelsOn IN (1047, 959, 552) AND OriginStateFips IN (24, 75, 9, 34, 32) GROUP BY Year, FlightNum
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk = '1900-1959' AND OriginWac IN (91, 41, 44) AND TaxiIn <= 78 GROUP BY WheelsOn
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTime BETWEEN 508 AND 1531 AND DayOfWeek IN (3) AND DivDistance BETWEEN 302 AND 760 GROUP BY Carrier
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE FirstDepTime IN (1842, 1346) AND TaxiIn <> 117 GROUP BY ArrTime, DepTimeBlk
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestWac BETWEEN 21 AND 23
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn BETWEEN 522 AND 1839 AND ArrTime <= 2138
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityName <= 'Louisville, KY' AND OriginStateName IN ('Michigan', 'Louisiana', 'Pennsylvania') GROUP BY Origin
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DepTime <> 1859 AND OriginAirportID BETWEEN 10431 AND 12094 AND CRSArrTime IN (2051, 2308, 2344, 1844, 1440)
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Cancelled
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TotalAddGTime IN (97, 149)
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest IN (0) AND CRSArrTime BETWEEN 1105 AND 2108 GROUP BY DestAirportSeqID, DayofMonth
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Quarter, AirlineID
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginState = 'NC' GROUP BY SecurityDelay
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime BETWEEN 51 AND 54 GROUP BY TotalAddGTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestState BETWEEN 'AR' AND 'WY' GROUP BY DivDistance
-SELECT SUM(DepDel15) FROM myStarTable WHERE Month BETWEEN 4 AND 10 GROUP BY DestStateName, CRSArrTime
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 9 AND DestStateName BETWEEN 'Louisiana' AND 'North Dakota' AND Flights IN (1) GROUP BY Month
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSElapsedTime >= 350 AND DestCityMarketID > 30779 AND CancellationCode IN ('A', 'C', 'noodles')
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime BETWEEN 146 AND 332 AND DestWac IN (1, 36, 67, 41) GROUP BY Origin, Distance
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay BETWEEN 19 AND 119 AND DestAirportSeqID IN (1114003, 1087402, 1244805, 1200702, 1219702) GROUP BY OriginAirportID, DivDistance
-SELECT SUM(ArrDelay) FROM myStarTable WHERE WeatherDelay BETWEEN 36 AND 103 AND DestStateFips < 47 AND CRSDepTime >= 1823 GROUP BY CancellationCode, Month
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID IN (1541103, 1161802, 1537602, 1479402, 1014602) GROUP BY DestCityMarketID, TailNum
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginStateName BETWEEN 'Arizona' AND 'Louisiana'
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (-2147483648, 3, 6, 5) AND ActualElapsedTime > 480
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn IN (1433, 2151, 2218, 50) AND DivArrDelay BETWEEN 247 AND 681
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled = 1
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips BETWEEN 22 AND 42 AND DepTime < 527 AND DestAirportSeqID < 1226402 GROUP BY OriginState, AirTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestStateFips BETWEEN 40 AND 48 AND WheelsOn IN (621, 1955, 1135, 1221, 1025) GROUP BY Year, TaxiOut
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestCityMarketID
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay, NASDelay
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTimeBlk IN ('1700-1759', '1200-1259') GROUP BY DestAirportID, Origin
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginAirportID IN (12197, 13230, 13931) AND DivAirportLandings BETWEEN 0 AND 1 AND DivReachedDest >= 1
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime BETWEEN 10 AND 1517 AND WheelsOn BETWEEN 1031 AND 1919 GROUP BY FlightNum
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Origin > 'IMT' AND DestCityMarketID < 34960 GROUP BY WheelsOff
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE CRSArrTime = 1120
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TaxiIn BETWEEN 11 AND 20
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY AirTime, OriginStateFips
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings <= 9 GROUP BY AirTime, DestStateName
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest >= 0 GROUP BY Cancelled
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime IN (150, 125, 89) AND AirTime <= 424 GROUP BY DivActualElapsedTime, ArrTimeBlk
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier IN ('FL', 'DL', 'F9') GROUP BY Quarter
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState < 'UT' AND Quarter BETWEEN -2147483648 AND 3
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirlineID >= 19790 AND WheelsOff = 909 GROUP BY LateAircraftDelay
-SELECT SUM(ArrDel15) FROM myStarTable WHERE WheelsOn BETWEEN 544 AND 1303
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID IN (19790) AND ArrTimeBlk IN ('1600-1659', '0600-0659', '2000-2059')
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestCityMarketID, Dest
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 347 AND 2043
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginStateName IN ('Rhode Island', 'Delaware', 'Idaho') GROUP BY CRSArrTime, DestAirportID
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOn
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Origin IN ('MSP', 'IMT', 'FLL', 'JAX', 'BKG') GROUP BY DistanceGroup, Flights
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 21 AND 1211 GROUP BY DivActualElapsedTime, DistanceGroup
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginAirportID
-SELECT SUM(DepDelay) FROM myStarTable WHERE FlightDate <= '2014-06-13'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights >= -2147483648 GROUP BY LateAircraftDelay
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID BETWEEN 32320 AND 33485
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DistanceGroup, DivReachedDest
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE CRSDepTime <= 10
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightDate
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup IN (7, 2, 5, 11) AND DepTime IN (1714, 1112, 1212, 741, 555)
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime >= 2204 GROUP BY TaxiOut
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportID
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginStateFips <> 28 GROUP BY ArrTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1098002 AND 1114003
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips IN (37, 24, 48, 33, 32) AND DepTime <> 511 AND Diverted = 1 GROUP BY DivReachedDest, CRSArrTime
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DepTime BETWEEN 649 AND 956 AND DestCityMarketID <> 33485 GROUP BY CarrierDelay, ArrTimeBlk
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month >= 10 AND DestCityMarketID IN (33342) AND OriginWac BETWEEN 5 AND 31
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirTime = 15 AND DivReachedDest <= 1 AND DayOfWeek IN (7, 6, 2)
-SELECT SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE SecurityDelay IN (4) GROUP BY Origin, TailNum
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiOut, Dest
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WeatherDelay IN (152, 13, 14) GROUP BY DayOfWeek
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestWac IN (37) GROUP BY UniqueCarrier
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay IN (24, 6, 10, 14) GROUP BY OriginStateName
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek BETWEEN -2147483648 AND 1
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID BETWEEN 30930 AND 31823 AND TotalAddGTime BETWEEN 20 AND 145 AND DivAirportLandings IN (2) GROUP BY Cancelled, Quarter
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips BETWEEN 13 AND 40 AND DayofMonth < 10 AND DepTimeBlk IN ('1800-1859', '1700-1759', '2200-2259', '1200-1259', '0700-0759') GROUP BY TaxiOut, WheelsOn
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CarrierDelay = 207 GROUP BY DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 31641 AND 33264
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings >= 1 GROUP BY OriginAirportSeqID
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TailNum < 'N889AS'
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TotalAddGTime, WheelsOn
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Origin <= 'TUS' AND OriginCityName > 'Waterloo, IA' AND Quarter BETWEEN -2147483648 AND 2 GROUP BY Cancelled, DestState
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Month > 6 GROUP BY Year
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY CarrierDelay
-SELECT SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (0, -2147483648, 1, -9999) GROUP BY Dest
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Origin < 'CWA' GROUP BY DestState, Quarter
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode BETWEEN 'ALL' AND 'noodles' GROUP BY UniqueCarrier, OriginWac
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState = 'NC' GROUP BY UniqueCarrier
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayofMonth
-SELECT SUM(DepDel15) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Month IN (4, 10, 5, 11, 7) AND DepTime <= 506
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff IN (1527) GROUP BY DestCityMarketID, OriginCityMarketID
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE UniqueCarrier IN ('US', 'UA', 'OO', 'FL', 'MQ') GROUP BY DestStateName
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Distance BETWEEN 516 AND 1107 AND ActualElapsedTime < 103 AND DayOfWeek <> -2147483648 GROUP BY TaxiOut
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivDistance IN (85, 209) GROUP BY Dest
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportSeqID >= 1537002 GROUP BY Carrier
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TotalAddGTime BETWEEN 78 AND 104 AND DivArrDelay <= 85 AND FlightDate <> '2014-09-16'
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(DepDelay) FROM myStarTable WHERE CRSArrTime >= 745 AND OriginAirportID IN (15607, 10135, 16218)
-SELECT SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID IN (1350202, 1201602)
-SELECT SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay > 169 AND DivReachedDest BETWEEN -2147483648 AND -9999 GROUP BY ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime IN (47, 300, 493, 31, 398) GROUP BY TotalAddGTime, LongestAddGTime
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityName IN ('Sacramento, CA', 'Wilmington, DE', 'Orlando, FL', 'Billings, MT', 'Hattiesburg/Laurel, MS') GROUP BY Distance, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1014003 AND 1558202 GROUP BY DestAirportID, DistanceGroup
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup IN (7, 1) AND CRSElapsedTime IN (447, 665, 642, 99, 356)
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY CRSElapsedTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportSeqID
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE NASDelay BETWEEN 57 AND 131 AND FlightDate <= '2014-02-27'
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, WheelsOff
-SELECT SUM(DepDel15) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup = 3 AND Year IN (-2147483648, 2014)
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DestAirportID, DestWac
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn BETWEEN 346 AND 2203 GROUP BY Dest, DayofMonth
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestState BETWEEN 'AK' AND 'TT' GROUP BY DepTime
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips BETWEEN 15 AND 29 AND DayOfWeek IN (2, 1, 6, 5, 7) GROUP BY DestAirportID
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestCityMarketID = 33728 AND Carrier <> 'AA'
-SELECT SUM(DepDelay) FROM myStarTable WHERE CancellationCode >= 'noodles' AND DivDistance = 60 GROUP BY Cancelled
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TotalAddGTime
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY CRSArrTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE FlightNum IN (5364, 388, 4554, 3058, 206) AND OriginWac IN (38, 41, 14, 15) GROUP BY DestState, DestCityName
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE FirstDepTime BETWEEN 831 AND 900
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DepTime < 1104 AND SecurityDelay IN (7, 9, 19) GROUP BY TaxiOut
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, SecurityDelay
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivReachedDest, CRSArrTime
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityMarketID <= 33459
-SELECT SUM(DepDelay) FROM myStarTable WHERE Carrier IN ('WN', 'AS', 'B6', 'MQ', 'F9') AND WeatherDelay > 140 GROUP BY DestState, CancellationCode
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN 1403 AND 1514 GROUP BY WeatherDelay, UniqueCarrier
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestStateFips > 6 AND TaxiIn BETWEEN 15 AND 18 GROUP BY OriginCityMarketID
-SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 1 AND 9 AND DestAirportSeqID <> 1129803 GROUP BY DivDistance, OriginWac
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Carrier < 'MQ' AND DivReachedDest IN (1, -9999, 0) AND SecurityDelay BETWEEN 4 AND 4 GROUP BY OriginStateFips
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest BETWEEN 0 AND 1 AND DaysSinceEpoch IN (16274, 16357, 16159, 16337)
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestCityMarketID BETWEEN 30146 AND 33367 AND WheelsOn < 1439 GROUP BY OriginWac, CRSElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DepTimeBlk = '1700-1759'
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut > 4 AND OriginAirportSeqID >= 1430702
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginWac BETWEEN 53 AND 85 AND CarrierDelay BETWEEN 297 AND 598 GROUP BY Diverted
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityMarketID >= 33029
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE TaxiIn = 85 AND OriginAirportID <= 15401 GROUP BY TaxiIn, DestAirportID
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, Distance
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DepTime BETWEEN 1447 AND 1902 AND LongestAddGTime = 26 GROUP BY OriginAirportID, DivArrDelay
+SELECT SUM(ArrDel15) FROM myStarTable WHERE FirstDepTime > 810 AND Year = 2014 AND DivArrDelay BETWEEN 27 AND 131 GROUP BY Origin
+SELECT SUM(DepDelay) FROM myStarTable WHERE WheelsOn BETWEEN 805 AND 932 GROUP BY Diverted, OriginAirportID
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate > '2014-01-31' GROUP BY TotalAddGTime, WheelsOff
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CancellationCode IN ('ALL', 'C', 'noodles') GROUP BY DestAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Quarter
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY CRSElapsedTime, WheelsOff
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivArrDelay IN (1172, 700) AND DepTime <> 949 GROUP BY DivArrDelay, ArrTime
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiIn IN (38, 23, 72, 91) AND DestState IN ('HI', 'WA', 'WI', 'KS') GROUP BY DivActualElapsedTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE WheelsOff BETWEEN 1548 AND 1824
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE ArrTime IN (510, 1801, 2051, 1423) AND Quarter > -2147483648 AND OriginWac > 43 GROUP BY SecurityDelay
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID IN (1077902, 1325602, 1033302, 1240203) AND Flights IN (-2147483648, 1) GROUP BY DistanceGroup
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginStateName, Year
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode >= 'A' AND FlightDate BETWEEN '2014-04-13' AND '2014-12-14' AND DivAirportLandings BETWEEN 0 AND 1 GROUP BY DepTime
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestStateName BETWEEN 'Indiana' AND 'Mississippi' AND Carrier <= 'US' AND Cancelled IN (-2147483648, 1, 0) GROUP BY TaxiIn
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay IN (34) AND ArrTimeBlk IN ('2300-2359', '1800-1859', '2100-2159', '1700-1759') GROUP BY AirTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivReachedDest
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Distance <> 447 AND DestState IN ('FL', 'PA', 'GA') GROUP BY OriginAirportSeqID, Carrier
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter IN (4, 3, 1, -2147483648) AND CRSElapsedTime IN (612) AND DepTimeBlk > '0001-0559' GROUP BY TaxiIn
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Carrier IN ('HA', 'B6') AND DepTime BETWEEN 110 AND 1423 AND DestCityMarketID <= 30158 GROUP BY FirstDepTime, Month
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings IN (0, -2147483648, 1, 9, 2) GROUP BY FlightNum
 SELECT SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY Quarter
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirlineID, CRSDepTime
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DistanceGroup
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime < 173 AND DepTimeBlk < '1200-1259' AND FlightNum < 2091 GROUP BY DestCityMarketID
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Cancelled IN (1) AND Diverted BETWEEN -2147483648 AND 0 AND LongestAddGTime > 11
-SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOff IN (140, 44, 2353) AND DestCityMarketID < 34842 AND DepTimeBlk <= '1000-1059' GROUP BY CRSDepTime, CancellationCode
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE NASDelay BETWEEN 149 AND 153 AND Cancelled BETWEEN 0 AND 1
-SELECT SUM(DepDelay) FROM myStarTable WHERE DivArrDelay BETWEEN 50 AND 230 GROUP BY DestStateFips
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CancellationCode IN ('C', 'A', 'noodles', 'B') AND AirlineID < 20437 AND Dest IN ('ERI', 'GSO', 'JNU', 'SGF') GROUP BY DepTimeBlk
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestState BETWEEN 'MS' AND 'SC' GROUP BY DivDistance, OriginAirportSeqID
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DestCityName BETWEEN 'Augusta, GA' AND 'New Bern/Morehead/Beaufort, NC' AND ArrTime IN (1336, 13, 1157) GROUP BY OriginStateName
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac <> 63 AND DivAirportLandings = 9 AND DayofMonth BETWEEN 10 AND 12 GROUP BY WheelsOff
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Cancelled IN (0) AND DistanceGroup IN (8, 5, 11, 10)
-SELECT SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk < '1300-1359' AND DestStateFips >= 15 GROUP BY DepTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate IN ('2014-12-07', '2014-06-22') GROUP BY OriginState, CancellationCode
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY SecurityDelay, Origin
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState BETWEEN 'AL' AND 'MO' GROUP BY TaxiIn
-SELECT SUM(DepDel15) FROM myStarTable
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY FirstDepTime, ArrTimeBlk
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (6, 3, 4, 7) GROUP BY DivArrDelay, DayofMonth
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FirstDepTime >= 1343
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY WeatherDelay
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Diverted
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState BETWEEN 'WI' AND 'WY' AND DayofMonth BETWEEN 23 AND 31 AND DivReachedDest BETWEEN -9999 AND -9999 GROUP BY TaxiOut
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightNum BETWEEN 501 AND 811 AND DestStateName BETWEEN 'Alabama' AND 'Maryland' AND DestWac BETWEEN 2 AND 54 GROUP BY FlightDate, AirTime
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID IN (33304, 35249, 32211, 30136) AND NASDelay >= 303 AND DivArrDelay < 1053 GROUP BY DepTimeBlk
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE TaxiOut IN (71, 122, 40, -9999) AND DivAirportLandings >= 0 AND Year BETWEEN -2147483648 AND 2014
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CancellationCode < 'noodles' GROUP BY FlightNum
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginWac IN (51) GROUP BY UniqueCarrier, DestState
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup = 3 AND TaxiIn BETWEEN 25 AND 99 GROUP BY OriginStateName
-SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay IN (201, 83) AND Carrier BETWEEN 'EV' AND 'FL' AND OriginStateFips IN (21, 38, 34, 19, 50) GROUP BY CRSDepTime, DestStateName
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DayofMonth IN (1, 25, 13, 30, 17) AND DivArrDelay BETWEEN 39 AND 199 GROUP BY CRSArrTime, FlightNum
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut BETWEEN 68 AND 127 AND ArrTimeBlk BETWEEN '1600-1659' AND '1800-1859' GROUP BY ArrTimeBlk
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier > 'FL' GROUP BY LongestAddGTime, CancellationCode
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID IN (33342, 31136) GROUP BY CRSArrTime, UniqueCarrier
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY OriginStateName, Flights
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter IN (1, 2)
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek < 2 AND Origin BETWEEN 'JAN' AND 'PIT'
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName < 'Maryland'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSDepTime
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn BETWEEN 1430 AND 2003
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips IN (56, 39) AND DestAirportID IN (12954, 13577, 11315, 11066) GROUP BY OriginCityName, DayOfWeek
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE ActualElapsedTime BETWEEN 80 AND 92 AND TaxiIn IN (1, 162, 54, 107) GROUP BY DivDistance, LateAircraftDelay
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips > 27 AND CRSDepTime BETWEEN 752 AND 1530 GROUP BY LateAircraftDelay
-SELECT SUM(DepDelay) FROM myStarTable WHERE CRSElapsedTime IN (186, 240, 485, 152) GROUP BY Month, DestCityName
-SELECT SUM(DepDelay) FROM myStarTable WHERE NASDelay <= 65 AND DepTime >= 907 GROUP BY OriginAirportSeqID
-SELECT SUM(ArrDelay) FROM myStarTable WHERE FlightDate IN ('2014-06-04') AND DivAirportLandings < 9 GROUP BY OriginStateName, OriginWac
-SELECT SUM(DepDelay) FROM myStarTable WHERE DistanceGroup = 10 AND DestStateFips BETWEEN 4 AND 72 GROUP BY UniqueCarrier, Year
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 4623 AND 7364 GROUP BY DayOfWeek, TotalAddGTime
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Diverted IN (-2147483648, 1, 0) AND SecurityDelay <= 22 AND FlightNum BETWEEN 3574 AND 3812 GROUP BY AirTime, FlightDate
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE FlightDate <= '2014-02-02' AND LongestAddGTime BETWEEN 8 AND 148 AND OriginCityName < 'Raleigh/Durham, NC' GROUP BY TaxiIn
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 37 AND 92
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID BETWEEN 20398 AND 20409 AND DayofMonth IN (16, 3, 7, 11, 12) AND OriginStateName <= 'Nebraska'
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1073103 AND 1275803 AND AirlineID > 20436 GROUP BY DepTimeBlk
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn > 17 AND ActualElapsedTime IN (101) AND DestWac <> 63 GROUP BY ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime BETWEEN 40 AND 943 AND OriginAirportID < 13198
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 33044 AND 33214 GROUP BY LateAircraftDelay, Flights
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn IN (2327, 138, 2035, 246, 646) AND Distance <= 1061 GROUP BY Origin, UniqueCarrier
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month BETWEEN -2147483648 AND 1 GROUP BY DayofMonth
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('1300-1359', '1900-1959', '2100-2159', '1100-1159', '1200-1259') GROUP BY DayOfWeek, DepTimeBlk
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn >= 2034 AND FlightDate >= '2014-01-10' GROUP BY OriginWac, DestStateFips
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, ArrTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID, DistanceGroup
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 37 AND 61
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DepTimeBlk, DestAirportSeqID
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CRSElapsedTime < 243 AND NASDelay BETWEEN 2 AND 115 AND DepTime IN (600, 2324, 553, 634, 2319) GROUP BY DestStateName, CancellationCode
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayofMonth
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE CarrierDelay IN (276) GROUP BY NASDelay, FlightDate
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut BETWEEN 72 AND 102 GROUP BY NASDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Year
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState BETWEEN 'CO' AND 'RI' AND LongestAddGTime BETWEEN 52 AND 101 GROUP BY WeatherDelay, OriginCityName
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DayofMonth = 1
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay IN (42, 16) GROUP BY FlightNum
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut IN (54, 153, 59, 15) AND OriginAirportID >= 10257 AND DepTime >= 309 GROUP BY DestAirportID, Month
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Dest, Year
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime BETWEEN 366 AND 437 AND CRSDepTime BETWEEN 548 AND 1915 GROUP BY Month
-SELECT SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay <> 15 AND WheelsOff IN (718, 1109, 829, 1022, 1318) AND FlightNum IN (4124, 1387, 809, 3990) GROUP BY AirTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '1200-1259' AND '1800-1859' GROUP BY DestStateName, CarrierDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState IN ('PA', 'PR', 'AK', 'UT') GROUP BY DestAirportID, OriginAirportID
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth BETWEEN 11 AND 16 AND Distance IN (137) AND WeatherDelay <> 82 GROUP BY DivAirportLandings, DestState
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE FirstDepTime <> 1940 AND Quarter > 3
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Carrier <> 'F9' AND TaxiIn <> 53 GROUP BY DestWac, DayofMonth
-SELECT SUM(DepDel15) FROM myStarTable WHERE DestWac <> 43 AND OriginWac > 66
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY WheelsOff, DivActualElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID IN (15607, 11193, 11109, 10561, 13184)
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime BETWEEN 22 AND 90 GROUP BY DistanceGroup
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut = 8 GROUP BY DayOfWeek, SecurityDelay
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestCityName = 'Medford, OR' AND TailNum <= 'N292WN' GROUP BY DestStateName, DivDistance
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay IN (22, 4, -9999, 14) AND WheelsOn IN (1846) GROUP BY DestAirportID, Distance
-SELECT SUM(DepDelay) FROM myStarTable WHERE FlightDate BETWEEN '2014-08-22' AND '2014-09-17' AND OriginStateFips IN (10, 18) GROUP BY FirstDepTime, DistanceGroup
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE WheelsOn BETWEEN 431 AND 2229 AND OriginStateName BETWEEN 'Arizona' AND 'Utah' AND DivActualElapsedTime IN (382, 1321, 445, 446) GROUP BY OriginCityMarketID
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Origin <> 'RNO' AND WheelsOff IN (205, 111) GROUP BY Origin, OriginCityName
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY NASDelay, SecurityDelay
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayOfWeek BETWEEN 3 AND 6 AND Diverted IN (1, 0, -2147483648) AND CarrierDelay BETWEEN 58 AND 252 GROUP BY OriginAirportSeqID, OriginStateFips
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE WeatherDelay >= 50 AND OriginCityName BETWEEN 'Champaign/Urbana, IL' AND 'Springfield, MO' AND TaxiOut BETWEEN 73 AND 131 GROUP BY OriginStateName
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LateAircraftDelay BETWEEN 58 AND 68 GROUP BY OriginStateFips, DivArrDelay
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk <> '1400-1459' GROUP BY Distance, LateAircraftDelay
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY DestAirportSeqID
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac BETWEEN 5 AND 88 AND FirstDepTime BETWEEN 942 AND 1545
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Distance <> 2504 AND CRSElapsedTime IN (262, 615, 397) GROUP BY Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier >= 'EV' GROUP BY CRSElapsedTime
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Month <= 9 AND TotalAddGTime BETWEEN 66 AND 121
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID BETWEEN 14843 AND 15096 AND WeatherDelay BETWEEN 39 AND 132 GROUP BY WheelsOff
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TailNum, Distance
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateFips < 38 AND DivArrDelay = 173 AND CRSArrTime BETWEEN 147 AND 1318
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName BETWEEN 'Jackson, WY' AND 'Mosinee, WI' AND DistanceGroup > 2 AND TotalAddGTime IN (5, 74, 45) GROUP BY TaxiIn, UniqueCarrier
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Dest BETWEEN 'CMX' AND 'MGM' AND NASDelay IN (60, 8, 13) GROUP BY Year, TotalAddGTime
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID IN (30559, 35991)
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY CRSArrTime, Carrier
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DayofMonth BETWEEN 3 AND 27 AND Year IN (-2147483648, 2014) GROUP BY FlightDate, TaxiIn
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk < '1200-1259'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime < 248 GROUP BY Distance, TotalAddGTime
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginStateFips BETWEEN -2147483648 AND 34 AND Diverted <= 0 GROUP BY DestCityName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled = 0 GROUP BY TotalAddGTime
-SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY Carrier, ArrTime
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings BETWEEN -2147483648 AND 9
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Cancelled IN (1, -2147483648, 0) AND CancellationCode IN ('B', 'noodles', 'C', 'ALL') GROUP BY DestCityName
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DaysSinceEpoch BETWEEN 16249 AND 16362 AND DestAirportSeqID IN (1288903, 1020803, 1338801, 1228002) GROUP BY CRSDepTime, DivActualElapsedTime
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID BETWEEN 10693 AND 13388 AND ArrTime IN (1222, 720, 2132, 1007)
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum BETWEEN 2032 AND 6459 AND AirlineID BETWEEN 20398 AND 20436 GROUP BY DayOfWeek, DestCityName
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE TailNum <= 'N830MQ' GROUP BY WeatherDelay
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DaysSinceEpoch = 16230 AND OriginWac > 41 GROUP BY DestAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY AirlineID
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE ActualElapsedTime >= 242
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportSeqID IN (1357702, 1018502, 1043403, 1584102) GROUP BY Quarter, OriginState
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY DivActualElapsedTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginWac > 4 AND TaxiOut BETWEEN 34 AND 119 AND DestCityName IN ('Iron Mountain/Kingsfd, MI', 'Jamestown, ND', 'Boston, MA', 'Nome, AK', 'Tampa, FL') GROUP BY FirstDepTime, OriginCityName
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 1 GROUP BY CRSArrTime
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTime = 704 AND DivAirportLandings BETWEEN 1 AND 2 AND OriginState >= 'MT' GROUP BY DistanceGroup, DaysSinceEpoch
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Diverted, DestCityMarketID
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginStateName >= 'Alaska'
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay >= 368 AND Cancelled >= -2147483648 AND FirstDepTime BETWEEN 555 AND 1738 GROUP BY TaxiOut
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestCityName IN ('Erie, PA', 'Missoula, MT', 'Augusta, GA', 'Shreveport, LA') AND WheelsOn BETWEEN 314 AND 1327
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay > 5 AND DestCityName < 'Buffalo, NY' GROUP BY AirlineID, TaxiIn
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID IN (11884, 13964) AND DestState <> 'NJ' AND DivAirportLandings <= 0 GROUP BY WeatherDelay, DistanceGroup
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName BETWEEN 'Missouri' AND 'Vermont' AND FlightNum IN (1334, 707, 266) AND Year <= 2014 GROUP BY OriginAirportSeqID, TaxiOut
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FirstDepTime, Origin
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DaysSinceEpoch > 16280 GROUP BY Dest
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac BETWEEN 37 AND 66 AND OriginStateName <= 'Utah' AND Dest BETWEEN 'DVL' AND 'TRI' GROUP BY OriginCityMarketID, Quarter
 SELECT SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings BETWEEN 9 AND 9
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek BETWEEN 5 AND 7 AND TaxiOut IN (98, 115, 72, 62) AND Month BETWEEN -2147483648 AND 12
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime IN (101, 14, 47) GROUP BY Diverted
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE ActualElapsedTime BETWEEN 248 AND 318 GROUP BY OriginAirportSeqID
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginStateName = 'Iowa' AND UniqueCarrier = 'F9' AND DestStateFips < 18
-SELECT SUM(ArrDelay) FROM myStarTable WHERE AirlineID >= 19977 AND CarrierDelay <> 240
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID IN (12441) GROUP BY CRSElapsedTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY FirstDepTime, DistanceGroup
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY DivArrDelay
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable
-SELECT SUM(DepDelay) FROM myStarTable WHERE Flights >= -2147483648 AND AirlineID BETWEEN 20366 AND 20398 AND FirstDepTime >= 1959 GROUP BY CRSElapsedTime, DepTime
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityName BETWEEN 'New Bern/Morehead/Beaufort, NC' AND 'Sitka, AK' AND DivDistance <> 0 AND DestAirportID IN (14588, 11097) GROUP BY TotalAddGTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Waterloo, IA', 'Elmira/Corning, NY', 'New York, NY', 'Manchester, NH', 'Scranton/Wilkes-Barre, PA') GROUP BY CancellationCode, WeatherDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID BETWEEN -2147483648 AND 19393 AND Month BETWEEN -2147483648 AND 3 GROUP BY WheelsOn, ActualElapsedTime
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityName >= 'Hilo, HI' AND OriginAirportID BETWEEN 10849 AND 11648 AND DestStateFips > 37 GROUP BY CancellationCode, ArrTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID BETWEEN 31097 AND 32129 AND Flights BETWEEN -2147483648 AND 1 AND AirTime BETWEEN 256 AND 395
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestAirportID >= 12339 AND Cancelled >= 1
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 1 AND DestAirportID <= 10620
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CancellationCode
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE Origin >= 'OAK' AND TaxiIn IN (52, 12) AND CRSArrTime > 2313 GROUP BY TailNum
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut IN (64, 39, 104, 59, 78) GROUP BY OriginCityName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID >= 31447 AND DestCityName <= 'Helena, MT' AND ArrTimeBlk >= '1600-1659' GROUP BY TaxiIn
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE FirstDepTime <> 1024 AND OriginAirportSeqID IN (1529502) AND CRSDepTime <> 809 GROUP BY Year, WheelsOff
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityName IN ('Waco, TX', 'Cincinnati, OH', 'Abilene, TX') GROUP BY FlightNum, OriginStateName
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY WheelsOn, Year
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay IN (440, 1508, 96, 158) AND FlightNum < 4195 GROUP BY OriginCityName, DestCityMarketID
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DivArrDelay IN (489, 257, 44) AND LateAircraftDelay <> 337 GROUP BY WeatherDelay
-SELECT SUM(ArrDelay) FROM myStarTable WHERE SecurityDelay BETWEEN -9999 AND 33 AND Origin <> 'BIL' GROUP BY OriginAirportSeqID, DivReachedDest
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE ActualElapsedTime BETWEEN 132 AND 349
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestState, FlightDate
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY WheelsOn, UniqueCarrier
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Carrier BETWEEN 'UA' AND 'VX' AND Origin <= 'PHF'
-SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiOut BETWEEN 74 AND 74 GROUP BY Carrier, OriginAirportSeqID
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest IN (-9999) AND DayOfWeek BETWEEN 5 AND 6 GROUP BY TaxiIn
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY TotalAddGTime
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestStateName, Year
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay IN (110) GROUP BY Dest
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE CRSElapsedTime BETWEEN 51 AND 341 AND DayOfWeek IN (6, 3, -2147483648, 4) GROUP BY DistanceGroup, DepTimeBlk
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay <= 0 GROUP BY OriginStateName
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE Quarter BETWEEN -2147483648 AND 2
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportID IN (11697) AND Origin BETWEEN 'DVL' AND 'LNK' GROUP BY OriginAirportSeqID, LongestAddGTime
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DistanceGroup
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE FirstDepTime < 1633 AND Month BETWEEN 7 AND 7 GROUP BY Month
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month BETWEEN 1 AND 6 AND NASDelay BETWEEN 65 AND 70 AND DestStateName BETWEEN 'Kentucky' AND 'Louisiana'
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightDate
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY AirlineID, OriginAirportSeqID
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayOfWeek
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Flights IN (-2147483648, 1) GROUP BY CancellationCode
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode IN ('noodles', 'C', 'A')
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightNum <> 7434 AND AirlineID < 20398
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier IN ('EV', 'OO', 'ALL', 'F9') AND AirTime IN (341, 37) AND FlightDate <> '2014-08-14' GROUP BY WeatherDelay, DivActualElapsedTime
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay <= 24 GROUP BY TaxiOut, DestState
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID IN (1082103) AND ActualElapsedTime <= 273 GROUP BY OriginCityMarketID, LateAircraftDelay
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE TotalAddGTime IN (105, 84, 128, 29)
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Aguadilla, PR', 'Sun Valley/Hailey/Ketchum, ID', 'Guam, TT', 'Panama City, FL', 'Lexington, KY') AND NASDelay BETWEEN 21 AND 72 GROUP BY DestState
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID BETWEEN 11823 AND 13476 AND Distance > 102 GROUP BY DivAirportLandings
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE LongestAddGTime IN (87, 36, 17) AND DivReachedDest BETWEEN -2147483648 AND 1
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY ArrTimeBlk, DepTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Carrier BETWEEN 'B6' AND 'HA' AND DepTime <= 1007 AND DepTimeBlk IN ('1100-1159', '1300-1359', '1200-1259', '1900-1959', '1700-1759') GROUP BY DivActualElapsedTime
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup > 7 GROUP BY WheelsOff
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek IN (3, -2147483648, 2, 5) AND ArrTimeBlk <> '1700-1759' AND DestAirportSeqID IN (1106702) GROUP BY TailNum
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted IN (1, -2147483648, 0) GROUP BY TaxiOut
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSDepTime BETWEEN 2047 AND 2250 AND CRSElapsedTime BETWEEN 203 AND 660 GROUP BY DestCityName, OriginWac
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, Month
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CancellationCode, Month
-SELECT SUM(DepDelay) FROM myStarTable WHERE Origin IN ('GSO') GROUP BY DestState, OriginWac
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime >= 1731 AND Diverted >= 0
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay < 14 GROUP BY ArrTime
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Distance BETWEEN 305 AND 826
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY OriginStateName
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DestAirportID IN (15411) GROUP BY Distance, ArrTimeBlk
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginState IN ('IL') AND OriginAirportSeqID <= 1104203 GROUP BY CarrierDelay, OriginCityName
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID < 13127 GROUP BY ArrTimeBlk, TaxiOut
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivActualElapsedTime, FlightDate
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOn IN (118, 459, 1718, 2003) AND DestState BETWEEN 'AL' AND 'WI' AND DestCityName = 'Pittsburgh, PA'
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay BETWEEN 6 AND 8 GROUP BY DivArrDelay, TaxiIn
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Distance
-SELECT SUM(DepDel15) FROM myStarTable
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTime IN (904) AND Cancelled <> 1 GROUP BY DayofMonth
-SELECT SUM(DepDelay) FROM myStarTable WHERE CarrierDelay BETWEEN 14 AND 19 AND TaxiIn BETWEEN 39 AND 51 GROUP BY WheelsOff, OriginCityName
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestState >= 'ND' AND DestStateName IN ('Rhode Island', 'Kansas', 'North Carolina') GROUP BY UniqueCarrier
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, FirstDepTime
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac IN (2, 42)
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivDistance < 157 AND Origin IN ('AUS') GROUP BY TaxiIn, DepTime
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTime IN (1016, 2124, 1243, 548, 1247) AND Diverted IN (0, 1, -2147483648) AND DestCityName > 'Manchester, NH'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year BETWEEN -2147483648 AND 2014 AND DayofMonth BETWEEN 10 AND 28
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TailNum = 'N945UW'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DepTime >= 1159 AND DivDistance BETWEEN 696 AND 2994 GROUP BY DivArrDelay
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateName BETWEEN 'South Carolina' AND 'Wyoming' GROUP BY DivReachedDest
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek BETWEEN 3 AND 7 AND OriginStateFips BETWEEN 12 AND 33 AND WheelsOn > 2112
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier, DivDistance
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Flights IN (1, -2147483648) AND DivDistance BETWEEN 376 AND 390 GROUP BY DivAirportLandings, WheelsOn
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirTime
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay > 298 AND Quarter >= 2 GROUP BY AirlineID
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTime < 731 GROUP BY OriginCityMarketID
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier > 'UA' AND OriginCityName BETWEEN 'Pittsburgh, PA' AND 'Texarkana, AR' GROUP BY DestStateName, DivAirportLandings
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime > 2202 AND DestCityMarketID BETWEEN 31867 AND 31995
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginAirportID IN (11013, 10208, 10874) GROUP BY ActualElapsedTime, Month
-SELECT SUM(DepDel15) FROM myStarTable WHERE DivDistance IN (227, 967, 255, 773, 3784) GROUP BY Quarter
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateFips BETWEEN 26 AND 53 AND CancellationCode BETWEEN 'B' AND 'noodles' GROUP BY DestCityMarketID
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips IN (53, 72, 16, 32) AND OriginWac IN (62, 54) GROUP BY DestAirportID, OriginState
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime IN (131, 128, 24, 44, 63) GROUP BY OriginCityName
-SELECT SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime IN (128, 78) AND TailNum BETWEEN 'N12924' AND 'N928DN' AND TotalAddGTime > 74 GROUP BY CRSDepTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest BETWEEN -9999 AND 1 GROUP BY ActualElapsedTime, ArrTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Origin BETWEEN 'BKG' AND 'GRB'
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginState
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 11140 AND 11624 AND DayOfWeek IN (-2147483648, 7, 5) AND DestStateName < 'Illinois' GROUP BY OriginStateFips
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup < 5 AND ActualElapsedTime > 81
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime BETWEEN 404 AND 425 AND DestWac > 14 AND TaxiOut BETWEEN 4 AND 16 GROUP BY OriginState, DestCityName
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime IN (150, 272, 40, 172, 394) GROUP BY DistanceGroup, DestCityMarketID
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN -2147483648 AND 1957 AND OriginStateName BETWEEN 'Georgia' AND 'Massachusetts'
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1068502, 1058102, 1025702, 1226402) AND DestState BETWEEN 'IN' AND 'NM' AND OriginAirportID IN (15412, 12953, 10561, 10926, 12264) GROUP BY DestAirportSeqID
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID <> 1419304 AND FlightNum BETWEEN 2519 AND 6273 AND DestAirportID IN (14908, 11624) GROUP BY ActualElapsedTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Distance <= 1294 AND OriginAirportID BETWEEN 10170 AND 10408 GROUP BY CarrierDelay
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier <> 'MQ' AND Quarter >= 3 GROUP BY DayofMonth
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateName > 'Montana' AND FlightDate BETWEEN '2014-07-24' AND '2014-08-15' AND DivActualElapsedTime BETWEEN 225 AND 884 GROUP BY Origin, Carrier
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE WeatherDelay <= 25 GROUP BY Dest
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivActualElapsedTime, Month
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginWac BETWEEN 5 AND 21 AND Distance BETWEEN 475 AND 611 AND DestStateFips BETWEEN 30 AND 55 GROUP BY DivDistance
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime = 50 AND Origin BETWEEN 'ADQ' AND 'LCH' GROUP BY DestStateName, DepTime
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayofMonth
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, Flights
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest <> -2147483648 AND UniqueCarrier <= 'UA' AND DestState IN ('WA', 'NY', 'OK', 'NH', 'NM')
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityMarketID > 33377 AND CRSDepTime <> 1755 GROUP BY SecurityDelay, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DayofMonth BETWEEN 1 AND 17 AND OriginWac < 38 GROUP BY DestStateName
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE LongestAddGTime BETWEEN 109 AND 122 GROUP BY DepTime
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID < 30141 GROUP BY TailNum, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier >= 'HA' AND DestStateName = 'Virginia' AND AirTime IN (543, 185, 20) GROUP BY DayofMonth
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Carrier BETWEEN 'HA' AND 'WN' AND DivActualElapsedTime IN (413, 951) GROUP BY DepTimeBlk, DepTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName IN ('Georgia', 'South Dakota') AND SecurityDelay <= 41 AND OriginWac BETWEEN 2 AND 34 GROUP BY OriginAirportSeqID
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID BETWEEN 33214 AND 33495 GROUP BY TotalAddGTime
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTime IN (839) AND TaxiIn BETWEEN -9999 AND 12 GROUP BY WheelsOff
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Dest BETWEEN 'FAY' AND 'GCK'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Quarter, DivReachedDest
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DepTime BETWEEN 1638 AND 1645 GROUP BY DivActualElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Origin BETWEEN 'MGM' AND 'SRQ' AND UniqueCarrier <= 'DL' AND CRSArrTime BETWEEN 1912 AND 2355 GROUP BY DistanceGroup
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime < 2208 GROUP BY OriginAirportSeqID, TailNum
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiIn <= 109 AND CancellationCode > 'C'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DivArrDelay <= 64 AND Carrier IN ('WN', 'DL') GROUP BY DivReachedDest
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime IN (321, 320, 120) AND DestStateFips IN (37, 5, 75) GROUP BY OriginStateFips
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance BETWEEN 109 AND 283
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayofMonth
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DayofMonth BETWEEN 14 AND 31 AND WeatherDelay IN (135, 194, 95, 27)
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestStateFips < 19 GROUP BY DivReachedDest, FlightNum
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DepTimeBlk
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest BETWEEN 0 AND 1
-SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOff > 1210
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateFips BETWEEN 46 AND 54 GROUP BY WheelsOff
-SELECT SUM(DepDelay) FROM myStarTable WHERE Dest > 'ADK'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportID IN (11076, 10361, 10299, 13851) AND OriginStateFips <> 28 GROUP BY DepTime, TailNum
-SELECT SUM(DepDel15) FROM myStarTable WHERE CarrierDelay BETWEEN 83 AND 262 GROUP BY UniqueCarrier
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiIn BETWEEN 27 AND 34 AND Cancelled BETWEEN 0 AND 1 GROUP BY Carrier, CRSDepTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier IN ('B6') GROUP BY ArrTime, DestAirportSeqID
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityName < 'Bellingham, WA' AND ArrTimeBlk BETWEEN '1500-1559' AND '1700-1759' GROUP BY DistanceGroup, DayofMonth
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance BETWEEN 307 AND 488 GROUP BY DestAirportID, Month
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateName
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY FlightNum
-SELECT SUM(DepDelay) FROM myStarTable WHERE Diverted >= 1 AND TotalAddGTime BETWEEN 60 AND 90 GROUP BY TaxiIn, Origin
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 11002 AND 13830 GROUP BY DepTimeBlk, Year
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff <> 2220 GROUP BY LongestAddGTime, DayOfWeek
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Origin BETWEEN 'GTR' AND 'VEL' GROUP BY DestAirportID
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips IN (20, 27, 29, 44) GROUP BY WheelsOff, OriginCityMarketID
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest >= -9999 AND CRSDepTime > 2001 GROUP BY OriginState
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime <= 1125 AND DestState IN ('NE', 'WV') GROUP BY WheelsOn
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Carrier IN ('WN', 'DL', 'OO', 'EV', 'MQ') AND Cancelled BETWEEN -2147483648 AND 1 AND CRSElapsedTime = 358 GROUP BY UniqueCarrier, TaxiIn
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestCityName <> 'Great Falls, MT' AND OriginAirportID <= 13873 GROUP BY TaxiIn
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY FirstDepTime, TaxiOut
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime IN (444, 121) GROUP BY Carrier
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 4473 AND 6055 AND WeatherDelay BETWEEN 105 AND 179 AND Distance <= 629 GROUP BY OriginAirportSeqID
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime IN (514)
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TotalAddGTime
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE LongestAddGTime BETWEEN 74 AND 193
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE WheelsOn BETWEEN 709 AND 957 GROUP BY DayOfWeek
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TailNum
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CRSElapsedTime BETWEEN 208 AND 447 GROUP BY NASDelay
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 14 AND 92 AND WheelsOff IN (1243) GROUP BY DivAirportLandings
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID <= 34588 AND DepTime BETWEEN 1028 AND 2018 GROUP BY ArrTimeBlk, CRSArrTime
-SELECT SUM(DepDelay) FROM myStarTable WHERE TaxiIn IN (101, 127, 31, 95)
-SELECT SUM(DepDelay) FROM myStarTable WHERE WeatherDelay IN (405, 33, 44, 11)
-SELECT SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID IN (30397, 31703, 32016)
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Origin >= 'VPS' AND DestAirportID BETWEEN 10713 AND 12896 AND ArrTime >= 534
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Year, OriginAirportSeqID
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier <> 'AS' GROUP BY DivReachedDest, TaxiIn
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier BETWEEN 'HA' AND 'WN' AND DestStateName IN ('Georgia', 'Maine', 'Missouri', 'Idaho')
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Cancelled, LongestAddGTime
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginAirportSeqID, TailNum
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOff >= 1134 AND Diverted BETWEEN -2147483648 AND 0 AND LongestAddGTime BETWEEN 37 AND 45 GROUP BY LateAircraftDelay, DayOfWeek
-SELECT SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportID
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirTime BETWEEN 14 AND 127 AND DestAirportSeqID IN (1013603, 1251102) GROUP BY Month
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY DestStateFips
-SELECT SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY WeatherDelay
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE AirTime BETWEEN 201 AND 348 AND UniqueCarrier BETWEEN 'AA' AND 'B6' GROUP BY OriginAirportID
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime = 366 GROUP BY OriginCityMarketID, TaxiIn
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (-9999, 0) GROUP BY DivReachedDest, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName IN ('Virginia', 'Alabama', 'Maryland') AND DivArrDelay BETWEEN 247 AND 312
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestStateName >= 'Delaware' AND TaxiOut <= 22 AND DivAirportLandings BETWEEN 2 AND 2
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DivDistance = 105
-SELECT SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek BETWEEN 5 AND 5 AND Cancelled > 0 AND CancellationCode >= 'ALL' GROUP BY DestStateFips, CRSDepTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DistanceGroup, AirTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE TaxiOut <= 134 AND CRSElapsedTime BETWEEN 164 AND 231 AND UniqueCarrier BETWEEN 'ALL' AND 'F9' GROUP BY SecurityDelay
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE NASDelay <= 327 AND FlightDate BETWEEN '2014-03-09' AND '2014-10-17' GROUP BY CRSArrTime, Origin
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE AirTime = 270 GROUP BY DistanceGroup
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState IN ('AZ', 'OK', 'NM', 'IA', 'WI') AND DestStateName BETWEEN 'Maryland' AND 'Montana' GROUP BY ArrTime, DivDistance
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Dest >= 'OAJ' GROUP BY LongestAddGTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE CRSElapsedTime <> 168 AND ActualElapsedTime BETWEEN 196 AND 208 AND OriginStateFips IN (78, 56, 42, 72, 35) GROUP BY OriginState
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportID BETWEEN 10372 AND 11697
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY TailNum, TaxiIn
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSArrTime IN (508) GROUP BY DepTimeBlk
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY WheelsOn, CRSArrTime
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DepTime, DestStateFips
-SELECT SUM(ArrDel15) FROM myStarTable WHERE Month BETWEEN -2147483648 AND 7 AND OriginAirportSeqID BETWEEN 1199603 AND 1477101 AND OriginCityMarketID < 32884
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff <= 2106 AND LongestAddGTime IN (6, 53, 121)
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay BETWEEN 50 AND 101 AND TailNum > 'N907DL' AND DepTimeBlk < '1200-1259' GROUP BY OriginCityMarketID
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName BETWEEN 'Colorado' AND 'Hawaii' GROUP BY Distance, DestWac
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1289102 AND 1295402 AND DestCityMarketID BETWEEN 30257 AND 33184 AND LongestAddGTime BETWEEN 14 AND 66
-SELECT SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateName = 'Hawaii' AND OriginAirportSeqID <> 1320402 AND FlightNum >= 898
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TaxiIn <> 22 AND UniqueCarrier = 'AA'
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '0600-0659' AND '2100-2159' AND OriginCityMarketID IN (33127, 34653) AND DayofMonth BETWEEN 18 AND 18
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivArrDelay, DestWac
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate BETWEEN '2014-02-25' AND '2014-08-30' AND SecurityDelay BETWEEN 9 AND 42 GROUP BY DestAirportID, WheelsOn
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier BETWEEN 'AS' AND 'US' GROUP BY Quarter
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate > '2014-08-23' AND CancellationCode IN ('A', 'C', 'noodles', 'ALL') AND DivDistance BETWEEN 896 AND 2398 GROUP BY NASDelay
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips BETWEEN 15 AND 39 GROUP BY Quarter
-SELECT SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk BETWEEN '1100-1159' AND '2200-2259' GROUP BY TaxiOut
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn <> 338 GROUP BY Flights
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE CarrierDelay BETWEEN 42 AND 208
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE CancellationCode IN ('ALL', 'B', 'noodles', 'C')
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Distance BETWEEN 451 AND 461 GROUP BY DestCityMarketID, OriginWac
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Distance, TotalAddGTime
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime IN (37, 8, 27, 60, 126)
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestState IN ('OR', 'CA', 'AL', 'MA', 'FL')
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (0, -2147483648) GROUP BY DestStateName, CRSDepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 11637 AND 14685 AND CRSElapsedTime >= 344
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestWac IN (3, 51, 52, 87) GROUP BY CRSArrTime
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn BETWEEN -9999 AND 80 AND SecurityDelay BETWEEN -9999 AND 4 AND Month <> 5 GROUP BY OriginAirportSeqID
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier > 'DL' AND CRSArrTime IN (427, 2333, 2215, 1856, 1752) AND DestState BETWEEN 'KY' AND 'VI'
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginWac, DivArrDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime IN (42) AND DestState <= 'MA'
-SELECT SUM(DepDel15) FROM myStarTable WHERE OriginState IN ('OR') GROUP BY Cancelled, TaxiIn
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, DivDistance
-SELECT SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier IN ('OO', 'WN', 'MQ', 'EV') GROUP BY LongestAddGTime
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE UniqueCarrier IN ('OO', 'MQ', 'ALL') GROUP BY OriginState
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 31997 AND 33970 AND CRSDepTime <> 2302 AND Cancelled BETWEEN 0 AND 1
-SELECT SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk IN ('0800-0859') AND LongestAddGTime BETWEEN 45 AND 93 AND DestAirportSeqID BETWEEN 1298202 AND 1469802 GROUP BY DivArrDelay
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TailNum
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE OriginWac <> 36 AND DestWac <= 23 AND OriginState BETWEEN 'MO' AND 'TN'
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month BETWEEN 7 AND 10 AND TaxiIn <> 82 AND ActualElapsedTime <= 370 GROUP BY TailNum, DestStateName
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime <= 552 AND OriginStateFips IN (53, 38) GROUP BY OriginAirportID, Carrier
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('State College, PA', 'Meridian, MS', 'Bakersfield, CA', 'Santa Maria, CA', 'Scranton/Wilkes-Barre, PA') AND CRSArrTime BETWEEN 27 AND 724
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay IN (103, 34, 20, 123, 125) GROUP BY DivReachedDest, DivArrDelay
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1219102) AND Quarter BETWEEN -2147483648 AND 1 AND DestState BETWEEN 'MD' AND 'OR'
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Dest BETWEEN 'ISN' AND 'TLH' AND NASDelay BETWEEN 129 AND 213 AND OriginStateFips BETWEEN 25 AND 78 GROUP BY NASDelay
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE TailNum <> 'N783AA' AND LateAircraftDelay BETWEEN -9999 AND 147 AND OriginAirportSeqID BETWEEN 1232002 AND 1477101
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportID, CRSElapsedTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'Hawaii' AND 'Rhode Island' AND Diverted BETWEEN -2147483648 AND 0
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn BETWEEN 15 AND 69 GROUP BY DepTime, OriginState
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DivReachedDest, DestStateName
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Origin, CRSArrTime
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac BETWEEN 22 AND 71 AND FlightDate <> '2014-02-26' GROUP BY AirTime, Dest
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay BETWEEN 76 AND 424 AND TailNum <= 'N198DN' AND DestCityName BETWEEN 'Fairbanks, AK' AND 'St. George, UT' GROUP BY FirstDepTime
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup BETWEEN 5 AND 6 GROUP BY ArrTimeBlk
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Month, NASDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityMarketID, FlightDate
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut, OriginCityName
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime > 441 AND ArrTimeBlk BETWEEN '0900-0959' AND '1400-1459'
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Carrier < 'EV'
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '1900-1959' AND 'ALL' AND ArrTimeBlk BETWEEN '1500-1559' AND '2000-2059' GROUP BY DayofMonth
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, LongestAddGTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivActualElapsedTime <= 1317 AND DivReachedDest IN (1, 0, -9999, -2147483648)
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityName IN ('Medford, OR', 'Lihue, HI', 'Phoenix, AZ', 'Gulfport/Biloxi, MS', 'Wrangell, AK') AND CarrierDelay BETWEEN 0 AND 89 GROUP BY Quarter
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance IN (1521, 868, 84, 29) GROUP BY AirlineID, DepTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay = 27 AND OriginAirportID >= 14828 AND DistanceGroup < 10 GROUP BY Quarter
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY FlightDate, CRSDepTime
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE NASDelay < 174 AND Dest IN ('HOU', 'SGF') AND TailNum BETWEEN 'N527MQ' AND 'N567AA' GROUP BY Flights, DayOfWeek
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime IN (3) GROUP BY FirstDepTime
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Dest
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DivActualElapsedTime, NASDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DestAirportSeqID = 1129202
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TotalAddGTime IN (83, -2147483648, 29) AND Carrier BETWEEN 'AS' AND 'FL' GROUP BY DivDistance, FlightNum
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightDate BETWEEN '2014-03-14' AND '2014-12-21' AND Quarter IN (3) AND DivDistance BETWEEN 604 AND 1166 GROUP BY LateAircraftDelay
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier BETWEEN 'AA' AND 'EV' AND WheelsOn > 1712 GROUP BY Diverted
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID IN (15919, 11641, 13388)
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY TaxiOut
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings IN (2) GROUP BY UniqueCarrier, TailNum
-SELECT SUM(DepDel15) FROM myStarTable WHERE DepTime <= 556 GROUP BY DayofMonth
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState IN ('RI', 'ALL', 'SC', 'UT') AND Year BETWEEN -2147483648 AND 2014
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTime < 700 AND OriginAirportSeqID >= 1474703 AND DestState BETWEEN 'CT' AND 'CT' GROUP BY CarrierDelay, DestCityName
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay BETWEEN 8 AND 41 AND OriginState <= 'SC' GROUP BY FirstDepTime
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE OriginCityName >= 'San Angelo, TX'
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName BETWEEN 'Baltimore, MD' AND 'St. Louis, MO'
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CarrierDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled <= 1 GROUP BY LateAircraftDelay, DepTime
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CRSDepTime IN (1037, 1730, 519, 833) AND OriginStateFips > 26 GROUP BY DestWac
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivDistance BETWEEN 93 AND 460
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk BETWEEN '0600-0659' AND '2000-2059' AND FlightDate IN ('2014-01-31', '2014-09-02') GROUP BY DestStateName, SecurityDelay
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk BETWEEN '0001-0559' AND '1300-1359' AND UniqueCarrier = 'UA' AND CRSDepTime <> 1422 GROUP BY Diverted, OriginStateName
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate IN ('2014-08-14', '2014-07-31', '2014-09-24', '2014-10-08') AND CRSArrTime >= 1025 AND CarrierDelay BETWEEN 19 AND 321
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime BETWEEN 51 AND 86 AND Year BETWEEN -2147483648 AND 2014 GROUP BY TailNum, FlightDate
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Diverted
-SELECT SUM(ArrDel15) FROM myStarTable WHERE FlightDate >= '2014-10-08'
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Distance
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivActualElapsedTime BETWEEN 273 AND 1527 GROUP BY DestAirportID, WheelsOff
-SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE UniqueCarrier BETWEEN 'B6' AND 'DL' AND CarrierDelay BETWEEN 67 AND 121 GROUP BY TaxiIn
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportID <= 12339 AND Quarter BETWEEN -2147483648 AND 1 AND ActualElapsedTime IN (365, 266, 617, 379, 39) GROUP BY DestAirportID, CRSElapsedTime
-SELECT SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (5, -2147483648) GROUP BY WheelsOff, Carrier
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month BETWEEN 3 AND 8 AND OriginCityName BETWEEN 'Birmingham, AL' AND 'Eau Claire, WI' AND DistanceGroup BETWEEN 5 AND 10 GROUP BY NASDelay
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk BETWEEN '2200-2259' AND 'ALL' GROUP BY CRSDepTime, TaxiIn
-SELECT SUM(ArrDelay) FROM myStarTable WHERE FlightDate BETWEEN '2014-05-19' AND '2014-06-25' GROUP BY OriginStateFips
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Carrier >= 'ALL' GROUP BY AirlineID, OriginCityName
-SELECT SUM(ArrDel15) FROM myStarTable WHERE DestStateFips BETWEEN 4 AND 55 AND CarrierDelay BETWEEN 102 AND 102 GROUP BY OriginAirportSeqID
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY TaxiOut, Month
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Distance IN (683, 742, 157, 274) AND DestStateName IN ('North Dakota', 'California', 'New York', 'Illinois', 'Louisiana')
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Cancelled < 1 AND TaxiIn = 10 AND AirTime IN (481, 145, 343, 80) GROUP BY Origin
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE CarrierDelay IN (51, 455, 186, 175, 82) AND DestStateName BETWEEN 'Delaware' AND 'Wyoming' AND OriginStateName <= 'Michigan'
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivDistance
-SELECT SUM(DepDelay) FROM myStarTable WHERE Cancelled IN (0, -2147483648, 1) AND ArrTime IN (739) GROUP BY OriginWac, SecurityDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ActualElapsedTime >= 373 AND WheelsOff BETWEEN 145 AND 1957 GROUP BY DivDistance
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE OriginWac IN (63, 11, 74, 45, 16) GROUP BY Origin, WheelsOn
-SELECT SUM(ArrDelay) FROM myStarTable WHERE Distance IN (490, 1158, 2267)
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOn, Diverted
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips IN (36, 13) AND ActualElapsedTime BETWEEN 110 AND 617 AND CRSElapsedTime BETWEEN 565 AND 575 GROUP BY OriginStateName, FlightDate
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY TailNum
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE AirTime IN (269) GROUP BY DestAirportID, AirlineID
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE NASDelay BETWEEN 123 AND 288
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('2100-2159', '2300-2359')
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DivActualElapsedTime BETWEEN 317 AND 609 GROUP BY DestAirportID
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled IN (1, 0, -2147483648) GROUP BY OriginState
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled BETWEEN -2147483648 AND 1 GROUP BY DestStateName, CancellationCode
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime IN (109, 56, 41, 100) AND CRSDepTime <> 1913 GROUP BY Cancelled, DepTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY FlightNum
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ArrTime, NASDelay
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime = 40 AND WeatherDelay <> 228 GROUP BY DistanceGroup
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, Month
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay <= 205 AND Diverted <> -2147483648 AND CarrierDelay > 39
-SELECT SUM(ArrDel15) FROM myStarTable WHERE LongestAddGTime IN (4, 53) AND DepTimeBlk BETWEEN '0600-0659' AND 'ALL' GROUP BY OriginCityName
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime IN (643, 629) GROUP BY OriginStateName, DepTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1158702, 1110902, 1200302) GROUP BY OriginAirportSeqID, TaxiIn
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CarrierDelay, DivArrDelay
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Month BETWEEN 7 AND 9 AND ArrTimeBlk IN ('2000-2059', '1000-1059') GROUP BY Origin
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime >= 281
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID BETWEEN 10397 AND 11726 GROUP BY OriginStateName, Flights
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY DestWac, WeatherDelay
-SELECT SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID IN (20409, 20436, 19790) AND DistanceGroup > 8
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Quarter BETWEEN -2147483648 AND 4 AND CarrierDelay IN (187, 228, 25, 238, 137) AND WheelsOn BETWEEN 731 AND 1619 GROUP BY DestStateName, NASDelay
-SELECT SUM(DepDel15) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier BETWEEN 'VX' AND 'WN' GROUP BY DivArrDelay
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID BETWEEN 30146 AND 30436 AND FlightNum BETWEEN 897 AND 1388 AND Cancelled BETWEEN -2147483648 AND 0 GROUP BY NASDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE WheelsOn IN (457, 1243, 1355)
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Carrier >= 'OO' GROUP BY DivArrDelay
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID IN (1524903, 1288903) AND UniqueCarrier < 'OO' AND DepTime BETWEEN 1232 AND 1727
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE LongestAddGTime BETWEEN 13 AND 85 GROUP BY FlightNum, DayOfWeek
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginState = 'MT' GROUP BY AirlineID, DivReachedDest
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportID > 10980 AND FlightDate IN ('2014-06-18', '2014-01-29', '2014-08-27', '2014-10-25', '2014-08-21') GROUP BY DestStateFips, TailNum
-SELECT SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay > 9 AND FlightNum > 106 GROUP BY OriginCityMarketID, DestAirportID
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime > 135 AND TaxiOut < 130 GROUP BY LongestAddGTime, OriginCityName
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, CRSElapsedTime
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE NASDelay BETWEEN 162 AND 378
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestWac BETWEEN 41 AND 65 AND CarrierDelay >= 36 GROUP BY Year, ArrTimeBlk
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE FlightDate < '2014-01-05' AND OriginAirportID <> 14193 GROUP BY Year
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY DayofMonth, FlightNum
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest BETWEEN 0 AND 1 GROUP BY Flights
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestState, Flights
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay >= 33 AND CRSDepTime BETWEEN 1928 AND 2345 AND Year BETWEEN 2014 AND 2014 GROUP BY Cancelled
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND TailNum BETWEEN 'N571UW' AND 'N8638A' AND ArrTime IN (1432) GROUP BY DivAirportLandings, Flights
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY UniqueCarrier
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime BETWEEN -9999 AND 90
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay BETWEEN 20 AND 935
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE SecurityDelay BETWEEN 1 AND 24
-SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ArrTimeBlk, DistanceGroup
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Quarter IN (3, 4, 2) AND LateAircraftDelay <> 121 AND WheelsOn IN (2153, 718, 655, 1638) GROUP BY FirstDepTime
-SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime IN (1008) AND Carrier BETWEEN 'AA' AND 'AS'
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestStateFips BETWEEN 5 AND 38 AND TotalAddGTime > 3
-SELECT SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest BETWEEN 1 AND 1 AND OriginCityMarketID = 33127 GROUP BY DestWac
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY Year
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTime IN (1615, 1208, 2006, 450) GROUP BY FirstDepTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Carrier BETWEEN 'HA' AND 'US' GROUP BY LateAircraftDelay
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter IN (3, 4, -2147483648, 1, 2)
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1098002 AND 1490503 GROUP BY CRSDepTime, OriginCityMarketID
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut IN (38, 83, 27) GROUP BY DivActualElapsedTime, DepTimeBlk
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayofMonth BETWEEN 4 AND 22 AND DivDistance > 600 GROUP BY TotalAddGTime, DestCityName
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth < 4 AND TailNum < 'N759GS'
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightDate IN ('2014-10-17', '2014-04-17', '2014-02-09', '2014-04-13') AND ActualElapsedTime <= 668
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiOut BETWEEN 48 AND 55
-SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Quarter > 3 GROUP BY UniqueCarrier
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY LateAircraftDelay, DestState
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportSeqID IN (1412202, 1234302) GROUP BY DestCityName
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips BETWEEN 34 AND 55 AND WheelsOn IN (1116, 1942, 2100, 1608) AND TailNum <> 'N614QX'
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY Origin
-SELECT SUM(DepDelay) FROM myStarTable WHERE CarrierDelay IN (37, 255) AND Quarter IN (3, 1, 2, -2147483648, 4) AND DivActualElapsedTime <> 1308 GROUP BY FlightNum, Cancelled
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1100303 AND 1161706 AND Quarter BETWEEN 4 AND 4
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn < 248 AND DestStateName = 'Wisconsin' GROUP BY CRSDepTime
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips IN (41, 46) GROUP BY Quarter
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TaxiOut, Year
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 1845 AND 1853 AND UniqueCarrier IN ('B6', 'F9', 'FL', 'AA') AND Carrier IN ('FL') GROUP BY ActualElapsedTime, DayofMonth
-SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable
-SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay <= 50
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestStateFips IN (18) GROUP BY TaxiIn, DistanceGroup
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestState IN ('GA', 'MO', 'VI', 'PA') AND DestCityName BETWEEN 'Eau Claire, WI' AND 'Waterloo, IA' AND DepTimeBlk IN ('1100-1159', '1800-1859', '2000-2059')
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter BETWEEN 2 AND 3 AND WheelsOn IN (1607, 506) AND Origin < 'CAK' GROUP BY Quarter, FlightDate
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTimeBlk > '0700-0759' GROUP BY DestState, DepTimeBlk
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportID BETWEEN 10620 AND 11648 GROUP BY WheelsOn
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DayofMonth <> 30
-SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestCityMarketID BETWEEN 30599 AND 33785 AND Distance BETWEEN 309 AND 628 GROUP BY DivAirportLandings
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE AirTime < 312
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY Year
-SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE FirstDepTime = 1954 AND UniqueCarrier BETWEEN 'AS' AND 'WN' GROUP BY Carrier, DivReachedDest
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityMarketID IN (32600) AND Cancelled IN (-2147483648, 1, 0) AND OriginAirportSeqID < 1164102 GROUP BY DayofMonth, ArrTimeBlk
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay <> 370 AND DestCityMarketID IN (31617, 32129, 31401, 32211, 32323) GROUP BY OriginState
-SELECT SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings IN (0, 9) GROUP BY Carrier, WheelsOn
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut IN (133, 86) AND ArrTimeBlk <= '1400-1459'
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestAirportSeqID, OriginState
-SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE Diverted IN (0) GROUP BY Quarter
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY FirstDepTime, Distance
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportID IN (13931)
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE WeatherDelay <= 92 AND DestStateFips <> 24
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month < 9 GROUP BY DistanceGroup, DivArrDelay
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID BETWEEN 10926 AND 14893
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE AirTime BETWEEN 277 AND 380 AND WheelsOff BETWEEN 653 AND 1502
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ActualElapsedTime <= 122 GROUP BY UniqueCarrier
-SELECT SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk BETWEEN '1500-1559' AND '1500-1559'
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut, DivArrDelay
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginAirportSeqID
-SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TaxiIn, DestState
-SELECT SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay BETWEEN 87 AND 143 GROUP BY OriginState, Cancelled
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY Cancelled
-SELECT SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CarrierDelay
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay = 129
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE WheelsOff < 2354 AND DayofMonth BETWEEN 11 AND 23 GROUP BY DivDistance, Dest
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TotalAddGTime BETWEEN 45 AND 149 GROUP BY DestState
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter IN (-2147483648, 3, 2, 1) AND DestStateFips BETWEEN 10 AND 15 AND LateAircraftDelay IN (30) GROUP BY DestAirportSeqID, WheelsOn
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Origin < 'MOB' AND DepTime IN (31) GROUP BY LateAircraftDelay, DestCityName
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityMarketID BETWEEN 31953 AND 33502 AND DayofMonth BETWEEN 7 AND 12 GROUP BY DivArrDelay, TailNum
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Month IN (1, 2, 4) AND Quarter BETWEEN -2147483648 AND 1 GROUP BY NASDelay, OriginAirportSeqID
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 10551 AND 11423 AND CarrierDelay <> 455 GROUP BY DestStateName
-SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginCityMarketID > 31066
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk IN ('2000-2059', '1000-1059') AND Carrier IN ('MQ', 'UA', 'FL', 'OO', 'DL') AND DayofMonth BETWEEN 1 AND 8 GROUP BY WeatherDelay, OriginWac
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiIn
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled IN (-2147483648, 1, 0) GROUP BY AirTime
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE SecurityDelay > 6 AND DayOfWeek BETWEEN -2147483648 AND 2 AND DestStateFips >= 23 GROUP BY Dest, Diverted
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityMarketID BETWEEN 31867 AND 34113 AND DestWac <> 22 GROUP BY FlightDate, FlightNum
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivDistance IN (170, 733, 173, 54) GROUP BY WheelsOff
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay BETWEEN 138 AND 184 GROUP BY OriginCityName, OriginState
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE SecurityDelay BETWEEN 3 AND 50
-SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportID, Diverted
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Quarter IN (2, 3, 4) AND FlightDate BETWEEN '2014-04-09' AND '2014-06-05' AND Diverted IN (0, -2147483648) GROUP BY DepTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE NASDelay BETWEEN 85 AND 119 AND DestState IN ('VI', 'MS', 'TN', 'PR') GROUP BY TailNum, FirstDepTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay IN (193) AND ArrTime >= 143
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter IN (2) AND ActualElapsedTime <= 137
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Diverted IN (1) AND DivDistance >= 849 AND DestStateFips IN (54, 42, 29, 15, 18) GROUP BY SecurityDelay
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Diverted, DestCityName
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportSeqID IN (1111102, 1199603, 1104103, 1133703, 1345902) AND CRSDepTime BETWEEN 1324 AND 1842
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivArrDelay, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY LateAircraftDelay, LongestAddGTime
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportID IN (14006, 14633, 12448) AND OriginStateName IN ('U.S. Virgin Islands', 'Indiana', 'Iowa', 'Florida', 'New Jersey') AND DestCityMarketID BETWEEN 30990 AND 33105 GROUP BY DepTime, OriginAirportID
-SELECT SUM(ArrDelay) FROM myStarTable WHERE AirlineID IN (19930, 21171, 20398, 20436, 19977) AND CRSDepTime BETWEEN 848 AND 949 GROUP BY TotalAddGTime
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk BETWEEN '0900-0959' AND '1600-1659' AND Quarter IN (4, 2)
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY SecurityDelay, Quarter
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiOut BETWEEN 102 AND 105 AND OriginStateName < 'Idaho'
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID BETWEEN 30140 AND 31049 AND OriginAirportID BETWEEN 10268 AND 14262 GROUP BY DestState
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate IN ('2014-04-04', '2014-12-27', '2014-01-03') AND DivAirportLandings IN (0, 1, 2, -2147483648)
-SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Cancelled IN (1, 0, -2147483648) AND LateAircraftDelay IN (179, 217) GROUP BY OriginCityMarketID
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivReachedDest <= -9999 AND ArrTimeBlk IN ('1900-1959') AND CRSDepTime < 1050 GROUP BY WheelsOff
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest <= 0 GROUP BY DestAirportID, CRSElapsedTime
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Diverted BETWEEN 0 AND 1 AND DestWac IN (3, 5, 66, 39) AND DivArrDelay BETWEEN 118 AND 402 GROUP BY CarrierDelay
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'California' AND 'Montana' AND Dest >= 'SMF' AND Quarter IN (1, 2, 3, 4) GROUP BY FlightNum, AirlineID
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY CarrierDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestAirportID < 11823 AND Diverted BETWEEN -2147483648 AND 0 AND DayOfWeek > -2147483648 GROUP BY DayOfWeek
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginStateName >= 'Massachusetts' AND DivArrDelay IN (331, 213)
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY CRSElapsedTime
-SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName IN ('Oregon', 'Alabama') AND OriginCityMarketID > 34150 GROUP BY WheelsOff
-SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1412202, 1013603, 1393102)
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginCityName BETWEEN 'Bloomington/Normal, IL' AND 'Omaha, NE' AND Quarter <> 3 AND WheelsOff BETWEEN 28 AND 1036
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirTime < 401 AND ActualElapsedTime BETWEEN 202 AND 388 AND DepTimeBlk IN ('0600-0659', '1400-1459') GROUP BY DestAirportID
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '2000-2059' AND '2300-2359' GROUP BY CRSElapsedTime, TaxiIn
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings IN (9, 2, -2147483648) AND OriginAirportSeqID BETWEEN 1084903 AND 1560702 AND CancellationCode IN ('noodles', 'ALL', 'B', 'C', 'A') GROUP BY DestStateFips
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY ArrTimeBlk
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Flights IN (1, -2147483648)
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY WeatherDelay
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier <= 'B6' AND DestWac <> 14 AND DayofMonth IN (2, 18, 25) GROUP BY CRSArrTime, ArrTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE CancellationCode BETWEEN 'noodles' AND 'noodles' AND Flights IN (1, -2147483648) GROUP BY DestWac, DayOfWeek
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportSeqID
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Carrier <> 'AA' AND Diverted >= -2147483648
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn >= 2009 AND Carrier BETWEEN 'AA' AND 'MQ'
-SELECT SUM(ArrDel15) FROM myStarTable WHERE CRSElapsedTime BETWEEN 211 AND 339 AND AirlineID IN (20409, 20355, 19393, 19977, 19930) AND DestWac IN (1, 34, 38, 54) GROUP BY Quarter
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY Year, Distance
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Year
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay IN (95)
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DestWac, DivReachedDest
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff < 1943 GROUP BY CRSDepTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginWac IN (2, 38) AND FlightNum BETWEEN 4617 AND 7376 AND Quarter BETWEEN -2147483648 AND 3 GROUP BY DestWac
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName BETWEEN 'Arizona' AND 'Mississippi' AND LongestAddGTime BETWEEN 66 AND 70 AND Diverted BETWEEN 0 AND 0 GROUP BY TaxiOut
-SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn <= 39
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DayOfWeek IN (4, -2147483648) AND DestCityMarketID IN (35991, 32575, 35041, 32888)
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode > 'C' AND WheelsOff BETWEEN 1745 AND 2148 AND DestAirportSeqID IN (1133602, 1066602, 1529502, 1188402) GROUP BY DayOfWeek
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DayofMonth > 18 AND NASDelay >= 44 GROUP BY DestCityName, NASDelay
-SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Distance IN (1727, 252, 873) GROUP BY WheelsOff, CRSDepTime
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID >= 11977 GROUP BY ArrTimeBlk
-SELECT SUM(DepDelay) FROM myStarTable GROUP BY Carrier, OriginStateName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = 1 GROUP BY OriginStateFips
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('2300-2359', '2200-2259') AND CRSElapsedTime <> 393 GROUP BY CarrierDelay
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY AirTime
-SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE WheelsOn BETWEEN 1317 AND 1547 AND DistanceGroup >= 5 GROUP BY DayOfWeek
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestState
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY CancellationCode, DayOfWeek
-SELECT SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY AirTime, Distance
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSDepTime BETWEEN 555 AND 717 AND ActualElapsedTime = 232 AND DestWac BETWEEN 38 AND 87 GROUP BY TailNum, FirstDepTime
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND DepTime IN (453, 103)
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginState IN ('AZ', 'LA', 'HI', 'CA', 'DE')
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime IN (173, 290, 339, 251, 450) AND DistanceGroup BETWEEN 4 AND 11 GROUP BY DestStateName
-SELECT SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime IN (490, 267, 538) AND CancellationCode BETWEEN 'ALL' AND 'noodles' AND SecurityDelay IN (33, -9999, 14, 15)
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE TaxiOut IN (9, 138, 60, 93) GROUP BY OriginAirportID
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Pago Pago, TT', 'Spokane, WA', 'Santa Fe, NM')
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TailNum
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY TotalAddGTime, UniqueCarrier
-SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime IN (102) AND ArrTimeBlk IN ('0001-0559', '1000-1059', '1600-1659', '0700-0759', '1100-1159') AND Flights IN (1, -2147483648)
-SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate BETWEEN '2014-07-08' AND '2014-09-14' AND LateAircraftDelay IN (259, 15) AND DivAirportLandings IN (-2147483648, 9, 2, 0) GROUP BY ArrTimeBlk
-SELECT SUM(DepDel15) FROM myStarTable
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestStateFips IN (21, 45, 32) AND OriginAirportSeqID <= 1348602 GROUP BY WeatherDelay
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek > 3 GROUP BY DivActualElapsedTime, TaxiOut
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1532302, 1379502, 1073905) AND WheelsOn >= 17 AND TailNum <> 'N752SW' GROUP BY DivReachedDest, Cancelled
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek IN (3, -2147483648)
+SELECT SUM(DepDelay) FROM myStarTable WHERE CRSDepTime BETWEEN 1628 AND 1740 AND Cancelled <> 1 AND LateAircraftDelay IN (17) GROUP BY TaxiOut, OriginState
+SELECT SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime BETWEEN 17 AND 214
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DestStateFips BETWEEN 33 AND 50 AND ActualElapsedTime >= 346 GROUP BY CRSElapsedTime
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID
+SELECT SUM(DepDelay) FROM myStarTable WHERE WheelsOn > 642 AND TotalAddGTime = 25
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY SecurityDelay
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DaysSinceEpoch BETWEEN 16210 AND 16335 GROUP BY CancellationCode
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime <> 194
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime IN (67, 23, 27, 46) GROUP BY DaysSinceEpoch, OriginStateName
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityName IN ('Champaign/Urbana, IL', 'Abilene, TX', 'Escanaba, MI', 'Denver, CO')
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DivReachedDest BETWEEN -9999 AND 0 AND AirlineID <> 20436
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DaysSinceEpoch IN (16327, 16152, 16281) GROUP BY AirTime, ArrTimeBlk
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateName IN ('Washington', 'North Dakota', 'Puerto Rico', 'Arkansas') GROUP BY TaxiOut
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE UniqueCarrier = 'OO' AND CRSArrTime IN (1116, 557, 1216) GROUP BY OriginCityMarketID, DestWac
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Cancelled BETWEEN -2147483648 AND 1 AND Year >= -2147483648
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TailNum IN ('N524UA', 'N189DN', 'N7811F', 'N582CA', 'N14514') GROUP BY TaxiIn
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate < '2014-09-12' AND TaxiIn < 127 AND OriginCityName < 'St. George, UT' GROUP BY DivDistance
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY CRSArrTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance BETWEEN 192 AND 1605 GROUP BY CarrierDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY CRSArrTime, Flights
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateFips IN (21, 25, 18, 35) AND Diverted BETWEEN 0 AND 0 AND DestCityName BETWEEN 'Harlingen/San Benito, TX' AND 'Lewiston, ID' GROUP BY CRSElapsedTime, FlightDate
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DestWac <= 13 AND Carrier <= 'WN'
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE FirstDepTime BETWEEN 1112 AND 1353 GROUP BY Month, DepTime
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportID IN (11337) AND WheelsOff <> 1030
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CarrierDelay = 142
+SELECT SUM(DepDel15) FROM myStarTable WHERE WheelsOff IN (1442) AND Month BETWEEN 4 AND 8 GROUP BY Month
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TotalAddGTime
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY AirTime
+SELECT SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay <> 99
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN 418 AND 932 GROUP BY Distance
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CancellationCode BETWEEN 'B' AND 'C' AND TaxiOut IN (3, 132, 37, 54, 39) AND TailNum <> 'N8642E' GROUP BY TailNum, Quarter
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE DivDistance IN (258, 264, 721, 485, 213) AND DestStateName BETWEEN 'Massachusetts' AND 'North Carolina'
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTime IN (2209, 143) AND DayofMonth BETWEEN -2147483648 AND 19 AND OriginAirportID BETWEEN 10154 AND 12266 GROUP BY DestState
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityName
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime BETWEEN 2 AND 146 GROUP BY OriginAirportSeqID, NASDelay
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Year BETWEEN 2014 AND 2014 AND WheelsOn > 22
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn BETWEEN 42 AND 67 GROUP BY OriginStateFips
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Dest IN ('AMA', 'BZN', 'ASE') GROUP BY CRSArrTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DestStateFips BETWEEN 54 AND 72 AND TaxiIn IN (33, 19, 76) GROUP BY DestAirportSeqID
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE Cancelled BETWEEN 1 AND 1 AND FlightNum BETWEEN 4641 AND 6429 GROUP BY Dest, AirlineID
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE NASDelay BETWEEN 58 AND 155 AND FirstDepTime BETWEEN 801 AND 1842 GROUP BY TaxiOut
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin < 'RSW' AND TotalAddGTime IN (84, 21, 43, 77, 124)
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivActualElapsedTime BETWEEN 469 AND 816 GROUP BY Quarter, AirTime
+SELECT SUM(ArrDel15) FROM myStarTable WHERE AirTime BETWEEN 289 AND 409 AND LateAircraftDelay IN (37) GROUP BY NASDelay
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginCityMarketID, DivAirportLandings
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY CRSArrTime
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE UniqueCarrier IN ('VX', 'F9', 'WN') AND AirlineID <> 19790 AND LateAircraftDelay IN (176, 146, 8, 217) GROUP BY DepTimeBlk, FlightDate
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay = 2 AND DestAirportID BETWEEN 11067 AND 14524
 SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest IN (-2147483648, 0, -9999) AND OriginWac >= -2147483648 GROUP BY OriginWac
-SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Flights
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginState
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CRSArrTime <> 1037 AND Dest IN ('SIT')
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'Alabama' AND 'Nevada'
-SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE Month IN (6, 11, 8, 4, 9) AND DestCityMarketID IN (33388)
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DayofMonth = 28 AND OriginAirportSeqID > 1127802 GROUP BY FlightDate
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Quarter BETWEEN 2 AND 3 AND Origin BETWEEN 'ALL' AND 'GCK' GROUP BY Cancelled, NASDelay
-SELECT SUM(DepDel15) FROM myStarTable WHERE Origin IN ('GPT', 'MDW', 'PDX') GROUP BY TotalAddGTime, ActualElapsedTime
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Carrier
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestCityName, WeatherDelay
-SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DayofMonth <= 17 AND ArrTime IN (1405, 2211, 1952) AND OriginWac IN (3, 5, 65, 85) GROUP BY OriginState, TotalAddGTime
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WeatherDelay < 101 AND TaxiOut IN (27) GROUP BY Flights, Carrier
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year <> -2147483648 AND CRSDepTime BETWEEN 109 AND 1406
-SELECT SUM(ArrDelay) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivArrDelay BETWEEN 125 AND 191 AND DestAirportSeqID >= 1299204 AND DayofMonth < 10 GROUP BY OriginCityMarketID
-SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime <> 112 GROUP BY UniqueCarrier
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier IN ('FL', 'F9') GROUP BY DivAirportLandings
-SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOn >= 1400
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, DestCityName
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TailNum BETWEEN 'N453UA' AND 'N615SW' AND OriginStateName BETWEEN 'Nebraska' AND 'Tennessee' GROUP BY AirTime, FlightNum
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime, OriginAirportID
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay <> 48
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Origin IN ('DCA', 'IAD') AND TaxiOut = 45 GROUP BY AirlineID
-SELECT SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportID
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest > -2147483648 AND CancellationCode IN ('noodles', 'ALL', 'A') GROUP BY FlightDate
-SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSArrTime >= 1725 AND CarrierDelay BETWEEN 17 AND 1139 AND Quarter BETWEEN 3 AND 4
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay BETWEEN 6 AND 200 AND OriginState <> 'UT'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips IN (31, 55, 33, 32) AND LateAircraftDelay BETWEEN 81 AND 157
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN 1236 AND 2359 GROUP BY ArrTime, UniqueCarrier
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSArrTime BETWEEN 1016 AND 2319 AND NASDelay >= 203 AND DestCityName <> 'ALL'
-SELECT SUM(DepDelay) FROM myStarTable WHERE DayofMonth <= 2 AND DestStateName IN ('Washington', 'Kansas', 'Michigan', 'Connecticut', 'Maine') AND FlightDate >= '2014-11-27' GROUP BY Month, DestCityMarketID
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE Origin > 'TUL' GROUP BY Carrier
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginWac IN (61, 22) AND LateAircraftDelay IN (25, 112)
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginCityMarketID IN (31714)
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter >= 1 GROUP BY Month
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY DestState
-SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TailNum BETWEEN 'N636JB' AND 'N682DA' AND FlightNum < 1797 GROUP BY Diverted, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE NASDelay <= 287 AND FlightNum IN (2434, 2307, 5668) GROUP BY DivActualElapsedTime, Diverted
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DepTime BETWEEN 904 AND 1639 AND DestState >= 'DE' GROUP BY Month
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights IN (1, -2147483648) AND DivArrDelay BETWEEN 138 AND 231 AND OriginAirportSeqID IN (1099002, 1537002)
-SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestAirportID <> 13029 AND Quarter IN (1, 3, -2147483648, 2) GROUP BY Dest, DestStateFips
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE TailNum IN ('N495CA', 'N603MQ', 'N1607B', 'N446UA', 'N794AS') AND AirlineID BETWEEN 19690 AND 19805 AND Month BETWEEN 9 AND 12 GROUP BY WeatherDelay
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DivAirportLandings IN (0) GROUP BY OriginCityMarketID
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityMarketID, DestWac
-SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
-SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY WheelsOn, AirlineID
-SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE TaxiOut <> 118
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestStateFips BETWEEN 15 AND 28 AND SecurityDelay IN (18) GROUP BY Month, ActualElapsedTime
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime > 1544 AND DestWac BETWEEN 41 AND 81 AND DistanceGroup >= 11 GROUP BY DestCityName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay IN (67) GROUP BY FlightDate, OriginState
-SELECT SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID < 31136 AND OriginWac IN (54, 52) AND DestAirportID IN (10154, 14520, 11433, 11041) GROUP BY DivArrDelay, DepTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestState IN ('OR') GROUP BY TaxiOut
-SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier IN ('OO', 'VX', 'AA', 'MQ', 'UA') AND WheelsOff BETWEEN 829 AND 1122 AND DestAirportSeqID IN (1411302, 1468502, 1119302, 1402702, 1345902)
-SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestStateFips > 54 GROUP BY TotalAddGTime
-SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestWac < 34 AND Dest <= 'GUC' AND DestCityMarketID BETWEEN 30070 AND 30361
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY TotalAddGTime
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE OriginAirportSeqID <= 1302402 AND Month <= 12
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE NASDelay BETWEEN 19 AND 152
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk IN ('2100-2159', '0700-0759', '1100-1159', '1400-1459') AND DestStateName > 'New Hampshire'
-SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CancellationCode, OriginStateName
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted, DestStateName
-SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted IN (-2147483648, 0, 1)
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DestWac
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE AirTime <> 520 AND Distance IN (1521, 1488, 410) GROUP BY WheelsOff, DepTimeBlk
-SELECT SUM(ArrDel15) FROM myStarTable WHERE WheelsOff IN (1000, 1611, 854, 1712) GROUP BY ActualElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityName BETWEEN 'Champaign/Urbana, IL' AND 'Modesto, CA' AND Origin BETWEEN 'MDT' AND 'WRG' AND Carrier < 'VX'
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest BETWEEN 0 AND 1 AND OriginStateName IN ('North Dakota', 'Tennessee') AND AirlineID BETWEEN 19790 AND 19805
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestStateName IN ('Wyoming', 'Utah', 'Arizona') AND LateAircraftDelay >= 146 AND AirlineID <> 20366 GROUP BY Carrier, TailNum
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate <> '2014-07-23'
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestState <> 'MN' AND DayofMonth > 7 AND Cancelled BETWEEN 1 AND 1 GROUP BY DivActualElapsedTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName IN ('Virginia', 'South Carolina') AND DivReachedDest IN (-2147483648, 0, 1, -9999) GROUP BY OriginStateName, NASDelay
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay BETWEEN 0 AND 8 AND Cancelled = 0
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE UniqueCarrier IN ('EV', 'ALL', 'WN', 'UA') AND OriginAirportSeqID = 1467903 AND DistanceGroup BETWEEN -2147483648 AND 11 GROUP BY DayOfWeek
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE ActualElapsedTime <> 480 AND WeatherDelay IN (213, -9999, 145) AND CRSArrTime BETWEEN 1949 AND 2235
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime <= 273 GROUP BY DivReachedDest, Quarter
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivDistance, DestCityName
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Month BETWEEN -2147483648 AND 10 AND AirTime > 150 AND OriginStateFips IN (78, 46, 49) GROUP BY Year, DestCityMarketID
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DayofMonth <= 12 AND NASDelay BETWEEN 15 AND 66 AND Flights BETWEEN 1 AND 1
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DaysSinceEpoch IN (16179, 16168, 16223) AND TaxiOut IN (65, 119, 76, 30) GROUP BY Distance
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings BETWEEN 9 AND 9 GROUP BY DistanceGroup, CRSDepTime
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DestCityName IN ('Gillette, WY', 'Adak Island, AK') GROUP BY DestState, Distance
+SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE FlightDate IN ('2014-08-23', '2014-03-24', '2014-11-03', '2014-03-26', '2014-10-31') GROUP BY DepTime
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestStateName BETWEEN 'Louisiana' AND 'New Jersey' AND CancellationCode IN ('A', 'B')
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName BETWEEN 'Greer, SC' AND 'Twin Falls, ID' AND ActualElapsedTime BETWEEN 199 AND 403 AND WheelsOn IN (853, 1143)
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest IN (0, 1, -2147483648, -9999) AND Flights <= 1 AND Origin IN ('TRI', 'LAR')
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum BETWEEN 2742 AND 4446 GROUP BY OriginCityName, DayofMonth
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut, DivArrDelay
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CarrierDelay BETWEEN 117 AND 291 GROUP BY ArrTimeBlk
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportID BETWEEN 14576 AND 14633
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestCityName, TotalAddGTime
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Year BETWEEN 2014 AND 2014 GROUP BY OriginState
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Diverted IN (-2147483648, 0) GROUP BY DayofMonth
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DivReachedDest = -9999 AND AirTime BETWEEN 89 AND 169 AND DayofMonth BETWEEN 5 AND 23 GROUP BY TaxiOut, Dest
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1133602 AND 1468902 AND NASDelay BETWEEN 63 AND 164
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityName <> 'Christiansted, VI'
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestStateName, DivDistance
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DaysSinceEpoch = 16120 GROUP BY DestStateName, TaxiIn
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE NASDelay < 170 GROUP BY DayofMonth
+SELECT SUM(DepDel15) FROM myStarTable WHERE Carrier BETWEEN 'EV' AND 'VX' AND OriginState IN ('CO', 'IL') GROUP BY OriginStateFips, Cancelled
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE DepTimeBlk <= '1800-1859' GROUP BY DaysSinceEpoch, Carrier
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY WeatherDelay, DivActualElapsedTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DistanceGroup BETWEEN 8 AND 8
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE DestStateFips IN (47, 16, 34)
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestWac IN (34, 64, 92, 15, 82) GROUP BY OriginCityName, ActualElapsedTime
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID <= 1337702 AND OriginState BETWEEN 'MI' AND 'ND'
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY Cancelled
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportID
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Month BETWEEN 4 AND 11 GROUP BY FlightNum, ActualElapsedTime
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateName
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted BETWEEN -2147483648 AND 1 GROUP BY LongestAddGTime, DepTime
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime BETWEEN 852 AND 1658 AND WheelsOff > 811 AND SecurityDelay IN (3, 7, 10, 14) GROUP BY UniqueCarrier, DistanceGroup
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportSeqID IN (1315802, 1560702, 1342402, 1348602) GROUP BY Distance
+SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOff >= 2253 AND OriginStateFips IN (2, 8, 27, 44) GROUP BY OriginAirportSeqID
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier = 'US' AND CRSElapsedTime < 373
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateFips IN (22, 13, 49)
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TailNum, DestStateFips
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DestStateFips BETWEEN 15 AND 46 AND DepTimeBlk IN ('2100-2159') AND SecurityDelay <> 4
+SELECT SUM(DepDel15) FROM myStarTable WHERE DayofMonth > 21
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CarrierDelay = 50 AND WheelsOff BETWEEN 331 AND 1217 AND OriginAirportSeqID IN (1329604, 1477101, 1320402) GROUP BY Quarter
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE TotalAddGTime BETWEEN 24 AND 135 GROUP BY FirstDepTime
+SELECT SUM(DepDel15) FROM myStarTable WHERE Carrier BETWEEN 'DL' AND 'WN'
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivDistance IN (746, 261, 334, 729, 80) GROUP BY TotalAddGTime
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CarrierDelay
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestCityMarketID < 34986 AND DaysSinceEpoch IN (16087, 16406, 16188, 16368, 16096) AND ActualElapsedTime < 479
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay IN (171) AND TailNum BETWEEN 'N216JB' AND 'N440LV' GROUP BY Dest
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier IN ('UA', 'ALL', 'OO', 'AA', 'F9') AND WeatherDelay >= 97 AND OriginAirportID BETWEEN 10599 AND 13230 GROUP BY DepTime, DestState
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Year, DepTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Year BETWEEN 2014 AND 2014 GROUP BY Cancelled, DayOfWeek
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportSeqID, CancellationCode
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 37 AND 2053 AND TaxiOut BETWEEN 85 AND 127 AND Quarter >= 3 GROUP BY UniqueCarrier, DepTimeBlk
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE FlightDate BETWEEN '2014-03-10' AND '2014-08-29' GROUP BY DayOfWeek
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestCityName > 'Rochester, MN' AND ActualElapsedTime < 284 AND DistanceGroup < 9 GROUP BY AirTime, DestStateFips
+SELECT SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName <> 'Fayetteville, AR' AND WheelsOn <> 446 AND CRSDepTime >= 2332
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Diverted BETWEEN -2147483648 AND 1 AND ActualElapsedTime BETWEEN 176 AND 668 GROUP BY DivActualElapsedTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightNum = 3876
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE Carrier IN ('AS', 'F9', 'AA', 'B6', 'UA') AND UniqueCarrier IN ('WN', 'ALL', 'UA', 'FL') GROUP BY DestStateFips, DepTimeBlk
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE WheelsOff = 1013 AND DivAirportLandings BETWEEN -2147483648 AND 1 AND OriginCityMarketID < 34699
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestStateName BETWEEN 'Colorado' AND 'Louisiana'
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Carrier
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DestWac
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY ActualElapsedTime, DayofMonth
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DepTime IN (1353) AND DestStateFips > 21 AND DestState BETWEEN 'OH' AND 'PA' GROUP BY FlightNum, SecurityDelay
+SELECT SUM(DepDelay) FROM myStarTable WHERE Quarter BETWEEN 1 AND 2 AND OriginCityMarketID >= 33256 GROUP BY NASDelay
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DestCityMarketID
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DivArrDelay <= 460 AND OriginStateName IN ('Texas', 'New Mexico') GROUP BY DepTimeBlk
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FirstDepTime IN (938, 1321, 755, 1728) AND FlightNum BETWEEN 1090 AND 4263 AND OriginCityMarketID IN (30268, 33342, 30994, 30693, 34256) GROUP BY CarrierDelay, OriginCityName
+SELECT SUM(DepDel15) FROM myStarTable WHERE CRSDepTime IN (2145) AND OriginStateFips BETWEEN 5 AND 50 AND OriginState BETWEEN 'CA' AND 'SD' GROUP BY LongestAddGTime, TaxiIn
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName BETWEEN 'Hobbs, NM' AND 'Monroe, LA' AND Cancelled BETWEEN -2147483648 AND 1 GROUP BY DestAirportSeqID
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WeatherDelay < 129 AND Cancelled BETWEEN -2147483648 AND 0 AND FirstDepTime > 1302 GROUP BY DepTimeBlk
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginStateFips = 23 AND OriginState <= 'TT' AND FlightNum BETWEEN 2654 AND 3088
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth IN (17, 28, 30)
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateName IN ('North Dakota') AND WheelsOff BETWEEN 7 AND 459 GROUP BY CRSElapsedTime, CarrierDelay
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE TaxiOut BETWEEN 71 AND 153 AND UniqueCarrier IN ('ALL', 'HA', 'OO', 'F9') AND TotalAddGTime <= 27 GROUP BY OriginStateName
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportSeqID < 1130802 GROUP BY DivActualElapsedTime
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginState IN ('GA', 'MI', 'WY') AND DepTime BETWEEN 1250 AND 2354 AND TailNum BETWEEN 'N372DA' AND 'N611MQ'
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime <= 1051 AND DivReachedDest BETWEEN 0 AND 0 GROUP BY FlightDate
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1197302, 1040802, 1115003, 1114603, 1325602) AND DestCityMarketID <> 30431 AND WheelsOn IN (538, 1240, 1003, 859, 1421) GROUP BY CancellationCode
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY WeatherDelay, Flights
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY DestAirportID
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TotalAddGTime < 90 GROUP BY TotalAddGTime
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestCityMarketID BETWEEN 31775 AND 31884 GROUP BY Month
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivDistance BETWEEN 86 AND 151 AND Month = 2
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginStateFips >= 31 GROUP BY Flights
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, OriginAirportSeqID
+SELECT SUM(ArrDelay) FROM myStarTable WHERE WheelsOn <> 750 AND DistanceGroup BETWEEN -2147483648 AND 6 AND NASDelay < 20 GROUP BY OriginWac, NASDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTime IN (21, 2237, 2350, 1319, 1543) AND Distance BETWEEN 628 AND 3417 GROUP BY DivArrDelay, OriginAirportID
+SELECT SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime < 100 AND FlightNum BETWEEN 4602 AND 5547 GROUP BY SecurityDelay, OriginStateName
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE NASDelay < 305 GROUP BY OriginStateName
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup BETWEEN 6 AND 8 GROUP BY FlightNum
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay < 44 AND Distance IN (332, 636)
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DaysSinceEpoch BETWEEN 16163 AND 16274 GROUP BY Month, Flights
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DivArrDelay, OriginCityMarketID
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable GROUP BY ArrTimeBlk
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime IN (2251) GROUP BY DestStateFips, DestCityMarketID
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestWac = 84 GROUP BY WheelsOff, DaysSinceEpoch
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE FirstDepTime < 1022 AND SecurityDelay IN (24)
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'Connecticut' AND 'Puerto Rico' AND OriginCityMarketID <> 30070 GROUP BY ArrTimeBlk
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup < 3 AND OriginCityName BETWEEN 'Chico, CA' AND 'Tallahassee, FL' GROUP BY DestCityMarketID
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportID >= 11823 GROUP BY TaxiIn
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE AirTime <> 282 AND DivAirportLandings IN (9, -2147483648, 1, 0) GROUP BY ArrTime
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTime > 2305 AND DestCityMarketID BETWEEN 33105 AND 34576 GROUP BY UniqueCarrier
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestWac = 34 GROUP BY DestWac, ActualElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID IN (1502403, 1100202, 1540103, 1133703, 1182304)
+SELECT SUM(DepDel15) FROM myStarTable WHERE NASDelay = 55 GROUP BY FlightDate
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(DepDel15) FROM myStarTable WHERE CRSElapsedTime BETWEEN 113 AND 241 AND OriginCityName BETWEEN 'Beaumont/Port Arthur, TX' AND 'Laredo, TX' AND DivArrDelay BETWEEN 291 AND 964 GROUP BY OriginState
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiOut BETWEEN 28 AND 42 GROUP BY Quarter
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY FlightNum, OriginCityMarketID
 SELECT SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginStateName <= 'Florida' AND AirTime BETWEEN 190 AND 297 GROUP BY AirlineID
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Lihue, HI', 'Bend/Redmond, OR', 'Grand Forks, ND')
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Carrier BETWEEN 'B6' AND 'FL'
-SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Distance BETWEEN 260 AND 846 AND OriginStateFips BETWEEN 20 AND 55 GROUP BY TailNum, UniqueCarrier
-SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOff <= 1717 AND DistanceGroup IN (3, 9, -2147483648, 5, 10) AND OriginWac BETWEEN 64 AND 72 GROUP BY DestCityMarketID
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivArrDelay IN (527) AND OriginStateName BETWEEN 'Missouri' AND 'Puerto Rico' GROUP BY CRSArrTime, DivActualElapsedTime
-SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND OriginWac > 84
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk BETWEEN '0800-0859' AND '2200-2259' GROUP BY Dest
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE AirTime IN (237, 427) GROUP BY CarrierDelay
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TaxiOut < 34
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay BETWEEN 118 AND 203 GROUP BY CRSDepTime, WheelsOff
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Cancelled BETWEEN 0 AND 0 AND SecurityDelay BETWEEN 19 AND 33 AND DestWac BETWEEN 23 AND 91 GROUP BY CRSDepTime
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE TailNum = 'N630WN' GROUP BY AirlineID
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '1000-1059' AND '1600-1659' AND DestStateName BETWEEN 'Illinois' AND 'Maryland' GROUP BY Year
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FlightNum, WeatherDelay
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff BETWEEN 1824 AND 2052 GROUP BY Origin
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DestAirportID BETWEEN 10731 AND 15497 GROUP BY TailNum
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE DestAirportSeqID IN (1484304, 1015703, 1043102, 1114002, 1463502)
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginAirportSeqID
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Diverted
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15) FROM myStarTable WHERE DistanceGroup IN (7) AND DivDistance BETWEEN 257 AND 405
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1114003 AND 1387302 AND AirlineID <> 20398 GROUP BY LongestAddGTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Month, DestStateName
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay IN (160, 34, 35, 101, 238) AND OriginCityName IN ('State College, PA', 'Portland, ME') AND ActualElapsedTime < 247
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY ArrTimeBlk, DivActualElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DivDistance = 92 AND OriginWac BETWEEN 16 AND 85 AND OriginCityName BETWEEN 'Cincinnati, OH' AND 'Kansas City, MO' GROUP BY CancellationCode, TotalAddGTime
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DistanceGroup BETWEEN 10 AND 11
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Origin <= 'FNT' GROUP BY OriginStateName
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month >= 11 AND LateAircraftDelay BETWEEN 64 AND 210
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportID BETWEEN 11618 AND 11648 AND FirstDepTime <= 553 GROUP BY DivReachedDest, CancellationCode
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TailNum BETWEEN 'N227FR' AND 'N556WN'
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE TaxiIn IN (127) AND Cancelled IN (1, 0, -2147483648)
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY TailNum
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE CRSElapsedTime <= 363 AND WeatherDelay IN (91, 185, 48, 53, 23) AND AirlineID IN (20409, 19690, 20366, 20398)
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivReachedDest IN (-9999, -2147483648, 0) AND Origin < 'PLN' AND DestCityMarketID BETWEEN 30325 AND 32320
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ActualElapsedTime IN (-2147483648, 25, 550, 369, 306) GROUP BY TaxiIn
+SELECT SUM(DepDel15) FROM myStarTable WHERE DaysSinceEpoch IN (16415, 16339) GROUP BY ArrTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginWac IN (91, 43, 45, 23, 31) AND WheelsOn <= 1716
+SELECT SUM(DepDel15) FROM myStarTable WHERE Month BETWEEN 3 AND 12 AND UniqueCarrier BETWEEN 'AA' AND 'MQ' AND FlightDate <> '2014-04-05' GROUP BY Distance
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DistanceGroup BETWEEN 8 AND 9 AND OriginAirportID IN (11067, 14689, 11618, 11013, 13303) AND AirTime < 120 GROUP BY Dest
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk < '1100-1159' AND DaysSinceEpoch BETWEEN 16110 AND 16235 AND TaxiIn BETWEEN 4 AND 71
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime > 9 AND ArrTimeBlk IN ('0900-0959', '0600-0659', '2200-2259', '1800-1859', '1400-1459') GROUP BY FlightNum
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime BETWEEN 2012 AND 2220 AND DivArrDelay BETWEEN 902 AND 964 GROUP BY DayofMonth
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DivActualElapsedTime IN (647, 422)
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY CRSDepTime, AirlineID
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightNum, Cancelled
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DaysSinceEpoch IN (16358, 16328) AND CRSDepTime BETWEEN 1219 AND 1743 GROUP BY WheelsOff
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Origin BETWEEN 'HDN' AND 'JNU' AND Dest BETWEEN 'AGS' AND 'RST' GROUP BY AirTime, DivArrDelay
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Dest, Year
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn = 22 AND DestAirportSeqID BETWEEN 1063104 AND 1217301
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID <= 11203 AND Dest BETWEEN 'ELM' AND 'TYS' GROUP BY DayofMonth
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE Carrier <= 'HA' AND WeatherDelay BETWEEN 61 AND 68 AND ArrTime BETWEEN 25 AND 910
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Flights <= 1 AND Quarter BETWEEN -2147483648 AND 4 AND TaxiOut IN (87, 106, 109) GROUP BY CancellationCode, DayofMonth
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay IN (162, 54) AND DepTimeBlk <> '0600-0659' AND OriginCityMarketID < 31049 GROUP BY OriginWac, OriginStateName
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE CRSElapsedTime > 270 AND OriginCityName IN ('Amarillo, TX', 'Santa Maria, CA', 'Hartford, CT', 'Wilmington, NC') AND WeatherDelay <> 119 GROUP BY DestWac
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY FlightDate, DivAirportLandings
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate <> '2014-08-05'
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY WeatherDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DaysSinceEpoch IN (16244, 16245, 16107, 16253, 16318) AND Flights IN (-2147483648, 1) AND Year IN (2014, -2147483648) GROUP BY DestCityName
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginAirportID BETWEEN 11697 AND 13377 AND ActualElapsedTime < 147 GROUP BY DestAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Diverted = 1
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay BETWEEN 5 AND 85 AND DayofMonth BETWEEN 12 AND 25 AND Dest < 'OAJ' GROUP BY DaysSinceEpoch, DestAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DivAirportLandings IN (-2147483648, 1, 0, 2, 9) AND DestAirportID >= 15897 GROUP BY CarrierDelay
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE UniqueCarrier BETWEEN 'ALL' AND 'F9' AND ActualElapsedTime IN (87, 350, 458) GROUP BY WheelsOn, CRSDepTime
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY Flights
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE CRSArrTime BETWEEN 742 AND 1142 AND TaxiIn IN (9)
+SELECT SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DayOfWeek IN (-2147483648, 1, 7) AND ArrTime IN (2048, 308, 740, 2104, 429) GROUP BY DivActualElapsedTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TaxiIn BETWEEN 9 AND 25 AND LongestAddGTime <= 146
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestCityName <= 'Nantucket, MA'
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY Flights
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY WeatherDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestCityMarketID BETWEEN 33256 AND 34457
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY Dest
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk >= '1600-1659' GROUP BY DestStateName
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DayofMonth IN (-2147483648, 3, 24, 13) AND Flights BETWEEN -2147483648 AND 1 GROUP BY CancellationCode
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY Cancelled
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 41 AND 106 GROUP BY WheelsOff
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID IN (35389, 35411, 30728)
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DivActualElapsedTime > 149 AND CRSElapsedTime BETWEEN 30 AND 493 GROUP BY DestStateName
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE CRSDepTime <= 2233 GROUP BY Carrier, DivActualElapsedTime
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestWac <> 51 AND DivActualElapsedTime BETWEEN 311 AND 352
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Quarter IN (2) AND FlightNum BETWEEN 2777 AND 3592 GROUP BY Month
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac BETWEEN 1 AND 21 AND DestAirportSeqID IN (1015403, 1086803, 1199502, 1452401) GROUP BY NASDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID IN (33486) AND CancellationCode <= 'C'
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTime BETWEEN 152 AND 902
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime BETWEEN 8 AND 114 GROUP BY Month, Diverted
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivReachedDest BETWEEN -2147483648 AND -9999 AND CRSDepTime >= 2130 GROUP BY DepTime
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateFips
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Carrier BETWEEN 'DL' AND 'MQ' AND DivArrDelay IN (331, 414) AND OriginState IN ('KY', 'ND', 'MI') GROUP BY DaysSinceEpoch
+SELECT SUM(DepDel15) FROM myStarTable WHERE DayOfWeek < 3 GROUP BY DepTime
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac < 66 AND AirlineID IN (19977) GROUP BY OriginAirportSeqID, DestAirportID
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier IN ('UA', 'MQ', 'OO') GROUP BY Dest
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginCityMarketID BETWEEN 30599 AND 32402 AND CRSDepTime IN (1954, 547) AND DaysSinceEpoch < 16156
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DaysSinceEpoch BETWEEN 16203 AND 16269 AND DestAirportID > 10431 GROUP BY Carrier, LongestAddGTime
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Diverted BETWEEN -2147483648 AND 1 GROUP BY LongestAddGTime
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk >= '1100-1159' AND FlightDate >= '2014-08-19' AND TailNum BETWEEN 'N10575' AND 'N703JB' GROUP BY WheelsOn, DestWac
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings BETWEEN 9 AND 9 AND WheelsOff BETWEEN 701 AND 1913 AND OriginWac < 83
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiOut IN (17, 121) AND DivDistance >= 770 GROUP BY FirstDepTime
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Carrier <> 'VX' AND CRSElapsedTime BETWEEN 46 AND 376 GROUP BY WheelsOff, Cancelled
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTimeBlk BETWEEN '0700-0759' AND '1000-1059' GROUP BY FirstDepTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSDepTime >= 1556
+SELECT SUM(DepDelay) FROM myStarTable WHERE CRSArrTime <> 1258 AND OriginState IN ('WA', 'VA', 'ID') GROUP BY TailNum, CRSElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE UniqueCarrier IN ('DL', 'AS', 'ALL') AND CancellationCode >= 'C' AND OriginState IN ('CO', 'KY', 'NV', 'AZ', 'VT') GROUP BY DestAirportID, TotalAddGTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup BETWEEN 4 AND 7 GROUP BY DivActualElapsedTime
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DayOfWeek
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE AirlineID IN (-2147483648, 19977, 20304) AND WeatherDelay >= 59
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FirstDepTime BETWEEN 1526 AND 1800 GROUP BY Year, NASDelay
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportID < 10551 AND TailNum IN ('N3AEAA', 'N857MQ') GROUP BY DestWac
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateName <= 'Connecticut' AND Carrier BETWEEN 'AA' AND 'ALL' AND DivReachedDest IN (1, -9999) GROUP BY UniqueCarrier, TotalAddGTime
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Year IN (2014, -2147483648)
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DayOfWeek
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY FlightNum
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Month = 1 AND ArrTimeBlk BETWEEN '1000-1059' AND '2100-2159'
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE OriginCityName IN ('Bloomington/Normal, IL', 'Austin, TX', 'Louisville, KY', 'Mobile, AL', 'Tampa, FL') AND LongestAddGTime IN (112, 167, 13, 46, 14) GROUP BY OriginCityName
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup IN (4, 2, 9) AND SecurityDelay BETWEEN 4 AND 7 AND OriginState BETWEEN 'ALL' AND 'CT'
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Month IN (7, -2147483648, 2, 5, 10) AND DaysSinceEpoch <> 16421 GROUP BY OriginCityName
+SELECT SUM(DepDel15) FROM myStarTable WHERE DivArrDelay BETWEEN 137 AND 140 AND TaxiIn IN (63, 66, 104, 196, 9) AND Quarter IN (3) GROUP BY WheelsOff
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CancellationCode IN ('B', 'C', 'A') GROUP BY OriginStateName
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable GROUP BY AirlineID
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY FirstDepTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk <> '2300-2359' AND Distance <> 1391 GROUP BY CancellationCode
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTime IN (1348, 1351) AND ArrTimeBlk < '1600-1659' AND DivReachedDest = -9999 GROUP BY Dest
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateName, DaysSinceEpoch
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay = 139
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID IN (1129202, 1294503, 1105703, 1336003) GROUP BY ArrTime
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE FirstDepTime BETWEEN 1354 AND 1507 AND Distance BETWEEN 691 AND 1609 AND DestAirportSeqID BETWEEN 1163002 AND 1324402 GROUP BY Carrier, OriginState
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Dest BETWEEN 'MMH' AND 'PSG' GROUP BY DepTime, LateAircraftDelay
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY OriginStateFips
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightNum >= 2889
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOff BETWEEN 101 AND 1724
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime IN (314, 232)
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivActualElapsedTime >= -9999 AND CarrierDelay BETWEEN 164 AND 173
+SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Flights BETWEEN -2147483648 AND 1 GROUP BY LongestAddGTime
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DaysSinceEpoch, FirstDepTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('0800-0859', '0001-0559') AND OriginWac IN (93, 72, 81) GROUP BY Carrier
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Dest >= 'PSP'
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TailNum >= 'N3736C' AND OriginStateFips IN (55, 24, 17)
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE TotalAddGTime > 52 AND LongestAddGTime <= 60 AND OriginState BETWEEN 'CO' AND 'NJ' GROUP BY TaxiIn, DestStateFips
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightDate <> '2014-04-13' AND Flights <> -2147483648 AND DivDistance <= 393
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestStateName, TailNum
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginState BETWEEN 'IL' AND 'NC' AND DestStateFips IN (55, 23, 75, 17, 18) GROUP BY DestWac
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY ArrTimeBlk, Carrier
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DayofMonth IN (16, 7, 11) AND DestCityName BETWEEN 'Devils Lake, ND' AND 'Rochester, NY' GROUP BY TailNum, OriginAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DepTime IN (801, 2036, 1311, 1243, 653) GROUP BY DivArrDelay, Month
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime >= 141 AND DestAirportSeqID BETWEEN 1336703 AND 1425403
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestStateName > 'Mississippi' AND ArrTimeBlk BETWEEN '1300-1359' AND '2200-2259' GROUP BY TailNum
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID <= 34960 AND Month <= 2 AND WeatherDelay < 10 GROUP BY DestStateName
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE TailNum BETWEEN 'N404WN' AND 'N588HA' AND AirlineID = 19690
+SELECT SUM(DepDelay) FROM myStarTable WHERE Flights >= -2147483648 GROUP BY TailNum, DestAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE WheelsOff BETWEEN 539 AND 2138 AND Carrier IN ('DL', 'ALL', 'B6', 'OO') GROUP BY AirTime
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum BETWEEN 4309 AND 4829 GROUP BY CRSDepTime, DivArrDelay
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ActualElapsedTime >= 115 AND DestWac IN (63) AND OriginState IN ('IA', 'ND') GROUP BY OriginStateFips
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID <> 31641 AND DistanceGroup >= 11 AND WheelsOn BETWEEN 501 AND 608
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestState < 'KY' GROUP BY DistanceGroup
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE NASDelay BETWEEN 29 AND 37 GROUP BY DestStateName, Year
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DaysSinceEpoch IN (16229, 16283) GROUP BY UniqueCarrier
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay BETWEEN 17 AND 106 AND OriginAirportSeqID <> 1104902
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE ArrTime IN (2259, 44, 46, 1023, 2228) GROUP BY FirstDepTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Month < 8 AND OriginStateName IN ('Georgia', 'Wisconsin', 'New York', 'Alabama', 'South Dakota')
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE WheelsOff BETWEEN 647 AND 2017 GROUP BY DivDistance
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE NASDelay IN (0, 183, 129, 290) GROUP BY WheelsOn, DestCityMarketID
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Month IN (4, 11, 8, 12, 6) AND Cancelled BETWEEN -2147483648 AND 0 AND TotalAddGTime IN (17, 29)
+SELECT SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSDepTime IN (2005) GROUP BY CarrierDelay, DepTime
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Laredo, TX', 'Phoenix, AZ', 'Sitka, AK', 'Hays, KS') GROUP BY DestAirportSeqID, DestWac
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestAirportID BETWEEN 13970 AND 14098 GROUP BY CRSArrTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode BETWEEN 'C' AND 'noodles' AND DestAirportID BETWEEN 10208 AND 14843 AND CRSArrTime BETWEEN 626 AND 1408 GROUP BY AirlineID
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Carrier <= 'AS'
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginStateName IN ('Indiana') AND Diverted IN (-2147483648, 0, 1)
+SELECT SUM(ArrDel15) FROM myStarTable WHERE TotalAddGTime BETWEEN 128 AND 148 GROUP BY TailNum
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE OriginStateFips BETWEEN 38 AND 53 AND DestAirportSeqID IN (1114604, 1198603, 1160302, 1251102) AND WheelsOn <= 809 GROUP BY Carrier, CancellationCode
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DestCityName, DestStateName
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginAirportSeqID <> 1133703 AND AirTime < 225 AND Origin IN ('DEN', 'GNV', 'BUF', 'BET')
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode IN ('B', 'C', 'A') AND DayofMonth <> 19
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID BETWEEN 31295 AND 32556 AND ArrTime IN (2152, 320, 1613) GROUP BY OriginStateFips
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DestStateName
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE ArrTimeBlk IN ('0700-0759', '0600-0659') AND CRSElapsedTime IN (152, 356) GROUP BY WeatherDelay, TaxiIn
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin IN ('DAL', 'OMA', 'CIU', 'BRD', 'IDA') GROUP BY FlightNum
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY UniqueCarrier
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginStateName BETWEEN 'Indiana' AND 'Vermont' AND TailNum IN ('N5DKAA', 'N332AA') GROUP BY TaxiOut
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestWac < 64 AND DivReachedDest <> -2147483648 AND TotalAddGTime BETWEEN 60 AND 61 GROUP BY DivActualElapsedTime
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut
 SELECT SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DestAirportSeqID IN (1217301, 1056103, 1324402, 1599102, 1558202) AND Year IN (-2147483648, 2014) GROUP BY DestWac
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestWac IN (2, 42) GROUP BY SecurityDelay
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CRSElapsedTime < 161 AND DestStateFips IN (56, 6, 24, 46) GROUP BY DestCityName, DistanceGroup
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DayofMonth <= 10 GROUP BY CarrierDelay, OriginCityMarketID
-SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTimeBlk IN ('0001-0559', '2300-2359', '2000-2059', '1100-1159', '1000-1059') AND WheelsOff <> 47
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY WheelsOff
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE NASDelay <= 60 AND DestAirportID BETWEEN 12323 AND 14109 GROUP BY OriginAirportID
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE TotalAddGTime < 107 GROUP BY Flights
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY Month
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE Month IN (2, 5) GROUP BY DestState, CRSArrTime
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE WeatherDelay IN (-2147483648, 7) AND DivAirportLandings BETWEEN -2147483648 AND 1 AND OriginWac <> 51 GROUP BY DivArrDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE NASDelay BETWEEN 43 AND 77 AND CarrierDelay BETWEEN 15 AND 176
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTimeBlk <= '2100-2159' AND TotalAddGTime IN (32, 21, 57, 14) GROUP BY DestState, Quarter
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Origin BETWEEN 'CAK' AND 'ISP' AND DivArrDelay IN (539, 458) GROUP BY Distance
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DivReachedDest IN (-2147483648, 1, -9999, 0)
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateFips BETWEEN 32 AND 49
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Month BETWEEN 3 AND 7 AND CancellationCode IN ('B', 'C') GROUP BY FirstDepTime, DivArrDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginAirportID >= 12889 GROUP BY WheelsOn, DestState
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DepTimeBlk BETWEEN '0600-0659' AND '2000-2059' AND DestWac BETWEEN 15 AND 16 AND DaysSinceEpoch BETWEEN 16294 AND 16389 GROUP BY DestAirportSeqID
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY Diverted
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID IN (1562401, 1130802, 1200302, 1075402) GROUP BY DestStateName
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivDistance IN (762, 417, 775, 627) AND DaysSinceEpoch BETWEEN 16288 AND 16374 AND Diverted BETWEEN 0 AND 1 GROUP BY CRSArrTime, SecurityDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Month IN (12, 2, 9, 1, 11) AND DaysSinceEpoch < 16144 GROUP BY DaysSinceEpoch
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE Diverted < 1 AND DepTimeBlk IN ('1600-1659', '1800-1859', '2000-2059', '2300-2359', 'ALL')
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Diverted > 0 AND CRSDepTime <= 1158 GROUP BY OriginAirportID
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivDistance BETWEEN 66 AND 919 AND Quarter >= 2 AND DayOfWeek > 6 GROUP BY AirTime, CarrierDelay
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted BETWEEN -2147483648 AND 0 AND FirstDepTime IN (2048, 1913, 1458, 556, 924) AND TaxiOut < 90
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Cancelled IN (0, 1, -2147483648) AND WeatherDelay BETWEEN 52 AND 63 GROUP BY LateAircraftDelay, DestState
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk = '0900-0959' GROUP BY Origin, LateAircraftDelay
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginWac BETWEEN 62 AND 87 AND NASDelay = 194 GROUP BY Diverted, FlightNum
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOff IN (1112, 110) GROUP BY DestCityName
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiOut
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime BETWEEN 247 AND 377 GROUP BY CancellationCode, AirTime
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY OriginCityName
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin IN ('PUB', 'SJU', 'CIU', 'BUF', 'LEX') AND Cancelled BETWEEN -2147483648 AND 0 AND DayOfWeek = 2 GROUP BY Dest
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DestCityMarketID IN (32177, 33256, 34952) GROUP BY Month
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DestStateFips IN (5, 9, 17) AND DivAirportLandings IN (2) GROUP BY DepTimeBlk
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName = 'Denver, CO' AND LateAircraftDelay IN (244, 230) GROUP BY Carrier, DistanceGroup
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginStateFips BETWEEN 54 AND 56 AND AirTime < 122
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityMarketID BETWEEN 30785 AND 33244 AND WheelsOn = 1318 AND TailNum <> 'N250AY' GROUP BY LongestAddGTime, TailNum
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE Origin BETWEEN 'TOL' AND 'TUL' AND DestAirportID BETWEEN 10154 AND 11471
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportSeqID, LateAircraftDelay
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginCityName, DivDistance
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityName IN ('Toledo, OH') AND DivArrDelay <= 1139 GROUP BY Origin
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE CarrierDelay BETWEEN 12 AND 111 AND Dest BETWEEN 'BRD' AND 'SGU' AND Flights BETWEEN -2147483648 AND 1 GROUP BY DistanceGroup
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DivArrDelay BETWEEN 53 AND 226 AND DestStateFips BETWEEN 18 AND 27
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode BETWEEN 'B' AND 'C' GROUP BY TaxiOut
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID < 1432103 AND Diverted BETWEEN -2147483648 AND 0 AND TotalAddGTime IN (16, 193, 101)
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier BETWEEN 'EV' AND 'HA' GROUP BY DepTime
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE TotalAddGTime IN (80, 74, 79, 30) AND WeatherDelay <= 92
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTime > 1537 AND SecurityDelay = 9 AND Diverted BETWEEN -2147483648 AND 1
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Quarter BETWEEN 4 AND 4 AND FirstDepTime BETWEEN 818 AND 1940 GROUP BY Carrier
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE ArrTime BETWEEN 453 AND 1424 GROUP BY CRSDepTime, Dest
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month BETWEEN 3 AND 10 AND WheelsOn BETWEEN 756 AND 1346 AND DepTimeBlk IN ('0900-0959', '1600-1659', '2300-2359', '2200-2259') GROUP BY DivActualElapsedTime, CancellationCode
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestStateName, TotalAddGTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportSeqID IN (1220603, 1037203, 1484202, 1099402) AND DivArrDelay < 507
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 995 AND 6398 AND DepTime BETWEEN 541 AND 1914 AND Flights BETWEEN -2147483648 AND 1
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter BETWEEN -2147483648 AND 3
+SELECT SUM(DepDelay) FROM myStarTable WHERE DivReachedDest <= 0 GROUP BY FlightNum
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Carrier <> 'VX' AND CRSElapsedTime BETWEEN 257 AND 396 AND DestState IN ('GA', 'OR', 'IL')
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivDistance
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTime BETWEEN 2115 AND 2253 AND Diverted >= -2147483648 GROUP BY DivAirportLandings, DestAirportID
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportID IN (15041, 13127, 10918, 10146, 13433) GROUP BY Year, TotalAddGTime
+SELECT SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSDepTime <= 1654 AND TotalAddGTime = 19
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestAirportSeqID < 1130802 AND DepTime BETWEEN 850 AND 1418 GROUP BY DestState, OriginAirportID
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable GROUP BY Year, OriginWac
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE AirlineID BETWEEN 20409 AND 20436 AND DivDistance < 896
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY OriginStateName, OriginWac
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE CRSElapsedTime IN (229, 152, 201, 437) AND CRSArrTime IN (941, 1155, 948, 138) AND FlightDate < '2014-12-26' GROUP BY DayOfWeek
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayofMonth BETWEEN 8 AND 15 AND OriginState > 'ME' GROUP BY CarrierDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Month BETWEEN 2 AND 4 AND DestStateName BETWEEN 'Connecticut' AND 'Nebraska' AND DistanceGroup >= 1 GROUP BY TotalAddGTime, CRSArrTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE Cancelled BETWEEN 0 AND 1 AND DestStateFips >= 48 AND WeatherDelay IN (505, 36)
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestWac IN (72, 45, 51) GROUP BY DestState
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE AirTime IN (352, 137) GROUP BY OriginCityName
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DistanceGroup IN (8) GROUP BY LongestAddGTime, DaysSinceEpoch
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY CRSElapsedTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestWac
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID < 30732 AND CancellationCode BETWEEN 'noodles' AND 'noodles' AND SecurityDelay IN (-2147483648, 41, -9999)
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY WeatherDelay, DivActualElapsedTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TotalAddGTime BETWEEN -2147483648 AND 29
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month BETWEEN 11 AND 11 AND DestState BETWEEN 'CA' AND 'LA' AND TaxiOut <> 76
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE AirTime < 153 AND Distance IN (842, 1175, 288, 659, 1166) AND DestAirportSeqID >= 1294503 GROUP BY DivReachedDest, AirTime
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE OriginAirportSeqID <> 1063104 AND WheelsOn <> 2357 AND LongestAddGTime <= 40 GROUP BY LateAircraftDelay
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Flights BETWEEN 1 AND 1 GROUP BY OriginCityMarketID
+SELECT SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Month IN (8, 1, 11, 7, -2147483648)
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID < 1329002 AND ArrTimeBlk IN ('1900-1959', '1300-1359', '0700-0759') GROUP BY CancellationCode, LongestAddGTime
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivAirportLandings BETWEEN -2147483648 AND 2 AND DivActualElapsedTime <> 529
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Distance BETWEEN 343 AND 844 AND Origin IN ('EUG', 'ISP', 'OME', 'MCO') GROUP BY DaysSinceEpoch, OriginAirportID
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TailNum <= 'N150UW' AND TaxiOut <> 41 AND OriginWac > 4 GROUP BY Origin, LongestAddGTime
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY CRSArrTime, Diverted
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime BETWEEN 28 AND 314 GROUP BY DivDistance, OriginAirportSeqID
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup IN (9, 11) AND CarrierDelay IN (155, 49, 71, 103)
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings <= 1 AND UniqueCarrier > 'B6' AND OriginStateFips BETWEEN 2 AND 72 GROUP BY DivReachedDest, DistanceGroup
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier BETWEEN 'F9' AND 'MQ' AND DestCityMarketID BETWEEN 31714 AND 34222 GROUP BY OriginStateName, Cancelled
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE FlightNum <= 3540 GROUP BY DayofMonth, NASDelay
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier IN ('FL') AND Year BETWEEN 2014 AND 2014 AND DayOfWeek IN (1, 6, 4, 7) GROUP BY OriginStateFips
+SELECT SUM(DepDel15) FROM myStarTable WHERE Quarter IN (2)
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE CRSArrTime IN (1900, 1709, 2313, 859) GROUP BY Distance, UniqueCarrier
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Diverted IN (-2147483648, 0, 1) GROUP BY FlightNum
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Carrier, TotalAddGTime
+SELECT SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY WeatherDelay
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE CRSArrTime >= 41 AND DestStateName IN ('Wyoming') AND DestAirportID BETWEEN 11537 AND 13029
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestAirportID, UniqueCarrier
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY SecurityDelay
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE ArrTime IN (943, 532, 124, 7, 331) AND DaysSinceEpoch BETWEEN 16121 AND 16407
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Year, DayOfWeek
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DepTimeBlk, DivReachedDest
+SELECT SUM(DepDelay) FROM myStarTable WHERE Diverted <= 0 AND TailNum IN ('N15986', 'N456AA', 'N494UA', 'N876AS', 'N392DA') AND Quarter <= 2
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID, CRSElapsedTime
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY CRSElapsedTime, OriginCityName
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(DepDelay) FROM myStarTable WHERE WeatherDelay BETWEEN 124 AND 319 AND TaxiOut IN (150, 16, 82, 133, 9) AND OriginStateName >= 'Indiana' GROUP BY AirTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DivDistance, OriginAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE TaxiOut BETWEEN 13 AND 68 AND WheelsOff <= 1619 AND DestAirportSeqID BETWEEN 1324402 AND 1348502 GROUP BY OriginStateName, DivActualElapsedTime
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportID IN (10372, 12884, 15412, 11624, 11122)
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier IN ('EV', 'B6') GROUP BY DivDistance
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE Distance <= 255 AND DestAirportSeqID BETWEEN 1217703 AND 1379602 GROUP BY WheelsOff
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginWac > 81 AND OriginCityName IN ('Harlingen/San Benito, TX', 'San Antonio, TX', 'Sacramento, CA', 'Bakersfield, CA', 'Wilmington, DE')
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DestAirportID BETWEEN 10918 AND 14457
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings IN (-2147483648, 2, 9, 0, 1)
 SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DivReachedDest
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Flights IN (-2147483648, 1) AND DestStateFips = 38
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CRSElapsedTime BETWEEN 227 AND 520 AND Carrier BETWEEN 'AS' AND 'DL' AND UniqueCarrier IN ('B6', 'AA', 'FL', 'UA', 'WN')
-SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE OriginAirportSeqID IN (1036102) AND UniqueCarrier BETWEEN 'B6' AND 'UA' AND ActualElapsedTime BETWEEN 78 AND 273
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE TaxiIn > 27 GROUP BY Month, CancellationCode
-SELECT SUM(DepDel15) FROM myStarTable WHERE DestAirportID < 12982 GROUP BY DepTimeBlk
-SELECT SUM(ArrDelay) FROM myStarTable WHERE ArrTime BETWEEN 708 AND 1233 AND LateAircraftDelay >= 21 GROUP BY TaxiOut, DepTime
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginAirportSeqID IN (1294503, 1410902) AND DepTime BETWEEN 24 AND 1422 GROUP BY TaxiOut
-SELECT SUM(DepDelay) FROM myStarTable WHERE Year BETWEEN 2014 AND 2014 AND CRSArrTime IN (2124, 2313) AND Carrier BETWEEN 'F9' AND 'F9'
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DestAirportID BETWEEN 10140 AND 12448 GROUP BY OriginStateFips
-SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE AirlineID BETWEEN 19690 AND 19805 GROUP BY OriginState
-SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 9
-SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, DepTime
-SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY CRSElapsedTime, AirTime
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY Carrier, OriginAirportID
-SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay IN (189, 43, 133, 101)
-SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportID BETWEEN 13198 AND 15376 AND FlightNum IN (6196, 6055, 5934, 730, 2012) GROUP BY SecurityDelay, OriginWac
-SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup BETWEEN 10 AND 10 AND DepTime IN (1315, 1616, 1325, 835) AND OriginAirportSeqID BETWEEN 1188402 AND 1289203
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled <> 1 AND LongestAddGTime BETWEEN 29 AND 54 AND DivArrDelay <= 80 GROUP BY ArrTimeBlk
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginCityMarketID IN (32402)
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Distance IN (2153, 1102, 775) AND DepTime IN (1203) AND DestWac BETWEEN 11 AND 61 GROUP BY FlightNum
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE LateAircraftDelay < 309 AND OriginAirportID IN (10423, 13127)
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateName >= 'Arizona' AND Year BETWEEN -2147483648 AND 2014 AND OriginWac BETWEEN 63 AND 87
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DayOfWeek BETWEEN 2 AND 7 AND DestWac BETWEEN 21 AND 61
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTime IN (721, 2351) GROUP BY DestState
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE CancellationCode IN ('B', 'ALL') GROUP BY DestAirportID
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTime BETWEEN 911 AND 918 AND TailNum BETWEEN 'N3FYAA' AND 'N699BR' GROUP BY OriginState, DaysSinceEpoch
+SELECT SUM(ArrDel15) FROM myStarTable WHERE SecurityDelay = 10 GROUP BY OriginAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ActualElapsedTime IN (459, 461) GROUP BY DayOfWeek, LateAircraftDelay
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginCityName BETWEEN 'Aguadilla, PR' AND 'Augusta, GA' AND ActualElapsedTime BETWEEN 186 AND 370 AND LateAircraftDelay IN (439, 1, 119, 238, 171) GROUP BY WeatherDelay, Dest
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DayofMonth < 27 AND OriginCityName BETWEEN 'Barrow, AK' AND 'Helena, MT' AND DivReachedDest IN (0, -2147483648, -9999, 1) GROUP BY LateAircraftDelay, CRSElapsedTime
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE DestCityMarketID IN (31092) AND FlightDate <= '2014-10-09' AND OriginCityName BETWEEN 'Boston, MA' AND 'West Palm Beach/Palm Beach, FL'
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE Cancelled BETWEEN 0 AND 1 AND Dest <> 'ATW' AND OriginAirportSeqID IN (1289605) GROUP BY Dest, ArrTime
+SELECT SUM(DepDelayMinutes), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable GROUP BY WeatherDelay, TaxiOut
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DepTime > 1401 AND DivActualElapsedTime BETWEEN 557 AND 1315
+SELECT SUM(ArrDel15), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Flights IN (1) AND OriginStateFips BETWEEN 8 AND 9 GROUP BY CRSArrTime
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1217302 AND 1221702 GROUP BY Carrier, OriginStateName
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY TaxiIn, FlightNum
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Flights > -2147483648
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE CarrierDelay IN (76, 197, 43) GROUP BY ArrTimeBlk, TaxiOut
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15) FROM myStarTable WHERE FlightDate BETWEEN '2014-10-02' AND '2014-12-25' AND TaxiOut IN (17, 132, 99, 54, 23)
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginCityName <> 'Medford, OR' AND TaxiIn IN (93) AND DivActualElapsedTime <> 147 GROUP BY DestWac, Distance
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DivActualElapsedTime BETWEEN 653 AND 948 GROUP BY DayofMonth
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE TaxiIn IN (82, 68, 7) AND DaysSinceEpoch BETWEEN 16073 AND 16422 GROUP BY Year, NASDelay
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestCityMarketID BETWEEN 31503 AND 34986 AND ArrTime >= 2241 AND Origin > 'HOB' GROUP BY ArrTime
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CancellationCode, Diverted
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable GROUP BY TaxiOut
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE DestStateName <= 'Oregon' AND DayofMonth IN (9, 10) GROUP BY NASDelay
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestStateName IN ('Arizona', 'Kentucky', 'Florida', 'Pennsylvania') GROUP BY WheelsOff, DivActualElapsedTime
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Dest
+SELECT SUM(DepDel15) FROM myStarTable WHERE FlightDate IN ('2014-06-28') GROUP BY TotalAddGTime, WeatherDelay
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY OriginState, AirlineID
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID BETWEEN 1082103 AND 1325602 AND DestAirportSeqID BETWEEN 1161706 AND 1198603 GROUP BY DivArrDelay
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE DestCityName BETWEEN 'Cleveland, OH' AND 'Santa Barbara, CA' AND DepTimeBlk IN ('0700-0759', '1700-1759', '0800-0859', '2100-2159') AND DepTime BETWEEN 1432 AND 1902
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestCityMarketID BETWEEN 30476 AND 30581 AND DestAirportID >= 10268
+SELECT SUM(DepDel15) FROM myStarTable WHERE CRSArrTime IN (2147, 1128, 1809, 1707, 955) AND Year BETWEEN -2147483648 AND 2014 GROUP BY DestAirportSeqID
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Origin
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE DestCityName <= 'Monroe, LA' AND UniqueCarrier IN ('FL', 'HA', 'VX') AND DepTime IN (122, 809)
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Diverted IN (0, 1, -2147483648) GROUP BY DestAirportID
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID = 34842
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE Diverted = 0 AND FlightNum < 1682 GROUP BY ActualElapsedTime
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CancellationCode IN ('ALL', 'B') GROUP BY OriginCityName, FlightDate
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY TaxiIn
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff IN (1614, 1944, 1026, 749) AND CRSArrTime <> 520 GROUP BY Distance
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DayOfWeek, OriginState
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DaysSinceEpoch BETWEEN 16183 AND 16349 AND TotalAddGTime <= 65 AND OriginStateFips BETWEEN 26 AND 39 GROUP BY Diverted, TotalAddGTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSArrTime
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DivAirportLandings IN (0, 1, 9, 2) AND CarrierDelay IN (233, 70, 147)
+SELECT SUM(DepDelay), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY LateAircraftDelay, CRSElapsedTime
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable GROUP BY DestWac
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID BETWEEN 1244805 AND 1458801 AND TaxiOut > 18 AND NASDelay IN (238, 73, 267, 94)
+SELECT SUM(DepDelay) FROM myStarTable WHERE AirTime IN (172, 111, 15, 289, 277)
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 3348 AND 6047 AND ArrTimeBlk IN ('2300-2359', '1300-1359', '1100-1159', '0900-0959') AND DivDistance BETWEEN 127 AND 967 GROUP BY FlightNum, TaxiIn
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivArrDelay BETWEEN 177 AND 294 AND TaxiIn BETWEEN 61 AND 89 GROUP BY CancellationCode
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Month IN (3) AND CRSArrTime BETWEEN 903 AND 1538
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime < 1745 AND CRSElapsedTime IN (31) GROUP BY DepTimeBlk
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE TaxiOut BETWEEN 2 AND 55 AND OriginCityName BETWEEN 'North Bend/Coos Bay, OR' AND 'Savannah, GA' GROUP BY TaxiOut, Quarter
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE Year BETWEEN -2147483648 AND 2014 AND CarrierDelay IN (2, 66) AND Dest IN ('FAT', 'SBA', 'DFW', 'GCK')
+SELECT SUM(DepDel15) FROM myStarTable WHERE Month IN (-2147483648, 12)
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY LongestAddGTime
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DepTimeBlk
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE ArrTimeBlk IN ('1700-1759') GROUP BY Cancelled, CRSDepTime
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY OriginCityMarketID, Carrier
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE FirstDepTime BETWEEN -9999 AND 2055 AND DivDistance <> 167 GROUP BY WheelsOff, OriginCityMarketID
+SELECT SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE ArrTime BETWEEN 651 AND 1216 GROUP BY FirstDepTime, DestState
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Diverted IN (0, -2147483648, 1) AND AirlineID IN (20437, 20304)
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk > '2200-2259' AND DivReachedDest < 1 GROUP BY NASDelay
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Quarter, DistanceGroup
+SELECT SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime BETWEEN 84 AND 148 AND DepTimeBlk <= '0700-0759' GROUP BY WeatherDelay
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginAirportID <> 14489 GROUP BY TailNum, UniqueCarrier
+SELECT SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup BETWEEN 5 AND 10 AND WheelsOff BETWEEN 825 AND 1031 AND DestCityName IN ('Beaumont/Port Arthur, TX', 'Sarasota/Bradenton, FL', 'Gunnison, CO') GROUP BY DivActualElapsedTime
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY Cancelled, DivActualElapsedTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Flights IN (1, -2147483648) AND TailNum IN ('N507MQ', 'N662SW', 'N741UW', 'N309JB') GROUP BY DayOfWeek
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CarrierDelay >= 69 AND OriginState IN ('TT', 'MT', 'TN')
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Carrier = 'OO' GROUP BY DestCityName, OriginState
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime BETWEEN 180 AND 609 GROUP BY DestWac, OriginAirportSeqID
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE ArrTime IN (836, 2130, 1955, 1632, 216) AND OriginCityName IN ('Las Vegas, NV', 'Valdosta, GA', 'Monroe, LA', 'Watertown, NY', 'Philadelphia, PA') AND OriginStateFips BETWEEN 6 AND 72
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime BETWEEN 359 AND 487 AND Quarter < 3 AND Year >= -2147483648 GROUP BY DestAirportSeqID
+SELECT SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE CRSArrTime BETWEEN 948 AND 2318 AND Year IN (2014, -2147483648) GROUP BY DivReachedDest
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE Carrier IN ('WN', 'UA', 'MQ', 'DL') AND Month IN (10, 8, 5, 11, 2) GROUP BY Year, CancellationCode
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DistanceGroup IN (10, 7, 11, 2, -2147483648) GROUP BY CRSElapsedTime
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DayOfWeek, DivAirportLandings
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Cancelled IN (1, 0, -2147483648) AND UniqueCarrier IN ('ALL', 'HA', 'FL', 'UA', 'WN') AND DestStateName BETWEEN 'Colorado' AND 'Iowa'
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime < 1545 AND SecurityDelay <= 16
+SELECT SUM(ArrDelay), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE TotalAddGTime IN (90, 71, 44)
+SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityMarketID = 30299 AND FirstDepTime < 2006
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE FirstDepTime IN (2028) AND ArrTime <= 831 GROUP BY DepTime
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, DivReachedDest
 SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter <> 2 AND LateAircraftDelay BETWEEN 86 AND 141 AND DepTimeBlk BETWEEN '1300-1359' AND '1800-1859' GROUP BY ActualElapsedTime, FirstDepTime
-SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE FirstDepTime <= 553 GROUP BY LateAircraftDelay, OriginStateFips
-SELECT SUM(DepDelay) FROM myStarTable WHERE DestCityName >= 'Oklahoma City, OK' AND CancellationCode IN ('C') AND FlightDate BETWEEN '2014-09-13' AND '2014-11-10' GROUP BY DepTime
-SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY Carrier
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestWac, CRSElapsedTime
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE TotalAddGTime IN (71, 85, 126, 113) AND DestAirportSeqID BETWEEN 1302402 AND 1558202
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE OriginStateFips BETWEEN 4 AND 78 AND DepTimeBlk BETWEEN '0600-0659' AND 'ALL'
-SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginWac <= 73 GROUP BY DestAirportID, DayOfWeek
-SELECT SUM(DepDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE FlightDate BETWEEN '2014-03-10' AND '2014-08-31' GROUP BY WheelsOff
-SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE SecurityDelay IN (1, 33, 19) GROUP BY OriginStateName, ArrTimeBlk
-SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE LateAircraftDelay IN (19) AND TailNum IN ('N378SW', 'N908DA') GROUP BY OriginStateFips
-SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Year BETWEEN -2147483648 AND 2014 GROUP BY NASDelay, Diverted
-SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime
-SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Distance BETWEEN 335 AND 721 AND DestState >= 'AK' GROUP BY TaxiIn
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DayOfWeek IN (5, 1) AND UniqueCarrier IN ('AS') AND TailNum >= 'N646UA'
-SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY FirstDepTime
-SELECT SUM(DepDel15) FROM myStarTable WHERE OriginWac IN (1, 5, 41, 72, 16)
-SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightDate >= '2014-02-17' AND OriginCityName >= 'Fargo, ND'
-SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter IN (3) AND OriginStateName IN ('Nebraska', 'Hawaii', 'Illinois')
-SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime BETWEEN 48 AND 90 AND FlightDate > '2014-02-03' AND DivActualElapsedTime <> 652 GROUP BY CRSArrTime, OriginWac
-SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE TotalAddGTime IN (67, 101, 17) AND Quarter IN (1, 4, 2, 3, -2147483648) AND CRSDepTime BETWEEN 205 AND 1001
-SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY TotalAddGTime, Flights
-SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable
-SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivDistance <> 395 AND OriginAirportSeqID IN (1468303) AND WeatherDelay IN (-9999, 109, 111, 51, 98) GROUP BY Carrier
-SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier IN ('DL', 'UA', 'F9', 'FL', 'VX') AND DestAirportID BETWEEN 10268 AND 14685
-SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE AirlineID BETWEEN 19977 AND 20366 AND Cancelled BETWEEN 0 AND 1 AND FlightDate > '2014-09-06' GROUP BY OriginCityMarketID
-SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime > 600 AND DestAirportID = 11292
-SELECT SUM(DepDel15), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable
-SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime
-SELECT SUM(ArrDelay) FROM myStarTable WHERE DestAirportID <= 15356 AND FlightNum < 6296 GROUP BY OriginState, FlightNum
-SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DepTime
-SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Year BETWEEN 2014 AND 2014 AND NASDelay BETWEEN 8 AND 146 GROUP BY DivAirportLandings
-SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE Origin IN ('HOU', 'PVD')
-SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE DestWac BETWEEN 37 AND 43
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTime IN (2350, 1008, 35) AND ArrTimeBlk IN ('1400-1459', 'ALL') GROUP BY OriginStateFips, CarrierDelay
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY WheelsOff, Origin
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY CRSDepTime, Dest
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE OriginCityMarketID BETWEEN 30728 AND 32402
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName BETWEEN 'Georgia' AND 'North Dakota'
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DayOfWeek BETWEEN 3 AND 7 AND OriginWac BETWEEN 3 AND 14
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DistanceGroup, CRSElapsedTime
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginWac BETWEEN 23 AND 45
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestStateName BETWEEN 'Missouri' AND 'Texas' GROUP BY Origin, DivAirportLandings
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestStateName = 'Maine'
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY CRSDepTime, DestAirportSeqID
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn IN (1252, 1325, 1038, 2326) AND DayofMonth IN (17, 6, 28, 15) GROUP BY OriginCityMarketID
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightDate
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE DepTime BETWEEN 740 AND 2031 GROUP BY WheelsOff, OriginStateName
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE WheelsOff < 1435 GROUP BY OriginStateName, NASDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FlightDate, WheelsOn
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable GROUP BY DepTime, TotalAddGTime
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DepTimeBlk IN ('1800-1859') AND DestCityName IN ('Knoxville, TN', 'Las Vegas, NV', 'Saginaw/Bay City/Midland, MI', 'Petersburg, AK', 'Denver, CO') GROUP BY OriginState
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Distance BETWEEN 277 AND 435 AND OriginStateName IN ('ALL', 'Louisiana', 'U.S. Pacific Trust Territories and Possessions', 'South Carolina', 'Mississippi') AND DayofMonth <= 1
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year BETWEEN -2147483648 AND 2014 AND FirstDepTime IN (2110, 1049) AND Quarter IN (1)
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter IN (-2147483648, 4, 1) AND DestAirportID BETWEEN 11109 AND 14108 AND Cancelled BETWEEN 0 AND 1 GROUP BY WeatherDelay, Origin
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Distance = 1919 GROUP BY Month, Year
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable GROUP BY DivActualElapsedTime, DestAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID <> 1342402 AND DivDistance IN (69, 186, 75, 397, 298)
+SELECT SUM(ArrDel15), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 1339 AND 5300
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE TaxiIn IN (109, 26, 74, 45, 14) GROUP BY DestStateName, TaxiOut
+SELECT SUM(DepDelay), SUM(ArrDel15) FROM myStarTable GROUP BY LongestAddGTime
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE CarrierDelay BETWEEN 5 AND 134 AND OriginCityName IN ('Pocatello, ID', 'Iron Mountain/Kingsfd, MI', 'Monroe, LA')
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Month <> 2 AND DestStateFips BETWEEN 9 AND 45 GROUP BY CarrierDelay, OriginCityMarketID
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE DistanceGroup BETWEEN 5 AND 7 GROUP BY DepTime
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE OriginStateFips IN (1, 56) AND Flights <= 1
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginAirportID > 11122 GROUP BY CarrierDelay
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter BETWEEN -2147483648 AND 1 AND Dest > 'RDU' AND Distance BETWEEN 252 AND 1282 GROUP BY NASDelay, Cancelled
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayOfWeek
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE Year IN (-2147483648, 2014) GROUP BY OriginCityMarketID
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName < 'Connecticut' AND NASDelay IN (67, 137, 93, 110) AND DivReachedDest IN (0, -2147483648, -9999, 1) GROUP BY CRSElapsedTime
+SELECT SUM(DepDelay) FROM myStarTable WHERE TaxiOut < 70 GROUP BY Carrier, OriginWac
+SELECT SUM(DepDelay) FROM myStarTable WHERE DayOfWeek <> 2 AND OriginStateFips BETWEEN 13 AND 26 AND ActualElapsedTime IN (84) GROUP BY OriginStateName
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DestAirportID IN (11067, 12206, 10643, 14986, 12884)
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE OriginAirportSeqID IN (1141303, 1027903, 1169703) AND Quarter IN (1, 4) GROUP BY CRSArrTime
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE OriginStateName BETWEEN 'Illinois' AND 'Wisconsin' GROUP BY DestWac, TaxiIn
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE TaxiIn >= 64 AND ArrTime BETWEEN 49 AND 943 GROUP BY DistanceGroup, FirstDepTime
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE AirlineID <> 19690 AND Cancelled IN (-2147483648, 1) AND Quarter IN (1, 4, -2147483648) GROUP BY DestStateFips, Year
+SELECT SUM(ArrDel15) FROM myStarTable WHERE TaxiIn BETWEEN 25 AND 45 AND DestAirportSeqID IN (1501603, 1469605)
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE FlightDate < '2014-12-13' AND TaxiIn >= 61 AND ActualElapsedTime BETWEEN 125 AND 480
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE TotalAddGTime > 149 GROUP BY ArrTimeBlk
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Origin IN ('SFO', 'STX', 'SBP', 'HYS') AND DivAirportLandings IN (1, 2, 0, -2147483648) GROUP BY DestWac
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestWac BETWEEN 62 AND 64 AND DivActualElapsedTime BETWEEN 256 AND 476 AND DayOfWeek >= 1 GROUP BY DestWac
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepDel15) FROM myStarTable WHERE AirlineID IN (20355, 19690, -2147483648) GROUP BY CarrierDelay, DestCityName
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE ArrTime BETWEEN 625 AND 2325 AND Carrier IN ('WN', 'F9', 'FL', 'AS', 'US') GROUP BY OriginWac, ArrTime
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay IN (16, 69) AND Year BETWEEN -2147483648 AND 2014 GROUP BY OriginStateName, DestStateFips
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Carrier IN ('F9', 'MQ', 'OO', 'B6') AND NASDelay IN (82, 23, 123, 75) GROUP BY DivReachedDest, TaxiOut
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestCityMarketID IN (35991, 32016, 31205) AND WheelsOff > 127 GROUP BY DayofMonth, DestStateFips
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime IN (75, 319, 609)
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginStateName BETWEEN 'Colorado' AND 'Puerto Rico'
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestStateFips BETWEEN -2147483648 AND 33 AND AirlineID BETWEEN 19805 AND 20398 GROUP BY DaysSinceEpoch, DivArrDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE CRSElapsedTime IN (101, 367)
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityName > 'Cincinnati, OH' GROUP BY DivActualElapsedTime, Diverted
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY ArrTime, DivArrDelay
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DestStateFips, NASDelay
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE Month BETWEEN 1 AND 3 AND DayOfWeek BETWEEN -2147483648 AND 4 GROUP BY TotalAddGTime, ArrTimeBlk
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Quarter = 3
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE FlightDate IN ('2014-05-12', '2014-09-01', '2014-07-29', '2014-07-09') AND NASDelay <> 65 GROUP BY Distance
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTimeBlk BETWEEN '0700-0759' AND '1500-1559'
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginAirportID
+SELECT SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk, Carrier
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable WHERE AirTime BETWEEN 57 AND 84 AND LateAircraftDelay BETWEEN 47 AND 176 AND Dest IN ('JAX', 'MKE') GROUP BY Diverted
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE DestAirportSeqID IN (1410002, 1188402, 1072804, 1302902) GROUP BY DistanceGroup
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY CRSElapsedTime
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE Dest BETWEEN 'PBI' AND 'TXK' AND NASDelay <= 165 GROUP BY Origin
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime BETWEEN 28 AND 41
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginState <> 'NY' AND TaxiIn IN (2, 70, 89, 42) AND DivAirportLandings BETWEEN -2147483648 AND 1
+SELECT SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable GROUP BY DivDistance, CRSElapsedTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestCityName = 'Gainesville, FL' GROUP BY DivArrDelay
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE WeatherDelay BETWEEN 72 AND 147 AND CRSElapsedTime < 327 AND DayofMonth IN (18, 6, 11)
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn <= 59 AND Diverted BETWEEN 0 AND 1 GROUP BY ArrTime, DestStateName
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Month BETWEEN 1 AND 3 AND ArrTimeBlk IN ('2200-2259', '2100-2159', '1700-1759') GROUP BY DaysSinceEpoch, ArrTime
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE Dest > 'SUX' AND DestAirportID BETWEEN 11278 AND 15582 AND DivAirportLandings BETWEEN 0 AND 1 GROUP BY SecurityDelay, DayOfWeek
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestAirportID > 11267 AND OriginStateFips < 25 AND FlightDate IN ('2014-08-23', '2014-07-23', '2014-05-26') GROUP BY DepTime, OriginStateName
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestCityName <= 'Medford, OR' GROUP BY OriginAirportSeqID, LongestAddGTime
+SELECT SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE TailNum <> 'N930AT' AND OriginStateName BETWEEN 'Montana' AND 'Puerto Rico' AND DestAirportSeqID IN (1504803, 1473003) GROUP BY Origin
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE Month BETWEEN 3 AND 11 GROUP BY DepTime
+SELECT SUM(DepDelay) FROM myStarTable WHERE Quarter IN (2, -2147483648) GROUP BY OriginCityName, Year
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE CRSDepTime <= 1855 GROUP BY DestState, OriginCityName
+SELECT SUM(ArrDel15) FROM myStarTable WHERE TaxiIn BETWEEN 27 AND 54 AND DivAirportLandings BETWEEN 0 AND 0 GROUP BY Diverted, OriginStateName
+SELECT SUM(ArrDel15), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Distance IN (411, 196, 3417, 667, 2599) AND DayOfWeek BETWEEN 2 AND 5 AND NASDelay BETWEEN 143 AND 281 GROUP BY DepTime, Flights
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY Year, DivAirportLandings
+SELECT SUM(DepDel15) FROM myStarTable WHERE DepTimeBlk IN ('2300-2359', '0700-0759', '1200-1259') AND DestAirportSeqID BETWEEN 1100303 AND 1409803 AND ArrTime BETWEEN 826 AND 1824 GROUP BY OriginWac, CarrierDelay
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE FlightNum IN (947) AND DepTime BETWEEN 803 AND 2351 GROUP BY CRSDepTime, FirstDepTime
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE CRSDepTime BETWEEN 526 AND 955
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay < 230 AND Flights IN (-2147483648, 1)
+SELECT SUM(ArrDelay) FROM myStarTable WHERE NASDelay > 43 GROUP BY CarrierDelay, OriginCityName
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY DestCityMarketID
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE AirTime BETWEEN 195 AND 339 AND DestStateName IN ('Indiana', 'Puerto Rico', 'Delaware', 'Alabama', 'Mississippi') AND FirstDepTime < 1649
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginStateName < 'Mississippi' GROUP BY Carrier
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DestAirportSeqID <> 1120302 AND SecurityDelay IN (33, 8, 15) AND OriginCityMarketID <> 34819 GROUP BY OriginStateFips
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DestAirportID, OriginState
+SELECT SUM(DepDelay) FROM myStarTable WHERE Quarter < 4 GROUP BY WeatherDelay
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DestCityName BETWEEN 'Denver, CO' AND 'Fort Myers, FL' AND ArrTimeBlk IN ('2300-2359', '1200-1259') GROUP BY NASDelay, ArrTime
+SELECT SUM(DepDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest, DistanceGroup
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY OriginStateFips
+SELECT SUM(ArrDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DestWac BETWEEN 5 AND 62 AND DaysSinceEpoch <= 16326 AND DistanceGroup IN (2) GROUP BY Cancelled
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1538902, 1468502, 1412202) GROUP BY Dest, UniqueCarrier
+SELECT SUM(DepDel15) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDelay) FROM myStarTable WHERE DestWac < 15 AND OriginStateName BETWEEN 'Minnesota' AND 'Ohio' GROUP BY DepTimeBlk, OriginStateFips
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginAirportID BETWEEN 11577 AND 13851 GROUP BY CRSElapsedTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE WheelsOn IN (1226, 1125) GROUP BY DivActualElapsedTime, DivAirportLandings
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayofMonth
+SELECT SUM(ArrDel15) FROM myStarTable WHERE OriginCityName >= 'Grand Rapids, MI' AND DestAirportID IN (11617, 10408, 11996) GROUP BY DestCityMarketID
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestStateName IN ('California') AND DivReachedDest IN (-9999, -2147483648, 0, 1) GROUP BY Dest, DestCityMarketID
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Month < 11 GROUP BY OriginWac, Distance
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE Quarter = 2 AND Origin <= 'ABE' AND OriginWac > 22
+SELECT SUM(ArrDelay) FROM myStarTable WHERE ActualElapsedTime > 310
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Diverted BETWEEN 0 AND 0 AND OriginWac IN (61, 35, 82, 51, 22) AND UniqueCarrier BETWEEN 'F9' AND 'US' GROUP BY AirlineID
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE FlightDate IN ('2014-04-27', '2014-08-05') AND OriginCityName < 'Milwaukee, WI'
+SELECT SUM(ArrDelay) FROM myStarTable GROUP BY Diverted
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE WheelsOff IN (2343, 256, 120, 246)
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DaysSinceEpoch IN (16431) AND OriginState = 'WI'
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable WHERE LateAircraftDelay IN (38)
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE DepTime BETWEEN 29 AND 449 AND ArrTimeBlk > '1700-1759' AND OriginStateFips IN (54, 26)
+SELECT SUM(ArrDelay) FROM myStarTable
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginState IN ('AK', 'NY', 'AR', 'VT')
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DestWac <= 64 AND OriginCityName BETWEEN 'Hancock/Houghton, MI' AND 'Rhinelander, WI'
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestWac IN (88, 12) GROUP BY OriginStateName, OriginWac
+SELECT SUM(DepDel15), SUM(DepDelay) FROM myStarTable
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE UniqueCarrier IN ('VX', 'FL', 'US', 'WN') GROUP BY TaxiIn
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted BETWEEN -2147483648 AND 1
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE ArrTimeBlk BETWEEN '1400-1459' AND 'ALL'
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivArrDelay < 206 AND OriginStateFips >= 26 AND DivDistance IN (502, 247, 313) GROUP BY DestWac, DistanceGroup
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY OriginStateName
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DestCityName
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTime >= 1828
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DestState <= 'NY' AND DaysSinceEpoch IN (16100, 16106) GROUP BY DaysSinceEpoch, DestWac
+SELECT SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DestState BETWEEN 'OH' AND 'PA' AND Diverted IN (-2147483648, 0, 1) GROUP BY OriginCityMarketID
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE SecurityDelay IN (9, -9999)
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1104902) AND DaysSinceEpoch BETWEEN 16132 AND 16331
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter BETWEEN 1 AND 3 AND FlightDate BETWEEN '2014-01-02' AND '2014-09-03' AND OriginWac IN (31) GROUP BY DestCityName, DayofMonth
+SELECT SUM(ArrDel15) FROM myStarTable WHERE TaxiIn = 30 AND OriginAirportSeqID = 1457002 AND Cancelled BETWEEN -2147483648 AND 1 GROUP BY ArrTime
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY DestState
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Carrier BETWEEN 'F9' AND 'UA' GROUP BY DestCityMarketID
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE DestCityMarketID BETWEEN 30894 AND 33728
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE LateAircraftDelay BETWEEN 153 AND 229
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOff IN (925)
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Distance = 658 GROUP BY WheelsOff, DistanceGroup
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE DestAirportSeqID IN (1100303, 1104103, 1072804, 1133703, 1148102) AND DayOfWeek IN (2, 5, 4, 7, 3) GROUP BY DestStateName
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest BETWEEN -9999 AND 1 AND DistanceGroup BETWEEN 7 AND 8 AND DestState = 'NV' GROUP BY DayofMonth, TotalAddGTime
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE OriginStateFips BETWEEN 41 AND 72 AND DestStateFips <= 22 GROUP BY FlightDate
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY UniqueCarrier, DestAirportSeqID
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier <= 'UA' AND Distance BETWEEN 574 AND 643 AND TailNum BETWEEN 'N1611B' AND 'N296JB'
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DistanceGroup BETWEEN 1 AND 8 AND DepTime < 136 AND LateAircraftDelay BETWEEN 160 AND 253 GROUP BY DivAirportLandings, DestAirportSeqID
+SELECT SUM(DepartureDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE TaxiIn BETWEEN 50 AND 109 AND DivArrDelay BETWEEN 107 AND 246
+SELECT SUM(DepDel15) FROM myStarTable WHERE Diverted IN (-2147483648, 1, 0) AND DestStateName <> 'Massachusetts' AND OriginCityMarketID >= 31612
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE FlightNum >= 658 GROUP BY Flights
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable WHERE UniqueCarrier IN ('HA', 'FL', 'EV', 'UA', 'DL') GROUP BY Dest
+SELECT SUM(DepDelay) FROM myStarTable WHERE Carrier BETWEEN 'DL' AND 'EV' AND DivDistance BETWEEN 103 AND 570 GROUP BY Distance
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY Cancelled
+SELECT SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE DepTime BETWEEN 1248 AND 2222 AND CancellationCode IN ('B', 'A', 'C')
+SELECT SUM(ArrDelay) FROM myStarTable WHERE FlightDate IN ('2014-10-18', '2014-06-20', '2014-06-04', '2014-12-14', '2014-09-05') AND WheelsOff BETWEEN 320 AND 738 GROUP BY ActualElapsedTime, AirTime
+SELECT SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE WheelsOff IN (1821, 1532, 1324, 1154) AND ActualElapsedTime >= 508 GROUP BY DestState
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE Month BETWEEN 4 AND 7 GROUP BY DayOfWeek
+SELECT SUM(DepDel15) FROM myStarTable WHERE OriginState IN ('ALL', 'LA', 'VI', 'IA', 'OR') GROUP BY DestCityName
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable GROUP BY ArrTimeBlk
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Quarter BETWEEN -2147483648 AND 3 AND Year BETWEEN -2147483648 AND 2014 AND LongestAddGTime IN (34, 131) GROUP BY AirlineID
+SELECT SUM(ArrDelay) FROM myStarTable WHERE Flights BETWEEN -2147483648 AND 1 AND DivAirportLandings <= 9 AND WeatherDelay <> 184 GROUP BY DestWac
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable WHERE TotalAddGTime IN (34, 97) GROUP BY DayofMonth
+SELECT SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable GROUP BY DivArrDelay
+SELECT SUM(ArrDel15) FROM myStarTable WHERE Quarter <> 3 GROUP BY DestStateName, Diverted
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY DestCityMarketID, TotalAddGTime
+SELECT SUM(ArrDel15), SUM(DepartureDelayGroups), SUM(DepDelay) FROM myStarTable WHERE WheelsOn IN (2302, 428, 2212, 433) AND DaysSinceEpoch BETWEEN 16084 AND 16358 GROUP BY DivActualElapsedTime, Carrier
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DaysSinceEpoch BETWEEN 16302 AND 16416 GROUP BY DestAirportSeqID, Carrier
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE DivAirportLandings IN (-2147483648, 1, 2) GROUP BY DestWac
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName BETWEEN 'New Hampshire' AND 'West Virginia' AND OriginState BETWEEN 'GA' AND 'NH' GROUP BY DestWac, NASDelay
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE OriginCityMarketID BETWEEN 31453 AND 32323 AND FirstDepTime <= 1640 AND SecurityDelay BETWEEN -2147483648 AND 18 GROUP BY SecurityDelay, Diverted
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivArrDelay IN (1153, 785, 583, 108) AND Distance BETWEEN 307 AND 1052 GROUP BY WheelsOn
+SELECT SUM(ArrDelay) FROM myStarTable WHERE FlightDate IN ('2014-07-18', '2014-09-29') AND CarrierDelay BETWEEN 50 AND 291 AND OriginCityMarketID >= 31726 GROUP BY TaxiIn, CRSElapsedTime
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY DayofMonth, WheelsOn
+SELECT SUM(ArrivalDelayGroups), SUM(DepDel15) FROM myStarTable WHERE WheelsOff IN (2059, 850, 140, 944, 929) AND TaxiOut IN (7) GROUP BY OriginAirportSeqID
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE WeatherDelay BETWEEN 124 AND 129 AND DestCityName BETWEEN 'Charlottesville, VA' AND 'Meridian, MS'
+SELECT SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable GROUP BY Dest
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE Cancelled IN (1, -2147483648, 0) AND DivDistance >= 151 AND Origin BETWEEN 'MKG' AND 'OTZ' GROUP BY NASDelay, TaxiOut
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE WheelsOn >= 123 GROUP BY WheelsOn, DistanceGroup
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE Origin BETWEEN 'SCE' AND 'WRG' GROUP BY WeatherDelay, DestWac
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE TailNum BETWEEN 'N317JB' AND 'N5ELAA' AND Dest <> 'SBN' GROUP BY FlightNum
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Month <= 11 AND Flights <= 1 GROUP BY SecurityDelay, DestAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE CRSDepTime >= 1108 GROUP BY TaxiIn
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY UniqueCarrier, DayOfWeek
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE OriginWac IN (1) AND OriginCityName IN ('Cordova, AK', 'Evansville, IN')
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightDate IN ('2014-06-28', '2014-03-22') GROUP BY FlightNum, OriginStateName
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTime BETWEEN 458 AND 2025 AND OriginStateFips <= 41 GROUP BY DivAirportLandings
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY DestCityMarketID, NASDelay
+SELECT SUM(DepDel15) FROM myStarTable WHERE TaxiIn BETWEEN 75 AND 94 GROUP BY DestCityMarketID
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable GROUP BY DestCityMarketID
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE Origin BETWEEN 'BIL' AND 'GTF' AND WeatherDelay <> 208 AND Diverted >= -2147483648
+SELECT SUM(DepDel15), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Flights
+SELECT SUM(DepDelay) FROM myStarTable GROUP BY DestCityMarketID, OriginStateFips
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE ArrTimeBlk IN ('2100-2159', '1500-1559', '1000-1059') AND OriginState BETWEEN 'ID' AND 'KY'
+SELECT SUM(DepartureDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE UniqueCarrier <> 'MQ' GROUP BY OriginStateFips
+SELECT SUM(DepDelay) FROM myStarTable WHERE DivActualElapsedTime < 533 AND DivReachedDest BETWEEN -9999 AND -9999 AND WheelsOff IN (1910, 1408, 712, 558)
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginWac BETWEEN 23 AND 85 GROUP BY Dest, FlightNum
+SELECT SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Carrier
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier <> 'EV' AND OriginWac IN (37) AND LateAircraftDelay <= 18 GROUP BY Dest
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginCityName = 'Des Moines, IA'
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE Year BETWEEN -2147483648 AND 2014 AND DivArrDelay IN (361, 348, 435)
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE Distance BETWEEN 441 AND 2075 AND TotalAddGTime <= 21 GROUP BY DestStateName, Dest
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable GROUP BY DivDistance, DestState
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateName IN ('Michigan', 'New Hampshire', 'Virginia', 'Wisconsin') AND OriginAirportID BETWEEN 11003 AND 13433 GROUP BY SecurityDelay
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE DivArrDelay IN (968, 818, 228, 802, 266) GROUP BY DivArrDelay, FlightDate
+SELECT SUM(DepDel15), SUM(ArrDel15) FROM myStarTable WHERE OriginAirportID <= 12206 GROUP BY DivArrDelay
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY Dest
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE LateAircraftDelay BETWEEN 89 AND 322 GROUP BY Month, OriginState
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE DestStateName IN ('North Carolina', 'Alaska') AND CRSElapsedTime < 210 GROUP BY Cancelled, CancellationCode
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DayofMonth, DestAirportSeqID
+SELECT SUM(DepDelayMinutes), SUM(DepDelay), SUM(DepDel15) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(ArrivalDelayGroups), SUM(ArrDelay) FROM myStarTable WHERE LongestAddGTime <= 25 AND NASDelay IN (211, 228) AND WeatherDelay <> 52 GROUP BY Quarter, CancellationCode
+SELECT SUM(DepDelay) FROM myStarTable
+SELECT SUM(ArrDel15) FROM myStarTable WHERE CRSElapsedTime = 475 GROUP BY DivDistance, Quarter
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable WHERE DestStateName BETWEEN 'Iowa' AND 'North Dakota'
+SELECT SUM(DepDel15), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE LongestAddGTime >= 19 AND DepTimeBlk BETWEEN '0001-0559' AND '1500-1559' GROUP BY CRSElapsedTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY DestState, DivReachedDest
+SELECT SUM(DepDelay) FROM myStarTable WHERE CancellationCode BETWEEN 'B' AND 'noodles' GROUP BY CarrierDelay
+SELECT SUM(DepDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Distance > 718 AND CRSArrTime BETWEEN 436 AND 1059 GROUP BY CancellationCode, AirlineID
+SELECT SUM(ArrDel15) FROM myStarTable GROUP BY NASDelay, FirstDepTime
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE OriginState BETWEEN 'AL' AND 'NJ' AND ArrTimeBlk >= '1600-1659' AND TailNum <= 'N533AS'
+SELECT SUM(DepDelay), SUM(ArrivalDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE UniqueCarrier <> 'AA' GROUP BY DayofMonth, TailNum
+SELECT SUM(ArrDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY DivArrDelay, OriginAirportSeqID
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups) FROM myStarTable GROUP BY WheelsOff
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY CRSDepTime
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY OriginWac, Cancelled
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(DepDelay) FROM myStarTable WHERE TaxiOut IN (69, 21, 135, 136, 107) GROUP BY TaxiIn, Distance
+SELECT SUM(ArrDelay), SUM(DepDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DepTimeBlk
+SELECT SUM(DepDel15) FROM myStarTable WHERE DestStateName < 'North Carolina' AND Cancelled BETWEEN 0 AND 1 AND Carrier IN ('AA', 'MQ') GROUP BY OriginAirportID, Flights
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE AirTime <= 387 GROUP BY Cancelled
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY SecurityDelay, OriginCityMarketID
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE OriginAirportSeqID IN (1432103, 1467903) AND CRSDepTime BETWEEN 805 AND 822 GROUP BY DayofMonth
+SELECT SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE AirlineID <> 19930 AND DestStateName <> 'Alabama' AND OriginCityName BETWEEN 'Manchester, NH' AND 'West Palm Beach/Palm Beach, FL'
+SELECT SUM(DepDelay) FROM myStarTable WHERE DivReachedDest <= -9999 GROUP BY OriginState
+SELECT SUM(DepartureDelayGroups), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY Origin
+SELECT SUM(ArrDelay) FROM myStarTable WHERE OriginCityName IN ('San Antonio, TX', 'Pellston, MI') GROUP BY DestWac, DestAirportSeqID
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE DivActualElapsedTime IN (714) GROUP BY OriginState
+SELECT SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE NASDelay BETWEEN 139 AND 175 GROUP BY DivAirportLandings, DistanceGroup
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay), SUM(ArrDel15) FROM myStarTable WHERE WheelsOn < 551 AND LateAircraftDelay IN (160) AND Flights BETWEEN -2147483648 AND 1 GROUP BY DayofMonth, DivActualElapsedTime
+SELECT SUM(ArrDel15), SUM(ArrDelay) FROM myStarTable WHERE WheelsOff < 922
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DaysSinceEpoch IN (16384, 16118, 16251, 16300, 16413) AND TotalAddGTime <> 95
+SELECT SUM(ArrDel15) FROM myStarTable WHERE DestAirportSeqID < 1101303 AND DepTime BETWEEN 340 AND 805
+SELECT SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable
+SELECT SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk BETWEEN '1000-1059' AND '2100-2159' GROUP BY DivAirportLandings
+SELECT SUM(DepDelayMinutes), SUM(DepDel15) FROM myStarTable WHERE ActualElapsedTime IN (498, 184, 155, 412) AND DestStateFips IN (37) GROUP BY DivAirportLandings, FlightNum
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum IN (2059) AND Origin BETWEEN 'MGM' AND 'MTJ' AND DayofMonth <> 4 GROUP BY DestWac
+SELECT SUM(DepDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE DepTimeBlk <= '1300-1359' AND SecurityDelay IN (14) GROUP BY AirTime
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Distance BETWEEN 666 AND 1172
+SELECT SUM(ArrDelayMinutes), SUM(DepDelay) FROM myStarTable WHERE Quarter BETWEEN 2 AND 3 AND OriginAirportSeqID BETWEEN 1114004 AND 1158702
+SELECT SUM(DepDel15) FROM myStarTable WHERE Diverted BETWEEN 0 AND 1
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN -2147483648 AND 2 AND DayofMonth BETWEEN 21 AND 25 GROUP BY ActualElapsedTime, OriginCityName
+SELECT SUM(ArrDel15), SUM(ArrivalDelayGroups) FROM myStarTable GROUP BY FirstDepTime, FlightDate
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE DistanceGroup <> 4 AND DestCityMarketID > 31637 AND LateAircraftDelay IN (439, 235) GROUP BY TotalAddGTime
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DivReachedDest BETWEEN -2147483648 AND 1 AND Carrier > 'US' AND FirstDepTime BETWEEN 1457 AND 1617 GROUP BY DestAirportID
+SELECT SUM(ArrDelay), SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE DestCityMarketID IN (31315, 34905, 32896, 32206) AND ArrTimeBlk BETWEEN '1000-1059' AND '2300-2359' GROUP BY WheelsOff
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE OriginStateFips BETWEEN 9 AND 22 AND DistanceGroup <> 2 AND OriginCityName <> 'Grand Rapids, MI' GROUP BY DestCityMarketID
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable WHERE Dest < 'IDA' AND DayOfWeek BETWEEN 2 AND 7
+SELECT SUM(DepDelay) FROM myStarTable WHERE ArrTimeBlk IN ('1300-1359', '1400-1459') AND DestCityMarketID = 30423 AND Distance BETWEEN 772 AND 1624 GROUP BY NASDelay, OriginStateName
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(ArrDel15) FROM myStarTable WHERE DestCityName >= 'Fayetteville, NC' GROUP BY DayOfWeek
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups) FROM myStarTable WHERE UniqueCarrier > 'EV' AND ActualElapsedTime BETWEEN 47 AND 174 AND DivAirportLandings >= 0 GROUP BY DestCityName, DestAirportSeqID
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable GROUP BY OriginAirportSeqID
+SELECT SUM(ArrDel15), SUM(DepDel15) FROM myStarTable GROUP BY LateAircraftDelay
+SELECT SUM(ArrDel15), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY WheelsOff
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable GROUP BY Flights, DepTime
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted BETWEEN 0 AND 1 AND AirlineID BETWEEN 20398 AND 20436 GROUP BY CRSDepTime, Dest
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE Diverted IN (1, -2147483648)
+SELECT SUM(ArrDelayMinutes), SUM(DepDelayMinutes) FROM myStarTable WHERE DistanceGroup BETWEEN 1 AND 6 AND FlightNum BETWEEN 1439 AND 2994 AND DestAirportID BETWEEN 10140 AND 14843
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrDelay) FROM myStarTable
+SELECT SUM(ArrDel15), SUM(DepDelayMinutes), SUM(DepartureDelayGroups) FROM myStarTable WHERE CancellationCode < 'B' GROUP BY DaysSinceEpoch, Flights
+SELECT SUM(ArrDelay), SUM(DepDelay), SUM(DepDel15) FROM myStarTable WHERE NASDelay BETWEEN 36 AND 393 GROUP BY OriginWac, DestStateFips
+SELECT SUM(DepDel15) FROM myStarTable GROUP BY CRSDepTime, NASDelay
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY DayofMonth
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepartureDelayGroups) FROM myStarTable WHERE TotalAddGTime IN (84, 69, 38, 60) AND ArrTimeBlk IN ('1000-1059') AND UniqueCarrier > 'FL' GROUP BY DaysSinceEpoch
+SELECT SUM(ArrDelayMinutes), SUM(DepDel15), SUM(ArrDel15) FROM myStarTable GROUP BY DaysSinceEpoch, DestCityName
+SELECT SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable WHERE WheelsOn IN (2037, 1400, 536, 801) AND Dest IN ('EWR', 'LFT', 'IAD', 'GTR')
+SELECT SUM(DepDelayMinutes), SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE ArrTimeBlk < '0700-0759' AND OriginWac BETWEEN 52 AND 81 GROUP BY DestAirportID
+SELECT SUM(DepDelay) FROM myStarTable WHERE OriginStateName BETWEEN 'Maine' AND 'Wisconsin' AND LongestAddGTime IN (103, 43, 79) AND DayofMonth IN (-2147483648, 19, 10, 28, 29)
+SELECT SUM(ArrivalDelayGroups), SUM(DepDelay), SUM(ArrDelayMinutes) FROM myStarTable WHERE ArrTime BETWEEN 118 AND 2214 GROUP BY DestCityMarketID, Year
+SELECT SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable GROUP BY UniqueCarrier
+SELECT SUM(ArrDelayMinutes), SUM(ArrDel15) FROM myStarTable GROUP BY TaxiIn
+SELECT SUM(ArrDelayMinutes), SUM(ArrDelay), SUM(DepDelayMinutes) FROM myStarTable GROUP BY TaxiIn
+SELECT SUM(ArrDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE WeatherDelay > 137 AND CRSElapsedTime BETWEEN 322 AND 507 GROUP BY Cancelled
+SELECT SUM(ArrDelay), SUM(DepartureDelayGroups), SUM(DepDelayMinutes) FROM myStarTable WHERE DivAirportLandings IN (0, -2147483648) GROUP BY WheelsOn
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE DivAirportLandings BETWEEN 0 AND 1 AND DepTime BETWEEN 1234 AND 1652
+SELECT SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE FlightNum <= 2110 GROUP BY SecurityDelay, Dest
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE DivArrDelay <> 509 GROUP BY WeatherDelay
+SELECT SUM(DepDelayMinutes), SUM(ArrivalDelayGroups), SUM(ArrDel15) FROM myStarTable WHERE FirstDepTime >= 920 AND Dest > 'CHO' AND Year BETWEEN -2147483648 AND 2014
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DayofMonth BETWEEN 3 AND 12 AND CarrierDelay IN (93, 17, 450) GROUP BY TailNum
+SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE FlightNum < 3844 GROUP BY DestStateName
+SELECT SUM(DepDelay), SUM(DepDelayMinutes), SUM(ArrDelayMinutes) FROM myStarTable WHERE LateAircraftDelay BETWEEN 55 AND 269
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Month < 6 AND AirTime = 226 AND Cancelled IN (0, 1, -2147483648) GROUP BY DepTimeBlk
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE Origin <= 'BLI' AND UniqueCarrier IN ('UA', 'US', 'VX') GROUP BY DayofMonth
+SELECT SUM(DepDel15), SUM(ArrDelay), SUM(DepDelay) FROM myStarTable WHERE ActualElapsedTime IN (379, 432) AND CRSDepTime <= 1151
+SELECT SUM(ArrDelay) FROM myStarTable WHERE LateAircraftDelay BETWEEN 11 AND 47 GROUP BY CRSArrTime, OriginAirportID
+SELECT SUM(DepDelayMinutes), SUM(ArrDelay) FROM myStarTable WHERE ArrTime BETWEEN 1518 AND 2227 AND DestState > 'MS' GROUP BY DestWac
+SELECT SUM(DepartureDelayGroups) FROM myStarTable WHERE OriginAirportSeqID > 1127402 AND DestWac BETWEEN 41 AND 43 AND OriginCityName IN ('Erie, PA', 'Ontario, CA', 'Las Vegas, NV', 'Sioux Falls, SD', 'Charlottesville, VA') GROUP BY Cancelled, Dest
+SELECT SUM(DepDelay), SUM(ArrDelay), SUM(DepDel15) FROM myStarTable WHERE Origin IN ('LMT', 'GRI', 'FAI')
+SELECT SUM(DepDelayMinutes), SUM(ArrDel15) FROM myStarTable WHERE ActualElapsedTime IN (405, 435, 402, 437) AND DayofMonth <> 25 GROUP BY CancellationCode
+SELECT SUM(DepartureDelayGroups), SUM(DepDel15) FROM myStarTable WHERE LongestAddGTime <> 79
+SELECT SUM(DepDel15), SUM(ArrivalDelayGroups), SUM(DepartureDelayGroups) FROM myStarTable WHERE LongestAddGTime < 135 GROUP BY TaxiOut
+SELECT SUM(ArrDelay) FROM myStarTable WHERE TaxiOut IN (82, 35, 99, 13, 45) AND DivActualElapsedTime BETWEEN 551 AND 614 GROUP BY WeatherDelay, DestAirportID
+SELECT SUM(DepDel15), SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE DistanceGroup IN (8) GROUP BY OriginAirportID, CarrierDelay
+SELECT SUM(ArrivalDelayGroups) FROM myStarTable WHERE FlightNum BETWEEN 5631 AND 6212 GROUP BY Month, DayOfWeek
+SELECT SUM(ArrDelayMinutes) FROM myStarTable WHERE Carrier >= 'AA' GROUP BY DestWac
+SELECT SUM(ArrDel15), SUM(DepDelay) FROM myStarTable WHERE CarrierDelay > 189 GROUP BY DestCityName
+SELECT SUM(DepartureDelayGroups) FROM myStarTable GROUP BY UniqueCarrier
+SELECT SUM(DepDelay), SUM(DepDel15), SUM(DepDelayMinutes) FROM myStarTable
+SELECT SUM(DepartureDelayGroups), SUM(DepDelay), SUM(ArrivalDelayGroups) FROM myStarTable WHERE ArrTime BETWEEN 123 AND 238
+SELECT SUM(DepDelayMinutes) FROM myStarTable GROUP BY OriginStateFips, WeatherDelay


### PR DESCRIPTION
1. When time column exists, treat it as a single value dimension
column in SegmentInfoProvider and fetch all its values.
2. Update StarTreeClusterIntegrationTest hardcoded query set to add
time column inside queries.