### PR TITLE
Fix Detection and Alert job runner that keeps working on the same monitoring window

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobContext.java
@@ -8,8 +8,6 @@ import com.linkedin.thirdeye.datalayer.dto.EmailConfigurationDTO;
 public class AlertJobContext extends JobContext {
 
   private Long alertConfigId;
-  private DateTime windowStartTime;
-  private DateTime windowEndTime;
   private EmailConfigurationDTO alertConfig;
 
   public Long getAlertConfigId() {
@@ -27,22 +25,4 @@ public class AlertJobContext extends JobContext {
   public void setAlertConfig(EmailConfigurationDTO alertConfig) {
     this.alertConfig = alertConfig;
   }
-
-  public DateTime getWindowStartTime() {
-    return windowStartTime;
-  }
-
-  public void setWindowStartTime(DateTime windowStartTime) {
-    this.windowStartTime = windowStartTime;
-  }
-
-  public DateTime getWindowEndTime() {
-    return windowEndTime;
-  }
-
-  public void setWindowEndTime(DateTime windowEndTime) {
-    this.windowEndTime = windowEndTime;
-  }
-
-
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
@@ -200,10 +200,10 @@ public class AlertJobScheduler implements JobScheduler, Runnable {
     alertJobContext.setEmailConfigurationDAO(emailConfigurationDAO);
     alertJobContext.setAlertConfigId(id);
     alertJobContext.setJobName(jobKey);
-    alertJobContext.setWindowStartTime(windowStartTime);
-    alertJobContext.setWindowEndTime(windowEndTime);
 
     job.getJobDataMap().put(AlertJobRunner.ALERT_JOB_CONTEXT, alertJobContext);
+    job.getJobDataMap().put(AlertJobRunner.ALERT_JOB_MONITORING_WINDOW_START_TIME, windowStartTime);
+    job.getJobDataMap().put(AlertJobRunner.ALERT_JOB_MONITORING_WINDOW_END_TIME, windowEndTime);
 
     try {
       quartzScheduler.scheduleJob(job, trigger);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobContext.java
@@ -8,8 +8,6 @@ import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 public class DetectionJobContext extends JobContext {
 
   private Long anomalyFunctionId;
-  private DateTime windowStartTime;
-  private DateTime windowEndTime;
   private AnomalyFunctionDTO anomalyFunctionSpec;
 
   public Long getAnomalyFunctionId() {
@@ -18,22 +16,6 @@ public class DetectionJobContext extends JobContext {
 
   public void setAnomalyFunctionId(Long anomalyFunctionId) {
     this.anomalyFunctionId = anomalyFunctionId;
-  }
-
-  public DateTime getWindowStartTime() {
-    return windowStartTime;
-  }
-
-  public void setWindowStartTime(DateTime windowStartTime) {
-    this.windowStartTime = windowStartTime;
-  }
-
-  public DateTime getWindowEndTime() {
-    return windowEndTime;
-  }
-
-  public void setWindowEndTime(DateTime windowEndTime) {
-    this.windowEndTime = windowEndTime;
   }
 
   public AnomalyFunctionDTO getAnomalyFunctionSpec() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
@@ -202,10 +202,10 @@ public class DetectionJobScheduler implements JobScheduler, Runnable {
     detectionJobContext.setAnomalyTaskDAO(anomalyTaskDAO);
     detectionJobContext.setAnomalyFunctionId(anomalyFunctionSpec.getId());
     detectionJobContext.setJobName(jobKey);
-    detectionJobContext.setWindowStartTime(windowStartTime);
-    detectionJobContext.setWindowEndTime(windowEndTime);
 
     job.getJobDataMap().put(DetectionJobRunner.DETECTION_JOB_CONTEXT, detectionJobContext);
+    job.getJobDataMap().put(DetectionJobRunner.DETECTION_JOB_MONITORING_WINDOW_START_TIME, windowStartTime);
+    job.getJobDataMap().put(DetectionJobRunner.DETECTION_JOB_MONITORING_WINDOW_END_TIME, windowEndTime);
 
     try {
       quartzScheduler.scheduleJob(job, trigger);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskGenerator.java
@@ -28,24 +28,24 @@ public class TaskGenerator {
 
   private static Logger LOG = LoggerFactory.getLogger(TaskGenerator.class);
 
-  public List<DetectionTaskInfo> createDetectionTasks(DetectionJobContext detectionJobContext)
+  public List<DetectionTaskInfo> createDetectionTasks(DetectionJobContext detectionJobContext,
+      DateTime monitoringWindowStartTime, DateTime monitoringWindowEndTime)
       throws Exception {
 
     List<DetectionTaskInfo> tasks = new ArrayList<>();
     AnomalyFunctionDTO anomalyFunctionSpec = detectionJobContext.getAnomalyFunctionSpec();
 
-    DateTime windowStartTime = detectionJobContext.getWindowStartTime();
-    DateTime windowEndTime = detectionJobContext.getWindowEndTime();
     long jobExecutionId = detectionJobContext.getJobExecutionId();
     // generate tasks
     String exploreDimensionsString = anomalyFunctionSpec.getExploreDimensions();
     if (StringUtils.isBlank(exploreDimensionsString)) {
       DetectionTaskInfo taskInfo = new DetectionTaskInfo(jobExecutionId,
-          windowStartTime, windowEndTime, anomalyFunctionSpec, null);
+          monitoringWindowStartTime, monitoringWindowEndTime, anomalyFunctionSpec, null);
       tasks.add(taskInfo);
     } else {
-        DetectionTaskInfo taskInfo = new DetectionTaskInfo(jobExecutionId, windowStartTime, windowEndTime,
-            anomalyFunctionSpec, exploreDimensionsString);
+      DetectionTaskInfo taskInfo =
+          new DetectionTaskInfo(jobExecutionId, monitoringWindowStartTime, monitoringWindowEndTime, anomalyFunctionSpec,
+              exploreDimensionsString);
         tasks.add(taskInfo);
     }
 
@@ -53,17 +53,16 @@ public class TaskGenerator {
 
   }
 
-  public List<AlertTaskInfo> createAlertTasks(AlertJobContext alertJobContext)
+  public List<AlertTaskInfo> createAlertTasks(AlertJobContext alertJobContext, DateTime monitoringWindowStartTime,
+      DateTime monitoringWindowEndTime)
       throws Exception{
 
     List<AlertTaskInfo> tasks = new ArrayList<>();
     EmailConfigurationDTO alertConfig = alertJobContext.getAlertConfig();
-    DateTime windowStartTime = alertJobContext.getWindowStartTime();
-    DateTime windowEndTime = alertJobContext.getWindowEndTime();
     long jobExecutionId = alertJobContext.getJobExecutionId();
 
 
-    AlertTaskInfo taskInfo = new AlertTaskInfo(jobExecutionId, windowStartTime, windowEndTime, alertConfig);
+    AlertTaskInfo taskInfo = new AlertTaskInfo(jobExecutionId, monitoringWindowStartTime, monitoringWindowEndTime, alertConfig);
     tasks.add(taskInfo);
     return tasks;
   }


### PR DESCRIPTION
In pull request #674, we fixed the problem where anomaly detection keeps working on the same monitoring windows. However, that fix would break adhoc detections.

This fix reverts back to the previous version and then decouples monitoring window start and end time from Detection and Alert JobContext.

The main idea of this fix is to keep JobContext stateless and pass the monitoring window start and end time as key-value pairs in jobExecutionContext.