### PR TITLE
StarTree: Added capability in server to auto convert star tree binary from v1 to v2 during index loading.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
@@ -35,6 +35,7 @@ public class IndexingConfig {
   private String lazyLoad;
   private Map<String, String> streamConfigs = new HashMap<String, String>();
   private String segmentFormatVersion;
+  private String starTreeFormat;
 
   public IndexingConfig() {
 
@@ -120,5 +121,11 @@ public class IndexingConfig {
     return result.toString();
   }
 
+  public String getStarTreeFormat() {
+    return starTreeFormat;
+  }
 
+  public void setStarTreeFormat(String starTreeFormat) {
+    this.starTreeFormat = starTreeFormat;
+  }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/IndexLoadingConfigMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/IndexLoadingConfigMetadata.java
@@ -32,10 +32,14 @@ public class IndexLoadingConfigMetadata {
   public static final String KEY_OF_LOADING_INVERTED_INDEX = "metadata.loading.inverted.index.columns";
   public static final String KEY_OF_SEGMENT_FORMAT_VERSION = "segment.format.version";
   public static final String KEY_OF_ENABLE_DEFAULT_COLUMNS = "enable.default.columns";
+  public static final String KEY_OF_STAR_TREE_FORMAT_VERSION = "startree.format.version";
+
   private final Set<String> _loadingInvertedIndexColumnSet = new HashSet<String>();
   private final String DEFAULT_SEGMENT_FORMAT = "v1";
+  private static final String DEFAULT_STAR_TREE_FORMAT = "V1";
   private String segmentVersionToLoad;
   private boolean enableDefaultColumns;
+  private final String starTreeVersionToLoad;
 
   public IndexLoadingConfigMetadata(Configuration tableDataManagerConfig) {
     List<String> valueOfLoadingInvertedIndexConfig = tableDataManagerConfig.getList(KEY_OF_LOADING_INVERTED_INDEX, null);
@@ -45,6 +49,7 @@ public class IndexLoadingConfigMetadata {
 
     segmentVersionToLoad = tableDataManagerConfig.getString(KEY_OF_SEGMENT_FORMAT_VERSION, DEFAULT_SEGMENT_FORMAT);
     enableDefaultColumns = tableDataManagerConfig.getBoolean(KEY_OF_ENABLE_DEFAULT_COLUMNS, false);
+    starTreeVersionToLoad = tableDataManagerConfig.getString(KEY_OF_STAR_TREE_FORMAT_VERSION, DEFAULT_STAR_TREE_FORMAT);
   }
 
   public void initLoadingInvertedIndexColumnSet(String[] columnCollections) {
@@ -73,5 +78,9 @@ public class IndexLoadingConfigMetadata {
 
   public boolean isEnableDefaultColumns() {
     return enableDefaultColumns;
+  }
+
+  public String getStarTreeVersionToLoad() {
+    return starTreeVersionToLoad;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -202,6 +202,7 @@ public class CommonConstants {
     public static final String DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS = "0";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.server.segment.fetcher";
     public static final String DEFAULT_SEGMENT_FORMAT_VERSION = "v1";
+    public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "v1";
   }
 
   public static class Metric {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
@@ -27,6 +27,8 @@ public class V1Constants {
   public static final String SEGMENT_CREATION_META = "creation.meta";
   public static final String STAR_TREE_INDEX_DIR = "star-tree";
   public static final String STAR_TREE_INDEX_FILE = "star-tree.bin";
+  public static final String STAR_TREE_V1_INDEX_FILE = "star-tree-on-heap.bin";
+  public static final String STAR_TREE_V2_INDEX_FILE = "star-tree-off-heap.bin";
   public static final String VERSIONS_FILE = "versions.vr";
   public static final String SEGMENT_DOWNLOAD_URL = "segment.download.url";
   public static final String SEGMENT_PUSH_TIME = "segment.push.time";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTree.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTree.java
@@ -17,12 +17,9 @@ package com.linkedin.pinot.core.startree;
 
 import com.google.common.collect.HashBiMap;
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.util.Map;
@@ -58,8 +55,8 @@ public class StarTree implements StarTreeInterf {
    * @return
    */
   @Override
-  public Version getVersion() {
-    return Version.V1;
+  public StarTreeFormatVersion getVersion() {
+    return StarTreeFormatVersion.V1;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeFormatVersion.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeFormatVersion.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+/**
+ * Enum for StarTree in-memory/on-disk format
+ * V1: On heap using HashMaps
+ * V2: Off-heap using byte buffers
+ */
+public enum StarTreeFormatVersion {
+  V1,
+  V2
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeInterf.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeInterf.java
@@ -26,11 +26,6 @@ import java.io.Serializable;
  */
 public interface StarTreeInterf extends Serializable {
 
-  enum Version {
-    V1,
-    V2
-  }
-
   /**
    * Returns the root of the StarTree.
    * @return
@@ -41,7 +36,7 @@ public interface StarTreeInterf extends Serializable {
    * Returns the version of star tree.
    * @return
    */
-  Version getVersion();
+  StarTreeFormatVersion getVersion();
 
   /**
    * Returns the total number of nodes in the star tree.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeV2.java
@@ -192,8 +192,8 @@ public class StarTreeV2 implements StarTreeInterf {
    * {@inheritDoc}
    * @return
    */
-  public Version getVersion() {
-    return Version.V2;
+  public StarTreeFormatVersion getVersion() {
+    return StarTreeFormatVersion.V2;
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeConverter.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeConverter.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.startree;
+
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test for Star Tree v1-v2 converter.
+ */
+public class TestStarTreeConverter {
+  private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+  private static final String SEGMENT_DIR_NAME = TMP_DIR + File.separator + "StarTreeFormatConverter";
+  private static final String SEGMENT_NAME = "starTreeSegment";
+
+  private IndexSegment _segment;
+  private StarTreeInterf _starTreeV1;
+  private File _indexDir;
+
+  /**
+   * Build the star tree index
+   * @throws Exception
+   */
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    StarTreeIndexTestSegmentHelper.buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, false);
+    _segment = StarTreeIndexTestSegmentHelper.loadSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
+    _starTreeV1 = _segment.getStarTree();
+    _indexDir = new File(SEGMENT_DIR_NAME, SEGMENT_NAME);
+
+  }
+
+  /**
+   * This test builds a star-tree in v1 format, and then performs multiple
+   * format conversions, and asserts that all conversions work as expected.
+   *
+   * @throws IOException
+   * @throws ClassNotFoundException
+   */
+  @Test
+  public void testConverter()
+      throws IOException, ClassNotFoundException {
+
+    // Convert from V1 to V1, this should be no-op.
+    StarTreeSerDe.convertStarTreeFormatIfNeeded(_indexDir, StarTreeFormatVersion.V1);
+    assertStarTreeVersion(_indexDir, StarTreeFormatVersion.V1);
+
+    // Convert from V1 to V2.
+    StarTreeSerDe.convertStarTreeFormatIfNeeded(_indexDir, StarTreeFormatVersion.V2);
+    assertStarTreeVersion(_indexDir, StarTreeFormatVersion.V2);
+
+    // Convert from V2 to V2, this should be no-op
+    StarTreeSerDe.convertStarTreeFormatIfNeeded(_indexDir, StarTreeFormatVersion.V2);
+    assertStarTreeVersion(_indexDir, StarTreeFormatVersion.V2);
+
+    // Convert from V2 to V1.
+    StarTreeSerDe.convertStarTreeFormatIfNeeded(_indexDir, StarTreeFormatVersion.V1);
+    assertStarTreeVersion(_indexDir, StarTreeFormatVersion.V1);
+  }
+
+  private void assertStarTreeVersion(File indexDir, StarTreeFormatVersion expectedVersion)
+      throws IOException {
+    File starTreeFile = new File(indexDir, V1Constants.STAR_TREE_INDEX_FILE);
+    Assert.assertEquals(StarTreeSerDe.getStarTreeVersion(starTreeFile), expectedVersion);
+  }
+
+  /**
+   * Cleanup any temporary files and directories.
+   * @throws IOException
+   */
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(new File(SEGMENT_DIR_NAME));
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.primitives.Longs;
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileWriter;
@@ -732,7 +733,14 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
             // in their filename don't work properly
             genConfig.setSegmentNamePostfix(Integer.toString(segmentNumber) + " %");
             genConfig.setEnableStarTreeIndex(createStarTreeIndex);
-            genConfig.setStarTreeIndexSpec(null);
+
+            // Enable off heap star tree format in the integration test.
+            StarTreeIndexSpec starTreeIndexSpec = null;
+            if (createStarTreeIndex) {
+              starTreeIndexSpec = new StarTreeIndexSpec();
+              starTreeIndexSpec.setEnableOffHeapFormat(true);
+            }
+            genConfig.setStarTreeIndexSpec(starTreeIndexSpec);
 
             final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
             driver.init(genConfig);

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/PerfBenchmarkDriver.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/PerfBenchmarkDriver.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.perf;
 
 import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.Tenant;
 import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
@@ -284,8 +285,9 @@ public class PerfBenchmarkDriver {
     AbstractTableConfig offlineTableConfig = AbstractTableConfig.init(jsonString);
     offlineTableConfig.getValidationConfig().setRetentionTimeUnit("DAYS");
     offlineTableConfig.getValidationConfig().setRetentionTimeValue("");
+    IndexingConfig indexingConfig = offlineTableConfig.getIndexingConfig();
     if (invertedIndexColumns != null && !invertedIndexColumns.isEmpty()) {
-      offlineTableConfig.getIndexingConfig().setInvertedIndexColumns(invertedIndexColumns);
+      indexingConfig.setInvertedIndexColumns(invertedIndexColumns);
     }
     helixResourceManager.addTable(offlineTableConfig);
   }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
+import com.linkedin.pinot.core.data.readers.FileFormat;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.tools.Command;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -22,16 +25,11 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.io.FileUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.core.data.readers.FileFormat;
-import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
-import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 
 
 /**


### PR DESCRIPTION
1. Added a new config setting "starTreeFormatVersion' in
TableIndexConfig that can take values 'V1' or 'V2'.

2. Depending on the setting in the config, and the star tree format in
the index the action taken is as follows:
   - If config version matches version in index, then no action is
     taken.
   - In case of mis-match, appropriate conversion is done on the fly and
     back up copies are made for each version (to avoid conversion in
future).

3. Added unit test for star tree format converter.

4. Enabled star tree v2 format in StarTreeClusterIntegrationTest.