### PR TITLE
Improve inequality performance on sorted columns

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/IntRanges.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/IntRanges.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.operator.filter;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.Pairs;
+
+
+/**
+ * Various utilities to deal with integer ranges, with both bounds being inclusive (eg. for docId ranges).
+ */
+public class IntRanges {
+  private static final boolean ENABLE_PRECONDITION_CHECKS = false;
+
+  /**
+   * Clips a range in place, making sure that its lower value is greater or equals to lowerBound and its upper value is
+   * smaller or equals to upperBound.
+   *
+   * @param range The range to clip
+   * @param lowerBound The lower bound
+   * @param upperBound The upper bound
+   */
+  public static void clip(Pairs.IntPair range, int lowerBound, int upperBound) {
+    range.setLeft(Math.max(range.getLeft(), lowerBound));
+    range.setRight(Math.min(range.getRight(), upperBound));
+  }
+
+  /**
+   * Checks whether a range is invalid (upper bound lower to the lower bound)
+   *
+   * @return true if the range is invalid
+   */
+  public static boolean isInvalid(Pairs.IntPair range) {
+    return range.getRight() < range.getLeft();
+  }
+
+  /**
+   * Checks whether two ranges are mergeable (either overlapping or adjacent), assuming neither is degenerate.
+   *
+   * @param firstRange The first range to check
+   * @param secondRange The second range to check
+   */
+  public static boolean rangesAreMergeable(Pairs.IntPair firstRange, Pairs.IntPair secondRange) {
+    if (ENABLE_PRECONDITION_CHECKS) {
+      Preconditions.checkArgument(!isInvalid(firstRange));
+      Preconditions.checkArgument(!isInvalid(secondRange));
+    }
+
+    final boolean rangesAreAtLeastOneUnitApart =
+        firstRange.getRight() < secondRange.getLeft() - 1 || secondRange.getRight() < firstRange.getLeft() - 1;
+    return !rangesAreAtLeastOneUnitApart;
+  }
+
+  /**
+   * Merge the second range into the first one, mutating the first one in place, assuming the ranges are not disjoint.
+   *
+   * @param firstRange The range to merge the second into
+   * @param secondRange The range to merge with the first one
+   */
+  public static void mergeIntoFirst(Pairs.IntPair firstRange, Pairs.IntPair secondRange) {
+    if (ENABLE_PRECONDITION_CHECKS) {
+      Preconditions.checkArgument(rangesAreMergeable(firstRange, secondRange));
+    }
+
+    firstRange.setLeft(Math.min(firstRange.getLeft(), secondRange.getLeft()));
+    firstRange.setRight(Math.max(firstRange.getRight(), secondRange.getRight()));
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
@@ -19,12 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.pinot.common.utils.Pairs;
 import com.linkedin.pinot.common.utils.Pairs.IntPair;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -54,7 +51,7 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
   private int endDocId;
 
   /**
-   * 
+   *
    * @param dataSource
    * @param startDocId inclusive
    * @param endDocId inclusive
@@ -77,20 +74,119 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
     Dictionary dictionary = dataSource.getDictionary();
     List<IntPair> pairs = new ArrayList<IntPair>();
     PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dictionary);
-    int[] dictionaryIds = evaluator.getMatchingDictionaryIds();
-    for (int i = 0; i < dictionaryIds.length; i++) {
-      IntPair pair = invertedIndex.getMinMaxRangeFor(dictionaryIds[i]);
-      //ensure that the pair is between (startDoc,endDoc) else trim/skip it accordingly
-      if (startDocId <= pair.getLeft()  && pair.getRight() <= endDocId) {
-        pairs.add(pair);
-      } else {
-        int newStart = Math.max(pair.getLeft(), startDocId);
-        int newEnd = Math.min(pair.getRight(), endDocId);
-        if (newStart <= newEnd) {
-          pairs.add(Pairs.intPair(newStart, newEnd));
+
+    // At this point, we need to create a list of matching docId ranges. There are two kinds of operators:
+    //
+    // - "Additive" operators, such as EQ, IN and RANGE build up a list of ranges and merge overlapping/adjacent ones,
+    //   clipping the ranges to [startDocId; endDocId]
+    //
+    // - "Subtractive" operators, such as NEQ and NOT IN build up a list of ranges that do not match and build a list of
+    //   matching intervals by subtracting a list of non-matching intervals from the given range of
+    //   [startDocId; endDocId]
+    //
+    // For now, we don't look at the cardinality of the column's dictionary, although we should do that if someone
+    // specifies a very large list of IN/NOT IN predicates relative to the column's cardinality or a very large/small
+    // range predicate relative to the cardinality. However, as adjacent ranges get merged before returning the final
+    // list of ranges, the only drawback is that we use a lot of memory during the filter block evaluation.
+
+    final int[] dictionaryIds;
+    boolean additiveRanges = true;
+
+    switch (predicate.getType()) {
+      case EQ:
+      case IN:
+      case RANGE:
+        dictionaryIds = evaluator.getMatchingDictionaryIds();
+        break;
+      case NEQ:
+      case NOT_IN:
+        additiveRanges = false;
+        dictionaryIds = evaluator.getNonMatchingDictionaryIds();
+        break;
+      case REGEX:
+        throw new RuntimeException("Regex is not supported");
+      default:
+        throw new RuntimeException("Unimplemented!");
+    }
+
+    if (0 < dictionaryIds.length) {
+      // Sort the dictionaryIds in ascending order, so that their respective ranges are adjacent if their
+      // dictionaryIds are adjacent
+      Arrays.sort(dictionaryIds);
+
+      IntPair lastPair = invertedIndex.getMinMaxRangeFor(dictionaryIds[0]);
+      IntRanges.clip(lastPair, startDocId, endDocId);
+
+      for (int i = 1; i < dictionaryIds.length; i++) {
+        IntPair currentPair = invertedIndex.getMinMaxRangeFor(dictionaryIds[i]);
+        IntRanges.clip(currentPair, startDocId, endDocId);
+
+        // If the previous range is degenerate, just keep the current one
+        if (IntRanges.isInvalid(lastPair)) {
+          lastPair = currentPair;
+          continue;
+        }
+
+        // If the current range is adjacent or overlaps with the previous range, merge it into the previous range,
+        // otherwise add the previous range and keep the current one to be added
+        if (IntRanges.rangesAreMergeable(lastPair, currentPair)) {
+          IntRanges.mergeIntoFirst(lastPair, currentPair);
+        } else {
+          if (!IntRanges.isInvalid(lastPair)) {
+            pairs.add(lastPair);
+          }
+          lastPair = currentPair;
         }
       }
+
+      // Add the last range if it's valid
+      if (!IntRanges.isInvalid(lastPair)) {
+        pairs.add(lastPair);
+      }
     }
+
+    if (!additiveRanges) {
+      // If the ranges are not additive ranges, our list of pairs is a list of "holes" in the [startDocId; endDocId]
+      // range. We need to take this list of pairs and invert it. To do so, there are three cases:
+      //
+      // - No holes, in which case the final range is [startDocId; endDocId]
+      // - One or more hole, in which case the final ranges are [startDocId; firstHoleStartDocId - 1] and
+      //   [lastHoleEndDocId + 1; endDocId] and ranges in between other holes
+      List<IntPair> newPairs = new ArrayList<>();
+      if (pairs.isEmpty()) {
+        newPairs.add(new IntPair(startDocId, endDocId));
+      } else {
+        // Add the first filled area (between startDocId and the first hole)
+        IntPair firstHole = pairs.get(0);
+        IntPair firstRange = new IntPair(startDocId, firstHole.getLeft() - 1);
+
+        if (!IntRanges.isInvalid(firstRange)) {
+          newPairs.add(firstRange);
+        }
+
+        // Add the filled areas between contiguous holes
+        int pairCount = pairs.size();
+        for (int i = 1; i < pairCount; i++) {
+          IntPair previousHole = pairs.get(i - 1);
+          IntPair currentHole = pairs.get(i);
+          IntPair range = new IntPair(previousHole.getRight() + 1, currentHole.getLeft() - 1);
+          if (!IntRanges.isInvalid(range)) {
+            newPairs.add(range);
+          }
+        }
+
+        // Add the last filled area (between the last hole and endDocId)
+        IntPair lastHole = pairs.get(pairs.size() - 1);
+        IntPair lastRange = new IntPair(lastHole.getRight() + 1, endDocId);
+
+        if (!IntRanges.isInvalid(lastRange)) {
+          newPairs.add(lastRange);
+        }
+      }
+
+      pairs = newPairs;
+    }
+
     LOGGER.debug("Creating a Sorted Block with pairs: {}", pairs);
     sortedBlock = new SortedBlock(dataSource.getOperatorName(), pairs);
     return sortedBlock;

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/IntRangesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/IntRangesTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.operator.filter;
+
+import com.linkedin.pinot.common.utils.Pairs;
+import com.linkedin.pinot.core.operator.filter.IntRanges;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Test for IntRanges.
+ */
+public class IntRangesTest {
+  @Test
+  public void testClip() {
+    Pairs.IntPair range = new Pairs.IntPair(10, 20);
+    IntRanges.clip(range, 0, 100);
+
+    assertEquals(range.getLeft(), 10);
+    assertEquals(range.getRight(), 20);
+
+    IntRanges.clip(range, 0, 18);
+    assertEquals(range.getLeft(), 10);
+    assertEquals(range.getRight(), 18);
+
+    IntRanges.clip(range, 12, 30);
+    assertEquals(range.getLeft(), 12);
+    assertEquals(range.getRight(), 18);
+
+    IntRanges.clip(range, 14, 16);
+    assertEquals(range.getLeft(), 14);
+    assertEquals(range.getRight(), 16);
+  }
+
+  @Test
+  public void testIsDegenerate() {
+    Pairs.IntPair valid = new Pairs.IntPair(10, 20);
+    assertFalse(IntRanges.isInvalid(valid));
+
+    valid = new Pairs.IntPair(15, 15);
+    assertFalse(IntRanges.isInvalid(valid));
+
+    Pairs.IntPair invalid = new Pairs.IntPair(15, 14);
+    assertTrue(IntRanges.isInvalid(invalid));
+  }
+
+  @Test
+  public void testRangesAreMergeable() {
+    Pairs.IntPair disjointA = new Pairs.IntPair(0, 10);
+    Pairs.IntPair disjointB = new Pairs.IntPair(12, 20);
+    assertFalse(IntRanges.rangesAreMergeable(disjointA, disjointB));
+    assertFalse(IntRanges.rangesAreMergeable(disjointB, disjointA));
+
+    Pairs.IntPair adjacentA = new Pairs.IntPair(0, 10);
+    Pairs.IntPair adjacentB = new Pairs.IntPair(11, 20);
+    assertTrue(IntRanges.rangesAreMergeable(adjacentA, adjacentB));
+    assertTrue(IntRanges.rangesAreMergeable(adjacentB, adjacentA));
+
+    Pairs.IntPair overlappingA = new Pairs.IntPair(0, 10);
+    Pairs.IntPair overlappingB = new Pairs.IntPair(10, 15);
+    assertTrue(IntRanges.rangesAreMergeable(overlappingA, overlappingB));
+    assertTrue(IntRanges.rangesAreMergeable(overlappingB, overlappingA));
+
+    Pairs.IntPair enclosedA = new Pairs.IntPair(0, 20);
+    Pairs.IntPair enclosedB = new Pairs.IntPair(5, 15);
+    assertTrue(IntRanges.rangesAreMergeable(enclosedA, enclosedB));
+    assertTrue(IntRanges.rangesAreMergeable(enclosedB, enclosedA));
+  }
+
+  @Test
+  public void testMergeIntoFirst() {
+    Pairs.IntPair a = new Pairs.IntPair(0, 10);
+    Pairs.IntPair b = new Pairs.IntPair(11, 20);
+    IntRanges.mergeIntoFirst(a, b);
+
+    // a should contain the merged interval
+    assertEquals(a.getLeft(), 0);
+    assertEquals(a.getRight(), 20);
+
+    // b should be unchanged
+    assertEquals(b.getLeft(), 11);
+    assertEquals(b.getRight(), 20);
+  }
+}


### PR DESCRIPTION
When a query predicate is specified on a sorted column, we gather the
matching dictionaryIds and convert them to a range list. For inequality
predicates, such as NEQ (not equals) or NOT_IN, when querying a high
cardinality column, it means that we have to hold on to a large list
of ranges during query processing.

This rewritten algorithm for computing the list of ranges merges
adjacent docId ranges and builds its list of ranges from the list of
excluded dictionaryIds, thus minimizing the number of ranges held
resident during query processing and lowering the amount of memory
used during effective range calculation.