### PR TITLE
fix for missing baselineVal and cuurentVal properties

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -72,7 +72,7 @@ function getAnomalies(tab) {
                     $(".anomaly-metric-tip").hide();
                     renderAnomalyTable(anomalyData, tab);
                 }else{
-                    tipToUser()
+                    tipToUser(tab)
                 }
 
                 //anomalyFunctionId and hash.fnCompareWeeks are only present in hash when anomaly
@@ -772,7 +772,7 @@ function attach_AnomalyTable_EventListeners(){
 
  }
 
-function tipToUser() {
+function tipToUser(tab) {
     var tipToUser = document.createElement("div");
     tipToUser.id = "anomaly-metric-tip";
     tipToUser.className = "tip-to-user uk-alert uk-form-row";

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/handlebars-methods.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/handlebars-methods.js
@@ -248,11 +248,17 @@ $(document).ready(function () {
             fnProperties[key] = value;
         }
 
-        var value = fnProperties[prop];
-        if(prop == "baseLineVal" || prop == "currentVal" ){
-            value =  value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+
+        var val = fnProperties[prop];
+        if(val){
+            if(prop == "baseLineVal" ||  prop == "currentVal" ){
+                val =  val.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            }
+            return val;
         }
-        return value;
+        return
+
     });
 
 


### PR DESCRIPTION
fix for missing baselineVal and currentVal properties: 
When properties are missing, we won't display any value