### PR TITLE
Use stream provider config to init message decoder

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -572,8 +572,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
     _realtimeSegment.setSegmentMetadata(segmentZKMetadata, schema);
 
     // Create message decoder
-    _messageDecoder = (KafkaMessageDecoder) Class.forName(_decoderClassName).newInstance();
-    _messageDecoder.init(new HashMap<String, String>(), _schema, _kafkaTopic);
+    _messageDecoder = kafkaStreamProviderConfig.getDecoder();
     _clientId = _kafkaPartitionId + "-" + NetUtil.getHostnameOrAddress();
 
     // Create field extractor


### PR DESCRIPTION
Use the Kafka stream provider config to properly initialize the
message decoder.