### PR TITLE
Remove warnings about no WAR client connector

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -84,7 +84,6 @@ public class ControllerStarter {
     component.getServers().add(Protocol.HTTP, Integer.parseInt(config.getControllerPort()));
     component.getClients().add(Protocol.FILE);
     component.getClients().add(Protocol.JAR);
-    component.getClients().add(Protocol.WAR);
 
     final Context applicationContext = component.getContext().createChildContext();
 

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/AdminApiService.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/AdminApiService.java
@@ -43,7 +43,6 @@ public class AdminApiService {
     adminApiComponent.getServers().add(Protocol.HTTP, httpPort);
     adminApiComponent.getClients().add(Protocol.FILE);
     adminApiComponent.getClients().add(Protocol.JAR);
-    adminApiComponent.getClients().add(Protocol.WAR);
 
     PinotAdminEndpointApplication adminEndpointApplication = new PinotAdminEndpointApplication();
     final Context applicationContext = adminApiComponent.getContext().createChildContext();


### PR DESCRIPTION
Remove warnings on the console referring to the unused WAR client
connector.