### PR TITLE
[PINOT-3349]: Adding new interfaces for StarTree & StarTreeIndexNode.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/IndexSegment.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/IndexSegment.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.core.indexsegment;
 
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.startree.StarTree;
+import com.linkedin.pinot.core.startree.StarTreeInterf;
 
 
 /**
@@ -66,7 +66,7 @@ public interface IndexSegment {
   public void destroy();
 
   /** Returns the StarTree index structure, or null if it does not exist */
-  StarTree getStarTree();
+  StarTreeInterf getStarTree();
 
   /**
    * Get the total size of the segment in bytes

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/IndexSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/IndexSegmentImpl.java
@@ -31,7 +31,7 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
 import com.linkedin.pinot.core.segment.store.SegmentDirectory;
-import com.linkedin.pinot.core.startree.StarTree;
+import com.linkedin.pinot.core.startree.StarTreeInterf;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -44,10 +44,10 @@ public class IndexSegmentImpl implements IndexSegment {
   private SegmentDirectory segmentDirectory;
   private final SegmentMetadataImpl segmentMetadata;
   private final Map<String, ColumnIndexContainer> indexContainerMap;
-  private final StarTree starTree;
+  private final StarTreeInterf starTree;
 
   public IndexSegmentImpl(SegmentDirectory segmentDirectory, SegmentMetadataImpl segmentMetadata,
-      Map<String, ColumnIndexContainer> columnIndexContainerMap, StarTree starTree) throws Exception {
+      Map<String, ColumnIndexContainer> columnIndexContainerMap, StarTreeInterf starTree) throws Exception {
     this.segmentDirectory = segmentDirectory;
     this.segmentMetadata = segmentMetadata;
     this.indexContainerMap = columnIndexContainerMap;
@@ -132,7 +132,7 @@ public class IndexSegmentImpl implements IndexSegment {
   }
 
   @Override
-  public StarTree getStarTree() {
+  public StarTreeInterf getStarTree() {
     return starTree;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
@@ -28,7 +28,8 @@ import com.linkedin.pinot.core.segment.index.converter.SegmentFormatConverter;
 import com.linkedin.pinot.core.segment.index.converter.SegmentFormatConverterFactory;
 import com.linkedin.pinot.core.segment.store.SegmentDirectory;
 import com.linkedin.pinot.core.segment.store.SegmentDirectoryPaths;
-import com.linkedin.pinot.core.startree.StarTree;
+import com.linkedin.pinot.core.startree.StarTreeInterf;
+import com.linkedin.pinot.core.startree.StarTreeSerDe;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,10 +95,10 @@ public class Loaders {
       }
 
       // load star tree index if it exists
-      StarTree starTree = null;
+      StarTreeInterf starTree = null;
       if (segmentReader.hasStarTree()) {
         LOGGER.debug("Loading star tree for segment: {}", segmentDirectory);
-        starTree = StarTree.fromBytes(segmentReader.getStarTreeStream());
+        starTree = StarTreeSerDe.fromBytes(segmentReader.getStarTreeStream());
       }
       return new IndexSegmentImpl(segmentDirectory, metadata, indexContainerMap, starTree);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNodeInterf.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNodeInterf.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+import java.util.Iterator;
+
+
+/**
+ * Interface for Star Tree Node.
+ */
+public interface StarTreeIndexNodeInterf {
+
+  static final int ALL = -1;
+
+  /**
+   * Returns the index for the dimension for this node.
+   * @return
+   */
+  int getDimensionName();
+
+  /**
+   * Set the id for dimension name.
+   * @param dimension
+   */
+  void setDimensionName(int dimension);
+
+  /**
+   * Return the dictionary id for the dimension value.
+   * @return
+   */
+  int getDimensionValue();
+
+  /**
+   * Get the dimension id for children.
+   * @return
+   */
+  int getChildDimensionName();
+
+  /**
+   * Sets the dimension value (dictionary id) for the node.
+   * @param dimensionValue
+   */
+  void setDimensionValue(int dimensionValue);
+
+  /**
+   * Returns the 'start' index in the raw documents for this node.
+   * @return
+   */
+  int getStartDocumentId();
+
+  /**
+   * Sets the 'start' index in the raw documents for this node.
+   * @param startDocumentId
+   */
+  void setStartDocumentId(int startDocumentId);
+
+  /**
+   * Returns the 'end' index in the raw documents for this node.
+   * @return
+   */
+  int getEndDocumentId();
+
+  /**
+   * Sets the 'end' index in the raw documents for this node.
+   * @param endDocumentId
+   */
+  void setEndDocumentId(int endDocumentId);
+
+  /**
+   * Returns the id for the aggregated document for this node.
+   * @return
+   */
+  int getAggregatedDocumentId();
+
+  /**
+   * Sets the id for the aggregated document for this node.
+   * @param aggregatedDocumentId
+   */
+  void setAggregatedDocumentId(int aggregatedDocumentId);
+
+  /**
+   * Returns the number of children for this node.
+   * @return
+   */
+  int getNumChildren();
+
+  /**
+   * Returns true if the node is a leaf (ie has no children), false otherwise.
+   * @return
+   */
+  boolean isLeaf();
+
+  /**
+   * Adds the provided node as a child of this node, for the given dimension value.
+   * @param child
+   * @param dimensionValue
+   */
+  void addChild(StarTreeIndexNodeInterf child, int dimensionValue);
+
+  /**
+   * Returns a child corresponding to the dimension value (dictionary id) for this node.
+   * If no such child exists, returns null.
+   * @param dimensionValue
+   * @return
+   */
+  StarTreeIndexNodeInterf getChildForDimensionValue(int dimensionValue);
+
+  /**
+   * Returns iterator over children of this node.
+   * @return
+   */
+  Iterator<? extends StarTreeIndexNodeInterf> getChildrenIterator();
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeInterf.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeInterf.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+import com.google.common.collect.HashBiMap;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+
+
+/**
+ * Interface for StarTree.
+ */
+public interface StarTreeInterf extends Serializable {
+
+  enum Version {
+    V1,
+    V2
+  }
+
+  /**
+   * Returns the root of the StarTree.
+   * @return
+   */
+  StarTreeIndexNodeInterf getRoot();
+
+  /**
+   * Returns the version of star tree.
+   * @return
+   */
+  Version getVersion();
+
+  /**
+   * Returns the total number of nodes in the star tree.
+   */
+  int getNumNodes();
+
+  /**
+   * Returns a bi-map of mapping between dimension name and
+   * its index.
+   * @return
+   */
+  HashBiMap<String, Integer> getDimensionNameToIndexMap();
+
+  /**
+   * Serializes and writes the StarTree on to the provided file.
+   * @param outputFile
+   */
+  void writeTree(File outputFile)
+      throws IOException;
+
+  /**
+   * Print the tree.
+   */
+  void printTree();
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeSerDe.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+import com.google.common.base.Preconditions;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.nio.ByteBuffer;
+
+
+/**
+ * Utility class for serializing/de-serializing the StarTree
+ * data structure.
+ */
+public class StarTreeSerDe {
+  public static final long MAGIC_MARKER = 0xBADDA55B00DAD00DL;
+  public static final int MAGIC_MARKER_SIZE_IN_BYTES = 8;
+
+  private static final String UTF8 = "UTF-8";
+  private static byte version = 1;
+
+  /**
+   * De-serializes a StarTree structure.
+   */
+  public static StarTreeInterf fromBytes(InputStream inputStream)
+      throws IOException, ClassNotFoundException {
+
+    BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
+    StarTreeInterf.Version version = getVersion(bufferedInputStream);
+
+    switch (version) {
+      case V1:
+        return fromBytesV1(bufferedInputStream);
+
+      case V2:
+        return fromBytesV2(bufferedInputStream);
+
+      default:
+        throw new RuntimeException("StarTree version number not recognized: " + version);
+    }
+  }
+
+  /**
+   * Write the V0 version of StarTree to the output file.
+   * @param starTree
+   * @param outputFile
+   * @throws IOException
+   */
+  public static void writeTreeV1(StarTreeInterf starTree, File outputFile)
+      throws IOException {
+    Preconditions.checkArgument(starTree.getVersion() == StarTreeInterf.Version.V1,
+        "Cannot write V1 version of star tree from another version");
+    starTree.writeTree(outputFile);
+  }
+
+  /**
+   * Write the V1 version of StarTree to the output file.
+   * @param starTree
+   * @param outputFile
+   * @throws IOException
+   */
+  public static void writeTreeV2(StarTreeInterf starTree, File outputFile)
+      throws IOException {
+    if (starTree.getVersion() == StarTreeInterf.Version.V1) {
+      writeTreeV2FromV1(starTree, outputFile);
+    } else {
+      starTree.writeTree(outputFile);
+    }
+  }
+
+  /**
+   * Utility method to StarTree version.
+   * Presence of {@value #MAGIC_MARKER} indicates version V1, while its
+   * absence indicates version V0.
+   *
+   * @param bufferedInputStream
+   * @return
+   * @throws IOException
+   */
+  private static StarTreeInterf.Version getVersion(BufferedInputStream bufferedInputStream)
+      throws IOException {
+    byte[] magicBytes = new byte[MAGIC_MARKER_SIZE_IN_BYTES];
+
+    bufferedInputStream.mark(MAGIC_MARKER_SIZE_IN_BYTES);
+    bufferedInputStream.read(magicBytes, 0, MAGIC_MARKER_SIZE_IN_BYTES);
+    bufferedInputStream.reset();
+
+    if (ByteBuffer.wrap(magicBytes).getLong() == MAGIC_MARKER) {
+      return StarTreeInterf.Version.V2;
+    } else {
+      return StarTreeInterf.Version.V1;
+    }
+  }
+
+  /**
+   * Given a StarTree in V1 format, serialize it into V2 format and write to the
+   * given file.
+   * @param starTree
+   * @param outputFile
+   */
+  private static void writeTreeV2FromV1(StarTreeInterf starTree, File outputFile) {
+    throw new RuntimeException("Feature not implemented yet.");
+  }
+
+  /**
+   * Utility method that de-serializes bytes from inputStream
+   * into the V0 version of star tree.
+   *
+   * @param inputStream
+   * @return
+   * @throws IOException
+   * @throws ClassNotFoundException
+   */
+  private static StarTreeInterf fromBytesV1(InputStream inputStream)
+      throws IOException, ClassNotFoundException {
+    ObjectInputStream ois = new ObjectInputStream(inputStream);
+    return (StarTree) ois.readObject();
+  }
+
+  /**
+   * Utility method that de-serializes bytes from inputStream into
+   * the V1 version of star tree.
+   *
+   * @param inputStream
+   * @return
+   */
+  private static StarTreeInterf fromBytesV2(InputStream inputStream) {
+    throw new RuntimeException("StarTree version V2 not implemented yet.");
+  }
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
@@ -19,31 +19,26 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.common.Block;
-import com.linkedin.pinot.core.common.BlockDocIdIterator;
 import com.linkedin.pinot.core.common.BlockSingleValIterator;
-import com.linkedin.pinot.core.common.BlockValIterator;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.segment.index.loader.Loaders;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
-import com.linkedin.pinot.core.startree.StarTree;
-import com.linkedin.pinot.core.startree.StarTreeIndexNode;
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
-
+import com.linkedin.pinot.core.startree.StarTreeInterf;
+import com.linkedin.pinot.core.startree.StarTreeSerDe;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
 
 public class SegmentDumpTool {
   @Argument
@@ -109,8 +104,8 @@ public class SegmentDumpTool {
     if (dumpStarTree) {
       System.out.println();
       File starTreeFile = new File(segmentDir, V1Constants.STAR_TREE_INDEX_FILE);
-      StarTree tree = StarTree.fromBytes(new FileInputStream(starTreeFile));
-      StarTreeIndexNode.printTree(tree.getRoot(), 0);
+      StarTreeInterf tree = StarTreeSerDe.fromBytes(new FileInputStream(starTreeFile));
+      tree.printTree();
     }
   }
 


### PR DESCRIPTION
This is a pre-cursor to the re-implementation in-memory & on-disk
representation of star tree:
1. Two new interfaces StarTreeInterf and StarTreeIndexNodeInterf have
been added.

2. All references to StarTree and StarTreeIndexNode have been replaced
to refer to the the new interfaces instead. The only exceptions are
clients that explicitly work on a specific version of StarTree (eg
OffHeapStarTreeBuilder that builds the current version of star tree).

3. Added a util class StarTreeSerDe that will handle the
serialization/de-serialization of the existing as well as future
implementation of the StarTree representation.

4. Validated by running all star tree tests.