### PR TITLE
Segment Completion corner cases

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -163,6 +163,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   private final ServerSegmentCompletionProtocolHandler _protocolHandler;
 
 
+  // TODO each time this method is called, we print reason for stop. Good to print only once.
   private boolean endCriteriaReached() {
     Preconditions.checkState(_state.shouldConsume(), "Incorrect state %s", _state);
     if (_state.equals(State.INITIAL_CONSUMING)) {
@@ -331,7 +332,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
    */
   private boolean buildSegment(boolean buildTgz) {
     // Build a segment from in-memory rows.If buildTgz is true, then build the tar.gz file as well
-    // TODO Use an auto-closeable objec to delete temp resources.
+    // TODO Use an auto-closeable object to delete temp resources.
     File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + _segmentNameStr + "-" + String.valueOf(now()));
 
     // lets convert the segment now
@@ -497,7 +498,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
 
   public void start() {
     _state = State.INITIAL_CONSUMING;
-    _consumerThread = new Thread(new PartitionConsumer(), "consumer_" + _kafkaTopic + "_" + _kafkaPartitionId + "_" + _startOffset);
+    _consumerThread = new Thread(_segmentNameStr);
     segmentLogger.info("Created new consumer thread {} for {}", _consumerThread, this.toString());
     _consumerThread.start();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -106,6 +106,7 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
       return;
     }
     RealtimeSegmentZKMetadata segmentZKMetadata = (RealtimeSegmentZKMetadata) inputSegmentZKMetadata;
+    LOGGER.info("Attempting to add realtime segment {} for table {}", segmentId, tableName);
 
     if (new File(_indexDir, segmentId).exists() && (segmentZKMetadata).getStatus() == Status.DONE) {
       // segment already exists on file, and we have committed the realtime segment in ZK. Treat it like an offline segment
@@ -129,7 +130,7 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
       }
       PinotHelixPropertyStoreZnRecordProvider propertyStoreHelper = PinotHelixPropertyStoreZnRecordProvider.forSchema(propertyStore);
       ZNRecord record = propertyStoreHelper.get(tableConfig.getValidationConfig().getSchemaName());
-      LOGGER.info("found schema {} ", tableConfig.getValidationConfig().getSchemaName());
+      LOGGER.info("Found schema {} ", tableConfig.getValidationConfig().getSchemaName());
       Schema schema = Schema.fromZNRecord(record);
       if (!isValid(schema, tableConfig.getIndexingConfig())) {
         LOGGER.error("Not adding segment {}", segmentId);
@@ -151,6 +152,7 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
           TarGzCompressionUtils.unTar(tempFile, tempSegmentFolder);
           FileUtils.deleteQuietly(tempFile);
           FileUtils.moveDirectory(tempSegmentFolder, new File(_indexDir, segmentId));
+          LOGGER.info("Replacing LLC Segment {}", segmentId);
           replaceLLSegment(segmentId);
           return;
         }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -116,7 +116,6 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       if (acquiredSegment == null) {
         throw new RuntimeException("Segment " + segmentNameStr + " + not present ");
       }
-      // TODO change
 
       try {
         if (!(acquiredSegment instanceof LLRealtimeSegmentDataManager)) {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -116,9 +116,16 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       if (acquiredSegment == null) {
         throw new RuntimeException("Segment " + segmentNameStr + " + not present ");
       }
-      LLRealtimeSegmentDataManager segmentDataManager = (LLRealtimeSegmentDataManager)acquiredSegment;
+      // TODO change
 
       try {
+        if (!(acquiredSegment instanceof LLRealtimeSegmentDataManager)) {
+          // We found a LLC segment that is not consuming right now, must be that we already swapped it with a
+          // segment that has been built. Nothing to do for this state transition.
+          LOGGER.info("Segment {} not an instance of LLRealtimeSegmentDataManager. Reporting success for the transition", acquiredSegment.getSegmentName());
+          return;
+        }
+        LLRealtimeSegmentDataManager segmentDataManager = (LLRealtimeSegmentDataManager)acquiredSegment;
         RealtimeSegmentZKMetadata metadata = ZKMetadataProvider.getRealtimeSegmentZKMetadata(propertyStore,
             segmentName.getTableName(), segmentNameStr);
         segmentDataManager.goOnlineFromConsuming(metadata);
@@ -126,9 +133,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         LOGGER.warn("State transition interrupted", e);
         throw new RuntimeException(e);
       } finally {
-        if (acquiredSegment != null) {
-          tableDataManager.releaseSegment(segmentDataManager);
-        }
+        tableDataManager.releaseSegment(acquiredSegment);
       }
     }
 


### PR DESCRIPTION
Handle the condition when a CONSUMING to ONLINE state transition happens after the local segment has
been retained (and swapped in place) by the consumer.

Name the segment consumption thread after the segment.