### PR TITLE
Adding fix for anomaly generation getting skipped in case of 1 granularity bucket

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -86,10 +86,7 @@ public class DetectionTaskRunner implements TaskRunner {
     Map<DimensionKey, MetricTimeSeries> res =
         timeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
     for (Map.Entry<DimensionKey, MetricTimeSeries> entry : res.entrySet()) {
-      if (entry.getValue().getTimeWindowSet().size() < 2) {
-        LOG.warn("Insufficient data for {} to run anomaly detection function", entry.getKey());
-        continue;
-      }
+
       try {
         // Run algorithm
         DimensionKey dimensionKey = entry.getKey();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -86,7 +86,10 @@ public class DetectionTaskRunner implements TaskRunner {
     Map<DimensionKey, MetricTimeSeries> res =
         timeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
     for (Map.Entry<DimensionKey, MetricTimeSeries> entry : res.entrySet()) {
-
+      if (entry.getValue().getTimeWindowSet().size() < 1) {
+        LOG.warn("Insufficient data for {} to run anomaly detection function", entry.getKey());
+        continue;
+      }
       try {
         // Run algorithm
         DimensionKey dimensionKey = entry.getKey();


### PR DESCRIPTION
Removing some old code which only processed anomaly detection if there were more than 1 bucket