### PR TITLE
Replace committed segment in the data table

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -368,6 +368,9 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
                 if (success) {
                   _state = State.COMMITTED;
                 } else {
+                  // If for any reason commit failed, we don't want to be in COMMITTING state when we hold.
+                  // Change the state to HOLDING before looping around.
+                  _state = State.HOLDING;
                   segmentLogger.info("Could not commit segment. Retrying after hold");
                   hold();
                 }
@@ -451,6 +454,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
         segmentLogger.warn("Received controller response {}", response);
         return false;
       }
+      _realtimeTableDataManager.replaceLLSegment(_segmentNameStr);
       FileUtils.deleteQuietly(new File(segTarFileName));
     } catch (FileNotFoundException e) {
       segmentLogger.error("Tar file {} not found", segTarFileName, e);


### PR DESCRIPTION
The server that gets to commit the LLC segment was not replacing the old in-memory
segment with the newly constructed indexed segment. As a result, the server can run
out of memory trying to load multiple segments.