### PR TITLE
Use maven batch mode for Travis

### DIFF
--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -28,4 +28,4 @@ if [ $? -ne 0 ]; then
   exit 0
 fi
 
-mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly=true
+mvn clean install -B -DskipTests=true -Dmaven.javadoc.skip=true -Dassembly.skipAssembly=true

--- a/.travis_test.sh
+++ b/.travis_test.sh
@@ -28,7 +28,7 @@ if [ $TRAVIS_JDK_VERSION != 'oraclejdk7' ]; then
   exit 0
 fi
 
-mvn test -P travis
+mvn test -B -P travis
 if [ $? -ne 0 ]; then
   exit 1
 fi


### PR DESCRIPTION
Use maven batch mode for Travis builds in order to suppress download
progress status indicators (eg. 123/456K) in the build logs.