### PR TITLE
Fix loader locks out entire page during loading

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/css/main.css
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/css/main.css
@@ -408,7 +408,7 @@ body a{
 
 
 .loader{
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0px;
     margin:0px;


### PR DESCRIPTION
Fix the issue in which the loader (spinning wheel) locks out the entire page when it is loading. Now the loader only locks out the loading area.