### PR TITLE
[PINOT-3430] Added server-side support for segment completion.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/KafkaStarterUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/KafkaStarterUtils.java
@@ -18,13 +18,11 @@ package com.linkedin.pinot.common.utils;
 import java.io.File;
 import java.security.Permission;
 import java.util.Properties;
-
+import org.I0Itec.zkclient.ZkClient;
+import org.apache.commons.io.FileUtils;
 import kafka.admin.TopicCommand;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServerStartable;
-
-import org.I0Itec.zkclient.ZkClient;
-import org.apache.commons.io.FileUtils;
 
 
 /**
@@ -119,9 +117,10 @@ public class KafkaStarterUtils {
     FileUtils.deleteQuietly(new File(serverStartable.serverConfig().logDirs().apply(0)));
   }
 
-  public static void createTopic(String kafkaTopic, String zkStr) {
+  public static void createTopic(String kafkaTopic, String zkStr, int partitionCount) {
     invokeTopicCommand(
-        new String[]{"--create", "--zookeeper", zkStr, "--replication-factor", "1", "--partitions", "10", "--topic",
+        new String[]{"--create", "--zookeeper", zkStr, "--replication-factor", "1", "--partitions", Integer.toString(
+            partitionCount), "--topic",
             kafkaTopic});
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/TarGzCompressionUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/TarGzCompressionUtils.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TarGzCompressionUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(TarGzCompressionUtils.class);
-  private static final String TAR_GZ_FILE_EXTENTION = ".tar.gz";
+  public static final String TAR_GZ_FILE_EXTENTION = ".tar.gz";
 
   /**
    * Creates a tar.gz file at the specified path with the contents of the

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommit.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommit.java
@@ -28,7 +28,6 @@ import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.restlet.swagger.Description;
 import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
@@ -132,8 +131,7 @@ public class LLCSegmentCommit extends PinotSegmentUploadRestletResource {
       // table
       LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
       final String rawTableName = segmentName.getTableName();
-      final String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(rawTableName);
-      final File tableDir = new File(baseDataDir, realtimeTableName);
+      final File tableDir = new File(baseDataDir, rawTableName);
       final File segmentFile = new File(tableDir, segmentNameStr);
 
       synchronized (_pinotHelixResourceManager) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTestUtils.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTestUtils.java
@@ -26,14 +26,14 @@ import com.linkedin.pinot.controller.ControllerStarter;
  *
  */
 public class ControllerTestUtils {
-  public static final String DEFAULT_CONTROLLER_INSTANCE_NAME = "localhost_11984";
+  private static final String DEFAULT_CONTROLLER_HOST_NAME = "localhost";
   public static final String DEFAULT_DATA_DIR = FileUtils.getTempDirectoryPath() + File.separator + "test-controller-" + System.currentTimeMillis();
   public static final String DEFAULT_CONTROLLER_API_PORT = "8998";
   public static final String DEFAULT_CONTROLLER_HOST = "localhost";
 
   public static ControllerConf getDefaultControllerConfiguration() {
     final ControllerConf conf = new ControllerConf();
-    conf.setControllerHost(DEFAULT_CONTROLLER_INSTANCE_NAME);
+    conf.setControllerHost(DEFAULT_CONTROLLER_HOST_NAME);
     conf.setControllerPort(DEFAULT_CONTROLLER_API_PORT);
     conf.setDataDir(DEFAULT_DATA_DIR);
     conf.setControllerVipHost("localhost");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/AbstractTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/AbstractTableDataManager.java
@@ -15,6 +15,17 @@
  */
 package com.linkedin.pinot.core.data.manager.offline;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.pinot.common.metadata.segment.IndexLoadingConfigMetadata;
@@ -25,18 +36,7 @@ import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.NamedThreadFactory;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public abstract  class AbstractTableDataManager implements TableDataManager {
@@ -59,6 +59,7 @@ public abstract  class AbstractTableDataManager implements TableDataManager {
   protected int _numberOfTableQueryExecutorThreads;
   protected IndexLoadingConfigMetadata _indexLoadingConfigMetadata;
   protected ServerMetrics _serverMetrics;
+  protected String _serverInstance;
 
 
   protected AbstractTableDataManager() {
@@ -66,7 +67,8 @@ public abstract  class AbstractTableDataManager implements TableDataManager {
   }
 
   @Override
-  public void init(TableDataManagerConfig tableDataManagerConfig, ServerMetrics serverMetrics) {
+  public void init(TableDataManagerConfig tableDataManagerConfig, ServerMetrics serverMetrics, String serverInstance) {
+    _serverInstance = serverInstance;
     _tableDataManagerConfig = tableDataManagerConfig;
     _serverMetrics = serverMetrics;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
@@ -64,7 +64,7 @@ public class FileBasedInstanceDataManager implements InstanceDataManager {
     for (String tableName : _instanceDataManagerConfig.getTableNames()) {
       TableDataManagerConfig tableDataManagerConfig =
           _instanceDataManagerConfig.getTableDataManagerConfig(tableName);
-      TableDataManager tableDataManager = TableDataManagerProvider.getTableDataManager(tableDataManagerConfig);
+      TableDataManager tableDataManager = TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, null);
       _tableDataManagerMap.put(tableName, tableDataManager);
     }
     _segmentMetadataLoader = getSegmentMetadataLoader(_instanceDataManagerConfig.getSegmentMetadataLoaderClass());
@@ -82,7 +82,7 @@ public class FileBasedInstanceDataManager implements InstanceDataManager {
     for (String tableName : _instanceDataManagerConfig.getTableNames()) {
       TableDataManagerConfig tableDataManagerConfig =
           _instanceDataManagerConfig.getTableDataManagerConfig(tableName);
-      TableDataManager tableDataManager = TableDataManagerProvider.getTableDataManager(tableDataManagerConfig);
+      TableDataManager tableDataManager = TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, null);
       _tableDataManagerMap.put(tableName, tableDataManager);
     }
     try {
@@ -220,7 +220,7 @@ public class FileBasedInstanceDataManager implements InstanceDataManager {
 
   @Override
   public void addSegment(ZkHelixPropertyStore<ZNRecord> propertyStore, AbstractTableConfig tableConfig,
-      InstanceZKMetadata instanceZKMetadata, SegmentZKMetadata segmentZKMetadata) throws Exception {
+      InstanceZKMetadata instanceZKMetadata, SegmentZKMetadata segmentZKMetadata, String serverInstance) throws Exception {
     throw new UnsupportedOperationException("Not support addSegment(...) in FileBasedInstanceDataManager yet!");
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/InstanceDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/InstanceDataManager.java
@@ -28,6 +28,6 @@ public interface InstanceDataManager extends DataManager {
   TableDataManager getTableDataManager(String tableName);
 
   void addSegment(ZkHelixPropertyStore<ZNRecord> propertyStore, AbstractTableConfig tableConfig,
-      InstanceZKMetadata instanceZKMetadata, SegmentZKMetadata segmentZKMetadata) throws Exception;
+      InstanceZKMetadata instanceZKMetadata, SegmentZKMetadata segmentZKMetadata, String serverInstance) throws Exception;
 
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/TableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/TableDataManager.java
@@ -15,6 +15,10 @@
  */
 package com.linkedin.pinot.core.data.manager.offline;
 
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.data.Schema;
@@ -24,11 +28,7 @@ import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
 import javax.annotation.Nonnull;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 
 /**
@@ -42,8 +42,9 @@ public interface TableDataManager {
    * Initialize TableDataManager based on given config.
    *
    * @param tableDataManagerConfig
+   * @param serverInstance
    */
-  void init(TableDataManagerConfig tableDataManagerConfig, ServerMetrics serverMetrics);
+  void init(TableDataManagerConfig tableDataManagerConfig, ServerMetrics serverMetrics, String serverInstance);
 
   void start();
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -15,11 +15,10 @@
  */
 package com.linkedin.pinot.core.data.manager.offline;
 
-import com.google.common.base.Preconditions;
-import com.linkedin.pinot.common.metrics.ServerMetrics;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
 import com.linkedin.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 
@@ -39,7 +38,8 @@ public class TableDataManagerProvider {
     keyToFunction.put("realtime", RealtimeTableDataManager.class);
   }
 
-  public static TableDataManager getTableDataManager(TableDataManagerConfig tableDataManagerConfig) {
+  public static TableDataManager getTableDataManager(TableDataManagerConfig tableDataManagerConfig,
+      String serverInstance) {
     Preconditions.checkNotNull(SERVER_METRICS);
 
     try {
@@ -47,7 +47,7 @@ public class TableDataManagerProvider {
           keyToFunction.get(tableDataManagerConfig.getTableDataManagerType().toLowerCase());
       if (cls != null) {
         TableDataManager tableDataManager = cls.newInstance();
-        tableDataManager.init(tableDataManagerConfig, SERVER_METRICS);
+        tableDataManager.init(tableDataManagerConfig, SERVER_METRICS, serverInstance);
         return tableDataManager;
       } else {
         throw new UnsupportedOperationException("No tableDataManager type found.");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -88,14 +88,16 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
   private final List<String> invertedIndexColumns;
   private Logger segmentLogger = LOGGER;
   private final SegmentVersion _segmentVersion;
+  private final RealtimeTableDataManager _realtimeTableDataManager;
 
   // An instance of this class exists only for the duration of the realtime segment that is currently being consumed.
   // Once the segment is committed, the segment is handled by OfflineSegmentDataManager
   public HLRealtimeSegmentDataManager(final RealtimeSegmentZKMetadata segmentMetadata,
       final AbstractTableConfig tableConfig, InstanceZKMetadata instanceMetadata,
-      RealtimeTableDataManager realtimeResourceManager, final String resourceDataDir, final ReadMode mode,
+      RealtimeTableDataManager realtimeTableDataManager, final String resourceDataDir, final ReadMode mode,
       final Schema schema, final ServerMetrics serverMetrics) throws Exception {
     super();
+    _realtimeTableDataManager = realtimeTableDataManager;
     final String segmentVersionStr = tableConfig.getIndexingConfig().getSegmentFormatVersion();
     _segmentVersion = SegmentVersion.fromStringOrDefault(segmentVersionStr);
     this.schema = schema;
@@ -156,7 +158,7 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
     realtimeSegment = new RealtimeSegmentImpl(schema, kafkaStreamProviderConfig.getSizeThresholdToFlushSegment(), tableName,
         segmentMetadata.getSegmentName(), kafkaStreamProviderConfig.getStreamName(), serverMetrics);
     realtimeSegment.setSegmentMetadata(segmentMetadata, this.schema);
-    notifier = realtimeResourceManager;
+    notifier = realtimeTableDataManager;
 
     segmentStatusTask = new TimerTask() {
       @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -16,143 +16,614 @@
 
 package com.linkedin.pinot.core.data.manager.realtime;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.metrics.ServerGauge;
+import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.common.segment.fetcher.SegmentFetcherFactory;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.NetUtil;
+import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.extractors.FieldExtractorFactory;
 import com.linkedin.pinot.core.data.extractors.PlainFieldExtractor;
 import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaMessageDecoder;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactoryImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
-import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
+import com.linkedin.pinot.server.realtime.ServerSegmentCompletionProtocolHandler;
 import kafka.message.MessageAndOffset;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Segment data manager for low level consumer realtime segments, which manages consumption and segment completion.
  */
 public class LLRealtimeSegmentDataManager extends SegmentDataManager {
+  private enum State {
+    // The state machine starts off with this state. While in this state we consume kafka events
+    // and index them in memory. We continue to be in this state until the end criteria is satisfied
+    // (time or number of rows)
+    INITIAL_CONSUMING,
+
+    // In this state, we consume from kafka until we reach the _finalOffset (exclusive)
+    CATCHING_UP,
+
+    // In this state, we sleep for MAX_HOLDING_TIME_MS, and the make a segmentConsumed() call to the
+    // controller.
+    HOLDING,
+
+    // We have been asked by the controller to retain the segment we have in memory at the current offset.
+    // We should build the segment, and replace it with the in-memory segment.
+    RETAINING,
+
+    // We have been asked by the controller to commit the segment at the current offset. Build the segment
+    // and make a segmentCommit() call to the controller.
+    COMMITTING,
+
+    // We have been asked to discard the in-memory segment we have. We will be serving queries, but not consuming
+    // anymore rows from kafka. We wait for a helix transition to go ONLINE, at which point, we can download the
+    // segment from the controller and replace it with the in-memory segment.
+    DISCARDED,
+
+    // We have replaced our in-memory segment with the segment that has been built locally.
+    RETAINED,
+
+    // We have committed our segment to the controller, and also replaced it locally with the constructed segment.
+    COMMITTED,
+
+    // Something went wrong, we need to download the segment when we get the ONLINE transition.
+    ERROR;
+
+    public boolean shouldConsume() {
+      if (this.equals(INITIAL_CONSUMING) || this.equals(CATCHING_UP)) {
+        return true;
+      }
+      return false;
+    }
+
+    public boolean isFinal() {
+      if (this.equals(ERROR) || this.equals(COMMITTED) || this.equals(RETAINED) || this.equals(DISCARDED)) {
+        return true;
+      }
+      return false;
+    }
+  }
   private static final Logger LOGGER = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class);
   private static final int KAFKA_MAX_FETCH_TIME_MILLIS = 1000;
 
   private final LLCRealtimeSegmentZKMetadata _segmentZKMetadata;
   private final AbstractTableConfig _tableConfig;
-  private final InstanceZKMetadata _instanceZKMetadata;
   private final RealtimeTableDataManager _realtimeTableDataManager;
-  private final String _absolutePath;
-  private final ReadMode _readMode;
+  private final String _decoderClassName;
+  private final KafkaMessageDecoder _messageDecoder;
+  private final int _segmentMaxRowCount;
+  private final String _resourceDataDir;
   private final Schema _schema;
   private final ServerMetrics _serverMetrics;
   private final RealtimeSegmentImpl _realtimeSegment;
-  private volatile boolean _stopConsuming;
-  private Thread _indexingThread;
+  private long _endOffset = Long.MAX_VALUE; // No upper limit on Kafka offset
+  private long _currentOffset;
+  private volatile State _state;
+  private int _numRowsConsumed = 0;
+  private long _startOffset = 0;
+  private long _startTimeMs = 0;
+  private final String _segmentNameStr;
+  private final SegmentVersion _segmentVersion;
 
+  // Segment end criteria
+  private long _consumeEndTime = 0;
+  private volatile long _finalOffset = -1;
+  private boolean _receivedStop = false;
+
+  // It takes 30s to locate controller leader, and more if there are multiple controller failures.
+  // For now, we let 31s pass for this state transition.
+  private final int _maxTimeForConsumingToOnlineSec = 31;
+
+  private Thread _consumerThread;
+  private final String _kafkaTopic;
+  private final int _kafkaPartitionId;
+  final String _clientId;
+  private final LLCSegmentName _segmentName;
+  private final PlainFieldExtractor _fieldExtractor;
+  private final SimpleConsumerWrapper _consumerWrapper;
+  private final File _resourceTmpDir;
+  private final String _tableName;
+  private final List<String> _invertedIndexColumns;
+  private final String _sortedColumn;
+  private Logger segmentLogger = LOGGER;
+  private final String _tableStreamName;
+  private AtomicLong _lastUpdatedRawDocuments = new AtomicLong(0);
+  private final String _instance;
+  private final ServerSegmentCompletionProtocolHandler _protocolHandler;
+
+
+  private boolean endCriteriaReached() {
+    Preconditions.checkState(_state.shouldConsume(), "Incorrect state %s", _state);
+    if (_state.equals(State.INITIAL_CONSUMING)) {
+      if (_consumeEndTime > 0) {
+        // We have a time-based constraint.
+        long now = now();
+        if (now >= _consumeEndTime) {
+          segmentLogger.info("Stopping consumption due to time limit start={} now={} numRows={}", _startTimeMs, now, _numRowsConsumed);
+          return true;
+        }
+      } else {
+        // We have a number-of-rows based constraint.
+        if (_numRowsConsumed >= _segmentMaxRowCount) {
+          segmentLogger.info("Stopping consumption due to row limit nRows={} maxNRows={}", _numRowsConsumed,
+              _segmentMaxRowCount);
+          return true;
+        }
+      }
+      return false;
+    } else if (_state.equals(State.CATCHING_UP)) {
+      if (_currentOffset == _finalOffset) {
+        segmentLogger.info("Caught up to offset {}", _finalOffset);
+        return true;
+      }
+      if (_currentOffset > _finalOffset) {
+        throw new RuntimeException("Offset higher in catchup mode: current " + _currentOffset + " final " + _finalOffset);
+      }
+    }
+    throw new RuntimeException("Unreachable");
+  }
+
+  private void consumeLoop() {
+    while(!_receivedStop && !endCriteriaReached()) {
+      // Consume for the next _kafkaReadTime ms, or we get to final offset, whichever happens earlier,
+      // Update _currentOffset upon return from this method
+      Iterable<MessageAndOffset> messagesAndOffsets = _consumerWrapper.fetchMessages(_currentOffset, _endOffset, KAFKA_MAX_FETCH_TIME_MILLIS);
+      Iterator<MessageAndOffset> msgIterator = messagesAndOffsets.iterator();
+
+      int batchSize = 0;
+      while (!_receivedStop && !endCriteriaReached() && msgIterator.hasNext()) {
+        // Get a batch of messages from Kafka
+        // Index each message
+        MessageAndOffset messageAndOffset = msgIterator.next();
+        byte[] array = messageAndOffset.message().payload().array();
+        int offset = messageAndOffset.message().payload().arrayOffset();
+        int length = messageAndOffset.message().payloadSize();
+        GenericRow row = _messageDecoder.decode(array, offset, length);
+
+        if (row != null) {
+          row = _fieldExtractor.transform(row);
+          boolean canTakeMore = _realtimeSegment.index(row);  // Ignore the boolean return
+          if (!canTakeMore) {
+            //TODO
+            // This condition can happen when we are catching up, (due to certain failure scenarios in kafka where
+            // offsets get changed with higher generation numbers for some pinot servers but not others).
+            // Also, it may be that we push in a row into the realtime segment, but it fails to index that row
+            // for some reason., so we may end up with less number of rows in the real segment. Actually, even 0 rows.
+            // In that case, we will see an exception when generating the segment.
+            // TODO We need to come up with how the system behaves in these cases and document/handle them
+            segmentLogger.warn("We got full during indexing");
+          }
+          batchSize++;
+        }
+        _currentOffset = messageAndOffset.nextOffset();
+        _numRowsConsumed++;
+      }
+      if (batchSize != 0) {
+        segmentLogger.debug("Indexed {} messages current offset {}", batchSize, _currentOffset);
+      } else {
+        // If there were no messages to be fetched from Kafka, wait for a little bit as to avoid hammering the
+        // Kafka broker
+        Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+      }
+    }
+  }
+
+  public class PartitionConsumer implements Runnable {
+    public void run() {
+      _startTimeMs = now();
+      try {
+        while (!_state.isFinal()) {
+          if (_state.shouldConsume()) {
+            consumeLoop();  // Consume until we reached the end criteria, or we are stopped.
+          }
+          if (_receivedStop) {
+            break;
+          }
+          // If we are sending segmentConsumed() to the controller, we are in HOLDING state.
+          _state = State.HOLDING;
+          SegmentCompletionProtocol.Response response = postSegmentConsumedMsg();
+          SegmentCompletionProtocol.ControllerResponseStatus status = response.getStatus();
+          long rspOffset = response.getOffset();
+          boolean success;
+          switch (status) {
+            case NOT_LEADER:
+              // Retain the same state
+              segmentLogger.warn("Got not leader response");
+              hold();
+              break;
+            case CATCH_UP:
+              if (rspOffset <= _currentOffset) {
+                // Something wrong with the controller. Back off and try again.
+                segmentLogger.error("Invalid catchup offset {} in controller response, current offset {}", rspOffset,
+                    _currentOffset);
+                hold();
+              } else {
+                _state = State.CATCHING_UP;
+                _finalOffset = rspOffset;
+                // We will restart consumption when we loop back above.
+              }
+              break;
+            case HOLD:
+              hold();
+              break;
+            case DISCARD:
+              // Keep this in memory, but wait for the online transition, and download when it comes in.
+              _state = State.DISCARDED;
+              break;
+            case KEEP:
+              _state = State.RETAINING;
+              success = buildSegmentAndReplace();
+              if (success) {
+                _state = State.RETAINED;
+              } else {
+                // Could not build segment for some reason. We can only download it.
+                _state = State.ERROR;
+              }
+              break;
+            case COMMIT:
+              _state = State.COMMITTING;
+              success = buildSegment(true);
+              if (!success) {
+                // We could not build the segment. Go into error state.
+                _state = State.ERROR;
+              } else {
+                success = commitSegment();
+                if (success) {
+                  _state = State.COMMITTED;
+                } else {
+                  // Back off and retry from holding state again.
+                  hold();
+                }
+              }
+              break;
+            default:
+              segmentLogger.error("Holding after response from Controller: {}", response.toJsonString());
+              hold();
+              break;
+          }
+        }
+      } catch (Exception e) {
+        segmentLogger.error("Exception while in work", e);
+        _state = State.ERROR;
+      }
+    }
+  }
+
+  private File makeSegmentDirPath() {
+    return new File(_resourceDataDir, _segmentZKMetadata.getSegmentName());
+  }
+
+  /**
+   *
+   * @param buildTgz true if you want the method to also build tgz file
+   * @return true if all succeeds.
+   */
+  private boolean buildSegment(boolean buildTgz) {
+    // Build a segment from in-memory rows.If buildTgz is true, then build the tar.gz file as well
+    // TODO Use an auto-closeable objec to delete temp resources.
+    File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + _segmentNameStr + "-" + String.valueOf(now()));
+
+    // lets convert the segment now
+    RealtimeSegmentConverter converter =
+        new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
+            _segmentZKMetadata.getTableName(), _segmentZKMetadata.getSegmentName(), _sortedColumn, _invertedIndexColumns);
+
+    logStatistics();
+    segmentLogger.info("Trying to build segment");
+    final long buildStartTime = now();
+    try {
+      converter.build(_segmentVersion);
+    } catch (Exception e) {
+      segmentLogger.error("Could not build segment", e);
+      FileUtils.deleteQuietly(tempSegmentFolder);
+      return false;
+    }
+    final long buildEndTime = now();
+    segmentLogger.info("Successfully built segment in {} ms", (buildEndTime - buildStartTime));
+    File destDir = makeSegmentDirPath();
+    FileUtils.deleteQuietly(destDir);
+    try {
+      FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], destDir);
+      if (buildTgz) {
+        TarGzCompressionUtils.createTarGzOfDirectory(destDir.getAbsolutePath());
+      }
+    } catch (IOException e) {
+      segmentLogger.error("Exception during move/tar segment", e);
+      FileUtils.deleteQuietly(tempSegmentFolder);
+      return false;
+    }
+    FileUtils.deleteQuietly(tempSegmentFolder);
+    return true;
+  }
+
+  private boolean commitSegment() {
+    // Send segmentCommit() to the controller
+    // if that succeeds, swap in-memory segment with the one built.
+    File destSeg = makeSegmentDirPath();
+    final String segTarFileName = destSeg.getAbsolutePath() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENTION;
+    try {
+      _protocolHandler.segmentCommit(_currentOffset, _segmentNameStr, new File(segTarFileName));
+    } catch (FileNotFoundException e) {
+      segmentLogger.error("Tar file {} not found", segTarFileName, e);
+      return false;
+    }
+    return true;
+  }
+
+  private boolean buildSegmentAndReplace() {
+    boolean success = buildSegment(false);
+    if (!success) {
+      return success;
+    }
+    _realtimeTableDataManager.replaceLLSegment(_segmentZKMetadata.getSegmentName());
+    return true;
+  }
+
+  private void hold() {
+    try {
+      Thread.sleep(SegmentCompletionProtocol.MAX_HOLD_TIME_MS);
+    } catch (InterruptedException e) {
+      segmentLogger.warn("Interrupted while holding");
+    }
+  }
+
+  private SegmentCompletionProtocol.Response postSegmentConsumedMsg() {
+    // Post segmentConsumed to current leader.
+    // Retry maybe once if leader is not found.
+    return _protocolHandler.segmentConsumed(_segmentNameStr, _currentOffset);
+  }
+
+  public void goOnlineFromConsuming(RealtimeSegmentZKMetadata metadata) throws InterruptedException {
+    // Takes 30s max to locate a new controller (more if there are multiple controller failures)
+    // set the timeout to 31s;
+    final long transitionStartTimeMs = now();
+    long timeoutMs =_maxTimeForConsumingToOnlineSec * 1000L;
+    LLCRealtimeSegmentZKMetadata llcMetadata = (LLCRealtimeSegmentZKMetadata)metadata;
+    final long endOffset = llcMetadata.getEndOffset();
+    stop(timeoutMs);
+    long now = now();
+    timeoutMs -= (now - transitionStartTimeMs);
+    if (timeoutMs <= 0) {
+      // we could not get it to stop. Throw an exception and let it go to error state.
+      throw new RuntimeException("Could not get to stop consumer thread" + _consumerThread);
+    }
+
+    switch (_state) {
+      case COMMITTED:
+      case RETAINED:
+        // Nothing to do. we already built local segment and swapped it with in-memory data.
+        break;
+      case DISCARDED:
+      case ERROR:
+        downloadSegmentAndReplace(llcMetadata);
+        break;
+      case CATCHING_UP:
+      case HOLDING:
+        // Allow to catch up upto final offset, and then replace.
+        if (_currentOffset > endOffset) {
+          // We moved ahead of the offset that is committed in ZK.
+          segmentLogger.warn("Current offset {} ahead of the offset in zk {}", _currentOffset, endOffset);
+          downloadSegmentAndReplace(llcMetadata);
+        } else {
+          boolean success = catchupToFinalOffset(endOffset, timeoutMs);
+          if (success) {
+            buildSegmentAndReplace();
+          } else {
+            downloadSegmentAndReplace(llcMetadata);
+          }
+        }
+        break;
+      default:
+        downloadSegmentAndReplace(llcMetadata);
+        break;
+    }
+  }
+
+  private void downloadSegmentAndReplace(LLCRealtimeSegmentZKMetadata metadata) {
+    File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + String.valueOf(now()));
+    File tempFile = new File(_resourceTmpDir, _segmentNameStr + ".tar.gz");
+    String uri = metadata.getDownloadUrl();
+    try {
+      SegmentFetcherFactory.getSegmentFetcherBasedOnURI(uri).fetchSegmentToLocal(uri, tempFile);
+      segmentLogger.info("Downloaded file from {} to {}; Length of downloaded file: {}", uri, tempFile,
+          tempFile.length());
+      TarGzCompressionUtils.unTar(tempFile, tempSegmentFolder);
+      FileUtils.deleteQuietly(tempFile);
+      FileUtils.moveDirectory(tempSegmentFolder, new File(_resourceTmpDir, _segmentNameStr));
+      _realtimeTableDataManager.replaceLLSegment(_segmentNameStr);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      FileUtils.deleteQuietly(tempSegmentFolder);
+    }
+  }
+
+  private long now() {
+    return System.currentTimeMillis();
+  }
+
+  private boolean catchupToFinalOffset(long endOffset, long timeoutMs) {
+    _finalOffset = endOffset;
+    _consumeEndTime = now() + timeoutMs;
+    consumeLoop();
+    if (_currentOffset != endOffset) {
+      // Timeout?
+      segmentLogger.error("Could not consume up to {} (current offset {})", endOffset, _currentOffset);
+      return false;
+    }
+
+    return true;
+  }
+
+  public void destroy() {
+    try {
+      stop(0);
+    } catch (InterruptedException e) {
+      segmentLogger.error("Could not stop consumer thread");
+    }
+    _realtimeSegment.destroy();
+  }
+
+  public void start() {
+    _state = State.INITIAL_CONSUMING;
+    _consumerThread = new Thread(new PartitionConsumer(), "consumer_" + _kafkaTopic + "_" + _kafkaPartitionId + "_" + _startOffset);
+    segmentLogger.info("Created new consumer thread {} for {}", _consumerThread, this.toString());
+    _consumerThread.start();
+  }
+
+  /**
+   * Stop the consuming thread.
+   * @param ms max number of millis allowed to wait. If 0, then no limit.
+   */
+  public void stop(long ms) throws InterruptedException {
+    _receivedStop = true;
+    _consumerThread.join(ms);
+  }
+
+  // Assume that this is called only on OFFLINE to CONSUMING transition.
+  // If the transition is OFFLINE to ONLINE, the caller should have downloaded the segment and we don't reach here.
   public LLRealtimeSegmentDataManager(RealtimeSegmentZKMetadata segmentZKMetadata, AbstractTableConfig tableConfig,
-      InstanceZKMetadata instanceZKMetadata, RealtimeTableDataManager realtimeTableDataManager, String absolutePath,
+      InstanceZKMetadata instanceZKMetadata, RealtimeTableDataManager realtimeTableDataManager, String resourceDataDir,
       ReadMode readMode, Schema schema, ServerMetrics serverMetrics) throws Exception {
     _segmentZKMetadata = (LLCRealtimeSegmentZKMetadata) segmentZKMetadata;
     _tableConfig = tableConfig;
-    _instanceZKMetadata = instanceZKMetadata;
     _realtimeTableDataManager = realtimeTableDataManager;
-    _absolutePath = absolutePath;
-    _readMode = readMode;
+    _resourceDataDir = resourceDataDir;
     _schema = schema;
     _serverMetrics = serverMetrics;
+    _segmentVersion = SegmentVersion.fromStringOrDefault(tableConfig.getIndexingConfig().getSegmentFormatVersion());
+    _instance = _realtimeTableDataManager.getServerInstance();
+    _protocolHandler = new ServerSegmentCompletionProtocolHandler(_instance);
 
-    // Load configs
     // TODO Validate configs
-    final String bootstrapNodes = _tableConfig.getIndexingConfig().getStreamConfigs()
+    IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
+    KafkaHighLevelStreamProviderConfig kafkaStreamProviderConfig = new KafkaHighLevelStreamProviderConfig();
+    kafkaStreamProviderConfig.init(tableConfig, instanceZKMetadata, schema);
+    final String bootstrapNodes = indexingConfig.getStreamConfigs()
         .get(CommonConstants.Helix.DataSource.STREAM_PREFIX + "." + CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST);
-    final String kafkaTopic = _tableConfig.getIndexingConfig().getStreamConfigs()
-        .get(CommonConstants.Helix.DataSource.STREAM_PREFIX + "." + CommonConstants.Helix.DataSource.Realtime.Kafka.TOPIC_NAME);
-    final LLCSegmentName segmentName = new LLCSegmentName(_segmentZKMetadata.getSegmentName());
-    final int kafkaPartitionId = segmentName.getPartitionId();
-    final String decoderClassName = _tableConfig.getIndexingConfig().getStreamConfigs()
+    _kafkaTopic = kafkaStreamProviderConfig.getTopicName();
+    _segmentNameStr = _segmentZKMetadata.getSegmentName();
+    _segmentName = new LLCSegmentName(_segmentNameStr);
+    _kafkaPartitionId = _segmentName.getPartitionId();
+    _decoderClassName = indexingConfig.getStreamConfigs()
         .get(CommonConstants.Helix.DataSource.STREAM_PREFIX + "." + CommonConstants.Helix.DataSource.Realtime.Kafka.DECODER_CLASS);
-    final int segmentMaxRowCount = Integer.parseInt(_tableConfig.getIndexingConfig().getStreamConfigs().get(
+    _segmentMaxRowCount = Integer.parseInt(_tableConfig.getIndexingConfig().getStreamConfigs().get(
         CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE));
+    _tableName = _tableConfig.getTableName();
+    segmentLogger = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class.getName() +
+        "_" + _segmentNameStr);
+    if (indexingConfig.getSortedColumn().isEmpty()) {
+      segmentLogger.info("RealtimeDataResourceZKMetadata contains no information about sorted column for segment {}",
+          _segmentName);
+      _sortedColumn = null;
+    } else {
+      String firstSortedColumn = indexingConfig.getSortedColumn().get(0);
+      if (_schema.hasColumn(firstSortedColumn)) {
+        segmentLogger.info("Setting sorted column name: {} from RealtimeDataResourceZKMetadata for segment {}",
+            firstSortedColumn, _segmentName);
+        _sortedColumn = firstSortedColumn;
+      } else {
+        segmentLogger.warn(
+            "Sorted column name: {} from RealtimeDataResourceZKMetadata is not existed in schema for segment {}.",
+            firstSortedColumn, _segmentName);
+        _sortedColumn = null;
+      }
+    }
+    //inverted index columns
+    _invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    _tableStreamName = _tableName + "_" + kafkaStreamProviderConfig.getStreamName();
+
 
     // Start new realtime segment
-    _realtimeSegment = new RealtimeSegmentImpl(schema, segmentMaxRowCount, tableConfig.getTableName(),
-        segmentZKMetadata.getSegmentName(), kafkaTopic, serverMetrics);
+    _realtimeSegment = new RealtimeSegmentImpl(schema, _segmentMaxRowCount, tableConfig.getTableName(),
+        segmentZKMetadata.getSegmentName(), _kafkaTopic, _serverMetrics);
     _realtimeSegment.setSegmentMetadata(segmentZKMetadata, schema);
 
     // Create message decoder
-    final KafkaMessageDecoder messageDecoder = (KafkaMessageDecoder) Class.forName(decoderClassName).newInstance();
-    messageDecoder.init(new HashMap<String, String>(), _schema, kafkaTopic);
+    _messageDecoder = (KafkaMessageDecoder) Class.forName(_decoderClassName).newInstance();
+    _messageDecoder.init(new HashMap<String, String>(), _schema, _kafkaTopic);
+    _clientId = _kafkaPartitionId + "-" + NetUtil.getHostnameOrAddress();
 
     // Create field extractor
-    final PlainFieldExtractor fieldExtractor = (PlainFieldExtractor) FieldExtractorFactory.getPlainFieldExtractor(schema);
+    _fieldExtractor = (PlainFieldExtractor) FieldExtractorFactory.getPlainFieldExtractor(schema);
+    _consumerWrapper = SimpleConsumerWrapper.forPartitionConsumption(new KafkaSimpleConsumerFactoryImpl(),
+        bootstrapNodes, _clientId, _kafkaTopic, _kafkaPartitionId);
+    _currentOffset = _segmentZKMetadata.getStartOffset();
+    _resourceTmpDir = new File(resourceDataDir, "_tmp");
+    if (!_resourceTmpDir.exists()) {
+      _resourceTmpDir.mkdirs();
+    }
+    start();
+  }
 
-    // Start indexing thread
-    _indexingThread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          // Create Kafka consumer
-          String clientId = kafkaPartitionId + "-" + NetUtil.getHostnameOrAddress();
-          SimpleConsumerWrapper consumerWrapper =
-              SimpleConsumerWrapper.forPartitionConsumption(new KafkaSimpleConsumerFactoryImpl(), bootstrapNodes,
-                  clientId, kafkaTopic, kafkaPartitionId);
-
-          // TODO Check for limit conditions (eg. stop consuming due to CONSUMING -> ONLINE state transition)
-          boolean notFull = true;
-          long currentOffset = _segmentZKMetadata.getStartOffset();
-
-          while (notFull) {
-            // Get a batch of messages from Kafka
-            final long endOffset = Long.MAX_VALUE; // No upper limit on Kafka offset
-            Iterable<MessageAndOffset> messagesAndOffsets =
-                consumerWrapper.fetchMessages(currentOffset, endOffset, KAFKA_MAX_FETCH_TIME_MILLIS);
-
-            // Index each message
-            int batchSize = 0;
-            for (MessageAndOffset messageAndOffset : messagesAndOffsets) {
-              byte[] array = messageAndOffset.message().payload().array();
-              int offset = messageAndOffset.message().payload().arrayOffset();
-              int length = messageAndOffset.message().payloadSize();
-              GenericRow row = messageDecoder.decode(array, offset, length);
-
-              if (row != null) {
-                row = fieldExtractor.transform(row);
-                notFull = _realtimeSegment.index(row);
-                batchSize++;
-              }
-              currentOffset = messageAndOffset.nextOffset();
-            }
-
-            if (batchSize != 0) {
-              LOGGER.debug("Indexed {} messages from partition {}, current offset {}", batchSize, kafkaPartitionId,
-                  currentOffset);
-            } else {
-              // If there were no messages to be fetched from Kafka, wait for a little bit as to avoid hammering the
-              // Kafka broker
-              Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-            }
-          }
-
-          // TODO Run the segment completion protocol here, flush the segment and such
-        } catch (Exception e) {
-          LOGGER.error("Caught exception while indexing events", e);
-        }
+  private void logStatistics() {
+    int numErrors, numConversions, numNulls, numNullCols;
+    if ((numErrors = _fieldExtractor.getTotalErrors()) > 0) {
+      _serverMetrics.addMeteredTableValue(_tableStreamName,
+          ServerMeter.ROWS_WITH_ERRORS, (long) numErrors);
+    }
+    Map<String, Integer> errorCount = _fieldExtractor.getError_count();
+    for (String column : errorCount.keySet()) {
+      if ((numErrors = errorCount.get(column)) > 0) {
+        segmentLogger.warn("Column {} had {} rows with errors", column, numErrors);
       }
-    }, "Realtime indexing thread for " + _segmentZKMetadata.getSegmentName());
-    _indexingThread.start();
+    }
+    if ((numConversions = _fieldExtractor.getTotalConversions()) > 0) {
+      _serverMetrics.addMeteredTableValue(_tableStreamName,
+          ServerMeter.ROWS_NEEDING_CONVERSIONS, (long) numConversions);
+      segmentLogger.info("{} rows needed conversions ", numConversions);
+    }
+    if ((numNulls = _fieldExtractor.getTotalNulls()) > 0) {
+      _serverMetrics.addMeteredTableValue(_tableStreamName,
+          ServerMeter.ROWS_WITH_NULL_VALUES, (long) numNulls);
+      segmentLogger.info("{} rows had null columns", numNulls);
+    }
+    if ((numNullCols = _fieldExtractor.getTotalNullCols()) > 0) {
+      _serverMetrics.addMeteredTableValue(_tableStreamName,
+          ServerMeter.COLUMNS_WITH_NULL_VALUES, (long) numNullCols);
+      segmentLogger.info("{} columns had null values", numNullCols);
+    }
+  }
+
+  // This should be done during commit? We may not always commit when we build a segment....
+  // TODO Call this method when we are loading the segment, which we do from table datamanager afaik
+  private void updateCurrentDocumentCountMetrics() {
+    int currentRawDocs = _realtimeSegment.getRawDocumentCount();
+    _serverMetrics.addValueToTableGauge(_tableName, ServerGauge.DOCUMENT_COUNT, (currentRawDocs - _lastUpdatedRawDocuments
+        .get()));
+    _lastUpdatedRawDocuments.set(currentRawDocs);
   }
 
   @Override
@@ -162,16 +633,6 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
 
   @Override
   public String getSegmentName() {
-    return _realtimeSegment.getSegmentName();
-  }
-
-  @Override
-  public void destroy() {
-    // TODO Implement!
-  }
-
-  public void goOnlineFromConsuming() {
-    // TODO Implement CONSUMING -> ONLINE state transition
-    LOGGER.error("CONSUMING -> ONLINE state transition not implemented");
+    return _segmentNameStr;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
-import static com.linkedin.pinot.common.utils.EqualityUtils.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -25,6 +24,10 @@ import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.stream.KafkaStreamMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.core.realtime.StreamProviderConfig;
+import static com.linkedin.pinot.common.utils.EqualityUtils.hashCodeOf;
+import static com.linkedin.pinot.common.utils.EqualityUtils.isEqual;
+import static com.linkedin.pinot.common.utils.EqualityUtils.isNullOrNotSameClass;
+import static com.linkedin.pinot.common.utils.EqualityUtils.isSameReference;
 import kafka.consumer.ConsumerConfig;
 
 
@@ -162,7 +165,10 @@ public class KafkaHighLevelStreamProviderConfig implements StreamProviderConfig 
   @Override
   public void init(AbstractTableConfig tableConfig, InstanceZKMetadata instanceMetadata, Schema schema) {
     this.indexingSchema = schema;
-    this.groupId = instanceMetadata.getGroupId(tableConfig.getTableName());
+    if (instanceMetadata != null) {
+      // For LL segments, instanceZkMetadata will be null
+      this.groupId = instanceMetadata.getGroupId(tableConfig.getTableName());
+    }
     KafkaStreamMetadata kafkaMetadata = new KafkaStreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
     this.kafkaTopicName = kafkaMetadata.getKafkaTopicName();
     this.decodeKlass = kafkaMetadata.getDecoderClass();

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -32,8 +32,6 @@ import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
 import org.apache.commons.httpclient.methods.multipart.Part;
 import org.apache.commons.httpclient.methods.multipart.PartSource;
 import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.apache.helix.InstanceType;
-import org.apache.helix.manager.zk.ZKHelixManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
@@ -52,11 +50,11 @@ public class ServerSegmentCompletionProtocolHandler {
     _instance = instance;
   }
 
-  public SegmentCompletionProtocol.Response segmentCommit(long offset, final File segmentTarFile) throws FileNotFoundException {
-    SegmentCompletionProtocol.SegmentCommitRequest request = new SegmentCompletionProtocol.SegmentCommitRequest(segmentTarFile.getName(), offset, _instance);
+  public SegmentCompletionProtocol.Response segmentCommit(long offset, final String segmentName, final File segmentTarFile) throws FileNotFoundException {
+    SegmentCompletionProtocol.SegmentCommitRequest request = new SegmentCompletionProtocol.SegmentCommitRequest(segmentName, offset, _instance);
     final InputStream inputStream = new FileInputStream(segmentTarFile);
     Part[] parts = {
-        new FilePart(segmentTarFile.getName(), new PartSource() {
+        new FilePart(segmentName, new PartSource() {
           @Override
           public long getLength() {
             return segmentTarFile.length();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/offline/OfflineTableDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/offline/OfflineTableDataManagerTest.java
@@ -15,9 +15,6 @@
  */
 package com.linkedin.pinot.core.offline;
 
-import com.google.common.collect.ImmutableList;
-import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -36,6 +33,8 @@ import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
+import com.google.common.collect.ImmutableList;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
@@ -45,6 +44,7 @@ import com.linkedin.pinot.core.data.manager.offline.OfflineTableDataManager;
 import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
 import com.linkedin.pinot.core.data.manager.offline.TableDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.yammer.metrics.core.MetricsRegistry;
 import static org.mockito.Mockito.*;
 
 
@@ -112,7 +112,7 @@ public class OfflineTableDataManagerTest {
       when(config.getReadMode()).thenReturn(readMode.toString());
       when(config.getIndexLoadingConfigMetadata()).thenReturn(null);
     }
-    tableDataManager.init(config, new ServerMetrics(new MetricsRegistry()));
+    tableDataManager.init(config, new ServerMetrics(new MetricsRegistry()), null);
     tableDataManager.start();
     Field segsMapField = AbstractTableDataManager.class.getDeclaredField("_segmentsMap");
     segsMapField.setAccessible(true);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -288,7 +288,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
             KafkaStarterUtils.DEFAULT_ZK_STR, KafkaStarterUtils.getDefaultKafkaConfiguration());
 
     // Create Kafka topic
-    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR);
+    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR, 10);
 
     // Start the Pinot cluster
     startController(true);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
@@ -468,7 +468,7 @@ public abstract class HybridClusterScanComparisonIntegrationTest extends HybridC
     // Drop and recreate the Kafka topic
     KafkaStarterUtils.deleteTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR);
     Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
-    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR);
+    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR, 10);
 
     // Recreate the realtime table
     addRealtimeTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", 900, "Days", KafkaStarterUtils.DEFAULT_ZK_STR,

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -15,10 +15,10 @@
  */
 package com.linkedin.pinot.integration.tests;
 
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import java.io.File;
 import java.util.Collections;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 
 
 /**
@@ -26,11 +26,16 @@ import java.util.Collections;
  *
  */
 public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegrationTest {
+  private static int KAFKA_PARTITION_COUNT = 2;
   protected void setUpTable(String tableName, String timeColumnName, String timeColumnType, String kafkaZkUrl,
       String kafkaTopic, File schemaFile, File avroFile) throws Exception {
     Schema schema = Schema.fromFile(schemaFile);
     addSchema(schemaFile, schema.getSchemaName());
     addLLCRealtimeTable(tableName, timeColumnName, timeColumnType, -1, "", KafkaStarterUtils.DEFAULT_KAFKA_BROKER, kafkaTopic, schema.getSchemaName(),
         null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier", Collections.<String>emptyList(), "mmap");
+  }
+
+  protected void createKafkaTopic(String kafkaTopic, String zkStr) {
+    KafkaStarterUtils.createTopic(kafkaTopic, zkStr, KAFKA_PARTITION_COUNT);
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -23,18 +23,15 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import kafka.server.KafkaServerStartable;
-
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
+import kafka.server.KafkaServerStartable;
 
 
 /**
@@ -68,7 +65,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
             KafkaStarterUtils.DEFAULT_ZK_STR, KafkaStarterUtils.getDefaultKafkaConfiguration());
 
     // Create Kafka topic
-    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR);
+    createKafkaTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR);
 
     // Start the Pinot cluster
     startController();
@@ -108,6 +105,10 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
     rs.close();
 
     waitForRecordCountToStabilizeToExpectedCount(h2RecordCount, timeInFiveMinutes);
+  }
+
+  protected void createKafkaTopic(String kafkaTopic, String zkStr) {
+    KafkaStarterUtils.createTopic(kafkaTopic, zkStr, 10);
   }
 
   @Override

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkRealtimeConsumptionSpeed.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkRealtimeConsumptionSpeed.java
@@ -19,11 +19,9 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.TestUtils;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
-import com.linkedin.pinot.integration.tests.BaseClusterIntegrationTest;
 import com.linkedin.pinot.integration.tests.OfflineClusterIntegrationTest;
 import com.linkedin.pinot.integration.tests.RealtimeClusterIntegrationTest;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -63,7 +61,7 @@ public class BenchmarkRealtimeConsumptionSpeed extends RealtimeClusterIntegratio
             KafkaStarterUtils.DEFAULT_ZK_STR, KafkaStarterUtils.getDefaultKafkaConfiguration());
 
     // Create Kafka topic
-    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR);
+    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR, 10);
 
     // Unpack data (needed to get the Avro schema)
     TarGzCompressionUtils.unTar(

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/RealtimeStressTest.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/RealtimeStressTest.java
@@ -61,7 +61,7 @@ public class RealtimeStressTest extends RealtimeClusterIntegrationTest {
             KafkaStarterUtils.DEFAULT_ZK_STR, KafkaStarterUtils.getDefaultKafkaConfiguration());
 
     // Create Kafka topic
-    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR);
+    KafkaStarterUtils.createTopic(KAFKA_TOPIC, KafkaStarterUtils.DEFAULT_ZK_STR, 10);
 
     // Unpack data (needed to get the Avro schema)
     TarGzCompressionUtils.unTar(

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -165,7 +165,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       LOGGER.info("Trying to add TableDataManager for table name: " + tableName);
       synchronized (_globalLock) {
         if (!_tableDataManagerMap.containsKey(tableName)) {
-          addTableIfNeed(tableConfig, tableName);
+          addTableIfNeed(tableConfig, tableName, null);
         }
       }
     }
@@ -176,7 +176,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   // Called for real-time segments only
   @Override
   public synchronized void addSegment(ZkHelixPropertyStore<ZNRecord> propertyStore, AbstractTableConfig tableConfig,
-      InstanceZKMetadata instanceZKMetadata, SegmentZKMetadata segmentZKMetadata) throws Exception {
+      InstanceZKMetadata instanceZKMetadata, SegmentZKMetadata segmentZKMetadata, String serverInstance) throws Exception {
     if (segmentZKMetadata == null || segmentZKMetadata.getTableName() == null) {
       throw new RuntimeException("Error: adding invalid SegmentMetadata!");
     }
@@ -192,7 +192,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       LOGGER.info("Trying to add TableDataManager for table name: " + tableName);
       synchronized (_globalLock) {
         if (!_tableDataManagerMap.containsKey(tableName)) {
-          addTableIfNeed(tableConfig, tableName);
+          addTableIfNeed(tableConfig, tableName, serverInstance);
         }
       }
     }
@@ -202,13 +202,13 @@ public class HelixInstanceDataManager implements InstanceDataManager {
 
   }
 
-  public synchronized void addTableIfNeed(AbstractTableConfig tableConfig, String tableName)
+  public synchronized void addTableIfNeed(AbstractTableConfig tableConfig, String tableName, String serverInstance)
       throws ConfigurationException {
     TableDataManagerConfig tableDataManagerConfig = getDefaultHelixTableDataManagerConfig(tableName);
     if (tableConfig != null) {
       tableDataManagerConfig.overrideConfigs(tableName, tableConfig);
     }
-    TableDataManager tableDataManager = TableDataManagerProvider.getTableDataManager(tableDataManagerConfig);
+    TableDataManager tableDataManager = TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, serverInstance);
     tableDataManager.start();
     addTableDataManager(tableName, tableDataManager);
   }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/HybridQuickstart.java
@@ -106,7 +106,7 @@ public class HybridQuickstart {
         KafkaStarterUtils.startServer(KafkaStarterUtils.DEFAULT_KAFKA_PORT, KafkaStarterUtils.DEFAULT_BROKER_ID,
             KafkaStarterUtils.DEFAULT_ZK_STR, KafkaStarterUtils.getDefaultKafkaConfiguration());
 
-    KafkaStarterUtils.createTopic("airlineStatsEvents", KafkaStarterUtils.DEFAULT_ZK_STR);
+    KafkaStarterUtils.createTopic("airlineStatsEvents", KafkaStarterUtils.DEFAULT_ZK_STR, 10);
   }
 
   public void execute() throws JSONException, Exception {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/RealtimeQuickStart.java
@@ -15,21 +15,17 @@
  */
 package com.linkedin.pinot.tools;
 
-import static com.linkedin.pinot.tools.Quickstart.prettyprintResponse;
-import static com.linkedin.pinot.tools.Quickstart.printStatus;
-
 import java.io.File;
-
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
-
 import com.google.common.collect.Lists;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.tools.Quickstart.color;
 import com.linkedin.pinot.tools.admin.command.QuickstartRunner;
 import com.linkedin.pinot.tools.streams.MeetupRsvpStream;
-
+import static com.linkedin.pinot.tools.Quickstart.prettyprintResponse;
+import static com.linkedin.pinot.tools.Quickstart.printStatus;
 import kafka.server.KafkaServerStartable;
 
 
@@ -63,7 +59,7 @@ public class RealtimeQuickStart {
         KafkaStarterUtils.startServer(KafkaStarterUtils.DEFAULT_KAFKA_PORT, KafkaStarterUtils.DEFAULT_BROKER_ID,
             KafkaStarterUtils.DEFAULT_ZK_STR, KafkaStarterUtils.getDefaultKafkaConfiguration());
 
-    KafkaStarterUtils.createTopic("meetupRSVPEvents", KafkaStarterUtils.DEFAULT_ZK_STR);
+    KafkaStarterUtils.createTopic("meetupRSVPEvents", KafkaStarterUtils.DEFAULT_ZK_STR, 10);
 
     File tempDir = new File("/tmp/" + String.valueOf(System.currentTimeMillis()));
 


### PR DESCRIPTION
Main changes are in LLRealtimeSegmentDataManager to support server-side state machine for
segment completion.

Other changes are:
- Passing around server helix instance ID so that it is available for segment completion protocol.
- Changing the number of partitions for integration test so that we can have some ONLINE segments
  as well as some consuming segments

There are still TODOs.
Unit tests pending, will be added in the next check-in, maybe after some re-factoring