### PR TITLE
Remove call to join() when the consumer thread replaces realtime segment

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -633,7 +633,12 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
    */
   public void stop() throws InterruptedException {
     _receivedStop = true;
-    _consumerThread.join();
+    // This method could be called either when we get an ONLINE transition or
+    // when we commit a segment and replace the realtime segment with a committed
+    // one. In the latter case, we don't want to call join.
+    if (Thread.currentThread() == _consumerThread) {
+      _consumerThread.join();
+    }
   }
 
   // TODO Make this a factory class.


### PR DESCRIPTION
The call to stop() can happen either from the consumer thread itself (when the segment
is committed or retained), or from the helix thread that executes the CONSUMING to ONLINE
state transtion. In the latter case, we want to call join() so that we wait for the
consumer thread to exit before examining the offsets. In the former case, we should
not be calling join().
