### PR TITLE
Look for metadata file in different versions of segment directory

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/request/helper/ControllerRequestBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/request/helper/ControllerRequestBuilder.java
@@ -54,12 +54,12 @@ public class ControllerRequestBuilder {
       String segmentAssignmentStrategy) throws JSONException {
     List<String> invertedIndexColumns = Collections.emptyList();
     return buildCreateOfflineTableJSON(tableName, serverTenant, brokerTenant, timeColumnName, timeType,
-        retentionTimeUnit, retentionTimeValue, numReplicas, segmentAssignmentStrategy, invertedIndexColumns, null);
+        retentionTimeUnit, retentionTimeValue, numReplicas, segmentAssignmentStrategy, invertedIndexColumns, null, "v1");
   }
 
   public static JSONObject buildCreateOfflineTableJSON(String tableName, String serverTenant, String brokerTenant,
       String timeColumnName, String timeType, String retentionTimeUnit, String retentionTimeValue, int numReplicas,
-      String segmentAssignmentStrategy, List<String> invertedIndexColumns, String loadMode) throws JSONException {
+      String segmentAssignmentStrategy, List<String> invertedIndexColumns, String loadMode, String segmentVersion) throws JSONException {
     JSONObject creationRequest = new JSONObject();
     creationRequest.put("tableName", tableName);
 
@@ -76,6 +76,7 @@ public class ControllerRequestBuilder {
     creationRequest.put("segmentsConfig", segmentsConfig);
     JSONObject tableIndexConfig = new JSONObject();
     tableIndexConfig.put("invertedIndexColumns", invertedIndexColumns);
+    tableIndexConfig.put("segmentFormatVersion", segmentVersion);
     if (loadMode != null && loadMode.equals("MMAP")) {
       tableIndexConfig.put("loadMode", "MMAP");
     } else {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResourceTest.java
@@ -45,7 +45,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     // Create a table with an invalid name
     JSONObject request = ControllerRequestBuilder.buildCreateOfflineTableJSON("bad__table__name", "default", "default",
         "potato", "DAYS", "DAYS", "5", 3, "BalanceNumSegmentAssignmentStrategy", Collections.<String>emptyList(),
-        "MMAP");
+        "MMAP", "v1");
 
     try {
       sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(),
@@ -58,7 +58,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     // Create a table with a valid name
     request = ControllerRequestBuilder.buildCreateOfflineTableJSON("valid_table_name", "default", "default",
         "potato", "DAYS", "DAYS", "5", 3, "BalanceNumSegmentAssignmentStrategy", Collections.<String>emptyList(),
-        "MMAP");
+        "MMAP", "v1");
 
     sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(), request.toString());
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -25,6 +25,7 @@ import com.linkedin.pinot.common.utils.time.TimeUtils;
 import com.linkedin.pinot.core.indexsegment.IndexType;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.store.SegmentDirectoryPaths;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
 import java.io.DataInputStream;
 import java.io.File;
@@ -79,16 +80,12 @@ public class SegmentMetadataImpl implements SegmentMetadata {
 
   public SegmentMetadataImpl(File indexDir) throws ConfigurationException, IOException {
     LOGGER.debug("SegmentMetadata location: {}", indexDir);
-    if (indexDir.isDirectory()) {
-      _metadataFile = new File(indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
-    } else {
-      _metadataFile = indexDir;
+    File tmpMetadataFile = SegmentDirectoryPaths.findMetadataFile(indexDir);
+    if (tmpMetadataFile == null) {
+      LOGGER.warn("Metadata file: {} does not exist in directory: {}", tmpMetadataFile, indexDir);
+      tmpMetadataFile = new File(indexDir, MetadataKeys.METADATA_FILE_NAME);
     }
-    if (!_metadataFile.exists()) {
-      String logMessage = String.format("Metadata file: %s does not exist in directory: %s", _metadataFile, indexDir);
-      LOGGER.error(logMessage);
-      throw new RuntimeException(logMessage);
-    }
+    _metadataFile = tmpMetadataFile;
     _segmentMetadataPropertiesConfiguration = new PropertiesConfiguration(_metadataFile);
     _columnMetadataMap = new HashMap<String, ColumnMetadata>();
     _allColumns = new HashSet<String>();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
@@ -15,8 +15,12 @@
  */
 package com.linkedin.pinot.core.segment.store;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.File;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,5 +45,24 @@ public class SegmentDirectoryPaths {
 
   public static boolean isV3Directory(File path) {
     return path.toString().endsWith(V3_SUBDIRECTORY_NAME);
+  }
+
+  public static @Nullable File findMetadataFile(@Nonnull File indexDir) {
+    Preconditions.checkNotNull(indexDir);
+    Preconditions.checkArgument(indexDir.exists(), "Path: %s to does not exist", indexDir);
+    if (! indexDir.isDirectory()) {
+      return indexDir;
+    }
+    File metadataFile = new File(indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
+    if (metadataFile.exists()) {
+      return metadataFile;
+    }
+
+    File v3Dir = segmentDirectoryFor(indexDir, SegmentVersion.v3);
+    metadataFile = new File(v3Dir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
+    if (metadataFile.exists()) {
+      return metadataFile;
+    }
+    return null;
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -1235,10 +1235,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     }
   }
 
-  protected long getCurrentServingNumDocs() {
+  protected long getCurrentServingNumDocs(String tableName) {
     ensurePinotConnectionIsCreated();
     com.linkedin.pinot.client.ResultSetGroup resultSetGroup =
-        _pinotConnection.execute("SELECT COUNT(*) from mytable LIMIT 0");
+        _pinotConnection.execute("SELECT COUNT(*) from " + tableName + " LIMIT 0");
     if (resultSetGroup.getResultSetCount() > 0) {
       return resultSetGroup.getResultSet(0).getInt(0);
     }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterSanityTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterSanityTest.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.config.Tenant;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.TenantRole;
 import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -67,7 +68,7 @@ public class ClusterSanityTest extends ClusterTest {
     startController();
     startBrokers(numBrokers);
     startServers(numServers);
-    addOfflineTable(TABLE_NAME, "", "", -1, "", tenantName, tenantName);
+    addOfflineTable("", "", -1, "", tenantName, tenantName, TABLE_NAME, SegmentVersion.v1);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.integration.tests;
 
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import java.io.File;
 import java.io.FileInputStream;
 import java.net.URL;
@@ -86,7 +87,7 @@ public class DefaultColumnsClusterIntegrationTest extends BaseClusterIntegration
     startServer();
 
     // Create the table.
-    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null);
+    addOfflineTable("DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, "mytable", SegmentVersion.v1);
 
     // Add the schema.
     if (sendSchema) {
@@ -141,7 +142,7 @@ public class DefaultColumnsClusterIntegrationTest extends BaseClusterIntegration
   protected void waitForSegmentsOnline()
       throws Exception {
     long timeInTwoMinutes = System.currentTimeMillis() + 2 * 60 * 1000L;
-    while (getCurrentServingNumDocs() < TOTAL_DOCS) {
+    while (getCurrentServingNumDocs("mytable") < TOTAL_DOCS) {
       if (System.currentTimeMillis() < timeInTwoMinutes) {
         Thread.sleep(1000);
       } else {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/InvertedIndexOfflineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/InvertedIndexOfflineIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import java.io.File;
 
 import org.testng.annotations.Test;
@@ -30,8 +31,8 @@ public class InvertedIndexOfflineIntegrationTest extends OfflineClusterIntegrati
   protected void setUpTable(File schemaFile, int numBroker, int numOffline) throws Exception {
     addSchema(schemaFile, "schemaFile");
     Schema schema = Schema.fromFile(schemaFile);
-    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, schema.getDimensionNames(),
-        null);
+    addOfflineTable("DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, schema.getDimensionNames(), null, "mytable",
+        SegmentVersion.v1);
   }
 
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.io.FileInputStream;
@@ -62,7 +63,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
 
   protected void setUpTable(File schemaFile, int numBroker, int numOffline) throws Exception {
     addSchema(schemaFile, "schemaFile");
-    addOfflineTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null);
+    addOfflineTable("DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, "mytable", SegmentVersion.v1);
   }
 
   protected void dropTable() throws Exception {
@@ -113,7 +114,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
     TOTAL_DOCS = 115545;
     long timeInTwoMinutes = System.currentTimeMillis() + 2 * 60 * 1000L;
     long numDocs;
-    while ((numDocs = getCurrentServingNumDocs()) < TOTAL_DOCS) {
+    while ((numDocs = getCurrentServingNumDocs("mytable")) < TOTAL_DOCS) {
       System.out.println("Current number of documents: " + numDocs);
       if (System.currentTimeMillis() < timeInTwoMinutes) {
         Thread.sleep(1000);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.FileUploadUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.helix.ControllerTestUtils;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.tools.query.comparison.QueryComparison;
 import com.linkedin.pinot.tools.query.comparison.SegmentInfoProvider;
 import com.linkedin.pinot.tools.query.comparison.StarTreeQueryGenerator;
@@ -105,10 +106,10 @@ public class StarTreeClusterIntegrationTest extends ClusterTest {
    * @throws Exception
    */
   private void addOfflineTables() throws Exception {
-    addOfflineTable(DEFAULT_TABLE_NAME, TIME_COLUMN_NAME, TIME_UNIT, RETENTION_TIME,
-        RETENTION_TIME_UNIT, null, null);
-    addOfflineTable(STAR_TREE_TABLE_NAME, TIME_COLUMN_NAME, TIME_UNIT, RETENTION_TIME,
-        RETENTION_TIME_UNIT, null, null);
+    addOfflineTable(TIME_COLUMN_NAME, TIME_UNIT, RETENTION_TIME, RETENTION_TIME_UNIT, null, null, DEFAULT_TABLE_NAME,
+        SegmentVersion.v1);
+    addOfflineTable(TIME_COLUMN_NAME, TIME_UNIT, RETENTION_TIME, RETENTION_TIME_UNIT, null, null, STAR_TREE_TABLE_NAME,
+        SegmentVersion.v1);
   }
 
   /**


### PR DESCRIPTION
V1 to v3 format converter deletes stale files after conversion. But parts
of code like segment refresh messages, look for segment metadata before
it can figure out the format to load. Looking for segment metadata
prevents refreshing converted segments even if stale metadata is deleted.
The order of loading metadata file is for backward compatibility.
The behavior to handle missing metadata file is same as before PR# 609