### PR TITLE
Re-write of StarTree and StarTreeIndexNode.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
@@ -36,6 +36,8 @@ public class StarTreeIndexSpec {
   private Set<String> _skipMaterializationForDimensions;
   private int skipMaterializationCardinalityThreshold = DEFAULT_SKIP_MATERIALIZATION_CARDINALITY_THRESHOLD;
 
+  private boolean enableOffHeapFormat = false;
+
   public StarTreeIndexSpec() {}
 
   public Integer getMaxLeafRecords() {
@@ -99,5 +101,21 @@ public class StarTreeIndexSpec {
         .add("maxLeafRecords", maxLeafRecords)
         .add("dimensionsSplitOrder", dimensionsSplitOrder)
         .toString();
+  }
+
+  /**
+   * Returns True if StarTreeV2 is enabled, False otherwise.
+   * @return
+   */
+  public boolean isEnableOffHeapFormat() {
+    return enableOffHeapFormat;
+  }
+
+  /**
+   * Enable/Disable StarTreeV2.
+   * @param enableOffHeapFormat
+   */
+  public void setEnableOffHeapFormat(boolean enableOffHeapFormat) {
+    this.enableOffHeapFormat = enableOffHeapFormat;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
@@ -38,6 +38,11 @@ public class V1Constants {
     public static final Long NULL_LONG = Long.MIN_VALUE;
     public static final Float NULL_FLOAT = Float.MIN_VALUE;
     public static final Double NULL_DOUBLE = Double.MIN_VALUE;
+
+    public static final int INTEGER_SIZE = Integer.SIZE / Byte.SIZE;
+    public static final int LONG_SIZE = Long.SIZE / Byte.SIZE;
+    public static final int FLOAT_SIZE = Float.SIZE / Byte.SIZE;
+    public static final int DOUBLE_SIZE = Double.SIZE / Byte.SIZE;
   }
 
   public static class Str {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
@@ -98,7 +98,7 @@ public class Loaders {
       StarTreeInterf starTree = null;
       if (segmentReader.hasStarTree()) {
         LOGGER.debug("Loading star tree for segment: {}", segmentDirectory);
-        starTree = StarTreeSerDe.fromBytes(segmentReader.getStarTreeStream());
+        starTree = StarTreeSerDe.fromFile(segmentReader.getStarTreeFile(), readMode);
       }
       return new IndexSegmentImpl(segmentDirectory, metadata, indexContainerMap, starTree);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
@@ -137,6 +137,13 @@ public abstract class SegmentDirectory implements AutoCloseable {
     public abstract InputStream getStarTreeStream();
 
     /**
+     * Get the StarTree index file.
+     *
+     * @return File for StarTree index.
+     */
+    public abstract File getStarTreeFile();
+
+    /**
      * Check if the segment has star tree
      */
     public abstract boolean hasStarTree();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -231,6 +231,11 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
     }
 
     @Override
+    public File getStarTreeFile() {
+      return SegmentLocalFSDirectory.this.starTreeIndexFile();
+    }
+
+    @Override
     public boolean hasStarTree() {
       return SegmentLocalFSDirectory.this.hasStarTree();
     }
@@ -286,6 +291,11 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
     @Override
     public InputStream getStarTreeStream() {
       return SegmentLocalFSDirectory.this.getStarTreeStream();
+    }
+
+    @Override
+    public File getStarTreeFile() {
+      return SegmentLocalFSDirectory.this.starTreeIndexFile();
     }
 
     @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeBuilderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeBuilderConfig.java
@@ -37,6 +37,7 @@ public class StarTreeBuilderConfig {
   private Set<String> _skipMaterializationFroDimensions;
   private int _skipMaterializationCardinalityThreshold =
       StarTreeIndexSpec.DEFAULT_SKIP_MATERIALIZATION_CARDINALITY_THRESHOLD;
+  private boolean enableOffHealpFormat;
 
   public StarTreeBuilderConfig() {
   }
@@ -106,5 +107,21 @@ public class StarTreeBuilderConfig {
    */
   public void setSkipMaterializationForDimensions(Set<String> skipMaterializationForDimensions) {
     _skipMaterializationFroDimensions = skipMaterializationForDimensions;
+  }
+
+  /**
+   * Returns True if StarTreeV2 is enabled, false otherwise.
+   * @return
+   */
+  public boolean isEnableOffHealpFormat() {
+    return enableOffHealpFormat;
+  }
+
+  /**
+   * Enable/Disable StarTreeV2
+   * @param enableOffHealpFormat
+   */
+  public void setEnableOffHealpFormat(boolean enableOffHealpFormat) {
+    this.enableOffHealpFormat = enableOffHealpFormat;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNode.java
@@ -119,17 +119,16 @@ public class StarTreeIndexNode implements StarTreeIndexNodeInterf, Serializable 
   }
 
   @Override
-  public void addChild(StarTreeIndexNodeInterf child, int dimensionValue) {
-    children.put(dimensionValue, (StarTreeIndexNode) child);
-  }
-
-  @Override
   public StarTreeIndexNodeInterf getChildForDimensionValue(int dimensionValue) {
     if (children != null && children.containsKey(dimensionValue)) {
       return children.get(dimensionValue);
     } else {
       return null;
     }
+  }
+
+  public void addChild(StarTreeIndexNodeInterf child, int dimensionValue) {
+    children.put(dimensionValue, (StarTreeIndexNode) child);
   }
 
   public void setChildren(Map<Integer, StarTreeIndexNode> children) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNodeInterf.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNodeInterf.java
@@ -104,13 +104,6 @@ public interface StarTreeIndexNodeInterf {
   boolean isLeaf();
 
   /**
-   * Adds the provided node as a child of this node, for the given dimension value.
-   * @param child
-   * @param dimensionValue
-   */
-  void addChild(StarTreeIndexNodeInterf child, int dimensionValue);
-
-  /**
    * Returns a child corresponding to the dimension value (dictionary id) for this node.
    * If no such child exists, returns null.
    * @param dimensionValue

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNodeV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeIndexNodeV2.java
@@ -1,0 +1,316 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import java.util.Iterator;
+import xerial.larray.buffer.LBufferAPI;
+
+
+public class StarTreeIndexNodeV2 implements StarTreeIndexNodeInterf {
+  public static final int INVALID_INDEX = -1;
+
+  // Number of fields of this class that will be serialized.
+  private static final int NUMBER_OF_SERIALIZABLE_FIELDS = 7;
+
+  // Hard-coded the serializable size of StarTreeIndexNodeV2 object.
+  private static final int NODE_SERIALIZABLE_SIZE = V1Constants.Numbers.INTEGER_SIZE * NUMBER_OF_SERIALIZABLE_FIELDS;
+
+  private static final long DIMENSION_NAME_OFFSET = 0;
+  private static final long DIMENSION_VALUE_OFFSET = DIMENSION_NAME_OFFSET + V1Constants.Numbers.INTEGER_SIZE;
+
+  private static final long START_DOCUMENT_ID_OFFSET = DIMENSION_VALUE_OFFSET + V1Constants.Numbers.INTEGER_SIZE;
+  private static final long END_DOCUMENT_ID_OFFSET = START_DOCUMENT_ID_OFFSET + V1Constants.Numbers.INTEGER_SIZE;
+  private static final long AGGREGATED_DOCUMENT_ID_OFFSET = END_DOCUMENT_ID_OFFSET + V1Constants.Numbers.INTEGER_SIZE;
+
+  private static final long CHILDREN_START_INDEX_OFFSET =
+      AGGREGATED_DOCUMENT_ID_OFFSET + V1Constants.Numbers.INTEGER_SIZE;
+  private static final long CHILDREN_END_INDEX_OFFSET = CHILDREN_START_INDEX_OFFSET + V1Constants.Numbers.INTEGER_SIZE;
+
+  private final LBufferAPI dataBuffer;
+
+  private int dimensionName;
+  private int dimensionValue;
+  private int startDocumentId;
+  private int endDocumentId;
+  private int aggregatedDocumentId;
+  private int childrenStartIndex;
+  private int childrenEndIndex;
+
+  /**
+   * Constructor for the class.
+   * - Reads all fields from the data buffer.
+   *
+   * @param dataBuffer
+   * @param nodeId
+   */
+  public StarTreeIndexNodeV2(LBufferAPI dataBuffer, int nodeId) {
+    this.dataBuffer = dataBuffer;
+    long offset = nodeId * NODE_SERIALIZABLE_SIZE;
+
+    dimensionName = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    dimensionValue = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    startDocumentId = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    endDocumentId = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    aggregatedDocumentId = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    childrenStartIndex = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    childrenEndIndex = dataBuffer.getInt(offset);
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public int getDimensionName() {
+    return dimensionName;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param dimensionName
+   */
+  @Override
+  public void setDimensionName(int dimensionName) {
+    this.dimensionName = dimensionName;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public int getDimensionValue() {
+    return dimensionValue;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param dimensionValue
+   */
+  @Override
+  public void setDimensionValue(int dimensionValue) {
+    this.dimensionValue = dimensionValue;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public int getStartDocumentId() {
+    return startDocumentId;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param startDocumentId
+   */
+  @Override
+  public void setStartDocumentId(int startDocumentId) {
+    this.startDocumentId = startDocumentId;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public int getEndDocumentId() {
+    return endDocumentId;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param endDocumentId
+   */
+  @Override
+  public void setEndDocumentId(int endDocumentId) {
+    this.endDocumentId = endDocumentId;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public int getAggregatedDocumentId() {
+    return aggregatedDocumentId;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param aggregatedDocumentId
+   */
+  @Override
+  public void setAggregatedDocumentId(int aggregatedDocumentId) {
+    this.aggregatedDocumentId = aggregatedDocumentId;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public int getNumChildren() {
+    return (childrenStartIndex != INVALID_INDEX) ? (childrenEndIndex - childrenStartIndex + 1) : 0;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public boolean isLeaf() {
+    return (childrenStartIndex == INVALID_INDEX);
+  }
+
+  /**
+   * {@inheritDoc}
+   * Performs binary search over children (that are sorted by dimension value)
+   * and returns child that matches the dimension value.
+   * Returns NULL if no child was found for the specified value.
+   *
+   * @param dimensionValue
+   * @return
+   */
+  @Override
+  public StarTreeIndexNodeInterf getChildForDimensionValue(int dimensionValue) {
+    if (isLeaf()) {
+      return null;
+    }
+
+    int lo = childrenStartIndex;
+    int hi = childrenEndIndex;
+
+    while (lo <= hi) {
+      int mid = lo + ((hi - lo) >>> 1);
+      StarTreeIndexNodeV2 midNode = new StarTreeIndexNodeV2(dataBuffer, mid);
+      int midValue = midNode.getDimensionValue();
+
+      if (midValue == dimensionValue) {
+        return midNode;
+      } else if (midValue < dimensionValue) {
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public Iterator<? extends StarTreeIndexNodeInterf> getChildrenIterator() {
+    return new ChildIterator();
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public int getChildDimensionName() {
+    long childDimensNameOffset = (childrenStartIndex * NODE_SERIALIZABLE_SIZE) + DIMENSION_NAME_OFFSET;
+    return (!isLeaf()) ? dataBuffer.getInt(childDimensNameOffset) : INVALID_INDEX;
+  }
+
+  /**
+   * Get the start index for children of this node.
+   * @return
+   */
+  public int getChildrenStartIndex() {
+    return childrenStartIndex;
+  }
+
+  /**
+   * Set the start index for children of this node.
+   * @param childrenStartIndex
+   */
+  public void setChildrenStartIndex(int childrenStartIndex) {
+    this.childrenStartIndex = childrenStartIndex;
+  }
+
+  /**
+   * Get the end index for children of this node.
+   * @return
+   */
+  public int getChildrenEndIndex() {
+    return childrenEndIndex;
+  }
+
+  /**
+   * Get Set the end index for children of this node.
+   * @param childrenEndIndex
+   */
+  public void setChildrenEndIndex(int childrenEndIndex) {
+    this.childrenEndIndex = childrenEndIndex;
+  }
+
+  /**
+   * Return the total size in bytes of fields that will be serialized.
+   * @return
+   */
+  public static int getSerializableSize() {
+    return NODE_SERIALIZABLE_SIZE;
+  }
+
+  /**
+   * Iterator over children nodes.
+   */
+  private class ChildIterator implements Iterator<StarTreeIndexNodeV2> {
+    private int curChildId;
+    private int endChildId;
+    private StarTreeIndexNodeV2 child;
+
+    public ChildIterator() {
+      curChildId = getChildrenStartIndex();
+      endChildId = getChildrenEndIndex();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return ((curChildId != INVALID_INDEX) && (curChildId <= endChildId));
+    }
+
+    @Override
+    public StarTreeIndexNodeV2 next() {
+      StarTreeIndexNodeV2 child = new StarTreeIndexNodeV2(dataBuffer, curChildId);
+      curChildId++;
+      return child;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException("Operation 'remove' not supported in class " + getClass().getName());
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeSerDe.java
@@ -16,12 +16,27 @@
 package com.linkedin.pinot.core.startree;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBiMap;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
-import java.nio.ByteBuffer;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import xerial.larray.buffer.LBuffer;
+import xerial.larray.buffer.LBufferAPI;
+import xerial.larray.mmap.MMapBuffer;
+import xerial.larray.mmap.MMapMode;
 
 
 /**
@@ -42,7 +57,7 @@ public class StarTreeSerDe {
       throws IOException, ClassNotFoundException {
 
     BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
-    StarTreeInterf.Version version = getVersion(bufferedInputStream);
+    StarTreeInterf.Version version = getStarTreeVersion(bufferedInputStream);
 
     switch (version) {
       case V1:
@@ -78,7 +93,7 @@ public class StarTreeSerDe {
   public static void writeTreeV2(StarTreeInterf starTree, File outputFile)
       throws IOException {
     if (starTree.getVersion() == StarTreeInterf.Version.V1) {
-      writeTreeV2FromV1(starTree, outputFile);
+      writeTreeV2FromV1((StarTree) starTree, outputFile);
     } else {
       starTree.writeTree(outputFile);
     }
@@ -93,7 +108,7 @@ public class StarTreeSerDe {
    * @return
    * @throws IOException
    */
-  private static StarTreeInterf.Version getVersion(BufferedInputStream bufferedInputStream)
+  public static StarTreeInterf.Version getStarTreeVersion(BufferedInputStream bufferedInputStream)
       throws IOException {
     byte[] magicBytes = new byte[MAGIC_MARKER_SIZE_IN_BYTES];
 
@@ -101,7 +116,11 @@ public class StarTreeSerDe {
     bufferedInputStream.read(magicBytes, 0, MAGIC_MARKER_SIZE_IN_BYTES);
     bufferedInputStream.reset();
 
-    if (ByteBuffer.wrap(magicBytes).getLong() == MAGIC_MARKER) {
+    LBufferAPI lBuffer = new LBuffer(MAGIC_MARKER_SIZE_IN_BYTES);
+    lBuffer.readFrom(magicBytes, 0);
+    long magicMarker = lBuffer.getLong(0);
+
+    if (magicMarker == MAGIC_MARKER) {
       return StarTreeInterf.Version.V2;
     } else {
       return StarTreeInterf.Version.V1;
@@ -114,8 +133,214 @@ public class StarTreeSerDe {
    * @param starTree
    * @param outputFile
    */
-  private static void writeTreeV2FromV1(StarTreeInterf starTree, File outputFile) {
-    throw new RuntimeException("Feature not implemented yet.");
+  private static void writeTreeV2FromV1(StarTree starTree, File outputFile)
+      throws IOException {
+    int headerSizeInBytes = computeV2HeaderSizeInBytes(starTree);
+    long totalSize = headerSizeInBytes + computeV2NodesSizeInBytes(starTree);
+
+    MMapBuffer mappedByteBuffer = new MMapBuffer(outputFile, 0, totalSize, MMapMode.READ_WRITE);
+    long offset = writeHeaderV2(starTree, headerSizeInBytes, mappedByteBuffer);
+
+    // Ensure that the computed offset is the same as actual offset.
+    Preconditions.checkState((offset == headerSizeInBytes), "Error writing Star Tree file, header size mis-match");
+
+    // Write the actual star tree nodes in level order.
+    writeNodesV2(starTree, mappedByteBuffer, offset);
+
+    mappedByteBuffer.flush();
+    mappedByteBuffer.close();
+  }
+
+  /**
+   * Helper method to write the star tree nodes for Star Tree V2
+   *
+   * @param starTree
+   * @param mappedByteBuffer
+   * @param offset
+   */
+  private static void writeNodesV2(StarTree starTree, MMapBuffer mappedByteBuffer, long offset) {
+    int index = 0;
+    Queue<StarTreeIndexNode> queue = new LinkedList<>();
+    StarTreeIndexNode root = (StarTreeIndexNode) starTree.getRoot();
+    queue.add(root);
+
+    while (!queue.isEmpty()) {
+      StarTreeIndexNode node = queue.poll();
+      List<StarTreeIndexNode> children = getSortedChildren(node); // Returns empty list instead of null.
+
+      int numChildren = children.size();
+      int startChildrenIndex = (numChildren != 0) ? (index + queue.size() + 1) : StarTreeIndexNodeV2.INVALID_INDEX;
+      int endChildrenIndex =
+          (numChildren != 0) ? (startChildrenIndex + numChildren - 1) : StarTreeIndexNodeV2.INVALID_INDEX;
+
+      offset = writeOneV2Node(mappedByteBuffer, offset, node, startChildrenIndex, endChildrenIndex);
+      for (StarTreeIndexNode child : children) {
+        queue.add(child);
+      }
+      index++;
+    }
+  }
+
+  /**
+   * Helper method to write the Header information for Star Tree V2
+   * - MAGIC_MARKER
+   * - Version
+   * - Header size
+   * - Dimension Name to Index Map
+   * - Number of nodes in the tree.
+   *
+   * @param starTree
+   * @param headerSizeInBytes
+   * @param mappedByteBuffer
+   * @return
+   * @throws UnsupportedEncodingException
+   */
+  private static long writeHeaderV2(StarTree starTree, int headerSizeInBytes, MMapBuffer mappedByteBuffer)
+      throws UnsupportedEncodingException {
+    long offset = 0;
+    mappedByteBuffer.putLong(offset, MAGIC_MARKER);
+    offset += V1Constants.Numbers.LONG_SIZE;
+
+    mappedByteBuffer.putInt(offset, version);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    mappedByteBuffer.putInt(offset, headerSizeInBytes);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    HashBiMap<String, Integer> dimensionNameToIndexMap = starTree.getDimensionNameToIndexMap();
+
+    mappedByteBuffer.putInt(offset, dimensionNameToIndexMap.size());
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    // Write the dimensionName to Index map
+    for (Map.Entry<String, Integer> entry : dimensionNameToIndexMap.entrySet()) {
+      String dimension = entry.getKey();
+      int index = entry.getValue();
+
+      mappedByteBuffer.putInt(offset, index);
+      offset += V1Constants.Numbers.INTEGER_SIZE;
+
+      int dimensionLength = dimension.length();
+      mappedByteBuffer.putInt(offset, dimensionLength);
+      offset += V1Constants.Numbers.INTEGER_SIZE;
+
+      mappedByteBuffer.readFrom(dimension.getBytes(UTF8), offset);
+      offset += dimensionLength;
+    }
+
+    mappedByteBuffer.putInt(offset, starTree.getNumNodes());
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+    return offset;
+  }
+
+  /**
+   * Helper method that returns a list of children for the given node, sorted based on
+   * the dimension value.
+   *
+   * @param node
+   * @return A list of sorted child nodes (empty if no children).
+   */
+  private static List<StarTreeIndexNode> getSortedChildren(StarTreeIndexNode node) {
+    Map<Integer, StarTreeIndexNode> children = node.getChildren();
+    if (children == null) {
+      return Collections.EMPTY_LIST;
+    }
+
+    List<StarTreeIndexNode> sortedChildren = new ArrayList<>();
+    sortedChildren.addAll(children.values());
+
+    Collections.sort(sortedChildren, new Comparator<StarTreeIndexNode>() {
+      @Override
+      public int compare(StarTreeIndexNode node1, StarTreeIndexNode node2) {
+        int v1 = node1.getDimensionValue();
+        int v2 = node2.getDimensionValue();
+
+        if (v1 < v2) {
+          return -1;
+        } else if (v1 > v2) {
+          return v1;
+        } else {
+          return 0;
+        }
+      }
+    });
+
+    return sortedChildren;
+  }
+
+  /**
+   * Helper method to write one StarTreeIndexNodeV2 into the mappedByteBuffer at the provided
+   * offset.
+   *
+   * @param mappedByteBuffer
+   * @param offset
+   * @param node
+   * @param startChildrenIndex
+   * @param endChildrenIndex
+   */
+  private static long writeOneV2Node(MMapBuffer mappedByteBuffer, long offset, StarTreeIndexNode node,
+      int startChildrenIndex, int endChildrenIndex) {
+    mappedByteBuffer.putInt(offset, node.getDimensionName());
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    mappedByteBuffer.putInt(offset, node.getDimensionValue());
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    mappedByteBuffer.putInt(offset, node.getStartDocumentId());
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    mappedByteBuffer.putInt(offset, node.getEndDocumentId());
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    mappedByteBuffer.putInt(offset, node.getAggregatedDocumentId());
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    mappedByteBuffer.putInt(offset, startChildrenIndex);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    mappedByteBuffer.putInt(offset, endChildrenIndex);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    return offset;
+  }
+
+  /**
+   * Helper method to compute size of tree in bytes, required to
+   * store in V2 format. The size is computed as follows:
+   * - Long (8 bytes) for magic marker
+   * - Integer (4 bytes) for size of the header
+   * - Integer (4 bytes) for version
+   * - Integer (4 bytes) to store number of dimensions.
+   * - Total size to store dimension name strings
+   * - Integer (4 bytes) per dimension to store the index of the string
+   * - Integer (4 bytes) to store total number of nodes in the tree.
+   * @param starTree
+   * @return
+   */
+  private static int computeV2HeaderSizeInBytes(StarTreeInterf starTree) {
+    int size = 20; // magic marker, version, size of header and number of dimensions
+
+    HashBiMap<String, Integer> dimensionNameToIndexMap = starTree.getDimensionNameToIndexMap();
+    for (String dimension : dimensionNameToIndexMap.keySet()) {
+      size += V1Constants.Numbers.INTEGER_SIZE; // For dimension index
+      size += V1Constants.Numbers.INTEGER_SIZE; // For length of dimension name
+      size += dimension.length(); // For dimension name
+    }
+
+    size += V1Constants.Numbers.INTEGER_SIZE; // For number of nodes.
+    return size;
+  }
+
+  /**
+   * Helper method to compute size of nodes of tree in bytes.
+   * The size is computed as follows:
+   * - Total number of nodes * size of one node
+   *
+   * @param starTree
+   * @return
+   */
+  private static long computeV2NodesSizeInBytes(StarTreeInterf starTree) {
+    return (starTree.getNumNodes() * StarTreeIndexNodeV2.getSerializableSize());
   }
 
   /**
@@ -141,6 +366,28 @@ public class StarTreeSerDe {
    * @return
    */
   private static StarTreeInterf fromBytesV2(InputStream inputStream) {
-    throw new RuntimeException("StarTree version V2 not implemented yet.");
+    throw new RuntimeException("StarTree Version V2 does not support reading from bytes.");
+  }
+
+  /**
+   *
+   * @param starTreeFile  Star Tree index file
+   * @param readMode Read mode MMAP or HEAP (direct memory), only applicable to StarTreeV2.
+   * @return
+   */
+  public static StarTreeInterf fromFile(File starTreeFile, ReadMode readMode)
+      throws IOException, ClassNotFoundException {
+
+    InputStream inputStream = new FileInputStream(starTreeFile);
+    BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
+    StarTreeInterf.Version starTreeVersion = getStarTreeVersion(bufferedInputStream);
+
+    if (starTreeVersion.equals(StarTreeInterf.Version.V1)) {
+      return fromBytesV1(bufferedInputStream);
+    } else if (starTreeVersion.equals(StarTreeInterf.Version.V2)) {
+      return new StarTreeV2(starTreeFile, readMode);
+    } else {
+      throw new RuntimeException("Unrecognized version for Star Tree " + starTreeVersion);
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeV2.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBiMap;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import xerial.larray.buffer.LBuffer;
+import xerial.larray.buffer.LBufferAPI;
+import xerial.larray.mmap.MMapBuffer;
+import xerial.larray.mmap.MMapMode;
+
+
+/**
+ * LBuffer based implementation of star tree interface.
+ */
+public class StarTreeV2 implements StarTreeInterf {
+  private static final long serialVersionUID = 1L;
+  private static final int DIMENSION_NAME_MAX_LENGTH = 4096;
+  private static final String UTF8 = "UTF-8";
+
+  // Buffer size for buffered reading of on-disk file into byte buffer.
+  private static final int BUFFER_SIZE = 10 * 1024 * 1024;
+
+  // Off heap buffer were the star tree is loaded.
+  LBufferAPI dataBuffer;
+
+  StarTreeIndexNodeV2 root;
+
+  // Offset of the root node in the file.
+  private int rootNodeOffset;
+
+  // Initial size of buffer to be allocated to read the star tree header.
+  private static final long STAR_TREE_HEADER_READER_SIZE = 10 * 1024;
+
+  int numNodes = 0;
+  private HashBiMap<String, Integer> dimensionNameToIndexMap;
+  private int version;
+
+  /**
+   * Constructor for the class.
+   * - Reads in the header
+   * - Loads/MMap's the StarTreeIndexNodeV2 array.
+   *
+   * @param starTreeFile
+   * @param readMode
+   * @throws IOException
+   */
+  public StarTreeV2(File starTreeFile, ReadMode readMode)
+      throws IOException {
+    int rootOffset = readHeader(starTreeFile);
+    long size = starTreeFile.length() - rootOffset;
+
+    if (readMode.equals(ReadMode.mmap)) {
+      dataBuffer = new MMapBuffer(starTreeFile, rootOffset, size, MMapMode.READ_ONLY);
+    } else {
+      dataBuffer = loadFromFile(starTreeFile, rootOffset);
+    }
+
+    // Root node is the first one.
+    root = new StarTreeIndexNodeV2(dataBuffer, 0);
+  }
+
+  /**
+   * Read the header information from the star tree file, and populate the
+   * following info:
+   * - Version
+   * - Dimension name to index map.
+   * - Number of nodes
+   * - Root offset.
+   *
+   * @throws UnsupportedEncodingException
+   * @param starTreeFile
+   */
+  private int readHeader(File starTreeFile)
+      throws IOException {
+    int offset = 0;
+
+    int size = (int) Math.min(starTreeFile.length(), STAR_TREE_HEADER_READER_SIZE);
+    MMapBuffer dataBuffer = new MMapBuffer(starTreeFile, offset, size, MMapMode.READ_ONLY);
+
+    Preconditions.checkState(StarTreeSerDe.MAGIC_MARKER == dataBuffer.getLong(offset),
+        "Invalid magic marker in Star Tree file");
+    offset += StarTreeSerDe.MAGIC_MARKER_SIZE_IN_BYTES;
+
+    version = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+    Preconditions.checkState(version == 1);
+
+    rootNodeOffset = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    // If header size turns out to be larger than initially thought, then re-map with the correct size.
+    if (rootNodeOffset > size) {
+      dataBuffer.close();
+      dataBuffer = new MMapBuffer(starTreeFile, 0, rootNodeOffset, MMapMode.READ_ONLY);
+    }
+
+    int numDimensions = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    dimensionNameToIndexMap = HashBiMap.create(numDimensions);
+    byte[] dimensionNameBytes = new byte[DIMENSION_NAME_MAX_LENGTH];
+
+    for (int i = 0; i < numDimensions; i++) {
+      int index = dataBuffer.getInt(offset);
+      offset += V1Constants.Numbers.INTEGER_SIZE;
+
+      int dimensionLength = dataBuffer.getInt(offset);
+      offset += V1Constants.Numbers.INTEGER_SIZE;
+
+      // Since we are re-using the same bytes for reading strings, assert we have allocated enough.
+      Preconditions.checkState(dimensionLength < DIMENSION_NAME_MAX_LENGTH);
+
+      // Ok to cast offset to int, as its value is too small at this point in the file.
+      dataBuffer.copyTo((int) offset, dimensionNameBytes, 0, dimensionLength);
+      offset += dimensionLength;
+
+      String dimensionName = new String(dimensionNameBytes, 0, dimensionLength, UTF8);
+      dimensionNameToIndexMap.put(dimensionName, index);
+    }
+
+    numNodes = dataBuffer.getInt(offset);
+    offset += V1Constants.Numbers.INTEGER_SIZE;
+
+    Preconditions.checkState((offset == rootNodeOffset), "Error reading Star Tree file, header length mis-match");
+
+    dataBuffer.close();
+    return offset;
+  }
+
+  /**
+   * Helper method that loads the star tree into a LBuffer, from
+   * the given file.
+   *
+   * @param starTreeFile
+   * @param rootOffset
+   * @return
+   * @throws IOException
+   */
+  private static LBufferAPI loadFromFile(File starTreeFile, long rootOffset)
+      throws IOException {
+    FileChannel fileChannel = new FileInputStream(starTreeFile).getChannel();
+    ByteBuffer byteBuffer = ByteBuffer.allocate(BUFFER_SIZE);
+
+    long start = rootOffset;
+    long end = starTreeFile.length();
+    long destOffset = 0;
+    LBufferAPI lBuffer = new LBuffer(end - start);
+
+    int bytesRead = 0;
+    while ((bytesRead = fileChannel.read(byteBuffer, start)) > 0) {
+      lBuffer.readFrom(byteBuffer.array(), 0, destOffset, bytesRead);
+      start += bytesRead;
+      destOffset += bytesRead;
+      byteBuffer.clear();
+    }
+    fileChannel.close();
+    return lBuffer;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public StarTreeIndexNodeInterf getRoot() {
+    return root;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  public Version getVersion() {
+    return Version.V2;
+  }
+
+  @Override
+  public int getNumNodes() {
+    return numNodes;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return
+   */
+  @Override
+  public HashBiMap<String, Integer> getDimensionNameToIndexMap() {
+    return dimensionNameToIndexMap;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param outputFile
+   * @throws IOException
+   */
+  @Override
+  public void writeTree(File outputFile)
+      throws IOException {
+    throw new RuntimeException("Method 'writeTree' not implemented for class " + getClass().getName());
+  }
+
+  @Override
+  public void printTree() {
+    throw new RuntimeException("Method 'printTree' not implemented for class " + getClass().getName());
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/BaseStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/BaseStarTreeIndexTest.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.segment.ReadMode;
@@ -163,7 +164,7 @@ public class BaseStarTreeIndexTest {
    * @param segmentName
    * @throws Exception
    */
-  Schema buildSegment(String segmentDirName, String segmentName)
+  Schema buildSegment(String segmentDirName, String segmentName, boolean enableOffHeapFormat)
       throws Exception {
     int ROWS = (int) MathUtils.factorial(NUM_DIMENSIONS);
     Schema schema = new Schema();
@@ -186,6 +187,7 @@ public class BaseStarTreeIndexTest {
     config.setOutDir(segmentDirName);
     config.setFormat(FileFormat.AVRO);
     config.setSegmentName(segmentName);
+    config.setStarTreeIndexSpec(buildStarTreeIndexSpec(enableOffHeapFormat));
 
     final List<GenericRow> data = new ArrayList<>();
     for (int row = 0; row < ROWS; row++) {
@@ -216,6 +218,19 @@ public class BaseStarTreeIndexTest {
 
     LOGGER.info("Built segment {} at {}", segmentName, segmentDirName);
     return schema;
+  }
+
+  /**
+   * Builds a star tree index spec for the test.
+   * - Use MaxLeafRecords as 1 to stress test.
+   * @return
+   * @param enableOffHeapFormat
+   */
+  private StarTreeIndexSpec buildStarTreeIndexSpec(boolean enableOffHeapFormat) {
+    StarTreeIndexSpec spec = new StarTreeIndexSpec();
+    spec.setMaxLeafRecords(1);
+    spec.setEnableOffHeapFormat(enableOffHeapFormat);
+    return spec;
   }
 
   /**

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeIndexTest.java
@@ -40,7 +40,7 @@ public class TestStarTreeIndexTest extends BaseStarTreeIndexTest {
   @BeforeSuite
   void setup()
       throws Exception {
-    _schema = buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
+    _schema = buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, false);
     _segment = loadSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeV2.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeV2.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+import com.google.common.collect.HashBiMap;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for StarTreeV2 class.
+ */
+public class TestStarTreeV2 extends BaseStarTreeIndexTest {
+
+  private static final String SEGMENT_NAME = "starTreeSegment";
+  private static final String SEGMENT_V2_NAME = "starTreeV2Segment";
+  private static final String SEGMENT_DIR_NAME = "/tmp/star-tree-index";
+  private static final String SEGMENT_V2_DIR_NAME = "/tmp/star-tree-v2-index";
+  private static final String STAR_TREE_V2_FILE_NAME = "starTreeV2";
+
+  private IndexSegment _segment;
+  private IndexSegment _segmentV2;
+  private StarTreeInterf _starTreeV1;
+  private File _starTreeV2File;
+  private Schema _schema;
+
+  /**
+   * Build the star tree.
+   * @throws Exception
+   */
+  @BeforeSuite
+  void setup()
+      throws Exception {
+    buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, false);
+    _segment = loadSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
+    _starTreeV1 = _segment.getStarTree();
+
+    _starTreeV2File = new File(SEGMENT_DIR_NAME, STAR_TREE_V2_FILE_NAME);
+    StarTreeSerDe.writeTreeV2(_starTreeV1, _starTreeV2File);
+
+    // Build the StarTreeV2 segment
+    _schema = buildSegment(SEGMENT_V2_DIR_NAME, SEGMENT_V2_NAME, true);
+    _segmentV2 = loadSegment(SEGMENT_V2_DIR_NAME, SEGMENT_V2_NAME);
+  }
+
+  /**
+   * Cleanup any temporary files and directories.
+   * @throws IOException
+   */
+  @AfterSuite
+  void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(new File(SEGMENT_DIR_NAME));
+    FileUtils.deleteDirectory(new File(SEGMENT_V2_DIR_NAME));
+  }
+
+  /**
+   * This test ensures that the StarTreeV2 in heap mode has the exact same
+   * contents as the original implementation of star tree.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testHeapMode()
+      throws IOException {
+    StarTreeV2 starTreeV2 = new StarTreeV2(_starTreeV2File, ReadMode.heap);
+    compareMetadata(_starTreeV1, starTreeV2);
+    compareTrees(_starTreeV1.getRoot(), starTreeV2.getRoot());
+  }
+
+  /**
+   * This test ensures that the StarTreeV2 in mmap mode has the exact same
+   * contents as the original implementation of star tree.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testMmapMode()
+      throws IOException {
+    StarTreeV2 starTreeV2 = new StarTreeV2(_starTreeV2File, ReadMode.mmap);
+
+    compareMetadata(_starTreeV1, starTreeV2);
+    compareTrees(_starTreeV1.getRoot(), starTreeV2.getRoot());
+  }
+
+  /**
+   * This test runs a set of queries on the StarTreeV2 segment, and ensures
+   * correctness of query results.
+   *
+   */
+  @Test
+  public void testQueries() {
+    testHardCodedQueries(_segmentV2, _schema);
+  }
+
+  /**
+   * Compare metadata information of the two trees:
+   * - Number of nodes
+   * - Dimension name to index map
+   *
+   * @param starTreeV1
+   * @param starTreeV2
+   */
+  private void compareMetadata(StarTreeInterf starTreeV1, StarTreeInterf starTreeV2) {
+    Assert.assertEquals(starTreeV2.getNumNodes(), _starTreeV1.getNumNodes(), "Number of nodes mist-match");
+
+    HashBiMap<String, Integer> dimensionNameToIndexMap1 = starTreeV1.getDimensionNameToIndexMap();
+    HashBiMap<String, Integer> dimensionNameToIndexMap2 = starTreeV2.getDimensionNameToIndexMap();
+    Assert.assertEquals(dimensionNameToIndexMap2.size(), dimensionNameToIndexMap1.size(),
+        "Dimension name index map size mis-match");
+
+    for (Map.Entry<String, Integer> entry : dimensionNameToIndexMap1.entrySet()) {
+      String key = entry.getKey();
+      Integer value = entry.getValue();
+
+      Assert.assertTrue(dimensionNameToIndexMap2.containsKey(key), "Missing dimension " + key);
+      Assert.assertEquals(dimensionNameToIndexMap2.get(key), value, "Dimension index mist-match");
+    }
+  }
+
+  /**
+   * Helper method to compare two star trees:
+   * - Compares all the values for the two nodes.
+   * - Ensures that either both or neither nodes have a star child.
+   * - All children of V1 can be found by iterating over children of V2 and vice-versa.
+   * - Performs DFS invoking the same test for all node pairs.
+   * @param rootV1
+   * @param rootV2
+   */
+  private void compareTrees(StarTreeIndexNodeInterf rootV1, StarTreeIndexNodeInterf rootV2) {
+    // Compare the nodes.
+    compareNodes(rootV1, rootV2);
+
+    // Assert star child either exists in both or does not exist at all.
+    StarTreeIndexNodeInterf star1 = rootV1.getChildForDimensionValue(StarTreeIndexNodeInterf.ALL);
+    StarTreeIndexNodeInterf star2 = rootV2.getChildForDimensionValue(StarTreeIndexNodeInterf.ALL);
+    Assert.assertEquals((star2 == null), (star1 == null));
+
+    // Assert both nodes have same number of children.
+    Assert.assertEquals(rootV1.getNumChildren(), rootV1.getNumChildren(), "Mis-match in number of children");
+
+    // Iterate over children of V2 and assert they are the same as children of V1.
+    int numChildren = 0;
+    Iterator<? extends StarTreeIndexNodeInterf> childrenIterator = rootV2.getChildrenIterator();
+    while (childrenIterator.hasNext()) {
+      StarTreeIndexNodeInterf childV2 = childrenIterator.next();
+      StarTreeIndexNodeInterf childV1 = rootV1.getChildForDimensionValue(childV2.getDimensionValue());
+
+      Assert.assertNotNull(childV1);
+      compareNodes(childV1, childV2);
+      numChildren++;
+    }
+    Assert.assertEquals(rootV2.getNumChildren(), numChildren, "Mis-match in number of children");
+
+    // Now iterate over children of V1 and assert they are the same as children of V2.
+    childrenIterator = rootV1.getChildrenIterator();
+    while (childrenIterator.hasNext()) {
+      StarTreeIndexNodeInterf childV1 = childrenIterator.next();
+      StarTreeIndexNodeInterf childV2 = rootV2.getChildForDimensionValue(childV1.getDimensionValue());
+      Assert.assertNotNull(childV2);
+      compareTrees(childV1, childV2);
+    }
+  }
+
+  /**
+   * Helper method to compare and assert that all values for the two nodes match.
+   * @param nodeV1
+   * @param nodeV2
+   */
+  private void compareNodes(StarTreeIndexNodeInterf nodeV1, StarTreeIndexNodeInterf nodeV2) {
+    Assert.assertEquals(nodeV2.getDimensionName(), nodeV1.getDimensionName(), "Dimension name mis-match");
+    Assert.assertEquals(nodeV2.getDimensionValue(), nodeV1.getDimensionValue(), "Dimension value mis-match");
+    Assert.assertEquals(nodeV2.getStartDocumentId(), nodeV1.getStartDocumentId(), "StartDocumentId mis-match");
+    Assert.assertEquals(nodeV2.getEndDocumentId(), nodeV2.getEndDocumentId(), "EndDocumentId mis-match");
+    Assert.assertEquals(nodeV2.getAggregatedDocumentId(), nodeV1.getAggregatedDocumentId(),
+        "AggregatedDocumentId mis-match");
+    Assert.assertEquals(nodeV2.getNumChildren(), nodeV1.getNumChildren(), "Number of children mis-match");
+    Assert.assertEquals(nodeV2.isLeaf(), nodeV1.isLeaf(), "IsLeaf mist-match");
+  }
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
@@ -104,7 +104,7 @@ public class SegmentDumpTool {
     if (dumpStarTree) {
       System.out.println();
       File starTreeFile = new File(segmentDir, V1Constants.STAR_TREE_INDEX_FILE);
-      StarTreeInterf tree = StarTreeSerDe.fromBytes(new FileInputStream(starTreeFile));
+      StarTreeInterf tree = StarTreeSerDe.fromFile(starTreeFile, ReadMode.mmap);
       tree.printTree();
     }
   }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
@@ -89,7 +89,7 @@ public class StarTreeIndexViewer {
       dictionaries.put(columnName, dataSource.getDictionary());
     }
     File starTreeFile = new File(segmentDir, V1Constants.STAR_TREE_INDEX_FILE);
-    StarTreeInterf tree = StarTreeSerDe.fromBytes(new FileInputStream(starTreeFile));
+    StarTreeInterf tree = StarTreeSerDe.fromFile(starTreeFile, ReadMode.mmap);
     dimensionNameToIndexMap = tree.getDimensionNameToIndexMap();
     StarTreeJsonNode jsonRoot = new StarTreeJsonNode("ROOT");
     build(tree.getRoot(), jsonRoot);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StarTreeV1ToV2Converter.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StarTreeV1ToV2Converter.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.tools.admin.command;
+
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.index.loader.Loaders;
+import com.linkedin.pinot.core.startree.StarTreeInterf;
+import com.linkedin.pinot.core.startree.StarTreeSerDe;
+import com.linkedin.pinot.tools.Command;
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class implements the Star Tree V1 to V2 converter.
+ */
+public class StarTreeV1ToV2Converter extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeV1ToV2Converter.class);
+
+  @Option(name = "-segmentDir", required = true, metaVar = "<String>", usage = "path to untarred input segment.")
+  private String _segmentDir;
+
+  @Option(name = "-outputDir", required = true, metaVar = "<String>", usage = "output directory for new segment")
+  private String _outputDir;
+
+  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
+      usage = "Print this message.")
+  private boolean _help = false;
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    File indexDir = new File(_segmentDir);
+    long start = System.currentTimeMillis();
+
+    LOGGER.info("Loading segment {}", indexDir.getName());
+    IndexSegment segment = Loaders.IndexSegment.load(indexDir, ReadMode.heap);
+
+    long end = System.currentTimeMillis();
+    LOGGER.info("Loaded segment {} in {} ms ", indexDir.getName(), (end - start));
+
+    start = end;
+    StarTreeInterf starTreeV1 = segment.getStarTree();
+    File starTreeV2File = new File(TMP_DIR, (V1Constants.STAR_TREE_INDEX_FILE + System.currentTimeMillis()));
+
+    // Convert the star tree v1 to v2
+    StarTreeSerDe.writeTreeV2(starTreeV1, starTreeV2File);
+
+    // Copy all the indexes into output directory.
+    File outputDir = new File(_outputDir);
+    FileUtils.deleteQuietly(outputDir);
+    FileUtils.copyDirectory(indexDir, outputDir);
+
+    // Delete the existing star tree v1 file from the output directory.
+    FileUtils.deleteQuietly(new File(_outputDir, V1Constants.STAR_TREE_INDEX_FILE));
+
+    // Move the temp star tree v2 file into the output directory.
+    FileUtils.moveFile(starTreeV2File, new File(_outputDir, V1Constants.STAR_TREE_INDEX_FILE));
+    end = System.currentTimeMillis();
+
+    LOGGER.info("Converted segment: {} ms", (end - start));
+    return true;
+  }
+
+  @Override
+  public String description() {
+    return "Convert Pinto Segment with Star Tree V1 format into Pinot Segment with Star Tree V2 format";
+  }
+
+  @Override
+  public boolean getHelp() {
+    return _help;
+  }
+
+  @Override
+  public String toString() {
+    return "StarTreeV1ToV2Converter -segmentDir " + _segmentDir + " -outputDir " + _outputDir;
+  }
+
+  public String getSegmentDir() {
+    return _segmentDir;
+  }
+
+  public StarTreeV1ToV2Converter setSegmentDir(String segmentDir) {
+    _segmentDir = segmentDir;
+    return this;
+  }
+
+  public String getOutputDir() {
+    return _outputDir;
+  }
+
+  public StarTreeV1ToV2Converter setOutputDir(String outputDir) {
+    _outputDir = outputDir;
+    return this;
+  }
+}


### PR DESCRIPTION
e-write of StarTree and StarTreeIndexNode.

Implemented new versions for star tree (StarTreeV2) and star tree node
(StarTreeIndexNodeV2). This achieves over 2X reduction in the serialized
size (1.1GB to 469MB). The feature is currently OFF by default, and
controlled via StarTreeBuilderConfig.

1. StarTreeV2 is a compact memory representation of StarTree with native
serialization/de-serialization support. And can be loaded either in
direct memory, or via memory mapped file. Used the Xerial LBuffer
library to be able to support data sizes larger than 2GB.

2. Added custom serializer/de-serializer for StarTreeV2, as opposed to
V1 that uses JAVA serialization/de-serialization.

3. Modified StarTreeIndexOperator to be able to work off of
StarTreeInterf, which can be implemented either by StarTree or
StarTreeV2.

4. Added a utility to convert a pinot segment with star tree v1 into a
pinot segment with star tree v2.

5. Added unit tests to test:
   - Reading/Writing of StarTreeV2.
   - Query processing using StarTreeV2.
