### PR TITLE
Delete old format files after converting segment to v3 format.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -84,6 +84,11 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     } else {
       _metadataFile = indexDir;
     }
+    if (!_metadataFile.exists()) {
+      String logMessage = String.format("Metadata file: %s does not exist in directory: %s", _metadataFile, indexDir);
+      LOGGER.error(logMessage);
+      throw new RuntimeException(logMessage);
+    }
     _segmentMetadataPropertiesConfiguration = new PropertiesConfiguration(_metadataFile);
     _columnMetadataMap = new HashMap<String, ColumnMetadata>();
     _allColumns = new HashSet<String>();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -84,6 +84,22 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
     File newLocation = SegmentDirectoryPaths.segmentDirectoryFor(v2SegmentDirectory, SegmentVersion.v3);
     LOGGER.info("v3 segment location for segment: {} is {}", v2Metadata.getName(), newLocation);
     v3TempDirectory.renameTo(newLocation);
+    deleteV2Files(v2SegmentDirectory);
+  }
+
+  private void deleteV2Files(File v2SegmentDirectory) {
+    LOGGER.info("Deleting files in v1 segment directory: {}", v2SegmentDirectory);
+    File[] files = v2SegmentDirectory.listFiles();
+    if (files == null) {
+      // unexpected condition but we don't want to stop server
+      LOGGER.error("v1 segment directory: {}  returned null list of files", v2SegmentDirectory);
+      return;
+    }
+    for (File file : files) {
+      if (file.isFile() && file.exists()) {
+        FileUtils.deleteQuietly(file);
+      }
+    }
   }
 
   @VisibleForTesting

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverterTest.java
@@ -119,12 +119,7 @@ public class SegmentV1V2ToV3FormatConverterTest {
 
     FileTime afterLoadTime = Files.getLastModifiedTime(v3Location.toPath());
     Assert.assertEquals(afterConversionTime, afterLoadTime);
-    // check that the loader can load original segment
-    IndexSegment v2IndexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v1LoadingConfig);
-    Assert.assertNotNull(v2IndexSegment);
-    Assert.assertEquals(SegmentVersion.valueOf(v2IndexSegment.getSegmentMetadata().getVersion()),
-        SegmentVersion.v1);
-    Assert.assertTrue(v3Location.exists());
   }
+
 
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoadersTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoadersTest.java
@@ -17,9 +17,7 @@ package com.linkedin.pinot.core.segment.index.loader;
 
 import com.linkedin.pinot.common.metadata.segment.IndexLoadingConfigMetadata;
 import com.linkedin.pinot.common.segment.ReadMode;
-import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
-import com.linkedin.pinot.core.data.readers.PinotSegmentRecordReader;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
@@ -109,27 +107,6 @@ public class LoadersTest {
       Assert.assertEquals(indexSegment.getSegmentMetadata().getVersion(), originalMetadata.getVersion());
       Assert.assertFalse(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
     }
-    {
-      // This block tests that server will load v3 based on configuration. Server correctly
-      // handles configuration flip-flopping between v1 and v3 to simulate testing for rollback to v1
-      // and then roll-forward to v3 again
-
-      // with config pointing to load v3, we convert and load v3.
-      IndexSegment indexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v3LoadingConfig);
-      Assert.assertEquals(SegmentVersion.valueOf(indexSegment.getSegmentMetadata().getVersion()),
-          SegmentVersion.v3);
-      Assert.assertTrue(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
-
-      // based on config, we can load v1 or v2...to simulate configuration rollback
-      IndexSegment indexSegment1 = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v1LoadingConfig);
-      Assert.assertEquals(SegmentVersion.valueOf(indexSegment1.getSegmentMetadata().getVersion()), SegmentVersion.v1);
-      Assert.assertTrue(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
-
-      // roll-forward configuration to v3 again
-      IndexSegment indexSegment2 = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v3LoadingConfig);
-      Assert.assertEquals(SegmentVersion.valueOf(indexSegment.getSegmentMetadata().getVersion()), SegmentVersion.v3);
-    }
-
   }
 
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllFieldSizeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllFieldSizeTest.java
@@ -24,8 +24,8 @@ import org.testng.annotations.Test;
 import java.util.Random;
 
 
-public class TestHllFieldSize {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestHllFieldSize.class);
+public class HllFieldSizeTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HllFieldSizeTest.class);
   private Random rand = new Random();
 
   @Test

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllIndexCreationTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllIndexCreationTest.java
@@ -46,8 +46,8 @@ import org.testng.annotations.Test;
 /**
  * Dictionary Index Size for Hll Field is roughly 10 times of the corresponding index for Long field.
  */
-public class TestHllIndexCreation {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestHllIndexCreation.class);
+public class HllIndexCreationTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HllIndexCreationTest.class);
   private static final String hllDeriveColumnSuffix = HllConstants.DEFAULT_HLL_DERIVE_COLUMN_SUFFIX;
 
   // change this to change the columns that need to create hll index on
@@ -187,14 +187,6 @@ public class TestHllIndexCreation {
       Assert.assertEquals(SegmentVersion.v3,
           SegmentVersion.valueOf(indexSegment.getSegmentMetadata().getVersion()));
 
-      FileTime afterLoadTime = Files.getLastModifiedTime(v3Location.toPath());
-      Assert.assertEquals(afterConversionTime, afterLoadTime);
-      // check that the loader can load original segment
-      IndexSegment v2IndexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v1LoadingConfig);
-      Assert.assertNotNull(v2IndexSegment);
-      Assert.assertEquals(SegmentVersion.valueOf(v2IndexSegment.getSegmentMetadata().getVersion()),
-          SegmentVersion.v1);
-      Assert.assertTrue(v3Location.exists());
     } finally {
       if (helper != null) {
         helper.cleanTempDir();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllStarTreeIndexTest.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * aggregation results computed using star-tree index operator are the same as
  * aggregation results computed by scanning raw docs.
  */
-public class TestHllStarTreeIndexTest extends BaseHllStarTreeIndexTest {
+public class HllStarTreeIndexTest extends BaseHllStarTreeIndexTest {
 
   private static final String SEGMENT_NAME = "starTreeSegment";
   private static final String SEGMENT_DIR_NAME = "/tmp/star-tree-index";

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllTypeConversionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllTypeConversionTest.java
@@ -28,8 +28,8 @@ import java.util.Random;
 /**
  * Test Conversion between Hll and String type
  */
-public class TestHllTypeConversion {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestHllTypeConversion.class);
+public class HllTypeConversionTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HllTypeConversionTest.class);
   private static Charset charset = Charset.forName("UTF-8");
   private Random rand = new Random();
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/OffheapStarTreeBuilderWithHllFieldTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/OffheapStarTreeBuilderWithHllFieldTest.java
@@ -31,9 +31,9 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 
-public class TestOffheapStarTreeBuilderWithHllField {
+public class OffheapStarTreeBuilderWithHllFieldTest {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(TestOffheapStarTreeBuilderWithHllField.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(OffheapStarTreeBuilderWithHllFieldTest.class);
   private static final long randomSeed = 31; // a fixed value
 
   private final String memberIdFieldName = "id";


### PR DESCRIPTION
After conversion to v3, we kept v1 format files around for easy rollback.
This format has undergone enough testing now. Keeping old format files around
wastes lot of space on heavily used multi-tenant clusters.

Next step is to generate v3 format segments so that conversion is not required.

Testing: UT + manual