### PR TITLE
Fixing default top value for queries to pinot

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -29,6 +29,7 @@ public class PqlUtils {
   private static final Joiner COMMA = Joiner.on(",");
   private static final Joiner EQUALS = Joiner.on(" = ");
   private static final Logger LOGGER = LoggerFactory.getLogger(PqlUtils.class);
+  private static final int DEFAULT_TOP = 300000;
 
   /**
    * Returns sql to calculate the sum of all raw metrics required for <tt>request</tt>, grouped by
@@ -102,8 +103,7 @@ public class PqlUtils {
     String groupByClause = getDimensionGroupByClause(groupBy, timeGranularity, dataTimeSpec);
     if (StringUtils.isNotBlank(groupByClause)) {
       sb.append(" ").append(groupByClause);
-      int bucketCount = Integer.MAX_VALUE;
-      sb.append(" TOP ").append(bucketCount);
+      sb.append(" TOP ").append(DEFAULT_TOP);
 
     }
 
@@ -128,8 +128,7 @@ public class PqlUtils {
     String groupByClause = getDimensionGroupByClause(groupBy, timeGranularity, dataTimeSpec);
     if (StringUtils.isNotBlank(groupByClause)) {
       sb.append(" ").append(groupByClause);
-      int bucketCount = Integer.MAX_VALUE;
-      sb.append(" TOP ").append(bucketCount);
+      sb.append(" TOP ").append(DEFAULT_TOP);
 
     }
 


### PR DESCRIPTION
Was seeing exception:
com.linkedin.thirdeye.client.cache.ResultSetGroupCacheLoader: Error when running pql:SELECT COUNT(*) FROM ollection WHERE  Date >= 408788 AND Date < 408955 GROUP BY dimension TOP 2147483647
! com.linkedin.pinot.client.PinotClientException: Query had processing exceptions: 
! [{"errorCode":700,"message":"java.lang.RuntimeException: Value for 'TOP' 2147483647 exceeded maximum allowed value of 300000