### PR TITLE
[PINOT-3709] Fix ConsumingToOnline transition when segment creation takes too long.

### DIFF
--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -583,7 +583,7 @@ public class LLRealtimeSegmentDataManagerTest {
     }
 
     @Override
-    public void stop(long maxWaitTime) {
+    public void stop() {
       _timeNow += _stopWaitTimeMs;
     }
 


### PR DESCRIPTION
It is best to wait until the consumer thread is stopped, because there is no way to interrupt
the thread to observe the state. Removed the timeout limitation on stopping the thread
and the timeout limitation on going to ONLINE state from CONSUMING