### PR TITLE
Fix the filter set does not show on frontend

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
@@ -195,13 +195,6 @@ public class AnomalyFunctionBean extends AbstractBean {
     this.filters = sortedFilters;
   }
 
-  @JsonIgnore
-  @JsonProperty("wrapper")
-  public void setFilters(Multimap<String, String> filterSet) {
-    String sortedFilters = ThirdEyeUtils.getSortedFiltersFromMultiMap(filterSet);
-    this.filters = sortedFilters;
-  }
-
   public void setActive(boolean isActive) {
     this.isActive = isActive;
   }


### PR DESCRIPTION
Filter set disappears after model mapper maps AnomalyFunctionBean to AnomalyFunctionDTO, which is used in frontend. The cause of this problem is that AnomalyFunctionBean has two setFilters; each of which takes different parameters. The two methods confuse model mapper and hence filter set is not successfully mapped.

Since the method setFilters(Multimap<String, String>) is no longer used due to the introduction of DimensionMap, we can remove this method as well.