### PR TITLE
Added metric to catch any Java de-serialization in data table.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
@@ -172,7 +172,7 @@ public class BrokerServerBuilder {
         reduceServiceRegistry, _brokerMetrics, _config);
 
     // Register SerDe for data-table.
-    DataTableSerDeRegistry.getInstance().register(new DataTableCustomSerDe());
+    DataTableSerDeRegistry.getInstance().register(new DataTableCustomSerDe(_brokerMetrics));
 
     LOGGER.info("Network initialized !!");
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
@@ -43,7 +43,12 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   // to the server. Note that this may be because we have exhausted the (fixed-size) pool for the server, and
   // also reached the maximum number of waiting requests for the server. The metric is counted on a per-table
   // basis.
-  REQUEST_DROPPED_DUE_TO_CONNECTION_ERROR("requestDropped", false);
+  REQUEST_DROPPED_DUE_TO_CONNECTION_ERROR("requestDropped", false),
+
+
+  // This metric is emitted when DataTableCustomSerDe falls back to Java based de-serialization.
+  // This implies that we have identified an object for which we have not implemented custom ser/de.
+  DATA_TABLE_OBJECT_DESERIALIZATION("dataTableObjectDeserialization", true);
 
   private final String brokerMeterName;
   private final String unit;


### PR DESCRIPTION
This change is to identify an objects that might have been missed when
implementing custom ser/de. Once all objects are identified, we will
remove the metric, and throw an exception instead.