### PR TITLE
Fix EqualityUtils to correctly compare Collections.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/EqualityUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/EqualityUtils.java
@@ -17,15 +17,17 @@ package com.linkedin.pinot.common.utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 /**
- * Various utilities to be used in implementing equals and hashCode.
+ * Various utilities in implementing {@link Object#equals(Object)} and {@link Object#hashCode()}.
  *
+ * For primitive float and double, {@code isEqual()} is not the same as Java == operator, {@code isEqual(NaN, NaN)}
+ * returns true instead of false.
  */
 public class EqualityUtils {
   private EqualityUtils() {
@@ -39,12 +41,20 @@ public class EqualityUtils {
     return left == right;
   }
 
+  /**
+   * Compare both arguments for equality, and consider {@code Float.NaN} to be equal to {@code Float.NaN} (unlike the
+   * Java == operator).
+   */
   public static boolean isEqual(float left, float right) {
-    return Float.compare(left, right) == 0;
+    return Float.floatToIntBits(left) == Float.floatToIntBits(right);
   }
 
+  /**
+   * Compare both arguments for equality, and consider {@code Double.NaN} to be equal to {@code Double.NaN} (unlike the
+   * Java == operator).
+   */
   public static boolean isEqual(double left, double right) {
-    return Double.compare(left, right) == 0;
+    return Double.doubleToLongBits(left) == Double.doubleToLongBits(right);
   }
 
   public static boolean isEqual(short left, short right) {
@@ -59,83 +69,59 @@ public class EqualityUtils {
     return left == right;
   }
 
-  public static boolean isEqual(Object[] left, Object[] right) {
+  public static boolean isEqual(@Nullable Object left, @Nullable Object right) {
+    if (left != null && right != null) {
+      return left.equals(right);
+    } else {
+      return left == right;
+    }
+  }
+
+  public static boolean isEqual(@Nullable Object[] left, @Nullable Object[] right) {
     return Arrays.deepEquals(left, right);
   }
 
-  public static boolean isEqual(Collection left, Collection right) {
+  @SuppressWarnings("unchecked")
+  public static boolean isEqualIgnoreOrder(@Nullable List left, @Nullable List right) {
     if (left != null && right != null) {
-      return left.toString().equals(right.toString());
-    } else {
-      return left == right;
-    }
-  }
-
-  public static boolean isEqualIgnoringOrder(List left, List right) {
-    if (left != null && right != null) {
-      ArrayList sortedLeft = new ArrayList(left);
-      ArrayList sortedRight = new ArrayList(right);
+      List sortedLeft = new ArrayList(left);
+      List sortedRight = new ArrayList(right);
       Collections.sort(sortedLeft);
       Collections.sort(sortedRight);
-      return sortedLeft.toString().equals(sortedRight.toString());
+      return sortedLeft.equals(sortedRight);
     } else {
       return left == right;
     }
   }
 
-  public static boolean isEqual(Map left, Map right) {
-    if (left != null && right != null) {
-      if (left.size() != right.size()) {
-        return false;
-      }
-      for (Object key : left.keySet()) {
-        if (right.containsKey(key)) {
-          Object leftValue = left.get(key);
-          Object rightValue = right.get(key);
-          if (!isEqual(leftValue, rightValue)) {
-            return false;
-          }
-        } else {
-          return false;
-        }
-      }
-      return true;
-    } else {
-      return left == right;
-    }
-  }
-
-  public static boolean isEqual(Object left, Object right) {
-    if (left != null)
-      return left.equals(right);
-    else
-      return null == right;
-  }
-
-  public static boolean isNullOrNotSameClass(Object left, Object right) {
+  public static boolean isNullOrNotSameClass(@Nonnull Object left, @Nullable Object right) {
     return right == null || left.getClass() != right.getClass();
   }
 
-  public static boolean isSameReference(Object left, Object right) {
+  public static boolean isSameReference(@Nullable Object left, @Nullable Object right) {
     return left == right;
   }
 
-  public static int hashCodeOf(Object o) {
-    if (o != null)
+  /**
+   * Given an object, return the hashcode of it. For {@code null}, return 0 instead.
+   */
+  public static int hashCodeOf(@Nullable Object o) {
+    if (o != null) {
       return o.hashCode();
-    else
+    } else {
       return 0;
+    }
   }
 
-  public static int hashCodeOf(int previousHashCode, Object o) {
-    return 31 * previousHashCode + hashCodeOf(o);
+  public static int hashCodeOf(int previousHashCode, @Nullable Object o) {
+    return 37 * previousHashCode + hashCodeOf(o);
   }
 
   public static int hashCodeOf(int previousHashCode, int value) {
-    return 31 * previousHashCode + value;
+    return 37 * previousHashCode + value;
   }
 
   public static int hashCodeOf(int previousHashCode, long value) {
-    return 31 * previousHashCode + (int) (value ^ (value >>> 32));
+    return 37 * previousHashCode + (int) (value ^ (value >>> 32));
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/EqualityUtilsTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/EqualityUtilsTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import junit.framework.Assert;
+import org.testng.annotations.Test;
+
+
+public class EqualityUtilsTest {
+
+  @Test
+  public void testPrimitiveType() {
+    Assert.assertTrue(EqualityUtils.isEqual(Float.NaN, Float.NaN));
+    Assert.assertTrue(EqualityUtils.isEqual(Double.NaN, Double.NaN));
+  }
+
+  @Test
+  public void testObjectArray() {
+    Integer[] integerArray1 = {1};
+    Integer[] integerArray1Copy = {1};
+    Integer[] integerArray2 = {1, 2};
+    Assert.assertFalse(EqualityUtils.isSameReference(integerArray1, integerArray1Copy));
+    Assert.assertTrue(EqualityUtils.isEqual(integerArray1, integerArray1Copy));
+    Assert.assertFalse(EqualityUtils.isEqual(integerArray1, integerArray2));
+  }
+
+  @Test
+  public void testListObject() {
+    List<Integer> list1 = Arrays.asList(1, 2);
+    List<Integer> list1Copy = Arrays.asList(1, 2);
+    List<Integer> list2 = Arrays.asList(2, 1);
+    Assert.assertFalse(EqualityUtils.isSameReference(list1, list1Copy));
+    Assert.assertTrue(EqualityUtils.isEqual(list1, list1Copy));
+    Assert.assertFalse(EqualityUtils.isEqual(list1, list2));
+    Assert.assertTrue(EqualityUtils.isEqualIgnoreOrder(list1, list2));
+  }
+
+  @Test
+  public void testSetObject() {
+    Set<Integer> set1 = Collections.singleton(1);
+    Set<Integer> set1Copy = Collections.singleton(1);
+    Set<Long> set2 = Collections.singleton(1L);
+    Assert.assertFalse(EqualityUtils.isSameReference(set1, set1Copy));
+    Assert.assertTrue(EqualityUtils.isEqual(set1, set1Copy));
+    Assert.assertFalse(EqualityUtils.isEqual(set1, set2));
+  }
+
+  @Test
+  public void testMapObject() {
+    Map<Integer, Integer> map1 = new HashMap<>();
+    map1.put(1, 1);
+    Map<Integer, Integer> map1Copy = new HashMap<>();
+    map1Copy.put(1, 1);
+    Map<Long, Integer> map2 = new HashMap<>();
+    map2.put(1L, 1);
+    Assert.assertFalse(EqualityUtils.isSameReference(map1, map1Copy));
+    Assert.assertTrue(EqualityUtils.isEqual(map1, map1Copy));
+    Assert.assertFalse(EqualityUtils.isEqual(map1, map2));
+  }
+
+  @Test
+  public void testNull() {
+    List list = new ArrayList();
+    Assert.assertTrue(EqualityUtils.isEqual(null, null));
+    Assert.assertTrue(EqualityUtils.isEqualIgnoreOrder(null, null));
+    Assert.assertTrue(EqualityUtils.isSameReference(null, null));
+    Assert.assertFalse(EqualityUtils.isEqual(list, null));
+    Assert.assertFalse(EqualityUtils.isEqualIgnoreOrder(list, null));
+    Assert.assertFalse(EqualityUtils.isSameReference(list, null));
+    Assert.assertTrue(EqualityUtils.isNullOrNotSameClass(list, null));
+    Assert.assertEquals(EqualityUtils.hashCodeOf(null), 0);
+  }
+}


### PR DESCRIPTION
Changes:
1. For Collections, should not compare the result of toString(), this will fail all collections without order
2. For all Objects (non primitive type), just use equals()
3. For float and double, should follow JAVA convension that NaN != NaN
4. When calculate hashcode for long, clear the high 32 bits