### PR TITLE
add hll column in segment with startree

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -40,6 +40,7 @@ public abstract class FieldSpec {
   private static final Float DEFAULT_DIM_NULL_VALUE_OF_FLOAT = Float.NEGATIVE_INFINITY;
   private static final Double DEFAULT_DIM_NULL_VALUE_OF_DOUBLE = Double.NEGATIVE_INFINITY;
 
+  private static final String DEFAULT_METRIC_NULL_VALUE_OF_STRING = "null";
   private static final Integer DEFAULT_METRIC_NULL_VALUE_OF_INT = 0;
   private static final Long DEFAULT_METRIC_NULL_VALUE_OF_LONG = 0L;
   private static final Float DEFAULT_METRIC_NULL_VALUE_OF_FLOAT = 0.0F;
@@ -149,6 +150,9 @@ public abstract class FieldSpec {
                 break;
               case DOUBLE:
                 _cachedDefaultNullValue = DEFAULT_METRIC_NULL_VALUE_OF_DOUBLE;
+                break;
+              case STRING:
+                _cachedDefaultNullValue = DEFAULT_METRIC_NULL_VALUE_OF_STRING;
                 break;
               default:
                 throw new UnsupportedOperationException(

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
@@ -23,6 +23,9 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class MetricFieldSpec extends FieldSpec {
 
+  private int fieldSize = -1;
+  private DerivedMetricType derivedMetricType = null;
+
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.
   public MetricFieldSpec() {
     super();
@@ -30,6 +33,30 @@ public final class MetricFieldSpec extends FieldSpec {
 
   public MetricFieldSpec(String name, DataType dataType) {
     super(name, dataType, true);
+  }
+
+  /**
+   * For Derived Fields
+   * @param name
+   * @param dataType
+   * @param derivedMetricType
+   */
+  public MetricFieldSpec(String name, DataType dataType, int fieldSize, DerivedMetricType derivedMetricType) {
+    super(name, dataType, true);
+    this.fieldSize = fieldSize;
+    this.derivedMetricType = derivedMetricType;
+  }
+
+  public int getFieldSize() {
+    if (fieldSize == -1) {
+      return getDataType().size();
+    } else {
+      return fieldSize;
+    }
+  }
+
+  public void setFieldSize(int fieldSize) {
+    this.fieldSize = fieldSize;
   }
 
   @JsonIgnore
@@ -41,5 +68,32 @@ public final class MetricFieldSpec extends FieldSpec {
   @Override
   public void setSingleValueField(boolean isSingleValueField) {
     Preconditions.checkArgument(isSingleValueField, "Unsupported multi-value for metric field.");
+  }
+
+  @JsonIgnore
+  public boolean isDerivedMetric() {
+    return derivedMetricType != null;
+  }
+
+  public DerivedMetricType getDerivedMetricType() {
+    return derivedMetricType;
+  }
+
+  public void setDerivedMetricType(DerivedMetricType derivedMetricType) {
+    this.derivedMetricType = derivedMetricType;
+  }
+
+  /**
+   * DerivedMetricType is assigned for all metric fields to allow derived metric field a customized type not in DataType.
+   * Since we cannot add a new type directly to DataType since Pinot currently has no support for a custom types.
+   *
+   * It is currently used for derived field recognition in MetricBuffer, may have other use cases in system later.
+   *
+   * Generally, a customized type value should be converted to a standard Pinot type value (like String)
+   * for serialization, and converted back after deserialization when in use.
+   */
+  public enum DerivedMetricType {
+    // customized types start from here
+    HLL
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
@@ -74,7 +74,7 @@ public class SchemaTest {
 
       String validSchema = makeSchema();
       Schema schema = mapper.readValue(validSchema, Schema.class);
-      Assert.assertFalse(schema.validate(LOGGER));
+      Assert.assertTrue(schema.validate(LOGGER)); // True since we have String metric like hll field
     }
     {
       singleValueDim = "false";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
@@ -15,18 +15,16 @@
  */
 package com.linkedin.pinot.core.data;
 
+import com.linkedin.pinot.common.data.RowEvent;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-
-import com.linkedin.pinot.common.data.RowEvent;
 
 
 /**
@@ -53,18 +51,24 @@ public class GenericRow implements RowEvent {
     return _fieldMap.get(fieldName);
   }
 
+  public void putField(String key, Object value) {
+    _fieldMap.put(key, value);
+  }
+
   @Override
   public String toString() {
     StringBuilder b = new StringBuilder();
     for (String key : _fieldMap.keySet()) {
-      if (_fieldMap.get(key) instanceof Object[]) {
-        b.append(key + " : " + Arrays.toString((Object[]) _fieldMap.get(key)) + ", ");
+      Object value = _fieldMap.get(key);
+      b.append(key);
+      b.append(" : ");
+      if (value instanceof Object[]) {
+        b.append(Arrays.toString((Object[]) value));
       } else {
-        b.append(key + " : " + _fieldMap.get(key) + ", ");
+        b.append(value);
       }
-
+      b.append(", ");
     }
-
     return b.toString();
   }
 
@@ -82,8 +86,8 @@ public class GenericRow implements RowEvent {
     return _fieldMap.equals(r._fieldMap);
   }
 
-static TypeReference typeReference = new TypeReference<Map<String, Object>>() {
-};
+  static TypeReference typeReference = new TypeReference<Map<String, Object>>() {};
+
   public static GenericRow fromBytes(byte[] buffer) throws IOException {
     Map<String, Object> fieldMap = (Map<String, Object>) OBJECT_MAPPER.readValue(buffer, typeReference);
     GenericRow genericRow = new GenericRow();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.data.extractors;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
@@ -121,6 +122,12 @@ public class PlainFieldExtractor implements FieldExtractor {
     boolean hasConversion = false;
 
     for (String column : _schema.getColumnNames()) {
+      FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
+      // Ignore transform of DerivedMetric
+      if (fieldSpec instanceof MetricFieldSpec && ((MetricFieldSpec) fieldSpec).isDerivedMetric()) {
+        continue;
+      }
+
       Object value;
 
       // Fetch value for this column.
@@ -191,7 +198,6 @@ public class PlainFieldExtractor implements FieldExtractor {
 
       // Assign default value for null value.
       if (value == null) {
-        FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
         if (fieldSpec.isSingleValueField()) {
           // Single-value field.
           value = fieldSpec.getDefaultNullValue();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -35,8 +35,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import com.linkedin.pinot.core.startree.hll.HllConfig;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +47,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Configuration properties used in the creation of index segments.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SegmentGeneratorConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentGeneratorConfig.class);
 
@@ -72,6 +76,8 @@ public class SegmentGeneratorConfig {
   private StarTreeIndexSpec _starTreeIndexSpec = null;
   private String _creatorVersion = null;
   private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
+
+  private HllConfig _hllConfig = null;
 
   public SegmentGeneratorConfig() {
   }
@@ -103,6 +109,7 @@ public class SegmentGeneratorConfig {
     _starTreeIndexSpec = config._starTreeIndexSpec;
     _creatorVersion = config._creatorVersion;
     _paddingCharacter = config._paddingCharacter;
+    _hllConfig = config._hllConfig;
   }
 
   public SegmentGeneratorConfig(Schema schema) {
@@ -373,6 +380,14 @@ public class SegmentGeneratorConfig {
 
   public void setStarTreeIndexSpec(StarTreeIndexSpec starTreeIndexSpec) {
     _starTreeIndexSpec = starTreeIndexSpec;
+  }
+
+  public HllConfig getHllConfig() {
+    return _hllConfig;
+  }
+
+  public void setHllConfig(HllConfig hllConfig) {
+    _hllConfig = hllConfig;
   }
 
   @JsonIgnore

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeBuilderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeBuilderConfig.java
@@ -34,8 +34,8 @@ public class StarTreeBuilderConfig {
   File outDir;
 
   private Set<String> skipStarNodeCreationForDimensions;
-  private Set<String> _skipMaterializationFroDimensions;
-  private int _skipMaterializationCardinalityThreshold =
+  private Set<String> skipMaterializationForDimensions;
+  private int skipMaterializationCardinalityThreshold =
       StarTreeIndexSpec.DEFAULT_SKIP_MATERIALIZATION_CARDINALITY_THRESHOLD;
   private boolean enableOffHealpFormat;
 
@@ -79,11 +79,11 @@ public class StarTreeBuilderConfig {
   }
 
   public int getSkipMaterializationCardinalityThreshold() {
-    return _skipMaterializationCardinalityThreshold;
+    return skipMaterializationCardinalityThreshold;
   }
 
   public void setSkipMaterializationCardinalityThreshold(int skipMaterializationCardinalityThreshold) {
-    _skipMaterializationCardinalityThreshold = skipMaterializationCardinalityThreshold;
+    this.skipMaterializationCardinalityThreshold = skipMaterializationCardinalityThreshold;
   }
 
   /**
@@ -98,7 +98,7 @@ public class StarTreeBuilderConfig {
    * @return
    */
   public Set<String> getSkipMaterializationForDimensions() {
-    return _skipMaterializationFroDimensions;
+    return skipMaterializationForDimensions;
   }
 
   /**
@@ -106,7 +106,7 @@ public class StarTreeBuilderConfig {
    * @param skipMaterializationForDimensions
    */
   public void setSkipMaterializationForDimensions(Set<String> skipMaterializationForDimensions) {
-    _skipMaterializationFroDimensions = skipMaterializationForDimensions;
+    this.skipMaterializationForDimensions = skipMaterializationForDimensions;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllConfig.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+
+/**
+ * HllConfig is the config for hll index generation.
+ * Note it is only effective when StarTree index generation is enabled.
+ */
+public class HllConfig {
+  private boolean enableHllIndex = true;
+  private int hllLog2m = HllConstants.DEFAULT_LOG2M;
+  private int hllFieldSize = HllUtil.getHllFieldSizeFromLog2m(HllConstants.DEFAULT_LOG2M);
+  private String hllDeriveColumnSuffix = HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX;
+  private Set<String> columnsToDeriveHllFields = new HashSet<>();
+
+  private transient Map<String, String> derivedHllFieldsMap;
+
+  /**
+   * HllConfig with empty columnsToDeriveHllFields, default hll log2m, default hll suffix.
+   */
+  public HllConfig() {
+  }
+
+  /**
+   * HllConfig with default hll log2m, default hll suffix.
+   * @param columnsToDeriveHllFields columns to generate hll index
+   */
+  public HllConfig(Set<String> columnsToDeriveHllFields) {
+    this(columnsToDeriveHllFields, HllConstants.DEFAULT_LOG2M);
+  }
+
+  /**
+   * HllConfig with default hll suffix.
+   * @param columnsToDeriveHllFields columns to generate hll index
+   * @param hllLog2m The log2m parameter defines the accuracy of the counter.
+   *                 The larger the log2m the better the accuracy.
+   *                 accuracy = 1.04/sqrt(2^log2m)
+   */
+  public HllConfig(Set<String> columnsToDeriveHllFields, int hllLog2m) {
+    this(columnsToDeriveHllFields, hllLog2m, HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX);
+  }
+
+  /**
+   *
+   * @param columnsToDeriveHllFields columns to generate hll index
+   * @param hllLog2m The log2m parameter defines the accuracy of the counter.
+   *                 The larger the log2m the better the accuracy.
+   *                 accuracy = 1.04/sqrt(2^log2m)
+   * @param hllDeriveColumnSuffix suffix of column used for hll index
+   */
+  public HllConfig(Set<String> columnsToDeriveHllFields, int hllLog2m, String hllDeriveColumnSuffix) {
+    Preconditions.checkNotNull(columnsToDeriveHllFields, "ColumnsToDeriveHllFields should not be null.");
+    Preconditions.checkNotNull(hllDeriveColumnSuffix, "HLL Derived Field Suffix should not be null.");
+    this.hllLog2m = hllLog2m;
+    this.hllFieldSize = HllUtil.getHllFieldSizeFromLog2m(hllLog2m);
+    this.columnsToDeriveHllFields = columnsToDeriveHllFields;
+    this.hllDeriveColumnSuffix = hllDeriveColumnSuffix;
+  }
+
+  public boolean isEnableHllIndex() {
+    return enableHllIndex;
+  }
+
+  public void setEnableHllIndex(boolean enableHllIndex) {
+    this.enableHllIndex = enableHllIndex;
+  }
+
+  public int getHllLog2m() {
+    return hllLog2m;
+  }
+
+  public void setHllLog2m(int hllLog2m) {
+    this.hllLog2m = hllLog2m;
+  }
+
+  public String getHllDeriveColumnSuffix() {
+    return hllDeriveColumnSuffix;
+  }
+
+  public void setHllDeriveColumnSuffix(String hllDeriveColumnSuffix) {
+    this.hllDeriveColumnSuffix = hllDeriveColumnSuffix;
+  }
+
+  public Set<String> getColumnsToDeriveHllFields() {
+    return columnsToDeriveHllFields;
+  }
+
+  public void setColumnsToDeriveHllFields(Set<String> columnsToDeriveHllFields) {
+    this.columnsToDeriveHllFields = columnsToDeriveHllFields;
+  }
+
+  @JsonIgnore
+  public int getHllFieldSize() {
+    return hllFieldSize;
+  }
+
+  @JsonIgnore
+  public Map<String, String> getDerivedHllFieldsMap() {
+    if (derivedHllFieldsMap == null) {
+      derivedHllFieldsMap = new HashMap<>();
+      for (String columnName : columnsToDeriveHllFields) {
+        derivedHllFieldsMap.put(columnName, columnName + hllDeriveColumnSuffix);
+      }
+    }
+    return derivedHllFieldsMap;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllConstants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllConstants.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+public class HllConstants {
+    public static final int DEFAULT_LOG2M = 5;
+    public static final String DEFAULT_HLL_DERIVE_COLUMN_SUFFIX = "_hll";
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllUtil.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableBiMap;
+import com.linkedin.pinot.core.data.GenericRow;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+
+/**
+ * Utility functions for manipulation of hll field.
+ */
+public class HllUtil {
+
+  private static final ImmutableBiMap<Integer, Integer> LOG2M_TO_SIZE_IN_BYTES =
+      ImmutableBiMap.of(5, 32, 6, 52, 7, 96, 8, 180, 9, 352);
+
+  private static final Charset charset = Charset.forName("UTF-8");
+
+  /**
+   * To display a row with hll fields properly,
+   * instead of directly invoking {@link GenericRow#toString()},
+   * hll fields should be inspected and transformed.
+   *
+   * @param row GenericRow
+   * @param hllDeriveColumnSuffix column with this suffix will be treated as hll column
+   * @return string representation of row
+   */
+  public static String inspectGenericRow(GenericRow row, String hllDeriveColumnSuffix) {
+    StringBuilder b = new StringBuilder();
+    for (String name : row.getFieldNames()) {
+      b.append(name);
+      b.append(" : ");
+      Object value = row.getValue(name);
+      if (value instanceof String && name.endsWith(hllDeriveColumnSuffix)) {
+        // hll field
+        b.append(convertStringToHll((String) value).cardinality());
+      } else if (value instanceof Object[]) {
+        b.append(Arrays.toString((Object[]) value));
+      } else {
+        b.append(value);
+      }
+      b.append(", ");
+    }
+    return b.toString();
+  }
+
+  public static int getHllFieldSizeFromLog2m(int log2m) {
+    Preconditions.checkArgument(LOG2M_TO_SIZE_IN_BYTES.containsKey(log2m),
+        "Log2m: " + log2m + " is not in valid range.");
+    return LOG2M_TO_SIZE_IN_BYTES.get(log2m);
+  }
+
+  public static int getLog2mFromHllFieldSize(int hllFieldSize) {
+    Preconditions.checkArgument(LOG2M_TO_SIZE_IN_BYTES.containsValue(hllFieldSize),
+        "HllFieldSize: " + hllFieldSize + " is not in valid range.");
+    return LOG2M_TO_SIZE_IN_BYTES.inverse().get(hllFieldSize);
+  }
+
+  public static String convertHllToString(HyperLogLog hll) {
+    try {
+      return new String(SerializationConverter.byteArrayToChars(hll.getBytes()));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static HyperLogLog convertStringToHll(String s) {
+    return buildHllFromBytes(SerializationConverter.charsToByteArray(s.toCharArray()));
+  }
+
+  /**
+   * Generate a hll from a single value, and convert it to string type.
+   * It is used for default derived field value.
+   * @param log2m
+   * @param value
+   * @return
+   */
+  public static String singleValueHllAsString(int log2m, Object value) {
+    HyperLogLog hll = new HyperLogLog(log2m);
+    hll.offer(value);
+    return convertHllToString(hll);
+  }
+
+  public static HyperLogLog buildHllFromBytes(byte[] bytes) {
+    try {
+      return HyperLogLog.Builder.build(bytes);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static HyperLogLog clone(HyperLogLog hll, int log2m) {
+    try {
+      HyperLogLog ret = new HyperLogLog(log2m);
+      ret.addAll(hll);
+      return ret;
+    } catch (CardinalityMergeException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Convert between byte array and char array, one byte is mapped to one char and vice versa.
+   * This is due to UTF-8 encoding for String type serialization used all over the system.
+   */
+  public static class SerializationConverter {
+
+    public static char[] byteArrayToChars(byte[] byteArray) {
+      char[] charArrayBuffer = new char[byteArray.length];
+      for (int i = 0; i < byteArray.length; i++) {
+        charArrayBuffer[i] = byteToChar(byteArray[i]);
+      }
+      return charArrayBuffer;
+    }
+
+    public static byte[] charsToByteArray(char[] chars) {
+      byte[] ret = new byte[chars.length];
+      for (int i = 0; i < ret.length; i++) {
+        ret[i] = charToByte(chars[i]);
+      }
+      return ret;
+    }
+
+    public static char byteToChar(byte b) {
+      return (char) b;
+    }
+
+    public static byte charToByte(char c) {
+      return (byte) c; // same as: (byte)((c & 0x000000FF))
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+import com.linkedin.pinot.common.data.*;
+import com.linkedin.pinot.core.data.readers.FileFormat;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentCreationDriverFactory;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.linkedin.pinot.core.segment.index.converter.SegmentV1V2ToV3FormatConverter;
+import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
+import com.linkedin.pinot.util.TestUtils;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
+public class SegmentWithHllIndexCreateHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SegmentWithHllIndexCreateHelper.class);
+
+    private File INDEX_DIR;
+    private File inputAvro;
+    private String timeColumnName;
+    private TimeUnit timeUnit;
+    private Schema schema;
+    private static final String hllDeriveColumnSuffix = HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX;
+
+    public SegmentWithHllIndexCreateHelper(String tempDirName, String avroDataPath,
+                                           String timeColumnName, TimeUnit timeUnit) throws IOException {
+        INDEX_DIR = Files.createTempDirectory(SegmentWithHllIndexCreateHelper.class.getName() + "_" + tempDirName).toFile();
+        LOGGER.info("INDEX_DIR: {}", INDEX_DIR.getAbsolutePath());
+        String filePath = TestUtils.getFileFromResourceUrl(
+                SegmentV1V2ToV3FormatConverter.class.getClassLoader().getResource(avroDataPath));
+        inputAvro = new File(filePath);
+        LOGGER.info("Input Avro: {}", inputAvro.getAbsolutePath());
+        this.timeColumnName = timeColumnName;
+        this.timeUnit = timeUnit;
+    }
+
+    /**
+     * must call this to clean up
+     */
+    public void cleanTempDir() {
+        if (INDEX_DIR != null) {
+            FileUtils.deleteQuietly(INDEX_DIR);
+        }
+    }
+
+    private static void printSchema(Schema schema) {
+        LOGGER.info("schemaName: {}", schema.getSchemaName());
+        LOGGER.info("Dimension columnNames: ");
+        int i = 0;
+        for (DimensionFieldSpec spec: schema.getDimensionFieldSpecs()) {
+            String columnInfo = i + " " + spec.getName();
+            if (!spec.isSingleValueField()) {
+                LOGGER.info(columnInfo + " Multi-Value.");
+            } else {
+                LOGGER.info(columnInfo);
+            }
+            i += 1;
+        }
+        LOGGER.info("Metric columnNames: ");
+        i = 0;
+        for (MetricFieldSpec spec: schema.getMetricFieldSpecs()) {
+            String columnInfo = i + " " + spec.getName();
+            if (!spec.isSingleValueField()) {
+                LOGGER.info(columnInfo + " Multi-Value.");
+            } else {
+                LOGGER.info(columnInfo);
+            }
+            i += 1;
+        }
+        LOGGER.info("Time column: {}", schema.getTimeColumnName());
+    }
+
+    private void addTimeColumnToSchema(SegmentGeneratorConfig segmentGenConfig) throws Exception {
+        // set time column in schema
+        DataFileStream<GenericRecord> dataStream =
+                new DataFileStream<>(new FileInputStream(inputAvro), new GenericDatumReader<GenericRecord>());
+        final TimeGranularitySpec gSpec = new TimeGranularitySpec(
+                 /* time column data type*/
+                SegmentTestUtils.getColumnType(dataStream.getSchema().getField(timeColumnName)),
+                timeUnit,
+                timeColumnName);
+        final TimeFieldSpec fSpec = new TimeFieldSpec(gSpec);
+        segmentGenConfig.getSchema().addField(timeColumnName, fSpec);
+        dataStream.close();
+    }
+
+    private void setupStarTreeConfig(SegmentGeneratorConfig segmentGenConfig) {
+        // StarTree related
+        segmentGenConfig.setEnableStarTreeIndex(true);
+        StarTreeIndexSpec starTreeIndexSpec = new StarTreeIndexSpec();
+        starTreeIndexSpec.setMaxLeafRecords(StarTreeIndexSpec.DEFAULT_MAX_LEAF_RECORDS);
+        segmentGenConfig.setStarTreeIndexSpec(starTreeIndexSpec);
+        LOGGER.info("segmentGenConfig Schema (w/o derived fields): ");
+        printSchema(segmentGenConfig.getSchema());
+    }
+
+    public SegmentIndexCreationDriver build(boolean enableStarTree, HllConfig hllConfig) throws Exception {
+        final SegmentGeneratorConfig segmentGenConfig = new SegmentGeneratorConfig(
+                SegmentTestUtils.extractSchemaFromAvroWithoutTime(inputAvro));
+
+        addTimeColumnToSchema(segmentGenConfig);
+
+        // set other fields in segmentGenConfig
+        segmentGenConfig.setInputFilePath(inputAvro.getAbsolutePath());
+        segmentGenConfig.setTimeColumnName(timeColumnName);
+        segmentGenConfig.setSegmentTimeUnit(timeUnit);
+        segmentGenConfig.setFormat(FileFormat.AVRO);
+        segmentGenConfig.setSegmentVersion(SegmentVersion.v1);
+        segmentGenConfig.setTableName("testTable");
+        segmentGenConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+        segmentGenConfig.createInvertedIndexForAllColumns();
+        segmentGenConfig.setSegmentName("starTreeSegment");
+        segmentGenConfig.setSegmentNamePostfix("1");
+
+        if (enableStarTree) {
+            setupStarTreeConfig(segmentGenConfig);
+            segmentGenConfig.setHllConfig(hllConfig);
+        }
+
+        final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
+        driver.init(segmentGenConfig);
+        /**
+         * derived field (hll) is added during the segment build process
+         *
+         * {@link SegmentIndexCreationDriverImpl#buildStarTree}
+         * {@link SegmentIndexCreationDriverImpl#augmentSchemaWithDerivedColumns}
+         * {@link SegmentIndexCreationDriverImpl#populateDefaultDerivedColumnValues}
+         */
+        driver.build();
+
+        LOGGER.info("segmentGenConfig Schema (w/ derived fields): ");
+        schema = segmentGenConfig.getSchema();
+        printSchema(schema);
+
+        return driver;
+    }
+
+    public Schema getSchema() {
+        if (schema == null) {
+            throw new RuntimeException("Call build first to get schema.");
+        }
+        return schema;
+    }
+
+    public File getIndexDir() {
+        return INDEX_DIR;
+    }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllFieldSize.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllFieldSize.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+
+
+public class TestHllFieldSize {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestHllFieldSize.class);
+  private Random rand = new Random();
+
+  @Test
+  public void testHllFieldSerializedSize()
+      throws Exception {
+    for (int i = 5; i < 10; i++) {
+      HyperLogLog hll = new HyperLogLog(i);
+      Assert.assertEquals(HllUtil.getHllFieldSizeFromLog2m(i), hll.getBytes().length);
+      LOGGER.info("Estimated: " + hll.cardinality());
+      for (int j = 0; j < 100; j++) {
+        hll.offer(rand.nextLong());
+      }
+      Assert.assertEquals(HllUtil.getHllFieldSizeFromLog2m(i), hll.getBytes().length);
+      LOGGER.info("Estimated: " + hll.cardinality());
+      for (int j = 0; j < 9900; j++) {
+        hll.offer(rand.nextLong());
+      }
+      Assert.assertEquals(HllUtil.getHllFieldSizeFromLog2m(i), hll.getBytes().length);
+      LOGGER.info("Estimated: " + hll.cardinality());
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllIndexSize.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllIndexSize.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+import com.linkedin.pinot.common.metadata.segment.IndexLoadingConfigMetadata;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.index.converter.SegmentV1V2ToV3FormatConverter;
+import com.linkedin.pinot.core.segment.index.loader.Loaders;
+import com.linkedin.pinot.core.segment.store.SegmentDirectoryPaths;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Dictionary Index Size for Hll Field is roughly 10 times of the corresponding index for Long field.
+ */
+public class TestHllIndexSize {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestHllIndexSize.class);
+  private static final String hllDeriveColumnSuffix = HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX;
+
+  // change this to change the columns that need to create hll index on
+  private static final Set<String> columnsToDeriveHllFields =
+      new HashSet<>(Arrays.asList("column1", "column2", "column3",
+          "count", "weeksSinceEpochSunday", "daysSinceEpoch",
+          "column17", "column18"));
+  private static final String AVRO_DATA = "data/test_data-sv.avro";
+  private static final String timeColumnName = "daysSinceEpoch";
+  private static final TimeUnit timeUnit = TimeUnit.DAYS;
+
+  private static final int hllLog2m = 5;
+
+  private IndexLoadingConfigMetadata v1LoadingConfig;
+  private IndexLoadingConfigMetadata v3LoadingConfig;
+
+  private HllConfig hllConfig;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    hllConfig = new HllConfig(columnsToDeriveHllFields, hllLog2m, hllDeriveColumnSuffix);
+
+    Configuration tableConfig = new PropertiesConfiguration();
+    tableConfig.addProperty(IndexLoadingConfigMetadata.KEY_OF_SEGMENT_FORMAT_VERSION, "v1");
+    v1LoadingConfig = new IndexLoadingConfigMetadata(tableConfig);
+
+    tableConfig.clear();
+    tableConfig.addProperty(IndexLoadingConfigMetadata.KEY_OF_SEGMENT_FORMAT_VERSION,  "v3");
+    v3LoadingConfig = new IndexLoadingConfigMetadata(tableConfig);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {}
+
+  @Test
+  public void testColumnStatsWithoutStarTree() {
+    SegmentWithHllIndexCreateHelper helper = null;
+    boolean hasException = false;
+    try {
+      LOGGER.debug("================ Without StarTree ================");
+      helper = new SegmentWithHllIndexCreateHelper(
+          "noStarTree", AVRO_DATA, timeColumnName, timeUnit);
+      SegmentIndexCreationDriver driver = helper.build(false, null);
+      LOGGER.debug("================ Cardinality ================");
+      for (String name : helper.getSchema().getColumnNames()) {
+        LOGGER.debug("* " + name + ": " + driver.getColumnStatisticsCollector(name).getCardinality());
+      }
+    } catch (Exception e) {
+      hasException = true;
+      LOGGER.error(e.getMessage());
+    } finally {
+      if (helper != null) {
+        helper.cleanTempDir();
+      }
+      Assert.assertEquals(hasException, false);
+    }
+  }
+
+  @Test
+  public void testColumnStatsWithStarTree() {
+    SegmentWithHllIndexCreateHelper helper = null;
+    boolean hasException = false;
+    try {
+      LOGGER.debug("================ With StarTree ================");
+      helper = new SegmentWithHllIndexCreateHelper(
+          "withStarTree", AVRO_DATA, timeColumnName, timeUnit);
+      SegmentIndexCreationDriver driver = helper.build(true, hllConfig);
+      LOGGER.debug("================ Cardinality ================");
+      for (String name : helper.getSchema().getColumnNames()) {
+        LOGGER.debug("* " + name + ": " + driver.getColumnStatisticsCollector(name).getCardinality());
+      }
+    } catch (Exception e) {
+      hasException = true;
+      LOGGER.error(e.getMessage());
+    } finally {
+      if (helper != null) {
+        helper.cleanTempDir();
+      }
+      Assert.assertEquals(hasException, false);
+    }
+  }
+
+  @Test
+  public void testConvert() throws Exception {
+    SegmentWithHllIndexCreateHelper helper = null;
+    try {
+      helper = new SegmentWithHllIndexCreateHelper(
+          "testConvert", AVRO_DATA, timeColumnName, timeUnit);
+
+      SegmentIndexCreationDriver driver = helper.build(true, hllConfig);
+
+      File segmentDirectory = new File(helper.getIndexDir(), driver.getSegmentName());
+      LOGGER.debug("Segment Directory: " + segmentDirectory.getAbsolutePath());
+
+
+      SegmentV1V2ToV3FormatConverter converter = new SegmentV1V2ToV3FormatConverter();
+      converter.convert(segmentDirectory);
+      File v3Location = SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3);
+      LOGGER.debug("v3Location: " + v3Location.getAbsolutePath());
+
+      Assert.assertTrue(v3Location.exists());
+      Assert.assertTrue(v3Location.isDirectory());
+      Assert.assertTrue(new File(v3Location, V1Constants.STAR_TREE_INDEX_FILE).exists());
+
+      SegmentMetadataImpl metadata = new SegmentMetadataImpl(v3Location);
+      LOGGER.debug("metadata all columns: " + metadata.getAllColumns());
+
+      Assert.assertEquals(metadata.getVersion(), SegmentVersion.v3.toString());
+      Assert.assertTrue(new File(v3Location, V1Constants.SEGMENT_CREATION_META).exists());
+      // Drop the star tree index file because it has invalid data
+      // new File(v3Location, V1Constants.STAR_TREE_INDEX_FILE).delete();
+      // new File(segmentDirectory, V1Constants.STAR_TREE_INDEX_FILE).delete();
+
+      FileTime afterConversionTime = Files.getLastModifiedTime(v3Location.toPath());
+
+      // verify that the segment loads correctly. This is necessary and sufficient
+      // full proof way to ensure that segment is correctly translated
+      IndexSegment indexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v3LoadingConfig);
+      Assert.assertNotNull(indexSegment);
+      Assert.assertEquals(indexSegment.getSegmentName(), metadata.getName());
+      Assert.assertEquals(SegmentVersion.v3,
+          SegmentVersion.valueOf(indexSegment.getSegmentMetadata().getVersion()));
+
+      FileTime afterLoadTime = Files.getLastModifiedTime(v3Location.toPath());
+      Assert.assertEquals(afterConversionTime, afterLoadTime);
+      // check that the loader can load original segment
+      IndexSegment v2IndexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v1LoadingConfig);
+      Assert.assertNotNull(v2IndexSegment);
+      Assert.assertEquals(SegmentVersion.valueOf(v2IndexSegment.getSegmentMetadata().getVersion()),
+          SegmentVersion.v1);
+      Assert.assertTrue(v3Location.exists());
+    } finally {
+      if (helper != null) {
+        helper.cleanTempDir();
+      }
+    }
+  }
+
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllTypeConversion.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllTypeConversion.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Random;
+
+
+/**
+ * Test Conversion between Hll and String type
+ */
+public class TestHllTypeConversion {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestHllTypeConversion.class);
+  private static Charset charset = Charset.forName("UTF-8");
+  private Random rand = new Random();
+
+  @Test
+  public void testConvertInByteRange()
+      throws Exception {
+    int max = Byte.MAX_VALUE;
+    int min = Byte.MIN_VALUE;
+
+    for (long i = min; i <= max; i++) { // use long type to prevent overflow
+      Assert.assertEquals(HllUtil.SerializationConverter.charToByte(
+          new String(new char[]{HllUtil.SerializationConverter.byteToChar((byte) i)}).toCharArray()[0]), i);
+    }
+  }
+
+  private void testConvertArraySize(int arraySize) {
+    byte[] byteArray = new byte[arraySize];
+    rand.nextBytes(byteArray);
+    String s = new String(HllUtil.SerializationConverter.byteArrayToChars(byteArray));
+
+    byte[] byteArray2 =
+        HllUtil.SerializationConverter.charsToByteArray(new String(s.getBytes(charset), charset).toCharArray());
+    Assert.assertTrue(Arrays.equals(byteArray, byteArray2));
+  }
+
+  @Test
+  public void testToStringFunctionality() {
+    int numOfTest = 100000;
+    int maxArraySize = 50;
+
+    for (int i = 0; i < maxArraySize; i++) {
+      LOGGER.info("Test Size: " + i);
+      for (int k = 0; k < numOfTest; k++) {
+        testConvertArraySize(i);
+      }
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestOffheapStarTreeBuilderWithHllField.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestOffheapStarTreeBuilderWithHllField.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree.hll;
+
+import com.linkedin.pinot.common.data.*;
+import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.startree.OffHeapStarTreeBuilder;
+import com.linkedin.pinot.core.startree.StarTreeBuilderConfig;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+
+public class TestOffheapStarTreeBuilderWithHllField {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestOffheapStarTreeBuilderWithHllField.class);
+  private static final long randomSeed = 31; // a fixed value
+
+  private final String memberIdFieldName = "id";
+  private final String hllDeriveFieldSuffix = HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX;
+  private final int log2m = 8; //HllUtil.Constants.DEFAULT_LOG2M;
+
+  private void testSimpleCore(int numDimensions, int numMetrics, int numSkipMaterializationDimensions,
+      int[] memberIdColumnValues, long preciseCardinality) throws Exception {
+    StarTreeBuilderConfig builderConfig = null;
+    try {
+      builderConfig = new StarTreeBuilderConfig();
+      Schema schema = new Schema();
+      builderConfig.dimensionsSplitOrder = new ArrayList<>();
+      builderConfig.setSkipMaterializationForDimensions(new HashSet<String>());
+      Set<String> skipMaterializationForDimensions = builderConfig.getSkipMaterializationForDimensions();
+
+      // add member id dimension spec
+      String dimName = memberIdFieldName;
+      DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec(dimName, DataType.INT, true);
+      schema.addField(dimName, dimensionFieldSpec);
+      // add other dimension specs
+      for (int i = 1; i < numDimensions; i++) {
+        dimName = "d" + (i + 1);
+        dimensionFieldSpec = new DimensionFieldSpec(dimName, DataType.STRING, true);
+        schema.addField(dimName, dimensionFieldSpec);
+
+        if (i < (numDimensions - numSkipMaterializationDimensions)) {
+          builderConfig.dimensionsSplitOrder.add(dimName);
+        } else {
+          builderConfig.getSkipMaterializationForDimensions().add(dimName);
+        }
+      }
+
+      schema.setTimeFieldSpec(new TimeFieldSpec("daysSinceEpoch", DataType.INT, TimeUnit.DAYS));
+      // add other metric specs
+      for (int i = 0; i < numMetrics - 1; i++) {
+        String metricName = "m" + (i + 1);
+        MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, DataType.INT);
+        schema.addField(metricName, metricFieldSpec);
+      }
+      // add hll metric
+      String hllMetricName = memberIdFieldName + hllDeriveFieldSuffix;
+      MetricFieldSpec hllDerivedFieldSpec = new MetricFieldSpec(hllMetricName, FieldSpec.DataType.STRING,
+          HllUtil.getHllFieldSizeFromLog2m(log2m), MetricFieldSpec.DerivedMetricType.HLL);
+      schema.addField(hllMetricName, hllDerivedFieldSpec);
+      //
+      builderConfig.maxLeafRecords = 10;
+      builderConfig.schema = schema;
+      builderConfig.setOutDir(new File("/tmp/startree"));
+      //
+      OffHeapStarTreeBuilder builder = new OffHeapStarTreeBuilder();
+      builder.init(builderConfig);
+      // fill values
+      HashMap<String, Object> map = new HashMap<>();
+      for (int row = 0; row < memberIdColumnValues.length; row++) {
+        // add member id column
+        dimName = memberIdFieldName;
+        map.put(dimName, memberIdColumnValues[row]);
+        // add other dimensions
+        for (int i = 1; i < numDimensions; i++) {
+          dimName = schema.getDimensionFieldSpecs().get(i).getName();
+          map.put(dimName, dimName + "-v" + row % (numDimensions - i));
+        }
+        // add time column
+        map.put("daysSinceEpoch", 1);
+        // add other metrics
+        for (int i = 0; i < numMetrics - 1; i++) {
+          String metName = schema.getMetricFieldSpecs().get(i).getName();
+          map.put(metName, 1);
+        }
+        // add hll column value
+        map.put(hllMetricName, HllUtil.singleValueHllAsString(log2m, memberIdColumnValues[row]));
+        //
+        GenericRow genericRow = new GenericRow();
+        genericRow.init(map);
+        builder.append(genericRow);
+      }
+      builder.build();
+
+      int totalDocs = builder.getTotalRawDocumentCount() + builder.getTotalAggregateDocumentCount();
+      Iterator<GenericRow> iterator = builder.iterator(0, totalDocs);
+      while (iterator.hasNext()) {
+        GenericRow row = iterator.next();
+        LOGGER.info(HllUtil.inspectGenericRow(row, hllDeriveFieldSuffix));
+      }
+
+      iterator = builder.iterator(builder.getTotalRawDocumentCount(), totalDocs);
+      GenericRow lastRow = null;
+      while (iterator.hasNext()) {
+        GenericRow row = iterator.next();
+        for (String skipDimension : skipMaterializationForDimensions) {
+          String rowValue = (String) row.getValue(skipDimension);
+          assert (rowValue.equals("ALL"));
+        }
+        lastRow = row;
+      }
+
+      assertApproximation(
+          HllUtil.convertStringToHll((String) lastRow.getValue(hllMetricName)).cardinality(),
+          preciseCardinality,
+          0.1
+      );
+    } finally {
+      if (builderConfig != null) {
+        FileUtils.deleteDirectory(builderConfig.getOutDir());
+      }
+    }
+  }
+
+  private static void assertApproximation(double estimate, double actual, double precision) {
+    estimate = Math.abs(estimate);
+    actual = Math.abs(actual);
+
+    double errorRate = 1;
+    if (actual > 0) {
+      errorRate = Math.abs((actual - estimate) / actual);
+    }
+    LOGGER.info("estimate: " + estimate + " actual: " + actual + " error (in rate): " + errorRate);
+    Assert.assertEquals(errorRate < precision, true);
+  }
+
+  private static class RandomNumberArray {
+    private static Random _rnd = new Random(randomSeed);
+
+    private final int[] arr;
+    private final HashSet<Integer> set = new HashSet<Integer>();
+
+    /**
+     * Data ranges between [0, size)
+     * @param size
+     * @param duplicationPerItem
+     */
+    RandomNumberArray(int size, int duplicationPerItem) {
+      List<Integer> lst = new ArrayList<Integer>();
+      for (int i = 0; i < size/duplicationPerItem; i++) {
+        Integer item = _rnd.nextInt(size);
+        for (int j = 0; j < duplicationPerItem; j++) {
+          lst.add(item); // add duplicates
+        }
+      }
+      // add remaining items
+      int st = lst.size();
+      for (int i = st; i < size; i++) {
+        Integer item = _rnd.nextInt(size);
+        lst.add(item);
+      }
+      // add to set
+      set.addAll(lst);
+      // shuffle
+      Collections.shuffle(lst, new Random(10L));
+      // toIntArray
+      arr = convertToIntArray(lst);
+      if (arr.length != size) {
+        throw new RuntimeException("should not happen");
+      }
+    }
+
+    private int[] convertToIntArray(List<Integer> list){
+      int[] ret = new int[list.size()];
+      for(int i = 0;i < ret.length;i++)
+        ret[i] = list.get(i);
+      return ret;
+    }
+
+    public int[] toIntArray() {
+      return arr;
+    }
+
+    public int size() {
+      return arr.length;
+    }
+
+    public int getPreciseCardinality() {
+      return set.size();
+    }
+  }
+
+  @Test
+  public void testSmallDuplicates() throws Exception {
+    RandomNumberArray rand = new RandomNumberArray(500, 1);
+    testSimpleCore(3, 3, 0, rand.toIntArray(), rand.getPreciseCardinality());
+  }
+
+  @Test
+  public void testMediumDuplicates() throws Exception {
+    RandomNumberArray rand = new RandomNumberArray(500, 5);
+    testSimpleCore(3, 3, 0, rand.toIntArray(), rand.getPreciseCardinality());
+  }
+
+  @Test
+  public void testLargeDuplicates() throws Exception {
+    RandomNumberArray rand = new RandomNumberArray(500, 50);
+    testSimpleCore(3, 3, 0, rand.toIntArray(), rand.getPreciseCardinality());
+  }
+
+  @Test
+  public void testSkipMaterialization() throws Exception {
+    RandomNumberArray rand = new RandomNumberArray(250, 3);
+    testSimpleCore(6, 4, 2, rand.toIntArray(), rand.getPreciseCardinality());
+  }
+
+}


### PR DESCRIPTION
This PR is the first step in integration of hyperloglog with startree index.
The detailed changes are follows:

1. Update MetricBuffer to support hll column, and the merge process. The hll column is stored in byte array and under type String, so all existing logic remains untacted.

2. Add hll column initialization logic in OffHeapStarTreeBuilder.

3. Add configs of hll column.

4. Unit Tests to ensure hll column and aggregation works. Integration tests will be added after query execution logic being updated in startree related operators.