### PR TITLE
Avoid join() with same thread on segment commit

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -633,7 +633,16 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
    */
   public void stop() throws InterruptedException {
     _receivedStop = true;
-    _consumerThread.join();
+    // This method could be called either when we get an ONLINE transition or
+    // when we commit a segment and replace the realtime segment with a committed
+    // one. In the latter case, we don't want to call join.
+    if (Thread.currentThread() != _consumerThread) {
+      Uninterruptibles.joinUninterruptibly(_consumerThread, 10, TimeUnit.MINUTES);
+
+      if (_consumerThread.isAlive()) {
+        segmentLogger.warn("Failed to stop consumer thread within 10 minutes");
+      }
+    }
   }
 
   // TODO Make this a factory class.


### PR DESCRIPTION
Avoid calling Thread.join() with the same thread on segment commit,
as that causes the segment replace to deadlock, causing GC issues
due to live references still being held.