### PR TITLE
[PINOT-3644] Remove watches on HL segments that are completed

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ZkUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ZkUtils.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.common.utils;
 
-import java.util.Arrays;
-import java.util.List;
 import org.apache.helix.HelixManager;
 import org.apache.helix.PropertyPathConfig;
 import org.apache.helix.PropertyType;
@@ -31,37 +29,23 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
  */
 public class ZkUtils {
   /**
-   * Returns a handle to the propertyStore, setting up a watch on all nodes under PROPERTYSTORE/clusterName, if
-   * setWatch is specified as true.
+   * Returns a handle to the propertyStore
    *
    * @param helixManager * A valid helix manager bound to a cluster.
    * @param clusterName The pathname under propertyStore that we want a handle for
-   * @param setWatch Must be set to true if it is desired to set up a watch on all nodes under the PROPERTYSTORE node.
    * @return A handle to the propertyStore.
    *
    * @note: Setting up a watch can lead to connection problems with zookeeper during a re-connect from the client. The
    * client ends up sending all the path names in the session request, and that can exceed the max size of a session
    * request if there are too many nodes, causing the connection to be dropped and retried (with the same parameters).
    */
-  public static ZkHelixPropertyStore<ZNRecord> getZkPropertyStore(HelixManager helixManager, String clusterName, boolean setWatch) {
+  public static ZkHelixPropertyStore<ZNRecord> getZkPropertyStore(HelixManager helixManager, String clusterName) {
     ZkBaseDataAccessor<ZNRecord> baseAccessor =
         (ZkBaseDataAccessor<ZNRecord>) helixManager.getHelixDataAccessor().getBaseDataAccessor();
     String propertyStorePath = PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, clusterName);
 
-    List<String> watchList = null;
-    if (setWatch) {
-      watchList = Arrays.asList(propertyStorePath);
-    }
-
-    ZkHelixPropertyStore<ZNRecord> propertyStore = new ZkHelixPropertyStore<ZNRecord>(baseAccessor, propertyStorePath, watchList);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = new ZkHelixPropertyStore<ZNRecord>(baseAccessor, propertyStorePath, null);
 
     return propertyStore;
-  }
-
-  /*
-   * This method gets a handle to the propertystore without creating a watch on the children.
-   */
-  public static ZkHelixPropertyStore<ZNRecord> getZkPropertyStore(HelixManager helixManager, String clusterName) {
-    return getZkPropertyStore(helixManager, clusterName, false);
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -156,7 +156,7 @@ public class PinotHelixResourceManager {
     _helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(_zkBaseUrl);
     _helixZkManager = HelixSetupUtils.setup(_helixClusterName, _helixZkURL, _instanceId, _isUpdateStateModel);
     _helixAdmin = _helixZkManager.getClusterManagmentTool();
-    _propertyStore = ZkUtils.getZkPropertyStore(_helixZkManager, _helixClusterName, false /* No recursive Watches */);
+    _propertyStore = ZkUtils.getZkPropertyStore(_helixZkManager, _helixClusterName);
     _helixDataAccessor = _helixZkManager.getHelixDataAccessor();
     _keyBuilder = _helixDataAccessor.keyBuilder();
     _segmentDeletionManager = new SegmentDeletionManager(_localDiskDir, _helixAdmin, _helixClusterName, _propertyStore);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -330,6 +330,9 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
 
             if (childNames != null && !childNames.isEmpty()) {
               for (String segmentName : childNames) {
+                if (!SegmentName.isHighLevelConsumerSegmentName(segmentName)) {
+                  continue;
+                }
                 String segmentPath = realtimeSegmentsPathForTable + "/" + segmentName;
                 RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = ZKMetadataProvider
                     .getRealtimeSegmentZKMetadata(_pinotHelixResourceManager.getPropertyStore(),
@@ -338,6 +341,8 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
                   LOGGER.info("Setting data change watch for real-time segment currently being consumed: {}",
                       segmentPath);
                   _zkClient.subscribeDataChanges(segmentPath, this);
+                } else {
+                  _zkClient.unsubscribeDataChanges(segmentPath, this);
                 }
               }
             }


### PR DESCRIPTION
ZkClient re-installs watches on all segments even after the watches have been triggered.
We need to explicitly remove them so that we are watching only one segment per table.