### PR TITLE
Fix REST API error messages

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/BasePinotControllerRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/BasePinotControllerRestletResource.java
@@ -133,7 +133,7 @@ public class BasePinotControllerRestletResource extends ServerResource {
 
   protected static JSONObject getErrorMsgInJson(String errorMsg) {
     JSONObject errorMsgJson = new JSONObject();
-    errorMsgJson.put("ERROR", errorMsgJson);
+    errorMsgJson.put("ERROR", errorMsg);
     return errorMsgJson;
   }
 }


### PR DESCRIPTION
Fix REST API error messages appearing as {"ERROR":{"$ref":"@"}}