### PR TITLE
Switching default behavior for Query Response Limit.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
@@ -72,7 +72,7 @@ public class BrokerServerBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServerBuilder.class);
   private static final long DEFAULT_BROKER_TIME_OUT_MS = 10 * 1000L;
   private static final long DEFAULT_BROKER_DELAY_SHUTDOWN_TIME_MS = 10 * 1000L;
-  private static final int BROKER_QUERY_RESPONSE_LIMIT = 10000;
+  private static final int DEFAULT_BROKER_QUERY_RESPONSE_LIMIT = Integer.MAX_VALUE;
   private static final String BROKER_QUERY_RESPONSE_LIMIT_CONFIG = "pinot.broker.query.response.limit";
 
   // Connection Pool Related
@@ -183,7 +183,7 @@ public class BrokerServerBuilder {
     }
     LOGGER.info("Broker timeout is - " + brokerTimeOutMs + " ms");
 
-    int queryResponseLimit = _config.getInt(BROKER_QUERY_RESPONSE_LIMIT_CONFIG, BROKER_QUERY_RESPONSE_LIMIT);
+    int queryResponseLimit = _config.getInt(BROKER_QUERY_RESPONSE_LIMIT_CONFIG, DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
     ReduceServiceRegistry reduceServiceRegistry = buildReduceServiceRegistry();
     _requestHandler = new BrokerRequestHandler(_routingTable, _timeBoundaryService, _scatterGather,
         reduceServiceRegistry, _brokerMetrics, brokerTimeOutMs, queryResponseLimit);

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/broker/BrokerRequestValidationTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/broker/BrokerRequestValidationTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.broker;
+
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import com.linkedin.pinot.requestHandler.BrokerRequestHandler;
+import java.io.File;
+import junit.framework.Assert;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test for BrokerRequest Validation:
+ * - Ensures query response limit is honored while validating a request.
+ */
+public class BrokerRequestValidationTest {
+
+  private static final int QUERY_RESPONSE_LIMIT = 100;
+  private static final String QUERY_RESPONSE_LIMIT_CONFIG = "pinot.broker.query.response.limit";
+  private static final CharSequence LIMIT_VALIDATION_STRING = "exceeded maximum allowed value";
+  private BrokerServerBuilder brokerBuilder;
+
+  /**
+   * Setup method to start the broker. Stars the broker with
+   * a query response limit of {@value QUERY_RESPONSE_LIMIT}
+   * @return
+   * @throws Exception
+   */
+  @BeforeClass
+  public BrokerServerBuilder setup()
+      throws Exception {
+    // Read default configurations.
+    PropertiesConfiguration config = new PropertiesConfiguration(
+        new File(BrokerServerBuilderTest.class.getClassLoader().getResource("broker.properties").toURI()));
+
+    // Set the value for query response limit.
+    config.addProperty(QUERY_RESPONSE_LIMIT_CONFIG, QUERY_RESPONSE_LIMIT);
+    brokerBuilder = new BrokerServerBuilder(config, null, null, null);
+
+    brokerBuilder.buildNetwork();
+    brokerBuilder.buildHTTP();
+    brokerBuilder.start();
+
+    return brokerBuilder;
+  }
+
+  /**
+   * Teardown method to stop the broker.
+   *
+   * @throws Exception
+   */
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    brokerBuilder.stop();
+  }
+
+  /**
+   * Test to ensure that values for 'TOP' smaller than or equal to the
+   * configured query response limit are validated, and others are not.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testTop()
+      throws Exception {
+
+    String baseQuery = "select count(*) from myTable group by myColumn TOP ";
+    String query = baseQuery + QUERY_RESPONSE_LIMIT;
+    String exceptionMessage = runQuery(query);
+    Assert.assertNull(exceptionMessage);
+
+    query = baseQuery + (QUERY_RESPONSE_LIMIT + 1);
+    exceptionMessage = runQuery(query);
+    Assert.assertTrue((exceptionMessage != null) && exceptionMessage.contains(LIMIT_VALIDATION_STRING));
+  }
+
+  /**
+   * Test to ensure that values for 'TOP' smaller than or equal to the
+   * configured query response limit are validated, and others are not.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testLimit()
+      throws Exception {
+
+    String baseQuery = "select * from myTable limit ";
+
+    String query = baseQuery + QUERY_RESPONSE_LIMIT;
+    String exceptionMessage = runQuery(query);
+    Assert.assertNull(exceptionMessage);
+
+    query = baseQuery + (QUERY_RESPONSE_LIMIT + 1);
+    exceptionMessage = runQuery(query);
+    Assert.assertTrue((exceptionMessage != null) && exceptionMessage.contains(LIMIT_VALIDATION_STRING));
+  }
+
+  /**
+   * Helper method to run the query.
+   *
+   * @param query
+   * @return Returns exception string if any, null otherwise.
+   * @throws Exception
+   */
+  private String runQuery(String query)
+      throws Exception {
+
+    BrokerRequestHandler brokerRequestHandler = brokerBuilder.getBrokerRequestHandler();
+    Pql2Compiler compiler = new Pql2Compiler();
+
+    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+
+    String exceptionMessage = null;
+    try {
+      brokerRequestHandler.validateRequest(brokerRequest);
+    } catch (Exception e) {
+      exceptionMessage = e.getMessage();
+    }
+    return exceptionMessage;
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -309,36 +309,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
     }
   }
 
-  /**
-   * Test for query validation:
-   * - Issues a query with larger than allowed 'limit'/'top' values and ensures
-   *   the response has the expected error code.
-   *
-   * @throws Exception
-   */
-  @Test
-  public void testQueryValidation()
-      throws Exception {
-    JSONObject response = postQuery("select * from myTable limit 99999");
-    JSONArray exceptions = response.getJSONArray("exceptions");
-    Assert.assertTrue(exceptions.length() > 0, "Expected exceptions in query response.");
-
-    JSONObject exception = exceptions.getJSONObject(0);
-    int errorCode = exception.getInt("errorCode");
-
-    Assert.assertEquals(errorCode, QueryException.QUERY_VALIDATION_ERROR_CODE, "Mis-match in error code.");
-
-    response = postQuery("select count(*) from myTable group by DaysSinceEpoch TOP 99999");
-    exceptions = response.getJSONArray("exceptions");
-    Assert.assertTrue(exceptions.length() > 0, "Expected exceptions in query response.");
-
-    exception = exceptions.getJSONObject(0);
-    errorCode = exception.getInt("errorCode");
-
-    Assert.assertEquals(errorCode, QueryException.QUERY_VALIDATION_ERROR_CODE, "Mis-match in error code.");
-
-  }
-
   @AfterClass
   public void tearDown() throws Exception {
     stopBroker();

--- a/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestHandler.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestHandler.java
@@ -189,7 +189,7 @@ public class BrokerRequestHandler {
    *
    * @param brokerRequest
    */
-  private void validateRequest(BrokerRequest brokerRequest) {
+  public void validateRequest(BrokerRequest brokerRequest) {
     if (brokerRequest.isSetAggregationsInfo()) {
       if (brokerRequest.isSetGroupBy()) {
         long topN = brokerRequest.getGroupBy().getTopN();


### PR DESCRIPTION
1. Setting default value to Integer.MAX_VALUE (when no config is specified).
2. Honor the config value, when specified.
3. Removed the test from integration test into a new unit test.