### PR TITLE
[PINOT-3696] Make segment commit time configurable.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -53,7 +53,7 @@ public class SegmentCompletionProtocol {
    * it  (via a SegmentCommit message) after the server has been notified that it is the committer.
    */
   private static final int DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC = 60;
-  private static long MAX_SEGMENT_COMMIT_TIME_MS = TimeUnit.SECONDS.convert(DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC, TimeUnit.MILLISECONDS);
+  private static long MAX_SEGMENT_COMMIT_TIME_MS = TimeUnit.MILLISECONDS.convert(DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC, TimeUnit.SECONDS);
 
   public enum ControllerResponseStatus {
     /** Never sent by the controller, but locally used by server when sending a request fails */

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.common.protocols;
 
+import java.util.concurrent.TimeUnit;
 import com.alibaba.fastjson.JSONObject;
 
 /*
@@ -51,7 +52,8 @@ public class SegmentCompletionProtocol {
    * MAX_SEGMENT_COMMIT_TIME_MS is the longest time (msecs) a server will take to complete building a segment and committing
    * it  (via a SegmentCommit message) after the server has been notified that it is the committer.
    */
-  private static long MAX_SEGMENT_COMMIT_TIME_MS = 15000;
+  private static final int DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC = 60;
+  private static long MAX_SEGMENT_COMMIT_TIME_MS = TimeUnit.SECONDS.convert(DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC, TimeUnit.MILLISECONDS);
 
   public enum ControllerResponseStatus {
     /** Never sent by the controller, but locally used by server when sending a request fails */
@@ -108,6 +110,10 @@ public class SegmentCompletionProtocol {
 
   public static void setMaxSegmentCommitTimeMs(long commitTimeMs) {
     MAX_SEGMENT_COMMIT_TIME_MS = commitTimeMs;
+  }
+
+  public static int getDefaultMaxSegmentCommitTimeSec() {
+    return DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC;
   }
 
   public static abstract class Request {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -51,7 +51,7 @@ public class SegmentCompletionProtocol {
    * MAX_SEGMENT_COMMIT_TIME_MS is the longest time (msecs) a server will take to complete building a segment and committing
    * it  (via a SegmentCommit message) after the server has been notified that it is the committer.
    */
-  public static final long MAX_SEGMENT_COMMIT_TIME_MS = 15000;
+  private static long MAX_SEGMENT_COMMIT_TIME_MS = 15000;
 
   public enum ControllerResponseStatus {
     /** Never sent by the controller, but locally used by server when sending a request fails */
@@ -101,6 +101,14 @@ public class SegmentCompletionProtocol {
   public static final Response RESP_DISCARD = new Response(ControllerResponseStatus.DISCARD, -1L);
   public static final Response RESP_COMMIT_SUCCESS = new Response(ControllerResponseStatus.COMMIT_SUCCESS, -1L);
   public static final Response RESP_COMMIT_CONTINUE = new Response(ControllerResponseStatus.COMMIT_CONTINUE, -1L);
+
+  public static long getMaxSegmentCommitTimeMs() {
+    return MAX_SEGMENT_COMMIT_TIME_MS;
+  }
+
+  public static void setMaxSegmentCommitTimeMs(long commitTimeMs) {
+    MAX_SEGMENT_COMMIT_TIME_MS = commitTimeMs;
+  }
 
   public static abstract class Request {
     final String _segmentName;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -52,7 +52,7 @@ public class SegmentCompletionProtocol {
    * MAX_SEGMENT_COMMIT_TIME_MS is the longest time (msecs) a server will take to complete building a segment and committing
    * it  (via a SegmentCommit message) after the server has been notified that it is the committer.
    */
-  private static final int DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC = 60;
+  private static final int DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC = 120;
   private static long MAX_SEGMENT_COMMIT_TIME_MS = TimeUnit.MILLISECONDS.convert(DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC, TimeUnit.SECONDS);
 
   public enum ControllerResponseStatus {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.StringUtil;
 
 public class ControllerConf extends PropertiesConfiguration {
@@ -48,7 +49,6 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final int DEFAULT_STATUS_CONTROLLER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
   private static final long DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS = 120_000L; // 2 minutes
   private static final int DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = 30;
-  private static final int DEFAULT_SEGMENT_COMMIT_TIMEOUT_SECONDS = 45;
 
   public ControllerConf(File file) throws ConfigurationException {
     super(file);
@@ -138,7 +138,7 @@ public class ControllerConf extends PropertiesConfiguration {
     if (containsKey(SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
       return Integer.parseInt((String)getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS));
     }
-    return DEFAULT_SEGMENT_COMMIT_TIMEOUT_SECONDS;
+    return SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSec();
   }
 
   public boolean isUpdateSegmentStateModel() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -20,10 +20,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
-
 import com.linkedin.pinot.common.utils.StringUtil;
 
 public class ControllerConf extends PropertiesConfiguration {
@@ -43,12 +41,14 @@ public class ControllerConf extends PropertiesConfiguration {
   private static final String VALIDATION_MANAGER_FREQUENCY_IN_SECONDS = "controller.validation.frequencyInSeconds";
   private static final String STATUS_CHECKER_FREQUENCY_IN_SECONDS = "controller.statuschecker.frequencyInSeconds";
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
+  private static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "controller.realtime.segment.commit.timeoutSeconds";
 
   private static final int DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
   private static final int DEFAULT_VALIDATION_CONTROLLER_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
   private static final int DEFAULT_STATUS_CONTROLLER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
   private static final long DEFAULT_EXTERNAL_VIEW_ONLINE_TO_OFFLINE_TIMEOUT_MILLIS = 120_000L; // 2 minutes
   private static final int DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = 30;
+  private static final int DEFAULT_SEGMENT_COMMIT_TIMEOUT_SECONDS = 45;
 
   public ControllerConf(File file) throws ConfigurationException {
     super(file);
@@ -106,6 +106,10 @@ public class ControllerConf extends PropertiesConfiguration {
     setProperty(DATA_DIR, dataDir);
   }
 
+  public void setRealtimeSegmentCommitTimeoutSeconds(int timoeutSec) {
+    setProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS, Integer.toString(timoeutSec));
+  }
+
   public void setUpdateSegmentStateModel(String updateStateModel) {
     setProperty(UPDATE_SEGMENT_STATE_MODEL, updateStateModel);
   }
@@ -128,6 +132,13 @@ public class ControllerConf extends PropertiesConfiguration {
 
   public String getDataDir() {
     return (String) getProperty(DATA_DIR);
+  }
+
+  public int getSegmentCommitTimeoutSeconds() {
+    if (containsKey(SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
+      return Integer.parseInt((String)getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS));
+    }
+    return DEFAULT_SEGMENT_COMMIT_TIMEOUT_SECONDS;
   }
 
   public boolean isUpdateSegmentStateModel() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -87,7 +87,7 @@ public class PinotLLCRealtimeSegmentManager {
     }
     INSTANCE = new PinotLLCRealtimeSegmentManager(helixAdmin, clusterName, helixManager, propertyStore,
         helixResourceManager, controllerConf);
-    SegmentCompletionManager.create(helixManager, INSTANCE);
+    SegmentCompletionManager.create(helixManager, INSTANCE, controllerConf);
   }
 
   protected PinotLLCRealtimeSegmentManager(HelixAdmin helixAdmin, String clusterName, HelixManager helixManager,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -28,6 +28,7 @@ import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.controller.ControllerConf;
 
 
 /**
@@ -65,11 +66,13 @@ public class SegmentCompletionManager {
     _segmentManager = segmentManager;
   }
 
-  public static SegmentCompletionManager create(HelixManager helixManager, PinotLLCRealtimeSegmentManager segmentManager) {
+  public static SegmentCompletionManager create(HelixManager helixManager,
+      PinotLLCRealtimeSegmentManager segmentManager, ControllerConf controllerConf) {
     if (_instance != null) {
       throw new RuntimeException("Cannot create multiple instances");
     }
     _instance = new SegmentCompletionManager(helixManager, segmentManager);
+    SegmentCompletionProtocol.setMaxSegmentCommitTimeMs(controllerConf.getSegmentCommitTimeoutSeconds() * 1000L);
     return _instance;
   }
 
@@ -234,7 +237,7 @@ public class SegmentCompletionManager {
     // time that we need to consider.
     // We may need to add some time here to allow for getting the lock? For now 0
     // We may need to add some time for the committer come back to us? For now 0.
-    public static final long MAX_TIME_ALLOWED_TO_COMMIT_MS = MAX_TIME_TO_NOTIFY_WINNER_MS + SegmentCompletionProtocol.MAX_SEGMENT_COMMIT_TIME_MS;
+    public static final long MAX_TIME_ALLOWED_TO_COMMIT_MS = MAX_TIME_TO_NOTIFY_WINNER_MS + SegmentCompletionProtocol.getMaxSegmentCommitTimeMs();
 
     public final Logger LOGGER;
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -73,8 +73,8 @@ public class SegmentCompletionManager {
       throw new RuntimeException("Cannot create multiple instances");
     }
     _instance = new SegmentCompletionManager(helixManager, segmentManager);
-    SegmentCompletionProtocol.setMaxSegmentCommitTimeMs(TimeUnit.SECONDS.convert(
-            controllerConf.getSegmentCommitTimeoutSeconds(), TimeUnit.MILLISECONDS)
+    SegmentCompletionProtocol.setMaxSegmentCommitTimeMs(TimeUnit.MILLISECONDS.convert(
+            controllerConf.getSegmentCommitTimeoutSeconds(), TimeUnit.SECONDS)
         );
     return _instance;
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommitTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommitTest.java
@@ -43,7 +43,7 @@ public class LLCSegmentCommitTest {
 
   @Test
   public void testSegmentCommit() throws Exception {
-    SegmentCompletionManager.create(createMockHelixManager(), null);
+    SegmentCompletionManager.create(createMockHelixManager(), null, new ControllerConf());
     FakeLLCSegmentCommit segmentCommit = new FakeLLCSegmentCommit();
     Representation representation;
     String strResponse;

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -207,7 +207,7 @@ public class SegmentCompletionTest {
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP);
 
     // Max time to commit passes
-    segmentCompletionMgr._secconds += 6 * SegmentCompletionProtocol.MAX_HOLD_TIME_MS/1000;
+    segmentCompletionMgr._secconds += SegmentCompletionProtocol.getMaxSegmentCommitTimeMs() * SegmentCompletionProtocol.MAX_HOLD_TIME_MS/1000;
 
     // s1 comes back with the updated offset, since it was asked to catch up.
     // The FSM will be aborted, and destroyed ...


### PR DESCRIPTION
Also changed the default to 45s.

The only downside of setting this value high is that the controller will allow this much time
before it declares the committer down, and pick one of the other contenders as a committer.