### PR TITLE
Improve display of Pinot processes

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -159,11 +159,8 @@
               </jvmSettings>
             </program>
             <program>
-              <mainClass>com.linkedin.pinot.tools.admin.PinotAdministrator</mainClass>
+              <mainClass>com.linkedin.pinot.tools.admin.PinotController</mainClass>
               <name>start-controller</name>
-              <commandLineArguments>
-                <commandLineArgument>StartController</commandLineArgument>
-              </commandLineArguments>
               <jvmSettings>
                 <initialMemorySize>1G</initialMemorySize>
                 <maxMemorySize>1G</maxMemorySize>
@@ -173,11 +170,8 @@
               </jvmSettings>
             </program>
             <program>
-              <mainClass>com.linkedin.pinot.tools.admin.PinotAdministrator</mainClass>
+              <mainClass>com.linkedin.pinot.tools.admin.PinotBroker</mainClass>
               <name>start-broker</name>
-              <commandLineArguments>
-                <commandLineArgument>StartBroker</commandLineArgument>
-              </commandLineArguments>
               <jvmSettings>
                 <initialMemorySize>1G</initialMemorySize>
                 <maxMemorySize>1G</maxMemorySize>
@@ -187,11 +181,8 @@
               </jvmSettings>
             </program>
             <program>
-              <mainClass>com.linkedin.pinot.tools.admin.PinotAdministrator</mainClass>
+              <mainClass>com.linkedin.pinot.tools.admin.PinotServer</mainClass>
               <name>start-server</name>
-              <commandLineArguments>
-                <commandLineArgument>StartServer</commandLineArgument>
-              </commandLineArguments>
               <jvmSettings>
                 <initialMemorySize>1G</initialMemorySize>
                 <maxMemorySize>1G</maxMemorySize>

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotBroker.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotBroker.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.tools.admin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Simple shim so that jps -l shows PinotBroker instead of PinotAdministrator
+ */
+public class PinotBroker {
+  public static void main(String[] args) throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.add("StartBroker");
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotController.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotController.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.tools.admin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Simple shim so that jps -l shows PinotController instead of PinotAdministrator
+ */
+public class PinotController {
+  public static void main(String[] args) throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.add("StartController");
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotServer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotServer.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.tools.admin;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Simple shim so that jps -l shows PinotServer instead of PinotAdministrator
+ */
+public class PinotServer {
+  public static void main(String[] args) throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.add("StartServer");
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}


### PR DESCRIPTION
Improve display of Pinot processes by using a specific class for each
Pinot process, so that external utilities (ps, jps -l) show either
PinotServer, PinotBroker or PinotController instead of
PinotAdministrator.