### PR TITLE
Enabling OffHeapStarTree by default:

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
@@ -36,7 +36,7 @@ public class StarTreeIndexSpec {
   private Set<String> _skipMaterializationForDimensions;
   private int skipMaterializationCardinalityThreshold = DEFAULT_SKIP_MATERIALIZATION_CARDINALITY_THRESHOLD;
 
-  private boolean enableOffHeapFormat = false;
+  private boolean enableOffHeapFormat = true;
 
   public StarTreeIndexSpec() {}
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/IndexLoadingConfigMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/IndexLoadingConfigMetadata.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.common.metadata.segment;
 
+import com.linkedin.pinot.common.utils.CommonConstants;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -36,7 +37,6 @@ public class IndexLoadingConfigMetadata {
 
   private final Set<String> _loadingInvertedIndexColumnSet = new HashSet<String>();
   private final String DEFAULT_SEGMENT_FORMAT = "v1";
-  private static final String DEFAULT_STAR_TREE_FORMAT = "ON_HEAP";
   private String segmentVersionToLoad;
   private boolean enableDefaultColumns;
   private final String starTreeVersionToLoad;
@@ -49,7 +49,8 @@ public class IndexLoadingConfigMetadata {
 
     segmentVersionToLoad = tableDataManagerConfig.getString(KEY_OF_SEGMENT_FORMAT_VERSION, DEFAULT_SEGMENT_FORMAT);
     enableDefaultColumns = tableDataManagerConfig.getBoolean(KEY_OF_ENABLE_DEFAULT_COLUMNS, false);
-    starTreeVersionToLoad = tableDataManagerConfig.getString(KEY_OF_STAR_TREE_FORMAT_VERSION, DEFAULT_STAR_TREE_FORMAT);
+    starTreeVersionToLoad = tableDataManagerConfig.getString(KEY_OF_STAR_TREE_FORMAT_VERSION,
+        CommonConstants.Server.DEFAULT_STAR_TREE_FORMAT_VERSION);
   }
 
   public void initLoadingInvertedIndexColumnSet(String[] columnCollections) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -202,7 +202,7 @@ public class CommonConstants {
     public static final String DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS = "0";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.server.segment.fetcher";
     public static final String DEFAULT_SEGMENT_FORMAT_VERSION = "v1";
-    public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "v1";
+    public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "OFF_HEAP";
   }
 
   public static class Metric {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
@@ -126,13 +126,23 @@ public class Loaders {
       return SegmentVersion.fromStringOrDefault(versionName);
     }
 
+    /**
+     * Helper method to determine the star tree format version to load.
+     * Determines the version based on the index loading config.
+     * If the config is null, returns the default value as specified in
+     * {@link CommonConstants.Server#DEFAULT_STAR_TREE_FORMAT_VERSION}.
+     *
+     * @param indexLoadingConfigMetadata Index loading config
+     * @return Star Tree format version to load
+     */
     private static StarTreeFormatVersion getStarTreeVersionToLoad(
         IndexLoadingConfigMetadata indexLoadingConfigMetadata) {
-      if (indexLoadingConfigMetadata == null) {
-        return StarTreeFormatVersion.ON_HEAP;
-      } else {
-        return StarTreeFormatVersion.valueOf(indexLoadingConfigMetadata.getStarTreeVersionToLoad().toUpperCase());
+      String starTreeFormatVersionString = CommonConstants.Server.DEFAULT_STAR_TREE_FORMAT_VERSION;
+
+      if (indexLoadingConfigMetadata != null) {
+        starTreeFormatVersionString = indexLoadingConfigMetadata.getStarTreeVersionToLoad();
       }
+      return StarTreeFormatVersion.valueOf(starTreeFormatVersionString);
     }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeSerDe.java
@@ -436,7 +436,7 @@ public class StarTreeSerDe {
 
     // If the star-tree file does not exist, this is not a star tree index, nothing to do here.
     if (!starTreeFile.exists()) {
-      LOGGER.info("Skipping Star Tree format conversion, as no star tree file exists for {}",
+      LOGGER.debug("Skipping Star Tree format conversion, as no star tree file exists for {}",
           starTreeFile.getAbsoluteFile());
       return;
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestSumStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestSumStarTreeIndexTest.java
@@ -40,7 +40,7 @@ public class TestSumStarTreeIndexTest extends BaseSumStarTreeIndexTest {
   @BeforeSuite
   void setup()
       throws Exception {
-    _schema = StarTreeIndexTestSegmentHelper.buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, false);
+    _schema = StarTreeIndexTestSegmentHelper.buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, true);
     _segment = StarTreeIndexTestSegmentHelper.loadSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
   }
 


### PR DESCRIPTION
1. StarTree index generator will generate the OffHeap format by default.
2. IndexLoadingConfig for starTreeFormatVersion now defaults to OffHeap
format.