### PR TITLE
Upgrade fastutil to 6.5.16 for some internal bug fixing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>6.5.9</version>
+        <version>6.5.16</version>
       </dependency>
       <dependency>
         <groupId>joda-time</groupId>


### PR DESCRIPTION
This is related to FloatOpenHashSet/DoubleOpenHashset.
In fastutil 6.5.9, if we index Float.NaN or Double.NaN into FloatOpenHashSet/DoubleOpenHashset. We cannot get the index from FloatOpenHashSet/DoubleOpenHashset. 
Example code:
    DoubleOpenHashSet set = new DoubleOpenHashSet();
    System.out.println(set.size());
    set.add(Double.NaN);
    System.out.println(set.size());
    System.out.println(set.contains(Double.NaN));

The output will be:
0
1
false

But we expect true here.