### PR TITLE
Add Kafka leader broker lookup and connection

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/KafkaStarterUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/KafkaStarterUtils.java
@@ -17,6 +17,8 @@ package com.linkedin.pinot.common.utils;
 
 import java.io.File;
 import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.commons.io.FileUtils;
@@ -45,6 +47,17 @@ public class KafkaStarterUtils {
     configureHostName(configuration, "localhost");
 
     return configuration;
+  }
+
+  public static List<KafkaServerStartable> startServers(final int brokerCount, final int port, final String zkStr,
+      final Properties configuration) {
+    List<KafkaServerStartable> startables = new ArrayList<>(brokerCount);
+
+    for (int i = 0; i < brokerCount; i++) {
+      startables.add(startServer(port + i, i, zkStr, "/tmp/kafka-" + Double.toHexString(Math.random()), configuration));
+    }
+
+    return startables;
   }
 
   public static KafkaServerStartable startServer(final int port, final int brokerId, final String zkStr,

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -27,6 +27,7 @@ import com.linkedin.pinot.common.utils.KafkaStarterUtils;
  */
 public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegrationTest {
   private static int KAFKA_PARTITION_COUNT = 2;
+
   protected void setUpTable(String tableName, String timeColumnName, String timeColumnType, String kafkaZkUrl,
       String kafkaTopic, File schemaFile, File avroFile) throws Exception {
     Schema schema = Schema.fromFile(schemaFile);
@@ -37,5 +38,10 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
 
   protected void createKafkaTopic(String kafkaTopic, String zkStr) {
     KafkaStarterUtils.createTopic(kafkaTopic, zkStr, KAFKA_PARTITION_COUNT);
+  }
+
+  @Override
+  protected int getKafkaBrokerCount() {
+    return 2;
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -46,7 +46,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
   private static final int SEGMENT_COUNT = 12;
   public static final int QUERY_COUNT = 1000;
   protected static final int ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH = 20000;
-  private KafkaServerStartable kafkaStarter;
+  private List<KafkaServerStartable> kafkaStarters;
 
   protected void setUpTable(String tableName, String timeColumnName, String timeColumnType, String kafkaZkUrl,
       String kafkaTopic, File schemaFile, File avroFile) throws Exception {
@@ -60,8 +60,8 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
   public void setUp() throws Exception {
     // Start ZK and Kafka
     startZk();
-    kafkaStarter =
-        KafkaStarterUtils.startServer(KafkaStarterUtils.DEFAULT_KAFKA_PORT, KafkaStarterUtils.DEFAULT_BROKER_ID,
+    kafkaStarters =
+        KafkaStarterUtils.startServers(getKafkaBrokerCount(), KafkaStarterUtils.DEFAULT_KAFKA_PORT,
             KafkaStarterUtils.DEFAULT_ZK_STR, KafkaStarterUtils.getDefaultKafkaConfiguration());
 
     // Create Kafka topic
@@ -107,6 +107,10 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
     waitForRecordCountToStabilizeToExpectedCount(h2RecordCount, timeInFiveMinutes);
   }
 
+  protected int getKafkaBrokerCount() {
+    return 1;
+  }
+
   protected void createKafkaTopic(String kafkaTopic, String zkStr) {
     KafkaStarterUtils.createTopic(kafkaTopic, zkStr, 10);
   }
@@ -148,7 +152,9 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
     stopBroker();
     stopController();
     stopServer();
-    KafkaStarterUtils.stopServer(kafkaStarter);
+    for (KafkaServerStartable kafkaStarter : kafkaStarters) {
+      KafkaStarterUtils.stopServer(kafkaStarter);
+    }
     try {
       stopZk();
     } catch (Exception e) {


### PR DESCRIPTION
Add support for looking up the current Kafka leader broker for a
partition and connect to it transparently. Updated integration test to
start more than one broker and confirm that the code looks up and
connects to a different broker than the initial one.