### PR TITLE
Pql for nonadditive (pre-aggregated) data

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -126,6 +126,13 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
          resultSetGroups.add(result);
        }
     } else {
+      if (collectionConfig != null && collectionConfig.isNonAdditive()) {
+        List<String> collectionDimensionNames =
+            CACHE_REGISTRY_INSTANCE.getCollectionSchemaCache().get(request.getCollection()).getDimensionNames();
+        PqlUtils.decorateRequestForPrecomputedDataset(request, collectionDimensionNames,
+            collectionConfig.getDimensionsHaveNoPreAggregation(), collectionConfig.getPreAggregatedKeyword());
+      }
+
       String sql = PqlUtils.getPql(request, dataTimeSpec);
       LOG.debug("PQL: {}", sql);
       ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache()

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -2,10 +2,12 @@ package com.linkedin.thirdeye.client.pinot;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -42,6 +44,50 @@ public class PqlUtils {
     return getPql(request.getCollection(), request.getMetricFunctions(),
         request.getStartTimeInclusive(), request.getEndTimeExclusive(), request.getFilterSet(),
         request.getGroupBy(), request.getGroupByTimeGranularity(), dataTimeSpec);
+  }
+
+  /**
+   * Definition of Pre-Computed Data: the data that has been pre-calculated or pre-aggregated, and does not require
+   * further aggregation (i.e., aggregation function of Pinot should do no-op). For such data, we assume that there
+   * exists a dimension value named "all", which is user-definable keyword in collection configuration, that stores
+   * the pre-aggregated value.
+   *
+   * By default, when a query does not specify any value on a certain dimension, Pinot aggregates all values at that
+   * dimension, which is an undesirable behavior for pre-computed data. Therefore, this method modifies the request's
+   * dimension filters such that the filter could pick out the "all" value for that dimension.
+   *
+   * Example: Suppose that we have a dataset with 3 dimensions: country, pageName, and osName, and the pre-aggregated
+   * keyword is 'all'. Further assume that the original request's filter = {'country'='US, IN'} and GroupBy dimension =
+   * pageName, then the decorated request has the new filter = {'country'='US, IN', 'osName' = 'all'}.
+   *
+   * @param request the original request
+   * @return a request that is decorated with additional filters for filtering out the pre-aggregated value on the
+   * unspecified dimensions.
+   */
+  public static void decorateRequestForPrecomputedDataset(ThirdEyeRequest request, List<String> allDimensions,
+      List<String> dimensionsHaveNoPreAggregation, String preAggregatedKeyword) {
+    Set<String> preComputedDimensionNames = new HashSet<>(allDimensions);
+
+    if (dimensionsHaveNoPreAggregation.size() != 0) {
+      preComputedDimensionNames.removeAll(dimensionsHaveNoPreAggregation);
+    }
+
+    Multimap<String, String> filterSet = request.getFilterSet();
+    Set<String> filterDimensions = filterSet.asMap().keySet();
+    if (filterDimensions.size() != 0) {
+      preComputedDimensionNames.removeAll(filterDimensions);
+    }
+
+    List<String> groupByDimensions = request.getGroupBy();
+    if (groupByDimensions.size() != 0) {
+      preComputedDimensionNames.removeAll(groupByDimensions);
+    }
+
+    if (preComputedDimensionNames.size() != 0) {
+      for (String preComputedDimensionName : preComputedDimensionNames) {
+        filterSet.put(preComputedDimensionName, preAggregatedKeyword);
+      }
+    }
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/CollectionConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/configs/CollectionConfig.java
@@ -1,16 +1,22 @@
 package com.linkedin.thirdeye.dashboard.configs;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import com.linkedin.thirdeye.client.MetricExpression;
+import java.util.concurrent.TimeUnit;
+
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CollectionConfig extends AbstractConfig {
 
   public static double DEFAULT_THRESHOLD = 0.01;
   public static String DEFAULT_TIMEZONE = "UTC";
+  public static String DEFAULT_PREAGGREGATED_KEYWORD = "all";
+  public static int DEFAULT_NONADDITIVE_BUCKET_SIZE = 5;
+  public static String DEFAULT_NONADDITIVE_BUCKET_UNIT = TimeUnit.MINUTES.toString();
 
   String collectionName;
   String collectionAlias;
@@ -21,6 +27,12 @@ public class CollectionConfig extends AbstractConfig {
   boolean metricAsDimension = false;
   String metricNamesColumn = null;
   String metricValuesColumn = null;
+
+  boolean isNonAdditive = false;
+  List<String> dimensionsHaveNoPreAggregation = Collections.emptyList();
+  String preAggregatedKeyword = DEFAULT_PREAGGREGATED_KEYWORD;
+  int nonAdditiveBucketSize = DEFAULT_NONADDITIVE_BUCKET_SIZE;
+  String nonAdditiveBucketUnit = DEFAULT_NONADDITIVE_BUCKET_UNIT;
 
   Map<String, String> derivedMetrics;
 
@@ -118,6 +130,47 @@ public class CollectionConfig extends AbstractConfig {
 
   public void setInvertColorMetrics(List<String> invertColorMetrics) {
     this.invertColorMetrics = invertColorMetrics;
+  }
+
+  public boolean isNonAdditive() {
+    return isNonAdditive;
+  }
+
+  public void setIsNonAdditive(boolean isNonAdditive) {
+    this.isNonAdditive = isNonAdditive;
+  }
+
+  public List<String> getDimensionsHaveNoPreAggregation() {
+    return dimensionsHaveNoPreAggregation;
+  }
+
+  public void setDimensionsHaveNoPreAggregation(List<String> dimensionsHaveNoPreAggregation) {
+    this.dimensionsHaveNoPreAggregation =
+        (dimensionsHaveNoPreAggregation == null) ? Collections.emptyList() : dimensionsHaveNoPreAggregation;
+  }
+
+  public String getPreAggregatedKeyword() {
+    return preAggregatedKeyword;
+  }
+
+  public void setPreAggregatedKeyword(String preAggregatedKeyword) {
+    this.preAggregatedKeyword = preAggregatedKeyword == null ? DEFAULT_PREAGGREGATED_KEYWORD : preAggregatedKeyword;
+  }
+
+  public int getNonAdditiveBucketSize() {
+    return nonAdditiveBucketSize;
+  }
+
+  public void setNonAdditiveBucketSize(int size) {
+    this.nonAdditiveBucketSize = size;
+  }
+
+  public String getNonAdditiveBucketUnit() {
+    return nonAdditiveBucketUnit;
+  }
+
+  public void setNonAdditiveBucketUnit(String bucketUnit) {
+    this.nonAdditiveBucketUnit = bucketUnit;
   }
 
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -308,7 +308,7 @@ public class DashboardResource {
         request.setFilters(ThirdEyeUtils.convertToMultiMap(filterJson));
       }
 
-      request.setTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity));
+      request.setTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity, collection));
 
       TabularViewHandler handler = new TabularViewHandler(queryCache);
       String jsonResponse = null;
@@ -408,7 +408,7 @@ public class DashboardResource {
       filterJson = URLDecoder.decode(filterJson, "UTF-8");
       request.setFilters(ThirdEyeUtils.convertToMultiMap(filterJson));
     }
-    request.setTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity));
+    request.setTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity, collection));
 
     TabularViewHandler handler = new TabularViewHandler(queryCache);
     String jsonResponse = null;
@@ -460,7 +460,7 @@ public class DashboardResource {
       filterJson = URLDecoder.decode(filterJson, "UTF-8");
       request.setFilters(ThirdEyeUtils.convertToMultiMap(filterJson));
     }
-    request.setTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity));
+    request.setTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity, collection));
     if (groupByDimensions != null && !groupByDimensions.isEmpty()) {
       request.setGroupByDimensions(Arrays.asList(groupByDimensions.trim().split(",")));
     }
@@ -508,7 +508,8 @@ public class DashboardResource {
     List<MetricExpression> metricExpressions =
         Utils.convertToMetricExpressions(metricsJson, MetricAggFunction.SUM, collection);
     request.setMetricExpressions(metricExpressions);
-    request.setAggregationTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity));
+    CollectionConfig collectionConfig = CACHE_REGISTRY_INSTANCE.getCollectionConfigCache().get(collection);
+    request.setAggregationTimeGranularity(Utils.getAggregationTimeGranularity(aggTimeGranularity, collection));
     CollectionSchema collectionSchema = CACHE_REGISTRY_INSTANCE.getCollectionSchemaCache().get(collection);
     if (!request.getAggregationTimeGranularity().getUnit().equals(TimeUnit.DAYS) ||
         !StringUtils.isBlank(collectionSchema.getTime().getFormat())) {


### PR DESCRIPTION
* Change to PQL query: For nonadditive (pre-aggregated) dataset, we assume that there exists one dimension value "all", which is user configurable, that aggregates all dimension values on the corresponding dimension name. Therefore, if a user does not specify which value s/he is looking at at that dimension, then ThirdEye automatically append filters such as "thatDimensionName=all;" after the query. Consequently, ThirdEye would get the pre-aggregated value instead of SUM up the non-additive dimension.

* Change to UI: For nonadditive (pre-aggregated) dataset, the time granularity on the UI no longer provide useful meaning. For instance, if the time granularity of the pre-aggrated dataset is 1 hour, then it is meaningless to set the granularity to 1 day on the UI. Therefore, the user could set the true time granularity of the dataset in web app configuration to override the time granularity on the UI.