### PR TITLE
Disable illegal setter for MetricFieldSpec and TimeFieldSpec.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.google.common.base.Preconditions;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
@@ -35,5 +36,10 @@ public final class MetricFieldSpec extends FieldSpec {
   @Override
   public FieldType getFieldType() {
     return FieldType.METRIC;
+  }
+
+  @Override
+  public void setSingleValueField(boolean isSingleValueField) {
+    Preconditions.checkArgument(isSingleValueField, "Unsupported multi-value for metric field.");
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
@@ -62,6 +62,21 @@ public final class TimeFieldSpec extends FieldSpec {
     return FieldType.TIME;
   }
 
+  @Override
+  public void setName(String name) {
+    // Ignore setName for TimeFieldSpec because we pick the name from TimeGranularitySpec.
+  }
+
+  @Override
+  public void setDataType(DataType dataType) {
+    // Ignore setDataType for TimeFieldSpec because we pick the data type from TimeGranularitySpec.
+  }
+
+  @Override
+  public void setSingleValueField(boolean isSingleValueField) {
+    Preconditions.checkArgument(isSingleValueField, "Unsupported multi-value for time field.");
+  }
+
   @JsonIgnore
   public String getIncomingTimeColumnName() {
     return _incomingGranularitySpec.getName();
@@ -77,8 +92,8 @@ public final class TimeFieldSpec extends FieldSpec {
 
     _incomingGranularitySpec = incomingGranularitySpec;
     if (_outgoingGranularitySpec == null) {
-      setName(incomingGranularitySpec.getName());
-      setDataType(incomingGranularitySpec.getDataType());
+      super.setName(incomingGranularitySpec.getName());
+      super.setDataType(incomingGranularitySpec.getDataType());
     }
   }
 
@@ -90,8 +105,8 @@ public final class TimeFieldSpec extends FieldSpec {
     Preconditions.checkNotNull(outgoingGranularitySpec);
 
     _outgoingGranularitySpec = outgoingGranularitySpec;
-    setName(outgoingGranularitySpec.getName());
-    setDataType(outgoingGranularitySpec.getDataType());
+    super.setName(outgoingGranularitySpec.getName());
+    super.setDataType(outgoingGranularitySpec.getDataType());
   }
 
   public TimeGranularitySpec getOutgoingGranularitySpec() {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
@@ -27,28 +27,23 @@ public class SchemaTest {
   public static final Logger LOGGER = LoggerFactory.getLogger(SchemaTest.class);
 
   private static String singleValueDim = "true";
-  private static String singleValueMetric = "true";
   private static String dimType = "\"STRING\"";
   private static String metricType = "\"LONG\"";
 
   private String makeSchema() {
-    return "{" +
-        "\"schemaName\":\"TestSchema\"," +
-        "   \"metricFieldSpecs\":[" +
-        "{\"dataType\":" + metricType + ", \"singleValueField\":" + singleValueMetric + ", \"delimiter\":\",\", \"name\":\"volume\", \"fieldType\":\"METRIC\"}" +
-        "    ], \"dimensionFieldSpecs\":[" +
-        "{\"dataType\":" + dimType + ", \"singleValueField\":" + singleValueDim + ", \"delimiter\":\",\", \"name\":\"page\", \"fieldType\":\"DIMENSION\"}" +
-        "    ], \"timeFieldSpec\":{" +
-        "       \"dataType\":\"LONG\"," +
-        "       \"incomingGranularitySpec\":{" +
-        "          \"dataType\":\"LONG\", \"timeType\":\"MILLISECONDS\", \"name\":\"tick\"" +
-        "        }, \"outgoingGranularitySpec\":{" +
-        "          \"dataType\":\"LONG\", \"timeType\":\"MILLISECONDS\", \"name\":\"tick\"" +
-        "        }," +
-        "        \"singleValueField\":true, \"delimiter\":null, \"name\":\"time\", \"fieldType\":\"TIME\", \"defaultNullValue\":-9223372036854775808"
-        +
-        "    }" +
-        " }";
+    return "{"
+        + "  \"schemaName\":\"TestSchema\","
+        + "  \"metricFieldSpecs\":["
+        + "    {\"dataType\":" + metricType + ",\"singleValueField\":true,\"name\":\"volume\"}"
+        + "  ],"
+        + "  \"dimensionFieldSpecs\":["
+        + "    {\"dataType\":" + dimType + ",\"singleValueField\":" + singleValueDim + ",\"name\":\"page\"}"
+        + "  ],"
+        + "  \"timeFieldSpec\":{"
+        + "    \"incomingGranularitySpec\":{\"dataType\":\"LONG\",\"timeType\":\"MILLISECONDS\",\"name\":\"tick\"},"
+        + "    \"defaultNullValue\":12345"
+        + "  }"
+        + "}";
   }
 
   @Test
@@ -56,7 +51,6 @@ public class SchemaTest {
     ObjectMapper mapper = new ObjectMapper();
     {
       singleValueDim = "true";
-      singleValueMetric = "true";
       dimType = "\"STRING\"";
       metricType = "\"LONG\"";
 
@@ -64,21 +58,8 @@ public class SchemaTest {
       Schema schema = mapper.readValue(validSchema, Schema.class);
       Assert.assertTrue(schema.validate(LOGGER));
     }
-
     {
       singleValueDim = "true";
-      singleValueMetric = "false";
-      dimType = "\"STRING\"";
-      metricType = "\"LONG\"";
-
-      String validSchema = makeSchema();
-      Schema schema = mapper.readValue(validSchema, Schema.class);
-      Assert.assertTrue(schema.validate(LOGGER));
-    }
-
-    {
-      singleValueDim = "true";
-      singleValueMetric = "true";
       dimType = "\"STRING\"";
       metricType = "\"BOOLEAN\"";
 
@@ -86,10 +67,8 @@ public class SchemaTest {
       Schema schema = mapper.readValue(validSchema, Schema.class);
       Assert.assertFalse(schema.validate(LOGGER));
     }
-
     {
-      singleValueDim = "true";
-      singleValueMetric = "true";
+      singleValueDim = "false";
       dimType = "\"STRING\"";
       metricType = "\"STRING\"";
 
@@ -97,12 +76,8 @@ public class SchemaTest {
       Schema schema = mapper.readValue(validSchema, Schema.class);
       Assert.assertFalse(schema.validate(LOGGER));
     }
-
-    /*
-     * Disabled until we fix default value for booleans
     {
-      singleValueDim = "true";
-      singleValueMetric = "true";
+      singleValueDim = "false";
       dimType = "\"BOOLEAN\"";
       metricType = "\"LONG\"";
 
@@ -110,8 +85,6 @@ public class SchemaTest {
       Schema schema = mapper.readValue(validSchema, Schema.class);
       Assert.assertTrue(schema.validate(LOGGER));
     }
-
-    */
   }
 
   @Test


### PR DESCRIPTION
1. Metric and Time FieldSpec only support single-value.
2. For TimeFieldSpec, name and dateType should be compatible to TimeGranularitySpec.