### PR TITLE
Replace assertEquals by assertTrue

### DIFF
--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -283,8 +283,8 @@ public class NettySingleConnectionIntegrationTest {
       byte[] b2 = new byte[serverResp.readableBytes()];
       serverResp.readBytes(b2);
       String gotResponse = new String(b2);
-      Assert.assertEquals(gotResponse, response, "Response Check at client");
-      Assert.assertEquals(server.getHandler().getRequest(), request, "Request Check at server");
+      Assert.assertTrue(gotResponse.equals(response), "Response Check at client");
+      Assert.assertTrue(server.getHandler().getRequest().equals(request), "Request Check at server");
     } finally {
       if (null != clientConn) {
         clientConn.close();


### PR DESCRIPTION
Replace assertEquals by assertTrue(value.equals()) for the Netty
integration test where large requests/responses are generated. Since
this test generates a 2 MiB request and on assertion failure both the
expected value and received value are printed, it causes the Travis
build to error out due to exceeding the 4 MB limit. With this, the
build will still fail but the log will be complete instead of being
filled with request_iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii...