### PR TITLE
Fixing incorrect buckets shows in case of simple date format

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
@@ -57,7 +57,7 @@ public class CollectionMaxDataTimeCacheLoader extends CacheLoader<String, Long> 
         if (StringUtils.isBlank(timeFormat) || TimeSpec.SINCE_EPOCH_FORMAT.equals(timeFormat)) {
           maxTime = timeSpec.getDataGranularity().toMillis(endTime + 1) - 1;
         } else {
-          DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZoneUTC();
+          DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(timeFormat);
           maxTime = DateTime.parse(String.valueOf(endTime), dateTimeFormatter).getMillis();
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -189,7 +189,7 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
     String timeFormat = collectionSchema.getTime().getFormat();
     if (timeFormat != null && !timeFormat.equals(TimeSpec.SINCE_EPOCH_FORMAT)) {
       isISOFormat = true;
-      dateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZoneUTC();
+      dateTimeFormatter = DateTimeFormat.forPattern(timeFormat);
     }
     if (request.getGroupByTimeGranularity() != null) {
       hasGroupByTime = true;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -173,24 +173,27 @@ public class PqlUtils {
     long endMillis = endExclusive.getMillis();
     long dataGranularityMillis = dataGranularity.toMillis();
 
-    // Shrink start and end as per data granularity
-    long startAlignmentDelta = startMillis % dataGranularityMillis;
-    if (startAlignmentDelta != 0) {
-      long startMillisAligned = startMillis + dataGranularityMillis - startAlignmentDelta;
-      start = new DateTime(startMillisAligned);
-    }
+    String timeField = timeFieldSpec.getColumnName();
+    String timeFormat = timeFieldSpec.getFormat();
+    if (timeFormat == null || TimeSpec.SINCE_EPOCH_FORMAT.equals(timeFormat)) {
+      // Shrink start and end as per data granularity
+      long startAlignmentDelta = startMillis % dataGranularityMillis;
+      if (startAlignmentDelta != 0) {
+        long startMillisAligned = startMillis + dataGranularityMillis - startAlignmentDelta;
+        start = new DateTime(startMillisAligned);
+      }
 
-    long endAligmentDelta = endMillis % dataGranularityMillis;
-    if (endAligmentDelta != 0) {
-      long endMillisAligned = endMillis - endAligmentDelta;
-      endExclusive = new DateTime(endMillisAligned);
+      long endAligmentDelta = endMillis % dataGranularityMillis;
+      if (endAligmentDelta != 0) {
+        long endMillisAligned = endMillis - endAligmentDelta;
+        endExclusive = new DateTime(endMillisAligned);
+      }
     }
 
     String startQueryTime;
     String endQueryTimeExclusive;
 
-    String timeField = timeFieldSpec.getColumnName();
-    String timeFormat = timeFieldSpec.getFormat();
+
     if (timeFormat == null || TimeSpec.SINCE_EPOCH_FORMAT.equals(timeFormat)) {
       long startInConvertedUnits = dataGranularity.convertToUnit(start.getMillis());
       long endInConvertedUnits = dataGranularity.convertToUnit(endExclusive.getMillis());
@@ -198,7 +201,7 @@ public class PqlUtils {
       endQueryTimeExclusive = (endInConvertedUnits == startInConvertedUnits + 1) ?
           startQueryTime : String.valueOf(endInConvertedUnits);
     } else {
-      DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZoneUTC();
+      DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(timeFormat);
       startQueryTime = dateTimeFormatter.print(start);
       endQueryTimeExclusive = dateTimeFormatter.print(endExclusive);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/WebappConfigResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/WebappConfigResource.java
@@ -91,7 +91,7 @@ public class WebappConfigResource {
   }
 
   @POST
-  @Path(value = "update/{id}/{collection}/{configType}")
+  @Path(value = "update/{id}/{collection}/{type}")
   public Response updateConfig(@PathParam("id") Long id, @PathParam("collection") String collection,
       @PathParam("type") WebappConfigType type, String payload) {
     try {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/pinot/PqlUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/pinot/PqlUtilsTest.java
@@ -42,7 +42,7 @@ public class PqlUtilsTest {
         // Incorrectly aligned date ranges, with format
         getBetweenClauseTestArgs("2016-01-01T01:00:00.000+00:00", "2016-01-01T23:00:00.000+00:00",
             "timeColumn", 2, TimeUnit.HOURS, "yyyyMMddHH",
-            " timeColumn >= 2016010102 AND timeColumn < 2016010122")
+            " timeColumn >= 2016010101 AND timeColumn < 2016010123")
     };
   }
 


### PR DESCRIPTION
For simple date format, the dashboard was converting the timestamps to offset by 7 hours