### PR TITLE
TE: Unify the imported package for Json related operations

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/SchemaCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/SchemaCacheLoader.java
@@ -9,7 +9,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/AbstractConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/AbstractConfig.java
@@ -1,9 +1,8 @@
 package com.linkedin.thirdeye.dashboard.configs;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.linkedin.thirdeye.api.CollectionSchema;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.modelmapper.ModelMapper;
 
 import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeConfig;
@@ -27,7 +26,6 @@ import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
 
 public abstract class AbstractManagerImpl<E extends AbstractDTO> implements AbstractManager<E> {
 
-  protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   protected static final ModelMapper MODEL_MAPPER = new ModelMapper();
   protected static GenericPojoDao genericPojoDao =
       DaoProviderUtil.getInstance(GenericPojoDao.class);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 import javax.sql.DataSource;
 
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -225,7 +225,7 @@ public class GenericPojoDao {
   }
 
   /**
-   * 
+   *
    * @param parameterizedSQL second part of the sql (omit select from table section)
    * @param parameterMap
    * @return

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AbstractBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AbstractBean.java
@@ -3,7 +3,7 @@ package com.linkedin.thirdeye.datalayer.pojo;
 
 import javax.persistence.MappedSuperclass;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import com.linkedin.thirdeye.datalayer.dto.AbstractDTO;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
@@ -10,9 +10,9 @@ import javax.persistence.Index;
 import javax.persistence.MappedSuperclass;
 
 import javax.persistence.Transient;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Multimap;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/GenericResultSetMapper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/GenericResultSetMapper.java
@@ -17,8 +17,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.node.ObjectNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.config.Configuration.AccessLevel;
 import org.modelmapper.convention.NameTokenizers;
@@ -104,7 +104,7 @@ public class GenericResultSetMapper {
          * Long.valueOf(val.toString())); } else { field.set(entityObj, val); }
          */
       }
-      entityObj = mapper.readValue(objectNode, entityClass);
+      entityObj = mapper.treeToValue(objectNode, entityClass);
       entityList.add((E) entityObj);
     }
 


### PR DESCRIPTION
Remove the remaining dependency to codehaus.jackson and move to fasterxml.jackson.

This unification prevents the errors (exceptions) that are induced when processing Json objects using the mix of codehaus and fastxml's class, e.g., reading a json object of codehaus using an ObjectMapper of fasterxml.

Please pay attention to line 107 of GenericResultSetMapper.java. The method readValue(JsonNode, Class) does not exist in fastxml; therefore, the method treeToValue(TreeNode, Class) is used instead. (ObjectNode at line 76 is a subclass of TreeNode.)