### PR TITLE
THIRDEYE-876 : Config driven support in thirdeye dashboard for tables having metrics as a dimension column

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/CollectionConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/CollectionConfig.java
@@ -16,6 +16,9 @@ public class CollectionConfig extends AbstractConfig {
 
   boolean isActive = true;
   boolean enableCount = false; // Default __COUNT metric
+  boolean metricAsDimension = false;
+  String metricNamesColumn = null;
+  String metricValuesColumn = null;
 
   Map<String, String> derivedMetrics;
 
@@ -65,6 +68,30 @@ public class CollectionConfig extends AbstractConfig {
 
   public void setEnableCount(boolean enableCount) {
     this.enableCount = enableCount;
+  }
+
+  public boolean isMetricAsDimension() {
+    return metricAsDimension;
+  }
+
+  public void setMetricAsDimension(boolean metricAsDimension) {
+    this.metricAsDimension = metricAsDimension;
+  }
+
+  public String getMetricValuesColumn() {
+    return metricValuesColumn;
+  }
+
+  public void setMetricValuesColumn(String metricValuesColumn) {
+    this.metricValuesColumn = metricValuesColumn;
+  }
+
+  public String getMetricNamesColumn() {
+    return metricNamesColumn;
+  }
+
+  public void setMetricNamesColumn(String metricNamesColumn) {
+    this.metricNamesColumn = metricNamesColumn;
   }
 
   public Map<String, String> getDerivedMetrics() {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/css/main.css
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/css/main.css
@@ -244,6 +244,8 @@ body a{
 
 .added-item{
     margin: 5px 0 5px 5px;
+    max-width: 100%;
+    overflow-wrap: break-word;
 }
 
 .remove-selection,

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/handlebars-methods.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/handlebars-methods.js
@@ -212,6 +212,7 @@ $(document).ready(function () {
         return obj[prop];
     });
 
+
     /* Add details-cell or heatmap-cell class to cells */
     Handlebars.registerHelper('classify', function (index) {
         if ((index + 1) % 3 == 0) {
@@ -246,9 +247,14 @@ $(document).ready(function () {
     //takes an object and a key as option param and returns an object as a scope
     Handlebars.registerHelper('lookupInMapByKey', function (mapObj, key) {
         var val = mapObj[key];
-        if (typeof val !== "undefined") {
+        if ((typeof val == "undefined") || (val == key)) {
+          val = "";
+        } else {
             val = "(" + val + ")";
         }
+        console.log("val", val);
+        console.log("key",key);
+
         return val;
     });
 


### PR DESCRIPTION
This pull request adds support for tables which have metric names as a dimension column, and metric values as a single metric column. It handles derived metrics as well.