### PR TITLE
Fix issue when creating StarTree segment with large dataset causing JVM crashes

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeDataTable.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeDataTable.java
@@ -15,13 +15,11 @@
  */
 package com.linkedin.pinot.core.startree;
 
+import com.linkedin.pinot.common.utils.Pairs.IntPair;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel.MapMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -29,16 +27,15 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
-
-import com.linkedin.pinot.common.utils.Pairs.IntPair;
-
 import xerial.larray.mmap.MMapBuffer;
 import xerial.larray.mmap.MMapMode;
 
 
+/**
+ * The StarTreeDataTable should be able to handle the memory range greater than 2GB.
+ * As a result, all fields related to memory position should be declared as long to avoid int overflow.
+ */
 public class StarTreeDataTable {
 
   private File file;
@@ -56,7 +53,7 @@ public class StarTreeDataTable {
   }
 
   /**
-   * 
+   *
    * @param startRecordId inclusive
    * @param endRecordId exclusive
    */
@@ -68,8 +65,8 @@ public class StarTreeDataTable {
     final MMapBuffer mappedByteBuffer;
     try {
       int length = endRecordId - startRecordId;
-      final int startOffset = startRecordId * totalSizeInBytes;
-      mappedByteBuffer = new MMapBuffer(file, startOffset, length * totalSizeInBytes, MMapMode.READ_WRITE);
+      final long startOffset = startRecordId * (long) totalSizeInBytes;
+      mappedByteBuffer = new MMapBuffer(file, startOffset, length * (long) totalSizeInBytes, MMapMode.READ_WRITE);
 
       List<Integer> idList = new ArrayList<Integer>();
       for (int i = startRecordId; i < endRecordId; i++) {
@@ -81,11 +78,12 @@ public class StarTreeDataTable {
 
         @Override
         public int compare(Integer o1, Integer o2) {
-          int pos1 = (o1) * totalSizeInBytes;
-          int pos2 = (o2) * totalSizeInBytes;
+          long pos1 = (o1) * (long) totalSizeInBytes;
+          long pos2 = (o2) * (long) totalSizeInBytes;
+
           //System.out.println("pos1="+ pos1 +" , pos2="+ pos2);
-          mappedByteBuffer.copyTo(pos1, buf1, 0, dimensionSizeInBytes);
-          mappedByteBuffer.copyTo(pos2, buf2, 0, dimensionSizeInBytes);
+          mappedByteBuffer.toDirectByteBuffer(pos1, dimensionSizeInBytes).get(buf1);
+          mappedByteBuffer.toDirectByteBuffer(pos2, dimensionSizeInBytes).get(buf2);
           IntBuffer bb1 = ByteBuffer.wrap(buf1).asIntBuffer();
           IntBuffer bb2 = ByteBuffer.wrap(buf2).asIntBuffer();
           for (int dimIndex : sortOrder) {
@@ -117,14 +115,14 @@ public class StarTreeDataTable {
         int thatRecordIdPos = currentPositions[thatRecordId];
 
         //swap the buffers
-        mappedByteBuffer.copyTo(thisRecordIdPos * totalSizeInBytes, buf1, 0, totalSizeInBytes);
-        mappedByteBuffer.copyTo(thatRecordIdPos * totalSizeInBytes, buf2, 0, totalSizeInBytes);
+        mappedByteBuffer.toDirectByteBuffer(thisRecordIdPos * (long) totalSizeInBytes, totalSizeInBytes).get(buf1);
+        mappedByteBuffer.toDirectByteBuffer(thatRecordIdPos * (long) totalSizeInBytes, totalSizeInBytes).get(buf2);
         //        mappedByteBuffer.position(thisRecordIdPos * totalSizeInBytes);
         //        mappedByteBuffer.get(buf1);
         //        mappedByteBuffer.position(thatRecordIdPos * totalSizeInBytes);
         //        mappedByteBuffer.get(buf2);
-        mappedByteBuffer.readFrom(buf2, 0, thisRecordIdPos * totalSizeInBytes, totalSizeInBytes);
-        mappedByteBuffer.readFrom(buf1, 0, thatRecordIdPos * totalSizeInBytes, totalSizeInBytes);
+        mappedByteBuffer.readFrom(buf2, 0, thisRecordIdPos * (long) totalSizeInBytes, totalSizeInBytes);
+        mappedByteBuffer.readFrom(buf1, 0, thatRecordIdPos * (long) totalSizeInBytes, totalSizeInBytes);
         //        mappedByteBuffer.position(thisRecordIdPos * totalSizeInBytes);
         //        mappedByteBuffer.put(buf2);
         //        mappedByteBuffer.position(thatRecordIdPos * totalSizeInBytes);
@@ -148,7 +146,7 @@ public class StarTreeDataTable {
   }
 
   /**
-   * 
+   *
    * @param startDocId inclusive
    * @param endDocId exclusive
    * @param colIndex
@@ -159,13 +157,13 @@ public class StarTreeDataTable {
     try {
       int length = endDocId - startDocId;
       Map<Integer, IntPair> rangeMap = new LinkedHashMap<>();
-      final int startOffset = startDocId * totalSizeInBytes;
-      mappedByteBuffer = new MMapBuffer(file, startOffset, length * totalSizeInBytes, MMapMode.READ_WRITE);
+      final long startOffset = startDocId * (long) totalSizeInBytes;
+      mappedByteBuffer = new MMapBuffer(file, startOffset, length * (long) totalSizeInBytes, MMapMode.READ_WRITE);
       int prevValue = -1;
       int prevStart = 0;
       byte[] dimBuff = new byte[dimensionSizeInBytes];
       for (int i = 0; i < length; i++) {
-        mappedByteBuffer.copyTo(i * totalSizeInBytes, dimBuff, 0, dimensionSizeInBytes);
+        mappedByteBuffer.toDirectByteBuffer(i * (long) totalSizeInBytes, dimensionSizeInBytes).get(dimBuff);
         int value = ByteBuffer.wrap(dimBuff).asIntBuffer().get(colIndex);
         if (prevValue != -1 && prevValue != value) {
           rangeMap.put(prevValue, new IntPair(startDocId + prevStart, startDocId + i));
@@ -192,8 +190,8 @@ public class StarTreeDataTable {
   public Iterator<Pair<byte[], byte[]>> iterator(int startDocId, int endDocId) throws IOException {
     try {
       final int length = endDocId - startDocId;
-      final int startOffset = startDocId * totalSizeInBytes;
-      final MMapBuffer mappedByteBuffer = new MMapBuffer(file, startOffset, length * totalSizeInBytes, MMapMode.READ_WRITE);
+      final long startOffset = startDocId * (long) totalSizeInBytes;
+      final MMapBuffer mappedByteBuffer = new MMapBuffer(file, startOffset, length * (long) totalSizeInBytes, MMapMode.READ_WRITE);
       return new Iterator<Pair<byte[], byte[]>>() {
         int pointer = 0;
 
@@ -211,12 +209,13 @@ public class StarTreeDataTable {
         public Pair<byte[], byte[]> next() {
           byte[] dimBuff = new byte[dimensionSizeInBytes];
           byte[] metBuff = new byte[metricSizeInBytes];
-          mappedByteBuffer.copyTo(pointer * totalSizeInBytes, dimBuff, 0, dimensionSizeInBytes);
-//          mappedByteBuffer.position(pointer * totalSizeInBytes);
-//          mappedByteBuffer.get(dimBuff);
+          mappedByteBuffer.toDirectByteBuffer(pointer * (long) totalSizeInBytes, dimensionSizeInBytes).get(dimBuff);
+//        mappedByteBuffer.position(pointer * totalSizeInBytes);
+//        mappedByteBuffer.get(dimBuff);
           if (metricSizeInBytes > 0) {
-            mappedByteBuffer.copyTo(pointer * totalSizeInBytes + dimensionSizeInBytes, metBuff, 0, metricSizeInBytes);
-//            mappedByteBuffer.get(metBuff);
+            mappedByteBuffer.toDirectByteBuffer(pointer * (long) totalSizeInBytes + dimensionSizeInBytes,
+                metricSizeInBytes).get(metBuff);
+//          mappedByteBuffer.get(metBuff);
           }
           pointer = pointer + 1;
           if(pointer == length){
@@ -235,7 +234,5 @@ public class StarTreeDataTable {
     } finally {
       //IOUtils.closeQuietly(randomAccessFile);
     }
-
   }
-
 }


### PR DESCRIPTION
This is an important bug fix since in current version, creating StarTree segment will always cause the JVM crashes when the length * totalSizeInBytes is greater than MAX_INT.

Since in byte representation, MAX_INT can only represent up to 2GB size, which means in order to deal with addresses of even large memory mapped file, we need to use the long type to represent the address space greater than 2GB.

The JVM crash is caused by the overflow of int type, which means when accessing the byte address greater than MAX_INT, current implementation results in a negative number address (integer overflow), causing MAP_ERR.