### PR TITLE
THIRDEYE-905 : Write a cleanup and regenerate anomalies tool

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/RawAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/RawAnomalyResultManager.java
@@ -10,4 +10,6 @@ public interface RawAnomalyResultManager extends AbstractManager<RawAnomalyResul
 
   List<RawAnomalyResultDTO> findUnmergedByFunctionId(Long functionId);
 
+  List<RawAnomalyResultDTO> findByFunctionId(Long functionId);
+
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RawAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RawAnomalyResultManagerImpl.java
@@ -99,10 +99,22 @@ public class RawAnomalyResultManagerImpl extends AbstractManagerImpl<RawAnomalyR
     //        + "and r.dataMissing=:dataMissing";
 
     Predicate predicate = Predicate.AND(//
-        Predicate.EQ("functionId", functionId), // 
+        Predicate.EQ("functionId", functionId), //
         Predicate.EQ("merged", false), //
         Predicate.EQ("dataMissing", false) //
     );
+    List<RawAnomalyResultBean> list = genericPojoDao.get(predicate, RawAnomalyResultBean.class);
+    List<RawAnomalyResultDTO> result = new ArrayList<>();
+    for (RawAnomalyResultBean bean : list) {
+      result.add(createRawAnomalyDTOFromBean(bean));
+    }
+    return result;
+  }
+
+  public List<RawAnomalyResultDTO> findByFunctionId(Long functionId) {
+    //    "select r from RawAnomalyResultDTO r where r.function.id = :functionId";
+
+    Predicate predicate = Predicate.EQ("functionId", functionId);
     List<RawAnomalyResultBean> list = genericPojoDao.get(predicate, RawAnomalyResultBean.class);
     List<RawAnomalyResultDTO> result = new ArrayList<>();
     for (RawAnomalyResultBean bean : list) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesConfig.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesConfig.java
@@ -1,0 +1,65 @@
+package com.linkedin.thirdeye.tools;
+
+
+public class CleanupAndRegenerateAnomaliesConfig {
+
+  // File containing db details
+  private String persistenceFile;
+  // Anomaly detector host who will run adhoc function
+  private String detectorHost;
+  private int detectorPort;
+  // Start time and end time in ISO format for adhoc run
+  private String startTimeIso;
+  private String endTimeIso;
+
+  // function ids to cleanup/regenerate
+  private String functionIds;
+  // datasets to cleanup/regenerate if functionIds not provided.
+  // will be ignored if functionIds provided
+  private String datasets;
+
+  public String getPersistenceFile() {
+    return persistenceFile;
+  }
+  public void setPersistenceFile(String persistenceFile) {
+    this.persistenceFile = persistenceFile;
+  }
+  public String getDetectorHost() {
+    return detectorHost;
+  }
+  public void setDetectorHost(String detectorHost) {
+    this.detectorHost = detectorHost;
+  }
+  public int getDetectorPort() {
+    return detectorPort;
+  }
+  public void setDetectorPort(int detectorPort) {
+    this.detectorPort = detectorPort;
+  }
+  public String getStartTimeIso() {
+    return startTimeIso;
+  }
+  public void setStartTimeIso(String startTimeIso) {
+    this.startTimeIso = startTimeIso;
+  }
+  public String getEndTimeIso() {
+    return endTimeIso;
+  }
+  public void setEndTimeIso(String endTimeIso) {
+    this.endTimeIso = endTimeIso;
+  }
+  public String getDatasets() {
+    return datasets;
+  }
+  public void setDatasets(String datasets) {
+    this.datasets = datasets;
+  }
+  public String getFunctionIds() {
+    return functionIds;
+  }
+  public void setFunctionIds(String functionIds) {
+    this.functionIds = functionIds;
+  }
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/resources/sample-cleanup-regenerate-config.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/sample-cleanup-regenerate-config.yml
@@ -1,8 +1,7 @@
-persistenceFile: /Users/npawar/pinotAbookInstance/dashboard-controller/persistence.yml
-detectorHost: lva1-app0038.corp.linkedin.com
-detectorPort: 1867
+persistenceFile: /tmp/persistence.yml
+detectorHost: localhost
+detectorPort: 8080
 startTimeIso: 2016-08-26
 endTimeIso: 2016-09-26
-datasets: 
-#ads_ingraph,feed_sessions_additive,feed_sessions_hourly_additive,feed_updates_viewed_additive,ptrans_hourly_additive,login_additive,reg_additive
-functionIds: 
+datasets: dataset1,dataset2
+functionIds: 1,2,43,6

--- a/thirdeye/thirdeye-pinot/src/test/resources/sample-cleanup-regenerate-config.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/sample-cleanup-regenerate-config.yml
@@ -1,0 +1,8 @@
+persistenceFile: /Users/npawar/pinotAbookInstance/dashboard-controller/persistence.yml
+detectorHost: lva1-app0038.corp.linkedin.com
+detectorPort: 1867
+startTimeIso: 2016-08-26
+endTimeIso: 2016-09-26
+datasets: 
+#ads_ingraph,feed_sessions_additive,feed_sessions_hourly_additive,feed_updates_viewed_additive,ptrans_hourly_additive,login_additive,reg_additive
+functionIds: 


### PR DESCRIPTION
This is a followup to https://github.com/linkedin/pinot/pull/604. This PR separates modes DELETE and GENERATE. It also adds capability to execute by functionIds. It removes the assumption of running on all datasets if functionIds/datasets is not provided