### PR TITLE
Improve invalid replicasPerPartition error message

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -194,7 +194,21 @@ public class PinotTableIdealStateBuilder {
       create = true;
     }
     LOGGER.info("Assigning partitions to instances for simple consumer for table {}", realtimeTableName);
-    final int nReplicas = Integer.valueOf(realtimeTableConfig.getValidationConfig().getReplicasPerPartition());
+
+    final String replicasPerPartition = realtimeTableConfig.getValidationConfig().getReplicasPerPartition();
+
+    if (replicasPerPartition == null || replicasPerPartition.isEmpty()) {
+      throw new RuntimeException("Invalid value for replicasPerPartition, expected a number: " + replicasPerPartition);
+    }
+
+    final int nReplicas;
+
+    try {
+      nReplicas = Integer.valueOf(replicasPerPartition);
+    } catch (NumberFormatException e) {
+      throw new RuntimeException("Invalid value for replicasPerPartition, expected a number: " + replicasPerPartition);
+    }
+
     final KafkaStreamMetadata kafkaMetadata = new KafkaStreamMetadata(realtimeTableConfig.getIndexingConfig().getStreamConfigs());
     final String topicName = kafkaMetadata.getKafkaTopicName();
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();


### PR DESCRIPTION
Add a better error message for when replicasPerPartition is not set or
invalid, as opposed to having "java.lang.NumberFormatException: null"