### PR TITLE
Adding connection pool properties

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -31,8 +31,6 @@
     <commons-io.version>2.4</commons-io.version>
     <commons-jexl.version>2.0</commons-jexl.version>
     <commons-cli.version>1.2</commons-cli.version>
-    <commons-pool2.version>2.4.2</commons-pool2.version>
-    <commons-dbcp2.version>2.1</commons-dbcp2.version>
     <mrunit.version>1.1.0</mrunit.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <jodatime.version>2.7</jodatime.version>
@@ -51,6 +49,7 @@
     <guice-persist.version>4.1.0</guice-persist.version>
     <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
     <hibernate-entirymanager.version>4.3.10.Final</hibernate-entirymanager.version>
+    <hibernate-c3p0.version>4.3.10.Final</hibernate-c3p0.version>
   </properties>
 
   <build>
@@ -277,14 +276,9 @@
         <version>${hibernate-entirymanager.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-dbcp2</artifactId>
-        <version>${commons-dbcp2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-pool2</artifactId>
-        <version>${commons-pool2.version}</version>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-c3p0</artifactId>
+        <version>${hibernate-c3p0.version}</version>
       </dependency>
 
       <!-- test dependencies -->

--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -31,6 +31,8 @@
     <commons-io.version>2.4</commons-io.version>
     <commons-jexl.version>2.0</commons-jexl.version>
     <commons-cli.version>1.2</commons-cli.version>
+    <commons-pool2.version>2.4.2</commons-pool2.version>
+    <commons-dbcp2.version>2.1</commons-dbcp2.version>
     <mrunit.version>1.1.0</mrunit.version>
     <slf4j-api.version>1.7.12</slf4j-api.version>
     <jodatime.version>2.7</jodatime.version>
@@ -273,6 +275,16 @@
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-entitymanager</artifactId>
         <version>${hibernate-entirymanager.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-dbcp2</artifactId>
+        <version>${commons-dbcp2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-pool2</artifactId>
+        <version>${commons-pool2.version}</version>
       </dependency>
 
       <!-- test dependencies -->

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -114,13 +114,9 @@
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-dbcp2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-pool2</artifactId>
-    </dependency>
+     <groupId>org.hibernate</groupId>
+     <artifactId>hibernate-c3p0</artifactId>
+   </dependency>
 
     <!--UI dependencies -->
     <dependency>

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -113,6 +113,14 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+    </dependency>
 
     <!--UI dependencies -->
     <dependency>

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceConfig.java
@@ -27,7 +27,6 @@ public class PersistenceConfig extends Configuration {
     private String password;
     private String url;
     private Map<String, String> properties = Maps.newLinkedHashMap();
-    private Map<String, String> connectionPoolProperties = Maps.newLinkedHashMap();
 
     public String getUser() {
       return user;
@@ -51,15 +50,6 @@ public class PersistenceConfig extends Configuration {
 
     public void setProperties(Map<String, String> properties) {
       this.properties = properties;
-    }
-
-
-    public Map<String, String> getConnectionPoolProperties() {
-      return connectionPoolProperties;
-    }
-
-    public void setConnectionPoolProperties(Map<String, String> connectionPoolProperties) {
-      this.connectionPoolProperties = connectionPoolProperties;
     }
 
     public String getUrl() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceConfig.java
@@ -27,6 +27,7 @@ public class PersistenceConfig extends Configuration {
     private String password;
     private String url;
     private Map<String, String> properties = Maps.newLinkedHashMap();
+    private Map<String, String> connectionPoolProperties = Maps.newLinkedHashMap();
 
     public String getUser() {
       return user;
@@ -50,6 +51,15 @@ public class PersistenceConfig extends Configuration {
 
     public void setProperties(Map<String, String> properties) {
       this.properties = properties;
+    }
+
+
+    public Map<String, String> getConnectionPoolProperties() {
+      return connectionPoolProperties;
+    }
+
+    public void setConnectionPoolProperties(Map<String, String> connectionPoolProperties) {
+      this.connectionPoolProperties = connectionPoolProperties;
     }
 
     public String getUrl() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
@@ -72,10 +72,12 @@ public abstract class PersistenceUtil {
       }
     }
     Map<String, String> defaultDbcpProperties = new HashMap<>();
-    defaultDbcpProperties.put("hibernate.dbcp.initialSize", "8");
-    defaultDbcpProperties.put("hibernate.dbcp.maxTotal", "50");
-    defaultDbcpProperties.put("hibernate.dbcp.maxIdle", "50");
-    defaultDbcpProperties.put("hibernate.dbcp.minIdle", "0");
+    defaultDbcpProperties.put("hibernate.connection.provider_class", "org.hibernate.c3p0.internal.C3P0ConnectionProvider");
+    defaultDbcpProperties.put("hibernate.c3p0.min_size", "5"); // initial pool size
+    defaultDbcpProperties.put("hibernate.c3p0.max_size", "50"); // max number of connections in pool
+    defaultDbcpProperties.put("hibernate.c3p0.timeout", "500");
+    defaultDbcpProperties.put("hibernate.c3p0.max_statements", "100"); // max statements to cache
+    defaultDbcpProperties.put("hibernate.c3p0.idle_test_period", "3000");
     for (String key : defaultDbcpProperties.keySet()) {
       String val = databaseConfiguration.getProperties().get(key);
       if (StringUtils.isBlank(val)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
@@ -52,24 +52,13 @@ public abstract class PersistenceUtil {
   public static Properties createDbPropertiesFromConfiguration(PersistenceConfig localConfiguration) {
     PersistenceConfig.DatabaseConfiguration databaseConfiguration =
         localConfiguration.getDatabaseConfiguration();
-    List<String> propertiesList = new ArrayList<>();
-    propertiesList.add("hibernate.dialect");
-    propertiesList.add("hibernate.show_sql");
-    propertiesList.add("hibernate.hbm2ddl.auto");
-    propertiesList.add("hibernate.archive.autodetection");
-    propertiesList.add("hibernate.connection.driver_class");
 
     Properties properties = new Properties();
     properties.setProperty("javax.persistence.jdbc.url", databaseConfiguration.getUrl());
     properties.setProperty("javax.persistence.jdbc.user", databaseConfiguration.getUser());
     properties.setProperty("javax.persistence.jdbc.password", databaseConfiguration.getPassword());
-    for (String p : propertiesList) {
-      String val = databaseConfiguration.getProperties().get(p);
-      if (val != null) {
-        properties.setProperty(p, val);
-      }
-    }
-    for (Entry<String, String> entry : databaseConfiguration.getConnectionPoolProperties().entrySet()) {
+
+    for (Entry<String, String> entry : databaseConfiguration.getProperties().entrySet()) {
       properties.setProperty(entry.getKey(), entry.getValue());
     }
     return properties;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
@@ -10,14 +10,12 @@ import io.dropwizard.jackson.Jackson;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import javax.validation.Validation;
 
-import org.apache.commons.lang3.StringUtils;
 
 public abstract class PersistenceUtil {
 
@@ -71,19 +69,8 @@ public abstract class PersistenceUtil {
         properties.setProperty(p, val);
       }
     }
-    Map<String, String> defaultDbcpProperties = new HashMap<>();
-    defaultDbcpProperties.put("hibernate.connection.provider_class", "org.hibernate.c3p0.internal.C3P0ConnectionProvider");
-    defaultDbcpProperties.put("hibernate.c3p0.min_size", "5"); // initial pool size
-    defaultDbcpProperties.put("hibernate.c3p0.max_size", "50"); // max number of connections in pool
-    defaultDbcpProperties.put("hibernate.c3p0.timeout", "500");
-    defaultDbcpProperties.put("hibernate.c3p0.max_statements", "100"); // max statements to cache
-    defaultDbcpProperties.put("hibernate.c3p0.idle_test_period", "3000");
-    for (String key : defaultDbcpProperties.keySet()) {
-      String val = databaseConfiguration.getProperties().get(key);
-      if (StringUtils.isBlank(val)) {
-        val = defaultDbcpProperties.get(key);
-      }
-      properties.setProperty(key, val);
+    for (Entry<String, String> entry : databaseConfiguration.getConnectionPoolProperties().entrySet()) {
+      properties.setProperty(entry.getKey(), entry.getValue());
     }
     return properties;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/persistence/PersistenceUtil.java
@@ -4,13 +4,20 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.jpa.JpaPersistModule;
+
 import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
+
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+
 import javax.validation.Validation;
+
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class PersistenceUtil {
 
@@ -63,6 +70,18 @@ public abstract class PersistenceUtil {
       if (val != null) {
         properties.setProperty(p, val);
       }
+    }
+    Map<String, String> defaultDbcpProperties = new HashMap<>();
+    defaultDbcpProperties.put("hibernate.dbcp.initialSize", "8");
+    defaultDbcpProperties.put("hibernate.dbcp.maxTotal", "50");
+    defaultDbcpProperties.put("hibernate.dbcp.maxIdle", "50");
+    defaultDbcpProperties.put("hibernate.dbcp.minIdle", "0");
+    for (String key : defaultDbcpProperties.keySet()) {
+      String val = databaseConfiguration.getProperties().get(key);
+      if (StringUtils.isBlank(val)) {
+        val = defaultDbcpProperties.get(key);
+      }
+      properties.setProperty(key, val);
     }
     return properties;
   }

--- a/thirdeye/thirdeye-pinot/src/test/resources/persistence.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/persistence.yml
@@ -8,3 +8,10 @@ databaseConfiguration:
     hibernate.hbm2ddl.auto: update
     hibernate.archive.autodetection: class, hbm
     hibernate.connection.driver_class: org.hsqldb.jdbcDriver
+  connectionPoolProperties:
+    hibernate.connection.provider_class: org.hibernate.c3p0.internal.C3P0ConnectionProvider
+    hibernate.c3p0.min_size: 5
+    hibernate.c3p0.max_size: 50
+    hibernate.c3p0.timeout: 500
+    hibernate.c3p0.max_statements: 100
+    hibernate.c3p0.idle_test_period: 3000

--- a/thirdeye/thirdeye-pinot/src/test/resources/persistence.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/persistence.yml
@@ -8,7 +8,6 @@ databaseConfiguration:
     hibernate.hbm2ddl.auto: update
     hibernate.archive.autodetection: class, hbm
     hibernate.connection.driver_class: org.hsqldb.jdbcDriver
-  connectionPoolProperties:
     hibernate.connection.provider_class: org.hibernate.c3p0.internal.C3P0ConnectionProvider
     hibernate.c3p0.min_size: 5
     hibernate.c3p0.max_size: 50


### PR DESCRIPTION
Setting hibernate.dbcp properties for connection pooling. These can be overriden from the persistence.yml if tuning needed.