### PR TITLE
THIRDEYE-908 : Redesign how schedulers pick up and schedule functions from db

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -103,13 +103,13 @@ public class ThirdEyeAnomalyApplication
           taskDriver.stop();
         }
         if (config.isScheduler()) {
-          detectionJobScheduler.stop();
+          detectionJobScheduler.shutdown();
         }
         if (config.isMonitor()) {
           monitorJobScheduler.stop();
         }
         if (config.isAlert()) {
-          alertJobScheduler.stop();
+          alertJobScheduler.shutdown();
         }
         if (config.isMerger()) {
           anomalyMergeExecutor.stop();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobResource.java
@@ -35,7 +35,7 @@ public class AlertJobResource {
 
   @GET
   public List<String> showActiveJobs() throws SchedulerException {
-    return alertJobScheduler.getActiveJobs();
+    return alertJobScheduler.getScheduledJobs();
   }
 
   @POST
@@ -78,5 +78,13 @@ public class AlertJobResource {
     }
     alertConfig.setActive(state);
     emailConfigurationDAO.update(alertConfig);
+  }
+
+  @POST
+  @Path("/{id}/restart")
+  public Response restart(@PathParam("id") Long id) throws Exception {
+    alertJobScheduler.stopJob(id);
+    alertJobScheduler.startJob(id);
+    return Response.ok().build();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
@@ -137,7 +137,7 @@ public class AlertJobScheduler implements JobScheduler, Runnable {
     }
   }
 
-  public void stop() throws SchedulerException {
+  public void shutdown() throws SchedulerException {
     scheduledExecutorService.shutdown();
     quartzScheduler.shutdown();
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
@@ -2,6 +2,9 @@ package com.linkedin.thirdeye.anomaly.alert;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.joda.time.DateTime;
 import org.quartz.CronScheduleBuilder;
@@ -30,11 +33,12 @@ import com.linkedin.thirdeye.datalayer.dto.EmailConfigurationDTO;
 /**
  * Scheduler for anomaly detection jobs
  */
-public class AlertJobScheduler implements JobScheduler {
+public class AlertJobScheduler implements JobScheduler, Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(AlertJobScheduler.class);
   private SchedulerFactory schedulerFactory;
   private Scheduler quartzScheduler;
+  private ScheduledExecutorService scheduledExecutorService;
   private JobManager anomalyJobDAO;
   private TaskManager anomalyTaskDAO;
   private EmailConfigurationManager emailConfigurationDAO;
@@ -51,9 +55,10 @@ public class AlertJobScheduler implements JobScheduler {
     } catch (SchedulerException e) {
       LOG.error("Exception while starting quartz scheduler", e);
     }
+    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
   }
 
-  public List<String> getActiveJobs() throws SchedulerException {
+  public List<String> getScheduledJobs() throws SchedulerException {
     List<String> activeJobKeys = new ArrayList<>();
     for (String groupName : quartzScheduler.getJobGroupNames()) {
       for (JobKey jobKey : quartzScheduler.getJobKeys(GroupMatcher.jobGroupEquals(groupName))) {
@@ -66,23 +71,74 @@ public class AlertJobScheduler implements JobScheduler {
   public void start() throws SchedulerException {
     quartzScheduler.start();
 
-    // start all active alert functions
-    List<EmailConfigurationDTO> alertConfigs = emailConfigurationDAO.findAll();
-    for (EmailConfigurationDTO alertConfig : alertConfigs) {
-      if (alertConfig.isActive()) {
-        AlertJobContext alertJobContext = new AlertJobContext();
-        alertJobContext.setAnomalyJobDAO(anomalyJobDAO);
-        alertJobContext.setAnomalyTaskDAO(anomalyTaskDAO);
-        alertJobContext.setEmailConfigurationDAO(emailConfigurationDAO);
-        alertJobContext.setAlertConfigId(alertConfig.getId());
-        String jobKey = getJobKey(alertConfig.getId());
-        alertJobContext.setJobName(jobKey);
-        scheduleJob(alertJobContext, alertConfig);
+    scheduledExecutorService.scheduleWithFixedDelay(this, 0, 30, TimeUnit.MINUTES);
+  }
+
+  public void run() {
+    try {
+      // read all alert configs
+      LOG.info("Reading all alert configs..");
+      List<EmailConfigurationDTO> alertConfigs = emailConfigurationDAO.findAll();
+
+      // get active jobs
+      List<String> scheduledJobs = getScheduledJobs();
+      LOG.info("Scheduled jobs {}", scheduledJobs);
+
+      for (EmailConfigurationDTO alertConfig : alertConfigs) {
+        Long id = alertConfig.getId();
+        String jobKey = getJobKey(id);
+        boolean isActive = alertConfig.isActive();
+        boolean isScheduled = scheduledJobs.contains(jobKey);
+
+        // for all jobs with isActive, but not in scheduled jobs,
+        // schedule them with quartz, as function is newly created, or newly activated
+        if (isActive && !isScheduled) {
+          LOG.info("Found active but not scheduled {}", id);
+          startJob(alertConfig, jobKey);
+        }
+        // for all jobs with not isActive, but in scheduled jobs,
+        // remove them from quartz, as function is newly deactivated
+        else if (!isActive && isScheduled) {
+          LOG.info("Found inactive but scheduled {}", id);
+          stopJob(jobKey);
+        }
+        // for all jobs with isActive, and isScheduled,
+        // updates to a function will be picked up automatically by the next run
+        // but check for cron updates
+        else if (isActive && isScheduled) {
+          String cronInDatabase = alertConfig.getCron();
+          List<Trigger> triggers = (List<Trigger>) quartzScheduler.getTriggersOfJob(JobKey.jobKey(jobKey));
+          CronTrigger cronTrigger = (CronTrigger) triggers.get(0);
+          String cronInSchedule = cronTrigger.getCronExpression();
+          // cron expression has been updated, restart this job
+          if (!cronInDatabase.equals(cronInSchedule)) {
+            LOG.info("Cron expression for config {} with jobKey {} has been changed from {}  to {}. "
+                + "Restarting schedule", id, jobKey, cronInSchedule, cronInDatabase);
+            stopJob(jobKey);
+            startJob(alertConfig, jobKey);
+          }
+        }
+
+        // for all jobs with not isActive, and not isScheduled, no change required
       }
+
+      // for any scheduled jobs, not having a function in the database,
+      // stop the schedule, as function has been deleted
+      for (String scheduledJobKey : scheduledJobs) {
+        Long configId = getIdFromJobKey(scheduledJobKey);
+        EmailConfigurationDTO alertConfigSpec = emailConfigurationDAO.findById(configId);
+        if (alertConfigSpec == null) {
+          LOG.info("Found scheduled, but not in database {}", configId);
+          stopJob(scheduledJobKey);
+        }
+      }
+    } catch (SchedulerException e) {
+      LOG.error("Exception in reading active jobs", e);
     }
   }
 
   public void stop() throws SchedulerException {
+    scheduledExecutorService.shutdown();
     quartzScheduler.shutdown();
   }
 
@@ -95,15 +151,20 @@ public class AlertJobScheduler implements JobScheduler {
       throw new IllegalStateException("Alert config with id " + id + " is not active");
     }
     String jobKey = getJobKey(alertConfig.getId());
+    startJob(alertConfig, jobKey);
+  }
+
+  public void startJob(EmailConfigurationDTO alertConfig, String jobKey) throws SchedulerException {
+
     if (quartzScheduler.checkExists(JobKey.jobKey(jobKey))) {
-      throw new IllegalStateException("Alert config with id " + id + " is already scheduled");
+      throw new IllegalStateException("Alert config  " + jobKey + " is already scheduled");
     }
 
     AlertJobContext alertJobContext = new AlertJobContext();
     alertJobContext.setAnomalyJobDAO(anomalyJobDAO);
     alertJobContext.setAnomalyTaskDAO(anomalyTaskDAO);
     alertJobContext.setEmailConfigurationDAO(emailConfigurationDAO);
-    alertJobContext.setAlertConfigId(id);
+    alertJobContext.setAlertConfigId(alertConfig.getId());
     alertJobContext.setJobName(jobKey);
 
     scheduleJob(alertJobContext, alertConfig);
@@ -111,11 +172,15 @@ public class AlertJobScheduler implements JobScheduler {
 
   public void stopJob(Long id) throws SchedulerException {
     String jobKey = getJobKey(id);
+    stopJob(jobKey);
+  }
+
+  public void stopJob(String jobKey) throws SchedulerException {
     if (!quartzScheduler.checkExists(JobKey.jobKey(jobKey))) {
-      throw new IllegalStateException("Cannot stop alert config with id " + id + ", it has not been scheduled");
+      throw new IllegalStateException("Cannot stop alert config " + jobKey + ", it has not been scheduled");
     }
     quartzScheduler.deleteJob(JobKey.jobKey(jobKey));
-    LOG.info("Stopped alert config {}", id);
+    LOG.info("Stopped alert config {}", jobKey);
   }
 
   public void runAdHoc(Long id, DateTime windowStartTime, DateTime windowEndTime) {
@@ -175,5 +240,11 @@ public class AlertJobScheduler implements JobScheduler {
   private String getJobKey(Long id) {
     String jobKey = String.format("%s_%d", TaskType.ALERT, id);
     return jobKey;
+  }
+
+  private Long getIdFromJobKey(String jobKey) {
+    String[] tokens = jobKey.split("_");
+    String id = tokens[tokens.length - 1];
+    return Long.valueOf(id);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobResource.java
@@ -34,8 +34,8 @@ public class DetectionJobResource {
   }
 
   @GET
-  public List<String> showActiveJobs() throws SchedulerException {
-    return detectionJobScheduler.getActiveJobs();
+  public List<String> showScheduledJobs() throws SchedulerException {
+    return detectionJobScheduler.getScheduledJobs();
   }
 
   @POST
@@ -78,5 +78,13 @@ public class DetectionJobResource {
     }
     anomalyFunctionSpec.setIsActive(state);
     anomalyFunctionSpecDAO.update(anomalyFunctionSpec);
+  }
+
+  @POST
+  @Path("/{id}/restart")
+  public Response restart(@PathParam("id") Long id) throws Exception {
+    detectionJobScheduler.stopJob(id);
+    detectionJobScheduler.startJob(id);
+    return Response.ok().build();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
@@ -3,6 +3,9 @@ package com.linkedin.thirdeye.anomaly.detection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.joda.time.DateTime;
 import org.quartz.CronScheduleBuilder;
@@ -31,11 +34,12 @@ import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 /**
  * Scheduler for anomaly detection jobs
  */
-public class DetectionJobScheduler implements JobScheduler {
+public class DetectionJobScheduler implements JobScheduler, Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(DetectionJobScheduler.class);
   private SchedulerFactory schedulerFactory;
   private Scheduler quartzScheduler;
+  private ScheduledExecutorService scheduledExecutorService;
   private JobManager anomalyJobDAO;
   private TaskManager anomalyTaskDAO;
   private AnomalyFunctionManager anomalyFunctionDAO;
@@ -53,9 +57,10 @@ public class DetectionJobScheduler implements JobScheduler {
     } catch (SchedulerException e) {
       LOG.error("Exception while starting quartz scheduler", e);
     }
+    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
   }
 
-  public List<String> getActiveJobs() throws SchedulerException {
+  public List<String> getScheduledJobs() throws SchedulerException {
     List<String> activeJobKeys = new ArrayList<>();
     for (String groupName : quartzScheduler.getJobGroupNames()) {
       for (JobKey jobKey : quartzScheduler.getJobKeys(GroupMatcher.jobGroupEquals(groupName))) {
@@ -68,25 +73,77 @@ public class DetectionJobScheduler implements JobScheduler {
   public void start() throws SchedulerException{
     quartzScheduler.start();
 
-    // start all active anomaly functions
-    List<AnomalyFunctionDTO>  functionSpecs = readAnomalyFunctionSpecs();
-    for (AnomalyFunctionDTO anomalyFunctionSpec : functionSpecs) {
-      if (anomalyFunctionSpec.getIsActive()) {
-        DetectionJobContext detectionJobContext = new DetectionJobContext();
-        detectionJobContext.setAnomalyFunctionDAO(anomalyFunctionDAO);
-        detectionJobContext.setAnomalyJobDAO(anomalyJobDAO);
-        detectionJobContext.setAnomalyTaskDAO(anomalyTaskDAO);
-        detectionJobContext.setAnomalyFunctionFactory(anomalyFunctionFactory);
-        detectionJobContext.setAnomalyFunctionId(anomalyFunctionSpec.getId());
-        String jobKey = getJobKey(anomalyFunctionSpec.getId(), anomalyFunctionSpec.getFunctionName());
-        detectionJobContext.setJobName(jobKey);
+    scheduledExecutorService.scheduleWithFixedDelay(this, 0, 30, TimeUnit.MINUTES);
+  }
 
-        scheduleJob(detectionJobContext, anomalyFunctionSpec);
+  public void run() {
+
+    try {
+      // read all anomaly functions
+      LOG.info("Reading all anomaly functions");
+      List<AnomalyFunctionDTO> anomalyFunctions = readAnomalyFunctionSpecs();
+
+      // get active jobs
+      List<String> scheduledJobs = getScheduledJobs();
+      LOG.info("Scheduled jobs {}", scheduledJobs);
+
+      for (AnomalyFunctionDTO anomalyFunction : anomalyFunctions) {
+        Long id = anomalyFunction.getId();
+        String jobKey = getJobKey(id, anomalyFunction.getFunctionName());
+        boolean isActive = anomalyFunction.getIsActive();
+        boolean isScheduled = scheduledJobs.contains(jobKey);
+
+        // for all jobs with isActive, but not in scheduled jobs,
+        // schedule them with quartz, as function is newly created, or newly activated
+        if (isActive && !isScheduled) {
+          LOG.info("Found active but not scheduled {}", id);
+          startJob(anomalyFunction, jobKey);
+        }
+        // for all jobs with not isActive, but in scheduled jobs,
+        // remove them from quartz, as function is newly deactivated
+        else if (!isActive && isScheduled) {
+          LOG.info("Found inactive but scheduled {}", id);
+          stopJob(jobKey);
+        }
+
+        // for all jobs with isActive, and isScheduled,
+        // updates to a function will be picked up automatically by the next run
+        // but check for cron updates
+        else if (isActive && isScheduled) {
+          String cronInDatabase = anomalyFunction.getCron();
+          List<Trigger> triggers = (List<Trigger>) quartzScheduler.getTriggersOfJob(JobKey.jobKey(jobKey));
+          CronTrigger cronTrigger = (CronTrigger) triggers.get(0);
+          String cronInSchedule = cronTrigger.getCronExpression();
+          // cron expression has been updated, restart this job
+          if (!cronInDatabase.equals(cronInSchedule)) {
+            LOG.info("Cron expression for function {} with jobKey {} has been changed from {}  to {}. "
+                + "Restarting schedule", id, jobKey, cronInSchedule, cronInDatabase);
+            stopJob(jobKey);
+            startJob(anomalyFunction, jobKey);
+          }
+        }
+
+        // for all jobs with not isActive, and not isScheduled, no change required
+
       }
+
+      // for any scheduled jobs, not having a function in the database,
+      // stop the schedule, as function has been deleted
+      for (String scheduledJobKey : scheduledJobs) {
+        Long functionId = getIdFromJobKey(scheduledJobKey);
+        AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(functionId);
+        if (anomalyFunctionSpec == null) {
+          LOG.info("Found scheduled, but not in database {}", functionId);
+          stopJob(scheduledJobKey);
+        }
+      }
+    } catch (SchedulerException e) {
+      LOG.error("Exception in reading active jobs", e);
     }
   }
 
   public void stop() throws SchedulerException{
+    scheduledExecutorService.shutdown();
     quartzScheduler.shutdown();
   }
 
@@ -99,10 +156,13 @@ public class DetectionJobScheduler implements JobScheduler {
       throw new IllegalStateException("Anomaly function spec with id " + id + " is not active");
     }
     String jobKey = getJobKey(anomalyFunctionSpec.getId(), anomalyFunctionSpec.getFunctionName());
-    if (quartzScheduler.checkExists(JobKey.jobKey(jobKey))) {
-      throw new IllegalStateException("Anomaly function with id " + id + " is already scheduled");
-    }
+    startJob(anomalyFunctionSpec, jobKey);
+  }
 
+  public void startJob(AnomalyFunctionDTO anomalyFunctionSpec, String jobKey) throws SchedulerException {
+    if (quartzScheduler.checkExists(JobKey.jobKey(jobKey))) {
+      throw new IllegalStateException("Anomaly function " + jobKey + " is already scheduled");
+    }
     DetectionJobContext detectionJobContext = new DetectionJobContext();
     detectionJobContext.setAnomalyFunctionDAO(anomalyFunctionDAO);
     detectionJobContext.setAnomalyJobDAO(anomalyJobDAO);
@@ -118,11 +178,15 @@ public class DetectionJobScheduler implements JobScheduler {
     AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(id);
     String functionName = anomalyFunctionSpec.getFunctionName();
     String jobKey = getJobKey(id, functionName);
+    stopJob(jobKey);
+  }
+
+  public void stopJob(String jobKey) throws SchedulerException {
     if (!quartzScheduler.checkExists(JobKey.jobKey(jobKey))) {
-      throw new IllegalStateException("Cannot stop anomaly function with id " + id + ", it has not been scheduled");
+      throw new IllegalStateException("Cannot stop anomaly function " + jobKey + ", it has not been scheduled");
     }
     quartzScheduler.deleteJob(JobKey.jobKey(jobKey));
-    LOG.info("Stopped function {}", id);
+    LOG.info("Stopped function {}", jobKey);
   }
 
   public void runAdHoc(Long id, DateTime windowStartTime, DateTime windowEndTime) {
@@ -187,5 +251,11 @@ public class DetectionJobScheduler implements JobScheduler {
   private String getJobKey(Long id, String functionName) {
     String jobKey = String.format("%s_%d", functionName, id);
     return jobKey;
+  }
+
+  private Long getIdFromJobKey(String jobKey) {
+    String[] tokens = jobKey.split("_");
+    String id = tokens[tokens.length - 1];
+    return Long.valueOf(id);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
@@ -142,7 +142,7 @@ public class DetectionJobScheduler implements JobScheduler, Runnable {
     }
   }
 
-  public void stop() throws SchedulerException{
+  public void shutdown() throws SchedulerException{
     scheduledExecutorService.shutdown();
     quartzScheduler.shutdown();
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/job/JobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/job/JobScheduler.java
@@ -6,7 +6,7 @@ import org.quartz.SchedulerException;
 
 public interface JobScheduler {
 
-  public List<String> getActiveJobs() throws SchedulerException;
+  public List<String> getScheduledJobs() throws SchedulerException;
 
   public void start() throws SchedulerException;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/job/JobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/job/JobScheduler.java
@@ -10,7 +10,7 @@ public interface JobScheduler {
 
   public void start() throws SchedulerException;
 
-  public void stop() throws SchedulerException;
+  public void shutdown() throws SchedulerException;
 
   public void startJob(Long id) throws SchedulerException;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
@@ -24,11 +24,6 @@ public abstract class ThirdEyeConfiguration extends Configuration {
   private String whitelistCollections = "";
   private String blacklistCollections = "";
 
-  private String detectorHost = "";
-  private int detectorPort = 0;
-  private String alertHost = "";
-  private int alertPort = 0;
-
   private String smtpHost = "";
   private int smtpPort = 0;
 
@@ -82,38 +77,6 @@ public abstract class ThirdEyeConfiguration extends Configuration {
 
   public String getFunctionConfigPath() {
     return getRootDir() + "/detector-config/anomaly-functions/functions.properties";
-  }
-
-  public String getDetectorHost() {
-    return detectorHost;
-  }
-
-  public void setDetectorHost(String detectorHost) {
-    this.detectorHost = detectorHost;
-  }
-
-  public int getDetectorPort() {
-    return detectorPort;
-  }
-
-  public void setDetectorPort(int detectorPort) {
-    this.detectorPort = detectorPort;
-  }
-
-  public String getAlertHost() {
-    return alertHost;
-  }
-
-  public void setAlertHost(String alertHost) {
-    this.alertHost = alertHost;
-  }
-
-  public int getAlertPort() {
-    return alertPort;
-  }
-
-  public void setAlertPort(int alertPort) {
-    this.alertPort = alertPort;
   }
 
   public String getSmtpHost() {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -285,10 +285,10 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
 
   private void cleanup() throws SchedulerException {
     if (detectionJobScheduler != null) {
-      detectionJobScheduler.stop();
+      detectionJobScheduler.shutdown();
     }
     if (alertJobScheduler != null) {
-      alertJobScheduler.stop();
+      alertJobScheduler.shutdown();
     }
     if (monitorJobScheduler != null) {
       monitorJobScheduler.stop();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
@@ -1,0 +1,84 @@
+package com.linkedin.thirdeye.tools;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.collections.Lists;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.linkedin.thirdeye.anomaly.utils.DetectionResourceHttpUtils;
+import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
+import com.linkedin.thirdeye.datalayer.bao.EmailConfigurationManager;
+import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
+
+/**
+ * Run adhoc queries to db
+ */
+public class RunAdhocDatabaseQueriesTool {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RunAdhocDatabaseQueriesTool.class);
+
+  private AnomalyFunctionManager anomalyFunctionDAO;
+  private EmailConfigurationManager emailConfigurationDAO;
+  private RawAnomalyResultManager rawResultDAO;
+  private MergedAnomalyResultManager mergedResultDAO;
+
+  public RunAdhocDatabaseQueriesTool(File persistenceFile)
+      throws Exception {
+    init(persistenceFile);
+  }
+
+  public void init(File persistenceFile) throws Exception {
+    DaoProviderUtil.init(persistenceFile);
+    anomalyFunctionDAO = DaoProviderUtil
+        .getInstance(com.linkedin.thirdeye.datalayer.bao.jdbc.AnomalyFunctionManagerImpl.class);
+    emailConfigurationDAO = DaoProviderUtil
+        .getInstance(com.linkedin.thirdeye.datalayer.bao.jdbc.EmailConfigurationManagerImpl.class);
+    rawResultDAO = DaoProviderUtil
+        .getInstance(com.linkedin.thirdeye.datalayer.bao.jdbc.RawAnomalyResultManagerImpl.class);
+    mergedResultDAO = DaoProviderUtil
+        .getInstance(com.linkedin.thirdeye.datalayer.bao.jdbc.MergedAnomalyResultManagerImpl.class);
+  }
+
+  private void toggleAnomalyFunction(Long id) {
+    AnomalyFunctionDTO anomalyFunction = anomalyFunctionDAO.findById(id);
+    anomalyFunction.setActive(true);
+    anomalyFunctionDAO.update(anomalyFunction);
+  }
+
+  private void updateField(Long id) {
+    AnomalyFunctionDTO anomalyFunction = anomalyFunctionDAO.findById(id);
+    anomalyFunction.setCron("0/20 * * * * ?");
+    anomalyFunctionDAO.update(anomalyFunction);
+  }
+
+  private void customFunction() {
+    List<AnomalyFunctionDTO> anomalyFunctionDTOs = anomalyFunctionDAO.findAll();
+    for (AnomalyFunctionDTO anomalyFunctionDTO : anomalyFunctionDTOs) {
+      anomalyFunctionDTO.setActive(false);
+      anomalyFunctionDAO.update(anomalyFunctionDTO);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+
+    File persistenceFile = new File(args[0]);
+    if (!persistenceFile.exists()) {
+      System.err.println("Missing file:" + persistenceFile);
+      System.exit(1);
+    }
+    RunAdhocDatabaseQueriesTool dq = new RunAdhocDatabaseQueriesTool(persistenceFile);
+  }
+
+}


### PR DESCRIPTION
This pull request introduces a new design of schedulers, where in they will poll the databse for changes. The dashboard has been decoupled form the schedulers, and the dashboard will now simply add/update/delete to database, not bothering about notifying the schedulers.
The scheulers will run every 30 minutes and make necessary changes to the schedules.

Testing done: https://docs.google.com/document/d/16W-dZ17Kz-t7lzBb1xdjeATz9dG287dVoMa22Q3M7Z0/edit