### PR TITLE
Bugfixing for fetching realtime segment metadata

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
@@ -309,7 +309,7 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
 
     if ((tableType == null || TableType.REALTIME.name().equalsIgnoreCase(tableType))
         && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-      String realtimeTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
       ret.put(getSegmentMetaData(realtimeTableName, segmentName, TableType.REALTIME));
     }
 


### PR DESCRIPTION
When trying to fetch Segment metadata.  OFFLINE  segments works, but for REALTIME segments, it returns errors like this, but in fact the realtime segment exists. 

"Error: segment hp_store_orders_REALTIME_1469781060717_0__0__1473917224261 not found."