### PR TITLE
Make indexing loop exit flag volatile

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -139,7 +139,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   // Segment end criteria
   private long _consumeEndTime = 0;
   private volatile long _finalOffset = -1;
-  private boolean _receivedStop = false;
+  private volatile boolean _receivedStop = false;
 
   // It takes 30s to locate controller leader, and more if there are multiple controller failures.
   // For now, we let 31s pass for this state transition.


### PR DESCRIPTION
Make the indexing loop exit flag variable volatile, so that it doesn't
get optimized away and cause the loop to be unable to be signalled
using the _receivedStop flag.