### PR TITLE
Generate timeseries for anomaly according to its function

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -67,10 +67,8 @@ public class DetectionTaskRunner implements TaskRunner {
 
     // Get existing anomalies for this time range and this function id
     knownAnomalies = getExistingAnomalies();
-    TimeSeriesResponse finalResponse = TimeSeriesUtil
-        .getTimeSeriesResponse(anomalyFunctionSpec, anomalyFunction,
-            detectionTaskInfo.getGroupByDimension(), windowStart.getMillis(),
-            windowEnd.getMillis());
+    TimeSeriesResponse finalResponse =
+        TimeSeriesUtil.getTimeSeriesResponse(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
 
     exploreDimensionsAndAnalyze(finalResponse);
     return taskResult;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -68,7 +68,7 @@ public class DetectionTaskRunner implements TaskRunner {
     // Get existing anomalies for this time range and this function id
     knownAnomalies = getExistingAnomalies();
     TimeSeriesResponse finalResponse =
-        TimeSeriesUtil.getTimeSeriesResponse(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
+        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
 
     exploreDimensionsAndAnalyze(finalResponse);
     return taskResult;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/AnomalyTimelinesView.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/AnomalyTimelinesView.java
@@ -1,0 +1,47 @@
+package com.linkedin.thirdeye.anomaly.views;
+
+import com.linkedin.thirdeye.dashboard.views.TimeBucket;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class AnomalyTimelinesView {
+  List<TimeBucket> timeBuckets = new ArrayList<>();
+  Map<String, String> summary = new HashMap<>();
+  List<Double> currentValues = new ArrayList<>();
+  List<Double> baselineValues = new ArrayList<>();
+
+  public List<TimeBucket> getTimeBuckets() {
+    return timeBuckets;
+  }
+
+  public void addTimeBuckets(TimeBucket timeBucket) {
+    this.timeBuckets.add(timeBucket);
+  }
+
+  public Map<String, String> getSummary() {
+    return summary;
+  }
+
+  public void addSummary(String key, String value) {
+    this.summary.put(key, value);
+  }
+
+  public List<Double> getCurrentValues() {
+    return currentValues;
+  }
+
+  public void addCurrentValues(Double currentValue) {
+    this.currentValues.add(currentValue);
+  }
+
+  public List<Double> getBaselineValues() {
+    return baselineValues;
+  }
+
+  public void addBaselineValues(Double baselineValue) {
+    this.baselineValues.add(baselineValue);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/DimensionFiltersCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/DimensionFiltersCacheLoader.java
@@ -30,7 +30,7 @@ public class DimensionFiltersCacheLoader extends CacheLoader<String, String> {
     String jsonFilters = null;
     try {
       LOGGER.info("Loading dimension filters cache {}", collection);
-      List<String> dimensions = Utils.getDimensions(collection);
+      List<String> dimensions = Utils.getSortedDimensionNames(collection);
       Map<String, List<String>> filters =
           Utils.getFilters(queryCache, collection, "filters", dimensions, startDateTime, endDateTime);
       jsonFilters = OBJECT_MAPPER.writeValueAsString(filters);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -9,6 +9,7 @@ import com.linkedin.thirdeye.dashboard.resources.DashboardResource;
 import com.linkedin.thirdeye.dashboard.resources.EmailResource;
 import com.linkedin.thirdeye.dashboard.resources.EntityManagerResource;
 
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -46,7 +47,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new AnomalyFunctionResource(config.getFunctionConfigPath()));
     env.jersey().register(new DashboardResource());
     env.jersey().register(new CacheResource());
-    env.jersey().register(new AnomalyResource(config.getFunctionConfigPath()));
+    env.jersey().register(new AnomalyResource(new AnomalyFunctionFactory(config.getFunctionConfigPath())));
     env.jersey().register(new EmailResource());
     env.jersey().register(new EntityManagerResource());
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -9,6 +9,7 @@ import com.linkedin.thirdeye.dashboard.resources.DashboardResource;
 import com.linkedin.thirdeye.dashboard.resources.EmailResource;
 import com.linkedin.thirdeye.dashboard.resources.EntityManagerResource;
 
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -46,9 +47,9 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new AnomalyFunctionResource(config.getFunctionConfigPath()));
     env.jersey().register(new DashboardResource());
     env.jersey().register(new CacheResource());
-    env.jersey().register( new AnomalyResource());
+    env.jersey().register(new AnomalyResource(config.getFunctionConfigPath()));
     env.jersey().register(new EmailResource());
-    env.jersey().register( new EntityManagerResource());
+    env.jersey().register(new EntityManagerResource());
   }
 
   public static void main(String[] args) throws Exception {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -9,7 +9,6 @@ import com.linkedin.thirdeye.dashboard.resources.DashboardResource;
 import com.linkedin.thirdeye.dashboard.resources.EmailResource;
 import com.linkedin.thirdeye.dashboard.resources.EntityManagerResource;
 
-import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -98,11 +98,14 @@ public class Utils {
 
   public static List<String> getDimensions(String collection)
       throws Exception {
-
-    DatasetConfigDTO datasetConfig = CACHE_REGISTRY.getDatasetConfigCache().get(collection);
-    List<String> dimensions = datasetConfig.getDimensions();
+    List<String> dimensions = getSchemaDimensionNames(collection);
     Collections.sort(dimensions);
     return dimensions;
+  }
+
+  public static List<String> getSchemaDimensionNames(String collection) throws Exception {
+    DatasetConfigDTO datasetConfig = CACHE_REGISTRY.getDatasetConfigCache().get(collection);
+    return datasetConfig.getDimensions();
   }
 
   public static List<String> getDimensionsToGroupBy(String collection, Multimap<String, String> filters)

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -96,9 +96,9 @@ public class Utils {
     return result;
   }
 
-  public static List<String> getDimensions(String collection)
+  public static List<String> getSortedDimensionNames(String collection)
       throws Exception {
-    List<String> dimensions = getSchemaDimensionNames(collection);
+    List<String> dimensions = new ArrayList<>(getSchemaDimensionNames(collection));
     Collections.sort(dimensions);
     return dimensions;
   }
@@ -110,7 +110,7 @@ public class Utils {
 
   public static List<String> getDimensionsToGroupBy(String collection, Multimap<String, String> filters)
       throws Exception {
-    List<String> dimensions = Utils.getDimensions(collection);
+    List<String> dimensions = Utils.getSortedDimensionNames(collection);
 
     List<String> dimensionsToGroupBy = new ArrayList<>();
     if (filters != null) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -113,9 +113,8 @@ public class AnomalyFunctionResource {
       throws Exception {
     // TODO: replace this with Job/Task framework and job tracker page
     BaseAnomalyFunction anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
-    TimeSeriesResponse finalResponse = TimeSeriesUtil
-        .getTimeSeriesResponse(anomalyFunctionSpec, anomalyFunction,
-            anomalyFunctionSpec.getExploreDimensions(), startTime, endTime);
+    TimeSeriesResponse finalResponse =
+        TimeSeriesUtil.getTimeSeriesResponse(anomalyFunction, startTime, endTime);
 
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
     List<RawAnomalyResultDTO> results = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -114,7 +114,7 @@ public class AnomalyFunctionResource {
     // TODO: replace this with Job/Task framework and job tracker page
     BaseAnomalyFunction anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
     TimeSeriesResponse finalResponse =
-        TimeSeriesUtil.getTimeSeriesResponse(anomalyFunction, startTime, endTime);
+        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunction, startTime, endTime);
 
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
     List<RawAnomalyResultDTO> results = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -86,13 +86,13 @@ public class AnomalyResource {
 
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
-  public AnomalyResource(String functionConfigPath) {
+  public AnomalyResource(AnomalyFunctionFactory anomalyFunctionFactory) {
     this.anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
     this.anomalyResultDAO = DAO_REGISTRY.getRawAnomalyResultDAO();
     this.anomalyMergedResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
     this.emailConfigurationDAO = DAO_REGISTRY.getEmailConfigurationDAO();
     this.datasetConfigDAO = DAO_REGISTRY.getDatasetConfigDAO();
-    this.anomalyFunctionFactory = new AnomalyFunctionFactory(functionConfigPath);
+    this.anomalyFunctionFactory = anomalyFunctionFactory;
   }
 
   /************** CRUD for anomalies of a collection ********************************************************/

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -525,10 +525,16 @@ public class AnomalyResource {
       long bucketMillis = TimeUnit.MILLISECONDS.convert(anomalyFunctionSpec.getBucketSize(), anomalyFunctionSpec.getBucketUnit());
       long bucketCount = (anomalyWindowEndTime - anomalyWindowStartTime) / bucketMillis;
       long paddingMillis = Math.max(1, (bucketCount / 2)) * bucketMillis;
-      paddingMillis = (paddingMillis <= TimeUnit.DAYS.toMillis(1)) ? paddingMillis : TimeUnit.DAYS.toMillis(1);
+      if (paddingMillis > TimeUnit.DAYS.toMillis(1)) {
+        paddingMillis = TimeUnit.DAYS.toMillis(1);
+      }
 
-      viewWindowStartTime = (viewWindowStartTime == 0) ? anomalyWindowStartTime - paddingMillis : viewWindowStartTime;
-      viewWindowEndTime = (viewWindowEndTime == 0) ? anomalyWindowEndTime + paddingMillis : viewWindowEndTime;
+      if (viewWindowStartTime == 0) {
+        viewWindowStartTime = anomalyWindowStartTime - paddingMillis;
+      }
+      if (viewWindowEndTime == 0) {
+        viewWindowEndTime = anomalyWindowEndTime + paddingMillis;
+      }
     }
 
     TimeGranularity timeGranularity =

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -35,7 +34,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.kafka.common.utils.Time;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.quartz.CronExpression;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -143,7 +143,7 @@ public class DashboardResource {
   public String getDimensions(@QueryParam("dataset") String collection) {
     String jsonDimensions = null;
     try {
-      List<String> dimensions = Utils.getDimensions(collection);
+      List<String> dimensions = Utils.getSortedDimensionNames(collection);
       jsonDimensions = OBJECT_MAPPER.writeValueAsString(dimensions);
     } catch (Exception e) {
       LOG.error("Error while fetching dimensions for collection: " + collection, e);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -277,7 +277,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
       try {
         mergedAnomalyResultDTOList.add((MergedAnomalyResultDTO) future.get(60, TimeUnit.SECONDS));
       } catch (InterruptedException | TimeoutException | ExecutionException e) {
-        LOG.info("Failed to convert MergedAnomalyResultDTO from bean: {}", e.toString());
+        LOG.warn("Failed to convert MergedAnomalyResultDTO from bean: {}", e.toString());
       }
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -275,7 +275,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     List<MergedAnomalyResultDTO> mergedAnomalyResultDTOList = new ArrayList<>(mergedAnomalyResultBeanList.size());
     for (Future future : mergedAnomalyResultDTOFutureList) {
       try {
-        mergedAnomalyResultDTOList.add((MergedAnomalyResultDTO) future.get(1, TimeUnit.SECONDS));
+        mergedAnomalyResultDTOList.add((MergedAnomalyResultDTO) future.get(60, TimeUnit.SECONDS));
       } catch (InterruptedException | TimeoutException | ExecutionException e) {
         LOG.info("Failed to convert MergedAnomalyResultDTO from bean: {}", e.toString());
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -205,7 +205,7 @@ public class DatasetConfigBean extends AbstractBean {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("id", getId()).add("dataset", dataset)
-        .add("dimensions", dimensions).add("dimensions", dimensions).add("timeUnit", timeUnit)
+        .add("dimensions", dimensions).add("timeUnit", timeUnit)
         .add("timeDuration", timeDuration).add("timeFormat", timeFormat).add("metricAsDimension", metricAsDimension)
         .add("metricNamesColumn", metricNamesColumn).add("metricValuesColumn", metricValuesColumn)
         .add("active", active).add("additive", additive)

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
@@ -1,6 +1,10 @@
 package com.linkedin.thirdeye.detector.function;
 
 import com.linkedin.pinot.pql.parsers.utils.Pair;
+import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.dashboard.views.TimeBucket;
+import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -8,6 +12,7 @@ import java.util.List;
 import java.util.Properties;
 
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,16 +56,63 @@ public abstract class BaseAnomalyFunction implements AnomalyFunction {
   /**
    * Useful when multiple time intervals are needed for fetching current vs baseline data
    *
-   * @param scheduleStartTime
-   * @param scheduleEndTime
+   * @param monitoringWindowStartTime
+   * @param monitoringWindowEndTime
    *
    * @return
    */
-  public List<Pair<Long, Long>> getDataRangeIntervals(Long scheduleStartTime,
-      Long scheduleEndTime) {
+  public List<Pair<Long, Long>> getDataRangeIntervals(Long monitoringWindowStartTime,
+      Long monitoringWindowEndTime) {
     List<Pair<Long, Long>> startEndTimeIntervals = new ArrayList<>();
-    startEndTimeIntervals.add(new Pair<>(scheduleStartTime, scheduleEndTime));
+    startEndTimeIntervals.add(new Pair<>(monitoringWindowStartTime, monitoringWindowEndTime));
     return startEndTimeIntervals;
+  }
+
+  /**
+   * Given the data which is used as the input of {@link #analyze}, this method returns the current and baseline
+   * time series to be presented in the frontend.
+   *
+   * For instance, if a function uses the average values of the past 3 weeks as the baseline, then this method should
+   * construct a baseline that contains the average value of the past 3 weeks.
+   *
+   * By default, this method returns the values in the previous week as baseline time series and ignores the
+   * information of known anomalies.
+   *
+   * Note that the usage of this method should be similar to the method {@link #analyze}, i.e., it does not take care
+   * of setting filters, dimension names, etc. for retrieving the data from the backend database. Specifically, it only
+   * processes the given data, i.e., timeSeries, for presentation purpose.
+   *
+   * @param viewWindowStartTime the start time bucket of current time series, inclusive.
+   * @param viewWindowEndTime the end time buckets of current time series, exclusive.
+   * @return Two set of time series: a current and a baseline values, to be represented in the frontend.
+   */
+  public AnomalyTimelinesView getPresentationTimeseries(MetricTimeSeries timeSeries, Long viewWindowStartTime,
+      Long viewWindowEndTime, List<RawAnomalyResultDTO> knownAnomalies) {
+
+    AnomalyTimelinesView anomalyTimelinesView = new AnomalyTimelinesView();
+    anomalyTimelinesView.addSummary("currentStart", Long.toString(viewWindowStartTime));
+    anomalyTimelinesView.addSummary("currentEnd", Long.toString(viewWindowEndTime));
+
+    // Metric
+    String metric = getSpec().getMetric();
+
+    // Compute the bucket size, so we can iterate in those steps
+    long bucketMillis = TimeUnit.MILLISECONDS.convert(getSpec().getBucketSize(), getSpec().getBucketUnit());
+
+    // Construct AnomalyTimelinesView
+    int bucketCount = (int) ((viewWindowEndTime - viewWindowStartTime) / bucketMillis);
+    for (int i = 0; i < bucketCount; ++i) {
+      long currentBucketMillis = viewWindowStartTime + i * bucketMillis;
+      long baselineBucketMillis = currentBucketMillis - TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS);
+      TimeBucket timebucket =
+          new TimeBucket(currentBucketMillis, currentBucketMillis + bucketMillis, baselineBucketMillis,
+              baselineBucketMillis + bucketMillis);
+      anomalyTimelinesView.addTimeBuckets(timebucket);
+      anomalyTimelinesView.addCurrentValues(timeSeries.get(currentBucketMillis, metric).doubleValue());
+      anomalyTimelinesView.addBaselineValues(timeSeries.get(baselineBucketMillis, metric).doubleValue());
+    }
+
+    return anomalyTimelinesView;
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
@@ -188,18 +188,10 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
   }
 
   @Override
-  public AnomalyTimelinesView getPresentationTimeseries(MetricTimeSeries timeSeries, Long viewWindowStartTime,
-      Long viewWindowEndTime, List<RawAnomalyResultDTO> knownAnomalies) {
+  public AnomalyTimelinesView getPresentationTimeseries(MetricTimeSeries timeSeries, long bucketMillis, String metric,
+      long viewWindowStartTime, long viewWindowEndTime, List<RawAnomalyResultDTO> knownAnomalies) {
 
     AnomalyTimelinesView anomalyTimelinesView = new AnomalyTimelinesView();
-    anomalyTimelinesView.addSummary("currentStart", Long.toString(viewWindowStartTime));
-    anomalyTimelinesView.addSummary("currentEnd", Long.toString(viewWindowEndTime));
-
-    // Metric
-    String metric = getSpec().getMetric();
-
-    // Compute the bucket size, so we can iterate in those steps
-    long bucketMillis = TimeUnit.MILLISECONDS.convert(getSpec().getBucketSize(), getSpec().getBucketUnit());
 
     // Compute baseline for comparison
     long baselineOffsetInMillis = TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.detector.function;
 
 import com.linkedin.pinot.pql.parsers.utils.Pair;
+import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
+import com.linkedin.thirdeye.dashboard.views.TimeBucket;
+import java.io.IOException;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,17 +52,17 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
     return new String [] {BASELINE, CHANGE_THRESHOLD, AVERAGE_VOLUME_THRESHOLD};
   }
 
-  public List<Pair<Long, Long>> getDataRangeIntervals(Long windowStartTime, Long windowEndTime) {
+  public List<Pair<Long, Long>> getDataRangeIntervals(Long monitoringWindowStartTime, Long monitoringWindowEndTime) {
     List<Pair<Long, Long>> startEndTimeIntervals = new ArrayList<>();
-    startEndTimeIntervals.add(new Pair<>(windowStartTime, windowEndTime));
+    startEndTimeIntervals.add(new Pair<>(monitoringWindowStartTime, monitoringWindowEndTime));
 
     try {
       Properties anomalyProps = getProperties();
       // Compute baseline for comparison
       String baselineProp = anomalyProps.getProperty(BASELINE);
-      long baselineMillis = getBaselineMillis(baselineProp);
+      long baselineMillis = getBaselineOffsetInMillis(baselineProp);
       startEndTimeIntervals
-          .add(new Pair<>(windowStartTime - baselineMillis, windowEndTime - baselineMillis));
+          .add(new Pair<>(monitoringWindowStartTime - baselineMillis, monitoringWindowEndTime - baselineMillis));
     } catch (Exception e) {
       LOGGER.error("Error reading the properties", e);
     }
@@ -86,7 +89,7 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
 
     // Compute baseline for comparison
     String baselineProp = props.getProperty(BASELINE);
-    long baselineMillis = getBaselineMillis(baselineProp);
+    long baselineMillis = getBaselineOffsetInMillis(baselineProp);
 
     // Compute the bucket size, so we can iterate in those steps
     long bucketMillis =
@@ -158,7 +161,7 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
     return subSet;
   }
 
-  long getBaselineMillis(String baselineProp) throws IllegalArgumentException {
+  long getBaselineOffsetInMillis(String baselineProp) throws IllegalArgumentException {
     // TODO: Expand options here and use regex to extract numeric parameter
     long baselineMillis;
     if ("w/w".equals(baselineProp)) {
@@ -182,5 +185,45 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
       }
     }
     return false;
+  }
+
+  @Override
+  public AnomalyTimelinesView getPresentationTimeseries(MetricTimeSeries timeSeries, Long viewWindowStartTime,
+      Long viewWindowEndTime, List<RawAnomalyResultDTO> knownAnomalies) {
+
+    AnomalyTimelinesView anomalyTimelinesView = new AnomalyTimelinesView();
+    anomalyTimelinesView.addSummary("currentStart", Long.toString(viewWindowStartTime));
+    anomalyTimelinesView.addSummary("currentEnd", Long.toString(viewWindowEndTime));
+
+    // Metric
+    String metric = getSpec().getMetric();
+
+    // Compute the bucket size, so we can iterate in those steps
+    long bucketMillis = TimeUnit.MILLISECONDS.convert(getSpec().getBucketSize(), getSpec().getBucketUnit());
+
+    // Compute baseline for comparison
+    long baselineOffsetInMillis = TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS);
+    try {
+      Properties props = getProperties();
+      String baselineProp = props.getProperty(BASELINE);
+      baselineOffsetInMillis = getBaselineOffsetInMillis(baselineProp);
+    } catch (IOException e) {
+      LOGGER.info("Cannot get function property when constructing presentation timeseires. Using WoW baseline values.");
+    }
+
+    // Construct AnomalyTimelinesView
+    int bucketCount = (int) ((viewWindowEndTime - viewWindowStartTime) / bucketMillis);
+    for (int i = 0; i < bucketCount; ++i) {
+      long currentBucketMillis = viewWindowStartTime + i * bucketMillis;
+      long baselineBucketMillis = currentBucketMillis - baselineOffsetInMillis;
+      TimeBucket timebucket =
+          new TimeBucket(currentBucketMillis, currentBucketMillis + bucketMillis, baselineBucketMillis,
+              baselineBucketMillis + bucketMillis);
+      anomalyTimelinesView.addTimeBuckets(timebucket);
+      anomalyTimelinesView.addCurrentValues(timeSeries.get(currentBucketMillis, metric).doubleValue());
+      anomalyTimelinesView.addBaselineValues(timeSeries.get(baselineBucketMillis, metric).doubleValue());
+    }
+
+    return anomalyTimelinesView;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -66,6 +66,21 @@ public abstract class ThirdEyeUtils {
     return getFilterSetFromDimensionKeyString(dimensionKeyString, collection, null);
   }
 
+  /**
+   * Returns or modifies a filter that can be for querying the results corresponding to the given dimension key.
+   *
+   * For example, if a dimension key = "IN,front_page,*,*" and the dimension names of this dataset is ["country",
+   * "page_name", "some_dimension", ...], then the two entries will be added or over-written in the filter:
+   * 1. "country"="IN" and 2. "page_name"="front_page".
+   *
+   * Note that if the given filter contains an entry: "country"=["IN", "US", "TW",...], then this entry is replaced by
+   * "country"="IN".
+   *
+   * @param dimensionKeyString a string that represents the dimension key
+   * @param collection the name of the dataset
+   * @param filterToDecorate if it is null, a new filter will be created; otherwise, it is modified.
+   * @return a filter that is modified according to the given dimensionKeyString.
+   */
   public static Multimap<String, String> getFilterSetFromDimensionKeyString(String dimensionKeyString,
       String collection, Multimap<String, String> filterToDecorate) {
     if (filterToDecorate == null) {
@@ -81,9 +96,12 @@ public abstract class ThirdEyeUtils {
     }
 
     if (schemaDimensionNames.size() > 0) {
-      List<String> dimensionValues =
-          org.apache.commons.lang3.StringUtils.isNotBlank(dimensionKeyString) ? Arrays.asList(dimensionKeyString.trim().split(","))
-              : Collections.emptyList();
+      List<String> dimensionValues;
+      if (StringUtils.isNotBlank(dimensionKeyString)) {
+        dimensionValues = Arrays.asList(dimensionKeyString.trim().split(","));
+      } else {
+        dimensionValues = Collections.emptyList();;
+      }
       for (int i = 0; i < dimensionValues.size(); ++i) {
         String dimensionValue = dimensionValues.get(i).trim();
         if (!dimensionValue.equals("") && !dimensionValue.equals("*")) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -142,7 +142,6 @@ function drawMetricTimeSeries(timeSeriesData, anomalyData, tab, placeholder) {
     var metrics = timeSeriesData["metrics"];
     var lineChartData = {};
     var barChartData = {};
-    var xTicksBaseline = [];
     var xTicksCurrent = [];
     var colors = {};
     var regions = [];
@@ -150,7 +149,6 @@ function drawMetricTimeSeries(timeSeriesData, anomalyData, tab, placeholder) {
     for (var t = 0, len = timeSeriesData["timeBuckets"].length; t < len; t++) {
         var timeBucket = timeSeriesData["timeBuckets"][t]["currentStart"];
         var currentEnd = timeSeriesData["timeBuckets"][t]["currentEnd"];
-        xTicksBaseline.push(timeBucket);
         xTicksCurrent.push(timeBucket);
     }
 
@@ -374,7 +372,7 @@ function drawMetricTimeSeries(timeSeriesData, anomalyData, tab, placeholder) {
 } //end of drawMetricTimeSeries
 
 
-function drawAnomalyTimeSeries(timeSeriesData,anomalyData, tab, placeholder, options) {
+function drawAnomalyTimeSeries(timeSeriesData, anomalyData, tab, placeholder, options) {
     console.log(" in drawAnomalyTimeSeries")
 
      var currentView = $("#anomalies");
@@ -383,25 +381,20 @@ function drawAnomalyTimeSeries(timeSeriesData,anomalyData, tab, placeholder, opt
      var dateTimeFormat = "%I:%M %p";
      if (aggTimeGranularity == "DAYS" ) {
          dateTimeFormat = "%m-%d";
-     }else if(timeSeriesData.summary.baselineEnd - timeSeriesData.summary.baselineStart > 86400000 ){
+     } else if (timeSeriesData.summary.currentEnd - timeSeriesData.summary.currentStart > 86400000 ){
          dateTimeFormat = "%m-%d %I %p";
      }
 
      var lineChartPlaceholder = $(placeholder, currentView)[0];
     console.log("lineChartPlaceholder")
     console.log(lineChartPlaceholder)
-     // Metric(s)
-     var metrics = timeSeriesData["metrics"];
      var lineChartData = {};
-     var xTicksBaseline = [];
      var xTicksCurrent = [];
      var colors = {};
      var regions = [];
 
      for (var t = 0, len = timeSeriesData["timeBuckets"].length; t < len; t++) {
          var timeBucket = timeSeriesData["timeBuckets"][t]["currentStart"];
-         var currentEnd = timeSeriesData["timeBuckets"][t]["currentEnd"];
-         xTicksBaseline.push(timeBucket);
          xTicksCurrent.push(timeBucket);
      }
 
@@ -415,27 +408,21 @@ function drawAnomalyTimeSeries(timeSeriesData,anomalyData, tab, placeholder, opt
      }
      lineChartData["time"] = xTicksCurrent;
 
-     for (var i = 0, mlen = metrics.length; i < mlen; i++) {
-         var baselineData = [];
-         var currentData = [];
+     var baselineData = [];
+     var currentData = [];
 
-         var indexOfBaseline = timeSeriesData["data"][metrics[i]]["schema"]["columnsToIndexMapping"]["baselineValue"];
-         var indexOfCurrent = timeSeriesData["data"][metrics[i]]["schema"]["columnsToIndexMapping"]["currentValue"];
-
-         for (var t = 0, tlen = timeSeriesData["timeBuckets"].length; t < tlen; t++) {
-
-             var baselineValue = timeSeriesData["data"][metrics[i]]["responseData"][t][indexOfBaseline];
-             var currentValue = timeSeriesData["data"][metrics[i]]["responseData"][t][indexOfCurrent];
-             baselineData.push(baselineValue);
-             currentData.push(currentValue);
-         }
-         lineChartData["baseline"] = baselineData;
-         lineChartData["current"] = currentData;
-
-         colors["baseline"] = '#1f77b4';
-         colors["current"] = '#ff5f0e';
-
+     for (var t = 0, tlen = timeSeriesData["currentValues"].length; t < tlen; t++) {
+         var baselineValue = timeSeriesData["baselineValues"][t];
+         var currentValue = timeSeriesData["currentValues"][t];
+         baselineData.push(baselineValue);
+         currentData.push(currentValue);
      }
+     lineChartData["baseline"] = baselineData;
+     lineChartData["current"] = currentData;
+
+     colors["baseline"] = '#1f77b4';
+     colors["current"] = '#ff5f0e';
+
      var defaultSettings = {
          bindto: lineChartPlaceholder,
          padding: {
@@ -544,26 +531,11 @@ function renderAnomalyThumbnails(data, tab) {
          var startTime = data[i]["startTime"];
          var endTime = data[i]["endTime"];
          var anomalyId = data[i]["id"]
-         var baselineStart = moment(parseInt(hash.currentStart)).add(-7, 'days')
-         var baselineEnd = moment(parseInt(hash.currentEnd)).add(-7, 'days')
-         var aggTimeGranularity = calcAggregateGranularity(hash.currentStart,hash.currentEnd);
-        var dataset = hash.dataset;
-        var compareMode = "WoW";
-        var currentStart = hash.currentStart;
-        var currentEnd = hash.currentEnd;
-        var metrics = hash.metrics;
-        var placeholder= "#d3charts-" + i;
-        var fnFiltersString = data[i]["function"]["filters"];
-        var filters = parseProperties( fnFiltersString, {arrayValues:true} );
+         var placeholder= "#d3charts-" + i;
+         var timeSeriesUrl = "/dashboard/anomaly-merged-result/timeseries/" + anomalyId;
+         var tab = hash.view;
 
-        filters = encodeURIComponent(JSON.stringify(filters));
-        var timeSeriesUrl = "/dashboard/data/tabular?dataset=" + dataset + "&compareMode=" + compareMode //
-            + "&currentStart=" + currentStart + "&currentEnd=" + currentEnd  //
-            + "&baselineStart=" + baselineStart + "&baselineEnd=" + baselineEnd   //
-            + "&aggTimeGranularity=" + aggTimeGranularity + "&metrics=" + metrics  + "&filters=" + filters;
-        var tab = hash.view;
-
-        getDataCustomCallback(timeSeriesUrl,tab).done(function (timeSeriesData) {
+        getDataCustomCallback(timeSeriesUrl, tab).done(function (timeSeriesData) {
             var anomalyRegionData = [];
             anomalyRegionData.push({startTime: parseInt(startTime), endTime: parseInt(endTime), id: anomalyId, regionColor: '#eedddd'});
             drawAnomalyTimeSeries(timeSeriesData, anomalyRegionData, tab, placeholder)

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -381,7 +381,7 @@ function drawAnomalyTimeSeries(timeSeriesData, anomalyData, tab, placeholder, op
      var dateTimeFormat = "%I:%M %p";
      if (aggTimeGranularity == "DAYS" ) {
          dateTimeFormat = "%m-%d";
-     } else if (timeSeriesData.summary.currentEnd - timeSeriesData.summary.currentStart > 86400000 ){
+     } else if (timeSeriesData.summary.currentEnd - timeSeriesData.summary.currentStart > 86400000){
          dateTimeFormat = "%m-%d %I %p";
      }
 
@@ -530,9 +530,11 @@ function renderAnomalyThumbnails(data, tab) {
      function requestLineChart(i) {
          var startTime = data[i]["startTime"];
          var endTime = data[i]["endTime"];
+         var aggTimeGranularity = calcAggregateGranularity(hash.currentStart,hash.currentEnd);
          var anomalyId = data[i]["id"]
          var placeholder= "#d3charts-" + i;
-         var timeSeriesUrl = "/dashboard/anomaly-merged-result/timeseries/" + anomalyId;
+         var timeSeriesUrl = "/dashboard/anomaly-merged-result/timeseries/" + anomalyId
+             + "?aggTimeGranularity=" + aggTimeGranularity + "&start=" + hash.currentStart + "&end=" + hash.currentEnd;
          var tab = hash.view;
 
         getDataCustomCallback(timeSeriesUrl, tab).done(function (timeSeriesData) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomaly-details.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomaly-details.js
@@ -32,59 +32,16 @@ function showAnomalyDetails(id) {
 }
 
 function lineChartForSingleAnomaly(mergeAnomalyData) {
-    var dataset = hash.dataset;
     var mergedAnomalyId = mergeAnomalyData.id;
 
     // TODO: remove console logs
     console.log(window.datasetConfig);
     console.log(mergeAnomalyData);
 
-    var aggTimeGranularity = calcAggregateGranularity(mergeAnomalyData.startTime, mergeAnomalyData.endTime);
-    console.log(aggTimeGranularity);
-
-    var extensionWindowMillis = (datasetConfig.dataGranularity == "DAYS") ? 86400000 : 2 * 3600000;
-    var fnProperties = parseProperties(mergeAnomalyData.function.properties);
-
-    var compare = 1;
-    var compareMode = "WOW";
-    //for
-    switch(fnProperties.baseline){
-        case "w/w":
-            compare = 1;
-            compareMode = "WOW";
-            break;
-        case "w/2w":
-            compare = 2;
-            compareMode = "WO2W";
-            break;
-        case "w/3w":
-            compare= 3;
-            compareMode= "WO3W";
-            break;
-        default:
-            compare = 1;
-            compareMode = "WOW";
-    }
-
-    var currentStart = mergeAnomalyData.startTime - extensionWindowMillis;
-    var currentEnd = mergeAnomalyData.endTime + extensionWindowMillis;
-
-    var baselineStart = moment(parseInt(currentStart)).add((-1* compare), 'weeks');
-    var baselineEnd = moment(parseInt(currentEnd)).add( (-1* compare), 'weeks');
-
-    var fnFiltersString = mergeAnomalyData.function.filters;
-    var filters = parseProperties( fnFiltersString, {arrayValues:true} );
-    filters = encodeURIComponent(JSON.stringify(filters));
-
-    var metrics = hash.metrics;
-
-    var timeSeriesUrl = "/dashboard/data/tabular?dataset=" + dataset + "&compareMode=" + compareMode //
-        + "&currentStart=" + currentStart + "&currentEnd=" + currentEnd  //
-        + "&baselineStart=" + baselineStart + "&baselineEnd=" + baselineEnd   //
-        + "&aggTimeGranularity=" + aggTimeGranularity + "&metrics=" + metrics+ "&filters=" + filters;
+    var timeSeriesUrl = "/dashboard/anomaly-merged-result/timeseries/" + mergeAnomalyData.id;
     var tab = hash.view;
 
-    getDataCustomCallback(timeSeriesUrl,tab ).done(function (timeSeriesData) {
+    getDataCustomCallback(timeSeriesUrl, tab).done(function (timeSeriesData) {
         //Error handling when data is falsy (empty, undefined or null)
         if (!timeSeriesData) {
             // do nothing
@@ -100,6 +57,6 @@ function lineChartForSingleAnomaly(mergeAnomalyData) {
         linechartSettings.data.subchart = {};
         linechartSettings.data.subchart.show = true;
 
-        drawAnomalyTimeSeries(timeSeriesData, anomalyRegionData, tab, placeholder,linechartSettings );
+        drawAnomalyTimeSeries(timeSeriesData, anomalyRegionData, tab, placeholder, linechartSettings);
     });
 }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomaly-details.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomaly-details.js
@@ -38,7 +38,28 @@ function lineChartForSingleAnomaly(mergeAnomalyData) {
     console.log(window.datasetConfig);
     console.log(mergeAnomalyData);
 
-    var timeSeriesUrl = "/dashboard/anomaly-merged-result/timeseries/" + mergeAnomalyData.id;
+    var aggTimeGranularity = calcAggregateGranularity(mergeAnomalyData.startTime, mergeAnomalyData.endTime);
+
+    var viewWindowStart = mergeAnomalyData.startTime;
+    var viewWindowEnd = mergeAnomalyData.endTime;
+
+    var extensionWindowMillis;
+    switch (aggTimeGranularity) {
+        case "DAYS":
+            extensionWindowMillis = 86400000;
+            break;
+        case "HOURS":
+        default:
+            var viewWindowSize = viewWindowEnd - viewWindowStart;
+            var multiplier = Math.max(2, parseInt(viewWindowSize / 3600000));
+            extensionWindowMillis = 3600000 * multiplier;
+    }
+
+    viewWindowStart -= extensionWindowMillis;
+    viewWindowEnd += extensionWindowMillis;
+
+    var timeSeriesUrl = "/dashboard/anomaly-merged-result/timeseries/" + mergeAnomalyData.id
+        + "?aggTimeGranularity=" + aggTimeGranularity + "&start=" + viewWindowStart + "&end=" + viewWindowEnd;
     var tab = hash.view;
 
     getDataCustomCallback(timeSeriesUrl, tab).done(function (timeSeriesData) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/function/TestUserRuleAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/function/TestUserRuleAnomalyFunction.java
@@ -31,7 +31,7 @@ public class TestUserRuleAnomalyFunction {
 
   @Test(dataProvider = "getBaselineMillisProvider")
   public void getBaselineMillis(String baselineProp, long expected) {
-    long actual = function.getBaselineMillis(baselineProp);
+    long actual = function.getBaselineOffsetInMillis(baselineProp);
     Assert.assertEquals(actual, expected);
   }
 


### PR DESCRIPTION
1. Add a method, named getPresentationTimeseries, to anomaly functions. This method returns the current and baseline values that are used for detecting anomalies. For instance, if a function needs to average the data in the past three weeks, then the returned baseline should be the average values of the past 3 weeks.

2. Create an endpoint that takes as input the anomaly ID and returns the corresponding time series.