### PR TITLE
Refine Pinot queries sent from ThirdEye for reducing query time.

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -198,7 +198,8 @@ public class PqlUtils {
       long startInConvertedUnits = dataGranularity.convertToUnit(start.getMillis());
       long endInConvertedUnits = dataGranularity.convertToUnit(endExclusive.getMillis());
       startQueryTime = String.valueOf(startInConvertedUnits);
-      endQueryTimeExclusive = String.valueOf(endInConvertedUnits);
+      endQueryTimeExclusive = (endInConvertedUnits == startInConvertedUnits + 1) ?
+          startQueryTime : String.valueOf(endInConvertedUnits);
     } else {
       DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZoneUTC();
       startQueryTime = dateTimeFormatter.print(start);


### PR DESCRIPTION
Assume that a query has a time range from 10PM to 11PM, the query was WHERE time >= 10PM AND time < 11PM. Now is refined to WHERE time = 10PM. The query time is reduced 60% to 90%.

=== Experimental Results ===
Previous:
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 took:1249 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 took:328 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY co took:795 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY co took:1244 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY br took:998 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY br took:1129 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY en took:1208 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY en took:895 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY de took:1211 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY de took:1287 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY co took:1420 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY co took:349 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY lo took:1028 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY lo took:1244 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY os took:832 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY os took:940 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY se took:1339 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY se took:1339 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY so took:975 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY so took:1028 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408759 AND hours < 408760 GROUP BY pa took:1193 ms
SELECT SUM(Views) FROM dataset WHERE hours >= 408927 AND hours < 408928 GROUP BY pa took:1521 ms

Current:
SELECT SUM(Views) FROM dataset WHERE hours = 408759 took:70 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 took:70 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY co took:73 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY co took:82 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY br took:77 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY br took:85 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY en took:84 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY en took:85 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY de took:85 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY de took:85 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY co took:85 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY co took:90 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY lo took:75 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY lo took:70 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY os took:74 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY os took:74 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY se took:103 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY se took:103 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY so took:102 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY so took:100 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408759 GROUP BY pa took:169 ms
SELECT SUM(Views) FROM dataset WHERE hours = 408927 GROUP BY pa took:446 ms
