### PR TITLE
Pretty print table REST API responses

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResource.java
@@ -164,7 +164,7 @@ public class PinotTableRestletResource extends BasePinotControllerRestletResourc
       ret.put(TableType.REALTIME.name(), config.toJSON());
     }
 
-    return new StringRepresentation(ret.toString());
+    return new StringRepresentation(ret.toString(2));
   }
 
   @HttpVerb("get")
@@ -180,7 +180,7 @@ public class PinotTableRestletResource extends BasePinotControllerRestletResourc
       tableArray.put(pinotTableName);
     }
     object.put("tables", tableArray);
-    return new StringRepresentation(object.toString());
+    return new StringRepresentation(object.toString(2));
   }
 
   @HttpVerb("get")


### PR DESCRIPTION
Pretty print table REST API responses, so that the list of tables has
at most one table per line and so that the table configuration is
readable by humans.