### PR TITLE
Adding transactional to findById for anomalyFunctions

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -363,13 +363,13 @@ public class AnomalyResource {
     }
     anomalyFunctionSpec.setCron(cron);
 
-    Long responseId = anomalyFunctionDAO.save(anomalyFunctionSpec);
+    anomalyFunctionDAO.update(anomalyFunctionSpec);
 
     if (isActive) {
-      detectionResourceHttpUtils.enableAnomalyFunction(String.valueOf(responseId));
+      detectionResourceHttpUtils.enableAnomalyFunction(String.valueOf(id));
     }
 
-    return Response.ok(responseId).build();
+    return Response.ok(id).build();
   }
 
   // Delete anomaly function

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/dao/AnomalyFunctionDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/dao/AnomalyFunctionDAO.java
@@ -5,8 +5,6 @@ import com.linkedin.thirdeye.db.entity.AnomalyFunctionSpec;
 
 import java.util.List;
 
-import javax.persistence.NoResultException;
-
 public class AnomalyFunctionDAO extends AbstractJpaDAO<AnomalyFunctionSpec> {
 
   private static final String GET_BY_COLLECTION =
@@ -15,21 +13,13 @@ public class AnomalyFunctionDAO extends AbstractJpaDAO<AnomalyFunctionSpec> {
   private static final String FIND_DISTINCT_METRIC_BY_COLLECTION =
       "SELECT DISTINCT(af.metric) FROM AnomalyFunctionSpec af WHERE af.collection = :collection";
 
-  private static final String FIND_BY_ID =
-      "SELECT af FROM AnomalyFunctionSpec af WHERE af.id = :id";
-
   public AnomalyFunctionDAO() {
     super(AnomalyFunctionSpec.class);
   }
 
   @Transactional
   public AnomalyFunctionSpec findById(Long id) {
-    try {
-      return getEntityManager().createQuery(FIND_BY_ID, AnomalyFunctionSpec.class)
-          .setParameter("id", id).getSingleResult();
-    } catch (NoResultException e) {
-      return null;
-    }
+    return super.findById(id);
   }
 
   @Transactional

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/dao/AnomalyFunctionDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/dao/AnomalyFunctionDAO.java
@@ -1,7 +1,11 @@
 package com.linkedin.thirdeye.db.dao;
 
+import com.google.inject.persist.Transactional;
 import com.linkedin.thirdeye.db.entity.AnomalyFunctionSpec;
+
 import java.util.List;
+
+import javax.persistence.NoResultException;
 
 public class AnomalyFunctionDAO extends AbstractJpaDAO<AnomalyFunctionSpec> {
 
@@ -11,10 +15,24 @@ public class AnomalyFunctionDAO extends AbstractJpaDAO<AnomalyFunctionSpec> {
   private static final String FIND_DISTINCT_METRIC_BY_COLLECTION =
       "SELECT DISTINCT(af.metric) FROM AnomalyFunctionSpec af WHERE af.collection = :collection";
 
+  private static final String FIND_BY_ID =
+      "SELECT af FROM AnomalyFunctionSpec af WHERE af.id = :id";
+
   public AnomalyFunctionDAO() {
     super(AnomalyFunctionSpec.class);
   }
 
+  @Transactional
+  public AnomalyFunctionSpec findById(Long id) {
+    try {
+      return getEntityManager().createQuery(FIND_BY_ID, AnomalyFunctionSpec.class)
+          .setParameter("id", id).getSingleResult();
+    } catch (NoResultException e) {
+      return null;
+    }
+  }
+
+  @Transactional
   public List<AnomalyFunctionSpec> findAllByCollection(String collection) {
     return getEntityManager().createQuery(GET_BY_COLLECTION, entityClass)
         .setParameter("collection", collection).getResultList();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/dao/AnomalyResultDAO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/dao/AnomalyResultDAO.java
@@ -46,8 +46,8 @@ public class AnomalyResultDAO extends AbstractJpaDAO<AnomalyResult> {
           + "OR (r.endTimeUtc >= :startTimeUtc AND r.endTimeUtc <= :endTimeUtc))";
 
   private static final String FIND_VALID_BY_TIME_EMAIL_ID =
-      "SELECT r FROM EmailConfiguration d JOIN d.functions f JOIN f.anomalies r "
-          + "WHERE d.id = :emailId AND ((r.startTimeUtc >= :startTimeUtc AND r.startTimeUtc <= :endTimeUtc) "
+      "SELECT r FROM EmailConfiguration d JOIN d.functions f, AnomalyResult r "
+          + "WHERE r.function.id=f.id AND d.id = :emailId AND ((r.startTimeUtc >= :startTimeUtc AND r.startTimeUtc <= :endTimeUtc) "
           + "OR (r.endTimeUtc >= :startTimeUtc AND r.endTimeUtc <= :endTimeUtc)) "
           + "AND r.dataMissing=:dataMissing";
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/entity/AnomalyJobSpec.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/db/entity/AnomalyJobSpec.java
@@ -48,9 +48,6 @@ public class AnomalyJobSpec extends AbstractBaseEntity {
       columnDefinition="TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
   private Timestamp lastModified;
 
-  @OneToMany(mappedBy = "job", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-  private List<AnomalyTaskSpec> anomalyTasks;
-
   public String getJobName() {
     return jobName;
   }
@@ -101,15 +98,6 @@ public class AnomalyJobSpec extends AbstractBaseEntity {
 
   public Timestamp getLastModified() {
     return lastModified;
-  }
-
-
-  public List<AnomalyTaskSpec> getAnomalyTasks() {
-    return anomalyTasks;
-  }
-
-  public void setAnomalyTasks(List<AnomalyTaskSpec> anomalyTasks) {
-    this.anomalyTasks = anomalyTasks;
   }
 
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/db/TestAnomalyFunctionDAO.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/db/TestAnomalyFunctionDAO.java
@@ -3,7 +3,11 @@ package com.linkedin.thirdeye.db;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
 import com.linkedin.thirdeye.db.dao.AbstractDbTestBase;
 import com.linkedin.thirdeye.db.entity.AnomalyFunctionSpec;
+
 import java.util.List;
+
+import javax.persistence.NoResultException;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -47,7 +51,7 @@ public class TestAnomalyFunctionDAO extends AbstractDbTestBase {
   }
 
   @Test(dependsOnMethods = { "testUpdate" })
-  public void testDelete() {
+  public void testDelete() throws NoResultException {
     anomalyFunctionDAO.deleteById(anomalyFunctionId);
     AnomalyFunctionSpec spec = anomalyFunctionDAO.findById(anomalyFunctionId);
     Assert.assertNull(spec);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/db/TestEmailConfigurationDAO.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/db/TestEmailConfigurationDAO.java
@@ -44,13 +44,13 @@ public class TestEmailConfigurationDAO extends AbstractDbTestBase {
   }
 
   @Test(dependsOnMethods = { "testFunctionEmailAssignment" })
-  public void testFndByFunctionId() {
+  public void testFindByFunctionId() {
     List<EmailConfiguration> emailConfigurations =
         emailConfigurationDAO.findByFunctionId(functionId);
     assertEquals(emailConfigurations.size(), 1);
   }
 
-  @Test(dependsOnMethods = { "testFndByFunctionId" })
+  @Test(dependsOnMethods = { "testFindByFunctionId" })
   public void testDelete() {
     emailConfigurationDAO.deleteById(emailConfigId);
     EmailConfiguration emailConfiguration = emailConfigurationDAO.findById(emailConfigId);


### PR DESCRIPTION
This pull request contains changes to add transactional to findById for anomaly functions, due to stale results issue. Also fixing findByEmailAndTime query