### PR TITLE
Limit number of groups in Aggregation-GroupBy query results.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByOperator.java
@@ -56,9 +56,10 @@ public class AggregationGroupByOperator extends BaseOperator {
    * @param aggregationsInfoList List of AggregationInfo (contains context for applying aggregation functions).
    * @param groupBy GroupBy to perform
    * @param projectionOperator Projection
+   * @param numGroupsLimit Limit on number of aggregation groups returned in the result
    */
   public AggregationGroupByOperator(IndexSegment indexSegment, List<AggregationInfo> aggregationsInfoList,
-      GroupBy groupBy, MProjectionOperator projectionOperator) {
+      GroupBy groupBy, MProjectionOperator projectionOperator, int numGroupsLimit) {
 
     Preconditions.checkNotNull(indexSegment);
     Preconditions.checkArgument((aggregationsInfoList != null) && (aggregationsInfoList.size() > 0));
@@ -68,7 +69,7 @@ public class AggregationGroupByOperator extends BaseOperator {
     _indexSegment = indexSegment;
     _aggregationInfoList = aggregationsInfoList;
     _projectionOperator = projectionOperator;
-    _groupByExecutor = new DefaultGroupByExecutor(indexSegment, aggregationsInfoList, groupBy);
+    _groupByExecutor = new DefaultGroupByExecutor(indexSegment, aggregationsInfoList, groupBy, numGroupsLimit);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DoubleGroupByResultHolder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DoubleGroupByResultHolder.java
@@ -16,6 +16,9 @@
 package com.linkedin.pinot.core.operator.aggregation.groupby;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.Pairs.IntDoublePair;
+import com.linkedin.pinot.core.util.IntDoubleIndexedPriorityQueue;
+import it.unimi.dsi.fastutil.ints.Int2DoubleOpenHashMap;
 import java.util.Arrays;
 
 
@@ -23,24 +26,38 @@ import java.util.Arrays;
  * Result Holder implemented using DoubleArray.
  */
 public class DoubleGroupByResultHolder implements GroupByResultHolder {
+
   private double[] _resultArray;
+  private Int2DoubleOpenHashMap _resultMap;
   private final double _defaultValue;
 
   private int _resultHolderCapacity;
   private final int _maxCapacity;
+  private boolean _minHeap;
+
+  private StorageMode _storageMode;
+  private IntDoubleIndexedPriorityQueue _priorityQueue;
 
   /**
    * Constructor for the class.
    *
-   * @param initialCapacity
-   * @param maxCapacity
-   * @param defaultValue
+   * @param initialCapacity Initial capacity for storage
+   * @param maxCapacity Max capacity of storage, beyond which trimming kicks in
+   * @param defaultValue Default value of un-initialized results (in array mode)
+   * @param minOrder Min ordering (in case of min aggregation functions)
    */
-  public DoubleGroupByResultHolder(int initialCapacity, int maxCapacity, double defaultValue) {
+  public DoubleGroupByResultHolder(int initialCapacity, int maxCapacity, double defaultValue,
+      boolean minOrder) {
     _resultHolderCapacity = initialCapacity;
     _defaultValue = defaultValue;
     _maxCapacity = maxCapacity;
+    _minHeap = !minOrder; // Max ordering requires min-heap for trimming results, and vice-versa.
 
+    // Used only when group keys need to be trimmed.
+    _resultMap = null;
+    _priorityQueue = null;
+
+    _storageMode = StorageMode.ARRAY_STORAGE;
     _resultArray = new double[initialCapacity];
     if (defaultValue != 0.0) {
       Arrays.fill(_resultArray, defaultValue);
@@ -48,12 +65,35 @@ public class DoubleGroupByResultHolder implements GroupByResultHolder {
   }
 
   /**
-   * {@inheritDoc}
+   * Constructor for the class, assumes max (max on top) ordering for trim.
    *
-   * @param capacity
+   * @param initialCapacity Initial capacity for storage
+   * @param maxCapacity Max capacity of storage, beyond which trimming kicks in
+   * @param defaultValue Default value of un-initialized results (in array mode)
+   */
+  public DoubleGroupByResultHolder(int initialCapacity, int maxCapacity, double defaultValue) {
+    this(initialCapacity, maxCapacity, defaultValue, false /* minOrdering */);
+  }
+
+  /**
+   * {@inheritDoc}
+   * For array mode, expands the array size as long as it is under {@link #_maxCapacity},
+   * else switches to map mode. For map mode, trims the result.
+   *
+   * @param capacity Capacity required (number of group keys expected to be stored)
    */
   @Override
   public void ensureCapacity(int capacity) {
+    // Nothing to be done for map mode.
+    if (_storageMode == StorageMode.MAP_STORAGE) {
+      return;
+    }
+
+    if (capacity > _maxCapacity) {
+      switchToMapMode(capacity);
+      return;
+    }
+
     Preconditions.checkArgument(capacity <= _maxCapacity);
 
     if (capacity > _resultHolderCapacity) {
@@ -85,13 +125,12 @@ public class DoubleGroupByResultHolder implements GroupByResultHolder {
    */
   @Override
   public double getDoubleResult(int groupKey) {
-    return _resultArray[groupKey];
+    return (_storageMode == StorageMode.ARRAY_STORAGE) ? _resultArray[groupKey] : _resultMap.get(groupKey);
   }
 
   @Override
   public <T> T getResult(int groupKey) {
-    throw new RuntimeException(
-        "Unsupported method getResult (returning Object) for class " + getClass().getName());
+    throw new RuntimeException("Unsupported method getResult (returning Object) for class " + getClass().getName());
   }
 
   /**
@@ -102,12 +141,72 @@ public class DoubleGroupByResultHolder implements GroupByResultHolder {
    */
   @Override
   public void setValueForKey(int groupKey, double newValue) {
-    _resultArray[groupKey] = newValue;
+    if (_storageMode == StorageMode.ARRAY_STORAGE) {
+      _resultArray[groupKey] = newValue;
+    } else {
+      _resultMap.put(groupKey, newValue);
+      _priorityQueue.put(groupKey, newValue);
+    }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * @param groupKey Key for which to set the value
+   * @param newValue Value to set
+   */
   @Override
   public void setValueForKey(int groupKey, Object newValue) {
     throw new RuntimeException(
         "Unsupported method 'setValueForKey' (with Object param) for class " + getClass().getName());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * Keys with 'lowest' values (as per the sort order) are trimmed away to reduce
+   * the size to _maxCapacity.
+   *
+   * @param targetSize Target size to trim the result set to.
+   * @return Array of keys that were trimmed out.
+   */
+  @Override
+  public int[] trimResults(int targetSize) {
+    if (_storageMode == StorageMode.ARRAY_STORAGE) {
+      return EMPTY_ARRAY; // Still in array mode, trimming has not kicked in yet.
+    }
+
+    int currentNumKeys = _resultMap.size();
+    if (currentNumKeys <= _maxCapacity) {
+      return EMPTY_ARRAY;
+    }
+
+    // Current number of keys has exceeded the max capacity, we need to remove some keys.
+    int numKeysToRemove = currentNumKeys - targetSize;
+    int[] removedGroupKeys = new int[numKeysToRemove];
+
+    for (int i = 0; i < numKeysToRemove; i++) {
+      IntDoublePair pair = _priorityQueue.poll();
+      int groupKey = pair.getIntValue();
+      _resultMap.remove(groupKey);
+      removedGroupKeys[i] = groupKey;
+    }
+    return removedGroupKeys;
+  }
+
+  /**
+   * Helper method to switch the storage from array mode to map mode.
+   *
+   * @param initialPriorityQueueSize Initial size of priority queue
+   */
+  private void switchToMapMode(int initialPriorityQueueSize) {
+    _storageMode = StorageMode.MAP_STORAGE;
+    _resultMap = new Int2DoubleOpenHashMap(_resultArray.length);
+    _priorityQueue = new IntDoubleIndexedPriorityQueue(initialPriorityQueueSize, _minHeap);
+
+    for (int id = 0; id < _resultArray.length; id++) {
+      _resultMap.put(id, _resultArray[id]);
+      _priorityQueue.put(id, _resultArray[id]);
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupByResultHolder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupByResultHolder.java
@@ -19,6 +19,13 @@ package com.linkedin.pinot.core.operator.aggregation.groupby;
  * Interface for ResultHolder to store results of GroupByAggregation.
  */
 public interface GroupByResultHolder {
+  int[] EMPTY_ARRAY = {};
+
+  // Array mode for size <= _maxCapacity, map mode otherwise.
+  enum StorageMode {
+    ARRAY_STORAGE,
+    MAP_STORAGE
+  }
 
   /**
    * Stores the given value (of type double) for the given groupKey.
@@ -65,4 +72,11 @@ public interface GroupByResultHolder {
    * @param capacity
    */
   void ensureCapacity(int capacity);
+
+  /**
+   * Trim the results to a pre-specified size.
+   * @param targetSize Target size to trim the result set to.
+   * @return List of group keys that were removed.
+   */
+  int[] trimResults(int targetSize);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupKeyGenerator.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.operator.aggregation.groupby;
 
 import com.linkedin.pinot.core.query.utils.Pair;
 import java.util.Iterator;
+import java.util.List;
 
 
 /**
@@ -78,6 +79,12 @@ public interface GroupKeyGenerator {
    * @return iterator of group keys.
    */
   Iterator<GroupKey> getUniqueGroupKeys();
+
+  /**
+   * Purge the given group keys.
+   * @param keysToPurge Group keys to purge
+   */
+  void purgeKeys(int[] keysToPurge);
 
   /**
    * This class encapsulates the integer group key and the string group key.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -36,11 +36,13 @@ public class AggregationGroupByPlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger("QueryPlanLog");
   private final IndexSegment _indexSegment;
   private final BrokerRequest _brokerRequest;
+  private int _numAggrGroupsLimit;
   private final ProjectionPlanNode _projectionPlanNode;
 
-  public AggregationGroupByPlanNode(IndexSegment indexSegment, BrokerRequest query) {
+  public AggregationGroupByPlanNode(IndexSegment indexSegment, BrokerRequest query, int numAggrGroupsLimit) {
     _indexSegment = indexSegment;
     _brokerRequest = query;
+    _numAggrGroupsLimit = numAggrGroupsLimit;
     _projectionPlanNode = new ProjectionPlanNode(_indexSegment, getAggregationGroupByRelatedColumns(),
         new DocIdSetPlanNode(_indexSegment, _brokerRequest, 5000));
   }
@@ -62,7 +64,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
   public Operator run() {
     MProjectionOperator projectionOperator = (MProjectionOperator) _projectionPlanNode.run();
     return new AggregationGroupByOperator(_indexSegment, _brokerRequest.getAggregationsInfo(),
-        _brokerRequest.getGroupBy(), projectionOperator);
+        _brokerRequest.getGroupBy(), projectionOperator, _numAggrGroupsLimit);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/IntDoubleIndexedPriorityQueue.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/IntDoubleIndexedPriorityQueue.java
@@ -93,7 +93,7 @@ public class IntDoubleIndexedPriorityQueue extends BaseIndexedPriorityQueue {
     }
 
     int index = _keyToIndexMap.get(key);
-    double value = _values.get(index);
+    double value = _values.getDouble(index);
     _reusablePair.setIntValue(index);
     _reusablePair.setDoubleValue(value);
 
@@ -118,7 +118,7 @@ public class IntDoubleIndexedPriorityQueue extends BaseIndexedPriorityQueue {
     IntDoublePair poll = peek();
     int lastIndex = _values.size() - 1;
     swapValues(0, lastIndex);
-    _values.remove(lastIndex);
+    _values.removeDouble(lastIndex);
 
     _keyToIndexMap.remove(_indexToKeyMap.get(lastIndex));
     _indexToKeyMap.remove(lastIndex);
@@ -145,7 +145,7 @@ public class IntDoubleIndexedPriorityQueue extends BaseIndexedPriorityQueue {
       throw new RuntimeException("Empty collection");
     }
     _reusablePair.setIntValue(_indexToKeyMap.get(0));
-    _reusablePair.setDoubleValue(_values.get(0));
+    _reusablePair.setDoubleValue(_values.getDouble(0));
     return _reusablePair;
   }
 
@@ -172,8 +172,8 @@ public class IntDoubleIndexedPriorityQueue extends BaseIndexedPriorityQueue {
 
     while (index != 0) {
       int parentIndex = getParentIndex(index);
-      double value = _values.get(index);
-      double parentValue = _values.get(parentIndex);
+      double value = _values.getDouble(index);
+      double parentValue = _values.getDouble(parentIndex);
 
       if (compare(parentValue, value) == 1) {
         swapValues(index, parentIndex);
@@ -210,8 +210,8 @@ public class IntDoubleIndexedPriorityQueue extends BaseIndexedPriorityQueue {
       } else if (rightChildIndex >= size) { // Node only has left child which will be the minimum.
         minIndex = leftChildIndex;
       } else { // Node has both left and right children, find the minimum of the two.
-        double leftChildValue = _values.get(leftChildIndex);
-        double rightChildValue = _values.get(rightChildIndex);
+        double leftChildValue = _values.getDouble(leftChildIndex);
+        double rightChildValue = _values.getDouble(rightChildIndex);
 
         if (compare(leftChildValue, rightChildValue) <= 0) {
           minIndex = leftChildIndex;
@@ -221,7 +221,7 @@ public class IntDoubleIndexedPriorityQueue extends BaseIndexedPriorityQueue {
       }
 
       // One of the children is out of order, need to sift down.
-      if (compare(_values.get(index), _values.get(minIndex)) == 1) {
+      if (compare(_values.getDouble(index), _values.getDouble(minIndex)) == 1) {
         swapValues(index, minIndex);
         index = minIndex;
         sifted = true;
@@ -261,7 +261,10 @@ public class IntDoubleIndexedPriorityQueue extends BaseIndexedPriorityQueue {
     if (index1 == index2) {
       return;
     }
-    Collections.swap(_values, index1, index2);
+
+    double tmp = _values.getDouble(index1);
+    _values.set(index1, _values.getDouble(index2));
+    _values.set(index2, tmp);
     swapKeys(index1, index2);
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/groupby/result/ObjectGroupByResultHolderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/groupby/result/ObjectGroupByResultHolderTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.operator.groupby.result;
+
+import com.linkedin.pinot.common.utils.Pairs;
+import com.linkedin.pinot.common.utils.Pairs.IntObjectPair;
+import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
+import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
+import com.linkedin.pinot.core.query.aggregation.function.AvgAggregationFunction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link ObjectGroupByResultHolder}
+ */
+public class ObjectGroupByResultHolderTest {
+
+  private static final int INITIAL_CAPACITY = 100;
+  private static final int MAX_CAPACITY = 1000;
+
+  /**
+   * Tests that trimming of results with max ordering is correct.
+   */
+  @Test
+  public void testMaxTrimResults() {
+    testTrimResults(false);
+  }
+
+  /**
+   * Tests that trimming of results with min ordering is correct.
+   */
+  @Test
+  public void testMinTrimResults() {
+    testTrimResults(true);
+  }
+
+  /**
+   * Helper method for testing trimming of results.
+   * @param minOrder Min ordering if true, max ordering else.
+   */
+  private void testTrimResults(final boolean minOrder) {
+    long seed = System.nanoTime();
+    Random random = new Random(seed);
+
+    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(INITIAL_CAPACITY, INITIAL_CAPACITY, minOrder);
+    List<IntObjectPair> expected = new ArrayList<>(MAX_CAPACITY);
+
+    for (int i = 0; i < INITIAL_CAPACITY; i++) {
+      AvgAggregationFunction.AvgPair avgPair =
+          new AvgAggregationFunction.AvgPair((double) random.nextInt(1000), (long) random.nextInt(100));
+      IntObjectPair value = new IntObjectPair(i, avgPair);
+      expected.add(value);
+      resultHolder.setValueForKey(i, avgPair);
+    }
+
+    // This will trigger switch from array based storage to map based storage.
+    resultHolder.ensureCapacity(MAX_CAPACITY);
+
+    for (int i = INITIAL_CAPACITY; i < MAX_CAPACITY; i++) {
+      AvgAggregationFunction.AvgPair avgPair =
+          new AvgAggregationFunction.AvgPair((double) random.nextInt(1000), (long) random.nextInt(100));
+      IntObjectPair value = new IntObjectPair(i, avgPair);
+      expected.add(value);
+      resultHolder.setValueForKey(i, avgPair);
+    }
+
+    Collections.sort(expected, new Pairs.IntObjectComparator(!minOrder));
+
+    // Trim the results to INITIAL_CAPACITY.
+    resultHolder.trimResults(INITIAL_CAPACITY);
+
+    // Ensure that all the correct group keys survive after trimming.
+    for (int i = 0; i < INITIAL_CAPACITY; i++) {
+      IntObjectPair pair = expected.get(i);
+      AvgAggregationFunction.AvgPair exp = (AvgAggregationFunction.AvgPair) pair.getObjectValue();
+      AvgAggregationFunction.AvgPair act = resultHolder.getResult(pair.getIntValue());
+
+      Assert.assertEquals(act.getFirst(), exp.getFirst());
+      Assert.assertEquals(act.getSecond(), exp.getSecond());
+    }
+  }
+}


### PR DESCRIPTION
In AggregationGroupByOperator, we compute all groups at segment level.
This can cause high heap usage (or even OOM), if number of groups is
extremely large (multi-million groups range). This change limits the
number of groups returned by group by operator to a pre-defined size.

1. Added MAX_NUM_GROUPS_ALLOWED that defaults to 1M, and can be
overwritten by unix env variable "pinot.max.aggr.groups".

2. ResultHolders switch from array mode to map mode, and start trimming
groups (based on sort order) to cap the number of groups to the limit.

3. Benchmark results, on 5.5B records, 3.6M unique keys (per segment), 17 segments:
   - Takes 800 MB as opposed to > 2 GB, with similar latency.
   - With ~40M keys per segment, existing code runs OOM, where as this
     change can still perform within < 1 GB of memory.

4. Added unit tests for the same.