### PR TITLE
Bump up guava dependency version to 19.0.

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -194,7 +194,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
- </dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+  </dependencies>
    <profiles>
     <profile>
       <id>profile-buildthrift</id>

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>11.0.2</version>
+        <version>19.0</version>
       </dependency>
       <dependency>
         <groupId>com.yammer.metrics</groupId>
@@ -523,7 +523,12 @@
         <artifactId>jcabi-log</artifactId>
         <version>0.17.1</version>
       </dependency>
-    </dependencies>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>3.0.0</version>
+      </dependency>
+      </dependencies>
   </dependencyManagement>
   <build>
     <defaultGoal>clean install</defaultGoal>


### PR DESCRIPTION
Bump up Guava library dependency version from 11.+ to 19.0 (latest).
Existing version is very old and lacks lot of functionality. We want
to use some functions from Futures class to implement scheduler. This
change also requires explicitly adding dependency on findbugs for
@Nonnull annotations used in our code.

Testing: clean build