### PR TITLE
Fix issues with adhoc anomaly detection for bucket in range

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
@@ -199,10 +199,10 @@ public class DetectionJobScheduler implements JobScheduler, Runnable {
     if (anomalyFunctionSpec == null) {
       throw new IllegalArgumentException("No function with id " + id);
     }
-    String triggerKey = String.format("anomaly_adhoc_trigger_%d", anomalyFunctionSpec.getId());
+    String triggerKey = String.format("anomaly_adhoc_trigger_%d_%d", windowStartTime.getMillis(), anomalyFunctionSpec.getId());
     Trigger trigger = TriggerBuilder.newTrigger().withIdentity(triggerKey).startNow().build();
 
-    String jobKey = "adhoc_" + getJobKey(anomalyFunctionSpec.getId(), anomalyFunctionSpec.getFunctionName());
+    String jobKey = "adhoc_" + windowStartTime.getMillis() + "_" + getJobKey(anomalyFunctionSpec.getId(), anomalyFunctionSpec.getFunctionName());
     JobDetail job = JobBuilder.newJob(DetectionJobRunner.class).withIdentity(jobKey).build();
 
     DetectionJobContext detectionJobContext = new DetectionJobContext();


### PR DESCRIPTION
1. Generate unique job key and trigger key using windowStartTime for adhoc detection jobs; otherwise, Quartz scheduler does not schedule new jobs that have the duplicated job and trigger key. This issue only occurs when multiple jobs are scheduled at the same time.

2. The monitoring window slides the distance according to the cron specified in anomaly function.