### PR TITLE
Replacing Java ser/de with custom ser/de in DataTable.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
@@ -26,7 +26,9 @@ import com.linkedin.pinot.common.metrics.MetricsHelper;
 import com.linkedin.pinot.common.query.ReduceServiceRegistry;
 import com.linkedin.pinot.common.response.BrokerResponseFactory;
 import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.common.utils.DataTableSerDeRegistry;
 import com.linkedin.pinot.core.query.reduce.BrokerReduceService;
+import com.linkedin.pinot.core.util.DataTableCustomSerDe;
 import com.linkedin.pinot.requestHandler.BrokerRequestHandler;
 import com.linkedin.pinot.routing.CfgBasedRouting;
 import com.linkedin.pinot.routing.HelixExternalViewBasedRouting;
@@ -168,6 +170,9 @@ public class BrokerServerBuilder {
     ReduceServiceRegistry reduceServiceRegistry = buildReduceServiceRegistry();
     _requestHandler = new BrokerRequestHandler(_routingTable, _timeBoundaryService, _scatterGather,
         reduceServiceRegistry, _brokerMetrics, _config);
+
+    // Register SerDe for data-table.
+    DataTableSerDeRegistry.getInstance().register(new DataTableCustomSerDe());
 
     LOGGER.info("Network initialized !!");
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTableJavaSerDe.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTableJavaSerDe.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import com.linkedin.pinot.common.Utils;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import javax.annotation.Nonnull;
+import org.apache.commons.compress.utils.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Java serialization/de-serialization based DataTableSerDe implementation.
+ */
+public class DataTableJavaSerDe implements DataTableSerDe {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataTableJavaSerDe.class);
+
+  /**
+   * @param object Object to serialize
+   * @return Serialized byte-array of the object
+   */
+  @Override
+  public byte[] serialize(Object object) {
+    return serializeJavaObject(object);
+  }
+
+  /**
+   * @param bytes Serialized byte-array
+   * @param dataType Enum type of the object
+   * @param <T> Type of the object
+   * @return De-serialized object
+   */
+  @Override
+  public <T extends Serializable> T deserialize(byte[] bytes, DataType dataType) {
+    return deserializeJavaObject(bytes);
+  }
+
+  /**
+   * Given an object, returns its enum {@link com.linkedin.pinot.common.utils.DataTableSerDe.DataType}
+   * @param object Object for which to get the data type.
+   * @return DataType of the object.
+   */
+  @Override
+  public DataType getObjectType(Object object) {
+    return DataType.Object;
+  }
+
+  /**
+   * Helper method to serialize an object using Java ser/de.
+   *
+   * @param object  to serialize
+   * @return Serialized byte[] for the object.
+   */
+  public static byte[] serializeJavaObject(@Nonnull Object object) {
+    byte[] bytes;
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ObjectOutput out = null;
+
+    try {
+      try {
+        out = new ObjectOutputStream(bos);
+        out.writeObject(object);
+      } catch (IOException e) {
+        LOGGER.error("Caught exception while serializing object for data table.", e);
+        Utils.rethrowException(e);
+      }
+
+      bytes = bos.toByteArray();
+    } finally {
+      IOUtils.closeQuietly((Closeable) out);
+      IOUtils.closeQuietly(bos);
+    }
+
+    return bytes;
+  }
+
+  /**
+   * Helper method to de-serialize an object using Java ser/de.
+   * @param bytes Java serialized byte-array of the object.
+   * @param <T> Type of the object
+   * @return De-serialized object
+   */
+  @SuppressWarnings("unchecked")
+  public static <T extends Serializable> T deserializeJavaObject(@Nonnull byte[] bytes) {
+
+    final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+    ObjectInputStream objectInputStream = null;
+    Object readObject;
+
+    try {
+      try {
+        objectInputStream = new ObjectInputStream(byteArrayInputStream);
+        readObject = objectInputStream.readObject();
+      } catch (final Exception e) {
+        throw new RuntimeException("Caught exception while deserializing DataTable: " + e);
+      }
+    } finally {
+      IOUtils.closeQuietly(objectInputStream);
+      IOUtils.closeQuietly(byteArrayInputStream);
+    }
+
+    return (T) readObject;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTableSerDe.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTableSerDe.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Interface for serialization/de-serialization of objects in data table.
+ *
+ */
+public interface DataTableSerDe {
+
+  /**
+   * Enum for data types supported for serialization/de-serialization.
+   */
+  enum DataType {
+    Object(-1),
+    String(0),
+    MutableLong(1),
+    Double(2),
+    DoubleArrayList(3),
+    AvgPair(4),
+    MinMaxRangePair(5),
+    HyperLogLog(6),
+    QuantileDigest(7),
+    HashMap(8),
+    IntOpenHashSet(9);
+
+    private int _value;
+    private static Map<Integer, DataType> _map = new HashMap<>();
+
+    // Map for integer to version for valueOf().
+    static {
+      for (DataType version : DataType.values()) {
+        _map.put(version._value, version);
+      }
+    }
+
+    DataType(int value) {
+      this._value = value;
+    }
+
+    public int getValue() {
+      return _value;
+    }
+
+    public static DataType valueOf(int value) {
+      if (!_map.containsKey(value)) {
+        throw new IllegalArgumentException("Illegal argument for valueOf enum " + value);
+      }
+      return _map.get(value);
+    }
+  }
+
+  /**
+   * Serialize the specified object into a byte-array.
+   * The byte-array can be de-serialized by {@ref deserialize}.
+   *
+   * @param object Object to serialize
+   * @return Serialized byte-array for the object
+   */
+  byte[] serialize(Object object);
+
+  /**
+   * De-serialize the specified byte-array into object of type T.
+   * Assumes that the object was serialized by {@ref serialize}.
+   *
+   * @param bytes Serialized byte-array
+   * @param dataType Enum type of the object
+   * @param <T> Class of the object
+   * @return De-serialized object
+   */
+  <T extends Serializable> T deserialize(byte[] bytes, DataType dataType);
+
+  DataType getObjectType(Object value);
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTableSerDeRegistry.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTableSerDeRegistry.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * DataTableSerDe Registry singleton.
+ *
+ */
+@ThreadSafe
+public class DataTableSerDeRegistry {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataTableSerDeRegistry.class);
+  private static DataTableSerDeRegistry _instance = new DataTableSerDeRegistry();
+
+  DataTableSerDe _dataTableSerDe;
+  DataTableSerDe _defaultDataTableSerDe;
+  boolean _registered;
+
+  public static DataTableSerDeRegistry getInstance() {
+    return _instance;
+  }
+
+  /**
+   * Private constructor for singleton.
+   */
+  private DataTableSerDeRegistry() {
+    _dataTableSerDe = null;
+    _defaultDataTableSerDe = new DataTableJavaSerDe();
+    _registered = false;
+  }
+
+  /**
+   * Registers the provided DataTableSerDe instance if none was registered yet.
+   * Throws {@link UnsupportedOperationException} if one was registered already.
+   *
+   * @param dataTableSerDe DataTableSerDe instance to register.
+   */
+  public synchronized void register(DataTableSerDe dataTableSerDe) {
+    if (!_registered) {
+      this._dataTableSerDe = dataTableSerDe;
+      _registered = true;
+    } else {
+      LOGGER.warn("DataTable serializer/de-serializer {} already registered, ignoring {}",
+          _dataTableSerDe.getClass().getName(), dataTableSerDe.getClass().getName());
+    }
+  }
+
+  /**
+   * Method to get the registered DataTableSerDe.
+   * <p> - Returns the DataTableSerDe, if one was registered.</p>
+   * <p> - Returns the default {@link DataTableJavaSerDe}, if none was registered. </p>
+   *
+   * @return Registered (or default) DataTableSerDe
+   */
+  public DataTableSerDe get() {
+    return (_dataTableSerDe != null) ? _dataTableSerDe : _defaultDataTableSerDe;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/primitive/MutableLongValue.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/primitive/MutableLongValue.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.common.utils.primitive;
 
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.io.Serializable;
-import java.util.Objects;
+import java.nio.ByteBuffer;
 
 
 /**
@@ -95,5 +95,29 @@ public class MutableLongValue extends Number implements Serializable, Comparable
   @Override
   public int hashCode() {
     return EqualityUtils.hashCodeOf(value);
+  }
+
+  /**
+   * Serializer for instance of the class.
+   * Serialized byte-array can be de-serialized by {@ref fromBytes}
+   *
+   * @return Serialized byte array for the instance.
+   */
+  public byte[] toBytes() {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(Long.SIZE >> 3);
+    byteBuffer.putLong(value);
+    return byteBuffer.array();
+  }
+
+  /**
+   * De-serializer for instance of the class.
+   * Assumes that byte-array was serialized by {@ref toBytes}
+   *
+   * @param bytes Serialized bytes for the instance
+   * @return De-serialized object from the provided byte-array.
+   */
+  public static MutableLongValue fromBytes(byte[] bytes) {
+    long value = ByteBuffer.wrap(bytes).getLong();
+    return new MutableLongValue(value);
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/DataTableBuilderTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/DataTableBuilderTest.java
@@ -28,11 +28,19 @@ import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
 public class DataTableBuilderTest {
   private static Logger LOGGER = LoggerFactory.getLogger(DataTableBuilderTest.class);
+
+  private DataTableSerDe _dataTableSerDe;
+
+  @BeforeClass
+  public void setup() {
+    _dataTableSerDe = DataTableSerDeRegistry.getInstance().get();
+  }
 
   @Test
   public void testException() throws Exception {
@@ -59,6 +67,8 @@ public class DataTableBuilderTest {
     final DataSchema schema = new DataSchema(columnNames, columnTypes);
 
     final DataTableBuilder builder = new DataTableBuilder(schema);
+    builder.setDataTableSerDe(_dataTableSerDe);
+
     builder.open();
     final Random r = new Random();
     final int NUM_ROWS = 100;
@@ -156,6 +166,8 @@ public class DataTableBuilderTest {
     String[] columnNames = new String[] { "col-0" };
     DataSchema schema = new DataSchema(columnNames, columnTypes);
     DataTableBuilder builder = new DataTableBuilder(schema);
+    builder.setDataTableSerDe(_dataTableSerDe);
+
     builder.open();
     Random r = new Random();
     int NUM_ROWS = 10;
@@ -191,6 +203,8 @@ public class DataTableBuilderTest {
     String[] columnNames = new String[] { "col-0" };
     DataSchema schema = new DataSchema(columnNames, columnTypes);
     DataTableBuilder builder = new DataTableBuilder(schema);
+    builder.setDataTableSerDe(_dataTableSerDe);
+
     builder.open();
     Random r = new Random();
     int NUM_ROWS = 10;
@@ -227,6 +241,8 @@ public class DataTableBuilderTest {
     String[] columnNames = new String[] { "col-0", "col-1" };
     DataSchema schema = new DataSchema(columnNames, columnTypes);
     DataTableBuilder builder = new DataTableBuilder(schema);
+    builder.setDataTableSerDe(_dataTableSerDe);
+
     builder.open();
     Random r = new Random();
     int NUM_ROWS = 100;
@@ -337,6 +353,8 @@ public class DataTableBuilderTest {
 
     DataSchema schema = new DataSchema(columnNames, columnTypes);
     DataTableBuilder builder = new DataTableBuilder(schema);
+    builder.setDataTableSerDe(_dataTableSerDe);
+
     builder.startRow();
     builder.setColumn(0, "sum_count");
     Map<String, Double> map = new HashMap<String, Double>();
@@ -517,5 +535,13 @@ public class DataTableBuilderTest {
     public int hashCode() {
       return new Integer(i).hashCode();
     }
+  }
+
+  /**
+   * Helper method to set the data table ser/de
+   * @param dataTableSerDe
+   */
+  protected void setDataTableSerDe(DataTableSerDe dataTableSerDe) {
+    _dataTableSerDe = dataTableSerDe;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -15,7 +15,9 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.List;
@@ -194,6 +196,29 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
       } else {
         return "0.0";
       }
+    }
+
+    /**
+     * Helper method to serialize an AvgPair into a byte-array
+     * @return Serialized byte-array for the AvgPair.
+     */
+    public byte[] toBytes() {
+      int size = (V1Constants.Numbers.DOUBLE_SIZE) + (V1Constants.Numbers.LONG_SIZE);
+      ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+      byteBuffer.putDouble(getFirst());
+      byteBuffer.putLong(getSecond());
+      return byteBuffer.array();
+    }
+
+    /**
+     * Helper method to de-serialize AvgPair from a byte-array
+     *
+     * @param bytes Serialized bytes of the AvgPair
+     * @return De-serialized AvgPair object from the byte-array
+     */
+    public static AvgPair fromBytes(byte[] bytes) {
+      ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+      return new AvgPair(byteBuffer.getDouble(), byteBuffer.getLong());
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -15,7 +15,9 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.List;
@@ -190,6 +192,30 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
     public String toString() {
       return new DecimalFormat("####################.##########",
           DecimalFormatSymbols.getInstance(Locale.US)).format((getSecond() - getFirst()));
+    }
+
+    /**
+     * Helper method to serialize a MinMaxRangePair into a byte-array.
+     *
+     * @return Serialized byte-array of for the MinMaxRangePair.
+     */
+    public byte[] toBytes() {
+      int size = 2 * V1Constants.Numbers.DOUBLE_SIZE;
+      ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+      byteBuffer.putDouble(getFirst());
+      byteBuffer.putDouble(getSecond());
+      return byteBuffer.array();
+    }
+
+    /**
+     * Helper method to de-serialize a MinMaxRangePair from a byte-array
+     *
+     * @param bytes Serialized byte-array for the MinMaxRangePair
+     * @return De-serialized MinMaxRangePair from byte-array
+     */
+    public static MinMaxRangePair fromBytes(byte[] bytes) {
+      ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+      return new MinMaxRangePair(byteBuffer.getDouble(), byteBuffer.getDouble());
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/DataTableCustomSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/DataTableCustomSerDe.java
@@ -1,0 +1,447 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.util;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.linkedin.pinot.common.utils.primitive.MutableLongValue;
+import com.linkedin.pinot.common.utils.DataTableJavaSerDe;
+import com.linkedin.pinot.core.query.aggregation.function.AvgAggregationFunction;
+import com.linkedin.pinot.core.query.aggregation.function.MinMaxRangeAggregationFunction;
+import com.linkedin.pinot.core.query.aggregation.function.quantile.digest.QuantileDigest;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Custom implementation of {@link com.linkedin.pinot.common.utils.DataTableSerDe} interface.
+ * Overrides ser/de methods from {@link DataTableJavaSerDe}
+ */
+public class DataTableCustomSerDe extends DataTableJavaSerDe {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataTableCustomSerDe.class);
+
+  /**
+   *
+   * @param object Object to serialize
+   * @return Serialized byte-array
+   */
+  @Override
+  public byte[] serialize(Object object) {
+    return serializeObject(object);
+  }
+
+  /**
+   *
+   * @param bytes Serialized byte-array
+   * @param dataType Enum type of the object
+   * @param <T> Type of object
+   * @return De-serialized object
+   */
+  @Override
+  public <T extends Serializable> T deserialize(byte[] bytes, DataType dataType) {
+    return deserializeObject(bytes, dataType);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends Serializable> T deserializeObject(@Nonnull byte[] bytes, DataType dataType) {
+    ByteBuffer byteBuffer;
+    switch (dataType) {
+      case String:
+        try {
+          return (T) new String(bytes, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+          LOGGER.error("Exception caught while de-serializing String", e);
+          throw new RuntimeException("String de-serialization error", e);
+        }
+
+      case MutableLong:
+        byteBuffer = ByteBuffer.wrap(bytes);
+        return (T) new MutableLongValue(byteBuffer.getLong());
+
+      case Double:
+        byteBuffer = ByteBuffer.wrap(bytes);
+        return (T) new Double(byteBuffer.getDouble());
+
+      case DoubleArrayList:
+        return (T) deserializeDoubleArray(bytes);
+
+      case AvgPair:
+        return (T) AvgAggregationFunction.AvgPair.fromBytes(bytes);
+
+      case MinMaxRangePair:
+        return (T) MinMaxRangeAggregationFunction.MinMaxRangePair.fromBytes(bytes);
+
+      case HyperLogLog:
+        try {
+          return (T) HyperLogLog.Builder.build(bytes);
+        } catch (IOException e) {
+          LOGGER.error("Exception caught while de-serializing HyperLogLog", e);
+          throw new RuntimeException("HyperLogLog de-serializing error", e);
+        }
+
+      case QuantileDigest:
+        return (T) deserializeQuantileDigest(bytes);
+
+      case HashMap:
+        return (T) deserializeHashMap(bytes);
+
+      case IntOpenHashSet:
+        return (T) deserializeIntOpenHashSet(bytes);
+
+      case Object:
+        return (T) deserializeJavaObject(bytes);
+
+      default:
+        throw new RuntimeException("Illegal object type found when de-serializing data table");
+    }
+  }
+
+  /**
+   * Serializer for the given object. Uses custom serialization for
+   * objects of supported types, and Java serialization
+   * for the rest.
+   *
+   * @param object Object to serialize
+   * @return Serialized bytes for the object.
+   */
+  @SuppressWarnings("unchecked")
+  public static byte[] serializeObject(@Nonnull Object object) {
+
+    if (object instanceof String) {
+      String value = (String) object;
+      try {
+        return value.getBytes("UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        LOGGER.error("Exception caught while serializing String", e);
+        throw new RuntimeException("String serialization error", e);
+      }
+    } else if (object instanceof MutableLongValue) {
+      MutableLongValue value = (MutableLongValue) object;
+      return value.toBytes();
+
+    } else if (object instanceof Double) {
+      Double value = (Double) object;
+      return serializeDouble(value);
+
+    } else if (object instanceof DoubleArrayList) {
+      DoubleArrayList value = (DoubleArrayList) object;
+      return serializeDoubleArrayList(value);
+
+    } else if (object instanceof AvgAggregationFunction.AvgPair) {
+      AvgAggregationFunction.AvgPair avgPair = (AvgAggregationFunction.AvgPair) object;
+      return avgPair.toBytes();
+
+    } else if (object instanceof MinMaxRangeAggregationFunction.MinMaxRangePair) {
+      MinMaxRangeAggregationFunction.MinMaxRangePair minMaxRangePair =
+          (MinMaxRangeAggregationFunction.MinMaxRangePair) object;
+      return minMaxRangePair.toBytes();
+
+    } else if (object instanceof HyperLogLog) {
+      try {
+        HyperLogLog hll = (HyperLogLog) object;
+        return hll.getBytes();
+      } catch (IOException e) {
+        LOGGER.error("Exception caught while serializing HyperLogLog", e);
+        throw new RuntimeException("HyperLogLog serialization error", e);
+      }
+    } else if (object instanceof QuantileDigest) {
+      QuantileDigest quantileDigest = (QuantileDigest) object;
+      return serializeQuantileDigest(quantileDigest);
+
+    } else if (object instanceof HashMap) {
+      HashMap<Object, Object> map = (HashMap<Object, Object>) object;
+      return serializeHashMap(map);
+
+    } else if (object instanceof IntOpenHashSet) {
+      IntOpenHashSet hashSet = (IntOpenHashSet) object;
+      return serializeIntOpenHashSet(hashSet);
+
+    } else {
+      return serializeJavaObject(object);
+    }
+  }
+
+  /**
+   *
+   * @param object Object for which to get the data type.
+   * @return DataType of the object
+   */
+  @Override
+  public DataType getObjectType(Object object) {
+    return getDataTypeOfObject(object);
+  }
+
+  /**
+   * Helper method to get the data type of the object.
+   * @param object Object for which to get the data type
+   * @return Data type of the object
+   */
+  public static DataType getDataTypeOfObject(Object object) {
+    if (object instanceof String) {
+      return DataType.String;
+
+    } else if (object instanceof MutableLongValue) {
+      return DataType.MutableLong;
+
+    } else if (object instanceof Double) {
+      return DataType.Double;
+
+    } else if (object instanceof DoubleArrayList) {
+      return DataType.DoubleArrayList;
+
+    } else if (object instanceof AvgAggregationFunction.AvgPair) {
+      return DataType.AvgPair;
+
+    } else if (object instanceof MinMaxRangeAggregationFunction.MinMaxRangePair) {
+      return DataType.MinMaxRangePair;
+
+    } else if (object instanceof HyperLogLog) {
+      return DataType.HyperLogLog;
+
+    } else if (object instanceof QuantileDigest) {
+      return DataType.QuantileDigest;
+
+    } else if (object instanceof HashMap) {
+      return DataType.HashMap;
+
+    } else if (object instanceof IntOpenHashSet) {
+      return DataType.IntOpenHashSet;
+
+    } else {
+      return DataType.Object;
+    }
+  }
+
+  /**
+   * Helper method to serialize a Double.
+   *
+   * @param value to serialize
+   * @return Serialized byte[] for the double value.
+   */
+  public static byte[] serializeDouble(Double value) {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(Double.SIZE >> 3);
+    byteBuffer.putDouble(value);
+    return byteBuffer.array();
+  }
+
+  /**
+   * Helper method to serialize a DoubleArray
+   *
+   * @param doubleArray DoubleArray to serialize
+   * @return Serialized value for the doubleArray
+   */
+  public static byte[] serializeDoubleArrayList(DoubleArrayList doubleArray) {
+    int numElements = doubleArray.size();
+    int size = (V1Constants.Numbers.INTEGER_SIZE) + (numElements * (V1Constants.Numbers.DOUBLE_SIZE));
+
+    ByteBuffer byteBuffer = ByteBuffer.allocate(size);
+    byteBuffer.putInt(numElements);
+
+    double[] elements = doubleArray.elements();
+    for (int i = 0; i < numElements; i++) {
+      byteBuffer.putDouble(elements[i]);
+    }
+    return byteBuffer.array();
+  }
+
+  /**
+   * Helper method to de-serialize DoubleArrayList
+   *
+   * @param bytes Serialized bytes for DoubleArrayList
+   * @return De-serialized DoubleArrayList from byte-array.
+   */
+  public static DoubleArrayList deserializeDoubleArray(byte[] bytes) {
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+
+    int numElements = byteBuffer.getInt();
+    DoubleArrayList doubleArray = new DoubleArrayList(numElements);
+
+    for (int i = 0; i < numElements; i++) {
+      doubleArray.add(byteBuffer.getDouble());
+    }
+    return doubleArray;
+  }
+
+  /**
+   * Helper method to serialize a HashMap into a byte-array.
+   *
+   * @param map Map to serialize
+   * @return Serialized byte-array for the HashMap.
+   */
+  public static byte[] serializeHashMap(HashMap<Object, Object> map) {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    try (DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
+      // Write the size of the map.
+      dataOutputStream.writeInt(map.size());
+
+      // Write the serialized key-value pairs
+      boolean first = true;
+      for (Map.Entry<Object, Object> entry : map.entrySet()) {
+
+        // Write the key and value type before writing the first key-value pair.
+        if (first) {
+          dataOutputStream.writeInt(getDataTypeOfObject(entry.getKey()).getValue());
+          dataOutputStream.writeInt(getDataTypeOfObject(entry.getValue()).getValue());
+          first = false;
+        }
+
+        byte[] bytes = serializeObject(entry.getKey());
+        dataOutputStream.writeInt(bytes.length);
+        dataOutputStream.write(bytes);
+
+        bytes = serializeObject(entry.getValue());
+        dataOutputStream.writeInt(bytes.length);
+        dataOutputStream.write(bytes);
+      }
+
+      dataOutputStream.flush();
+      return byteArrayOutputStream.toByteArray();
+
+    } catch (IOException e) {
+      LOGGER.error("Exception caught while serializing HashMap", e);
+      throw new RuntimeException("HashMap serialization error", e);
+    }
+  }
+
+  /**
+   * Helper method to de-serialize a HashMap
+   *
+   * @param bytes Serialized bytes for the HashMap
+   * @return De-serialized HashMap from the byte-array
+   */
+  public static Map deserializeHashMap(byte[] bytes) {
+    if (bytes.length == 0) {
+      return Collections.EMPTY_MAP;
+    }
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    int size = byteBuffer.getInt();
+
+    HashMap<Object, Object> map = new HashMap<>(size);
+    if (size == 0) {
+      return map;
+    }
+
+    DataType keyType = DataType.valueOf(byteBuffer.getInt());
+    DataType valueType = DataType.valueOf(byteBuffer.getInt());
+
+    for (int i = 0; i < size; i++) {
+      int numBytes = byteBuffer.getInt();
+      byte[] keyBytes = new byte[numBytes];
+      byteBuffer.get(keyBytes);
+      Object key = deserializeObject(keyBytes, keyType);
+
+      numBytes = byteBuffer.getInt();
+      byte[] valueBytes = new byte[numBytes];
+      byteBuffer.get(valueBytes);
+      Object value = deserializeObject(valueBytes, valueType);
+
+      map.put(key, value);
+    }
+    return map;
+  }
+
+  /**
+   * Helper method to serialize QuantileDigest into a byte-array
+   *
+   * @param quantileDigest to serialize
+   * @return Serialized byte-array for the QuantileDigest.
+   */
+  public static byte[] serializeQuantileDigest(QuantileDigest quantileDigest) {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    try (DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
+      quantileDigest.serialize(dataOutputStream);
+      return byteArrayOutputStream.toByteArray();
+
+    } catch (IOException e) {
+      LOGGER.error("Exception caught while serializing QuantileDigest", e);
+      throw new RuntimeException("Serialization error for QuantileDigest", e);
+    }
+  }
+
+  /**
+   * Helper method to de-serialize QuantileDigest from a byte-array
+   *
+   * @param bytes Serialized bytes for the QuantileDigest object
+   * @return De-serialized QuantileDigest from the given byte-array
+   */
+  public static QuantileDigest deserializeQuantileDigest(byte[] bytes) {
+    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+    try (DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream)) {
+      return QuantileDigest.deserialize(dataInputStream);
+
+    } catch (IOException e) {
+      LOGGER.error("De-serialization error for QuantileDigest", e);
+      throw new RuntimeException("QuantileDigest de-serialization error", e);
+    }
+  }
+
+  /**
+   * Helper method to serialize IntOpenHashSet into a byte-array
+   *
+   * @param set to serialize
+   * @return Serialized byte-array for the IntOpenHashSet
+   */
+  private static byte[] serializeIntOpenHashSet(IntOpenHashSet set) {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+    try (DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
+      // Write the size of the set.
+      dataOutputStream.writeInt(set.size());
+      for (Integer value : set) {
+        dataOutputStream.writeInt(value);
+      }
+      return byteArrayOutputStream.toByteArray();
+
+    } catch (IOException e) {
+      LOGGER.error("Exception caught while serializing IntOpenHashSet", e);
+      throw new RuntimeException("HashMap serialization error", e);
+    }
+  }
+
+  /**
+   * Helper method to de-serialize IntOpenHashSet from a byte-array
+   *
+   * @param bytes Serialized bytes for the IntOpenHashSet
+   * @return De-serialized IntOpenHashSet from the given byte-array
+   */
+  public static IntOpenHashSet deserializeIntOpenHashSet(byte[] bytes) {
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    int size = byteBuffer.getInt();
+
+    IntOpenHashSet hashSet = new IntOpenHashSet(size);
+    for (int i = 0; i < size; i++) {
+      hashSet.add(byteBuffer.getInt());
+    }
+    return hashSet;
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/DataTableBuilderWithCustomSerDeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/DataTableBuilderWithCustomSerDeTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.util;
+
+import com.linkedin.pinot.common.utils.DataTableBuilderTest;
+import com.linkedin.pinot.common.utils.DataTableJavaSerDe;
+import com.linkedin.pinot.common.utils.DataTableSerDe;
+import com.linkedin.pinot.common.utils.DataTableSerDeRegistry;
+import com.linkedin.pinot.core.util.DataTableCustomSerDe;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for DataTableBuilder class.
+ * Registers {@link DataTableCustomSerDe} ser/de and runs the tests
+ * in {@link DataTableBuilderTest}.
+ */
+public class DataTableBuilderWithCustomSerDeTest extends DataTableBuilderTest {
+
+  private DataTableSerDe javaSerDe;
+  private DataTableSerDe customSerDe;
+  /**
+   * Setup before all tests.
+   * <p> - Sets up DataTableCustomSerDe for ser/de of data table.</p>
+   */
+  @BeforeClass
+  public void setup() {
+    javaSerDe = new DataTableJavaSerDe();
+    customSerDe = new DataTableCustomSerDe();
+
+    DataTableSerDeRegistry.getInstance().register(customSerDe);
+    super.setup();
+  }
+
+  @Test
+  public void testSimple()
+      throws Exception {
+    super.testSimple();
+
+    // Backward compatibility test
+    super.setDataTableSerDe(javaSerDe);
+    super.testSimple();
+  }
+
+  @Test
+  public void testStringArray() throws Exception {
+    super.testStringArray();
+
+    // Backward compatibility test
+    super.setDataTableSerDe(javaSerDe);
+    super.testStringArray();
+  }
+
+  @Test
+  public void testIntArray() throws Exception {
+    super.testIntArray();
+
+    // Backward compatibility test
+    super.setDataTableSerDe(javaSerDe);
+    super.testIntArray();
+  }
+
+  @Test
+  public void testComplexDataTypes() throws Exception {
+    super.testComplexDataTypes();
+
+    // Backward compatibility test
+    super.setDataTableSerDe(javaSerDe);
+    super.testComplexDataTypes();
+  }
+
+  @Test
+  public void testSerDeSpeed() throws Exception {
+    super.testSerDeserSpeed();
+
+    // Backward compatibility test
+    super.setDataTableSerDe(javaSerDe);
+    super.testSerDeserSpeed();
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/DataTableCustomSerDeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/DataTableCustomSerDeTest.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.util;
+
+import com.linkedin.pinot.common.utils.DataTableSerDe;
+import com.linkedin.pinot.common.utils.DataTableSerDeRegistry;
+import com.linkedin.pinot.common.utils.primitive.MutableLongValue;
+import com.linkedin.pinot.core.query.aggregation.function.AvgAggregationFunction;
+import com.linkedin.pinot.core.query.aggregation.function.MinMaxRangeAggregationFunction;
+import com.linkedin.pinot.core.util.DataTableCustomSerDe;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.apache.commons.lang.RandomStringUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link DataTableCustomSerDe} class.
+ */
+public class DataTableCustomSerDeTest {
+  private static final int NUM_ITERATIONS = 100;
+
+  Random random;
+  long randomSeed;
+  DataTableSerDe serde;
+
+
+  @BeforeClass
+  private void setup() {
+    randomSeed = System.currentTimeMillis();
+    random = new Random(randomSeed);
+    serde = new DataTableCustomSerDe();
+
+    // Register the custom data table ser/de.
+    DataTableSerDeRegistry.getInstance().register(new DataTableCustomSerDe());
+  }
+
+  /**
+   * Test for ser/de of MutableLong
+   */
+  @Test
+  public void testMutableLong() {
+
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      MutableLongValue expected = new MutableLongValue(random.nextLong());
+      byte[] bytes = serde.serialize(expected);
+
+      MutableLongValue actual = serde.deserialize(bytes, DataTableSerDe.DataType.MutableLong);
+      Assert.assertEquals(actual.getValue(), expected.getValue(), "Random seed: " + random);
+    }
+  }
+
+  /**
+   * Test for ser/de of Double
+   */
+  @Test
+  public void testDouble() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      Double expected = random.nextDouble();
+      byte[] bytes = serde.serialize(expected);
+
+      Double actual = serde.deserialize(bytes, DataTableSerDe.DataType.Double);
+      Assert.assertEquals(actual, expected, "Random seed: " + randomSeed);
+    }
+  }
+
+  /**
+   * Test for ser/de of DoubleArrayList
+   */
+  @Test
+  public void testDoubleArrayList() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      int size = random.nextInt(100);
+      DoubleArrayList expected = new DoubleArrayList(size);
+
+      for (int j = 0; j < size; j++) {
+        expected.add(random.nextDouble());
+      }
+
+      byte[] bytes = serde.serialize(expected);
+      DoubleArrayList actual = serde.deserialize(bytes, DataTableSerDe.DataType.DoubleArrayList);
+
+      for (int j = 0; j < size; j++) {
+        Assert.assertEquals(actual.getDouble(j), expected.getDouble(j), "Random seed: " + randomSeed);
+      }
+    }
+  }
+
+  /**
+   * Test for ser/de of AvgPair
+   */
+  @Test
+  public void testAvgPair() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      AvgAggregationFunction.AvgPair expected =
+          new AvgAggregationFunction.AvgPair(random.nextDouble(), random.nextLong());
+
+      byte[] bytes = serde.serialize(expected);
+      AvgAggregationFunction.AvgPair actual = serde.deserialize(bytes, DataTableSerDe.DataType.AvgPair);
+      Assert.assertEquals(actual.getFirst(), expected.getFirst());
+      Assert.assertEquals(actual.getSecond(), expected.getSecond(), "Random seed: " + randomSeed);
+    }
+  }
+
+  /**
+   * Test for ser/de of MinMaxRangePair
+   */
+  @Test
+  public void testMinMaxRangePair() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      MinMaxRangeAggregationFunction.MinMaxRangePair expected =
+          new MinMaxRangeAggregationFunction.MinMaxRangePair(random.nextDouble(), random.nextDouble());
+
+      byte[] bytes = serde.serialize(expected);
+      MinMaxRangeAggregationFunction.MinMaxRangePair actual =
+          serde.deserialize(bytes, DataTableSerDe.DataType.MinMaxRangePair);
+      Assert.assertEquals(actual.getFirst(), expected.getFirst());
+      Assert.assertEquals(actual.getSecond(), expected.getSecond(), "Random seed: " + randomSeed);
+    }
+  }
+
+  /**
+   * Test for ser/de of HashMap&lt;String, Double&gt;
+   */
+  @Test
+  public void testStringDoubleHashMap() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      Map<String, Double> expected = new HashMap<>();
+
+      int size = random.nextInt(100);
+      for (int j = 0; j < size; j++) {
+        expected.put(RandomStringUtils.random(random.nextInt(20), true, true), random.nextDouble());
+      }
+
+      byte[] bytes = serde.serialize(expected);
+      HashMap<String, Double> actual = serde.deserialize(bytes, DataTableSerDe.DataType.HashMap);
+
+      Assert.assertEquals(actual.size(), expected.size(), "Random seed: " + randomSeed);
+      for (Map.Entry<String, Double> entry : expected.entrySet()) {
+        String key = entry.getKey();
+        Assert.assertTrue(actual.containsKey(key), "Random seed: " + randomSeed);
+        Assert.assertEquals(actual.get(key), entry.getValue(), "Random seed: " + randomSeed);
+      }
+    }
+  }
+
+  /**
+   * Test for ser/de of IntOpenHashSet
+   */
+  @Test
+  public void testIntOpenHashSet() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      int size = random.nextInt(100);
+
+      IntOpenHashSet expected = new IntOpenHashSet(size);
+      for (int j = 0; j < size; j++) {
+        expected.add(random.nextInt());
+      }
+
+      byte[] bytes = serde.serialize(expected);
+      IntOpenHashSet actual = serde.deserialize(bytes, DataTableSerDe.DataType.IntOpenHashSet);
+
+      Assert.assertEquals(actual.size(), expected.size(), "Random seed: " + randomSeed);
+      IntIterator iterator = expected.iterator();
+      while (iterator.hasNext()) {
+        Assert.assertTrue(actual.contains(iterator.nextInt()), "Random seed: " + randomSeed);
+      }
+    }
+  }
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
@@ -17,7 +17,9 @@ package com.linkedin.pinot.server.starter;
 
 import com.linkedin.pinot.common.metrics.MetricsHelper;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.utils.DataTableSerDeRegistry;
 import com.linkedin.pinot.core.data.manager.offline.TableDataManagerProvider;
+import com.linkedin.pinot.core.util.DataTableCustomSerDe;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 
@@ -134,6 +136,9 @@ public class ServerBuilder {
     LOGGER.info("Trying to Load Instance DataManager by Class : " + className);
     DataManager instanceDataManager = (DataManager) Class.forName(className).newInstance();
     instanceDataManager.init(_serverConf.getInstanceDataManagerConfig());
+
+    // Register the custom ser/de for DataTable on the server side.
+    DataTableSerDeRegistry.getInstance().register(new DataTableCustomSerDe());
     return instanceDataManager;
   }
 


### PR DESCRIPTION
1. Added custom serializer/de-serializer for various class (including
maps) for DataTable.
   - Created an interface DataTableSerde (in pinot-common).
   - Added DataTableJavaSerDe a new implementation of the interface (in
     pinot-common) that preserves the existing functionality (Java based
ser/de).
   - Added DataTableCustomSerDe implementation (in pinot-core) that
     implements custom ser/de for various classes. This needs to be in
pinot-core as it dependes on classes that are in pinot-core (eg AvgPair,
HyperLogLog, etc).
   - DataTableSerDeRegistery is a singleton that holds on to one of the
     implementations, that is registered during startup of
broker/server.

2. Changes are backward compatible, ie broker with new code can still
de-serialize DataTable from server with old code.

3. Added tests for the new implementations. Also enhanced existing tests
to work with the new custom ser/de.

4. Also performed manual testing to ensure that broker with new code can
successfully de-serialize DataTable from server without the new code.