### PR TITLE
Disabling retention in integration tests.

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -231,8 +231,8 @@ public abstract class ClusterTest extends ControllerTest {
   protected void addHybridTable(String tableName, String timeColumnName, String timeColumnType, String kafkaZkUrl,
       String kafkaTopic, String schemaName, String serverTenant, String brokerTenant, File avroFile,
       String sortedColumn, List<String> invertedIndexColumns, String loadMode) throws Exception {
-    int retentionDays = 900;
-    String retentionTimeUnit = "Days";
+    int retentionDays = -1;
+    String retentionTimeUnit = "";
     addRealtimeTable(tableName, timeColumnName, timeColumnType, retentionDays, retentionTimeUnit, kafkaZkUrl,
         kafkaTopic, schemaName, serverTenant, brokerTenant, avroFile, 20000, sortedColumn, invertedIndexColumns, loadMode);
     addOfflineTable(tableName, timeColumnName, timeColumnType, retentionDays, retentionTimeUnit, brokerTenant,

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/InvertedIndexOfflineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/InvertedIndexOfflineIntegrationTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import com.linkedin.pinot.common.data.Schema;
 /**
- * enables indexes on a bunch of columns 
+ * enables indexes on a bunch of columns
  *
  */
 @Test
@@ -30,7 +30,7 @@ public class InvertedIndexOfflineIntegrationTest extends OfflineClusterIntegrati
   protected void setUpTable(File schemaFile, int numBroker, int numOffline) throws Exception {
     addSchema(schemaFile, "schemaFile");
     Schema schema = Schema.fromFile(schemaFile);
-    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", 3000, "DAYS", null, null, schema.getDimensionNames(),
+    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, schema.getDimensionNames(),
         null);
   }
 

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -65,7 +65,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
 
   protected void setUpTable(File schemaFile, int numBroker, int numOffline) throws Exception {
     addSchema(schemaFile, "schemaFile");
-    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", 3000, "DAYS", null, null);
+    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null);
   }
 
   protected void dropTable() throws Exception {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -55,7 +55,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
       String kafkaTopic, File schemaFile, File avroFile) throws Exception {
     Schema schema = Schema.fromFile(schemaFile);
     addSchema(schemaFile, schema.getSchemaName());
-    addRealtimeTable(tableName, timeColumnName, timeColumnType, 900, "Days", kafkaZkUrl, kafkaTopic, schema.getSchemaName(),
+    addRealtimeTable(tableName, timeColumnName, timeColumnType, -1, "", kafkaZkUrl, kafkaTopic, schema.getSchemaName(),
         null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier");
   }
 

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -70,9 +70,9 @@ public class StarTreeClusterIntegrationTest extends ClusterTest {
 
   private static final String TIME_COLUMN_NAME = "DaysSinceEpoch";
   private static final String TIME_UNIT = "daysSinceEpoch";
-  private static final String RETENTION_TIME_UNIT = "DAYS";
+  private static final String RETENTION_TIME_UNIT = "";
 
-  private static final int RETENTION_TIME = 3000;
+  private static final int RETENTION_TIME = -1;
   private static final int SEGMENT_COUNT = 12;
   private static final long TIMEOUT_IN_MILLISECONDS = 30 * 1000;
   private static final long TIMEOUT_IN_SECONDS = 3600;

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -80,7 +80,7 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     startBroker();
     startServer();
 
-    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", 3000, "DAYS", null, null);
+    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null);
 
     ensureDirectoryExistsAndIsEmpty(_tmpDir);
     ensureDirectoryExistsAndIsEmpty(_segmentsDir);


### PR DESCRIPTION
    During a recent debugging of integration test failure, it was found that
    we set a retention value of 900 days during setting up tables for
    integration tests. Most these tests use the airline data for which some
    records are now > 900 days old, and getting deleted during the test.
    
    The fix is to disable retention by not setting valid retention time
    value and unit.
