### PR TITLE
Fixing controller segments stale issue when push segments with url protocol.

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -449,16 +449,17 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
       return repr;
     }
 
-    if (segmentFile.exists()) {
-      FileUtils.deleteQuietly(segmentFile);
-    }
-    FileUtils.moveFile(dataFile, segmentFile);
-
     PinotResourceManagerResponse response;
     if (!isSegmentTimeValid(metadata)) {
       response = new PinotResourceManagerResponse("Invalid segment start/end time", false);
     } else {
       if (downloadUrl == null) {
+        // We only move segment file to data directory when Pinot Controller will
+        // serve the data downloading from Pinot Servers.
+        if (segmentFile.exists()) {
+          FileUtils.deleteQuietly(segmentFile);
+        }
+        FileUtils.moveFile(dataFile, segmentFile);
         downloadUrl = ControllerConf.constructDownloadUrl(tableName, dataFile.getName(), vip);
       }
       // TODO: this will read table configuration again from ZK. We should optimize that


### PR DESCRIPTION
Right now we keep all the segment files to data directory.This contains a lot of tmp file when this table is uploaded with url only protocol.

We should only move segment files to data directory when Pinot Controller will be actually serving data downloading from Pinot Servers.