### PR TITLE
Added a utility to reduce number of replicas for an offline table

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotNumReplicaChanger.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotNumReplicaChanger.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotNumReplicaChanger.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotNumReplicaChanger.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.tools;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.model.IdealState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.base.Function;
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.utils.helix.HelixHelper;
+import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import javax.annotation.Nullable;
+
+
+public class PinotNumReplicaChanger extends PinotSegmentRebalancer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotNumReplicaChanger.class);
+
+  public PinotNumReplicaChanger(String zkAddress, String clusterName, boolean dryRun) {
+    super(zkAddress, clusterName, dryRun);
+  }
+
+  private static void usage() {
+    System.out.println("Usage: PinotNumReplicaChanger <zkAddress> <clusterName> <tableName> <numReplicas>");
+    System.out.println("Example: localhost:2181 PinotCluster myTable_OFFLINE 5");
+    System.exit(1);
+  }
+
+  public void changeNumReplicas(final String tableName)
+      throws Exception {
+    // Get the number of replicas in the tableconfig.
+    final String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    final AbstractTableConfig offlineTableConfig =
+        ZKMetadataProvider.getOfflineTableConfig(getPropertyStore(), offlineTableName);
+    final int newNumReplicas = Integer.parseInt(offlineTableConfig.getValidationConfig().getReplication());
+
+    // Now get the idealstate, and get the number of replicas in it.
+    IdealState currentIdealState = getZkHelixAdmin().getResourceIdealState(getClusterName(), offlineTableName);
+    int currentNumReplicas = Integer.parseInt(currentIdealState.getReplicas());
+
+    if (newNumReplicas > currentNumReplicas) {
+      LOGGER.info("Increasing replicas not yet supported");
+    } else if (newNumReplicas == currentNumReplicas) {
+      LOGGER.info("Number of replicas ({}) match in table definition and Idealstate. Nothing to do for {}",
+          newNumReplicas, offlineTableName);
+    } else if (newNumReplicas < currentNumReplicas) {
+      if (isDryRun()) {
+        IdealState newIdealState = updateIdealState(currentIdealState, newNumReplicas);
+        LOGGER.info("Final segment Assignment:");
+        printSegmentAssignment(newIdealState.getRecord().getMapFields());
+      } else {
+        HelixHelper.updateIdealState(getHelixManager(), offlineTableName, new Function<IdealState, IdealState>() {
+          @Nullable
+          @Override
+          public IdealState apply(IdealState idealState) {
+            return updateIdealState(idealState, newNumReplicas);
+          }
+        }, RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0f));
+        waitForStable(offlineTableName);
+        LOGGER.info("Successfully changed numReplicas to {} for table {}", newNumReplicas, offlineTableName);
+        LOGGER.warn("*** You need to rebalance table {} ***", offlineTableName);
+      }
+    }
+  }
+
+  private IdealState updateIdealState(IdealState idealState, int newNumReplicas) {
+    idealState.setReplicas(Integer.toString(newNumReplicas));
+    Set<String> segmentIds = idealState.getPartitionSet();
+    for (String segmentId : segmentIds) {
+      Map<String, String> instanceStateMap = idealState.getInstanceStateMap(segmentId);
+      if (instanceStateMap.size() > newNumReplicas) {
+        Set<String> keys = instanceStateMap.keySet();
+        while (instanceStateMap.size() > newNumReplicas) {
+          instanceStateMap.remove(keys.iterator().next());
+        }
+      } else if (instanceStateMap.size() < newNumReplicas) {
+        throw new RuntimeException("Segment " + segmentId + " has " + instanceStateMap.size() +
+            " replicas but want changed to " + newNumReplicas);
+      }
+    }
+    return idealState;
+  }
+
+  public static void main(String[] args) throws Exception {
+    final boolean dryRun = true;
+    if (args.length != 3) {
+      usage();
+    }
+    final String zkAddress = args[0];
+    final String clusterName = args[1];
+    final String tableName = args[2];
+
+    PinotNumReplicaChanger replicaChanger = new PinotNumReplicaChanger(zkAddress, clusterName, dryRun);
+
+    replicaChanger.changeNumReplicas(tableName);
+
+    if (dryRun) {
+      System.out.println("That was a dryrun");
+    }
+
+  }
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotZKChanger.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotZKChanger.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.tools;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.commons.math.stat.descriptive.DescriptiveStatistics;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyPathConfig;
+import org.apache.helix.PropertyType;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.manager.zk.ZNRecordSerializer;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+/**
+ * This class provides a base class for utilities that change zookeeper state in a cluster
+ */
+public abstract class PinotZKChanger {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotZKChanger.class);
+
+  protected ZKHelixAdmin helixAdmin;
+  protected HelixManager helixManager;
+  protected String clusterName;
+  protected ZkHelixPropertyStore<ZNRecord> propertyStore;
+  protected ObjectMapper objectMapper;
+
+  public PinotZKChanger(String zkAddress, String clusterName) {
+    this.clusterName = clusterName;
+    helixAdmin = new ZKHelixAdmin(zkAddress);
+    helixManager =
+        HelixManagerFactory
+            .getZKHelixManager(clusterName, "PinotNumReplicaChanger", InstanceType.ADMINISTRATOR, zkAddress);
+    try {
+      helixManager.connect();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    ZNRecordSerializer serializer = new ZNRecordSerializer();
+    String path = PropertyPathConfig.getPath(PropertyType.PROPERTYSTORE, clusterName);
+    propertyStore = new ZkHelixPropertyStore<>(zkAddress, serializer, path);
+    objectMapper = new ObjectMapper();
+  }
+
+  /**
+   * return true if IdealState = ExternalView
+   * @return
+   */
+  public int isStable(String tableName) {
+    IdealState idealState = helixAdmin.getResourceIdealState(clusterName, tableName);
+    ExternalView externalView = helixAdmin.getResourceExternalView(clusterName, tableName);
+    Map<String, Map<String, String>> mapFieldsIS = idealState.getRecord().getMapFields();
+    Map<String, Map<String, String>> mapFieldsEV = externalView.getRecord().getMapFields();
+    int numDiff = 0;
+    for (String segment : mapFieldsIS.keySet()) {
+      Map<String, String> mapIS = mapFieldsIS.get(segment);
+      Map<String, String> mapEV = mapFieldsEV.get(segment);
+
+      for (String server : mapIS.keySet()) {
+        String state = mapIS.get(server);
+        if (mapEV == null || mapEV.get(server) == null || !mapEV.get(server).equals(state)) {
+          LOGGER.info("Mismatch: segment" + segment + " server:" + server + " state:" + state);
+          numDiff = numDiff + 1;
+        }
+      }
+    }
+    return numDiff;
+  }
+
+  protected void waitForStable(String resourceName)
+      throws InterruptedException {
+    int diff;
+    Thread.sleep(3000);
+    do {
+      diff = isStable(resourceName);
+      if (diff == 0) {
+        break;
+      } else {
+        LOGGER.info(
+            "Waiting for externalView to match idealstate for table:" + resourceName + " Num segments difference:" + diff);
+        Thread.sleep(30000);
+      }
+    } while (diff > 0);
+  }
+
+  protected void printSegmentAssignment(Map<String, Map<String, String>> mapping) throws Exception {
+    StringWriter sw = new StringWriter();
+    objectMapper.writerWithDefaultPrettyPrinter().writeValue(sw, mapping);
+    LOGGER.info(sw.toString());
+    Map<String, List<String>> serverToSegmentMapping = new TreeMap<>();
+    for (String segment : mapping.keySet()) {
+      Map<String, String> serverToStateMap = mapping.get(segment);
+      for (String server : serverToStateMap.keySet()) {
+        if (!serverToSegmentMapping.containsKey(server)) {
+          serverToSegmentMapping.put(server, new ArrayList<String>());
+        }
+        serverToSegmentMapping.get(server).add(segment);
+      }
+    }
+    DescriptiveStatistics stats = new DescriptiveStatistics();
+    for (String server : serverToSegmentMapping.keySet()) {
+      List<String> list = serverToSegmentMapping.get(server);
+      LOGGER.info("server " + server + " has " + list.size() + " segments");
+      stats.addValue(list.size());
+    }
+    LOGGER.info("Segment Distrbution stat");
+    LOGGER.info(stats.toString());
+  }
+
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotAdministrator.java
@@ -26,11 +26,11 @@ import org.kohsuke.args4j.spi.SubCommands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.tools.Command;
-import com.linkedin.pinot.tools.PinotNumReplicaChanger;
 import com.linkedin.pinot.tools.admin.command.AddSchemaCommand;
 import com.linkedin.pinot.tools.admin.command.AddTableCommand;
 import com.linkedin.pinot.tools.admin.command.AddTenantCommand;
 import com.linkedin.pinot.tools.admin.command.AvroSchemaToPinotSchema;
+import com.linkedin.pinot.tools.admin.command.ChangeNumReplicasCommand;
 import com.linkedin.pinot.tools.admin.command.ChangeTableState;
 import com.linkedin.pinot.tools.admin.command.CreateSegmentCommand;
 import com.linkedin.pinot.tools.admin.command.DeleteClusterCommand;
@@ -80,7 +80,7 @@ public class PinotAdministrator {
       @SubCommand(name = "ShowClusterInfo", impl = ShowClusterInfoCommand.class),
       @SubCommand(name = "AvroSchemaToPinotSchema", impl = AvroSchemaToPinotSchema.class),
       @SubCommand(name = "RebalanceTable", impl = RebalanceTableCommand.class),
-      @SubCommand(name = "ChangeNumReplicas", impl = PinotNumReplicaChanger.class),
+      @SubCommand(name = "ChangeNumReplicas", impl = ChangeNumReplicasCommand.class),
       @SubCommand(name = "ValidateConfig", impl = ValidateConfigCommand.class),
       @SubCommand(name = "VerifySegmentState", impl = VerifySegmentState.class),
       @SubCommand(name = "PinotSegmentConverter", impl = PinotSegmentConverter.class)

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/PinotAdministrator.java
@@ -15,7 +15,18 @@
  */
 package com.linkedin.pinot.tools.admin;
 
+import java.lang.reflect.Field;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.SubCommand;
+import org.kohsuke.args4j.spi.SubCommandHandler;
+import org.kohsuke.args4j.spi.SubCommands;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.tools.Command;
+import com.linkedin.pinot.tools.PinotNumReplicaChanger;
 import com.linkedin.pinot.tools.admin.command.AddSchemaCommand;
 import com.linkedin.pinot.tools.admin.command.AddTableCommand;
 import com.linkedin.pinot.tools.admin.command.AddTenantCommand;
@@ -38,16 +49,6 @@ import com.linkedin.pinot.tools.admin.command.UploadSegmentCommand;
 import com.linkedin.pinot.tools.admin.command.ValidateConfigCommand;
 import com.linkedin.pinot.tools.admin.command.VerifySegmentState;
 import com.linkedin.pinot.tools.segment.converter.PinotSegmentConverter;
-import java.lang.reflect.Field;
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.CmdLineException;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
-import org.kohsuke.args4j.spi.SubCommand;
-import org.kohsuke.args4j.spi.SubCommandHandler;
-import org.kohsuke.args4j.spi.SubCommands;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -79,6 +80,7 @@ public class PinotAdministrator {
       @SubCommand(name = "ShowClusterInfo", impl = ShowClusterInfoCommand.class),
       @SubCommand(name = "AvroSchemaToPinotSchema", impl = AvroSchemaToPinotSchema.class),
       @SubCommand(name = "RebalanceTable", impl = RebalanceTableCommand.class),
+      @SubCommand(name = "ChangeNumReplicas", impl = PinotNumReplicaChanger.class),
       @SubCommand(name = "ValidateConfig", impl = ValidateConfigCommand.class),
       @SubCommand(name = "VerifySegmentState", impl = VerifySegmentState.class),
       @SubCommand(name = "PinotSegmentConverter", impl = PinotSegmentConverter.class)

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ChangeNumReplicasCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ChangeNumReplicasCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.tools.admin.command;
+
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.tools.Command;
+import com.linkedin.pinot.tools.PinotNumReplicaChanger;
+
+
+public class ChangeNumReplicasCommand extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(StartBrokerCommand.class);
+
+  @Option(name = "-zkAddress", required = false, metaVar = "<http>", usage = "HTTP address of Zookeeper.")
+  private String _zkAddress = DEFAULT_ZK_ADDRESS;
+
+  @Option(name = "-clusterName", required = false, metaVar = "<String>", usage = "Pinot cluster name.")
+  private String _clusterName = "PinotCluster";
+
+  @Option(name = "-tableName", required = true, metaVar = "<String>", usage = "Table name to rebalance (e.g. myTable_OFFLINE)")
+  private String _tableName;
+
+  @Option(name = "-exec", required = false, metaVar = "<boolean>", usage = "Execute command (Run the replica changer)")
+  private boolean _exec;
+
+  @Option(name = "-help", required = false, help = true, aliases = { "-h", "--h", "--help" },
+      usage = "Print this message.")
+  private boolean _help = false;
+
+  public boolean getHelp() {
+    return _help;
+  }
+
+  @Override
+  public boolean execute() throws Exception {
+    boolean _dryRun = !_exec;
+    PinotNumReplicaChanger replicaChanger = new PinotNumReplicaChanger(_zkAddress, _clusterName, _dryRun);
+    replicaChanger.changeNumReplicas(_tableName);
+    if (_dryRun) {
+      LOGGER.info("That was a dryrun");
+      LOGGER.info("Use the -exec option to actually execute the command");
+    }
+    return true;
+  }
+
+  @Override
+  public String description() {
+    return "Re-writes idealState to reflect the value of numReplicas in table config";
+  }
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ChangeNumReplicasCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ChangeNumReplicasCommand.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.tools.admin.command;
 
 import org.kohsuke.args4j.Option;
@@ -44,6 +43,11 @@ public class ChangeNumReplicasCommand extends AbstractBaseAdminCommand implement
 
   public boolean getHelp() {
     return _help;
+  }
+
+  @Override
+  public String getName() {
+    return "ChangeNumReplicas";
   }
 
   @Override

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -49,6 +49,10 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
   }
 
   @Override
+  public String getName() {
+    return "RebalanceTable";
+  }
+  @Override
   public boolean execute() throws Exception {
     boolean _dryRun = !_exec;
     PinotSegmentRebalancer rebalancer = new PinotSegmentRebalancer(_zkAddress, _clusterName, _dryRun);


### PR DESCRIPTION
If we want to reduce the number of replicas for an offline table, then
running helix AutoRebalanceStragy to recompute partitions does not work.
It does work if we want to increase number of replicas.

Added a separate utility command to reduce the number of replicas.

Also fixed the Rebalancer to account for IdealState changes during the time
th command is run.