### PR TITLE
Re-architected server query execution to hand over query to the scheduler for execution.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import java.util.concurrent.atomic.AtomicLong;
+import org.antlr.v4.runtime.misc.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +87,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * @param phase The query phase for which to log time
    * @param nanos The number of nanoseconds that the phase execution took to complete
    */
-  public void addPhaseTiming(final BrokerRequest request, final QP phase, final long nanos) {
+  public void addPhaseTiming(@Nullable final BrokerRequest request, final QP phase, final long nanos) {
     final String fullTimerName = buildMetricName(request, phase.getQueryPhaseName());
     addValueToTimer(fullTimerName, nanos, TimeUnit.NANOSECONDS);
   }
@@ -124,7 +125,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * @param metricName The metric name to register
    * @return The complete metric name
    */
-  private String buildMetricName(BrokerRequest request, String metricName) {
+  private String buildMetricName(@Nullable BrokerRequest request, String metricName) {
     if (request != null && request.getQuerySource() != null && request.getQuerySource().getTableName() != null) {
       return _metricPrefix + request.getQuerySource().getTableName() + "." + metricName;
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/FCFSQueryScheduler.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.utils.DataTable;
+import java.util.concurrent.Callable;
+import javax.annotation.Nonnull;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * First Come First Served(FCFS) query scheduler.
+ * The FCFS policy applies across all tables.
+ * This is similar to the existing query scheduling logic.
+ */
+public class FCFSQueryScheduler extends QueryScheduler {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(FCFSQueryScheduler.class);
+
+  public FCFSQueryScheduler(@Nonnull Configuration schedulerConfig, @Nonnull QueryExecutor queryExecutor) {
+    super(schedulerConfig, queryExecutor);
+    Preconditions.checkNotNull(queryExecutor);
+  }
+
+  @Override
+  public ListenableFuture<DataTable> submit(final QueryRequest queryRequest) {
+    ListenableFuture<DataTable> queryResultFuture = queryRunners.submit(new Callable<DataTable>() {
+      @Override
+      public DataTable call() {
+        return queryExecutor.processQuery(queryRequest);
+      }
+    });
+
+    return queryResultFuture;
+  }
+
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.utils.DataTable;
+import java.util.concurrent.Executors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration.Configuration;
+
+/**
+ * Abstract class providing common scheduler functionality
+ * including query runner and query worker pool
+ */
+public abstract class QueryScheduler {
+
+  public static final String QUERY_RUNNER_CONFIG_KEY = "query_runner_threads";
+  public static final String QUERY_WORKER_CONFIG_KEY = "query_worker_threads";
+
+  public static final int DEFAULT_QUERY_RUNNER_THREADS;
+  public static final int DEFAULT_QUERY_WORKER_THREADS;
+
+  int numQueryRunnerThreads;
+  int numQueryWorkerThreads;
+
+  // This executor service will run the "main" operation of query processing
+  // including planning, distributing operators across threads, waiting and
+  // reducing the results from the parallel set of operators (MCombineOperator)
+  //
+  protected ListeningExecutorService queryRunners;
+
+  // TODO: in future, this should be driven by configured policy
+  // like poolPerTable or QoS based pools etc
+  // The policy should also determine how many threads we use per query
+
+  // These are worker threads to parallelize execution of query operators
+  // across groups of segments.
+  protected ListeningExecutorService queryWorkers;
+
+  final QueryExecutor queryExecutor;
+  static {
+    int numCores = Runtime.getRuntime().availableProcessors();
+    // arbitrary...but not completely arbitrary
+    DEFAULT_QUERY_RUNNER_THREADS = numCores;
+    DEFAULT_QUERY_WORKER_THREADS = 2 * numCores;
+  }
+
+  public QueryScheduler(@Nullable QueryExecutor queryExecutor) {
+    numQueryRunnerThreads = DEFAULT_QUERY_RUNNER_THREADS;
+    numQueryWorkerThreads = DEFAULT_QUERY_WORKER_THREADS;
+    this.queryExecutor = queryExecutor;
+    queryRunners = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numQueryRunnerThreads));
+    queryWorkers = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numQueryWorkerThreads));
+  }
+
+  public QueryScheduler(@Nonnull Configuration schedulerConfig, QueryExecutor queryExecutor) {
+    Preconditions.checkNotNull(schedulerConfig);
+    numQueryRunnerThreads = schedulerConfig.getInt(QUERY_RUNNER_CONFIG_KEY, DEFAULT_QUERY_RUNNER_THREADS);
+    numQueryWorkerThreads = schedulerConfig.getInt(QUERY_WORKER_CONFIG_KEY, DEFAULT_QUERY_WORKER_THREADS);
+    queryRunners = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numQueryRunnerThreads));
+    queryWorkers = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numQueryWorkerThreads));
+    this.queryExecutor = queryExecutor;
+  }
+
+  public abstract ListenableFuture<DataTable> submit(@Nullable QueryRequest queryRequest);
+
+  public @Nullable QueryExecutor getQueryExecutor() {
+    return queryExecutor;
+  }
+}

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -97,6 +97,13 @@
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-log</artifactId>
     </dependency>
+    <!-- test -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.8.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/conf/ServerConf.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/conf/ServerConf.java
@@ -26,15 +26,20 @@ import org.apache.commons.configuration.ConfigurationException;
  */
 public class ServerConf {
 
-  private static String PINOT_ = "pinot.";
-  private static String PINOT_SERVER_INSTANCE = "pinot.server.instance";
-  private static String PINOT_SERVER_METRICS = "pinot.server.metrics";
-  private static String PINOT_SERVER_QUERY = "pinot.server.query.executor";
-  private static String PINOT_SERVER_REQUEST = "pinot.server.request";
-  private static String PINOT_SERVER_NETTY = "pinot.server.netty";
-  private static String PINOT_SERVER_INSTANCE_DATA_MANAGER_CLASS = "pinot.server.instance.data.manager.class";
-  private static String PINOT_SERVER_QUERY_EXECUTOR_CLASS = "pinot.server.query.executor.class";
-  private static String PINOT_SERVER_REQUEST_HANDLER_FACTORY_CLASS = "pinot.server.requestHandlerFactory.class";
+  private static final String PINOT_ = "pinot.";
+  private static final String PINOT_SERVER_INSTANCE = "pinot.server.instance";
+  private static final String PINOT_SERVER_METRICS = "pinot.server.metrics";
+  private static final String PINOT_SERVER_QUERY = "pinot.server.query.executor";
+  private static final String PINOT_SERVER_REQUEST = "pinot.server.request";
+  private static final String PINOT_SERVER_NETTY = "pinot.server.netty";
+  private static final String PINOT_SERVER_INSTANCE_DATA_MANAGER_CLASS = "pinot.server.instance.data.manager.class";
+  private static final String PINOT_SERVER_QUERY_EXECUTOR_CLASS = "pinot.server.query.executor.class";
+  private static final String PINOT_SERVER_REQUEST_HANDLER_FACTORY_CLASS = "pinot.server.requestHandlerFactory.class";
+  private static final String PINOT_SERVER_QUERY_SCHEDULER_CLASS_CONFIG_KEY = "pinot.server.query.scheduler.class" ;
+  private static final String DEFAULT_QUERY_SCHEDULER_CLASS_NAME =
+      "com.linkedin.pinot.core.query.scheduler.FCFSQueryScheduler";
+
+  private static final String PINOT_QUERY_SCHEDULER_PREFIX = "pinot.query.scheduler";
 
   private Configuration _serverConf;
 
@@ -78,8 +83,16 @@ public class ServerConf {
     return _serverConf.getString(PINOT_SERVER_QUERY_EXECUTOR_CLASS);
   }
 
+  public String getQuerySchedulerClassName() {
+    return _serverConf.getString(PINOT_SERVER_QUERY_SCHEDULER_CLASS_CONFIG_KEY,
+        DEFAULT_QUERY_SCHEDULER_CLASS_NAME);
+  }
+
   public String getRequestHandlerFactoryClassName() {
     return _serverConf.getString(PINOT_SERVER_REQUEST_HANDLER_FACTORY_CLASS);
   }
 
+  public Configuration getSchedulerConfig() {
+    return _serverConf.subset(PINOT_QUERY_SCHEDULER_PREFIX);
+  }
 }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.server.request;
+
+import com.google.common.base.Function;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.linkedin.pinot.common.exception.QueryException;
+import com.linkedin.pinot.common.metrics.ServerMeter;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.metrics.ServerQueryPhase;
+import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.request.InstanceRequest;
+import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
+import com.linkedin.pinot.serde.SerDe;
+import com.linkedin.pinot.transport.netty.NettyServer;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ScheduledRequestHandler implements NettyServer.RequestHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledRequestHandler.class);
+
+  private final ServerMetrics serverMetrics;
+  private final QueryScheduler queryScheduler;
+
+  public ScheduledRequestHandler(QueryScheduler queryScheduler, ServerMetrics serverMetrics) {
+    this.queryScheduler = queryScheduler;
+    this.serverMetrics = serverMetrics;
+  }
+
+  @Override
+  public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext,
+      ByteBuf request) {
+    final long queryStartTime = System.nanoTime();
+    serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
+
+    LOGGER.debug("Processing request : {}", request);
+
+    byte[] byteArray = new byte[request.readableBytes()];
+    request.readBytes(byteArray);
+    SerDe serDe = new SerDe(new TCompactProtocol.Factory());
+    final InstanceRequest instanceRequest = new InstanceRequest();
+
+    if (! serDe.deserialize(instanceRequest, byteArray)) {
+      LOGGER.error("Failed to deserialize query request from broker ip: {}",
+          ((InetSocketAddress) channelHandlerContext.channel().remoteAddress()).getAddress().getHostAddress());
+      DataTable result = new DataTable();
+      result.addException(QueryException.INTERNAL_ERROR);
+      serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_DESERIALIZATION_EXCEPTIONS, 1);
+      return Futures.immediateFuture(serializeDataTable(null, serverMetrics, result, queryStartTime));
+    }
+    long deserializationEndTime = System.nanoTime();
+    final BrokerRequest brokerRequest = instanceRequest.getQuery();
+    serverMetrics.addPhaseTiming(brokerRequest, ServerQueryPhase.REQUEST_DESERIALIZATION, deserializationEndTime - queryStartTime);
+    LOGGER.debug("Processing requestId:{},request={}", instanceRequest.getRequestId(), instanceRequest);
+    final QueryRequest queryRequest = new QueryRequest(instanceRequest);
+    String brokerId = instanceRequest.isSetBrokerId() ? instanceRequest.getBrokerId() :
+        ((InetSocketAddress) channelHandlerContext.channel().remoteAddress()).getAddress().getHostAddress();
+    // we will set the ip address as client id. This is good enough for start.
+    // Ideally, broker should send it's identity as part of the request
+    queryRequest.setClientId(brokerId);
+
+    final long schedulerSubmitTime = System.nanoTime();
+    ListenableFuture<DataTable> queryTask = queryScheduler.submit(queryRequest);
+
+    // following future will provide default response in case of uncaught
+    // exceptions from query processing
+    ListenableFuture<DataTable> queryResponse =
+        Futures.catching(queryTask, Throwable.class, new Function<Throwable, DataTable>() {
+          @Nullable
+          @Override
+          public DataTable apply(@Nullable Throwable input) {
+            // this is called iff queryTask fails with unhandled exception
+            serverMetrics.addMeteredGlobalValue(ServerMeter.UNCAUGHT_EXCEPTIONS, 1);
+            DataTable result = new DataTable();
+            result.addException(QueryException.INTERNAL_ERROR);
+            return result;
+          }
+        });
+
+    // transform the DataTable to serialized byte[] to send back to broker
+    ListenableFuture<byte[]> serializedQueryResponse = Futures.transform(queryResponse, new Function<DataTable, byte[]>() {
+      @Nullable
+      @Override
+      public byte[] apply(@Nullable DataTable instanceResponse) {
+        long totalNanos = System.nanoTime() - schedulerSubmitTime;
+        serverMetrics.addPhaseTiming(brokerRequest, ServerQueryPhase.QUERY_PROCESSING, totalNanos);
+        return serializeDataTable(instanceRequest, serverMetrics, instanceResponse, queryStartTime);
+      }
+    });
+
+    return serializedQueryResponse;
+  }
+
+  static byte[] serializeDataTable(@Nullable InstanceRequest instanceRequest,
+      ServerMetrics metrics,
+      DataTable instanceResponse, long queryStartTime) {
+    byte[] responseByte;
+    long serializationStartTime = System.nanoTime();
+    long requestId = instanceRequest != null ? instanceRequest.getRequestId() : -1;
+    String brokerId = instanceRequest != null ? instanceRequest.getBrokerId() : "null";
+
+    try {
+      if (instanceResponse == null) {
+        LOGGER.warn("Instance response is null for requestId: {}, brokerId: {}", requestId, brokerId);
+        responseByte = new byte[0];
+      } else {
+        responseByte = instanceResponse.toBytes();
+      }
+    } catch (Exception e) {
+      metrics.addMeteredGlobalValue(ServerMeter.RESPONSE_SERIALIZATION_EXCEPTIONS, 1);
+      LOGGER.error("Got exception while serializing response for requestId: {}, brokerId: {}",
+          requestId, brokerId, e);
+      responseByte = null;
+    }
+    long serializationEndTime = System.nanoTime();
+    BrokerRequest brokerRequest = instanceRequest != null ? instanceRequest.getQuery() : null;
+
+    metrics.addPhaseTiming(brokerRequest, ServerQueryPhase.RESPONSE_SERIALIZATION,
+        serializationEndTime - serializationStartTime);
+    metrics.addPhaseTiming(brokerRequest, ServerQueryPhase.TOTAL_QUERY_TIME,
+        serializationEndTime - queryStartTime);
+    return responseByte;
+  }
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/request/SimpleRequestHandlerFactory.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/request/SimpleRequestHandlerFactory.java
@@ -16,39 +16,28 @@
 package com.linkedin.pinot.server.request;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.linkedin.pinot.transport.netty.NettyServer.RequestHandler;
 import com.linkedin.pinot.transport.netty.NettyServer.RequestHandlerFactory;
-
 
 /**
  * A simple implementation of RequestHandlerFactory.
  * Only return a SimpleRequestHandler.
- *
- *
  */
 public class SimpleRequestHandlerFactory implements RequestHandlerFactory {
 
-  private QueryExecutor _queryExecutor;
+  private QueryScheduler _queryScheduler;
 
   private ServerMetrics _serverMetrics;
 
-  public SimpleRequestHandlerFactory() {
-
-  }
-
-  public SimpleRequestHandlerFactory(QueryExecutor queryExecutor, ServerMetrics serverMetrics) {
-    _queryExecutor = queryExecutor;
+  public SimpleRequestHandlerFactory(QueryScheduler scheduler, ServerMetrics serverMetrics) {
+    this._queryScheduler = scheduler;
     _serverMetrics = serverMetrics;
-  }
-
-  public void init(QueryExecutor queryExecutor) {
-    _queryExecutor = queryExecutor;
   }
 
   @Override
   public RequestHandler createNewRequestHandler() {
-    return new SimpleRequestHandler(_queryExecutor, _serverMetrics);
+    return new SimpleRequestHandler(_queryScheduler.getQueryExecutor(), _serverMetrics);
   }
 
 }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/FileBasedServer.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/FileBasedServer.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.server.starter;
 
+import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 
@@ -89,9 +90,9 @@ public class FileBasedServer {
 
     LOGGER.info("Trying to build QueryExecutor");
     final QueryExecutor queryExecutor = serverBuilder.buildQueryExecutor(instanceDataManager);
-
+    final QueryScheduler queryScheduler = serverBuilder.buildQueryScheduler(queryExecutor);
     LOGGER.info("Trying to build RequestHandlerFactory");
-    RequestHandlerFactory simpleRequestHandlerFactory = serverBuilder.buildRequestHandlerFactory(queryExecutor);
+    RequestHandlerFactory simpleRequestHandlerFactory = serverBuilder.buildRequestHandlerFactory(queryScheduler);
     LOGGER.info("Trying to build NettyServer");
 
     NettyServer nettyServer = new NettyTCPServer(_serverPort, simpleRequestHandlerFactory, null);

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/integration/InstanceServerStarter.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/integration/InstanceServerStarter.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.server.integration;
 
 import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 import java.util.ArrayList;
@@ -65,7 +66,8 @@ public class InstanceServerStarter {
     sendQueryToQueryExecutor(getMinQuery(), queryExecutor);
 
     LOGGER.info("Trying to build RequestHandlerFactory");
-    RequestHandlerFactory simpleRequestHandlerFactory = serverBuilder.buildRequestHandlerFactory(queryExecutor);
+    QueryScheduler queryScheduler = serverBuilder.buildQueryScheduler(queryExecutor);
+    RequestHandlerFactory simpleRequestHandlerFactory = serverBuilder.buildRequestHandlerFactory(queryScheduler);
     LOGGER.info("Trying to build NettyServer");
 
     System.out.println(getMaxQuery());

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/request/ScheduledRequestHandlerTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/request/ScheduledRequestHandlerTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.server.request;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.exception.QueryException;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.request.InstanceRequest;
+import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.common.utils.DataTableBuilder;
+import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
+import com.linkedin.pinot.serde.SerDe;
+import com.yammer.metrics.core.MetricsRegistry;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class ScheduledRequestHandlerTest {
+
+  public static Logger LOGGER = LoggerFactory.getLogger(ScheduledRequestHandlerTest.class);
+
+  private ServerMetrics serverMetrics;
+  private ChannelHandlerContext channelHandlerContext;
+  private QueryScheduler queryScheduler;
+
+  @BeforeTest
+  public void setupTestMethod() {
+    serverMetrics = new ServerMetrics(new MetricsRegistry());
+    channelHandlerContext = mock(ChannelHandlerContext.class, RETURNS_DEEP_STUBS);
+    when(channelHandlerContext.channel().remoteAddress())
+        .thenAnswer(new Answer<InetSocketAddress>() {
+          @Override
+          public InetSocketAddress answer(InvocationOnMock invocationOnMock)
+              throws Throwable {
+            return new InetSocketAddress("localhost", 60000);
+          }
+        });
+
+    queryScheduler = mock(QueryScheduler.class);
+  }
+
+  @Test
+  public void testBadRequest()
+      throws Exception {
+    ScheduledRequestHandler handler = new ScheduledRequestHandler(queryScheduler, serverMetrics);
+    String requestBadString = "foobar";
+    byte[] requestData = requestBadString.getBytes();
+    ByteBuf buffer = Unpooled.wrappedBuffer(requestData);
+    ListenableFuture<byte[]> response = handler.processRequest(channelHandlerContext, buffer);
+    // The handler method is expected to return immediately
+    Assert.assertTrue(response.isDone());
+    byte[] responseBytes = response.get();
+    Assert.assertTrue(responseBytes.length > 0);
+    DataTable expectedDT = new DataTable();
+    expectedDT.addException(QueryException.INTERNAL_ERROR);
+    Assert.assertEquals(responseBytes, expectedDT.toBytes());
+  }
+
+  private InstanceRequest getInstanceRequest() {
+    InstanceRequest request = new InstanceRequest();
+    request.setBrokerId("broker");
+    request.setEnableTrace(false);
+    request.setRequestId(1);
+    request.setSearchSegments(Arrays.asList("segment1", "segment2"));
+    request.setQuery(new BrokerRequest());
+    return request;
+  }
+
+  private ByteBuf getSerializedInstanceRequest(InstanceRequest request) {
+    SerDe serDe = new SerDe(new TCompactProtocol.Factory());
+    byte[] requestData = serDe.serialize(request);
+    return Unpooled.wrappedBuffer(requestData);
+  }
+
+  @Test
+  public void testQueryProcessingException()
+      throws Exception {
+    ScheduledRequestHandler handler = new ScheduledRequestHandler(new QueryScheduler(null) {
+      @Override
+      public ListenableFuture<DataTable> submit(QueryRequest queryRequest) {
+        return queryWorkers.submit(new Callable<DataTable>() {
+          @Override
+          public DataTable call()
+              throws Exception {
+            throw new RuntimeException("query processing error");
+          }
+        });
+      }
+    }, serverMetrics);
+
+    ByteBuf requestBuf = getSerializedInstanceRequest(getInstanceRequest());
+    ListenableFuture<byte[]> responseFuture = handler.processRequest(channelHandlerContext, requestBuf);
+    byte[] bytes = responseFuture.get(2, TimeUnit.SECONDS);
+    // we get DataTable with exception information in case of query processing exception
+    Assert.assertTrue(bytes.length > 0);
+    DataTable expectedDT = new DataTable();
+    expectedDT.addException(QueryException.INTERNAL_ERROR);
+    Assert.assertEquals(bytes, expectedDT.toBytes());
+  }
+
+  @Test
+  public void testValidQueryResponse()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    ScheduledRequestHandler handler = new ScheduledRequestHandler(new QueryScheduler(null) {
+      @Override
+      public ListenableFuture<DataTable> submit(QueryRequest queryRequest) {
+        return queryRunners.submit(new Callable<DataTable>() {
+          @Override
+          public DataTable call()
+              throws Exception {
+            String[] columns = new String[] { "foo", "bar"};
+            FieldSpec.DataType[] columnTypes = new FieldSpec.DataType[] {
+              FieldSpec.DataType.STRING,
+              FieldSpec.DataType.INT
+            };
+            DataTableBuilder.DataSchema dataSchema = new DataTableBuilder.DataSchema(
+                columns, columnTypes);
+            DataTableBuilder dtBuilder = new DataTableBuilder(dataSchema);
+            dtBuilder.open();
+            dtBuilder.startRow();
+            dtBuilder.setColumn(0, "mars");
+            dtBuilder.setColumn(1, 10);
+            dtBuilder.finishRow();
+            dtBuilder.startRow();
+            dtBuilder.setColumn(0, "jupiter");
+            dtBuilder.setColumn(1, 100);
+            dtBuilder.finishRow();
+            dtBuilder.seal();
+            return dtBuilder.build();
+          }
+        });
+      }
+    }, serverMetrics);
+
+    ByteBuf requestBuf = getSerializedInstanceRequest(getInstanceRequest());
+    ListenableFuture<byte[]> responseFuture = handler.processRequest(channelHandlerContext, requestBuf);
+    byte[] responseBytes = responseFuture.get(2, TimeUnit.SECONDS);
+    DataTable responseDT = new DataTable(responseBytes);
+    Assert.assertEquals(responseDT.getNumberOfRows(), 2);
+    Assert.assertEquals(responseDT.getString(0, 0), "mars");
+    Assert.assertEquals(responseDT.getInt(0, 1), 10);
+    Assert.assertEquals(responseDT.getString(1, 0), "jupiter");
+    Assert.assertEquals(responseDT.getInt(1, 1), 100);
+  }
+
+}

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.transport.netty;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.channel.ChannelHandlerContext;
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -521,7 +523,7 @@ public class NettySingleConnectionIntegrationTest {
     }
 
     @Override
-    public byte[] processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
+    public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
       byte[] b = new byte[request.readableBytes()];
       request.readBytes(b);
       if (null != _responseHandlingLatch) {
@@ -534,7 +536,7 @@ public class NettySingleConnectionIntegrationTest {
       _request = new String(b);
 
       //LOG.info("Server got the request (" + _request + ")");
-      return _response.getBytes();
+      return Futures.immediateFuture(_response.getBytes());
     }
 
     public String getRequest() {

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/perf/ScatterGatherPerfServer.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/perf/ScatterGatherPerfServer.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.transport.perf;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.CountDownLatch;
 
@@ -153,7 +155,7 @@ public class ScatterGatherPerfServer {
     }
 
     @Override
-    public byte[] processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
+    public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
       byte[] b = new byte[request.readableBytes()];
       request.readBytes(b);
       if (null != _responseHandlingLatch) {
@@ -175,7 +177,7 @@ public class ScatterGatherPerfServer {
         }
       }
       //LOG.info("Server got the request (" + _request + ")");
-      return _response.getBytes();
+      return Futures.immediateFuture(_response.getBytes());
     }
 
     public String getRequest() {

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.transport.scattergather;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -654,7 +656,7 @@ public class ScatterGatherTest {
     }
 
     @Override
-    public byte[] processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
+    public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
 
       if (_sleepTimeMS > 0) {
         try {
@@ -672,7 +674,7 @@ public class ScatterGatherTest {
       _request.add(new String(dst));
       int index = _index.incrementAndGet();
       String res = _responses.get(index);
-      return res.getBytes();
+      return Futures.immediateFuture(res.getBytes());
     }
 
     public List<String> getRequest() {


### PR DESCRIPTION
This commit changes the server to pass query request to the
scheduler for execution instead of executing the query in
the receiving Netty server thread. Scheduler by default has two
executor pools - QueryRunners which will execute the query, and
QueryWorkers which are used by the query runtime to parallelize
operators across segments. Added a First Come First Served query
scheduler that matches existing scheduling functionality by
immediately sending the query to the QueryRunners for execution.
This commit also adds a ScheduledRequestHandler which _will_ replace
SimpleRequestHandler to use QueryScheduler in future.

Current code continues to use SimpleRequestHandler. The impacting change
of this commit is to run queries in separate executors and to return
ListenableFutures to the caller.

Testing:
1. Additional unit tests and existing integration tests
2. Query execution on local cluster
3. Performance tests