### PR TITLE
Exclude pulling in netty from org.jboss.netty group

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,10 @@
             <groupId>com.github.sgroschupf</groupId>
             <artifactId>zkclient</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.jboss.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
       </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
we are unnecessary pulling in netty from org.jboss.netty group via zookeeper. Note, zookeeper does not need netty for client-server communication. This should have marked optional in zookeeper see https://issues.apache.org/jira/browse/ZOOKEEPER-1681 