### PR TITLE
fix for ratio metric display on time-series

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -39,6 +39,11 @@ function getAnomalies(tab) {
             }
             renderAnomalyLineChart(timeSeriesData, anomalyData, tab);
             renderAnomalyTable(anomalyData, tab);
+
+            //anomalyFunctionId is only present in hash when anomaly
+            // function run adhoc was requested on self service tab
+            //needs to be removed to be able to view other functions in later queries on the anomalies view
+            delete hash.anomalyFunctionId
         });
     });
 };
@@ -148,7 +153,7 @@ function drawAnomalyTimeSeries(timeSeriesData, anomalyData, tab) {
             y: {
                 tick: {
                     //format integers with comma-grouping for thousands
-                    format: d3.format(',.0f')
+                    format: d3.format(",.1 ")
                 }
             }
         },

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/contributors.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/contributors.js
@@ -177,7 +177,7 @@ function renderContributionTimeSeries(ajaxData) {
                     y: {
                         tick: {
                             //format integers with comma-grouping for thousands
-                            format: d3.format(',.0f')
+                            format: d3.format(",.1 ")
                         }
                     }
                 },

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/tabular.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/tabular.js
@@ -169,7 +169,7 @@ function drawTimeSeries(timeSeriesData, tab) {
             y: {
                 tick: {
                     //format integers with comma-grouping for thousands
-                    format: d3.format(',.0f')
+                    format: d3.format(",.1 ")
                 }
             }
         },

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/timeseries.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/timeseries.js
@@ -69,7 +69,7 @@ function renderTimeSeriesUsingC3(d, tab) {  //time-series-area
             y: {
                 tick: {
                     //format integers with comma-grouping for thousands
-                    format: d3.format(',.0f')
+                    format: d3.format(",.1 ")
                 }
             }
         },


### PR DESCRIPTION
 changing time series tick-format to display 1 digit decimal precision while trimming insignificant trailing zeros