### PR TITLE
[PINOT-3203] Controller code changes for Low-level consumer segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.protocols;
+
+import com.alibaba.fastjson.JSONObject;
+
+/*
+ * TODO Add unit tests for this after we finalize the protocol elements.
+ * TODO Finalize the protocol elements.
+ *
+ * This class encapsulates the segment completion protocol used by the server and the controller for
+ * low-level kafka consumer realtime segments. The protocol has two requests: SegmentConsumedRequest
+ * and SegmentCommitRequest.It has a response that may contain different status codes depending on the state machine
+ * that the controller drives for that segment. All responses have two elements -- status and an offset.
+ *
+ * The overall idea is that when a server has completed consuming a segment until the "end criteria" that
+ * is set (in the table configuration), it sends a SegmentConsumedRequest to the controller (leader).  The
+ * controller may respond with a HOLD, asking the server to NOT consume any new kafka messages, but get back
+ * to the controller after a while.
+ *
+ * Meanwhile, the controller co-ordinates the SegmentConsumedRequest messages from replicas and selects a server
+ * to commit the segment. The server uses SegmentCommitRequest message, in which it also posts the completed
+ * segment to the controller.
+ *
+ * The controller may respond with a failure for this commit message, but on success, the controller changes the
+ * segment state to ONLINE in idealstate, and adds new CONSUMING segments as well.
+ *
+ * For details see the design document
+ * https://github.com/linkedin/pinot/wiki/Low-level-kafka-consumers
+ */
+public class SegmentCompletionProtocol {
+  /**
+   * MAX_HOLD_TIME_MS is the maximum time (msecs) for which a server will be in HOLDING state, after which it will
+   * send in a SegmentConsumedRequest with its current offset in kafka.
+   */
+  public static final long MAX_HOLD_TIME_MS = 3000;
+  /**
+   * MAX_SEGMENT_COMMIT_TIME_MS is the longest time (msecs) a server will take to complete building a segment and committing
+   * it  (via a SegmentCommit message) after the server has been notified that it is the committer.
+   */
+  public static final long MAX_SEGMENT_COMMIT_TIME_MS = 15000;
+
+  public enum ControllerResponseStatus {
+    /** Never sent by the controller, but locally used by server when sending a request fails */
+    NOT_SENT,
+
+    /** Server should send back a SegmentCommitRequest after processing this response */
+    COMMIT,
+
+    /** Server should send SegmentConsumedRequest after waiting for less than MAX_HOLD_TIME_MS */
+    HOLD,
+
+    /** Server should consume kafka events to catch up to the offset contained in this response */
+    CATCH_UP,
+
+    /** Server should discard the rows in memory */
+    DISCARD,
+
+    /** Server should build a segment out of the rows in memory, and replace in-memory rows with the segment built */
+    KEEP,
+
+    /** Server should locate the current controller leader and re-send the message */
+    NOT_LEADER,
+
+    /** Commit failed. Server should go back to HOLDING state and re-start with the SegmentConsumed message  */
+    FAILED,
+
+    /** Commit succeeded, behave exactly like KEEP */
+    COMMIT_SUCCESS,
+
+    /** Never sent by the controller, but locally used by the controller during the segmentCommit() processing */
+    COMMIT_CONTINUE,
+  }
+
+  public static final String STATUS_KEY = "status";
+  public static final String OFFSET_KEY = "offset";
+
+  public static final String MSG_TYPE_CONSUMED = "segmentConsumed";
+  public static final String MSG_TYPE_COMMMIT = "segmentCommit";
+
+  public static final String PARAM_SEGMENT_NAME = "name";
+  public static final String PARAM_OFFSET = "offset";
+  public static final String PARAM_INSTANCE_ID = "instance";
+
+  // Canned responses
+  public static final Response RESP_NOT_LEADER = new Response(ControllerResponseStatus.NOT_LEADER, -1L);
+  public static final Response RESP_FAILED = new Response(ControllerResponseStatus.FAILED, -1L);
+  public static final Response RESP_DISCARD = new Response(ControllerResponseStatus.DISCARD, -1L);
+  public static final Response RESP_COMMIT_SUCCESS = new Response(ControllerResponseStatus.COMMIT_SUCCESS, -1L);
+  public static final Response RESP_COMMIT_CONTINUE = new Response(ControllerResponseStatus.COMMIT_CONTINUE, -1L);
+
+  public static abstract class Request {
+    final String _segmentName;
+    final long _offset;
+    final String _instanceId;
+
+    public Request(String segmentName, long offset, String instanceId) {
+      _segmentName = segmentName;
+      _instanceId = instanceId;
+      _offset = offset;
+    }
+
+    public abstract String getUrl(String hostPort);
+
+    protected String getUri(String msgType) {
+      return "/" + msgType + "?" +
+        PARAM_SEGMENT_NAME + "=" + _segmentName + "&" +
+        PARAM_OFFSET + "=" + _offset + "&" +
+        PARAM_INSTANCE_ID + "=" + _instanceId;
+    }
+  }
+
+  public static class SegmentConsumedRequest extends Request {
+    /**
+     *
+     * @param segmentName Name of the LLC segment
+     * @param offset Next offset from which the kafka client will consume, if it does.
+     * @param instanceId Name of the instance reporting this event.
+     */
+    public SegmentConsumedRequest(String segmentName, long offset, String instanceId) {
+      super(segmentName, offset, instanceId);
+    }
+    @Override
+      public String getUrl(final String hostPort) {
+        return "http://" + hostPort + getUri(MSG_TYPE_CONSUMED);
+      }
+  }
+
+  public static class SegmentCommitRequest extends Request {
+    /**
+     *
+     * @param segmentName Name of the LLC segment
+     * @param offset Next offset from which the kafka client will consume, if it does.
+     * @param instanceId Name of the instance reporting this event.
+     */
+    public SegmentCommitRequest(String segmentName, long offset, String instanceId) {
+      super(segmentName, offset, instanceId);
+    }
+    @Override
+      public String getUrl(final String hostPort) {
+        return "http://" + hostPort + getUri(MSG_TYPE_COMMMIT);
+      }
+  }
+
+  public static class Response {
+    final ControllerResponseStatus _status;
+    final long _offset;
+
+    public Response(String jsonRespStr) {
+      JSONObject jsonObject = JSONObject.parseObject(jsonRespStr);
+      long offset = -1;
+      if (jsonObject.containsKey(OFFSET_KEY)) {
+        offset = jsonObject.getLong(OFFSET_KEY);
+      }
+      _offset = offset;
+
+      String statusStr = jsonObject.getString(STATUS_KEY);
+      ControllerResponseStatus status;
+      try {
+        status = ControllerResponseStatus.valueOf(statusStr);
+      } catch (Exception e) {
+        status = ControllerResponseStatus.FAILED;
+      }
+      _status = status;
+    }
+
+    public Response(ControllerResponseStatus status, long offset) {
+      _status = status;
+      _offset = offset;
+    }
+
+    public ControllerResponseStatus getStatus() {
+      return _status;
+    }
+
+    public long getOffset() {
+      return _offset;
+    }
+
+    public String toJsonString() {
+      return "{\"" + STATUS_KEY + "\":" + "\"" + _status.name() + "\"," +
+        "\"" + OFFSET_KEY + "\":" + _offset + "}";
+    }
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -17,9 +17,11 @@
 package com.linkedin.pinot.controller.helix.core.realtime;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
@@ -30,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
@@ -51,6 +54,7 @@ public class PinotLLCRealtimeSegmentManager {
   private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private final PinotHelixResourceManager _helixResourceManager;
   private final String _clusterName;
+  private boolean _amILeader = false;
 
   public static synchronized void create(HelixAdmin helixAdmin, String clusterName, HelixManager helixManager, ZkHelixPropertyStore propertyStore, PinotHelixResourceManager helixResourceManager) {
     if (INSTANCE != null) {
@@ -76,6 +80,33 @@ public class PinotLLCRealtimeSegmentManager {
       throw new RuntimeException("Not yet created");
     }
     return INSTANCE;
+  }
+
+  // TODO Hook this up for leadership transfer
+  public void onBecomeLeader() {
+    if (isLeader()) {
+      if (!_amILeader) {
+        // We were not leader before, now we are.
+        _amILeader = true;
+        LOGGER.info("Became leader");
+        // Scanning tables to check for incomplete table additions is optional if we make table addtition operations
+        // idempotent.The user can retry the failed operation and it will work.
+        //
+        // Go through all partitions of all tables that have LL configured, and check that they have as many
+        // segments in CONSUMING state in Idealstate as there are kafka partitions.
+        completeCommittingSegments();
+      } else {
+        // We already had leadership, nothing to do.
+        LOGGER.info("Already leader. Duplicate notification");
+      }
+    } else {
+      _amILeader = false;
+      LOGGER.info("Lost leadership");
+    }
+  }
+
+  private boolean isLeader() {
+    return _helixManager.isLeader();
   }
 
   /*
@@ -132,9 +163,14 @@ public class PinotLLCRealtimeSegmentManager {
     _propertyStore.set(path, znRecord, AccessOption.PERSISTENT);
   }
 
+  protected ZNRecord getKafkaPartitionAssignment(final String realtimeTableName) {
+    final String path = makeKafkaPartitionPath(realtimeTableName);
+    return _propertyStore.get(path, null, AccessOption.PERSISTENT);
+  }
+
   protected void setupInitialSegments(String realtimeTableName, ZNRecord partitionAssignment, long startOffset,
       IdealState idealState, boolean create) {
-    List<String> currentSegments = getExistingLLCSegments(realtimeTableName);
+    List<String> currentSegments = getExistingSegments(realtimeTableName);
     // Make sure that there are no low-level segments existing.
     if (currentSegments != null) {
       for (String segment : currentSegments) {
@@ -183,6 +219,7 @@ public class PinotLLCRealtimeSegmentManager {
     updateHelixIdealState(idealState, realtimeTableName, idealStateEntries, create);
   }
 
+  // Update the helix idealstate when a new table is added.
   protected void updateHelixIdealState(final IdealState idealState, String realtimeTableName, final Map<String, List<String>> idealStateEntries,
       boolean create) {
     if (create) {
@@ -196,6 +233,40 @@ public class PinotLLCRealtimeSegmentManager {
         }
       }, RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0f));
     }
+  }
+
+  // Update the helix state when an old segment commits and a new one is to be started.
+  protected void updateHelixIdealState(final String realtimeTableName, final List<String> newInstances,
+      final String oldSegmentNameStr, final String newSegmentNameStr) {
+    HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
+      @Override
+      public IdealState apply(IdealState idealState) {
+        return updateForNewRealtimeSegment(idealState, newInstances, oldSegmentNameStr, newSegmentNameStr);
+      }
+    }, RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0f));
+  }
+
+  protected static IdealState updateForNewRealtimeSegment(IdealState idealState,
+      final List<String> newInstances, final String oldSegmentNameStr, final String newSegmentNameStr) {
+    if (oldSegmentNameStr != null) {
+      // Update the old ones to be ONLINE
+      Set<String>  oldInstances = idealState.getInstanceSet(oldSegmentNameStr);
+      for (String instance : oldInstances) {
+        idealState.setPartitionState(oldSegmentNameStr, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
+      }
+    }
+
+    // We may have (for whatever reason) a different instance list in the idealstate for the new segment.
+    // If so, clear it, and then set the instance state for the set of instances that we know should be there.
+    Map<String, String> stateMap = idealState.getInstanceStateMap(newSegmentNameStr);
+    if (stateMap != null) {
+      stateMap.clear();
+    }
+    for (String instance : newInstances) {
+      idealState.setPartitionState(newSegmentNameStr, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
+    }
+
+    return idealState;
   }
 
   private IdealState addLLCRealtimeSegmentsInIdealState(final IdealState idealState, Map<String, List<String>> idealStateEntries) {
@@ -213,11 +284,176 @@ public class PinotLLCRealtimeSegmentManager {
     return idealState;
   }
 
-  protected List<String> getExistingLLCSegments(String realtimeTableName) {
+  protected List<String> getExistingSegments(String realtimeTableName) {
     return  _propertyStore.getChildNames(PinotRealtimeSegmentManager.getSegmentsPath() + "/" + realtimeTableName, AccessOption.PERSISTENT);
   }
 
+  protected List<ZNRecord> getExistingSegmentMetadata(String realtimeTableName) {
+    return _propertyStore.getChildren(PinotRealtimeSegmentManager.getSegmentsPath() + "/" + realtimeTableName, null, 0);
+
+  }
+
   protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records) {
-    _propertyStore.createChildren(paths, records, AccessOption.PERSISTENT);
+    _propertyStore.setChildren(paths, records, AccessOption.PERSISTENT);
+  }
+
+  protected List<String> getAllRealtimeTables() {
+    return _helixResourceManager.getAllRealtimeTables();
+  }
+
+  protected IdealState getTableIdealState(String realtimeTableName) {
+    return HelixHelper.getTableIdealState(_helixManager, realtimeTableName);
+  }
+
+  /**
+   * This method is invoked after the realtime segment is uploaded but before a response is sent to the server.
+   * It updates the propertystore segment metadata from IN_PROGRESS to DONE, and also creates new propertystore
+   * records for new segments, and puts them in idealstate in CONSUMING state.
+   *
+   * @param rawTableName Raw table name
+   * @param committingSegmentNameStr Committing segment name
+   * @param nextOffset The offset with which the next segment should start.
+   * @return
+   */
+  // TODO Change this to be tableName rather than realtimeTableName
+  public boolean commitSegment(String rawTableName, final String committingSegmentNameStr, long nextOffset) {
+    final long now = System.currentTimeMillis();
+    final String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(rawTableName);
+
+    final LLCRealtimeSegmentZKMetadata oldSegMetadata = getRealtimeSegmentZKMetadata(realtimeTableName,
+        committingSegmentNameStr);
+    final LLCSegmentName oldSegmentName = new LLCSegmentName(committingSegmentNameStr);
+    final int partitionId = oldSegmentName.getPartitionId();
+    final int oldSeqNum = oldSegmentName.getSequenceNumber();
+    oldSegMetadata.setEndOffset(nextOffset);
+    oldSegMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+    oldSegMetadata.setEndTime(now);
+    final ZNRecord oldZnRecord = oldSegMetadata.toZNRecord();
+    final String oldZnodePath = PinotRealtimeSegmentManager.getSegmentsPath() + "/" + realtimeTableName + "/" + committingSegmentNameStr;
+
+    final ZNRecord partitionAssignment = getKafkaPartitionAssignment(realtimeTableName);
+    List<String> newInstances = partitionAssignment.getListField(Integer.toString(partitionId));
+    final Map<String, List<String>> idealStateEntries = new HashMap<>(1);
+
+    // Construct segment metadata and idealstate for the new segment
+    final int newSeqNum = oldSeqNum + 1;
+    final long newStartOffset = nextOffset;
+    LLCSegmentName newHolder = new LLCSegmentName(oldSegmentName.getTableName(), partitionId, newSeqNum, now);
+    final String newSegmentNameStr = newHolder.getSegmentName();
+    final LLCRealtimeSegmentZKMetadata newSegMetadata = new LLCRealtimeSegmentZKMetadata();
+    newSegMetadata.setCreationTime(System.currentTimeMillis());
+    newSegMetadata.setStartOffset(newStartOffset);
+    newSegMetadata.setNumReplicas(newInstances.size());
+    newSegMetadata.setTableName(realtimeTableName);
+    newSegMetadata.setSegmentName(newSegmentNameStr);
+    newSegMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+    final ZNRecord newZnRecord = newSegMetadata.toZNRecord();
+    final String newZnodePath = PinotRealtimeSegmentManager.getSegmentsPath() + "/" + realtimeTableName + "/" + newSegmentNameStr;
+
+    idealStateEntries.put(newSegmentNameStr, newInstances);
+
+    List<String> paths = new ArrayList<>(2);
+    paths.add(oldZnodePath);
+    paths.add(newZnodePath);
+    List<ZNRecord> records = new ArrayList<>(2);
+    records.add(oldZnRecord);
+    records.add(newZnRecord);
+    /*
+     * Update zookeeper in two steps.
+     *
+     * Step 1: Update PROPERTYSTORE to change the segment metadata for old segment and add a new one for new segment
+     * Step 2: Update IDEALSTATES to include the new segment in the idealstate for the table in CONSUMING state, and change
+     *         the old segment to ONLINE state.
+     *
+     * The controller may fail between these two steps, so when a new controller takes over as leader, it needs to
+     * check whether there are any recent segments in PROPERTYSTORE that are not accounted for in idealState. If so,
+     * it should create the new segments in idealState.
+     *
+     * If the controller fails after step-2, we are fine because the idealState has the new segments.
+     * If the controller fails before step-1, the server will see this as an upload failure, and will re-try.
+     */
+    writeSegmentsToPropertyStore(paths, records);
+
+    // TODO Introduce a controller failure here for integration testing
+
+    updateHelixIdealState(realtimeTableName, newInstances, committingSegmentNameStr, newSegmentNameStr);
+    return true;
+  }
+
+  public LLCRealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(String realtimeTableName, String segmentName) {
+    return new LLCRealtimeSegmentZKMetadata(_propertyStore.get(
+          ZKMetadataProvider.constructPropertyStorePathForSegment(realtimeTableName, segmentName), null, AccessOption.PERSISTENT));
+  }
+
+  private void completeCommittingSegments() {
+    for (String realtimeTableName : getAllRealtimeTables()) {
+      completeCommittingSegments(realtimeTableName);
+    }
+  }
+
+  protected void completeCommittingSegments(String realtimeTableName) {
+    IdealState idealState = getTableIdealState(realtimeTableName);
+    Set<String> segmentNamesIS = idealState.getPartitionSet();
+    List<ZNRecord> segmentMetadataList = getExistingSegmentMetadata(realtimeTableName);
+    if (segmentMetadataList == null || segmentMetadataList.isEmpty()) {
+      return;
+    }
+    final List<LLCSegmentName> segmentNames = new ArrayList<>(segmentMetadataList.size());
+
+    for (ZNRecord segment : segmentMetadataList) {
+      if (SegmentName.isLowLevelConsumerSegmentName(segment.getId())) {
+        segmentNames.add(new LLCSegmentName(segment.getId()));
+      }
+    }
+
+    if (segmentNames.isEmpty()) {
+      return;
+    }
+
+    Collections.sort(segmentNames, Collections.reverseOrder());
+
+    int curPartition = segmentNames.get(0).getPartitionId();  // Current kafka partition we are working on.
+    final int nSegments = segmentNames.size();
+
+    /*
+     * We only need to look at the most recent segment in the kafka partition. If that segment is also present
+     * in the idealstate, we are good.
+     * Otherwise, we need to add that segment to the idealstate:
+     * - We find the current instance assignment for that partition and update idealstate accordingly.
+     * NOTE: It may be that the kafka assignment of instances has changed for this partition. In that case,
+     * we need to also modify the numPartitions field in the segment metadata.
+     * TODO Modify numPartitions field in segment metadata and re-write it in propertystore.
+     * The numPartitions field in the metadata is used by SegmentCompletionManager
+     */
+    for (int i = 0; i < nSegments; i++) {
+      final LLCSegmentName segmentName = segmentNames.get(i);
+      if (segmentName.getPartitionId() == curPartition) {
+        final String curSegmentNameStr = segmentName.getSegmentName();
+        if (!segmentNamesIS.contains(curSegmentNameStr)) {
+          LOGGER.info("{}:Repairing segment for partition {}. Segment {} not found in idealstate", realtimeTableName, curPartition,
+              curSegmentNameStr);
+
+          final ZNRecord partitionAssignment = getKafkaPartitionAssignment(realtimeTableName);
+          List<String> newInstances = partitionAssignment.getListField(Integer.toString(curPartition));
+          LOGGER.info("{}: Assigning segment {} to {}", realtimeTableName, curSegmentNameStr, newInstances);
+          // TODO Re-write num-partitions in metadata if needed.
+
+          String prevSegmentNameStr = null;
+          // If there was a prev segment in the same partition, then we need to fix it to be ONLINE.
+          if (i < nSegments-1) {
+            LLCSegmentName prevSegmentName = segmentNames.get(i+1);
+            if (prevSegmentName.getPartitionId() == segmentName.getPartitionId()) {
+              prevSegmentNameStr = prevSegmentName.getSegmentName();
+            }
+          }
+          updateHelixIdealState(realtimeTableName, newInstances, prevSegmentNameStr, curSegmentNameStr);
+          // Skip all other segments in this partition.
+        }
+        curPartition--;
+      }
+      if (curPartition < 0) {
+        break;
+      }
+    }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -1,0 +1,734 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.realtime;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCSegmentName;
+
+
+/**
+ * This is a singleton class in the controller that drives the state machines for segments that are in the
+ * committing stage.
+ *
+ * SegmentCompletionManager has a sub-class that represents the FSM that the segment goes through while
+ * executing the segment completion protocol between pinot servers and pinot controller. The protocol is
+ * described in SegmentCompletionProtocol.
+ */
+public class SegmentCompletionManager {
+  // TODO Can we log using the segment name in the log message?
+  public static Logger LOGGER = LoggerFactory.getLogger(SegmentCompletionManager.class);
+  private enum State {
+    HOLDING,          // the segment has started finalizing.
+    COMMITTER_DECIDED, // We know who the committer will be, we will let them know next time they call segmentConsumed()
+    COMMITTER_NOTIFIED, // we notified the committer to commit.
+    COMMITTER_UPLOADING,  // committer is uploading.
+    COMMITTING, // we are in the process of committing to zk
+    COMMITTED,    // We already committed a segment.
+    ABORTED,      // state machine is aborted. we will start a fresh one when the next segmentConsumed comes in.
+  }
+
+  private static SegmentCompletionManager _instance = null;
+
+  private final HelixManager _helixManager;
+  // A map that holds the FSM for each segment.
+  private final Map<String, SegmentCompletionFSM> _fsmMap = new ConcurrentHashMap<>();
+  private final PinotLLCRealtimeSegmentManager _segmentManager;
+
+  // TODO keep some history of past committed segments so that we can avoid looking up PROPERTYSTORE if some server comes in late.
+
+  protected SegmentCompletionManager(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager) {
+    _helixManager = helixManager;
+    _segmentManager = segmentManager;
+  }
+
+  public static SegmentCompletionManager create(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager) {
+    if (_instance != null) {
+      throw new RuntimeException("Cannot create multiple instances");
+    }
+    _instance = new SegmentCompletionManager(helixManager, segmentManager);
+    return _instance;
+  }
+
+  public static SegmentCompletionManager getInstance() {
+    if (_instance == null) {
+      throw new RuntimeException("Not yet created");
+    }
+    return _instance;
+  }
+
+  protected long getCurrentTimeMs() {
+    return System.currentTimeMillis();
+  }
+
+  // We need to make sure that we never create multiple FSMs for the same segment, so this method must be synchronized.
+  private synchronized SegmentCompletionFSM lookupOrCreateFsm(final LLCSegmentName segmentName, String msgType,
+      long offset) {
+    final String segmentNameStr = segmentName.getSegmentName();
+    SegmentCompletionFSM fsm = _fsmMap.get(segmentNameStr);
+    if (fsm == null) {
+      // Look up propertystore to see if this is a completed segment
+      ZNRecord segment;
+      try {
+        // TODO if we keep a list of last few committed segments, we don't need to go to zk for this.
+        LLCRealtimeSegmentZKMetadata segmentMetadata = _segmentManager.getRealtimeSegmentZKMetadata(
+            segmentName.getTableName(), segmentName.getSegmentName());
+        if (segmentMetadata.getStatus().equals(CommonConstants.Segment.Realtime.Status.DONE)) {
+          // Best to go through the state machine for this case as well, so that all code regarding state handling is in one place
+          // Also good for synchronization, because it is possible that multiple threads take this path, and we don't want
+          // multiple instances of the FSM to be created for the same commit sequence at the same time.
+          final long endOffset = segmentMetadata.getEndOffset();
+          fsm = new SegmentCompletionFSM(_segmentManager, this, segmentName, segmentMetadata.getNumReplicas(), endOffset);
+        } else {
+          // Segment is finalizing, and this is the first one to respond. Create an entry
+          fsm = new SegmentCompletionFSM(_segmentManager, this, segmentName, segmentMetadata.getNumReplicas());
+        }
+        LOGGER.info("Created FSM {}", fsm);
+        _fsmMap.put(segmentNameStr, fsm);
+      } catch (Exception e) {
+        // Server gone wonky. Segment does not exist in propstore
+        LOGGER.error("Exception reading segment read from propertystore {}", segmentNameStr, e);
+        throw new RuntimeException("Segment read from propertystore " + segmentNameStr, e);
+      }
+    }
+    return fsm;
+  }
+
+  /**
+   * This method is to be called when a server calls in with the segmentConsumed() API, reporting an offset in kafka
+   * that it currently has (i.e. next offset that it will consume, if it continues to consume).
+   *
+   * @param segmentNameStr Name of the LLC segment
+   * @param instanceId Instance that sent the segmentConsumed() request
+   * @param offset Kafka offset reported by the instance
+   * @return the protocol repsonse to be returned to the server.
+   */
+  public SegmentCompletionProtocol.Response segmentConsumed(final String segmentNameStr, final String instanceId, final long offset) {
+    if (!_helixManager.isLeader()) {
+      return SegmentCompletionProtocol.RESP_NOT_LEADER;
+    }
+    LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
+    SegmentCompletionFSM fsm = lookupOrCreateFsm(segmentName, SegmentCompletionProtocol.MSG_TYPE_CONSUMED, offset);
+    SegmentCompletionProtocol.Response response = fsm.segmentConsumed(instanceId, offset);
+    if (fsm.isDone()) {
+      LOGGER.info("Removing FSM (if present):{}", fsm.toString());
+      _fsmMap.remove(segmentNameStr);
+    }
+    return response;
+  }
+
+  /**
+   * This method is to be called when a server calls in with the segmentCommit() API. The server sends in the segment
+   * along with the API, but it is the caller's responsibility to save the segment after this call (and before the
+   * segmentCommitEnd() call).
+   *
+   * If successful, this method will return Response.COMMIT_CONTINUE, in which case, the caller should save the incoming
+   * segment and then call segmentCommitEnd().
+   *
+   * Otherwise, this method will return a protocol response to be returned to the client right away (without saving the
+   * incoming segment).
+   *
+   * @param segmentNameStr  Name of the LLC segment
+   * @param instanceId  Instance that sent the segmentCommit() request
+   * @param offset  Kafka offset reported by the instance.
+   * @return
+   */
+  public SegmentCompletionProtocol.Response segmentCommitStart(final String segmentNameStr, final String instanceId, final long offset) {
+    if (!_helixManager.isLeader()) {
+      return SegmentCompletionProtocol.RESP_NOT_LEADER;
+    }
+    LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
+    SegmentCompletionFSM fsm = lookupOrCreateFsm(segmentName, SegmentCompletionProtocol.MSG_TYPE_CONSUMED, offset);
+    SegmentCompletionProtocol.Response response = fsm.segmentCommitStart(instanceId, offset);
+    if (fsm.isDone()) {
+      LOGGER.info("Removing FSM (if present):{}", fsm.toString());
+      _fsmMap.remove(segmentNameStr);
+    }
+    return response;
+  }
+
+  /**
+   * This method is to be called when the segment sent in by the server has been saved locally in the correct path that
+   * is downloadable by the servers.
+   *
+   * It returns a response code to be sent back to the client.
+   *
+   * If the repsonse code is not COMMIT_SUCCESS, then the caller may remove the segment that has been saved.
+   *
+   * @param segmentNameStr  Name of the LLC segment
+   * @param instanceId Instance that sent the segmentConsumed() request.
+   * @param offset Kafka offset reported by the client.
+   * @param success whether saving the segment was successful or not.
+   * @return
+   */
+  public SegmentCompletionProtocol.Response segmentCommitEnd(final String segmentNameStr, final String instanceId,
+      final long offset, boolean success) {
+    if (!_helixManager.isLeader()) {
+      return SegmentCompletionProtocol.RESP_NOT_LEADER;
+    }
+    LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
+    SegmentCompletionFSM fsm = lookupOrCreateFsm(segmentName, SegmentCompletionProtocol.MSG_TYPE_CONSUMED, offset);
+    SegmentCompletionProtocol.Response response = fsm.segmentCommitEnd(instanceId, offset, success);
+    if (fsm.isDone()) {
+      LOGGER.info("Removing FSM (if present):{}", fsm.toString());
+      _fsmMap.remove(segmentNameStr);
+    }
+    return response;
+  }
+
+
+  /**
+   * This class implements the FSM on the controller side for each completing segment.
+   *
+   * An FSM is is created when we first hear about a segment (typically through the segmentConsumed message).
+   * When an FSM is created, it may have one of two start states (HOLDING, or COMMITTED), depending on the 
+   * constructor used.
+   *
+   * We kick off an FSM in the COMMITTED state (rare) when we find that PROPERTYSTORE already has the segment
+   * with the Status set to DONE.
+   *
+   * We kick off an FSM in the HOLDING state (typical) when a sementConsumed() message arrives from the
+   * first server we hear from.
+   *
+   * The FSM does not have a timer. It is clocked by the servers, which, typically, are retransmitting their
+   * segmentConsumed() message every so often (SegmentCompletionProtocol.MAX_HOLD_TIME_MS).
+   *
+   * See https://github.com/linkedin/pinot/wiki/Low-level-kafka-consumers
+   */
+  private static class SegmentCompletionFSM {
+    // We will have some variation between hosts, so we add 10% to the max hold time to pick a winner.
+    // If there is more than 10% variation, then it is handled as an error case (i.e. the first few to
+    // come in will have a winner, and the later ones will just download the segment)
+    public static final long  MAX_TIME_TO_PICK_WINNER_MS =
+      SegmentCompletionProtocol.MAX_HOLD_TIME_MS + (SegmentCompletionProtocol.MAX_HOLD_TIME_MS / 10);
+
+    // Once we pick a winner, the winner may get notified in the next call, so add one hold time plus some.
+    public static final long MAX_TIME_TO_NOTIFY_WINNER_MS = MAX_TIME_TO_PICK_WINNER_MS +
+      SegmentCompletionProtocol.MAX_HOLD_TIME_MS + (SegmentCompletionProtocol.MAX_HOLD_TIME_MS / 10);
+
+    // Once the winner is notified, the are expected to commit right away. At this point, it is the segment commit
+    // time that we need to consider.
+    // We may need to add some time here to allow for getting the lock? For now 0
+    // We may need to add some time for the committer come back to us? For now 0.
+    public static final long MAX_TIME_ALLOWED_TO_COMMIT_MS = MAX_TIME_TO_NOTIFY_WINNER_MS + SegmentCompletionProtocol.MAX_SEGMENT_COMMIT_TIME_MS;
+
+    public final Logger LOGGER;
+
+    State _state = State.HOLDING;   // Typically start off in HOLDING state.
+    final long _startTime;
+    private final LLCSegmentName _segmentName;
+    private final int _numReplicas;
+    private final Map<String, Long> _commitStateMap;
+    private long _winningOffset = -1L;
+    private String _winner;
+    private final PinotLLCRealtimeSegmentManager _segmentManager;
+    private final SegmentCompletionManager _segmentCompletionManager;
+
+    // Ctor that starts the FSM in HOLDING state
+    public SegmentCompletionFSM(PinotLLCRealtimeSegmentManager segmentManager,
+        SegmentCompletionManager segmentCompletionManager, LLCSegmentName segmentName, int numReplicas) {
+      _segmentName = segmentName;
+      _numReplicas = numReplicas;
+      _segmentManager = segmentManager;
+      _commitStateMap = new HashMap<>(_numReplicas);
+      _segmentCompletionManager = segmentCompletionManager;
+      _startTime = _segmentCompletionManager.getCurrentTimeMs();
+      LOGGER = LoggerFactory.getLogger("SegmentFinalizerFSM_"  + segmentName.getSegmentName());
+    }
+
+    // Ctor that starts the FSM in COMMITTED state
+    public SegmentCompletionFSM(PinotLLCRealtimeSegmentManager segmentManager,
+        SegmentCompletionManager segmentCompletionManager, LLCSegmentName segmentName, int numReplicas,
+        long winningOffset) {
+      // Constructor used when we get an event after a segment is committed.
+      this(segmentManager, segmentCompletionManager, segmentName, numReplicas);
+      _state = State.COMMITTED;
+      _winningOffset = winningOffset;
+      _winner = "UNKNOWN";
+    }
+
+    @Override
+    public String toString() {
+      return "{" + _segmentName.getSegmentName() + "," + _state + "," + _startTime + "," + _winner + "," + _winningOffset + "}";
+    }
+
+    // SegmentCompletionManager releases the FSM from the hashtable when it is done.
+    public boolean isDone() {
+      return _state.equals(State.COMMITTED) || _state.equals(State.ABORTED);
+    }
+
+    /*
+     * We just heard from a server that it has reached completion stage, and is reporting the offset
+     * that the server is at. Since multiple servers can come in at the same time for this segment,
+     * we need to synchronize on the FSM to handle the messages. The processing time itself is small,
+     * so we should be OK with this synchronization.
+     */
+    public SegmentCompletionProtocol.Response segmentConsumed(String instanceId, long offset) {
+      final long now = _segmentCompletionManager.getCurrentTimeMs();
+      // We can synchronize the entire block for the SegmentConsumed message.
+      synchronized (this) {
+        LOGGER.info("Processing segmentConsumed({}, {})", instanceId, offset);
+        _commitStateMap.put(instanceId, offset);
+        switch (_state) {
+          case HOLDING:
+            return HOLDING__consumed(instanceId, offset, now);
+
+          case COMMITTER_DECIDED: // This must be a retransmit
+            return COMMITTER_DECIDED__consumed(instanceId, offset, now);
+
+          case COMMITTER_NOTIFIED:
+            return COMMITTER_NOTIFIED__consumed(instanceId, offset, now);
+
+          case COMMITTER_UPLOADING:
+            return COMMITTER_UPLOADING__consumed(instanceId, offset, now);
+
+          case COMMITTING:
+            return COMMITTING__consumed(instanceId, offset, now);
+
+          case COMMITTED:
+            return COMMITTED__consumed(instanceId, offset);
+
+          case ABORTED:
+            // FSM has been aborted, just return HOLD
+            return hold(instanceId, offset);
+
+          default:
+            return fail(instanceId, offset);
+        }
+      }
+    }
+
+    /*
+     * A server has sent segmentConsumed() message. The caller will save the segment if we return
+     * COMMIT_CONTINUE. We need to verify that it is the same server that we notified as the winner
+     * and the offset is the same as what is coming in with the commit. We can then move to
+     * COMMITTER_UPLOADING and wait for the segmentCommitEnd() call.
+     *
+     * In case of descrepancy we move the state machine to ABORTED state so that this FSM is removed
+     * from the map, and things start over. In this case, we respond to the server with a 'hold' so
+     * that they re-transmit their segmentConsumed() message and start over.
+     */
+    public SegmentCompletionProtocol.Response segmentCommitStart(String instanceId, long offset) {
+      long now = _segmentCompletionManager.getCurrentTimeMs();
+      synchronized (this) {
+        LOGGER.info("Processing segmentCommit({}, {})", instanceId, offset);
+        switch (_state) {
+          case HOLDING:
+            return HOLDING__commit(instanceId, offset, now);
+
+          case COMMITTER_DECIDED:
+            return COMMITTER_DECIDED__commit(instanceId, offset, now);
+
+          case COMMITTER_NOTIFIED:
+            return COMMITTER_NOTIFIED__commit(instanceId, offset, now);
+
+          case COMMITTER_UPLOADING:
+            return COMMITTER_UPLOADING__commit(instanceId, offset, now);
+
+          case COMMITTING:
+            return COMMITTING__commit(instanceId, offset, now);
+
+          case COMMITTED:
+            return COMMITTED__commit(instanceId, offset);
+
+          case ABORTED:
+            return hold(instanceId, offset);
+
+          default:
+            return fail(instanceId, offset);
+        }
+      }
+    }
+
+    /*
+     * We can get this call only when the state is COMMITTER_UPLOADING. Also, the instanceId should be equal to
+     * the _winner.
+     */
+    public SegmentCompletionProtocol.Response segmentCommitEnd(String instanceId, long offset, boolean success) {
+      synchronized (this) {
+        LOGGER.info("Processing segmentCommit({}, {})", instanceId, offset);
+        if (!_state.equals(State.COMMITTER_UPLOADING) || !instanceId.equals(_winner)) {
+          // State changed while we were out of sync. return a failed commit.
+          LOGGER.warn("State change during upload: state={} segment={} winner={} winningOffset={}",
+              _state, _segmentName.getSegmentName(), _winner, _winningOffset);
+          _state = State.ABORTED;
+          return SegmentCompletionProtocol.RESP_FAILED;
+        }
+        if (!success) {
+          LOGGER.error("Segment upload failed");
+          _state = State.ABORTED;
+          return SegmentCompletionProtocol.RESP_FAILED;
+        }
+        SegmentCompletionProtocol.Response response = updateZk(instanceId, offset);
+        if (response != null) {
+          return response;
+        }
+      }
+      return new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.FAILED, -1L);
+    }
+
+
+    // Helper methods that log the current state and the response sent
+    private SegmentCompletionProtocol.Response fail(String instanceId, long offset) {
+      LOGGER.info("{}:FAIL for instance={} offset={}", _state, instanceId, offset);
+      return SegmentCompletionProtocol.RESP_FAILED;
+    }
+
+    private SegmentCompletionProtocol.Response commit(String instanceId, long offset) {
+      LOGGER.info("{}:COMMIT for instance={} offset={}", _state, instanceId, offset);
+      return new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT, offset);
+    }
+
+    private SegmentCompletionProtocol.Response discard(String instanceId, long offset) {
+      LOGGER.warn("{}:DISCARD for instance={} offset={}", _state, instanceId, offset);
+      return SegmentCompletionProtocol.RESP_DISCARD;
+    }
+
+    private SegmentCompletionProtocol.Response keep(String instanceId, long offset) {
+      LOGGER.info("{}:KEEP for instance={} offset={}", _state, instanceId, offset);
+      return new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.KEEP, offset);
+    }
+
+    private SegmentCompletionProtocol.Response catchup(String instanceId, long offset) {
+      LOGGER.info("{}:CATCHUP for instance={} offset={}", _state, instanceId, offset);
+      return new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP,
+          _winningOffset);
+    }
+
+    private SegmentCompletionProtocol.Response hold(String instanceId, long offset) {
+      LOGGER.info("{}:HOLD for instance={} offset={}", _state, instanceId, offset);
+      return new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.HOLD, offset);
+    }
+
+    private SegmentCompletionProtocol.Response abortAndReturnHold(long now, String instanceId, long offset) {
+      _state = State.ABORTED;
+      return hold(instanceId, offset);
+    }
+
+    private SegmentCompletionProtocol.Response abortIfTooLateAndReturnHold(long now, String instanceId, long offset) {
+      if (now > _startTime + MAX_TIME_ALLOWED_TO_COMMIT_MS) {
+        LOGGER.warn("{}:Aborting FSM (too late) instance={} offset={} now={} start={}", _state, instanceId,
+            offset, now, _startTime);
+        return abortAndReturnHold(now, instanceId, offset);
+      }
+      return null;
+    }
+
+    /*
+     * If we have waited "enough", or we have all replicas reported, then we can pick a winner.
+     * 
+     * Otherwise, we ask the server that is reporting to come back again later until one of these conditions hold.
+     *
+     * If we can pick a winner then we go to COMMITTER_DECIDED or COMMITTER_NOTIIFIED (if the instance
+     * in this call is the same as winner).
+     *
+     * If we can go to COMMITTER_NOTIFIED then we respond with a COMMIT message, otherwise with a HOLD message.
+     */
+    private SegmentCompletionProtocol.Response HOLDING__consumed(String instanceId, long offset, long now) {
+      SegmentCompletionProtocol.Response response;
+      // If we are past the max time to pick a winner, or we have heard from all replicas,
+      // we are ready to pick a winner.
+      if (now > _startTime + MAX_TIME_TO_PICK_WINNER_MS || _commitStateMap.size() == _numReplicas) {
+        LOGGER.info("{}:Picking winner time={} size={}", _state, now-_startTime, _commitStateMap.size());
+        pickWinner(instanceId);
+        if (_winner.equals(instanceId)) {
+          LOGGER.info("{}:Committer notified winner instance={} offset={}", _state, instanceId, offset);
+          response = commit(instanceId, offset);
+          _state = State.COMMITTER_NOTIFIED;
+        } else {
+          LOGGER.info("{}:Committer decided winner={} offset={}", _state, _winner, _winningOffset);
+          response = catchup(instanceId, offset);
+          _state = State.COMMITTER_DECIDED;
+        }
+      } else {
+        response = hold(instanceId, offset);
+      }
+      return response;
+    }
+
+    /*
+     * This not a good state to receive a commit message, but then it may be that the controller
+     * failed over while in the COMMITTER_NOTIFIED state...
+     */
+    private SegmentCompletionProtocol.Response HOLDING__commit(String instanceId, long offset, long now) {
+      return processCommitWhileHolding(instanceId, offset, now);
+    }
+
+    /*
+     * We have already decided who the committer is, but have not let them know yet. If this is the committer that
+     * we decided, then respond back with COMMIT. Otherwise, if the offset is smaller, respond back with a CATCHUP.
+     * Otherwise, just have the server HOLD. Since the segment is not committed yet, we cannot ask them to KEEP or
+     * DISCARD etc. If the committer fails for any reason, we will need a new committer.
+     */
+    private SegmentCompletionProtocol.Response COMMITTER_DECIDED__consumed(String instanceId, long offset, long now) {
+      if (offset > _winningOffset) {
+        LOGGER.warn("{}:Aborting FSM (offset larger than winning) instance={} offset={} now={} winning={}", _state, instanceId,
+            offset, now, _winningOffset);
+        return abortAndReturnHold(now, instanceId, offset);
+      }
+      SegmentCompletionProtocol.Response response;
+      if (_winner.equals(instanceId)) {
+        if (_winningOffset == offset) {
+          LOGGER.info("{}:Notifying winner instance={} offset={}", _state, instanceId, offset);
+          response = commit(instanceId, offset);
+          _state = State.COMMITTER_NOTIFIED;
+        } else {
+          // Winner coming back with a different offset.
+          LOGGER.warn("{}:Winner coming back with different offset for instance={} offset={} prevWinnOffset={}", _state,
+              instanceId, offset, _winningOffset);
+          response = abortAndReturnHold(now, instanceId, offset);
+        }
+      } else  if (offset == _winningOffset) {
+        // Wait until winner has posted the segment.
+        response = hold(instanceId, offset);
+      } else {
+        response = catchup(instanceId, offset);
+      }
+      if (now > _startTime + MAX_TIME_TO_NOTIFY_WINNER_MS) {
+        // Winner never got back to us. Abort the completion protocol and start afresh.
+        // We can potentially optimize here to see if this instance has the highest so far, and re-elect them to
+        // be winner, but for now, we will abort it and restart
+        response = abortAndReturnHold(now, instanceId, offset);
+      }
+      return response;
+    }
+
+    /*
+     * We have already decided who the committer is, but have not let them know yet. So, we don't expect
+     * a commit() call here.
+     */
+    private SegmentCompletionProtocol.Response COMMITTER_DECIDED__commit(String instanceId, long offset,
+        long now) {
+      return processCommitWhileHolding(instanceId, offset, now);
+    }
+
+    /*
+     * We have notified the committer. If we get a consumed message from another server, we can ask them to 
+     * catchup (if the offset is lower). If anything else, then we pretty much ask them to hold.
+     */
+    private SegmentCompletionProtocol.Response COMMITTER_NOTIFIED__consumed(String instanceId, long offset, long now) {
+      SegmentCompletionProtocol.Response response;
+      // We have already picked a winner and notified them but we have not heard from them yet.
+      // Common case here is that another server is coming back to us with its offset. We either respond back with HOLD or CATCHUP.
+      // If the winner is coming back again, then we have some more conditions to look at.
+      response = abortIfTooLateAndReturnHold(now, instanceId, offset);
+      if (response != null) {
+        return response;
+      }
+      if (instanceId.equals(_winner)) {
+        // Winner is coming back to after holding. Somehow they never heard us return COMMIT.
+        // Allow them to be winner again, since we are still within time to pick a winner.
+        if (offset == _winningOffset) {
+          response = commit(instanceId, offset);
+        } else {
+          // Something seriously wrong. Abort the FSM
+          response = discard(instanceId, offset);
+          LOGGER.warn("{}:Aborting for instance={} offset={}", _state, instanceId, offset);
+          _state = State.ABORTED;
+        }
+      } else {
+        // Common case: A different instance is reporting.
+        if (offset == _winningOffset) {
+          // Wait until winner has posted the segment before asking this server to KEEP the segment.
+          response = hold(instanceId, offset);
+        } else if (offset < _winningOffset) {
+          response = catchup(instanceId, offset);
+        } else {
+          // We have not yet committed, so ask the new responder to hold. They may be the new leader in case the
+          // committer fails.
+          response = hold(instanceId, offset);
+        }
+      }
+      return response;
+    }
+
+    /*
+     * We have notified the committer. If we get a consumed message from another server, we can ask them to 
+     * catchup (if the offset is lower). If anything else, then we pretty much ask them to hold.
+     */
+    private SegmentCompletionProtocol.Response COMMITTER_NOTIFIED__commit(String instanceId, long offset, long now) {
+      SegmentCompletionProtocol.Response response = null;
+      response = checkBadCommitRequest(instanceId, offset, now);
+      if (response != null) {
+        return response;
+      }
+      LOGGER.info("{}:Uploading for instance={} offset={}", _state, instanceId, offset);
+      _state = State.COMMITTER_UPLOADING;
+      return SegmentCompletionProtocol.RESP_COMMIT_CONTINUE;
+    }
+
+    private SegmentCompletionProtocol.Response COMMITTER_UPLOADING__consumed(String instanceId, long offset, long now) {
+      return processConsumedAfterCommitStart(instanceId, offset, now);
+    }
+
+    private SegmentCompletionProtocol.Response COMMITTER_UPLOADING__commit(String instanceId, long offset,
+        long now) {
+      return processCommitWhileUploading(instanceId, offset, now);
+    }
+
+    private SegmentCompletionProtocol.Response COMMITTING__consumed(String instanceId, long offset, long now) {
+      return processConsumedAfterCommitStart(instanceId, offset, now);
+    }
+
+    private SegmentCompletionProtocol.Response COMMITTING__commit(String instanceId, long offset,
+        long now) {
+      return processCommitWhileUploading(instanceId, offset, now);
+    }
+
+    private SegmentCompletionProtocol.Response COMMITTED__consumed(String instanceId, long offset) {
+      SegmentCompletionProtocol.Response
+          response;// Server reporting an offset on an already completed segment. Depending on the offset, either KEEP or DISCARD.
+      if (offset == _winningOffset) {
+        response = keep(instanceId, offset);
+      } else {
+        // Return DISCARD. It is hard to say how long the server will take to complete things.
+        response = discard(instanceId, offset);
+      }
+      return response;
+    }
+
+    private SegmentCompletionProtocol.Response COMMITTED__commit(String instanceId, long offset) {
+      if (offset == _winningOffset) {
+        return keep(instanceId, offset);
+      }
+      return discard(instanceId, offset);
+    }
+
+
+    // A common method when the state is > COMMITTER_NOTIFIED.
+    private SegmentCompletionProtocol.Response processConsumedAfterCommitStart(String instanceId, long offset, long now) {
+      SegmentCompletionProtocol.Response response;
+      // We have already picked a winner, and may or many not have heard from them.
+      // Common case here is that another server is coming back to us with its offset. We either respond back with HOLD or CATCHUP.
+      // It may be that we never heard from the committer, or the committer is taking too long to commit the segment.
+      // In that case, we abort the FSM and start afresh (i.e, return HOLD).
+      // If the winner is coming back again, then we have some more conditions to look at.
+      response = abortIfTooLateAndReturnHold(now, instanceId, offset);
+      if (response != null) {
+        return null;
+      }
+      if (instanceId.equals(_winner)) {
+        // The winner is coming back to report its offset. Take a decision based on the offset reported, and whether we
+        // already notified them
+        // Winner is supposedly already in the commit call. Something wrong.
+        LOGGER.warn("{}:Aborting FSM because winner is reporting a segment while it is also committing instance={} offset={} now={}",
+            _state, instanceId, offset, now);
+        // Ask them to hold, just in case the committer fails for some reason..
+        return abortAndReturnHold(now, instanceId, offset);
+      } else {
+        // Common case: A different instance is reporting.
+        if (offset == _winningOffset) {
+          // Wait until winner has posted the segment before asking this server to KEEP the segment.
+          response = hold(instanceId, offset);
+        } else if (offset < _winningOffset) {
+          response = catchup(instanceId, offset);
+        } else {
+          // We have not yet committed, so ask the new responder to hold. They may be the new leader in case the
+          // committer fails.
+          response = hold(instanceId, offset);
+        }
+      }
+      return response;
+    }
+
+    private SegmentCompletionProtocol.Response updateZk(String instanceId, long offset) {
+      boolean success;
+      if (!_state.equals(State.COMMITTER_UPLOADING)) {
+        // State changed while we were out of sync. return a failed commit.
+        LOGGER.warn("State change during upload: state={} segment={} winner={} winningOffset={}",
+            _state, _segmentName.getSegmentName(), _winner, _winningOffset);
+        return SegmentCompletionProtocol.RESP_FAILED;
+      }
+      LOGGER.info("Committing segment {} at offset {} winner {}", _segmentName.getSegmentName(), offset, instanceId);
+      _state = State.COMMITTING;
+      success = _segmentManager.commitSegment(_segmentName.getTableName(), _segmentName.getSegmentName(), _winningOffset);
+      if (success) {
+        _state = State.COMMITTED;
+        LOGGER.info("Committed segment {} at offset {} winner {}", _segmentName.getSegmentName(), offset, instanceId);
+        return SegmentCompletionProtocol.RESP_COMMIT_SUCCESS;
+      }
+      return null;
+    }
+
+
+    private SegmentCompletionProtocol.Response processCommitWhileUploading(String instanceId, long offset, long now) {
+      LOGGER.info("Processing segmentCommit({}, {})", instanceId, offset);
+      SegmentCompletionProtocol.Response response = abortIfTooLateAndReturnHold(now, instanceId, offset);
+      if (response != null) {
+        return response;
+      }
+      // Another committer (or same) came in while one was uploading. Ask them to hold in case this one fails.
+      return new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.HOLD, offset);
+    }
+
+    private SegmentCompletionProtocol.Response checkBadCommitRequest(String instanceId, long offset, long now) {
+      SegmentCompletionProtocol.Response response = abortIfTooLateAndReturnHold(now, instanceId, offset);
+      if (response != null) {
+        return response;
+      } else  if (instanceId.equals(_winner) && offset != _winningOffset) {
+        // Hmm. Committer has been notified, but either a different one is committing, or offset is different
+        LOGGER.warn("{}:Aborting FSM (bad commit req) instance={} offset={} now={} winning={}", _state, instanceId,
+            offset, now, _winningOffset);
+        return abortAndReturnHold(now, instanceId, offset);
+      }
+      return null;
+    }
+
+    private SegmentCompletionProtocol.Response processCommitWhileHolding(String instanceId, long offset, long now) {
+      LOGGER.info("Processing segmentCommit({}, {})", instanceId, offset);
+      SegmentCompletionProtocol.Response response = abortIfTooLateAndReturnHold(now, instanceId, offset);
+      if (response != null) {
+        return response;
+      }
+      // We cannot get a commit if we are in this state, so ask them to hold. Maybe we are starting after a failover.
+      // The server will re-send the segmentConsumed message.
+      return hold(instanceId, offset);
+    }
+
+    // TODO TBD whether the segment is saved here or before entering the FSM.
+    private boolean saveTheSegment() throws InterruptedException {
+      // XXX: this can fail
+      return true;
+    }
+
+    // Pick a winner, preferring this instance if tied for highest.
+    // Side-effect: Sets the _winner and _winningOffset
+    private void pickWinner(String preferredInstance) {
+      long maxSoFar = -1;
+      String winner = null;
+      for (Map.Entry<String, Long> entry : _commitStateMap.entrySet()) {
+        if (entry.getValue() > maxSoFar) {
+          maxSoFar = entry.getValue();
+          winner = entry.getKey();
+        }
+      }
+      _winningOffset = maxSoFar;
+      if (_commitStateMap.get(preferredInstance) == maxSoFar) {
+        winner = preferredInstance;
+      }
+      _winner =  winner;
+    }
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1,0 +1,340 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.realtime;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCSegmentName;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class SegmentCompletionTest {
+
+  private MockPinotLLCRealtimeSegmentManager segmentManager;
+  private MockSegmentCompletionManager segmentCompletionMgr;
+  private Map<String, Object> fsmMap;
+  private String segmentNameStr;
+  private final String s1 = "S1";
+  private final String s2 = "S2";
+  private final String s3 = "S3";
+
+  private final long s1Offset = 20L;
+  private final long s2Offset = 40L;
+  private final long s3Offset = 30L;
+
+  @BeforeMethod
+  public void testCaseSetup() throws Exception {
+    testCaseSetup(true);
+  }
+
+  public void testCaseSetup(boolean isLeader) throws Exception {
+    segmentManager = new MockPinotLLCRealtimeSegmentManager();
+    final int partitionId = 23;
+    final int seqId = 12;
+    final long now = System.currentTimeMillis();
+    final String tableName = "someTable";
+    final LLCSegmentName segmentName = new LLCSegmentName(tableName, partitionId, seqId, now);
+    segmentNameStr = segmentName.getSegmentName();
+    final LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+    metadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+    metadata.setNumReplicas(3);
+    segmentManager._segmentMetadata = metadata;
+
+    segmentCompletionMgr = new MockSegmentCompletionManager(segmentManager, isLeader);
+    segmentManager._segmentCompletionMgr = segmentCompletionMgr;
+
+    Field fsmMapField = SegmentCompletionManager.class.getDeclaredField("_fsmMap");
+    fsmMapField.setAccessible(true);
+    fsmMap = (Map<String, Object>)fsmMapField.get(segmentCompletionMgr);
+  }
+
+  // Simulate a new controller taking over with an empty completion manager object,
+  // but segment metadata is fine in zk
+  private void replaceSegmentCompletionManager() throws Exception {
+    long oldSecs = segmentCompletionMgr._secconds;
+    segmentCompletionMgr = new MockSegmentCompletionManager(segmentManager, true);
+    segmentCompletionMgr._secconds = oldSecs;
+    Field fsmMapField = SegmentCompletionManager.class.getDeclaredField("_fsmMap");
+    fsmMapField.setAccessible(true);
+    fsmMap = (Map<String, Object>)fsmMapField.get(segmentCompletionMgr);
+  }
+
+  @Test
+  public void testHappyPath() throws Exception {
+    SegmentCompletionProtocol.Response response;
+    // s1 sends offset of 20, gets HOLD at t = 5s;
+    segmentCompletionMgr._secconds = 5;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s2 sends offset of 40, gets HOLD
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s3 sends offset of 30, gets catchup to 40
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s3Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
+    Assert.assertEquals(response.getOffset(), s2Offset);
+    // Now s1 comes back, and is asked to catchup.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
+    // s2 is asked to commit.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+    // s3 comes back with new caught up offset, it should get a HOLD, since commit is not done yet.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s2 executes a succesful commit
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentCommitStart(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_CONTINUE);
+
+    segmentCompletionMgr._secconds += 5;
+    response = segmentCompletionMgr.segmentCommitEnd(segmentNameStr, s2, s2Offset, true);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
+
+    // Now the FSM should have disappeared from the map
+    Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
+
+    // Now if s3 or s1 come back, they are asked to keep the segment they have.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
+
+    // And the FSM should be removed.
+    Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
+  }
+
+  @Test
+  public void testDelayedServer() throws Exception {
+    SegmentCompletionProtocol.Response response;
+    // s1 sends offset of 20, gets HOLD at t = 5s;
+    final int startTimeSecs = 5;
+    segmentCompletionMgr._secconds = startTimeSecs;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s2 sends offset of 40, gets HOLD
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // Now s1 comes back again, and is asked to hold
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s2 is asked to commit.
+    segmentCompletionMgr._secconds += SegmentCompletionProtocol.MAX_HOLD_TIME_MS/1000;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+
+    // Now s3 comes up with a better offset, but we ask it to hold, since the committer has not committed yet.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s2Offset + 10);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s2 commits.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentCommitStart(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_CONTINUE);
+    segmentCompletionMgr._secconds += 5;
+    response = segmentCompletionMgr.segmentCommitEnd(segmentNameStr, s2, s2Offset, true);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
+    // Now the FSM should have disappeared from the map
+    Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
+
+    // Now s3 comes back to get a discard.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s2Offset + 10);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.DISCARD);
+    // Now the FSM should have disappeared from the map
+    Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
+  }
+
+  // We test the case when the committer is asked to commit, but they never come back.
+  @Test
+  public void testCommitterFailure() throws Exception {
+    SegmentCompletionProtocol.Response response;
+    // s1 sends offset of 20, gets HOLD at t = 5s;
+    final int startTimeSecs = 5;
+    segmentCompletionMgr._secconds = startTimeSecs;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s2 sends offset of 40, gets HOLD
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s3 is asked to hole
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s3Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
+    Assert.assertEquals(response.getOffset(), s2Offset);
+    // Now s2 is asked to commit.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+
+    // Time passes, s2 never comes back.
+    segmentCompletionMgr._secconds += SegmentCompletionProtocol.MAX_HOLD_TIME_MS/1000;
+
+    // But since s1 and s3 are in HOLDING state, they should come back again. s1 is asked to catchup
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
+
+    // Max time to commit passes
+    segmentCompletionMgr._secconds += 6 * SegmentCompletionProtocol.MAX_HOLD_TIME_MS/1000;
+
+    // s1 comes back with the updated offset, since it was asked to catch up.
+    // The FSM will be aborted, and destroyed ...
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+
+    Assert.assertFalse(fsmMap.containsKey(segmentNameStr));
+
+    // s1 comes back again, a new FSM created
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+
+    // s3 comes back
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+
+    // And winner chosen when the last one does not come back at all
+    segmentCompletionMgr._secconds += 5;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+
+    // The FSM is still present to complete the happy path as before.
+    Assert.assertTrue(fsmMap.containsKey(segmentNameStr));
+  }
+
+  @Test
+  public void testControllerFailureDuringCommit() throws Exception {
+    SegmentCompletionProtocol.Response response;
+    // s1 sends offset of 20, gets HOLD at t = 5s;
+    segmentCompletionMgr._secconds = 5;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s2 sends offset of 40, gets HOLD
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+    // s3 sends offset of 30, gets catchup to 40
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s3Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
+    Assert.assertEquals(response.getOffset(), s2Offset);
+    // Now s1 comes back, and is asked to catchup.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
+    // s2 is asked to commit.
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+
+    // Now the controller fails, and a new one takes over, with no knowledge of what was done before.
+    replaceSegmentCompletionManager();
+
+    // s3 comes back with the correct offset but is asked to hold.
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s3, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+
+    // s1 comes back, and still asked to hold.
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.HOLD);
+
+    // s2 has no idea the controller failed, so it comes back with a commit,but the controller asks it to hold,
+    // (essentially a commit failure)
+    segmentCompletionMgr._secconds += 1;
+    response = segmentCompletionMgr.segmentCommitStart(segmentNameStr, s2, s2Offset);
+    Assert.assertTrue(response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
+
+    // So s2 goes back into HOLDING state. s1 and s3 are already holding, so now it will get COMMIT back.
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s2, s2Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
+  }
+
+  @Test
+  public void testNotLeader() throws Exception {
+    testCaseSetup(false);
+    SegmentCompletionProtocol.Response response;
+
+    response = segmentCompletionMgr.segmentConsumed(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER);
+
+    response = segmentCompletionMgr.segmentCommitStart(segmentNameStr, s1, s1Offset);
+    Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER);
+  }
+
+  private static HelixManager createMockHelixManager(boolean isLeader) {
+    HelixManager helixManager = mock(HelixManager.class);
+    when(helixManager.isLeader()).thenReturn(isLeader);
+    return helixManager;
+  }
+
+  public static class MockPinotLLCRealtimeSegmentManager extends PinotLLCRealtimeSegmentManager {
+    public static final String clusterName = "someCluster";
+    public LLCRealtimeSegmentZKMetadata _segmentMetadata;
+    public MockSegmentCompletionManager _segmentCompletionMgr;
+
+    protected MockPinotLLCRealtimeSegmentManager() {
+      super(null, clusterName, null, null, null);
+    }
+
+    @Override
+    public LLCRealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(String realtimeTableName, String segmentName) {
+      return _segmentMetadata;
+    }
+
+    @Override
+    public boolean commitSegment(String rawTableName, String committingSegmentName, long nextOffset) {
+      _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+      _segmentMetadata.setEndOffset(nextOffset);
+      _segmentMetadata.setEndTime(_segmentCompletionMgr.getCurrentTimeMs());
+      return true;
+    }
+
+    @Override
+    protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records) {
+      _segmentMetadata = new LLCRealtimeSegmentZKMetadata(records.get(0));  // Updated record that we are writing to ZK
+    }
+  }
+
+  public static class MockSegmentCompletionManager extends SegmentCompletionManager {
+    public long _secconds;
+    protected MockSegmentCompletionManager(PinotLLCRealtimeSegmentManager segmentManager, boolean isLeader) {
+      super(createMockHelixManager(isLeader), segmentManager);
+    }
+    @Override
+    protected long getCurrentTimeMs() {
+      return _secconds * 1000L;
+    }
+  }
+}


### PR DESCRIPTION
Updated PinotLLCRealtimeSegmentManager to support closing an old segment in propertystore
and creating new ones in idealstate. Added tests for the new methods.

Added a tentative protocol file (actual protocol elements TBF) and an FSM implementation
for closing segments when multiple servers inform the controller about their offsets, and
the controller ensures that one of them commits the segment.

Added test cases to test the scenarios described in the design documents.