### PR TITLE
Use the null character as a padding character so that we will be able to support strings with '%'

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -71,7 +71,7 @@ public class SegmentGeneratorConfig {
   private String _starTreeIndexSpecFile = null;
   private StarTreeIndexSpec _starTreeIndexSpec = null;
   private String _creatorVersion = null;
-  private char _paddingCharacter = V1Constants.Str.LEGACY_STRING_PAD_CHAR;
+  private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
 
   public SegmentGeneratorConfig() {
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/ColumnMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/ColumnMetadata.java
@@ -140,7 +140,7 @@ public class ColumnMetadata {
             .getKeyFor(column, V1Constants.MetadataKeys.Column.TOTAL_NUMBER_OF_ENTRIES));
     builder.setTotalNumberOfEntries(totalNumberOfEntries);
 
-    char paddingCharacter = V1Constants.Str.LEGACY_STRING_PAD_CHAR;
+    char paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
     if (config
         .containsKey(V1Constants.MetadataKeys.Segment.SEGMENT_PADDING_CHARACTER)) {
       String padding = config.getString(V1Constants.MetadataKeys.Segment.SEGMENT_PADDING_CHARACTER);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -72,7 +72,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   private boolean _hasStarTree;
   private StarTreeMetadata _starTreeMetadata = null;
   private String _creatorName;
-  private char _paddingCharacter = V1Constants.Str.LEGACY_STRING_PAD_CHAR;
+  private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
 
   public SegmentMetadataImpl(File indexDir) throws ConfigurationException, IOException {
     LOGGER.debug("SegmentMetadata location: {}", indexDir);


### PR DESCRIPTION
Use the null character as a padding character so that we will be able to support strings with '%'. An earlier diff made the padding character configurable and added tests for those.