### PR TITLE
Fix display of decimal numbers on anomaly charts

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -229,8 +229,14 @@ function drawMetricTimeSeries(timeSeriesData, anomalyData, tab, placeholder) {
             },
             y: {
                 tick: {
-                    //format integers with comma-grouping for thousands
-                    format: d3.format(",.1 ")
+                    //format integers with comma-grouping for thousands and round to 2 decimal numbers for floats
+                    format: function (d) {
+                        if (d % 1 == 0) {
+                            return d3.format(",")(d);
+                        } else {
+                            return d3.format(",.2f")(d);
+                        }
+                    }
                 }
             }
         },
@@ -473,8 +479,14 @@ function drawAnomalyTimeSeries(timeSeriesData,anomalyData, tab, placeholder, opt
              y: {
                  show: true,
                  tick: {
-                     //format integers with comma-grouping for thousands
-                     format: d3.format(",.1")
+                     //format integers with comma-grouping for thousands and round to 2 decimal numbers for floats
+                     format: function (d) {
+                         if (d % 1 == 0) {
+                             return d3.format(",")(d);
+                         } else {
+                             return d3.format(",.2f")(d);
+                         }
+                     }
                  },
                  min: 0
              }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -229,7 +229,6 @@ function drawMetricTimeSeries(timeSeriesData, anomalyData, tab, placeholder) {
             },
             y: {
                 tick: {
-                    //format integers with comma-grouping for thousands and round to 2 decimal numbers for floats
                     format: function (d) {
                         return getFormattedNumber(d);
                     }
@@ -475,7 +474,6 @@ function drawAnomalyTimeSeries(timeSeriesData,anomalyData, tab, placeholder, opt
              y: {
                  show: true,
                  tick: {
-                     //format integers with comma-grouping for thousands and round to 2 decimal numbers for floats
                      format: function (d) {
                          return getFormattedNumber(d);
                      }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -231,11 +231,7 @@ function drawMetricTimeSeries(timeSeriesData, anomalyData, tab, placeholder) {
                 tick: {
                     //format integers with comma-grouping for thousands and round to 2 decimal numbers for floats
                     format: function (d) {
-                        if (d % 1 == 0) {
-                            return d3.format(",")(d);
-                        } else {
-                            return d3.format(",.2f")(d);
-                        }
+                        return getFormattedNumber(d);
                     }
                 }
             }
@@ -481,11 +477,7 @@ function drawAnomalyTimeSeries(timeSeriesData,anomalyData, tab, placeholder, opt
                  tick: {
                      //format integers with comma-grouping for thousands and round to 2 decimal numbers for floats
                      format: function (d) {
-                         if (d % 1 == 0) {
-                             return d3.format(",")(d);
-                         } else {
-                             return d3.format(",.2f")(d);
-                         }
+                         return getFormattedNumber(d);
                      }
                  },
                  min: 0
@@ -763,25 +755,12 @@ function tipToUser(tab) {
     $("#" + tab + "-display-chart-section").append(tipToUser)
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+//format integers with comma-grouping for thousands and round to 2 decimal numbers for floats
+function getFormattedNumber(number) {
+    if (number % 1 == 0) {
+        return d3.format(",")(number);
+    } else {
+        return d3.format(",.2f")(number);
+    }
+}
 


### PR DESCRIPTION
1. Round decimal numbers to 2 decimal places on the chart.
2. Remove digits after decimal if the number is an integer.

For example:
Previously               --> Now
14.000000000001 --> 14.00
14                            --> 14
14000                     --> 14,000
14000.01555          --> 14,000.02