### PR TITLE
Handle having no sorted column in LLC

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -566,7 +566,9 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
 
 
     List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.add(indexingConfig.getSortedColumn().get(0));
+    if (!indexingConfig.getSortedColumn().isEmpty()) {
+      invertedIndexColumns.add(indexingConfig.getSortedColumn().get(0));
+    }
     // Start new realtime segment
     _realtimeSegment = new RealtimeSegmentImpl(schema, _segmentMaxRowCount, tableConfig.getTableName(),
         segmentZKMetadata.getSegmentName(), _kafkaTopic, _serverMetrics, invertedIndexColumns);


### PR DESCRIPTION
Don't blindly add the first sorted column to the list of inverted
index columns if there are no sorted columns