### PR TITLE
Add console output for all Pinot services

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -110,6 +110,10 @@
       <artifactId>helix-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-log</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.linkedin.pinot</groupId>
       <artifactId>pinot-common</artifactId>
       <version>${project.version}</version>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -121,6 +121,10 @@
     <scope>test</scope>
   </dependency>
     <!-- End Helix Related Depedency -->
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-log</artifactId>
+    </dependency>
 
   </dependencies>
   <build>

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -79,6 +79,8 @@ public class ControllerStarter {
   }
 
   public void start() {
+    LOGGER.info("Starting Pinot controller");
+
     Utils.logVersions();
 
     component.getServers().add(Protocol.HTTP, Integer.parseInt(config.getControllerPort()));
@@ -87,7 +89,7 @@ public class ControllerStarter {
 
     final Context applicationContext = component.getContext().createChildContext();
 
-    LOGGER.info("injecting conf and resource manager to the api context");
+    LOGGER.info("Injecting configuration and resource manager to the API context");
     applicationContext.getAttributes().put(ControllerConf.class.toString(), config);
     applicationContext.getAttributes().put(PinotHelixResourceManager.class.toString(), helixResourceManager);
     MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
@@ -104,20 +106,23 @@ public class ControllerStarter {
     final ControllerMetrics controllerMetrics = new ControllerMetrics(_metricsRegistry);
 
     try {
-      LOGGER.info("starting pinot helix resource manager");
+      LOGGER.info("Starting Pinot Helix resource manager and connecting to Zookeeper");
       helixResourceManager.start();
       // Helix resource manager must be started in order to create PinotLLCRealtimeSegmentManager
       PinotLLCRealtimeSegmentManager.create(helixResourceManager, config);
-      LOGGER.info("starting api component");
+      LOGGER.info("Starting Pinot REST API component");
       component.start();
-      LOGGER.info("starting retention manager");
+      LOGGER.info("Starting retention manager");
       retentionManager.start();
-      LOGGER.info("starting validation manager");
+      LOGGER.info("Starting validation manager");
       validationManager.start();
-      LOGGER.info("starting realtime segments manager");
+      LOGGER.info("Starting realtime segment manager");
       realtimeSegmentsManager.start(controllerMetrics);
-      LOGGER.info("starting segments status manager");
+      LOGGER.info("Starting segment status manager");
       segmentStatusChecker.start(controllerMetrics);
+      LOGGER.info("Pinot controller ready and listening on port {} for API requests", config.getControllerPort());
+      LOGGER.info("Controller services available at http://{}:{}/", config.getControllerHost(),
+          config.getControllerPort());
     } catch (final Exception e) {
       LOGGER.error("Caught exception while starting controller", e);
       Utils.rethrowException(e);
@@ -153,27 +158,27 @@ public class ControllerStarter {
 
   public void stop() {
     try {
-      LOGGER.info("stopping validation manager");
+      LOGGER.info("Stopping validation manager");
       validationManager.stop();
 
-      LOGGER.info("stopping retention manager");
+      LOGGER.info("Stopping retention manager");
       retentionManager.stop();
 
-      LOGGER.info("stopping api component");
+      LOGGER.info("Stopping API component");
       component.stop();
 
-      LOGGER.info("stopping realtime segments manager");
+      LOGGER.info("Stopping realtime segment manager");
       realtimeSegmentsManager.stop();
 
-      LOGGER.info("stopping resource manager");
+      LOGGER.info("Stopping resource manager");
       helixResourceManager.stop();
 
-      LOGGER.info("stopping segments status manager");
+      LOGGER.info("Stopping segment status manager");
       segmentStatusChecker.stop();
 
       executorService.shutdownNow();
     } catch (final Exception e) {
-      LOGGER.error("Caught exception", e);
+      LOGGER.error("Caught exception while shutting down", e);
     }
   }
 

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -93,6 +93,10 @@
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-log</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -77,6 +77,7 @@ public class HelixServerStarter {
 
   public HelixServerStarter(String helixClusterName, String zkServer, Configuration pinotHelixProperties)
       throws Exception {
+    LOGGER.info("Starting Pinot server");
     _helixClusterName = helixClusterName;
     _pinotHelixProperties = pinotHelixProperties;
     String hostname = pinotHelixProperties.getString(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST,
@@ -93,6 +94,7 @@ public class HelixServerStarter {
     pinotHelixProperties.addProperty("pinot.server.instance.id", _instanceId);
     startServerInstance(pinotHelixProperties);
 
+    LOGGER.info("Connecting Helix components");
     // Replace all white-spaces from list of zkServers.
     String zkServers = zkServer.replaceAll("\\s+", "");
     _helixManager =
@@ -141,6 +143,8 @@ public class HelixServerStarter {
         });
 
     ControllerLeaderLocator.create(_helixManager);
+
+    LOGGER.info("Pinot server ready");
 
     // Create metrics for mmap stuff
     _serverInstance.getServerMetrics().addCallbackGauge(
@@ -213,12 +217,10 @@ public class HelixServerStarter {
     setupHelixSystemProperties(moreConfigurations);
 
     if (_serverInstance == null) {
-      LOGGER.info("Trying to create a new ServerInstance!");
       _serverInstance = new ServerInstance();
-      LOGGER.info("Trying to initial ServerInstance!");
       _serverInstance.init(_serverConf, new MetricsRegistry());
-      LOGGER.info("Trying to start ServerInstance!");
       _serverInstance.start();
+      LOGGER.info("Started server instance");
     }
   }
 

--- a/pinot-tools/src/main/resources/conf/pinot-broker-log4j.properties
+++ b/pinot-tools/src/main/resources/conf/pinot-broker-log4j.properties
@@ -14,9 +14,23 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=INFO, brokerLog
+log4j.rootLogger=INFO, brokerLog, consoleWarn
 
 log4j.appender.brokerLog=org.apache.log4j.FileAppender
 log4j.appender.brokerLog.layout=org.apache.log4j.PatternLayout
 log4j.appender.brokerLog.File=pinotBroker.log
 log4j.appender.brokerLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n
+
+# Output broker starter logs to the console
+log4j.logger.com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter=INFO, consoleLog
+log4j.appender.consoleLog=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleLog.Target=System.out
+log4j.appender.consoleLog.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.consoleLog.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %color{%-5p} %c{1} - %m%n
+
+# Display all warnings on the console
+log4j.appender.consoleWarn=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleWarn.Target=System.out
+log4j.appender.consoleWarn.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.consoleWarn.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %color{%-5p} %c{1} - %m%n
+log4j.appender.consoleWarn.Threshold=WARN

--- a/pinot-tools/src/main/resources/conf/pinot-controller-log4j.properties
+++ b/pinot-tools/src/main/resources/conf/pinot-controller-log4j.properties
@@ -14,9 +14,24 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=INFO, controllerLog
+log4j.rootLogger=INFO, controllerLog, consoleWarn
 
+# Direct most logs to the log file
 log4j.appender.controllerLog=org.apache.log4j.FileAppender
 log4j.appender.controllerLog.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerLog.File=pinotController.log
 log4j.appender.controllerLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n
+
+# Output controller starter logs to the console
+log4j.logger.com.linkedin.pinot.controller.ControllerStarter=INFO, consoleLog
+log4j.appender.consoleLog=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleLog.Target=System.out
+log4j.appender.consoleLog.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.consoleLog.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %color{%-5p} %c{1} - %m%n
+
+# Display all warnings on the console
+log4j.appender.consoleWarn=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleWarn.Target=System.out
+log4j.appender.consoleWarn.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.consoleWarn.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %color{%-5p} %c{1} - %m%n
+log4j.appender.consoleWarn.Threshold=WARN

--- a/pinot-tools/src/main/resources/conf/pinot-server-log4j.properties
+++ b/pinot-tools/src/main/resources/conf/pinot-server-log4j.properties
@@ -14,9 +14,23 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=INFO, serverLog
+log4j.rootLogger=INFO, serverLog, consoleWarn
 
 log4j.appender.serverLog=org.apache.log4j.FileAppender
 log4j.appender.serverLog.layout=org.apache.log4j.PatternLayout
 log4j.appender.serverLog.File=pinotServer.log
 log4j.appender.serverLog.layout.ConversionPattern=%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c] [%x] %m%n
+
+# Output server starter logs to the console
+log4j.logger.com.linkedin.pinot.server.starter.helix.HelixServerStarter=INFO, consoleLog
+log4j.appender.consoleLog=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleLog.Target=System.out
+log4j.appender.consoleLog.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.consoleLog.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %color{%-5p} %c{1} - %m%n
+
+# Display all warnings on the console
+log4j.appender.consoleWarn=org.apache.log4j.ConsoleAppender
+log4j.appender.consoleWarn.Target=System.out
+log4j.appender.consoleWarn.layout=com.jcabi.log.MulticolorLayout
+log4j.appender.consoleWarn.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %color{%-5p} %c{1} - %m%n
+log4j.appender.consoleWarn.Threshold=WARN

--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,11 @@
         <artifactId>antlr4-annotations</artifactId>
         <version>4.3</version>
       </dependency>
+      <dependency>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-log</artifactId>
+        <version>0.17.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
Add console output for the controller, broker and server, along with
port and status information when start up is completed. Display
warnings and errors on the console with colored output.