### PR TITLE
Support array offsets in Kafka message decoding

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -96,6 +97,11 @@ public class KafkaJSONMessageDecoder implements KafkaMessageDecoder {
       LOGGER.error("error decoding , ", e);
     }
     return null;
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, int offset, int length) {
+    return decode(Arrays.copyOfRange(payload, offset, offset + length));
   }
 
   private Object stringToDataType(FieldSpec spec, String inString) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaMessageDecoder.java
@@ -28,13 +28,22 @@ public interface KafkaMessageDecoder {
    * @param props
    * @throws Exception
    */
-  public void init(Map<String, String> props, Schema indexingSchema, String kafkaTopicName) throws Exception;
+  void init(Map<String, String> props, Schema indexingSchema, String kafkaTopicName) throws Exception;
 
   /**
    *
    * @param payload
    * @return
    */
-  public GenericRow decode(byte[] payload);
+  GenericRow decode(byte[] payload);
 
+  /**
+   * Decodes a row.
+   *
+   * @param payload The buffer from which to read the row.
+   * @param offset The offset into the array from which the row contents starts
+   * @param length The length of the row contents in bytes
+   * @return A new row decoded from the buffer
+   */
+  GenericRow decode(byte[] payload, int offset, int length);
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -182,9 +182,14 @@ public abstract class ClusterTest extends ControllerTest {
 
     @Override
     public GenericRow decode(byte[] payload) {
+      return decode(payload, 0, payload.length);
+    }
+
+    @Override
+    public GenericRow decode(byte[] payload, int offset, int length) {
       try {
         GenericData.Record avroRecord =
-            _reader.read(null, _decoderFactory.binaryDecoder(payload, 0, payload.length, null));
+            _reader.read(null, _decoderFactory.binaryDecoder(payload, offset, length, null));
         return _rowGenerator.transform(avroRecord, _avroSchema);
       } catch (Exception e) {
         LOGGER.error("Caught exception", e);


### PR DESCRIPTION
Add support for specifying offsets in arrays for Kafka message
decoding to avoid copying and slicing of arrays.