### PR TITLE
THIRDEYE-884 : Restructure the way columns are named in thirdeye-hadoop rollup

### DIFF
--- a/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/config/ThirdEyeConfig.java
+++ b/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/config/ThirdEyeConfig.java
@@ -136,10 +136,6 @@ public final class ThirdEyeConfig {
           transformDimensions.add(spec.getDimensionName());
         }
       }
-      Map<String, String> whitelist = topKWhitelist.getWhitelist();
-      if (whitelist != null) {
-        transformDimensions.addAll(whitelist.keySet());
-      }
     }
     return transformDimensions;
   }

--- a/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/config/ThirdEyeConstants.java
+++ b/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/config/ThirdEyeConstants.java
@@ -6,7 +6,7 @@ import org.joda.time.format.DateTimeFormatter;
 public final class ThirdEyeConstants {
   public static final String TOPK_VALUES_FILE = "topk_values";
   public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormat.forPattern("YYYY-MM-dd-HHmmss");
-  public static final String RAW_DIMENSION_SUFFIX = "_raw";
+  public static final String TOPK_DIMENSION_SUFFIX = "_topk";
   public static final String OTHER = "other";
   public static final String EMPTY_STRING = "";
   public static final Number EMPTY_NUMBER = 0;

--- a/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/segment/creation/SegmentCreationPhaseMapReduceJob.java
+++ b/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/segment/creation/SegmentCreationPhaseMapReduceJob.java
@@ -212,27 +212,11 @@ public class SegmentCreationPhaseMapReduceJob {
       // Set star tree config
       StarTreeIndexSpec starTreeIndexSpec = new StarTreeIndexSpec();
 
-      // _raw dimensions should not be in star tree split order
-      // if a dimension has a _raw column, we will include only
-      // the column with topk, and skip _raw column for materialization in star tree
-      Set<String> skipMaterializationForDimensions = new HashSet<>();
-      Set<String> transformDimensionsSet = thirdeyeConfig.getTransformDimensions();
-      LOGGER.info("Dimensions with _raw column {}", transformDimensionsSet);
-      for (String transformDimension : transformDimensionsSet) {
-        String rawDimension = transformDimension + ThirdEyeConstants.RAW_DIMENSION_SUFFIX;
-        skipMaterializationForDimensions.add(rawDimension);
-        LOGGER.info("Adding {} to skipMaterialization set", rawDimension);
-      }
-      starTreeIndexSpec.setSkipMaterializationForDimensions(skipMaterializationForDimensions);
-      LOGGER.info("Setting skipMaterializationForDimensions {}", skipMaterializationForDimensions);
-
       if (thirdeyeConfig.getSplit() != null) {
         starTreeIndexSpec.setMaxLeafRecords(thirdeyeConfig.getSplit().getThreshold());
         LOGGER.info("Setting split threshold to {}", starTreeIndexSpec.getMaxLeafRecords());
         List<String> splitOrder = thirdeyeConfig.getSplit().getOrder();
         if (splitOrder != null) {
-          LOGGER.info("Removing from splitOrder, any dimensions which are also in skipMaterializationForDimensions");
-          splitOrder.removeAll(skipMaterializationForDimensions);
           starTreeIndexSpec.setDimensionsSplitOrder(splitOrder);
         }
         LOGGER.info("Setting splitOrder {}", splitOrder);

--- a/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/topk/TopKPhaseJob.java
+++ b/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/topk/TopKPhaseJob.java
@@ -373,17 +373,8 @@ public class TopKPhaseJob extends Configured {
             for (DimensionValueMetricPair pair : topKQueue) {
               topkDimensionValues.addValue(dimension, pair.getDimensionValue());
             }
-
           }
         }
-
-        // Get whitelist
-        Set<String> whitelistValues = whitelist.get(dimension);
-        if (whitelistValues != null) {
-          LOGGER.info("Adding whitelist values for {} : {}", dimension, whitelistValues);
-          topkDimensionValues.addAllValues(dimension, whitelistValues);
-        }
-
       }
 
       if (topkDimensionValues.getTopKDimensions().size() > 0) {

--- a/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/util/ThirdeyePinotSchemaUtils.java
+++ b/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/util/ThirdeyePinotSchemaUtils.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
-import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
@@ -68,7 +67,7 @@ public class ThirdeyePinotSchemaUtils {
 
       if (transformDimensions.contains(dimensionName)) {
         fieldSpec = new DimensionFieldSpec();
-        dimensionName = dimensionName + ThirdEyeConstants.RAW_DIMENSION_SUFFIX;
+        dimensionName = dimensionName + ThirdEyeConstants.TOPK_DIMENSION_SUFFIX;
         fieldSpec.setName(dimensionName);
         fieldSpec.setDataType(DataType.STRING);
         fieldSpec.setSingleValueField(true);

--- a/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/derivedcolumn/transformation/DerivedColumnNoTransformationTest.java
+++ b/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/derivedcolumn/transformation/DerivedColumnNoTransformationTest.java
@@ -33,6 +33,7 @@ import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.hadoop.io.AvroSerialization;
 import org.apache.avro.mapred.AvroKey;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -218,6 +219,7 @@ public class DerivedColumnNoTransformationTest {
     private Map<String, Set<String>> topKDimensionsMap;
     private String timeColumnName;
     private List<MetricType> metricTypes;
+    private Map<String, Set<String>> whitelist;
 
     @Override
     public void setup(Context context) throws IOException, InterruptedException {
@@ -230,6 +232,7 @@ public class DerivedColumnNoTransformationTest {
       metricNames = config.getMetricNames();
       metricTypes = config.getMetricTypes();
       timeColumnName = config.getTimeColumnName();
+      whitelist = config.getWhitelist();
 
       outputSchema = new Schema.Parser().parse(configuration.get(DerivedColumnTransformationPhaseConstants.DERIVED_COLUMN_TRANSFORMATION_PHASE_OUTPUT_SCHEMA.toString()));
 
@@ -259,18 +262,37 @@ public class DerivedColumnNoTransformationTest {
       for (String dimension : dimensionsNames) {
         String dimensionName = dimension;
         String dimensionValue = ThirdeyeAvroUtils.getDimensionFromRecord(inputRecord, dimension);
-        // add column for topk + whitelist
+
+        // add original dimension value with whitelist applied
+        String whitelistDimensionValue = dimensionValue;
+        if (whitelist != null) {
+          Set<String> whitelistDimensions = whitelist.get(dimensionName);
+          if (CollectionUtils.isNotEmpty(whitelistDimensions)) {
+            // whitelist config exists for this dimension but value not present in whitelist
+            if (!whitelistDimensions.contains(dimensionValue)) {
+              whitelistDimensionValue = ThirdEyeConstants.OTHER;
+            }
+          }
+        }
+        outputRecord.put(dimensionName, whitelistDimensionValue);
+
+        // add column for topk, if topk config exists for that column
         if (topKDimensionsMap.containsKey(dimensionName)) {
           Set<String> topKDimensionValues = topKDimensionsMap.get(dimensionName);
-          if (topKDimensionValues != null && topKDimensionValues.contains(dimensionValue)) {
-            outputRecord.put(dimensionName, dimensionValue);
-          } else {
-            outputRecord.put(dimensionName, ThirdEyeConstants.OTHER);
+          // if topk config exists for that dimension
+          if (CollectionUtils.isNotEmpty(topKDimensionValues)) {
+            String topkDimensionName = dimensionName + ThirdEyeConstants.TOPK_DIMENSION_SUFFIX;
+            String topkDimensionValue = dimensionValue;
+            // topk config exists for this dimension, but value not present in topk
+            if (!topKDimensionValues.contains(dimensionValue) &&
+                (whitelist == null || whitelist.get(dimensionName) == null || !whitelist.get(dimensionName).contains(dimensionValue))) {
+              topkDimensionValue = ThirdEyeConstants.OTHER;
+            }
+            outputRecord.put(topkDimensionName, topkDimensionValue);
           }
-          dimensionName = dimension + ThirdEyeConstants.RAW_DIMENSION_SUFFIX;
         }
-        outputRecord.put(dimensionName, dimensionValue);
       }
+
 
       // metrics
       for (int i = 0; i < metricNames.size(); i ++) {

--- a/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/derivedcolumn/transformation/DerivedSchemaGenerationTest.java
+++ b/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/derivedcolumn/transformation/DerivedSchemaGenerationTest.java
@@ -63,13 +63,11 @@ public class DerivedSchemaGenerationTest {
 
     thirdeyeConfig = ThirdEyeConfig.fromProperties(props);
     outputSchema = job.newSchema(thirdeyeConfig);
-    Assert.assertEquals(inputSchema.getFields().size() + 2, outputSchema.getFields().size(),
+    Assert.assertEquals(inputSchema.getFields().size() + 1, outputSchema.getFields().size(),
         "Input schema should not be same as output schema if topk/whitelist in config");
 
-    Assert.assertEquals(outputSchema.getField("d2_raw") != null, true,
-        "Output schema should have _raw entries for columsn in topk/whitelist");
-    Assert.assertEquals(outputSchema.getField("d3_raw") != null, true,
-        "Output schema should have _raw entries for columsn in whitelist");
+    Assert.assertEquals(outputSchema.getField("d2_topk") != null, true,
+        "Output schema should have _topk entries for columsn in topk");
   }
 
 }

--- a/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/topk/TopkPhaseTest.java
+++ b/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/topk/TopkPhaseTest.java
@@ -218,9 +218,9 @@ public class TopkPhaseTest {
     Assert.assertTrue("Topk file failed to generate!", topKFile.exists());
     TopKDimensionValues topk = OBJECT_MAPPER.readValue(new FileInputStream(topKFile), TopKDimensionValues.class);
     Map<String, Set<String>> topkMap = topk.getTopKDimensions();
-    Assert.assertEquals("Incorrect topk object", topkMap.size(), 2);
+    Assert.assertEquals("Incorrect topk object", topkMap.size(), 1);
     Assert.assertEquals("Incorrect topk values in topk object", Sets.newHashSet("pqr1"), topkMap.get("d2"));
-    Assert.assertEquals("Incorrect whitelist values in topk object", Sets.newHashSet("xyz2"), topkMap.get("d3"));
+    Assert.assertEquals("Incorrect whitelist values in topk object", null, topkMap.get("d3"));
   }
 
 

--- a/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/util/ThirdeyePinotSchemaUtilsTest.java
+++ b/thirdeye/thirdeye-hadoop/src/test/java/com/linkedin/thirdeye/hadoop/util/ThirdeyePinotSchemaUtilsTest.java
@@ -57,8 +57,8 @@ public class ThirdeyePinotSchemaUtilsTest {
   public void testThirdeyeConfigToPinotSchemaGeneration() throws Exception {
     Schema schema = ThirdeyePinotSchemaUtils.createSchema(thirdeyeConfig);
 
-    Assert.assertEquals(schema.getAllFieldSpecs().size(), 9, "Incorrect pinot schema fields list size");
-    List<String> dimensions = Arrays.asList("d1", "d1_raw", "d2", "d2_raw", "d3");
+    Assert.assertEquals(schema.getAllFieldSpecs().size(), 8, "Incorrect pinot schema fields list size");
+    List<String> dimensions = Arrays.asList("d1", "d2", "d2_topk", "d3");
     Assert.assertEquals(schema.getDimensionNames().containsAll(dimensions), true,
         "New schema dimensions " + schema.getDimensionNames() + " is missing dimensions");
 

--- a/thirdeye/thirdeye-hadoop/src/test/resources/transformation_schema.avsc
+++ b/thirdeye/thirdeye-hadoop/src/test/resources/transformation_schema.avsc
@@ -18,7 +18,7 @@
         },
         {
             "doc": "dimension 2",
-            "name": "d2_raw",
+            "name": "d2_topk",
             "type": [
                 "null",
                 "string"


### PR DESCRIPTION
This pull request contains changes to restructure the way columns are named in top k rollup.
Topk columns will be created as column_topk, whereas the raw values will be kept ins column. Both columns will use the whitelist.
Tested for the following scenarios for a column:
1) No topk config, no whitelist config (No extra columsn created) 
2) No topk config, whitelist config (No extra columns created, but only whitelist values kept)
3) Topk config, no whitelist config (Extra column created, original column has all values, _topk column has only topk)
4) Topk config and whitelist config (Extra column created, original column hass whitelist values, _topk column has topk+whitelist values)