### PR TITLE
Adding fix for pinot schema deserialization

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/SchemaCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/SchemaCacheLoader.java
@@ -23,6 +23,7 @@ public class SchemaCacheLoader extends CacheLoader<String, Schema> {
 
   private static final String UTF_8 = "UTF-8";
   private static final String SCHEMA_ENDPOINT = "schemas/";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final CloseableHttpClient controllerClient;
   private final HttpHost controllerHost;
@@ -43,12 +44,8 @@ public class SchemaCacheLoader extends CacheLoader<String, Schema> {
         LOGGER.error("Schema {} not found, {}", collection, res.getStatusLine().toString());
       }
       InputStream content = res.getEntity().getContent();
-
-      Schema schema = new ObjectMapper().readValue(content, Schema.class);
+      Schema schema = OBJECT_MAPPER.readValue(content, Schema.class);
       return schema;
-    } catch (Exception e) {
-      LOGGER.error("Exception in retrieving schema", e);
-      return null;
     } finally {
       if (res.getEntity() != null) {
         EntityUtils.consume(res.getEntity());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/SchemaCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/SchemaCacheLoader.java
@@ -9,10 +9,10 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheLoader;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.thirdeye.client.pinot.PinotThirdEyeClientConfig;
@@ -43,8 +43,12 @@ public class SchemaCacheLoader extends CacheLoader<String, Schema> {
         LOGGER.error("Schema {} not found, {}", collection, res.getStatusLine().toString());
       }
       InputStream content = res.getEntity().getContent();
+
       Schema schema = new ObjectMapper().readValue(content, Schema.class);
       return schema;
+    } catch (Exception e) {
+      LOGGER.error("Exception in retrieving schema", e);
+      return null;
     } finally {
       if (res.getEntity() != null) {
         EntityUtils.consume(res.getEntity());


### PR DESCRIPTION
The field delimiter was removed from pinot schema and is causing our schema loading to fail. Pinot schema is using codehaus and has support for ignoring unknown