### PR TITLE
Set connection timeout and connection manager timeout for multiget request

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/http/MultiGetRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/http/MultiGetRequest.java
@@ -103,6 +103,9 @@ public class MultiGetRequest {
           HttpClient client = new HttpClient(connectionManager);
           GetMethod getMethod = new GetMethod(url);
           getMethod.getParams().setSoTimeout(timeoutMs);
+          // if all connections in the connection manager are busy this will wait to retrieve a connection
+          // set time to wait to retrieve a connection from connection manager
+          client.getParams().setConnectionManagerTimeout(timeoutMs);
           client.executeMethod(getMethod);
           return getMethod;
         }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -91,7 +91,9 @@ public class ControllerStarter {
     LOGGER.info("injecting conf and resource manager to the api context");
     applicationContext.getAttributes().put(ControllerConf.class.toString(), config);
     applicationContext.getAttributes().put(PinotHelixResourceManager.class.toString(), helixResourceManager);
-    applicationContext.getAttributes().put(HttpConnectionManager.class.toString(), new MultiThreadedHttpConnectionManager());
+    MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+    connectionManager.getParams().setConnectionTimeout(config.getServerAdminRequestTimeoutSeconds());
+    applicationContext.getAttributes().put(HttpConnectionManager.class.toString(), connectionManager);
     applicationContext.getAttributes().put(Executor.class.toString(), executorService);
 
     controllerRestApp.setContext(applicationContext);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/ServerTableSizeReader.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import org.apache.commons.httpclient.ConnectTimeoutException;
+import org.apache.commons.httpclient.ConnectionPoolTimeoutException;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -83,6 +85,10 @@ public class ServerTableSizeReader {
       } catch (ExecutionException e) {
         if (Throwables.getRootCause(e) instanceof SocketTimeoutException) {
           LOGGER.warn("Server request to read table size was timed out for table: {}", table, e);
+        } else if (Throwables.getRootCause(e) instanceof ConnectTimeoutException) {
+          LOGGER.warn("Server request to read table size timed out waiting for connection. table: {}", table, e);
+        } else if (Throwables.getRootCause(e) instanceof ConnectionPoolTimeoutException) {
+          LOGGER.warn("Server request to read table size timed out on getting a connection from pool, table: {}", table, e);
         } else {
           LOGGER.warn("Execution exception while reading segment sizes for table: {}", table, e);
         }


### PR DESCRIPTION
Set connection timeout for requests to read server table sizes and connection
manager pool timeout (time to wait for getting a connection from the pool)
for reading table sizes from server. Log warnings if the connection timeout
is reached.