### PR TITLE
Add pause when waiting for EV change

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -290,6 +290,9 @@ public class PinotHelixResourceManager {
 
         // All segments match with the expected external view state
         return true;
+      } else {
+        // Segment doesn't exist in EV, wait for a little bit
+        Uninterruptibles.sleepUninterruptibly(_externalViewUpdateRetryInterval, TimeUnit.MILLISECONDS);
       }
     }
 


### PR DESCRIPTION
Add pause when waiting for EV change if the segment isn't present in
the EV. This avoids hammering ZK in certain conditions (eg. waiting
for EV change when all servers for a given segment are offline).