### PR TITLE
Remove log message that warns on Java ser/de.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/DataTableCustomSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/DataTableCustomSerDe.java
@@ -94,7 +94,6 @@ public class DataTableCustomSerDe extends DataTableJavaSerDe {
       if (_brokerMetrics != null) {
         _brokerMetrics.addMeteredGlobalValue(BrokerMeter.DATA_TABLE_OBJECT_DESERIALIZATION, 1);
       }
-      LOGGER.warn("Identified Java serialized object in data table {}", object.getClass().getName());
     }
     return object;
   }


### PR DESCRIPTION
There are too many of these messages for high QPS use cases. And we are
already emitting a metric on the same, so removing the message.