### PR TITLE
Add a limit on number of aggregation groups in query response.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByOperator.java
@@ -56,9 +56,10 @@ public class AggregationGroupByOperator extends BaseOperator {
    * @param aggregationsInfoList List of AggregationInfo (contains context for applying aggregation functions).
    * @param groupBy GroupBy to perform
    * @param projectionOperator Projection
+   * @param numGroupsLimit Limit on number of aggr groups allowed, beyond which the results are truncated
    */
   public AggregationGroupByOperator(IndexSegment indexSegment, List<AggregationInfo> aggregationsInfoList,
-      GroupBy groupBy, MProjectionOperator projectionOperator) {
+      GroupBy groupBy, MProjectionOperator projectionOperator, int numGroupsLimit) {
 
     Preconditions.checkNotNull(indexSegment);
     Preconditions.checkArgument((aggregationsInfoList != null) && (aggregationsInfoList.size() > 0));
@@ -68,7 +69,7 @@ public class AggregationGroupByOperator extends BaseOperator {
     _indexSegment = indexSegment;
     _aggregationInfoList = aggregationsInfoList;
     _projectionOperator = projectionOperator;
-    _groupByExecutor = new DefaultGroupByExecutor(indexSegment, aggregationsInfoList, groupBy);
+    _groupByExecutor = new DefaultGroupByExecutor(indexSegment, aggregationsInfoList, groupBy, numGroupsLimit);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -36,11 +36,13 @@ public class AggregationGroupByPlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger("QueryPlanLog");
   private final IndexSegment _indexSegment;
   private final BrokerRequest _brokerRequest;
+  private int _numAggrGroupsLimit;
   private final ProjectionPlanNode _projectionPlanNode;
 
-  public AggregationGroupByPlanNode(IndexSegment indexSegment, BrokerRequest query) {
+  public AggregationGroupByPlanNode(IndexSegment indexSegment, BrokerRequest query, int numAggrGroupsLimit) {
     _indexSegment = indexSegment;
     _brokerRequest = query;
+    _numAggrGroupsLimit = numAggrGroupsLimit;
     _projectionPlanNode = new ProjectionPlanNode(_indexSegment, getAggregationGroupByRelatedColumns(),
         new DocIdSetPlanNode(_indexSegment, _brokerRequest, 5000));
   }
@@ -62,7 +64,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
   public Operator run() {
     MProjectionOperator projectionOperator = (MProjectionOperator) _projectionPlanNode.run();
     return new AggregationGroupByOperator(_indexSegment, _brokerRequest.getAggregationsInfo(),
-        _brokerRequest.getGroupBy(), projectionOperator);
+        _brokerRequest.getGroupBy(), projectionOperator, _numAggrGroupsLimit);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -46,8 +46,13 @@ import org.slf4j.LoggerFactory;
  */
 public class InstancePlanMakerImplV2 implements PlanMaker {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstancePlanMakerImplV2.class);
+
   private static final String ENABLE_NEW_AGGREGATION_GROUP_BY_CFG = "new.aggregation.groupby";
+  private static final String NUM_AGGR_GROUPS_LIMIT = "num.aggr.groups.limit";
+  private static final int DEFAULT_NUM_AGGR_GROUPS_LIMIT = 1_000_000;
+
   private boolean _enableNewAggregationGroupByCfg = false;
+  private int _numAggrGroupsLimit; // Limit on number of groups, beyond which results are truncated
 
   /**
    * Default constructor.
@@ -66,6 +71,11 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     _enableNewAggregationGroupByCfg =
         queryExecutorConfig.getConfig().getBoolean(ENABLE_NEW_AGGREGATION_GROUP_BY_CFG, true);
     LOGGER.info("New AggregationGroupBy operator: {}", (_enableNewAggregationGroupByCfg) ? "Enabled" : "Disabled");
+
+    // Read the limit on number of aggregation groups in query result from config.
+    _numAggrGroupsLimit =
+        queryExecutorConfig.getConfig().getInt(NUM_AGGR_GROUPS_LIMIT, DEFAULT_NUM_AGGR_GROUPS_LIMIT);
+    LOGGER.info("Maximum number of allowed groups for group-by query results: '{}'", _numAggrGroupsLimit);
   }
 
   @Override
@@ -88,7 +98,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
         // Aggregation GroupBy
         if (enableNewAggregationGroupBy) {
           // New implementation of group-by aggregations
-          return new AggregationGroupByPlanNode(indexSegment, brokerRequest);
+          return new AggregationGroupByPlanNode(indexSegment, brokerRequest, _numAggrGroupsLimit);
         } else {
           // Old implementation of group-by aggregations
           if (isGroupKeyFitForLong(indexSegment, brokerRequest)) {


### PR DESCRIPTION
Queries with huge numbers of aggregation groups (millions range)
increase heap usage, and may lead to OOM. This change adds a
configurable limit on the number of aggregation groups, once query
execution crosses that number, it skips processing rest of the
documents, and returns truncated results.

1. Added a server config 'num.aggr.groups.limit', with a default value
of 1 million.

2. GroupByExecutor will skip processing all remaining blocks (with a
warning logged) once this limit is reached.