### PR TITLE
Bump up zookeeper version to 3.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.5</version>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Recent upgrade to zk client version 0.7 breaks PerfBenchmarkRunner
for some missing classes at runtime. Upgrading zookeeper version
to 3.4.5 to test this.

Testing:
1. PerfBenchmarkRunner works
2. multi-product testing