### PR TITLE
separate hll config and startree

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
@@ -157,6 +157,12 @@ public interface SegmentMetadata {
   Character getPaddingCharacter();
 
   /**
+   * returns Hll Log2m parameter
+   * @return
+   */
+  int getHllLog2m();
+
+  /**
    * @return
    */
   public Map<String, String> toMap();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/StarTreeMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/StarTreeMetadata.java
@@ -31,8 +31,6 @@ public class StarTreeMetadata {
   private long _maxLeafRecords;
   private long _skipMaterializationCardinality;
 
-  private boolean _enableHll;
-  private int _hllLog2m;
   private Map<String, String> _hllOriginToDerivedColumnMap;
 
   public StarTreeMetadata() {
@@ -76,22 +74,6 @@ public class StarTreeMetadata {
 
   public void setSkipMaterializationForDimensions(List<String> skipMaterializationForDimensions) {
     _skipMaterializationForDimensions = skipMaterializationForDimensions;
-  }
-
-  public boolean isEnableHll() {
-    return _enableHll;
-  }
-
-  public void setEnableHll(boolean enableHll) {
-    _enableHll = enableHll;
-  }
-
-  public int getHllLog2m() {
-    return _hllLog2m;
-  }
-
-  public void setHllLog2m(int hllLog2m) {
-    _hllLog2m = hllLog2m;
   }
 
   public String getDerivedHllColumnFromOrigin(String originColumn) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.helix.retention;
 
+import com.linkedin.pinot.core.startree.hll.HllConstants;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -458,6 +459,11 @@ public class RetentionManagerTest {
       @Override
       public Character getPaddingCharacter() {
         return V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
+      }
+
+      @Override
+      public int getHllLog2m() {
+        return HllConstants.DEFAULT_LOG2M;
       }
 
     };

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.validation;
 
+import com.linkedin.pinot.core.startree.hll.HllConstants;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -481,5 +482,9 @@ public class ValidationManagerTest {
       return V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
     }
 
+    @Override
+    public int getHllLog2m() {
+      return HllConstants.DEFAULT_LOG2M;
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DefaultAggregationExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DefaultAggregationExecutor.java
@@ -236,7 +236,7 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
       case HLL_PREAGGREGATED:
         HyperLogLog hllPreaggregated = resultHolder.getResult();
         if (hllPreaggregated == null) {
-          return new HyperLogLog(_segmentMetadata.getStarTreeMetadata().getHllLog2m());
+          return new HyperLogLog(_segmentMetadata.getHllLog2m());
         } else {
           return hllPreaggregated;
         }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionFactory.java
@@ -74,7 +74,7 @@ public class AggregationFunctionFactory {
         return new DistinctCountHLLAggregationFunction();
 
       case FASTHLL_AGGREGATION_FUNCTION:
-        return new FastHllAggregationFunction(segmentMetadata.getStarTreeMetadata().getHllLog2m());
+        return new FastHllAggregationFunction(segmentMetadata.getHllLog2m());
 
       case PERCENTILE50_AGGREGATION_FUNCTION:
         return new PercentileAggregationFunction(50);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
@@ -45,7 +45,6 @@ public class SimpleSegmentMetadata implements SegmentMetadata {
   private long _size;
   private String _segmentName;
   private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
-  private int _hllLog2m = HllConstants.DEFAULT_LOG2M;
 
   public SimpleSegmentMetadata(String resourceName) {
     init(resourceName, new Schema());
@@ -206,6 +205,7 @@ public class SimpleSegmentMetadata implements SegmentMetadata {
 
   @Override
   public int getHllLog2m() {
-    return _hllLog2m;
+    return HllConstants.DEFAULT_LOG2M;
   }
+
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.query.utils;
 
 import com.linkedin.pinot.common.segment.StarTreeMetadata;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.startree.hll.HllConstants;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,6 +45,7 @@ public class SimpleSegmentMetadata implements SegmentMetadata {
   private long _size;
   private String _segmentName;
   private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
+  private int _hllLog2m = HllConstants.DEFAULT_LOG2M;
 
   public SimpleSegmentMetadata(String resourceName) {
     init(resourceName, new Schema());
@@ -200,5 +202,10 @@ public class SimpleSegmentMetadata implements SegmentMetadata {
 
   @Override public Character getPaddingCharacter() {
     return _paddingCharacter;
+  }
+
+  @Override
+  public int getHllLog2m() {
+    return _hllLog2m;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -229,6 +229,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     properties.setProperty(SEGMENT_TOTAL_NULLS, String.valueOf(totalNulls));
     properties.setProperty(SEGMENT_TOTAL_CONVERSIONS, String.valueOf(totalConversions));
     properties.setProperty(SEGMENT_TOTAL_NULL_COLS, String.valueOf(totalNullCols));
+    properties.setProperty(SEGMENT_HLL_LOG2M, config.getHllConfig().getHllLog2m());
 
     StarTreeIndexSpec starTreeIndexSpec = config.getStarTreeIndexSpec();
     if (starTreeIndexSpec != null) {
@@ -240,8 +241,6 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           starTreeIndexSpec.getskipMaterializationCardinalityThreshold());
       properties.setProperty(STAR_TREE_SKIP_MATERIALIZATION_FOR_DIMENSIONS,
           starTreeIndexSpec.getskipMaterializationForDimensions());
-      properties.setProperty(STAR_TREE_HLL_ENABLED, config.getHllConfig().isEnableHllIndex());
-      properties.setProperty(STAR_TREE_HLL_LOG2M, config.getHllConfig().getHllLog2m());
     }
 
     String timeColumn = config.getTimeColumnName();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -108,11 +108,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     enableHllIndex = config.getHllConfig().isEnableHllIndex();
 
     if (enableHllIndex && !createStarTree) {
-      LOGGER.warn("Hll configuration works only with star tree. " +
-          "Star Tree generation is not specified. " +
-          "This will not add derived hll fields.");
-      config.getHllConfig().setEnableHllIndex(false);
-      enableHllIndex = false;
+      throw new IllegalArgumentException("Derived HLL fields generation will not work if StarTree is not enabled.");
     }
 
     addDerivedFieldsInSchema();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
@@ -105,8 +105,6 @@ public class V1Constants {
           "star.tree.skip.materialization.for.dimensions";
       public static final String STAR_TREE_SKIP_MATERIALIZATION_CARDINALITY =
           "star.tree.skip.materialization.cardinality";
-      public static final String STAR_TREE_HLL_ENABLED = "startree.hll.enabled";
-      public static final String STAR_TREE_HLL_LOG2M = "startree.hll.log2m";
     }
 
     public static class Segment {
@@ -131,6 +129,7 @@ public class V1Constants {
       public static final String SEGMENT_TOTAL_NULLS = "segment.total.nulls";
       public static final String SEGMENT_TOTAL_CONVERSIONS = "segment.total.conversions";
       public static final String SEGMENT_TOTAL_NULL_COLS = "segment.total.null.cols";
+      public static final String SEGMENT_HLL_LOG2M = "segment.hll.log2m";
 
       // not using currently
       public static final String SEGMENT_INDEX_TYPE = "segment.index.type";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/ColumnMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/ColumnMetadata.java
@@ -103,7 +103,7 @@ public class ColumnMetadata {
       switch (derivedMetricType) {
         case HLL:
           try {
-            final int hllLog2m = config.getInt(V1Constants.MetadataKeys.StarTree.STAR_TREE_HLL_LOG2M);
+            final int hllLog2m = config.getInt(V1Constants.MetadataKeys.Segment.SEGMENT_HLL_LOG2M);
             builder.setFieldSize(HllUtil.getHllFieldSizeFromLog2m(hllLog2m));
             final String originColumnName = config.getString(getKeyFor(column, ORIGIN_COLUMN));
             builder.setOriginColumnName(originColumnName);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -75,6 +75,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   private StarTreeMetadata _starTreeMetadata = null;
   private String _creatorName;
   private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
+  private int _hllLog2m = HllConstants.DEFAULT_LOG2M;
 
   public SegmentMetadataImpl(File indexDir) throws ConfigurationException, IOException {
     LOGGER.debug("SegmentMetadata location: {}", indexDir);
@@ -278,6 +279,9 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     // Segment Name
     _segmentName = _segmentMetadataPropertiesConfiguration.getString(Segment.SEGMENT_NAME);
 
+    // Set hll log2m
+    _hllLog2m = _segmentMetadataPropertiesConfiguration.getInt(Segment.SEGMENT_HLL_LOG2M, HllConstants.DEFAULT_LOG2M);
+
     // StarTree config here
     _hasStarTree = _segmentMetadataPropertiesConfiguration.getBoolean(
         MetadataKeys.StarTree.STAR_TREE_ENABLED, false);
@@ -296,14 +300,6 @@ public class SegmentMetadataImpl implements SegmentMetadata {
    */
   private void initStarTreeMetadata() {
     _starTreeMetadata = new StarTreeMetadata();
-
-    // Set hll
-    _starTreeMetadata.setEnableHll(
-        _segmentMetadataPropertiesConfiguration.getBoolean(MetadataKeys.StarTree.STAR_TREE_HLL_ENABLED,
-            false));
-    _starTreeMetadata.setHllLog2m(
-        _segmentMetadataPropertiesConfiguration.getInt(MetadataKeys.StarTree.STAR_TREE_HLL_LOG2M,
-            HllConstants.DEFAULT_LOG2M));
 
     // Build Derived Column Map
     Map<String, String> hllOriginToDerivedColumnMap = new HashMap<>();
@@ -564,6 +560,11 @@ public class SegmentMetadataImpl implements SegmentMetadata {
 
   @Override public Character getPaddingCharacter() {
     return _paddingCharacter;
+  }
+
+  @Override
+  public int getHllLog2m() {
+    return _hllLog2m;
   }
 
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/hll/HllConfig.java
@@ -24,12 +24,12 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 
 
 /**
- * This HllConfig is used at segment generation.
- * HllConfig is the config for hll index generation.
- * Note it is only effective when StarTree index generation is enabled.
+ * HllConfig is used at segment generation.
+ *
+ * If columnsToDeriveHllFields are specified and not empty,
+ * segment builder will generate corresponding hll derived fields on the fly.
  */
 public class HllConfig {
-  private boolean enableHllIndex = false;
   private int hllLog2m = HllConstants.DEFAULT_LOG2M;
   private int hllFieldSize = HllUtil.getHllFieldSizeFromLog2m(HllConstants.DEFAULT_LOG2M);
   private String hllDeriveColumnSuffix = HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX;
@@ -38,55 +38,36 @@ public class HllConfig {
   private transient Map<String, String> derivedHllFieldToOriginMap;
 
   /**
-   * HllConfig with empty columnsToDeriveHllFields, default hll log2m, default hll suffix.
-   * Hll Index is disabled.
+   * HllConfig with default hll log2m. No Hll derived field is generated.
    */
   public HllConfig() {
   }
 
   /**
-   * HllConfig with default hll log2m, default hll suffix.
-   * @param columnsToDeriveHllFields columns to generate hll index
-   */
-  public HllConfig(Set<String> columnsToDeriveHllFields) {
-    this(columnsToDeriveHllFields, HllConstants.DEFAULT_LOG2M);
-  }
-
-  /**
-   * HllConfig with default hll suffix.
-   * @param columnsToDeriveHllFields columns to generate hll index
+   * HllConfig with customized hll log2m. No Hll derived field is generated.
    * @param hllLog2m The log2m parameter defines the accuracy of the counter.
    *                 The larger the log2m the better the accuracy.
    *                 accuracy = 1.04/sqrt(2^log2m)
    */
-  public HllConfig(Set<String> columnsToDeriveHllFields, int hllLog2m) {
-    this(columnsToDeriveHllFields, hllLog2m, HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX);
+  public HllConfig(int hllLog2m) {
+    this.hllLog2m = hllLog2m;
   }
 
   /**
-   *
-   * @param columnsToDeriveHllFields columns to generate hll index
+   * Hll derived field generation is enabled when columnsToDeriveHllFields is not empty.
    * @param hllLog2m The log2m parameter defines the accuracy of the counter.
    *                 The larger the log2m the better the accuracy.
    *                 accuracy = 1.04/sqrt(2^log2m)
+   * @param columnsToDeriveHllFields columns to generate hll index
    * @param hllDeriveColumnSuffix suffix of column used for hll index
    */
-  public HllConfig(Set<String> columnsToDeriveHllFields, int hllLog2m, String hllDeriveColumnSuffix) {
+  public HllConfig(int hllLog2m, Set<String> columnsToDeriveHllFields, String hllDeriveColumnSuffix) {
     Preconditions.checkNotNull(columnsToDeriveHllFields, "ColumnsToDeriveHllFields should not be null.");
     Preconditions.checkNotNull(hllDeriveColumnSuffix, "HLL Derived Field Suffix should not be null.");
-    this.enableHllIndex = true;
     this.hllLog2m = hllLog2m;
     this.hllFieldSize = HllUtil.getHllFieldSizeFromLog2m(hllLog2m);
     this.hllDeriveColumnSuffix = hllDeriveColumnSuffix;
     this.columnsToDeriveHllFields = columnsToDeriveHllFields;
-  }
-
-  public boolean isEnableHllIndex() {
-    return enableHllIndex;
-  }
-
-  public void setEnableHllIndex(boolean enableHllIndex) {
-    this.enableHllIndex = enableHllIndex;
   }
 
   public int getHllLog2m() {
@@ -111,6 +92,15 @@ public class HllConfig {
 
   public void setColumnsToDeriveHllFields(Set<String> columnsToDeriveHllFields) {
     this.columnsToDeriveHllFields = columnsToDeriveHllFields;
+  }
+
+  /**
+   * Hll derived field generation is enabled when columnsToDeriveHllFields is not empty.
+   * @return
+   */
+  @JsonIgnore
+  public boolean isEnableHllIndex() {
+    return columnsToDeriveHllFields.size() > 0;
   }
 
   @JsonIgnore

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/ColumnMetadataTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/ColumnMetadataTest.java
@@ -200,17 +200,16 @@ public class ColumnMetadataTest {
       // Build the Segment metadata.
       helper = new SegmentWithHllIndexCreateHelper(
           "testHllIndexRelatedMetadata", "data/test_data-sv.avro", "daysSinceEpoch", TimeUnit.DAYS);
-      helper.build(true, new HllConfig(new HashSet<String>(Arrays.asList("column7")), 8, "_hllSuffix"));
+      helper.build(true, new HllConfig(9, new HashSet<String>(Arrays.asList("column7")), "_hllSuffix"));
 
       // Load segment metadata.
       IndexSegment segment = Loaders.IndexSegment.load(helper.getSegmentDirectory(), ReadMode.mmap);
       SegmentMetadataImpl metadata = (SegmentMetadataImpl) segment.getSegmentMetadata();
+      Assert.assertEquals(metadata.getHllLog2m(), 9);
 
       // Verify Hll Related Info
       StarTreeMetadata starTreeMetadata = metadata.getStarTreeMetadata();
-      Assert.assertEquals(starTreeMetadata.isEnableHll(), true);
-      Assert.assertEquals(starTreeMetadata.getHllLog2m(), 8);
-
+      Assert.assertNotNull(starTreeMetadata);
       ColumnMetadata column = metadata.getColumnMetadataFor("column7_hllSuffix");
       Assert.assertEquals(column.getDerivedMetricType(), MetricFieldSpec.DerivedMetricType.HLL);
       Assert.assertEquals(column.getOriginColumnName(), "column7");

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/BaseHllStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/BaseHllStarTreeIndexTest.java
@@ -47,7 +47,8 @@ public class BaseHllStarTreeIndexTest {
    * to mimic actual use cases
    */
   private static final Set<String> columnsToDeriveHllFields = new HashSet<>(Arrays.asList("d3", "d4"));
-  protected static final HllConfig HLL_CONFIG = new HllConfig(columnsToDeriveHllFields);
+  protected static final HllConfig HLL_CONFIG = new HllConfig(
+      HllConstants.DEFAULT_LOG2M, columnsToDeriveHllFields, HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX);
 
   protected String[] _hardCodedQueries =
           new String[]{

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllIndexCreation.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/TestHllIndexCreation.java
@@ -68,7 +68,7 @@ public class TestHllIndexCreation {
 
   @BeforeMethod
   public void setUp() throws Exception {
-    hllConfig = new HllConfig(columnsToDeriveHllFields, hllLog2m, hllDeriveColumnSuffix);
+    hllConfig = new HllConfig(hllLog2m, columnsToDeriveHllFields, hllDeriveColumnSuffix);
 
     Configuration tableConfig = new PropertiesConfiguration();
     tableConfig.addProperty(IndexLoadingConfigMetadata.KEY_OF_SEGMENT_FORMAT_VERSION, "v1");

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/HllIndexSentinelTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/HllIndexSentinelTest.java
@@ -74,7 +74,7 @@ public class HllIndexSentinelTest {
           "column17", "column18"));
 
   private static final HllConfig hllConfig =
-      new HllConfig(columnsToDeriveHllFields, hllLog2m, hllDeriveColumnSuffix);
+      new HllConfig(hllLog2m, columnsToDeriveHllFields, hllDeriveColumnSuffix);
 
   private void setupTableManager() throws Exception {
     TableDataManagerProvider.setServerMetrics(new ServerMetrics(new MetricsRegistry()));


### PR DESCRIPTION
This PR separates hll config and startree, so hll config will take effect when startree is not specified. This is used when outside users choose to generate hll columns by their own (not through the segment generator on the fly)