### PR TITLE
Disable helix flapping connection check on server and keep it enabled on controllers

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -162,6 +162,13 @@ public class CommonConstants {
     public static final int DEFAULT_BROKER_QUERY_PORT = 8099;
     public static final String KEY_OF_SERVER_NETTY_HOST = "pinot.server.netty.host";
 
+    public static final String HELIX_MANAGER_FLAPPING_TIME_WINDOW_KEY = "helixmanager.flappingTimeWindow";
+    public static final String HELIX_MANAGER_MAX_DISCONNECT_THRESHOLD_KEY = "helixmanager.maxDisconnectThreshold";
+    public static final String CONFIG_OF_HELIX_FLAPPING_TIMEWINDOW_MS = "pinot.server.flapping.timeWindowMs";
+    public static final String CONFIG_OF_HELIX_MAX_DISCONNECT_THRESHOLD = "pinot.server.flapping.maxDisconnectThreshold";
+    public static final String DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS = "1";
+    public static final String DEFAULT_HELIX_FLAPPING_MAX_DISCONNECT_THRESHOLD = "100";
+
   }
 
   public static class Server {
@@ -182,7 +189,6 @@ public class CommonConstants {
         "pinot.server.segment.minRetryDelayMillis";
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";
     public static final String CONFIG_OF_ENABLE_DEFAULT_COLUMNS = "pinot.server.instance.enable.default.columns";
-    public static final String CONFIG_OF_HELIX_FLAPPING_TIMEWINDOW_MS = "pinot.server.flapping.timeWindowMs";
 
     public static final String DEFAULT_ADMIN_API_PORT = "8097";
     public static final String DEFAULT_READ_MODE = "heap";
@@ -199,7 +205,6 @@ public class CommonConstants {
         "com.linkedin.pinot.server.request.SimpleRequestHandlerFactory";
     public static final String DEFAULT_SEGMENT_LOAD_MAX_RETRY_COUNT = "5";
     public static final String DEFAULT_SEGMENT_LOAD_MIN_RETRY_DELAY_MILLIS = "60000";
-    public static final String DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS = "0";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.server.segment.fetcher";
     public static final String DEFAULT_SEGMENT_FORMAT_VERSION = "v1";
     public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "OFF_HEAP";

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -63,7 +63,6 @@ public class HelixSetupUtils {
   public static synchronized HelixManager setup(String helixClusterName, String zkPath, String pinotControllerInstanceId,
       boolean isUpdateStateModel) {
 
-    setupConfigForHelix();
     try {
       createHelixClusterIfNeeded(helixClusterName, zkPath, isUpdateStateModel);
     } catch (final Exception e) {
@@ -77,18 +76,6 @@ public class HelixSetupUtils {
       LOGGER.error("Caught exception", e);
       return null;
     }
-  }
-
-  private static void setupConfigForHelix(){
-
-    // setup helix properties. These settings are not advertised and
-    // hence we've to System.setProperty().
-    // [PINOT-2435] setup helix to never disconnect from ZK if there is flapping
-    // Controller is considered flapping if it disconnects maxDisconnectThreshold number
-    // of times at that instant (same millisecond)
-    final String helixFlappingTimeWindowPropName = "helixmanager.flappingTimeWindow";
-    System.setProperty(helixFlappingTimeWindowPropName, Integer.toString(0));
-    LOGGER.info("Setting helix flappingTimeWindow to 0");
   }
 
   public static void createHelixClusterIfNeeded(String helixClusterName, String zkPath) {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/DefaultHelixStarterServerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/DefaultHelixStarterServerConfig.java
@@ -65,8 +65,8 @@ public class DefaultHelixStarterServerConfig {
     serverConf.addProperty(CommonConstants.Server.CONFIG_OF_QUERY_EXECUTOR_CLASS,
         CommonConstants.Server.DEFAULT_QUERY_EXECUTOR_CLASS);
 
-    serverConf.addProperty(CommonConstants.Server.CONFIG_OF_HELIX_FLAPPING_TIMEWINDOW_MS,
-        CommonConstants.Server.DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS);
+    serverConf.addProperty(CommonConstants.Helix.CONFIG_OF_HELIX_FLAPPING_TIMEWINDOW_MS,
+        CommonConstants.Helix.DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS);
 
     // request handler factory parameters
     serverConf.addProperty(CommonConstants.Server.CONFIG_OF_REQUEST_HANDLER_FACTORY_CLASS,

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -229,9 +229,18 @@ public class HelixServerStarter {
   }
 
   private void setupHelixSystemProperties(Configuration conf) {
-    System.setProperty("helixmanager.flappingTimeWindow",
-        conf.getString(CommonConstants.Server.CONFIG_OF_HELIX_FLAPPING_TIMEWINDOW_MS,
-            CommonConstants.Server.DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS));
+    // [PINOT-2435] [PINOT-3927] Disable helix detection of flapping connection
+    // Helix will shutdown and effectively remove the instance from cluster if
+    // it detects flapping while the process continues to run
+    // Helix ignores the value if it is <= 0. Hence, setting time window to small value
+    // and number of connection failures within that window to high value
+    System.setProperty(CommonConstants.Helix.HELIX_MANAGER_FLAPPING_TIME_WINDOW_KEY,
+        conf.getString(CommonConstants.Helix.CONFIG_OF_HELIX_FLAPPING_TIMEWINDOW_MS,
+            CommonConstants.Helix.DEFAULT_HELIX_FLAPPING_TIMEWINDOW_MS));
+
+    System.setProperty(CommonConstants.Helix.HELIX_MANAGER_MAX_DISCONNECT_THRESHOLD_KEY,
+        conf.getString(CommonConstants.Helix.CONFIG_OF_HELIX_MAX_DISCONNECT_THRESHOLD,
+            CommonConstants.Helix.DEFAULT_HELIX_FLAPPING_MAX_DISCONNECT_THRESHOLD));
   }
 
   public void stop() {


### PR DESCRIPTION
Previously, code was setting flappingTimeWindow to 0 which did
not take effect because Helix checks for values greater than 0.
With this change, server will detect flapping if it disconnects
100 times within 1 ms (by default) which is highly unlikely.