### PR TITLE
[PINOT-3631] Upgrade to kafka 0.9

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -262,7 +262,7 @@ public class HelixHelper {
     };
 
     // Removing partitions from ideal state
-    LOGGER.info("Trying to remove resource from idealstats");
+    LOGGER.info("Trying to remove resource {} from idealstate", resourceTag);
     HelixHelper.updateIdealState(helixManager, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, updater,
         DEFAULT_RETRY_POLICY);
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -209,6 +209,7 @@ public class PinotTableIdealStateBuilder {
     final String topicName = kafkaMetadata.getKafkaTopicName();
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();
     final int nPartitions = getPartitionsCount(kafkaMetadata);
+    LOGGER.info("Assigning {} partitions to instances for simple consumer for table {}", nPartitions, realtimeTableName);
 
     segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas,
         kafkaMetadata.getKafkaConsumerProperties().get("auto.offset.reset"), kafkaMetadata.getBootstrapHosts(),

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
     <avro.version>1.7.6</avro.version>
     <helix.version>0.6.5</helix.version>
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
-    <kafka.version>0.8.2.0</kafka.version>
-    <zkclient.version>0.3</zkclient.version>
+    <kafka.version>0.9.0.1</kafka.version>
+    <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.2.2</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
     <!-- Sets the VM argument line used when unit tests are run. -->


### PR DESCRIPTION
Turns out that kafka partition metadata is a list that is not necessarily ordered.
We need to search for the partition we are interested in, and get the offset for that
partition.

This but could have shown up anytime, it is not a change in the kafka response.