### PR TITLE
[PINOT-3479] Provide best effort segment size if the segment is being pre-processed

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.core.segment.store;
 
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,5 +37,9 @@ public class SegmentDirectoryPaths {
         throw new UnsupportedOperationException("Segment path for version: " + version +
             " and segmentIndexDirectory: " + segmentIndexDirectory + " can not be determined ");
     }
+  }
+
+  public static boolean isV3Directory(File path) {
+    return path.toString().endsWith(V3_SUBDIRECTORY_NAME);
   }
 }


### PR DESCRIPTION
Table size reader may find that the segment on disk is not yet pre-processed. So,
expected sub-directory v3/ may be missing. This caused size reader to throw an unhandled
exception. The server will not provide the best effort size estimation for this case.
If the expected v3/ directory is missing, server will provide aggregate length of files
from parent directory

Testing: UT + manual