### PR TITLE
Clean up the System.output inside the tests.

### DIFF
--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
@@ -268,14 +268,12 @@ public class SchemaTest {
         TimeUnit.DAYS, TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd" , "Date");
     TimeGranularitySpec outgoingTimeGranularitySpec = new TimeGranularitySpec(DataType.STRING, 1,
         TimeUnit.DAYS, TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "Date");
-    System.out.println(incomingTimeGranularitySpec);
+//    System.out.println(incomingTimeGranularitySpec);
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testSchema")
         .addTime(incomingTimeGranularitySpec, outgoingTimeGranularitySpec).build();
     String jsonSchema = schema.getJSONSchema();
     Schema schemaFromJson = Schema.fromString(jsonSchema);
     Assert.assertEquals(schemaFromJson, schema);
     Assert.assertEquals(schemaFromJson.hashCode(), schema.hashCode());
-
-
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/IndexLoadingConfigMetadataTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/IndexLoadingConfigMetadataTest.java
@@ -34,7 +34,7 @@ public class IndexLoadingConfigMetadataTest {
     IndexLoadingConfigMetadata indexLoadingConfigMetadata = new IndexLoadingConfigMetadata(resourceMetadata);
     Set<String> loadingInvertedIndexColumns = indexLoadingConfigMetadata.getLoadingInvertedIndexColumns();
 
-    System.out.println("loadingInvertedIndexColumns is " + Arrays.toString(loadingInvertedIndexColumns.toArray(new String[0])));
+//    System.out.println("loadingInvertedIndexColumns is " + Arrays.toString(loadingInvertedIndexColumns.toArray(new String[0])));
     Assert.assertEquals(10, loadingInvertedIndexColumns.size());
     for (int j = 0; j < 10; ++j) {
       String columnName = "col" + j;

--- a/pinot-common/src/test/java/com/linkedin/pinot/request/BrokerRequestSerializationTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/request/BrokerRequestSerializationTest.java
@@ -40,7 +40,8 @@ import com.linkedin.pinot.common.request.SelectionSort;
 public class BrokerRequestSerializationTest {
 
   @Test
-  public static void testSerialization() {
+  public static void testSerialization()
+      throws TException {
     BrokerRequest req = new BrokerRequest();
 
     // Populate Query Type
@@ -103,24 +104,28 @@ public class BrokerRequestSerializationTest {
     agg.putToAggregationParams("key1", "dummy1");
     req.addToAggregationsInfo(agg);
 
-    int numRequests = 100000;
-    TimerContext t = MetricsHelper.startTimer();
-    TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
-    //TSerializer serializer = new TSerializer();
-    //Compact : Size 183 , Serialization Latency : 0.03361ms
-    // Normal : Size 385 , Serialization Latency : 0.01144ms
+    TSerializer normalSerializer = new TSerializer();
+    TSerializer compactSerializer = new TSerializer(new TCompactProtocol.Factory());
+    normalSerializer.serialize(req);
+    compactSerializer.serialize(req);
 
-    for (int i = 0; i < numRequests; i++) {
-      try {
-        serializer.serialize(req);
-        //System.out.println(s3.length);
-        //break;
-      } catch (TException e) {
-        e.printStackTrace();
-      }
-    }
-    t.stop();
-    System.out.println("Latency is :" + (t.getLatencyMs() / (float) numRequests));
+//    int numRequests = 100000;
+//    TimerContext t = MetricsHelper.startTimer();
+//    TSerializer serializer = new TSerializer(new TCompactProtocol.Factory());
+//    //TSerializer serializer = new TSerializer();
+//    //Compact : Size 183 , Serialization Latency : 0.03361ms
+//    // Normal : Size 385 , Serialization Latency : 0.01144ms
+//
+//    for (int i = 0; i < numRequests; i++) {
+//      try {
+//        serializer.serialize(req);
+//        //System.out.println(s3.length);
+//        //break;
+//      } catch (TException e) {
+//        e.printStackTrace();
+//      }
+//    }
+//    t.stop();
+//    System.out.println("Latency is :" + (t.getLatencyMs() / (float) numRequests));
   }
-
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/request/BrokerResponseNativeTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/request/BrokerResponseNativeTest.java
@@ -58,13 +58,13 @@ public class BrokerResponseNativeTest {
     QueryProcessingException processingException = new QueryProcessingException(400, errorMsgStr);
     expected.addToExceptions(processingException);
     String brokerString = expected.toJsonString();
-    System.out.println(brokerString);
+//    System.out.println(brokerString);
     BrokerResponseNative newBrokerResponse = BrokerResponseNative.fromJsonString(brokerString);
     Assert.assertEquals(newBrokerResponse.getProcessingExceptions().get(0).getErrorCode(),
         QueryException.BROKER_RESOURCE_MISSING_ERROR.getErrorCode());
     Assert.assertEquals(newBrokerResponse.getProcessingExceptions().get(0).getMessage(),
         QueryException.BROKER_RESOURCE_MISSING_ERROR.getMessage());
-    System.out.println(newBrokerResponse.getProcessingExceptions().get(1));
+//    System.out.println(newBrokerResponse.getProcessingExceptions().get(1));
     Assert.assertEquals(newBrokerResponse.getProcessingExceptions().get(1).getErrorCode(), 400);
     Assert.assertEquals(newBrokerResponse.getProcessingExceptions().get(1).getMessage(), errorMsgStr);
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -79,9 +79,9 @@ public class PinotHelixResourceManagerTest {
       throws InterruptedException {
     Set<String> servers = pinotHelixResourceManager.getAllInstancesForServerTenant(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME);
     BiMap<String, String> endpoints = pinotHelixResourceManager.getDataInstanceAdminEndpoints(servers);
-    for (Map.Entry<String, String> endpointEntry : endpoints.entrySet()) {
-      System.out.println(endpointEntry.getKey() + " -- " + endpointEntry.getValue());
-    }
+//    for (Map.Entry<String, String> endpointEntry : endpoints.entrySet()) {
+//      System.out.println(endpointEntry.getKey() + " -- " + endpointEntry.getValue());
+//    }
 
     for (int i = 0; i < numInstances; i++) {
       Assert.assertTrue(endpoints.inverse().containsKey("localhost:" + String.valueOf(adminPortStart + i)));

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/chunk/creator/impl/ChunkIndexCreationDriverImplTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/chunk/creator/impl/ChunkIndexCreationDriverImplTest.java
@@ -89,7 +89,7 @@ public class ChunkIndexCreationDriverImplTest {
   public void test2() throws Exception {
     final IndexSegmentImpl segment =
         (IndexSegmentImpl) Loaders.IndexSegment.load(INDEX_DIR.listFiles()[0], ReadMode.mmap);
-    System.out.println("INdex dir:" + INDEX_DIR);
+//    System.out.println("INdex dir:" + INDEX_DIR);
     final DataSource ds = segment.getDataSource("column1");
     final Block bl = ds.nextBlock();
     final BlockValSet valSet = bl.getBlockValueSet();
@@ -143,7 +143,7 @@ public class ChunkIndexCreationDriverImplTest {
       b.append(docId + ",");
       docId = it.next();
     }
-    System.out.println(b.toString());
+//    System.out.println(b.toString());
   }
 
   @Test(enabled = false)
@@ -168,7 +168,7 @@ public class ChunkIndexCreationDriverImplTest {
       b.append(docId + ",");
       docId = it.next();
     }
-    System.out.println(b.toString());
+//    System.out.println(b.toString());
   }
 
   @Test(enabled = false)
@@ -194,7 +194,7 @@ public class ChunkIndexCreationDriverImplTest {
       b.append(docId + ",");
       docId = it.next();
     }
-    System.out.println(b.toString());
+//    System.out.println(b.toString());
   }
 
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -80,7 +80,7 @@ public class RealtimeSegmentTest {
     schema = SegmentTestUtils.extractSchemaFromAvro(new File(filePath), fieldTypeMap, TimeUnit.MINUTES);
 
     StreamProviderConfig config = new FileBasedStreamProviderConfig(FileFormat.AVRO, filePath, schema);
-    System.out.println(config);
+//    System.out.println(config);
     StreamProvider provider = new FileBasedStreamProviderImpl();
     final String tableName = RealtimeSegmentTest.class.getSimpleName() + ".noTable";
     provider.init(config, tableName, new ServerMetrics(new MetricsRegistry()));

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestOffheapStarTreeBuilder.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestOffheapStarTreeBuilder.java
@@ -89,7 +89,7 @@ public class TestOffheapStarTreeBuilder {
     Iterator<GenericRow> iterator = builder.iterator(0, totalDocs);
     while(iterator.hasNext()) {
       GenericRow row = iterator.next();
-      System.out.println(row);
+//      System.out.println(row);
     }
 
     iterator = builder.iterator(builder.getTotalRawDocumentCount(), totalDocs);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeDataTable.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeDataTable.java
@@ -23,10 +23,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Random;
-
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
@@ -50,20 +49,20 @@ public class TestStarTreeDataTable {
     out.close();
     dos.flush();
     dos.close();
-    print(data);
-    System.out.println("BEFORE SORTING: " + tempFile.length());
+//    print(data);
+//    System.out.println("BEFORE SORTING: " + tempFile.length());
     int[][] input = read(tempFile, ROWS, COLS);
 
     int[] sortOrder = new int[COLS];
     for (int i = 0; i < COLS; i++) {
       sortOrder[i] = i;
     }
-    
+
     StarTreeDataTable sorter = new StarTreeDataTable(tempFile, COLS * (Integer.SIZE / 8), 0, sortOrder);
     sorter.sort(0, ROWS);
-    System.out.println("AFTER SORTING");
+//    System.out.println("AFTER SORTING");
     int[][] output = read(tempFile, ROWS, COLS);
-    print(output);
+//    print(output);
     Arrays.sort(input, new Comparator<int[]>() {
       @Override
       public int compare(int[] o1, int[] o2) {
@@ -75,12 +74,14 @@ public class TestStarTreeDataTable {
         return 0;
       }
     });
-    if (compare(input, output, ROWS)) {
-      System.out.println("PASSED");
-    } else {
-      System.out.println("FAILED");
-    }
-    System.out.println(sorter.groupByIntColumnCount(0, ROWS, 0));
+
+    Assert.assertTrue(compare(input, output, ROWS));
+//    if (compare(input, output, ROWS)) {
+//      System.out.println("PASSED");
+//    } else {
+//      System.out.println("FAILED");
+//    }
+//    System.out.println(sorter.groupByIntColumnCount(0, ROWS, 0));
 
   }
 
@@ -97,9 +98,9 @@ public class TestStarTreeDataTable {
   }
 
   public static void print(int[][] output) {
-    for (int i = 0; i < output.length; i++) {
-      System.out.println(Arrays.toString(output[i]));
-    }
+//    for (int i = 0; i < output.length; i++) {
+//      System.out.println(Arrays.toString(output[i]));
+//    }
   }
 
   public static int[][] read(File tempFile, int numRows, int numCols) throws IOException {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/util/CrcUtilsTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/util/CrcUtilsTest.java
@@ -66,8 +66,8 @@ public class CrcUtilsTest {
     final com.linkedin.pinot.core.indexsegment.IndexSegment segment = Loaders.IndexSegment.load(new File(makeSegmentAndReturnPath()), ReadMode.mmap);
     final SegmentMetadata m = segment.getSegmentMetadata();
 
-    System.out.println(m.getCrc());
-    System.out.println(m.getIndexCreationTime());
+//    System.out.println(m.getCrc());
+//    System.out.println(m.getIndexCreationTime());
 
     FileUtils.deleteQuietly(INDEX_DIR);
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/util/CustomBitSetTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/util/CustomBitSetTest.java
@@ -51,8 +51,8 @@ public class CustomBitSetTest {
     customBitSet.setBit(0);
     customBitSet.setBit(100);
     customBitSet.setBit(250);
-    System.out.println(customBitSet.findNthBitSetAfter(0, 1));
-    System.out.println(customBitSet.findNthBitSetAfter(100, 1));
+//    System.out.println(customBitSet.findNthBitSetAfter(0, 1));
+//    System.out.println(customBitSet.findNthBitSetAfter(100, 1));
     customBitSet.close();
 
   }
@@ -132,7 +132,7 @@ public class CustomBitSetTest {
 
       long nthBitSetAfter = customBitSet.findNthBitSetAfter(startSearchIndex, nthBitToFind);
       if (nthBitSetAfter != expectedIndex) {
-        System.out.println("Bits set " + bitsOnCopy + ", searching for " + nthBitToFind + "th bit from " + startSearchIndex);
+//        System.out.println("Bits set " + bitsOnCopy + ", searching for " + nthBitToFind + "th bit from " + startSearchIndex);
         nthBitSetAfter = customBitSet.findNthBitSetAfter(startSearchIndex, nthBitToFind);
       }
       Assert.assertEquals(nthBitSetAfter, expectedIndex, "Bits set " +

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/util/PinotDataCustomBitSetTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/util/PinotDataCustomBitSetTest.java
@@ -51,8 +51,8 @@ public class PinotDataCustomBitSetTest {
     bitset.setBit(0);
     bitset.setBit(100);
     bitset.setBit(250);
-    System.out.println(bitset.findNthBitSetAfter(0, 1));
-    System.out.println(bitset.findNthBitSetAfter(100, 1));
+//    System.out.println(bitset.findNthBitSetAfter(0, 1));
+//    System.out.println(bitset.findNthBitSetAfter(100, 1));
     bitset.close();
 
   }
@@ -132,7 +132,7 @@ public class PinotDataCustomBitSetTest {
 
       long nthBitSetAfter = bitset.findNthBitSetAfter(startSearchIndex, nthBitToFind);
       if (nthBitSetAfter != expectedIndex) {
-        System.out.println("Bits set " + bitsOnCopy + ", searching for " + nthBitToFind + "th bit from " + startSearchIndex);
+//        System.out.println("Bits set " + bitsOnCopy + ", searching for " + nthBitToFind + "th bit from " + startSearchIndex);
         nthBitSetAfter = bitset.findNthBitSetAfter(startSearchIndex, nthBitToFind);
       }
       Assert.assertEquals(nthBitSetAfter, expectedIndex, "Bits set " +

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/reader/FixedBitWidthRowColDataFileReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/reader/FixedBitWidthRowColDataFileReaderTest.java
@@ -40,7 +40,7 @@ public class FixedBitWidthRowColDataFileReaderTest {
   public void testReadIntFromByteBuffer() {
     int maxBits = 1;
     while (maxBits < 32) {
-      System.out.println("START MAX BITS:" + maxBits);
+//      System.out.println("START MAX BITS:" + maxBits);
       int numElements = 100;
       CustomBitSet customBitSet = CustomBitSet.withBitLength(numElements
           * maxBits);
@@ -72,7 +72,7 @@ public class FixedBitWidthRowColDataFileReaderTest {
         }
         Assert.assertEquals(readInt, values[i]);
       }
-      System.out.println("END MAX BITS:" + maxBits);
+//      System.out.println("END MAX BITS:" + maxBits);
       maxBits = maxBits + 1;
       customBitSet.close();
     }
@@ -92,7 +92,7 @@ public class FixedBitWidthRowColDataFileReaderTest {
       File file = new File(fileName);
       CustomBitSet bitset = null;
       try {
-        System.out.println("START MAX BITS:" + maxBits);
+//        System.out.println("START MAX BITS:" + maxBits);
         int numElements = 100;
         bitset = CustomBitSet.withBitLength(numElements * maxBits);
         int max = (int) Math.pow(2, maxBits);
@@ -136,7 +136,7 @@ public class FixedBitWidthRowColDataFileReaderTest {
         mmapReader.close();
         dataBuffer.close();
 
-        System.out.println("END MAX BITS:" + maxBits);
+//        System.out.println("END MAX BITS:" + maxBits);
       } finally {
         file.delete();
         bitset.close();
@@ -158,7 +158,7 @@ public class FixedBitWidthRowColDataFileReaderTest {
       File file = new File(fileName);
       CustomBitSet bitset = null;
       try {
-        System.out.println("START MAX BITS:" + maxBits);
+//        System.out.println("START MAX BITS:" + maxBits);
         int numElements = 100;
         int requiredBits = maxBits + 1;
         bitset = CustomBitSet.withBitLength(numElements * requiredBits);
@@ -207,7 +207,7 @@ public class FixedBitWidthRowColDataFileReaderTest {
         mmapReader.close();
         mmapBuffer.close();
 
-        System.out.println("END MAX BITS:" + maxBits);
+//        System.out.println("END MAX BITS:" + maxBits);
       } finally {
         file.delete();
         bitset.close();

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/reader/FixedByteWidthRowColDataFileReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/reader/FixedByteWidthRowColDataFileReaderTest.java
@@ -50,7 +50,7 @@ public class FixedByteWidthRowColDataFileReaderTest {
     dos.flush();
     dos.close();
     RandomAccessFile raf = new RandomAccessFile(f, "rw");
-    System.out.println("file size: " + raf.getChannel().size());
+//    System.out.println("file size: " + raf.getChannel().size());
     raf.close();
     
     PinotDataBuffer heapBuffer = PinotDataBuffer.fromFile(f, ReadMode.heap, FileChannel.MapMode.READ_ONLY, "testing");
@@ -100,7 +100,7 @@ public class FixedByteWidthRowColDataFileReaderTest {
     dos.flush();
     dos.close();
     RandomAccessFile raf = new RandomAccessFile(f, "rw");
-    System.out.println("file size: " + raf.getChannel().size());
+//    System.out.println("file size: " + raf.getChannel().size());
     raf.close();
     PinotDataBuffer heapBuffer = PinotDataBuffer.fromFile(f, ReadMode.heap, FileChannel.MapMode.READ_ONLY, "testing-heap");
     FixedByteSingleValueMultiColReader heapReader = new FixedByteSingleValueMultiColReader(heapBuffer, numRows, numCols, new int[] { 4, 4 });

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/writer/FixedBitWidthRowColDataFileWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/writer/FixedBitWidthRowColDataFileWriterTest.java
@@ -65,7 +65,7 @@ public class FixedBitWidthRowColDataFileWriterTest {
 
       writer.close();
       final RandomAccessFile raf = new RandomAccessFile(file, "r");
-      System.out.println("file size:" + raf.length());
+//      System.out.println("file size:" + raf.length());
       final byte[] b = new byte[(int) raf.length()];
       raf.read(b);
       final byte[] byteArray = set.toByteArray();

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/writer/FixedByteSkipListSCMVWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/writer/FixedByteSkipListSCMVWriterTest.java
@@ -72,16 +72,16 @@ public class FixedByteSkipListSCMVWriterTest {
     dis.read(bitsetBytes);
     CustomBitSet customBit = CustomBitSet.withByteBuffer(numBytesForBitmap, ByteBuffer.wrap(bitsetBytes));
     offset = 0;
-    System.out.println(customBit);
-    RandomAccessFile raf = new RandomAccessFile(file, "r");
-    System.out.println("totalNumValues:" + totalNumValues);
-    System.out.println("totalDocs:" + rows);
-    System.out.println("raf.length():" + raf.length());
-    System.out.println("numChunks:" + numChunks);
-    System.out.println("getTotalSize:" + writer.getTotalSize());
-    System.out.println("getRawDataSize:" + writer.getRawDataSize());
-    System.out.println("getBitsetSize:" + writer.getBitsetSize());
-    System.out.println("getChunkOffsetHeaderSize:" + writer.getChunkOffsetHeaderSize());
+//    System.out.println(customBit);
+//    RandomAccessFile raf = new RandomAccessFile(file, "r");
+//    System.out.println("totalNumValues:" + totalNumValues);
+//    System.out.println("totalDocs:" + rows);
+//    System.out.println("raf.length():" + raf.length());
+//    System.out.println("numChunks:" + numChunks);
+//    System.out.println("getTotalSize:" + writer.getTotalSize());
+//    System.out.println("getRawDataSize:" + writer.getRawDataSize());
+//    System.out.println("getBitsetSize:" + writer.getBitsetSize());
+//    System.out.println("getChunkOffsetHeaderSize:" + writer.getChunkOffsetHeaderSize());
     for (int i = 0; i < rows; i++) {
       Assert.assertTrue(customBit.isBitSet(offset));
       for (int j = 0; j < data[i].length; j++) {
@@ -91,7 +91,7 @@ public class FixedByteSkipListSCMVWriterTest {
     }
     dis.close();
     file.delete();
-    raf.close();
+//    raf.close();
     customBit.close();
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/writer/FixedByteWidthRowColDataFileWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/writer/FixedByteWidthRowColDataFileWriterTest.java
@@ -188,7 +188,7 @@ public class FixedByteWidthRowColDataFileWriterTest {
     int cols = 1;
     String testString1 = new String(bytes1);
     String testString2 = new String(bytes2);
-    System.out.println(Arrays.toString(bytes2));
+//    System.out.println(Arrays.toString(bytes2));
     int stringColumnMaxLength = Math.max(testString1.getBytes().length, testString2.getBytes().length);
     int[] columnSizes = new int[] { stringColumnMaxLength };
     FixedByteSingleValueMultiColWriter writer = new FixedByteSingleValueMultiColWriter(file, rows, cols, columnSizes);
@@ -230,7 +230,7 @@ public class FixedByteWidthRowColDataFileWriterTest {
       int cols = 1;
       String testString1 = new String(bytes1);
       String testString2 = new String(bytes2);
-      System.out.println(Arrays.toString(bytes2));
+//      System.out.println(Arrays.toString(bytes2));
       int stringColumnMaxLength = Math.max(testString1.getBytes().length, testString2.getBytes().length);
       int[] columnSizes = new int[]{stringColumnMaxLength};
       FixedByteSingleValueMultiColWriter writer = new FixedByteSingleValueMultiColWriter(file, rows, cols, columnSizes);

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/AndOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/AndOperatorTest.java
@@ -49,7 +49,7 @@ public class AndOperatorTest {
       final BlockDocIdIterator iterator = blockDocIdSet.iterator();
       int docId;
       while ((docId = iterator.next()) != Constants.EOF) {
-        System.out.println(docId);
+//        System.out.println(docId);
       }
     }
     andOperator.close();
@@ -75,7 +75,7 @@ public class AndOperatorTest {
       final BlockDocIdIterator iterator = blockDocIdSet.iterator();
       int docId;
       while ((docId = iterator.next()) != Constants.EOF) {
-        System.out.println(docId);
+//        System.out.println(docId);
       }
     }
     andOperator.close();
@@ -105,7 +105,7 @@ public class AndOperatorTest {
       final BlockDocIdIterator iterator = blockDocIdSet.iterator();
       int docId;
       while ((docId = iterator.next()) != Constants.EOF) {
-        System.out.println(docId);
+//        System.out.println(docId);
       }
     }
     andOperator.close();
@@ -135,7 +135,7 @@ public class AndOperatorTest {
       final BlockDocIdIterator iterator = blockDocIdSet.iterator();
       int docId;
       while ((docId = iterator.next()) != Constants.EOF) {
-        System.out.println(docId);
+//        System.out.println(docId);
       }
     }
     andOperator.close();

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/OrOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/OrOperatorTest.java
@@ -124,7 +124,7 @@ public class OrOperatorTest {
       final BlockDocIdIterator iterator = blockDocIdSet.iterator();
       int docId;
       while ((docId = iterator.next()) != Constants.EOF) {
-        System.out.println(docId);
+//        System.out.println(docId);
         Assert.assertEquals(expectedIterator.next().intValue(), docId);
       }
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/QueriesSentinelTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/QueriesSentinelTest.java
@@ -89,7 +89,7 @@ public class QueriesSentinelTest {
     instanceDataManager.init(new FileBasedInstanceDataManagerConfig(serverConf.subset("pinot.server.instance")));
     instanceDataManager.start();
 
-    System.out.println("************************** : " + new File(INDEX_DIR, "segment").getAbsolutePath());
+//    System.out.println("************************** : " + new File(INDEX_DIR, "segment").getAbsolutePath());
     File segmentFile = new File(INDEX_DIR, "segment").listFiles()[0];
     segmentName = segmentFile.getName();
     final IndexSegment indexSegment = ColumnarSegmentLoader.load(segmentFile, ReadMode.heap);
@@ -250,7 +250,7 @@ public class QueriesSentinelTest {
 
   private void setUpTestQueries(String table) throws FileNotFoundException, IOException {
     final String filePath = TestUtils.getFileFromResourceUrl(getClass().getClassLoader().getResource(AVRO_DATA));
-    System.out.println(filePath);
+//    System.out.println(filePath);
     final List<String> dims = new ArrayList<String>();
     dims.add("column1");
     dims.add("column2");
@@ -292,7 +292,7 @@ public class QueriesSentinelTest {
     driver.init(config);
     driver.build();
 
-    System.out.println("built at : " + INDEX_DIR.getAbsolutePath());
+//    System.out.println("built at : " + INDEX_DIR.getAbsolutePath());
   }
 
   @Test

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/QueryExceptionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/QueryExceptionTest.java
@@ -80,7 +80,7 @@ public class QueryExceptionTest {
     instanceDataManager.init(new FileBasedInstanceDataManagerConfig(serverConf.subset("pinot.server.instance")));
     instanceDataManager.start();
 
-    System.out.println("************************** : " + new File(INDEX_DIR, "segment").getAbsolutePath());
+//    System.out.println("************************** : " + new File(INDEX_DIR, "segment").getAbsolutePath());
     File segmentFile = new File(INDEX_DIR, "segment").listFiles()[0];
     segmentName = segmentFile.getName();
     final IndexSegment indexSegment = ColumnarSegmentLoader.load(segmentFile, ReadMode.heap);
@@ -114,7 +114,7 @@ public class QueryExceptionTest {
     driver.init(config);
     driver.build();
 
-    System.out.println("built at : " + INDEX_DIR.getAbsolutePath());
+//    System.out.println("built at : " + INDEX_DIR.getAbsolutePath());
   }
 
   @Test

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
@@ -245,7 +245,7 @@ public class RealtimeQueriesSentinelTest {
 
   private void setUpTestQueries(String table) throws FileNotFoundException, IOException {
     final String filePath = TestUtils.getFileFromResourceUrl(getClass().getClassLoader().getResource(AVRO_DATA));
-    System.out.println(filePath);
+//    System.out.println(filePath);
     final List<String> dims = new ArrayList<String>();
     dims.add("column1");
     dims.add("column2");
@@ -290,8 +290,8 @@ public class RealtimeQueriesSentinelTest {
     } catch (Exception e) {
       e.printStackTrace();
     }
-    System.out.println("Current raw events indexed: " + realtimeSegmentImpl.getRawDocumentCount() + ", totalDocs = "
-        + realtimeSegmentImpl.getSegmentMetadata().getTotalDocs());
+//    System.out.println("Current raw events indexed: " + realtimeSegmentImpl.getRawDocumentCount() + ", totalDocs = "
+//        + realtimeSegmentImpl.getSegmentMetadata().getTotalDocs());
     realtimeSegmentImpl.setSegmentMetadata(getRealtimeSegmentZKMetadata());
     return realtimeSegmentImpl;
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/executor/BrokerReduceServiceTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/executor/BrokerReduceServiceTest.java
@@ -131,7 +131,7 @@ public class BrokerReduceServiceTest {
       File parent = new File(INDEXES_DIR, "segment_" + String.valueOf(i));
       String segmentName = parent.list()[0];
       _indexSegmentList.add(ColumnarSegmentLoader.load(new File(parent, segmentName), ReadMode.mmap));
-      System.out.println("built at : " + segmentDir.getAbsolutePath());
+//      System.out.println("built at : " + segmentDir.getAbsolutePath());
     }
   }
 
@@ -424,7 +424,7 @@ public class BrokerReduceServiceTest {
       LOGGER.info("Num Docs Scanned is " + brokerResponse.getNumDocsScanned());
       LOGGER.info("Total Docs for BrokerResponse is " + brokerResponse.getTotalDocs());
 
-      System.out.println(brokerResponse.toJson());
+//      System.out.println(brokerResponse.toJson());
     } catch (Exception e) {
       e.printStackTrace();
       // Should never happen

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
@@ -126,7 +126,7 @@ public class QueryExecutorTest {
       String segmentName = parent.list()[0];
       _indexSegmentList.add(ColumnarSegmentLoader.load(new File(parent, segmentName), ReadMode.mmap));
 
-      System.out.println("built at : " + segmentDir.getAbsolutePath());
+//      System.out.println("built at : " + segmentDir.getAbsolutePath());
     }
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/BitmapInvertedIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/BitmapInvertedIndexTest.java
@@ -115,6 +115,6 @@ public class BitmapInvertedIndexTest {
     invertedIndexColumns = new String[iiColumns.size()];
     iiColumns.toArray(invertedIndexColumns);
     segmentDirectory = new File(INDEX_DIR, driver.getSegmentName());
-    System.out.println("built at : " + INDEX_DIR.getAbsolutePath());
+//    System.out.println("built at : " + INDEX_DIR.getAbsolutePath());
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/BlocksTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/BlocksTest.java
@@ -50,7 +50,7 @@ public class BlocksTest {
       FileUtils.deleteQuietly(INDEX_DIR);
     }
 
-    System.out.println(INDEX_DIR.getAbsolutePath());
+//    System.out.println(INDEX_DIR.getAbsolutePath());
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
 
     final SegmentGeneratorConfig config =

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/IntArraysTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/IntArraysTest.java
@@ -61,7 +61,7 @@ public class IntArraysTest {
       FileUtils.deleteQuietly(INDEX_DIR);
     }
 
-    System.out.println(INDEX_DIR.getAbsolutePath());
+//    System.out.println(INDEX_DIR.getAbsolutePath());
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
 
     final SegmentGeneratorConfig config =

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -818,7 +818,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
           producer.send(messagesToWrite);
         }
 
-        System.out.println("rowsRemaining = " + rowsRemaining);
+//        System.out.println("rowsRemaining = " + rowsRemaining);
         rowsRemaining -= rowsInThisBatch;
       }
 
@@ -1042,7 +1042,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
               }
 
               if (onlinePartitionCount == expectedSegmentCount) {
-                System.out.println("Got " + expectedSegmentCount + " online tables, unlatching the main thread");
+//                System.out.println("Got " + expectedSegmentCount + " online tables, unlatching the main thread");
                 latch.countDown();
                 _hasBeenTriggered = true;
               }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/FileBasedSentineTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/FileBasedSentineTest.java
@@ -129,7 +129,7 @@ public class FileBasedSentineTest extends ControllerTest {
     final JSONObject selectionRequestResponse = postQuery("select * from 'table1' limit 100",
         "http://localhost:" + FileBasedServerBrokerStarters.BROKER_CLIENT_PORT);
 
-    System.out.println(selectionRequestResponse.toString(1));
+//    System.out.println(selectionRequestResponse.toString(1));
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -159,7 +159,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
               }
 
               if (onlinePartitionCount == offlineSegmentCount) {
-                System.out.println("Got " + offlineSegmentCount + " online tables, unlatching the main thread");
+//                System.out.println("Got " + offlineSegmentCount + " online tables, unlatching the main thread");
                 latch.countDown();
               }
             }
@@ -171,7 +171,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
     // Upload the segments
     int i = 0;
     for (String segmentName : _tarDir.list()) {
-      System.out.println("Uploading segment " + (i++) + " : " + segmentName);
+//      System.out.println("Uploading segment " + (i++) + " : " + segmentName);
       File file = new File(_tarDir, segmentName);
       FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, file, file.length());
     }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -104,7 +104,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
     // Upload the segments
     int i = 0;
     for (String segmentName : _tarDir.list()) {
-      System.out.println("Uploading segment " + (i++) + " : " + segmentName);
+//      System.out.println("Uploading segment " + (i++) + " : " + segmentName);
       File file = new File(_tarDir, segmentName);
       FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, file, file.length());
     }
@@ -115,7 +115,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
     long timeInTwoMinutes = System.currentTimeMillis() + 2 * 60 * 1000L;
     long numDocs;
     while ((numDocs = getCurrentServingNumDocs("mytable")) < TOTAL_DOCS) {
-      System.out.println("Current number of documents: " + numDocs);
+//      System.out.println("Current number of documents: " + numDocs);
       if (System.currentTimeMillis() < timeInTwoMinutes) {
         Thread.sleep(1000);
       } else {

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/integration/IntegrationTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/integration/IntegrationTest.java
@@ -124,7 +124,7 @@ public class IntegrationTest {
 
       _indexSegmentList.add(ColumnarSegmentLoader.load(new File(new File(INDEXES_DIR, "segment_" + String.valueOf(i)), driver.getSegmentName()), ReadMode.mmap));
 
-      System.out.println("built at : " + segmentDir.getAbsolutePath());
+//      System.out.println("built at : " + segmentDir.getAbsolutePath());
     }
 
   }
@@ -145,8 +145,8 @@ public class IntegrationTest {
     try {
       QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest);
-      System.out.println(instanceResponse.getLong(0, 0));
-      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
+//      System.out.println(instanceResponse.getLong(0, 0));
+//      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
     } catch (Exception e) {
       e.printStackTrace();
       throw new RuntimeException(e);
@@ -166,8 +166,8 @@ public class IntegrationTest {
     try {
       QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest);
-      System.out.println(instanceResponse.getLong(0, 0));
-      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
+//      System.out.println(instanceResponse.getLong(0, 0));
+//      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
     } catch (Exception e) {
       e.printStackTrace();
       throw new RuntimeException(e);
@@ -191,8 +191,8 @@ public class IntegrationTest {
     try {
       QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest);
-      System.out.println(instanceResponse.getDouble(0, 0));
-      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
+//      System.out.println(instanceResponse.getDouble(0, 0));
+//      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
     } catch (Exception e) {
       e.printStackTrace();
       throw new RuntimeException(e);
@@ -213,8 +213,8 @@ public class IntegrationTest {
     try {
       QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest);
-      System.out.println(instanceResponse.getDouble(0, 0));
-      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
+//      System.out.println(instanceResponse.getDouble(0, 0));
+//      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
     } catch (Exception e) {
       e.printStackTrace();
       throw new RuntimeException(e);
@@ -233,8 +233,8 @@ public class IntegrationTest {
     try {
       QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest);
-      System.out.println(instanceResponse.getDouble(0, 0));
-      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
+//      System.out.println(instanceResponse.getDouble(0, 0));
+//      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
     } catch (Exception e) {
       e.printStackTrace();
       throw new RuntimeException(e);

--- a/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilderTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilderTest.java
@@ -59,8 +59,8 @@ public class BalancedRandomRoutingTableBuilderTest {
     ServerToSegmentSetMap previous = routingTableIterator.next();
     while (routingTableIterator.hasNext()) {
       ServerToSegmentSetMap current = routingTableIterator.next();
-      System.out.println("current = " + current);
-      System.out.println("previous = " + previous);
+//      System.out.println("current = " + current);
+//      System.out.println("previous = " + previous);
       if (!current.equals(previous)) {
         // Routing tables differ, test is successful
         return;

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/ServerInstanceTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/ServerInstanceTest.java
@@ -31,8 +31,8 @@ public class ServerInstanceTest {
     {
       ServerInstance instance1 = new ServerInstance("localhost", 8080);
       ServerInstance instance2 = new ServerInstance("localhost", 8080);
-      System.out.println("Instance 1 :" + instance1);
-      System.out.println("Instance 2 :" + instance2);
+//      System.out.println("Instance 1 :" + instance1);
+//      System.out.println("Instance 2 :" + instance2);
       Assert.assertEquals(instance2, instance1, "Localhost server-instances with same port");
     }
 
@@ -40,16 +40,16 @@ public class ServerInstanceTest {
     {
       ServerInstance instance1 = new ServerInstance("test-host", 8080);
       ServerInstance instance2 = new ServerInstance("test-host", 8080);
-      System.out.println("Instance 1 :" + instance1);
-      System.out.println("Instance 2 :" + instance2);
+//      System.out.println("Instance 1 :" + instance1);
+//      System.out.println("Instance 2 :" + instance2);
       Assert.assertEquals(instance2, instance1, "Localhost server-instances with same port");
     }
     // same hostname but different port
     {
       ServerInstance instance1 = new ServerInstance("localhost", 8081);
       ServerInstance instance2 = new ServerInstance("localhost", 8082);
-      System.out.println("Instance 1 :" + instance1);
-      System.out.println("Instance 2 :" + instance2);
+//      System.out.println("Instance 1 :" + instance1);
+//      System.out.println("Instance 2 :" + instance2);
       Assert.assertFalse(instance1.equals(instance2), "Localhost server-instances with same port");
     }
 
@@ -57,8 +57,8 @@ public class ServerInstanceTest {
     {
       ServerInstance instance1 = new ServerInstance("abcd", 8080);
       ServerInstance instance2 = new ServerInstance("abce", 8080);
-      System.out.println("Instance 1 :" + instance1);
-      System.out.println("Instance 2 :" + instance2);
+//      System.out.println("Instance 1 :" + instance1);
+//      System.out.println("Instance 2 :" + instance2);
       Assert.assertFalse(instance1.equals(instance2), "Localhost server-instances with same port");
     }
 

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/routing/RandomRoutingTableTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/routing/RandomRoutingTableTest.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.routing.PercentageBasedRoutingTableSelector;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,10 +48,12 @@ import com.linkedin.pinot.transport.common.SegmentIdSet;
 public class RandomRoutingTableTest {
 
   @Test
-  public void testHelixExternalViewBasedRoutingTable() throws Exception {
+  public void testHelixExternalViewBasedRoutingTable()
+      throws Exception {
+    URL resourceUrl = getClass().getClassLoader().getResource("SampleExternalView.json");
+    Assert.assertNotNull(resourceUrl);
+    String fileName = resourceUrl.getFile();
     String tableName = "testTable_OFFLINE";
-    String fileName = RandomRoutingTableTest.class.getClassLoader().getResource("SampleExternalView.json").getFile();
-    System.out.println(fileName);
     InputStream evInputStream = new FileInputStream(fileName);
     ZNRecordSerializer znRecordSerializer = new ZNRecordSerializer();
     ZNRecord externalViewRecord = (ZNRecord) znRecordSerializer.deserialize(IOUtils.toByteArray(evInputStream));
@@ -84,14 +87,14 @@ public class RandomRoutingTableTest {
         Assert.assertTrue(arrays[j] / totalRuns <= 31);
         Assert.assertTrue(arrays[j] / totalRuns >= 28);
       }
-      //System.out.println(Arrays.toString(arrays) + " : " + new StandardDeviation().evaluate(arrays) + " : " + new Mean().evaluate(arrays));
+//      System.out.println(Arrays.toString(arrays) + " : " + new StandardDeviation().evaluate(arrays) + " : " + new Mean().evaluate(arrays));
     }
     for (int i = 0; i < globalArrays.length; ++i) {
       Assert.assertTrue(globalArrays[i] / totalRuns <= 31);
       Assert.assertTrue(globalArrays[i] / totalRuns >= 28);
     }
-    System.out.println(Arrays.toString(globalArrays) + " : " + new StandardDeviation().evaluate(globalArrays) + " : "
-        + new Mean().evaluate(globalArrays));
+//    System.out.println(Arrays.toString(globalArrays) + " : " + new StandardDeviation().evaluate(globalArrays) + " : "
+//        + new Mean().evaluate(globalArrays));
   }
 
   /**

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -90,7 +90,7 @@ public class NettySingleConnectionIntegrationTest {
       String gotResponse = new String(b2);
       Assert.assertEquals(gotResponse, server.getResponseStr(), "Response Check at client");
       Assert.assertEquals(server.getHandler().getRequest(), request, "Request Check at server");
-      System.out.println(metric);
+//      System.out.println(metric);
     } finally {
       if (null != clientConn) {
         clientConn.close();
@@ -144,7 +144,7 @@ public class NettySingleConnectionIntegrationTest {
       PoolStats stats;
       /* Validate with no connection in pool */
       Thread.sleep(3000);   // Give the pool enough time to create connections (in this case, 2 connections minSize)
-      System.out.println("Validating with no used objects in the pool");
+//      System.out.println("Validating with no used objects in the pool");
       pool.validate(false);
       stats = pool.getStats(); // System.out.println(stats);
       Assert.assertEquals(2, stats.getPoolSize());
@@ -155,7 +155,7 @@ public class NettySingleConnectionIntegrationTest {
       future.setCancellable(cancellable);
       NettyClientConnection conn = future.getOne();
       stats = pool.getStats(); // System.out.println(stats);
-      System.out.println("Validating with one used object in the pool");
+//      System.out.println("Validating with one used object in the pool");
       pool.validate(false);
       Assert.assertEquals(2, stats.getPoolSize());
       Assert.assertEquals(0, stats.getTotalBadDestroyed());
@@ -167,7 +167,7 @@ public class NettySingleConnectionIntegrationTest {
       Thread.sleep(2000); // Wait for the client channel to be closed.
       pool.validate(false);
       Thread.sleep(5000); // Wait for the callback into AsyncPoolImpl after the destroy thread completes destroying the connection
-      System.out.println("Validating with one used object in the pool, after server shutdown");
+//      System.out.println("Validating with one used object in the pool, after server shutdown");
       stats = pool.getStats(); // System.out.println(stats);
       Assert.assertEquals(2, stats.getPoolSize());
       Assert.assertEquals(1, stats.getTotalBadDestroyed());

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
@@ -96,7 +96,7 @@ public class ScatterGatherTest {
       Map<ServerInstance, SegmentIdSet> resultMap = ctxt.getSelectedServers();
       Assert.assertEquals(resultMap.size(), 1, "Count");
       Assert.assertEquals(resultMap.get(serverInstance1), pg, "Element check");
-      System.out.println(ctxt);
+//      System.out.println(ctxt);
     }
 
     {
@@ -132,7 +132,7 @@ public class ScatterGatherTest {
       Assert.assertEquals(resultMap.size(), 2, "Count");
       Assert.assertEquals(resultMap.get(serverInstance1), pg, "Element check");
       Assert.assertEquals(resultMap.get(serverInstance2), pg2, "Element check");
-      System.out.println(ctxt);
+//      System.out.println(ctxt);
     }
 
     {
@@ -164,14 +164,14 @@ public class ScatterGatherTest {
       Map<ServerInstance, SegmentIdSet> resultMap = ctxt.getSelectedServers();
       Assert.assertEquals(resultMap.size(), 1, "Count");
       Assert.assertEquals(resultMap.get(serverInstance1), pg, "Element check"); // first server is getting selected
-      System.out.println(ctxt);
+//      System.out.println(ctxt);
 
       // Run selection again. Now the second server should be selected
       scImpl.selectServices(ctxt);
       resultMap = ctxt.getSelectedServers();
       Assert.assertEquals(resultMap.size(), 1, "Count");
       Assert.assertEquals(resultMap.get(serverInstance2), pg, "Element check"); // second server is getting selected
-      System.out.println(ctxt);
+//      System.out.println(ctxt);
     }
 
     {
@@ -203,14 +203,14 @@ public class ScatterGatherTest {
       Map<ServerInstance, SegmentIdSet> resultMap = ctxt.getSelectedServers();
       Assert.assertEquals(resultMap.size(), 2, "Count");
       Assert.assertFalse(resultMap.get(serverInstance1).equals(resultMap.get(serverInstance2)), "Element check"); // first server is getting selected
-      System.out.println(ctxt);
+//      System.out.println(ctxt);
 
       // Run selection again. Now the second server should be selected
       scImpl.selectServices(ctxt);
       resultMap = ctxt.getSelectedServers();
       Assert.assertEquals(resultMap.size(), 2, "Count");
       Assert.assertFalse(resultMap.get(serverInstance1).equals(resultMap.get(serverInstance2)), "Element check"); // first server is getting selected
-      System.out.println(ctxt);
+//      System.out.println(ctxt);
     }
   }
 
@@ -474,10 +474,8 @@ public class ScatterGatherTest {
     Map<ServerInstance, Throwable> errorMap = fut.getError();
     Assert.assertEquals(errorMap.size(), 1, "One error");
     Assert.assertNotNull(errorMap.get(serverInstance4), "Server4 returned timeout");
-    System.out.println("Error is :" + errorMap.get(serverInstance4));
 
     Thread.sleep(3000);
-    System.out.println("Pool Stats :" + pool.getStats());
     pool.getStats().refresh();
     Assert.assertEquals(pool.getStats().getTotalBadDestroyed(), 1, "Total Bad destroyed");
 
@@ -592,10 +590,10 @@ public class ScatterGatherTest {
     Map<ServerInstance, Throwable> errorMap = fut.getError();
     Assert.assertEquals(errorMap.size(), 1, "One error");
     Assert.assertNotNull(errorMap.get(serverInstance4), "Server4 returned timeout");
-    System.out.println("Error is :" + errorMap.get(serverInstance4));
+//    System.out.println("Error is :" + errorMap.get(serverInstance4));
 
     Thread.sleep(3000);
-    System.out.println("Pool Stats :" + pool.getStats());
+//    System.out.println("Pool Stats :" + pool.getStats());
     pool.getStats().refresh();
     Assert.assertEquals(pool.getStats().getTotalBadDestroyed(), 1, "Total Bad destroyed");
 
@@ -780,7 +778,7 @@ public class ScatterGatherTest {
 
     @Override
     public ServerInstance selectServer(SegmentId p, List<ServerInstance> orderedServers, Object hashKey) {
-      System.out.println("Partition :" + p + ", Ordered Servers :" + orderedServers);
+//      System.out.println("Partition :" + p + ", Ordered Servers :" + orderedServers);
       return orderedServers.get(0);
     }
   }


### PR DESCRIPTION
Inside tests, we should never depend on System.output to catch the failure.
Several tests are not checked by Assert, but only by System.output (not checked at all).
This is the first step to make the tests log more clear.
The next step is digging into each test and cover all the checks into Assert.
