### PR TITLE
Handling race condition among workers

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
@@ -150,7 +150,7 @@ public class TaskDriver {
         try {
           success = anomalyTaskDAO
               .updateStatusAndWorkerId(workerId, anomalyTaskSpec.getId(), allowedOldTaskStatus,
-                  TaskStatus.RUNNING);
+                  TaskStatus.RUNNING, anomalyTaskSpec.getVersion());
           LOG.info(Thread.currentThread().getId() + " : Task acquired success: {}", success);
         } catch (Exception e) {
           LOG.warn("[{}] in acquiring task by threadId {} and workerId {}",

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AbstractManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AbstractManager.java
@@ -4,13 +4,14 @@ import java.util.List;
 import java.util.Map;
 
 import com.linkedin.thirdeye.datalayer.dto.AbstractDTO;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
 
 
 public interface AbstractManager<E extends AbstractDTO> {
 
   Long save(E entity);
 
-  void update(E entity);
+  int update(E entity);
 
   E findById(Long id);
 
@@ -21,4 +22,6 @@ public interface AbstractManager<E extends AbstractDTO> {
   List<E> findAll();
 
   List<E> findByParams(Map<String, Object> filters);
+
+  int update(E entity, Predicate predicate);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/TaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/TaskManager.java
@@ -13,7 +13,7 @@ public interface TaskManager extends AbstractManager<TaskDTO>{
   List<TaskDTO> findByStatusOrderByCreateTime(TaskStatus status, int fetchSize, boolean asc);
 
   boolean updateStatusAndWorkerId(Long workerId, Long id, Set<TaskStatus> allowedOldStatus,
-      TaskStatus newStatus);
+      TaskStatus newStatus, int expectedVersion);
 
   void updateStatusAndTaskEndTime(Long id, TaskStatus oldStatus, TaskStatus newStatus,
       Long taskEndTime);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
@@ -21,6 +21,8 @@ import com.linkedin.thirdeye.datalayer.pojo.AnomalyFunctionBean;
 import com.linkedin.thirdeye.datalayer.pojo.MergedAnomalyResultBean;
 import com.linkedin.thirdeye.datalayer.pojo.RawAnomalyResultBean;
 import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,11 +64,16 @@ public abstract class AbstractManagerImpl<E extends AbstractDTO> implements Abst
     return id;
   }
 
-
   @Override
-  public void update(E entity) {
+  public int update(E entity, Predicate predicate) {
     AbstractBean bean = convertDTO2Bean(entity, beanClass);
-    genericPojoDao.update(bean);
+    return genericPojoDao.update(bean, predicate);
+  }
+  
+  @Override
+  public int update(E entity) {
+    AbstractBean bean = convertDTO2Bean(entity, beanClass);
+    return genericPojoDao.update(bean);
   }
 
   public E findById(Long id) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/EmailConfigurationManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/EmailConfigurationManagerImpl.java
@@ -44,10 +44,10 @@ public class EmailConfigurationManagerImpl extends AbstractManagerImpl<EmailConf
   }
 
   @Override
-  public void update(EmailConfigurationDTO emailConfigurationDTO) {
+  public int update(EmailConfigurationDTO emailConfigurationDTO) {
     EmailConfigurationBean emailConfigurationBean =
         (EmailConfigurationBean) convertEmailConfigurationDTO2Bean(emailConfigurationDTO);
-    genericPojoDao.update(emailConfigurationBean);
+    return genericPojoDao.update(emailConfigurationBean);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -51,13 +51,18 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     return id;
   }
 
-  public void update(MergedAnomalyResultDTO mergedAnomalyResultDTO) {
+  public int update(MergedAnomalyResultDTO mergedAnomalyResultDTO) {
     if (mergedAnomalyResultDTO.getId() == null) {
-      save(mergedAnomalyResultDTO);
+      Long id = save(mergedAnomalyResultDTO);
+      if (id > 0) {
+        return 1;
+      } else {
+        return 0;
+      }
     } else {
       MergedAnomalyResultBean mergeAnomalyBean =
           convertMergeAnomalyDTO2Bean(mergedAnomalyResultDTO);
-      genericPojoDao.update(mergeAnomalyBean);
+      return genericPojoDao.update(mergeAnomalyBean);
     }
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RawAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RawAnomalyResultManagerImpl.java
@@ -41,7 +41,7 @@ public class RawAnomalyResultManagerImpl extends AbstractManagerImpl<RawAnomalyR
     return id;
   }
 
-  public void update(RawAnomalyResultDTO entity) {
+  public int update(RawAnomalyResultDTO entity) {
     RawAnomalyResultBean bean =
         (RawAnomalyResultBean) convertDTO2Bean(entity, RawAnomalyResultBean.class);
     if (entity.getFeedback() != null) {
@@ -56,7 +56,7 @@ public class RawAnomalyResultManagerImpl extends AbstractManagerImpl<RawAnomalyR
     if (entity.getFunction() != null) {
       bean.setFunctionId(entity.getFunction().getId());
     }
-    genericPojoDao.update(bean);
+    return genericPojoDao.update(bean);
   }
 
   public RawAnomalyResultDTO findById(Long id) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
@@ -72,14 +72,19 @@ public class TaskManagerImpl extends AbstractManagerImpl<TaskDTO> implements Tas
 
   @Override
   public boolean updateStatusAndWorkerId(Long workerId, Long id, Set<TaskStatus> permittedOldStatus,
-      TaskStatus newStatus) {
+      TaskStatus newStatus, int expectedVersion) {
     // TODO: add proper transaction here
     TaskDTO task = findById(id);
     if (permittedOldStatus.contains(task.getStatus())) {
       task.setStatus(newStatus);
       task.setWorkerId(workerId);
-      save(task);
-      return true;
+      //increment the version
+      task.setVersion(expectedVersion + 1);
+      Predicate predicate = Predicate.AND(
+          Predicate.EQ("id", id),
+          Predicate.EQ("version", expectedVersion));
+      int update = update(task, predicate);
+      return update == 1;
     } else {
       return false;
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AbstractDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AbstractDTO.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.datalayer.dto;
 
 public abstract class AbstractDTO {
   private Long id;
+  private int version;
 
   public Long getId() {
     return id;
@@ -10,4 +11,13 @@ public abstract class AbstractDTO {
   public void setId(Long id) {
     this.id = id;
   }
+
+  public int getVersion() {
+    return version;
+  }
+
+  public void setVersion(int version) {
+    this.version = version;
+  }
+  
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/GenericJsonEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/GenericJsonEntity.java
@@ -2,4 +2,12 @@ package com.linkedin.thirdeye.datalayer.entity;
 
 public class GenericJsonEntity extends AbstractJsonEntity {
 
+  @Override
+  public String toString() {
+    return "GenericJsonEntity [id=" + id + ", beanClass=" + beanClass + ", version=" + version
+        + ", createTime=" + createTime + ", updateTime=" + updateTime + ", jsonVal=" + jsonVal
+        + "]";
+  }
+
+ 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/TaskBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/TaskBean.java
@@ -24,7 +24,6 @@ public class TaskBean extends AbstractBean {
   private long endTime;
   private String taskInfo;
   private Timestamp lastModified;
-  private int version;
 
   public Long getWorkerId() {
     return workerId;
@@ -89,14 +88,6 @@ public class TaskBean extends AbstractBean {
 
   public void setLastModified(Timestamp lastModified) {
     this.lastModified = lastModified;
-  }
-
-  public int getVersion() {
-    return version;
-  }
-
-  public void setVersion(int version) {
-    this.version = version;
   }
 
   public Long getJobId() {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -48,13 +48,15 @@ public class TestAnomalyTaskManager extends AbstractManagerTestBase {
   public void testUpdateStatusAndWorkerId() {
     TaskStatus newStatus = TaskStatus.RUNNING;
     Long workerId = 1L;
-
+    TaskDTO taskDTO = taskDAO.findById(anomalyTaskId1);
     boolean status =
-        taskDAO.updateStatusAndWorkerId(workerId, anomalyTaskId1, allowedOldTaskStatus, newStatus);
+        taskDAO.updateStatusAndWorkerId(workerId, anomalyTaskId1, allowedOldTaskStatus, newStatus, taskDTO.getVersion());
     TaskDTO anomalyTask = taskDAO.findById(anomalyTaskId1);
     Assert.assertTrue(status);
     Assert.assertEquals(anomalyTask.getStatus(), newStatus);
     Assert.assertEquals(anomalyTask.getWorkerId(), workerId);
+    Assert.assertEquals(anomalyTask.getVersion(), taskDTO.getVersion() + 1);
+
   }
 
   @Test(dependsOnMethods = {"testUpdateStatusAndWorkerId"})


### PR DESCRIPTION
The caller has the option to update the version when an update is invoked. I am still debating if we should convert all updates into compare and set. This forces the callers to hold on the returned version otherwise we will have to do one additional read.

Also change the base manager interface to return the number of rows that were successfully updated