### PR TITLE
Check routing table size in HLC/LLC switching

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
@@ -86,8 +86,8 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
 //      if (!_brokerRoutingTable.containsKey(tableName) && !_llcBrokerRoutingTable.containsKey(tableName)) {
 //        return null;
 //      }
-      if (_brokerRoutingTable.containsKey(tableName)) {
-        if (_llcBrokerRoutingTable.containsKey(tableName)) {
+      if (_brokerRoutingTable.containsKey(tableName) && _brokerRoutingTable.get(tableName).size() != 0) {
+        if (_llcBrokerRoutingTable.containsKey(tableName) && _llcBrokerRoutingTable.get(tableName).size() != 0) {
           // Has both high and low-level segments. Follow what the routing table selector says.
           if (_routingTableSelector.shouldUseLLCRouting(tableName)) {
             serverToSegmentSetMaps = _llcBrokerRoutingTable.get(tableName);


### PR DESCRIPTION
Check the size of the routing tables when switching between high
level consumer and low level consumer routing tables.