### PR TITLE
Adding ability for load metrics tool to read from collectionSchema in absence of pinotSchema, adding whitelist

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobRunner.java
@@ -123,7 +123,7 @@ public class DetectionJobRunner implements Job {
       DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(collection);
       TimeSpec timespec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
       TimeGranularity dataGranularity = timespec.getDataGranularity();
-      String timeFormat = datasetConfig.getTimeFormat();
+      String timeFormat = timespec.getFormat();
       if (dataGranularity.getUnit().equals(TimeUnit.DAYS)) {
         DateTimeZone dataTimeZone = Utils.getDataTimeZone(collection);
         DateTimeFormatter inputDataDateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZone(dataTimeZone);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
@@ -139,7 +139,7 @@ public class ThirdEyeCacheRegistry {
     cacheRegistry.registerDashboardsCache(dashboardsCache);
 
     // Collections cache
-    CollectionsCache collectionsCache = new CollectionsCache(datasetConfigDAO);
+    CollectionsCache collectionsCache = new CollectionsCache(datasetConfigDAO, config);
     cacheRegistry.registerCollectionsCache(collectionsCache);
 
     // DatasetConfig cache
@@ -165,11 +165,12 @@ public class ThirdEyeCacheRegistry {
     // as weeklyService starts before hourlyService finishes,
     // causing NPE in reading collectionsCache
 
+    cacheResource.refreshCollections();
+
     cacheResource.refreshDatasetConfigCache();
     cacheResource.refreshMetricConfigCache();
     cacheResource.refreshDashoardConfigsCache();
 
-    cacheResource.refreshCollections();
     cacheResource.refreshMaxDataTimeCache();
     cacheResource.refreshDimensionFiltersCache();
     cacheResource.refreshDashboardsCache();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionsCache.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionsCache.java
@@ -4,6 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jersey.repackaged.com.google.common.collect.Lists;
+
+import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
 import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 
@@ -11,11 +18,14 @@ public class CollectionsCache {
 
   private AtomicReference<List<String>> collectionsRef;
   private DatasetConfigManager datasetConfigDAO;
+  private String whitelistCollections;
+  private static final Logger LOG = LoggerFactory.getLogger(CollectionsCache.class);
 
 
-  public CollectionsCache(DatasetConfigManager datasetConfigDAO) {
+  public CollectionsCache(DatasetConfigManager datasetConfigDAO, ThirdEyeConfiguration config) {
     this.collectionsRef = new AtomicReference<>();
     this.datasetConfigDAO = datasetConfigDAO;
+    this.whitelistCollections = config.getWhitelistCollections();
   }
 
 
@@ -24,15 +34,28 @@ public class CollectionsCache {
   }
 
   public void loadCollections() {
-
-    List<DatasetConfigDTO> datasetConfigs = datasetConfigDAO.findActive();
     List<String> collections = new ArrayList<>();
-    for (DatasetConfigDTO datasetConfigDTO : datasetConfigs) {
-      collections.add(datasetConfigDTO.getDataset());
+
+    if (StringUtils.isNotBlank(whitelistCollections)) {
+      List<String> whitelist = Lists.newArrayList(whitelistCollections.split(","));
+      for (String collection : whitelist) {
+        DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(collection);
+        if (datasetConfig == null || !datasetConfig.isActive()) {
+          LOG.info("Skipping collection {} due to missing dataset config or status inactive", collection);
+          continue;
+        }
+        collections.add(collection);
+      }
+    } else {
+      List<DatasetConfigDTO> datasetConfigs = datasetConfigDAO.findActive();
+      for (DatasetConfigDTO datasetConfigDTO : datasetConfigs) {
+        collections.add(datasetConfigDTO.getDataset());
+      }
     }
+
+    LOG.info("Loading collections {}", collections);
     collectionsRef.set(collections);
   }
-
 
 }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/CacheResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/CacheResource.java
@@ -68,10 +68,10 @@ public class CacheResource {
   @POST
   @Path("/refresh/datasetConfig")
   public Response refreshDatasetConfigCache() {
-    List<DatasetConfigDTO> datasetConfigs = DAO_REGISTRY.getDatasetConfigDAO().findAll();
+    List<String> collections = CACHE_INSTANCE.getCollectionsCache().getCollections();
     LoadingCache<String,DatasetConfigDTO> cache = CACHE_INSTANCE.getDatasetConfigCache();
-    for (DatasetConfigDTO datasetConfig : datasetConfigs) {
-      cache.refresh(datasetConfig.getDataset());
+    for (String collection : collections) {
+      cache.refresh(collection);
     }
     return Response.ok().build();
   }
@@ -79,10 +79,13 @@ public class CacheResource {
   @POST
   @Path("/refresh/metricConfig")
   public Response refreshMetricConfigCache() {
-    List<MetricConfigDTO> metricConfigs = DAO_REGISTRY.getMetricConfigDAO().findAll();
     LoadingCache<MetricDataset, MetricConfigDTO> cache = CACHE_INSTANCE.getMetricConfigCache();
-    for (MetricConfigDTO metricConfig : metricConfigs) {
-      cache.refresh(new MetricDataset(metricConfig.getName(), metricConfig.getDataset()));
+    List<String> collections = CACHE_INSTANCE.getCollectionsCache().getCollections();
+    for (String collection : collections) {
+      List<MetricConfigDTO> metricConfigs = DAO_REGISTRY.getMetricConfigDAO().findByDataset(collection);
+      for (MetricConfigDTO metricConfig : metricConfigs) {
+        cache.refresh(new MetricDataset(metricConfig.getName(), metricConfig.getDataset()));
+      }
     }
     return Response.ok().build();
   }
@@ -90,10 +93,10 @@ public class CacheResource {
   @POST
   @Path("/refresh/dashboardConfigs")
   public Response refreshDashoardConfigsCache() {
-    List<DatasetConfigDTO> datasetConfigs = DAO_REGISTRY.getDatasetConfigDAO().findAll();
+    List<String> collections = CACHE_INSTANCE.getCollectionsCache().getCollections();
     LoadingCache<String,List<DashboardConfigDTO>> cache = CACHE_INSTANCE.getDashboardConfigsCache();
-    for (DatasetConfigDTO datasetConfig : datasetConfigs) {
-      cache.refresh(datasetConfig.getDataset());
+    for (String collection : collections) {
+      cache.refresh(collection);
     }
     return Response.ok().build();
   }


### PR DESCRIPTION
Whitelist has been added back to speed up dev time. If whitelist is left blank, it will load all metrics as expected
The load metrics tools has been modified to load from collection schema in absence of pinot schema. This will help us bring the new database tables on par with the existing prod dashboard setup.