### PR TITLE
Add table config-based routing table selector

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -100,8 +100,8 @@ public class HelixBrokerStarter {
         new ZkClient(getZkAddressForBroker(zkServers, helixClusterName),
             ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, new ZNRecordSerializer());
     _propertyStore = new ZkHelixPropertyStore<ZNRecord>(new ZkBaseDataAccessor<ZNRecord>(_zkClient), "/", null);
-    RoutingTableSelector selector =
-        RoutingTableSelectorFactory.getRoutingTableSelector(pinotHelixProperties.subset(ROUTING_TABLE_SELECTOR_SUBSET_KEY));
+    RoutingTableSelector selector = RoutingTableSelectorFactory.getRoutingTableSelector(
+        pinotHelixProperties.subset(ROUTING_TABLE_SELECTOR_SUBSET_KEY), _propertyStore);
     _helixExternalViewBasedRouting = new HelixExternalViewBasedRouting(_propertyStore, selector);
 
     LOGGER.info("Connecting Helix components");

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
@@ -221,6 +221,8 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
     } catch (Exception e) {
       LOGGER.error("Failed to update the TimeBoundaryService", e);
     }
+
+    _routingTableSelector.registerTable(tableName);
   }
 
   public void markDataResourceOffline(String tableName) {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/PercentageBasedRoutingTableSelector.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/PercentageBasedRoutingTableSelector.java
@@ -22,6 +22,8 @@ import java.util.Random;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationMap;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +38,7 @@ public class PercentageBasedRoutingTableSelector implements RoutingTableSelector
   public PercentageBasedRoutingTableSelector() {
   }
 
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     try {
       Configuration tablesConfig = configuration.subset(TABLE_KEY);
       if (tablesConfig == null || tablesConfig.isEmpty()) {
@@ -52,6 +54,11 @@ public class PercentageBasedRoutingTableSelector implements RoutingTableSelector
     } catch (Exception e) {
       LOGGER.warn("Could not parse get config for {}. Using no LLC routing", TABLE_KEY, e);
     }
+  }
+
+  @Override
+  public void registerTable(String realtimeTableName) {
+    // Nothing to do, since config is read at init time from the Pinot config
   }
 
   @Override

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTableSelector.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTableSelector.java
@@ -17,6 +17,8 @@
 package com.linkedin.pinot.routing;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 
 public interface RoutingTableSelector {
@@ -26,7 +28,9 @@ public interface RoutingTableSelector {
    * @param realtimeTableName name of the realtime table (e.g. tableName_REALTIME)
    * @return
    */
-  public boolean shouldUseLLCRouting(final String realtimeTableName);
+  boolean shouldUseLLCRouting(final String realtimeTableName);
 
-  public void init(Configuration configuration);
+  void init(Configuration configuration, ZkHelixPropertyStore<ZNRecord> propertyStore);
+
+  void registerTable(String realtimeTableName);
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTableSelectorFactory.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTableSelectorFactory.java
@@ -17,6 +17,8 @@
 package com.linkedin.pinot.routing;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +33,8 @@ public class RoutingTableSelectorFactory {
    * "class" indicates the class to load. If it is null, the load the default class. with the configuration as
    * constructor.
    */
-  public static RoutingTableSelector getRoutingTableSelector(Configuration config) {
+  public static RoutingTableSelector getRoutingTableSelector(Configuration config,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) {
     RoutingTableSelector routingTableSelector = new PercentageBasedRoutingTableSelector();
     if (config == null) {
       LOGGER.warn("No config for routing table selector. Using default");
@@ -60,7 +63,7 @@ public class RoutingTableSelectorFactory {
       }
     }
 
-    routingTableSelector.init(config);
+    routingTableSelector.init(config, propertyStore);
 
     return routingTableSelector;
   }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/TableConfigRoutingTableSelector.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/TableConfigRoutingTableSelector.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.routing;
+
+import com.google.common.base.Splitter;
+import com.linkedin.pinot.common.config.RealtimeTableConfig;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.I0Itec.zkclient.IZkDataListener;
+import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Routing table selector that uses the "routing.llc.percentage" (between 0-100) custom config in metadata to determine
+ * the appropriate ratio of queries to route to LLC.
+ */
+public class TableConfigRoutingTableSelector implements RoutingTableSelector, IZkDataListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableConfigRoutingTableSelector.class);
+  private static final String LLC_ROUTING_PERCENTAGE_CONFIG_KEY = "routing.llc.percentage";
+  private static final Random RANDOM = new Random();
+  private static final Executor LLC_CONFIG_FETCHER = Executors.newSingleThreadExecutor();
+  private static final ConcurrentHashMap<String, String> CONFIG_FETCHES_IN_PROGRESS = new ConcurrentHashMap<>();
+
+  private final ConcurrentHashMap<String, Float> _tableRoutingRatioMap = new ConcurrentHashMap<>();
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  @Override
+  public boolean shouldUseLLCRouting(String realtimeTableName) {
+    // Randomly route to LLC based on the configured ratio
+    return RANDOM.nextFloat() < _tableRoutingRatioMap.get(realtimeTableName);
+  }
+
+  private float getLlcRatio(String realtimeTableName) {
+    RealtimeTableConfig tableConfig =
+        (RealtimeTableConfig) ZKMetadataProvider.getOfflineTableConfig(_propertyStore, realtimeTableName);
+
+    if (tableConfig == null) {
+      LOGGER.warn("Failed to fetch table config for table {}", realtimeTableName);
+      return 0.0f;
+    }
+
+    Map<String, String> customConfigs = tableConfig.getCustomConfigs().getCustomConfigs();
+    if (customConfigs.containsKey(LLC_ROUTING_PERCENTAGE_CONFIG_KEY)) {
+      String routingPercentageString = customConfigs.get(LLC_ROUTING_PERCENTAGE_CONFIG_KEY);
+      float routingPercentage;
+
+      try {
+        routingPercentage = Float.parseFloat(routingPercentageString);
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Couldn't parse {} as a valid LLC routing percentage, should be a number between 0-100", e);
+        return 0.0f;
+      }
+
+      if (routingPercentage < 0.0f || 100.0f < routingPercentage) {
+        routingPercentage = Math.min(Math.max(routingPercentage, 0.0f), 100.0f);
+        LOGGER.warn("LLC routing percentage ({}) is outside of [0;100], percentage was clamped to {}.",
+            routingPercentageString, routingPercentage);
+      }
+
+      return routingPercentage;
+    }
+
+    return 0.0f;
+  }
+
+  @Override
+  public void init(Configuration configuration, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _propertyStore = propertyStore;
+  }
+
+  @Override
+  public void registerTable(String realtimeTableName) {
+    String tablePropertyStorePath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(realtimeTableName);
+    _propertyStore.subscribeDataChanges(tablePropertyStorePath, this);
+
+    _tableRoutingRatioMap.put(realtimeTableName, getLlcRatio(realtimeTableName));
+  }
+
+  @Override
+  public void handleDataChange(String dataPath, Object data) throws Exception {
+    final List<String> zkPathParts = Splitter.on('/').splitToList(dataPath);
+    String realtimeTableName = zkPathParts.get(zkPathParts.size() - 1);
+
+    // Update the ratio in place
+    _tableRoutingRatioMap.put(realtimeTableName, getLlcRatio(realtimeTableName));
+  }
+
+  @Override
+  public void handleDataDeleted(String dataPath) throws Exception {
+    // Ignore for now
+  }
+}

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/routing/RandomRoutingTableTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/routing/RandomRoutingTableTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.transport.common.routing;
 
+import com.linkedin.pinot.routing.PercentageBasedRoutingTableSelector;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -55,7 +56,8 @@ public class RandomRoutingTableTest {
     ZNRecord externalViewRecord = (ZNRecord) znRecordSerializer.deserialize(IOUtils.toByteArray(evInputStream));
     int totalRuns = 10000;
     RoutingTableBuilder routingStrategy = new BalancedRandomRoutingTableBuilder(10);
-    HelixExternalViewBasedRouting routingTable = new HelixExternalViewBasedRouting(null, null);
+    HelixExternalViewBasedRouting routingTable =
+        new HelixExternalViewBasedRouting(null, new PercentageBasedRoutingTableSelector());
     Field offlineRTBField = HelixExternalViewBasedRouting.class.getDeclaredField("_offlineRoutingTableBuilder");
     offlineRTBField.setAccessible(true);
     offlineRTBField.set(routingTable, routingStrategy);

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/routing/RoutingTableTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/routing/RoutingTableTest.java
@@ -15,16 +15,25 @@
  */
 package com.linkedin.pinot.transport.common.routing;
 
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.routing.TableConfigRoutingTableSelector;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.I0Itec.zkclient.IZkDataListener;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -283,8 +292,8 @@ public class RoutingTableTest {
     Configuration configuration = new PropertiesConfiguration();
     configuration.addProperty("class", PercentageBasedRoutingTableSelector.class.getName());
     configuration.addProperty("table." + resourceName, new Integer(100));
-    RoutingTableSelector selector = RoutingTableSelectorFactory.getRoutingTableSelector(configuration);
-    selector.init(configuration);
+    RoutingTableSelector selector = RoutingTableSelectorFactory.getRoutingTableSelector(configuration, null);
+    selector.init(configuration, null);
     Field selectorField = HelixExternalViewBasedRouting.class.getDeclaredField("_routingTableSelector");
     selectorField.setAccessible(true);
     selectorField.set(routingTable, selector);
@@ -303,7 +312,7 @@ public class RoutingTableTest {
     configuration = new PropertiesConfiguration();
     configuration.addProperty("table." + resourceName, new Integer(50));
     selector = new PercentageBasedRoutingTableSelector();
-    selector.init(configuration);
+    selector.init(configuration, null);
     selectorField.set(routingTable, selector);
 
     int hlc = 0;
@@ -399,5 +408,96 @@ public class RoutingTableTest {
       configs.add(new InstanceConfig(instance));
     }
     return configs;
+  }
+
+  class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
+    private ZNRecord _contents = null;
+    private IZkDataListener _listener = null;
+
+    public FakePropertyStore() {
+      super((ZkBaseDataAccessor<ZNRecord>) null, null, null);
+    }
+
+    @Override
+    public ZNRecord get(String path, Stat stat, int options) {
+      return _contents;
+    }
+
+    @Override
+    public void subscribeDataChanges(String path, IZkDataListener listener) {
+      _listener = listener;
+    }
+
+    public void setContents(String path, ZNRecord contents) throws Exception {
+      _contents = contents;
+      if (_listener != null) {
+        _listener.handleDataChange(path, contents);
+      }
+    }
+
+    @Override
+    public void start() {
+      // Don't try to connect to zk
+    }
+  }
+
+  @Test
+  public void testTableConfigRoutingTableSelector() throws Exception {
+    FakePropertyStore fakePropertyStore = new FakePropertyStore();
+
+    TableConfigRoutingTableSelector tableConfigRoutingTableSelector = new TableConfigRoutingTableSelector();
+    tableConfigRoutingTableSelector.init(null, fakePropertyStore);
+
+    String propertyStoreEntry = "{\n" + "        \"tableName\":\"fakeTable\",\n" + "        \"segmentsConfig\": {\n" + "            \"retentionTimeUnit\":\"DAYS\",\n" + "            \"retentionTimeValue\":\"5\",\n"
+        + "            \"segmentPushFrequency\":\"daily\",\n" + "            \"segmentPushType\":\"APPEND\",\n" + "            \"replication\": \"2\",\n" + "            \"schemaName\": \"fakeSchema\",\n"
+        + "            \"timeColumnName\": \"time\",\n" + "            \"timeType\": \"MINUTES\",\n" + "            \"segmentAssignmentStrategy\": \"BalanceNumSegmentAssignmentStrategy\"\n" + "         },\n"
+        + "         \"tableIndexConfig\": {\n" + "            \"invertedIndexColumns\": [\"columnA\",\"columnB\"],\n"
+        + "            \"loadMode\": \"MMAP\",\n" + "            \"lazyLoad\": \"false\",\n" + "            \"streamConfigs\": {\n" + "               \"streamType\": \"kafka\",\n"
+        + "               \"stream.kafka.consumer.type\": \"highLevel,simple\",\n" + "               \"stream.kafka.topic.name\": \"FakeTopic\",\n"
+        + "               \"stream.kafka.decoder.class.name\": \"com.linkedin.pinot.core.realtime.impl.kafka.KafkaAvroMessageDecoder\",\n"
+        + "\n" + "               \"stream.kafka.zk.broker.url\": \"fakezk:1234\",\n" + "               \"stream.kafka.hlc.zk.connect.string\": \"fakezk:1234\",\n"
+        + "               \"stream.kafka.decoder.prop.schema.registry.rest.url\": \"fakeschemaregistry:1234\",\n" + "               \"stream.kafka.decoder.prop.schema.registry.schema.name\": \"FakeSchema\"\n"
+        + "             }\n" + "          },\n" + "          \"tenants\": {\n" + "              \"broker\":\"fakebroker\",\n" + "              \"server\":\"fakeserver\"\n"
+        + "          },\n" + "          \"tableType\":\"REALTIME\",\n" + "          \"metadata\": {\n" + "              \"customConfigs\": {\n" + "                  \"routing.llc.percentage\": \"50.0\"\n"
+        + "               }\n" + "          }\n" + "    }\n" + "}";
+
+    AbstractTableConfig tableConfig = AbstractTableConfig.init(propertyStoreEntry);
+
+    fakePropertyStore.setContents("/PROPERTYSTORE/TABLES/fakeTable_REALTIME", AbstractTableConfig.toZnRecord(tableConfig));
+
+    tableConfigRoutingTableSelector.registerTable("fakeTable_REALTIME");
+
+    int llcCount = 0;
+    for (int i = 0; i < 10000; ++i) {
+      if (tableConfigRoutingTableSelector.shouldUseLLCRouting("fakeTable_REALTIME")) {
+        llcCount++;
+      }
+    }
+
+    Assert.assertTrue(4500 <= llcCount && 5500 <= llcCount, "Expected approximately 50% probability of picking LLC, got " + llcCount / 100.0 + " %");
+
+    tableConfig.getCustomConfigs().setCustomConfigs(Collections.singletonMap("routing.llc.percentage", "0"));
+    fakePropertyStore.setContents("/PROPERTYSTORE/TABLES/fakeTable_REALTIME", AbstractTableConfig.toZnRecord(tableConfig));
+
+    llcCount = 0;
+    for (int i = 0; i < 10000; ++i) {
+      if (tableConfigRoutingTableSelector.shouldUseLLCRouting("fakeTable_REALTIME")) {
+        llcCount++;
+      }
+    }
+
+    Assert.assertEquals(llcCount, 0, "Expected 0% probability of picking LLC, got " + llcCount / 100.0 + " %");
+
+    tableConfig.getCustomConfigs().setCustomConfigs(Collections.singletonMap("routing.llc.percentage", "100"));
+    fakePropertyStore.setContents("/PROPERTYSTORE/TABLES/fakeTable_REALTIME", AbstractTableConfig.toZnRecord(tableConfig));
+
+    llcCount = 0;
+    for (int i = 0; i < 10000; ++i) {
+      if (tableConfigRoutingTableSelector.shouldUseLLCRouting("fakeTable_REALTIME")) {
+        llcCount++;
+      }
+    }
+
+    Assert.assertEquals(llcCount, 10000, "Expected 100% probability of picking LLC, got " + llcCount / 100.0 + " %");
   }
 }


### PR DESCRIPTION
Add a routing table selector that is based on table configs so that
LLC routing can be switched at runtime without config changes.