### PR TITLE
Remove anomalys dependancy on dimension key

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertTaskRunner.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.anomaly.alert;
 
+import com.linkedin.thirdeye.api.DimensionMap;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -115,9 +116,9 @@ public class AlertTaskRunner implements TaskRunner {
     }
 
     // Group by dimension key, then sort according to anomaly result compareTo method.
-    Map<String, List<MergedAnomalyResultDTO>> groupedResults = new TreeMap<>();
+    Map<DimensionMap, List<MergedAnomalyResultDTO>> groupedResults = new TreeMap<>();
     for (MergedAnomalyResultDTO result : results) {
-      String dimensions = result.getDimensions();
+      DimensionMap dimensions = result.getDimensions();
       if (!groupedResults.containsKey(dimensions)) {
         groupedResults.put(dimensions, new ArrayList<>());
       }
@@ -126,9 +127,9 @@ public class AlertTaskRunner implements TaskRunner {
     // sort each list of anomaly results afterwards and keep track of sequence number in a new list
     Map<MergedAnomalyResultDTO, String> anomaliesWithLabels = new LinkedHashMap<>();
     int counter = 1;
-    for (List<MergedAnomalyResultDTO> resultsByDimensionKey : groupedResults.values()) {
-      Collections.sort(resultsByDimensionKey);
-      for (MergedAnomalyResultDTO result : resultsByDimensionKey) {
+    for (List<MergedAnomalyResultDTO> resultsByExploredDimensions : groupedResults.values()) {
+      Collections.sort(resultsByExploredDimensions);
+      for (MergedAnomalyResultDTO result : resultsByExploredDimensions) {
         anomaliesWithLabels.put(result, String.valueOf(counter));
         counter++;
       }
@@ -166,7 +167,7 @@ public class AlertTaskRunner implements TaskRunner {
   }
 
   private void sendAlertForAnomalies(String collectionAlias, List<MergedAnomalyResultDTO> results,
-      Map<String, List<MergedAnomalyResultDTO>> groupedResults, List<String> dimensionNames)
+      Map<DimensionMap, List<MergedAnomalyResultDTO>> groupedResults, List<String> dimensionNames)
       throws JobExecutionException {
 
     long anomalyStartMillis = results.get(0).getStartTime();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.anomaly.detection;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.linkedin.pinot.pql.parsers.utils.Pair;
+import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.client.MetricExpression;
 import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
@@ -79,9 +80,8 @@ public abstract class TimeSeriesUtil {
    * Returns the time series that were used by the given anomaly function for detecting the anomaly.
    *
    * @param anomalyFunction the anomaly function that detects the anomaly
-   * @param dimensionKeyString the string representation of {@link com.linkedin.thirdeye.api.DimensionKey}, which is
-   *                           used to construct the filter for retrieving the corresponding data that was used to
-   *                           detected the anomaly
+   * @param dimensionMap a dimension map that is used to construct the filter for retrieving the corresponding data
+   *                     that was used to detected the anomaly
    * @param timeGranularity time granularity for the frontend
    * @param viewWindowStart inclusive
    * @param viewWindowEnd exclusive
@@ -90,7 +90,7 @@ public abstract class TimeSeriesUtil {
    * @throws ExecutionException
    */
   public static TimeSeriesResponse getTimeSeriesResponseForPresentation(BaseAnomalyFunction anomalyFunction,
-      String dimensionKeyString, TimeGranularity timeGranularity, long viewWindowStart, long viewWindowEnd)
+      DimensionMap dimensionMap, TimeGranularity timeGranularity, long viewWindowStart, long viewWindowEnd)
       throws JobExecutionException, ExecutionException {
     AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunction.getSpec();
 
@@ -104,7 +104,7 @@ public abstract class TimeSeriesUtil {
     }
 
     // Decorate the filter according to dimensionKeyString
-    filters = ThirdEyeUtils.getFilterSetFromDimensionKeyString(dimensionKeyString, anomalyFunctionSpec.getCollection(), filters);
+    filters = ThirdEyeUtils.getFilterSetFromDimensionMap(dimensionMap, filters);
 
     // groupByDimensions (i.e., exploreDimensions) should be empty when retrieving time series for anomalies, because
     // each anomaly should have a time series with a specific set of dimension values, which is specified in filters.

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.anomaly.merge;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
+import com.linkedin.thirdeye.api.DimensionMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -35,7 +36,6 @@ import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
-import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
@@ -213,32 +213,20 @@ public class AnomalyMergeExecutor implements Runnable {
     if (StringUtils.isNotBlank(exploreDimensions)) {
       timeSeriesRequest.setGroupByDimensions(Arrays.asList(exploreDimensions.trim().split(",")));
 
-      List<String> collectionDimensions = null;
-      try {
-        DatasetConfigDTO datasetConfig = CACHE_REGISTRY_INSTANCE.
-            getDatasetConfigCache().get(anomalyFunctionSpec.getCollection());
-        collectionDimensions = datasetConfig.getDimensions();
-      } catch (Exception e) {
-        LOG.error("Exception when reading collection schema cache", e);
-      }
-
-      String anomalyDimensionValues = anomalyMergedResult.getDimensions();
-      String[] dimensionValues = anomalyDimensionValues.split(","); // e.g., "RU, oz-winner, *, *"
-      for (int i = 0; i < dimensionValues.length; ++i) {
-        String dimensionValue = dimensionValues[i];
-        if (!StringUtils.isBlank(dimensionValue) && !"*".equals(dimensionValue)) {
-          String dimensionName = collectionDimensions.get(i);
-          filters.removeAll(dimensionName);
-          if (dimensionValue.equalsIgnoreCase("other")) {
-            filters.put(dimensionName, dimensionValue);
-            filters.put(dimensionName, dimensionValue.toLowerCase());
-            filters.put(dimensionName, "");
-          } else {
-            // Only add a specific dimension value filter if there are more values present for the same dimension
-            filters.put(dimensionName, dimensionValue);
-          }
-          LOG.info("Adding filter : [{} = {}] in the query", dimensionName, dimensionValue);
+      DimensionMap exploredDimensions = anomalyMergedResult.getDimensions();
+      for (Map.Entry<String, String> entry : exploredDimensions.getDimensionMap().entrySet()) {
+        String dimensionName = entry.getKey();
+        String dimensionValue = entry.getValue();
+        filters.removeAll(dimensionName);
+        if (dimensionValue.equalsIgnoreCase("other")) {
+          filters.put(dimensionName, dimensionValue);
+          filters.put(dimensionName, dimensionValue.toLowerCase());
+          filters.put(dimensionName, "");
+        } else {
+          // Only add a specific dimension value filter if there are more values present for the same dimension
+          filters.put(dimensionName, dimensionValue);
         }
+        LOG.info("Adding filter : [{} = {}] in the query", dimensionName, dimensionValue);
       }
     }
 
@@ -356,18 +344,18 @@ public class AnomalyMergeExecutor implements Runnable {
   private void performMergeBasedOnFunctionIdAndDimensions(AnomalyFunctionDTO function,
       AnomalyMergeConfig mergeConfig, List<RawAnomalyResultDTO> unmergedResults,
       List<MergedAnomalyResultDTO> output) {
-    Map<String, List<RawAnomalyResultDTO>> dimensionsResultMap = new HashMap<>();
+    Map<DimensionMap, List<RawAnomalyResultDTO>> dimensionsResultMap = new HashMap<>();
     for (RawAnomalyResultDTO anomalyResult : unmergedResults) {
-      String dimensions = anomalyResult.getDimensions();
-      if (!dimensionsResultMap.containsKey(dimensions)) {
-        dimensionsResultMap.put(dimensions, new ArrayList<>());
+      DimensionMap exploredDimensions = anomalyResult.getDimensions();
+      if (!dimensionsResultMap.containsKey(exploredDimensions)) {
+        dimensionsResultMap.put(exploredDimensions, new ArrayList<>());
       }
-      dimensionsResultMap.get(dimensions).add(anomalyResult);
+      dimensionsResultMap.get(exploredDimensions).add(anomalyResult);
     }
-    for (String dimensions : dimensionsResultMap.keySet()) {
+    for (DimensionMap exploredDimensions : dimensionsResultMap.keySet()) {
       MergedAnomalyResultDTO latestMergedResult =
-          mergedResultDAO.findLatestByFunctionIdDimensions(function.getId(), dimensions);
-      List<RawAnomalyResultDTO> unmergedResultsByDimensions = dimensionsResultMap.get(dimensions);
+          mergedResultDAO.findLatestByFunctionIdDimensions(function.getId(), exploredDimensions.toString());
+      List<RawAnomalyResultDTO> unmergedResultsByDimensions = dimensionsResultMap.get(exploredDimensions);
 
       // TODO : get mergeConfig from function
       List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
@@ -375,11 +363,11 @@ public class AnomalyMergeExecutor implements Runnable {
               mergeConfig.getMaxMergeDurationLength(), mergeConfig.getSequentialAllowedGap());
       for (MergedAnomalyResultDTO mergedResult : mergedResults) {
         mergedResult.setFunction(function);
-        mergedResult.setDimensions(dimensions);
+        mergedResult.setDimensions(exploredDimensions);
       }
       LOG.info(
           "Merging [{}] raw anomalies into [{}] merged anomalies for function id : [{}] and dimensions : [{}]",
-          unmergedResultsByDimensions.size(), mergedResults.size(), function.getId(), dimensions);
+          unmergedResultsByDimensions.size(), mergedResults.size(), function.getId(), exploredDimensions);
       output.addAll(mergedResults);
     }
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -214,7 +214,7 @@ public class AnomalyMergeExecutor implements Runnable {
       timeSeriesRequest.setGroupByDimensions(Arrays.asList(exploreDimensions.trim().split(",")));
 
       DimensionMap exploredDimensions = anomalyMergedResult.getDimensions();
-      for (Map.Entry<String, String> entry : exploredDimensions.getDimensionMap().entrySet()) {
+      for (Map.Entry<String, String> entry : exploredDimensions.entrySet()) {
         String dimensionName = entry.getKey();
         String dimensionValue = entry.getValue();
         filters.removeAll(dimensionName);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
@@ -70,6 +70,26 @@ public class DimensionMap implements SortedMap<String, String>, Comparable<Dimen
     return OBJECT_MAPPER.writeValueAsString(this);
   }
 
+  /**
+   * Returns a JSON string representation of this dimension map for {@link com.linkedin.thirdeye.datalayer.dao.GenericPojoDao}
+   * to persistent the map to backend database.
+   *
+   * It returns the generic string representation of this dimension map if any exception occurs when generating the JSON
+   * string. In that case, the constructor {@link DimensionMap(String)} will be invoked during the construction of that
+   * dimension map.
+   *
+   * @return a JSON string representation of this dimension map for {@link com.linkedin.thirdeye.datalayer.dao.GenericPojoDao}
+   * to persistent the map to backend database.
+   */
+  @Override
+  public String toString() {
+    try {
+      return this.toJson();
+    } catch (JsonProcessingException e) {
+      return super.toString();
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (o instanceof DimensionMap) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
@@ -20,6 +20,17 @@ import org.apache.commons.lang.ObjectUtils;
 public class DimensionMap implements Comparable<DimensionMap> {
   private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+  public DimensionMap() {
+  }
+
+  /**
+   * (Backward compatibility) For deleting old anomalies
+   * @param dimensionKeyString
+   */
+  public DimensionMap(String dimensionKeyString) {
+
+  }
+
   // Dimension name to dimension value
   private SortedMap<String, String> dimensionMap = Collections.emptySortedMap();
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
@@ -1,0 +1,140 @@
+package com.linkedin.thirdeye.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.ObjectUtils;
+
+
+/**
+ * Wrapper class to represent key-value pairs of explored dimension name and value. The paris of explore dimensions are
+ * sorted by their dimension names in ascending order.
+ */
+public class DimensionMap implements Comparable<DimensionMap> {
+  private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  // Dimension name to dimension value
+  private SortedMap<String, String> dimensionMap = Collections.emptySortedMap();
+
+  public SortedMap<String, String> getDimensionMap() {
+    return Collections.unmodifiableSortedMap(dimensionMap);
+  }
+
+  public void setDimensionMap(Map<String, String> dimensionMap) {
+    this.dimensionMap = new TreeMap<>(dimensionMap);
+  }
+
+  public static DimensionMap fromJsonString(String dimensionMapJsonString)
+      throws IOException {
+    return OBJECT_MAPPER.readValue(dimensionMapJsonString, DimensionMap.class);
+  }
+
+  /**
+   * Returns a dimension map according to the given dimension key.
+   *
+   * Assume that the given dimension key is [US,front_page,*,*,...] and the schema dimension names are
+   * [country,page_name,...], then this method return this dimension map: {country=US; page_name=front_page;}
+   *
+   * @param dimensionKey the dimension key to be used to covert to explored dimensions
+   * @param schemaDimensionNames the schema dimension names
+   * @return the key-value pair of dimension value and dimension name according to the given dimension key.
+   */
+  public static DimensionMap fromDimensionKey(DimensionKey dimensionKey, List<String> schemaDimensionNames) {
+    DimensionMap dimensionMap = new DimensionMap();
+    if (CollectionUtils.isNotEmpty(schemaDimensionNames)) {
+      SortedMap<String, String> exploredDimensionMap = new TreeMap<>();
+      String[] dimensionValues = dimensionKey.getDimensionValues();
+      for (int i = 0; i < dimensionValues.length; ++i) {
+        String dimensionValue = dimensionValues[i].trim();
+        if (!dimensionValue.equals("") && !dimensionValue.equals("*")) {
+          String dimensionName = schemaDimensionNames.get(i);
+          exploredDimensionMap.put(dimensionName, dimensionValue);
+        }
+      }
+      dimensionMap.setDimensionMap(exploredDimensionMap);
+    } else {
+      dimensionMap.setDimensionMap(Collections.emptySortedMap());
+    }
+    return dimensionMap;
+  }
+
+  public int size() {
+    return dimensionMap.size();
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      return this.toString();
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof DimensionMap) {
+      DimensionMap otherDimensionMap = (DimensionMap) o;
+      return ObjectUtils.equals(dimensionMap, otherDimensionMap.dimensionMap);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return dimensionMap.hashCode();
+  }
+
+  /**
+   * Returns the compared result of the string representation of dimension maps.
+   *
+   * @param o the other explored dimensions.
+   */
+  @Override
+  public int compareTo(DimensionMap o) {
+    if (dimensionMap == null && o.dimensionMap == null) {
+      return 0;
+    } else if (dimensionMap == null) {
+      return -1;
+    } else if (o.dimensionMap == null) {
+      return 1;
+    }
+
+    Iterator<Map.Entry<String, String>> thisIte = dimensionMap.entrySet().iterator();
+    Iterator<Map.Entry<String, String>> thatIte = o.dimensionMap.entrySet().iterator();
+    if (thisIte.hasNext()) {
+      // o has a smaller map
+      if (!thatIte.hasNext()) {
+        return 1;
+      }
+
+      Map.Entry<String, String> thisEntry = thisIte.next();
+      Map.Entry<String, String> thatEntry = thatIte.next();
+      // Compare dimension name first
+      int diff = ObjectUtils.compare(thisEntry.getKey(), thatEntry.getKey());
+      if (diff != 0) {
+        return diff;
+      }
+      // Compare dimension value afterwards
+      diff = ObjectUtils.compare(thisEntry.getValue(), thatEntry.getValue());
+      if (diff != 0) {
+        return diff;
+      }
+    }
+
+    // o has a larger map
+    if (thatIte.hasNext()) {
+      return -1;
+    }
+
+    return 0;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.dashboard.resources;
 
 import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
 import com.linkedin.thirdeye.api.DimensionKey;
+import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.client.DAORegistry;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesResponse;
@@ -131,12 +132,13 @@ public class AnomalyFunctionResource {
       try {
         // Run algorithm
         DimensionKey dimensionKey = entry.getKey();
+        DimensionMap dimensionMap = DimensionMap.fromDimensionKey(dimensionKey, collectionDimensions);
         MetricTimeSeries metricTimeSeries = entry.getValue();
         LOG.info("Analyzing anomaly function with dimensionKey: {}, windowStart: {}, windowEnd: {}",
             dimensionKey, startTime, endTime);
 
         List<RawAnomalyResultDTO> resultsOfAnEntry = anomalyFunction
-            .analyze(dimensionKey, metricTimeSeries, new DateTime(startTime), new DateTime(endTime),
+            .analyze(dimensionMap, metricTimeSeries, new DateTime(startTime), new DateTime(endTime),
                 new ArrayList<>());
         if (resultsOfAnEntry.size() != 0) {
           results.addAll(resultsOfAnEntry);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -34,7 +33,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
@@ -43,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
 import com.linkedin.thirdeye.client.DAORegistry;
@@ -64,14 +61,12 @@ import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
-import jersey.repackaged.com.google.common.base.Joiner;
-import jersey.repackaged.com.google.common.collect.Lists;
-
 @Path(value = "/dashboard")
 @Produces(MediaType.APPLICATION_JSON)
 public class AnomalyResource {
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
   private static final Logger LOG = LoggerFactory.getLogger(AnomalyResource.class);
+  private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static final String DEFAULT_CRON = "0 0 0 * * ?";
   private static final String UTF8 = "UTF-8";
@@ -113,7 +108,7 @@ public class AnomalyResource {
       @QueryParam("startTimeIso") String startTimeIso,
       @QueryParam("endTimeIso") String endTimeIso,
       @QueryParam("metric") String metric,
-      @QueryParam("dimensions") String dimensionMapJson) {
+      @QueryParam("dimensions") String exploredDimensions) {
 
     if (StringUtils.isBlank(dataset)) {
       throw new IllegalArgumentException("dataset is a required query param");
@@ -129,20 +124,21 @@ public class AnomalyResource {
     }
     List<MergedAnomalyResultDTO> anomalyResults = new ArrayList<>();
     try {
-      DimensionMap dimensionMap = null;
-      if (StringUtils.isNotBlank(dimensionMapJson)) {
-        // get dimensions map from request
-        dimensionMapJson = URLDecoder.decode(dimensionMapJson, UTF8 );
+      if (StringUtils.isNotBlank(exploredDimensions)) {
+        // Decode dimensions map from request, which may contain encode symbols such as "%20D", etc.
+        exploredDimensions = URLDecoder.decode(exploredDimensions, UTF8);
         try {
-          dimensionMap = DimensionMap.fromJsonString(dimensionMapJson);
+          // Ensure the dimension names are sorted in order to match the string in backend database
+          DimensionMap sortedDimensions = OBJECT_MAPPER.readValue(exploredDimensions, DimensionMap.class);
+          exploredDimensions = OBJECT_MAPPER.writeValueAsString(sortedDimensions);
         } catch (IOException e) {
-          LOG.warn("Unable to construct explore dimensions to dimension map: {}", e.toString());
+          LOG.warn("exploreDimensions may not be sorted because failed to read it as a json string: {}", e.toString());
         }
       }
 
       if (StringUtils.isNotBlank(metric)) {
-        if (MapUtils.isNotEmpty(dimensionMap.getDimensionMap())) {
-          anomalyResults = anomalyMergedResultDAO.findByCollectionMetricDimensionsTime(dataset, metric, dimensionMap.toString(), startTime.getMillis(), endTime.getMillis());
+        if (StringUtils.isNotBlank(exploredDimensions)) {
+          anomalyResults = anomalyMergedResultDAO.findByCollectionMetricDimensionsTime(dataset, metric, exploredDimensions, startTime.getMillis(), endTime.getMillis());
         } else {
           anomalyResults = anomalyMergedResultDAO.findByCollectionMetricTime(dataset, metric, startTime.getMillis(), endTime.getMillis());
         }
@@ -422,8 +418,7 @@ public class AnomalyResource {
       if (result == null) {
         throw new IllegalArgumentException("AnomalyResult not found with id " + anomalyResultId);
       }
-      ObjectMapper mapper = new ObjectMapper();
-      AnomalyFeedbackDTO feedbackRequest = mapper.readValue(payload, AnomalyFeedbackDTO.class);
+      AnomalyFeedbackDTO feedbackRequest = OBJECT_MAPPER.readValue(payload, AnomalyFeedbackDTO.class);
       AnomalyFeedbackDTO feedback = result.getFeedback();
       if (feedback == null) {
         feedback = new AnomalyFeedbackDTO();
@@ -451,8 +446,7 @@ public class AnomalyResource {
       if (result == null) {
         throw new IllegalArgumentException("AnomalyResult not found with id " + anomalyResultId);
       }
-      ObjectMapper mapper = new ObjectMapper();
-      AnomalyFeedbackDTO feedbackRequest = mapper.readValue(payload, AnomalyFeedbackDTO.class);
+      AnomalyFeedbackDTO feedbackRequest = OBJECT_MAPPER.readValue(payload, AnomalyFeedbackDTO.class);
       AnomalyFeedbackDTO feedback = result.getFeedback();
       if (feedback == null) {
         feedback = new AnomalyFeedbackDTO();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -10,7 +10,7 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
       long emailId);
 
   List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
-      String metric, String[] dimensions, long startTime, long endTime);
+      String metric, String dimensions, long startTime, long endTime);
 
   List<MergedAnomalyResultDTO> findByCollectionMetricTime(String collection, String metric,
       long startTime, long endTime);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -128,11 +128,11 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
   @Override
   public List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
-      String metric, String[] dimensions, long startTime, long endTime) {
+      String metric, String dimensions, long startTime, long endTime) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("collection", collection);
     filterParams.put("metric", metric);
-    filterParams.put("dimensions", dimensions[0]);
+    filterParams.put("dimensions", dimensions);
     filterParams.put("startTime", startTime);
     filterParams.put("endTime", endTime);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -1,6 +1,5 @@
 package com.linkedin.thirdeye.datalayer.bao.jdbc;
 
-import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
@@ -17,7 +16,6 @@ import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.pojo.EmailConfigurationBean;
 import com.linkedin.thirdeye.datalayer.pojo.MergedAnomalyResultBean;
 import com.linkedin.thirdeye.datalayer.util.Predicate;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -1,6 +1,5 @@
 package com.linkedin.thirdeye.datalayer.dao;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -19,7 +18,6 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.modelmapper.ModelMapper;
-import org.modelmapper.PropertyMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -465,4 +463,5 @@ public class GenericPojoDao {
     Class<? extends AbstractIndexEntity> indexEntityClass;
     List<String> indexTableColumns;
   }
+  
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.datalayer.dao;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -18,7 +19,7 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.modelmapper.ModelMapper;
-import org.modelmapper.TypeMap;
+import org.modelmapper.PropertyMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,8 +111,8 @@ public class GenericPojoDao {
   static ModelMapper MODEL_MAPPER = new ModelMapper();
 
   static {
-    MODEL_MAPPER.addMappings(new RawAnomalyResultBean.RawAnomalyResultBeanIndexMap());
-    MODEL_MAPPER.addMappings(new MergedAnomalyResultBean.MergedAnomalyResultBeanIndexMap());
+    MODEL_MAPPER.addMappings(new RawAnomalyResultBeanIndexMap());
+    MODEL_MAPPER.addMappings(new MergedAnomalyResultBeanIndexMap());
   }
 
   static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -470,6 +471,28 @@ public class GenericPojoDao {
     String indexTableName;
     Class<? extends AbstractIndexEntity> indexEntityClass;
     List<String> indexTableColumns;
+  }
+
+  public static class RawAnomalyResultBeanIndexMap extends PropertyMap<RawAnomalyResultBean, RawAnomalyResultIndex> {
+    @Override
+    protected void configure() {
+      try {
+        map(OBJECT_MAPPER.writeValueAsString(source.getDimensions())).setDimensions(null);
+      } catch (JsonProcessingException e) {
+        LOG.warn("Failed to convert sorted dimension map to json string for persistence: {}", e.toString());
+      }
+    }
+  }
+
+  public static class MergedAnomalyResultBeanIndexMap extends PropertyMap<MergedAnomalyResultBean, MergedAnomalyResultIndex> {
+    @Override
+    protected void configure() {
+      try {
+        map(OBJECT_MAPPER.writeValueAsString(source.getDimensions())).setDimensions(null);
+      } catch (JsonProcessingException e) {
+        LOG.warn("Failed to convert sorted dimension map to json string for persistence: {}", e.toString());
+      }
+    }
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -109,14 +109,12 @@ public class GenericPojoDao {
   GenericResultSetMapper genericResultSetMapper;
 
   static ModelMapper MODEL_MAPPER = new ModelMapper();
-
   static {
     MODEL_MAPPER.addMappings(new RawAnomalyResultBeanIndexMap());
     MODEL_MAPPER.addMappings(new MergedAnomalyResultBeanIndexMap());
   }
 
   static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
 
   public GenericPojoDao() {}
 
@@ -477,7 +475,7 @@ public class GenericPojoDao {
     @Override
     protected void configure() {
       try {
-        map(OBJECT_MAPPER.writeValueAsString(source.getDimensions())).setDimensions(null);
+        map(source.getDimensions().toJson()).setDimensions(null);
       } catch (JsonProcessingException e) {
         LOG.warn("Failed to convert sorted dimension map to json string for persistence: {}", e.toString());
       }
@@ -488,7 +486,7 @@ public class GenericPojoDao {
     @Override
     protected void configure() {
       try {
-        map(OBJECT_MAPPER.writeValueAsString(source.getDimensions())).setDimensions(null);
+        map(source.getDimensions().toJson()).setDimensions(null);
       } catch (JsonProcessingException e) {
         LOG.warn("Failed to convert sorted dimension map to json string for persistence: {}", e.toString());
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -109,11 +109,6 @@ public class GenericPojoDao {
   GenericResultSetMapper genericResultSetMapper;
 
   static ModelMapper MODEL_MAPPER = new ModelMapper();
-  static {
-    MODEL_MAPPER.addMappings(new RawAnomalyResultBeanIndexMap());
-    MODEL_MAPPER.addMappings(new MergedAnomalyResultBeanIndexMap());
-  }
-
   static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public GenericPojoDao() {}
@@ -470,27 +465,4 @@ public class GenericPojoDao {
     Class<? extends AbstractIndexEntity> indexEntityClass;
     List<String> indexTableColumns;
   }
-
-  public static class RawAnomalyResultBeanIndexMap extends PropertyMap<RawAnomalyResultBean, RawAnomalyResultIndex> {
-    @Override
-    protected void configure() {
-      try {
-        map(source.getDimensions().toJson()).setDimensions(null);
-      } catch (JsonProcessingException e) {
-        LOG.warn("Failed to convert sorted dimension map to json string for persistence: {}", e.toString());
-      }
-    }
-  }
-
-  public static class MergedAnomalyResultBeanIndexMap extends PropertyMap<MergedAnomalyResultBean, MergedAnomalyResultIndex> {
-    @Override
-    protected void configure() {
-      try {
-        map(source.getDimensions().toJson()).setDimensions(null);
-      } catch (JsonProcessingException e) {
-        LOG.warn("Failed to convert sorted dimension map to json string for persistence: {}", e.toString());
-      }
-    }
-  }
-
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -18,6 +18,7 @@ import javax.sql.DataSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,6 +108,11 @@ public class GenericPojoDao {
   GenericResultSetMapper genericResultSetMapper;
 
   static ModelMapper MODEL_MAPPER = new ModelMapper();
+
+  static {
+    MODEL_MAPPER.addMappings(new RawAnomalyResultBean.RawAnomalyResultBeanIndexMap());
+    MODEL_MAPPER.addMappings(new MergedAnomalyResultBean.MergedAnomalyResultBeanIndexMap());
+  }
 
   static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/MergedAnomalyResultIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/MergedAnomalyResultIndex.java
@@ -1,5 +1,8 @@
 package com.linkedin.thirdeye.datalayer.entity;
 
+import com.linkedin.thirdeye.api.DimensionMap;
+
+
 public class MergedAnomalyResultIndex extends AbstractIndexEntity {
 
 
@@ -10,7 +13,7 @@ public class MergedAnomalyResultIndex extends AbstractIndexEntity {
   long endTime;
   String collection;
   String metric;
-  String dimensions;
+  DimensionMap dimensions;
   boolean notified;
 
   public long getAnomalyFeedbackId() {
@@ -37,11 +40,11 @@ public class MergedAnomalyResultIndex extends AbstractIndexEntity {
     this.collection = collection;
   }
 
-  public String getDimensions() {
+  public DimensionMap getDimensions() {
     return dimensions;
   }
 
-  public void setDimensions(String dimensions) {
+  public void setDimensions(DimensionMap dimensions) {
     this.dimensions = dimensions;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/RawAnomalyResultIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/RawAnomalyResultIndex.java
@@ -1,12 +1,15 @@
 package com.linkedin.thirdeye.datalayer.entity;
 
+import com.linkedin.thirdeye.api.DimensionMap;
+
+
 public class RawAnomalyResultIndex extends AbstractIndexEntity {
   long functionId;
   long anomalyFeedbackId;
   long jobId;
   long startTime;
   long endTime;
-  String dimensions;
+  DimensionMap dimensions;
   boolean merged;
   boolean dataMissing;
 
@@ -34,11 +37,11 @@ public class RawAnomalyResultIndex extends AbstractIndexEntity {
     this.dataMissing = dataMissing;
   }
 
-  public String getDimensions() {
+  public DimensionMap getDimensions() {
     return dimensions;
   }
 
-  public void setDimensions(String dimensions) {
+  public void setDimensions(DimensionMap dimensions) {
     this.dimensions = dimensions;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -175,11 +175,4 @@ public class MergedAnomalyResultBean extends AbstractBean
         + weight + ", createdTime=" + createdTime + ", message='" + message + '\'' + ", notified="
         + notified + '}';
   }
-
-  public static class MergedAnomalyResultBeanIndexMap extends PropertyMap<MergedAnomalyResultBean, MergedAnomalyResultIndex> {
-    @Override
-    protected void configure() {
-      map(source.getDimensions().toString()).setDimensions(null);
-    }
-  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -1,8 +1,12 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
+import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.entity.MergedAnomalyResultIndex;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang.ObjectUtils;
+import org.modelmapper.PropertyMap;
+
 
 public class MergedAnomalyResultBean extends AbstractBean
     implements Comparable<MergedAnomalyResultBean> {
@@ -11,7 +15,7 @@ public class MergedAnomalyResultBean extends AbstractBean
   private List<Long> rawAnomalyIdList;
   private String collection;
   private String metric;
-  private String dimensions;
+  private DimensionMap dimensions;
   private Long startTime;
   private Long endTime;
   // significance level
@@ -71,11 +75,11 @@ public class MergedAnomalyResultBean extends AbstractBean
     this.endTime = endTime;
   }
 
-  public String getDimensions() {
+  public DimensionMap getDimensions() {
     return dimensions;
   }
 
-  public void setDimensions(String dimensions) {
+  public void setDimensions(DimensionMap dimensions) {
     this.dimensions = dimensions;
   }
 
@@ -170,5 +174,12 @@ public class MergedAnomalyResultBean extends AbstractBean
         + ", startTime=" + startTime + ", endTime=" + endTime + ", score=" + score + ", weight="
         + weight + ", createdTime=" + createdTime + ", message='" + message + '\'' + ", notified="
         + notified + '}';
+  }
+
+  public static class MergedAnomalyResultBeanIndexMap extends PropertyMap<MergedAnomalyResultBean, MergedAnomalyResultIndex> {
+    @Override
+    protected void configure() {
+      map(source.getDimensions().toString()).setDimensions(null);
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
@@ -176,11 +176,4 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
     }
     return ObjectUtils.compare(getId(), o.getId());
   }
-
-  public static class RawAnomalyResultBeanIndexMap extends PropertyMap<RawAnomalyResultBean, RawAnomalyResultIndex> {
-    @Override
-    protected void configure() {
-      map(source.getDimensions().toString()).setDimensions(null);
-    }
-  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
@@ -1,11 +1,16 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
+import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.entity.RawAnomalyResultIndex;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
 import java.util.Objects;
 
 import org.apache.commons.lang.ObjectUtils;
 import org.joda.time.DateTime;
 
 import com.google.common.base.MoreObjects;
+import org.modelmapper.PropertyMap;
+
 
 public class RawAnomalyResultBean extends AbstractBean implements Comparable<RawAnomalyResultBean> {
 
@@ -13,7 +18,7 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
   private Long AnomalyFeedbackId;
   private Long startTime;
   private Long endTime;
-  private String dimensions;
+  private DimensionMap dimensions;
 
   // significance level
   private double score;
@@ -30,11 +35,11 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
     creationTimeUtc = DateTime.now().getMillis();
   }
 
-  public String getDimensions() {
+  public DimensionMap getDimensions() {
     return dimensions;
   }
 
-  public void setDimensions(String dimensions) {
+  public void setDimensions(DimensionMap dimensions) {
     this.dimensions = dimensions;
   }
 
@@ -170,5 +175,12 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
       return diff;
     }
     return ObjectUtils.compare(getId(), o.getId());
+  }
+
+  public static class RawAnomalyResultBeanIndexMap extends PropertyMap<RawAnomalyResultBean, RawAnomalyResultIndex> {
+    @Override
+    protected void configure() {
+      map(source.getDimensions().toString()).setDimensions(null);
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
@@ -1,10 +1,10 @@
 package com.linkedin.thirdeye.detector.function;
 
+import com.linkedin.thirdeye.api.DimensionMap;
 import java.util.List;
 
 import org.joda.time.DateTime;
 
-import com.linkedin.thirdeye.api.DimensionKey;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
@@ -18,8 +18,8 @@ public interface AnomalyFunction {
 
   /**
    * Analyzes a metric time series and returns any anomalous points / intervals.
-   * @param dimensionKey
-   *          The dimension combination corresponding to timeSeries.
+   * @param exploredDimensions
+   *          Pairs of dimension value and name corresponding to timeSeries.
    * @param timeSeries
    *          The metric time series data.
    * @param windowStart
@@ -31,7 +31,7 @@ public interface AnomalyFunction {
    * @return
    *         A list of anomalies that were not previously known.
    */
-  List<RawAnomalyResultDTO> analyze(DimensionKey dimensionKey, MetricTimeSeries timeSeries,
+  List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions, MetricTimeSeries timeSeries,
       DateTime windowStart, DateTime windowEnd, List<RawAnomalyResultDTO> knownAnomalies)
       throws Exception;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.detector.function;
 
+import com.linkedin.thirdeye.api.DimensionMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -34,7 +35,7 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
   }
 
   @Override
-  public List<RawAnomalyResultDTO> analyze(DimensionKey dimensionKey,
+  public List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions,
       MetricTimeSeries timeSeries, DateTime windowStart, DateTime windowEnd,
       List<RawAnomalyResultDTO> knownAnomalies) throws Exception {
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
@@ -78,7 +79,7 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
         anomalyResult.setProperties(getSpec().getProperties());
         anomalyResult.setStartTime(timeBucket);
         anomalyResult.setEndTime(timeBucket + bucketMillis); // point-in-time
-        anomalyResult.setDimensions(CSV.join(dimensionKey.getDimensionValues()));
+        anomalyResult.setDimensions(exploredDimensions);
         anomalyResult.setScore(averageValue);
         anomalyResult.setWeight(Math.abs(deviationFromThreshold)); // higher change, higher the severity
         String message =

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.detector.function;
 
 import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
+import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.dashboard.views.TimeBucket;
 import java.io.IOException;
 import java.text.NumberFormat;
@@ -18,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
-import com.linkedin.thirdeye.api.DimensionKey;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 
@@ -70,7 +70,7 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
   }
 
   @Override
-  public List<RawAnomalyResultDTO> analyze(DimensionKey dimensionKey, MetricTimeSeries timeSeries,
+  public List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions, MetricTimeSeries timeSeries,
       DateTime windowStart, DateTime windowEnd, List<RawAnomalyResultDTO> knownAnomalies)
       throws Exception {
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
@@ -105,8 +105,7 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
 
     // Check if this time series even meets our volume threshold
     if (averageValue < volumeThreshold) {
-      LOGGER.info("{} does not meet volume threshold {}: {}", dimensionKey, volumeThreshold,
-          averageValue);
+      LOGGER.info("{} does not meet volume threshold {}: {}", exploredDimensions, volumeThreshold, averageValue);
       return anomalyResults; // empty list
     }
     // iterate through baseline keys
@@ -120,7 +119,7 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
       double baselineValue = timeSeries.get(baselineKey, metric).doubleValue();
       if (isAnomaly(currentValue, baselineValue, changeThreshold)) {
         RawAnomalyResultDTO anomalyResult = new RawAnomalyResultDTO();
-        anomalyResult.setDimensions(CSV.join(dimensionKey.getDimensionValues()));
+        anomalyResult.setDimensions(exploredDimensions);
         anomalyResult.setProperties(getSpec().getProperties());
         anomalyResult.setStartTime(currentKey);
         anomalyResult.setEndTime(currentKey + bucketMillis); // point-in-time

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -9,11 +9,10 @@ import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
-import com.linkedin.thirdeye.dashboard.Utils;
 
+import com.linkedin.thirdeye.api.DimensionMap;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,54 +73,30 @@ public abstract class ThirdEyeUtils {
     return filterSet;
   }
 
-  public static Multimap<String, String> getFilterSetFromDimensionKeyString(String dimensionKeyString, String collection) {
-    return getFilterSetFromDimensionKeyString(dimensionKeyString, collection, null);
-  }
-
   /**
-   * Returns or modifies a filter that can be for querying the results corresponding to the given dimension key.
+   * Returns or modifies a filter that can be for querying the results corresponding to the given dimension map.
    *
-   * For example, if a dimension key = "IN,front_page,*,*" and the dimension names of this dataset is ["country",
-   * "page_name", "some_dimension", ...], then the two entries will be added or over-written in the filter:
-   * 1. "country"="IN" and 2. "page_name"="front_page".
+   * For example, if a dimension map = {country=IN,page_name=front_page}, then the two entries will be added or
+   * over-written to the given filter.
    *
-   * Note that if the given filter contains an entry: "country"=["IN", "US", "TW",...], then this entry is replaced by
-   * "country"="IN".
+   * Note that if the given filter contains an entry: country=["IN", "US", "TW",...], then this entry is replaced by
+   * country=IN.
    *
-   * @param dimensionKeyString a string that represents the dimension key
-   * @param collection the name of the dataset
+   * @param dimensionMap the dimension map to add to the filter
    * @param filterToDecorate if it is null, a new filter will be created; otherwise, it is modified.
-   * @return a filter that is modified according to the given dimensionKeyString.
+   * @return a filter that is modified according to the given dimension map.
    */
-  public static Multimap<String, String> getFilterSetFromDimensionKeyString(String dimensionKeyString,
-      String collection, Multimap<String, String> filterToDecorate) {
+  public static Multimap<String, String> getFilterSetFromDimensionMap(DimensionMap dimensionMap,
+      Multimap<String, String> filterToDecorate) {
     if (filterToDecorate == null) {
       filterToDecorate = HashMultimap.create();
     }
 
-    List<String> schemaDimensionNames;
-    try {
-      schemaDimensionNames = Utils.getSchemaDimensionNames(collection);
-    } catch (Exception e) {
-      LOG.info("Filter is not decorated: Unable to get schema dimension names for collection -- {}. ", collection);
-      schemaDimensionNames = Collections.emptyList();
-    }
-
-    if (schemaDimensionNames.size() > 0) {
-      List<String> dimensionValues;
-      if (StringUtils.isNotBlank(dimensionKeyString)) {
-        dimensionValues = Arrays.asList(dimensionKeyString.trim().split(","));
-      } else {
-        dimensionValues = Collections.emptyList();;
-      }
-      for (int i = 0; i < dimensionValues.size(); ++i) {
-        String dimensionValue = dimensionValues.get(i).trim();
-        if (!dimensionValue.equals("") && !dimensionValue.equals("*")) {
-          String dimensionName = schemaDimensionNames.get(i);
-          filterToDecorate.removeAll(dimensionName);
-          filterToDecorate.put(dimensionName, dimensionValue);
-        }
-      }
+    for (Map.Entry<String, String> entry : dimensionMap.getDimensionMap().entrySet()) {
+      String dimensionName = entry.getKey();
+      String dimensionValue = entry.getValue();
+      filterToDecorate.removeAll(dimensionName);
+      filterToDecorate.put(dimensionName, dimensionValue);
     }
 
     return filterToDecorate;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -92,7 +92,7 @@ public abstract class ThirdEyeUtils {
       filterToDecorate = HashMultimap.create();
     }
 
-    for (Map.Entry<String, String> entry : dimensionMap.getDimensionMap().entrySet()) {
+    for (Map.Entry<String, String> entry : dimensionMap.entrySet()) {
       String dimensionName = entry.getKey();
       String dimensionValue = entry.getValue();
       filterToDecorate.removeAll(dimensionName);

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/common/handlebars-methods.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/common/handlebars-methods.js
@@ -83,34 +83,22 @@ $(document).ready(function () {
         }
     });
 
-
-    //Helper for anomaly function form, here we can set the desired display of any function property
-    Handlebars.registerHelper('displayAnomalyResultDimensionValue', function (value) {
-
-        var displayValue = value.replace(/[,*\s]/g, "");
-        if(displayValue.length == 0){
-            displayValue = "ALL";
-        }
-        return displayValue
-    });
-
-    Handlebars.registerHelper('displayAnomalyResultExploreDimensions', function (dimensionNamesString, dimensionValuesString) {
-
-        var dimensionNames = dimensionNamesString.replace(/[\s]/g, "").split(",");
-        if (dimensionNames.length == 1) {
-            return dimensionValuesString.replace(/[,*\s]/g, "");
-        }
-
-        var dimensionValues = dimensionValuesString.replace(/[*\s]/g, "").split(",");
-        var displayValue = "";
+    Handlebars.registerHelper('displayAnomalyResultExploreDimensions', function (dimensionMap) {
+        var dimensionString = "";
         var separator = "";
-        for (var i = 0; i < dimensionNames.length; ++i) {
-            if (dimensionValues[i]) {
-                displayValue = displayValue + separator + dimensionNames[i] + ": " + dimensionValues[i];
+        var mapSize = 0;
+        for (var dimensionName in dimensionMap) {
+            if (dimensionMap.hasOwnProperty(dimensionName)) {
+                dimensionString += separator + dimensionName + ":" + dimensionMap[dimensionName];
                 separator = "; ";
+                ++mapSize;
             }
         }
-        return displayValue
+        if (mapSize == 0) {
+            return "ALL";
+        } else {
+            return dimensionString;
+        }
     });
 
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies-tab/anomalies.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies-tab/anomalies.ftl
@@ -31,11 +31,8 @@
                         <div>
                             <div class="small-label">dimension:</div>
                             <div class="dimension">
-                            <span style="font-weight: 800;font-size:14px; ">{{#if
-                                anomalyData/function/exploreDimensions}}{{displayAnomalyResultExploreDimensions anomalyData/function/exploreDimensions anomalyData/dimensions}}
-                                {{else}}
-                                    {{displayAnomalyResultDimensionValue anomalyData/dimensions}}
-                                {{/if}}
+                            <span style="font-weight: 800;font-size:14px; ">
+                                {{displayAnomalyResultExploreDimensions anomalyData/dimensions}}
                             </span>
 
                             <div class="change" style="margin-top:6px;">

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies-tab/anomaly-details.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies-tab/anomaly-details.ftl
@@ -69,11 +69,7 @@
                     {{displayDateRange rawAnomaly/startTime rawAnomaly/endTime}}
                 </td>
                 <td>
-                   {{#if rawAnomaly/function/exploreDimensions}}
-                      {{displayAnomalyResultExploreDimensions rawAnomaly/function/exploreDimensions rawAnomaly/dimensions}}
-                   {{else}}
-                      {{displayAnomalyResultDimensionValue rawAnomaly/dimensions}}
-                   {{/if}}
+                    {{displayAnomalyResultExploreDimensions rawAnomaly/dimensions}}
                 </td>
                 <td>
                     {{message}}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -182,10 +182,8 @@ public abstract class AbstractManagerTestBase {
     anomalyResult.setStartTime(System.currentTimeMillis());
     anomalyResult.setEndTime(System.currentTimeMillis());
     anomalyResult.setWeight(10.1);
-    SortedMap<String, String> exploredDimensions = new TreeMap<>();
-    exploredDimensions.put("dimensionName", "dimensionValue");
     DimensionMap dimensionMap = new DimensionMap();
-    dimensionMap.setDimensionMap(exploredDimensions);
+    dimensionMap.put("dimensionName", "dimensionValue");
     anomalyResult.setDimensions(dimensionMap);
     anomalyResult.setCreationTimeUtc(System.currentTimeMillis());
     return anomalyResult;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -1,11 +1,14 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
 
 import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
 import java.sql.Connection;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 import jersey.repackaged.com.google.common.collect.Lists;
@@ -179,7 +182,11 @@ public abstract class AbstractManagerTestBase {
     anomalyResult.setStartTime(System.currentTimeMillis());
     anomalyResult.setEndTime(System.currentTimeMillis());
     anomalyResult.setWeight(10.1);
-    anomalyResult.setDimensions("xyz dimension");
+    SortedMap<String, String> exploredDimensions = new TreeMap<>();
+    exploredDimensions.put("dimensionName", "dimensionValue");
+    DimensionMap dimensionMap = new DimensionMap();
+    dimensionMap.setDimensionMap(exploredDimensions);
+    anomalyResult.setDimensions(dimensionMap);
     anomalyResult.setCreationTimeUtc(System.currentTimeMillis());
     return anomalyResult;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -79,9 +81,17 @@ public class TestMergedAnomalyResultManager extends AbstractManagerTestBase {
 
   @Test(dependsOnMethods = {"testMergedResultCRUD"})
   public void testFindByCollectionMetricDimensions() {
+    String exploredDimensionString;
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      exploredDimensionString = mapper.writeValueAsString(mergedResult.getDimensions());
+    } catch (JsonProcessingException e) {
+      exploredDimensionString = "";
+    }
     List<MergedAnomalyResultDTO> mergedResults = mergedResultDAO
         .findByCollectionMetricDimensionsTime(mergedResult.getCollection(), mergedResult.getMetric(),
-           mergedResult.getDimensions().toString(), 0, System.currentTimeMillis());
+           exploredDimensionString, 0, System.currentTimeMillis());
+
     Assert.assertEquals(mergedResults.get(0), mergedResult);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
@@ -81,7 +81,7 @@ public class TestMergedAnomalyResultManager extends AbstractManagerTestBase {
   public void testFindByCollectionMetricDimensions() {
     List<MergedAnomalyResultDTO> mergedResults = mergedResultDAO
         .findByCollectionMetricDimensionsTime(mergedResult.getCollection(), mergedResult.getMetric(),
-           new String[] {mergedResult.getDimensions()}, 0, System.currentTimeMillis());
+           mergedResult.getDimensions().toString(), 0, System.currentTimeMillis());
     Assert.assertEquals(mergedResults.get(0), mergedResult);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/function/TestUserRuleAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/function/TestUserRuleAnomalyFunction.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.detector.function;
 
+import com.linkedin.thirdeye.api.DimensionMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -118,7 +119,7 @@ public class TestUserRuleAnomalyFunction {
   private void setAnomalyResultFields(RawAnomalyResultDTO anomalyResult) {
     anomalyResult.setProperties("properties");
     anomalyResult.setWeight(3);
-    anomalyResult.setDimensions("dimensions");
+    anomalyResult.setDimensions(new DimensionMap());
   }
 
   @DataProvider(name = "getFilteredAndMergedAnomalyResultsProvider")

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/function/TestUserRuleAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/function/TestUserRuleAnomalyFunction.java
@@ -119,7 +119,9 @@ public class TestUserRuleAnomalyFunction {
   private void setAnomalyResultFields(RawAnomalyResultDTO anomalyResult) {
     anomalyResult.setProperties("properties");
     anomalyResult.setWeight(3);
-    anomalyResult.setDimensions(new DimensionMap());
+    anomalyResult.setDimensions(new DimensionMap() {{
+      put("dimensionName", "dimensionName");
+    }});
   }
 
   @DataProvider(name = "getFilteredAndMergedAnomalyResultsProvider")


### PR DESCRIPTION
Add a new class DimensionMap to replace the usage of dimension key for anomaly related operations.

DimensionMap extends SortedMap<String, String> and hence it can be  directly converted to and converted back from the Json string of Map format.

The reason that DimensionMap extends SortedMap instead of Map is that the string representations of dimension maps are used to check the equality of anomalies and hence the map needs to make sure the dimension name-value pair are sorted in a certain order, which is the alphabetical order of dimension names.