### PR TITLE
Fetch initial Kafka offset on table creation

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -209,9 +209,9 @@ public class PinotTableIdealStateBuilder {
     final String topicName = kafkaMetadata.getKafkaTopicName();
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();
     final int nPartitions = getPartitionsCount(kafkaMetadata);
-    // TODO Get/Infer the initial offset from table Config?
-    final long startOffset = 0L;
-    segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas, 0L,
+
+    segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas,
+        kafkaMetadata.getKafkaConsumerProperties().get("auto.offset.reset"), kafkaMetadata.getBootstrapHosts(),
         idealState, create);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -196,6 +196,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   }
 
   private void consumeLoop() {
+    segmentLogger.info("Starting consumption loop start offset {}, end offset {}", _currentOffset, _endOffset);
     while(!_receivedStop && !endCriteriaReached()) {
       // Consume for the next _kafkaReadTime ms, or we get to final offset, whichever happens earlier,
       // Update _currentOffset upon return from this method


### PR DESCRIPTION
Fetch the Kafka start offset on a per-partition basis when creating a
new LLC realtime table, so that tables consuming from an already
existing Kafka topic have a valid start offset.