### PR TITLE
thirdeye build fix

### DIFF
--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -161,7 +161,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.8</version>
+        <version>1.7</version>
         <configuration>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <transformers>

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -19,7 +19,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Path("dashboard")
+@Path("thirdeye")
 @Produces(MediaType.APPLICATION_JSON)
 public class AnomalyFunctionResource {
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Path("dashboard")
 @Produces(MediaType.APPLICATION_JSON)
 public class AnomalyFunctionResource {
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -19,7 +19,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Path("thirdeye")
+@Path("thirdeye/function")
 @Produces(MediaType.APPLICATION_JSON)
 public class AnomalyFunctionResource {
 
@@ -65,7 +65,7 @@ public class AnomalyFunctionResource {
    * "MIN_MAX_THRESHOLD":["min","max"] }
    */
   @GET
-  @Path("metadata/anomaly-function")
+  @Path("metadata")
   public Map<String, Object> getAnomalyFunctionMetadata() {
     return anomalyFunctionMetadata;
   }
@@ -76,7 +76,7 @@ public class AnomalyFunctionResource {
    * eg. ["SUM","AVG","COUNT"]
    */
   @GET
-  @Path("metadata/metric-function")
+  @Path("metric-function")
   public MetricAggFunction[] getMetricFunctions() {
     return MetricAggFunction.values();
   }


### PR DESCRIPTION
adding build fix
- maven shade plugin was updated in an earlier checkin, version 1.8 is not downloadable, reverting back to 1.7.
- adding @PATH in AnomalyFunctionResource with end point '/thirdeye' 