### PR TITLE
Fix query issue for non-additive dataset

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
@@ -1,11 +1,14 @@
 package com.linkedin.thirdeye.client;
 
+import com.linkedin.thirdeye.dashboard.configs.CollectionConfig;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
+import java.util.Set;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -14,6 +17,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.api.TimeGranularity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Request object containing all information for a {@link ThirdEyeClient} to retrieve data. Request
@@ -130,6 +136,9 @@ public class ThirdEyeRequest {
   }
 
   public static class ThirdEyeRequestBuilder {
+    private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeRequestBuilder.class);
+    private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
+
     private String collection;
     private List<MetricFunction> metricFunctions;
     private DateTime startTime;
@@ -213,7 +222,7 @@ public class ThirdEyeRequest {
       return this;
     }
 
-    /** See {@link #setGroupBy(List)} */
+    /** See {@link #setGroupBy(Collection)} */
     public ThirdEyeRequestBuilder setGroupBy(String... names) {
       return setGroupBy(Arrays.asList(names));
     }
@@ -230,7 +239,7 @@ public class ThirdEyeRequest {
       return this;
     }
 
-    /** See {@link ThirdEyeRequestBuilder#addGroupBy(List)} */
+    /** See {@link ThirdEyeRequestBuilder#addGroupBy(Collection)} */
     public ThirdEyeRequestBuilder addGroupBy(String... names) {
       return addGroupBy(Arrays.asList(names));
     }
@@ -246,9 +255,60 @@ public class ThirdEyeRequest {
     }
 
     public ThirdEyeRequest build(String requestReference) {
+      try {
+        CollectionConfig collectionConfig = CACHE_REGISTRY_INSTANCE.getCollectionConfigCache().get(collection);
+        if (collectionConfig != null && collectionConfig.isNonAdditive()) {
+          List<String> collectionDimensionNames =
+              CACHE_REGISTRY_INSTANCE.getCollectionSchemaCache().get(collection).getDimensionNames();
+          decorateFilterSetForPrecomputedDataset(filterSet, groupBy, collectionDimensionNames,
+              collectionConfig.getDimensionsHaveNoPreAggregation(), collectionConfig.getPreAggregatedKeyword());
+        }
+      } catch (Exception e) {
+        LOG.debug("Collection config for collection {} does not exist", collection);
+      }
       return new ThirdEyeRequest(requestReference, this);
     }
 
-  }
+    /**
+     * Definition of Pre-Computed Data: the data that has been pre-calculated or pre-aggregated, and does not require
+     * further aggregation (i.e., aggregation function of Pinot should do no-op). For such data, we assume that there
+     * exists a dimension value named "all", which is user-definable keyword in collection configuration, that stores
+     * the pre-aggregated value.
+     *
+     * By default, when a query does not specify any value on a certain dimension, Pinot aggregates all values at that
+     * dimension, which is an undesirable behavior for pre-computed data. Therefore, this method modifies the request's
+     * dimension filters such that the filter could pick out the "all" value for that dimension.
+     *
+     * Example: Suppose that we have a dataset with 3 dimensions: country, pageName, and osName, and the pre-aggregated
+     * keyword is 'all'. Further assume that the original request's filter = {'country'='US, IN'} and GroupBy dimension =
+     * pageName, then the decorated request has the new filter = {'country'='US, IN', 'osName' = 'all'}.
+     *
+     * @param filterSet the original filterSet. <dt><b>Postconditions:</b><dd> filterSet is decorated with additional
+     * filters for filtering out the pre-aggregated value on the unspecified dimensions.
+     */
+    public static void decorateFilterSetForPrecomputedDataset(Multimap<String, String> filterSet,
+        List<String> groupByDimensions, List<String> allDimensions, List<String> dimensionsHaveNoPreAggregation,
+        String preAggregatedKeyword) {
+      Set<String> preComputedDimensionNames = new HashSet<>(allDimensions);
 
+      if (dimensionsHaveNoPreAggregation.size() != 0) {
+        preComputedDimensionNames.removeAll(dimensionsHaveNoPreAggregation);
+      }
+
+      Set<String> filterDimensions = filterSet.asMap().keySet();
+      if (filterDimensions.size() != 0) {
+        preComputedDimensionNames.removeAll(filterDimensions);
+      }
+
+      if (groupByDimensions.size() != 0) {
+        preComputedDimensionNames.removeAll(groupByDimensions);
+      }
+
+      if (preComputedDimensionNames.size() != 0) {
+        for (String preComputedDimensionName : preComputedDimensionNames) {
+          filterSet.put(preComputedDimensionName, preAggregatedKeyword);
+        }
+      }
+    }
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -126,13 +126,6 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
          resultSetGroups.add(result);
        }
     } else {
-      if (collectionConfig != null && collectionConfig.isNonAdditive()) {
-        List<String> collectionDimensionNames =
-            CACHE_REGISTRY_INSTANCE.getCollectionSchemaCache().get(request.getCollection()).getDimensionNames();
-        PqlUtils.decorateRequestForPrecomputedDataset(request, collectionDimensionNames,
-            collectionConfig.getDimensionsHaveNoPreAggregation(), collectionConfig.getPreAggregatedKeyword());
-      }
-
       String sql = PqlUtils.getPql(request, dataTimeSpec);
       LOG.debug("PQL: {}", sql);
       ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache()

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -47,50 +47,6 @@ public class PqlUtils {
   }
 
   /**
-   * Definition of Pre-Computed Data: the data that has been pre-calculated or pre-aggregated, and does not require
-   * further aggregation (i.e., aggregation function of Pinot should do no-op). For such data, we assume that there
-   * exists a dimension value named "all", which is user-definable keyword in collection configuration, that stores
-   * the pre-aggregated value.
-   *
-   * By default, when a query does not specify any value on a certain dimension, Pinot aggregates all values at that
-   * dimension, which is an undesirable behavior for pre-computed data. Therefore, this method modifies the request's
-   * dimension filters such that the filter could pick out the "all" value for that dimension.
-   *
-   * Example: Suppose that we have a dataset with 3 dimensions: country, pageName, and osName, and the pre-aggregated
-   * keyword is 'all'. Further assume that the original request's filter = {'country'='US, IN'} and GroupBy dimension =
-   * pageName, then the decorated request has the new filter = {'country'='US, IN', 'osName' = 'all'}.
-   *
-   * @param request the original request
-   * @return a request that is decorated with additional filters for filtering out the pre-aggregated value on the
-   * unspecified dimensions.
-   */
-  public static void decorateRequestForPrecomputedDataset(ThirdEyeRequest request, List<String> allDimensions,
-      List<String> dimensionsHaveNoPreAggregation, String preAggregatedKeyword) {
-    Set<String> preComputedDimensionNames = new HashSet<>(allDimensions);
-
-    if (dimensionsHaveNoPreAggregation.size() != 0) {
-      preComputedDimensionNames.removeAll(dimensionsHaveNoPreAggregation);
-    }
-
-    Multimap<String, String> filterSet = request.getFilterSet();
-    Set<String> filterDimensions = filterSet.asMap().keySet();
-    if (filterDimensions.size() != 0) {
-      preComputedDimensionNames.removeAll(filterDimensions);
-    }
-
-    List<String> groupByDimensions = request.getGroupBy();
-    if (groupByDimensions.size() != 0) {
-      preComputedDimensionNames.removeAll(groupByDimensions);
-    }
-
-    if (preComputedDimensionNames.size() != 0) {
-      for (String preComputedDimensionName : preComputedDimensionNames) {
-        filterSet.put(preComputedDimensionName, preAggregatedKeyword);
-      }
-    }
-  }
-
-  /**
    * Returns pqls to handle tables where metric names are a single dimension column,
    * and the metric values are all in a single value column
    * @param request


### PR DESCRIPTION
Fix query issue for non-additive dataset, which throws java.util.ConcurrentModificationException occasionally.

The cause of this problem is that the query for non-additive (pre-computed) data are modified for adding additional filters for selecting pre-aggregated dimension value. If a query was used as a hash key and its filter is modified, then java.util.ConcurrentModificationException could be thrown when use the query as a hash key in the second time.

For example: A query Q is created --> Q is inserted to a hash map for exploiting the benefit of asynchronous queries --> Before send Q to Pinot, Q's filter is modified for non-additive dataset --> Q is used as the key to retrieve the asynchronous results --> ConcurrentModificationException is thrown when calculating the hashcode of Q.

The fix modifies the query's filter when the query is created, i.e., the first step of above example.