### PR TITLE
[PINOT-3469]: Add a max allowed value for 'TOP' and 'LIMIT' in the query.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
@@ -72,6 +72,8 @@ public class BrokerServerBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServerBuilder.class);
   private static final long DEFAULT_BROKER_TIME_OUT_MS = 10 * 1000L;
   private static final long DEFAULT_BROKER_DELAY_SHUTDOWN_TIME_MS = 10 * 1000L;
+  private static final int BROKER_QUERY_RESPONSE_LIMIT = 10000;
+  private static final String BROKER_QUERY_RESPONSE_LIMIT_CONFIG = "pinot.broker.query.response.limit";
 
   // Connection Pool Related
   private KeyedPool<ServerInstance, NettyClientConnection> _connPool;
@@ -181,9 +183,10 @@ public class BrokerServerBuilder {
     }
     LOGGER.info("Broker timeout is - " + brokerTimeOutMs + " ms");
 
+    int queryResponseLimit = _config.getInt(BROKER_QUERY_RESPONSE_LIMIT_CONFIG, BROKER_QUERY_RESPONSE_LIMIT);
     ReduceServiceRegistry reduceServiceRegistry = buildReduceServiceRegistry();
     _requestHandler = new BrokerRequestHandler(_routingTable, _timeBoundaryService, _scatterGather,
-        reduceServiceRegistry, _brokerMetrics, brokerTimeOutMs);
+        reduceServiceRegistry, _brokerMetrics, brokerTimeOutMs, queryResponseLimit);
 
     LOGGER.info("Network initialized !!");
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
@@ -36,6 +36,7 @@ public class QueryException {
   public static final int MERGE_RESPONSE_ERROR_CODE = 500;
   public static final int FEDERATED_BROKER_UNAVAILABLE_ERROR_CODE = 550;
   public static final int COMBINE_GROUP_BY_EXCEPTION_ERROR_CODE = 600;
+  public static final int QUERY_VALIDATION_ERROR_CODE = 700;
   public static final int UNKNOWN_ERROR_CODE = 1000;
 
   public static final ProcessingException JSON_PARSING_ERROR = new ProcessingException(JSON_PARSING_ERROR_CODE);
@@ -60,6 +61,7 @@ public class QueryException {
   public static final ProcessingException COMBINE_GROUP_BY_EXCEPTION_ERROR =
       new ProcessingException(COMBINE_GROUP_BY_EXCEPTION_ERROR_CODE);
 
+  public static final ProcessingException QUERY_VALIDATION_ERROR = new ProcessingException(QUERY_VALIDATION_ERROR_CODE);
   public static final ProcessingException UNKNOWN_ERROR = new ProcessingException(UNKNOWN_ERROR_CODE);
 
   static {
@@ -77,6 +79,7 @@ public class QueryException {
     INTERNAL_ERROR.setMessage("InternalError");
     MERGE_RESPONSE_ERROR.setMessage("MergeResponseError");
     FEDERATED_BROKER_UNAVAILABLE_ERROR.setMessage("FederatedBrokerUnavailable");
+    QUERY_VALIDATION_ERROR.setMessage("QueryValidationError");
     UNKNOWN_ERROR.setMessage("UnknownError");
   }
 


### PR DESCRIPTION
In order to protect the servers running into issues such as
out-of-heap-memory etc, introducing a cap on the max value for these.

1. This value can be configured via the broker config
"pinot.broker.query.response.limit" and has a defaul value of 10k.

2. For queries larger then this value, we error out and return an
exception in the BrokerResponse.

3. Added tests for the same.
