### PR TITLE
Throw exception on ideal state update failures

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -68,7 +68,7 @@ public class HelixHelper {
    */
   public static void updateIdealState(final HelixManager helixManager, final String resourceName,
       final Function<IdealState, IdealState> updater, RetryPolicy policy) {
-    policy.attempt(new Callable<Boolean>() {
+    boolean successful = policy.attempt(new Callable<Boolean>() {
       @Override
       public Boolean call() {
         HelixDataAccessor dataAccessor = helixManager.getHelixDataAccessor();
@@ -117,6 +117,10 @@ public class HelixHelper {
         }
       }
     });
+
+    if (!successful) {
+      throw new RuntimeException("Failed to update ideal state for resource " + resourceName);
+    }
   }
 
   /**

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicy.java
@@ -20,15 +20,14 @@ import java.util.concurrent.Callable;
 
 /**
  * Retry policy, encapsulating the logic needed to retry an operation until it succeeds.
- *
- * @author jfim
  */
 public interface RetryPolicy {
   /**
    * Attempts to do the operation until it succeeds, aborting if an exception is thrown by the operation.
    *
    * @param operation The operation to attempt, which returns true on success and false on failure.
-   * @return true if the operation succeeded or false if the number of retries
+   * @return true if the operation succeeded or false if the operation did not succeed within the retries specified by
+   * this retry policy
    */
   boolean attempt(Callable<Boolean> operation);
 }


### PR DESCRIPTION
PINOT-3377 If the ideal state update fails, throw an exception instead
of failing silently.