### PR TITLE
Quick bug fix: Temporary disable adaptive baseline values in anomalies tab

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
@@ -56,7 +56,11 @@ public class AnomalyFunctionFactory {
       throw new IllegalArgumentException("Unsupported type " + type);
     }
     String className = props.getProperty(type);
-    anomalyFunction = (BaseAnomalyFunction) Class.forName(className).newInstance();
+    try {
+      anomalyFunction = (BaseAnomalyFunction) Class.forName(className).newInstance();
+    } catch (ClassNotFoundException e) {
+      anomalyFunction = new PresentationalAnomalyFunction();
+    }
 
     anomalyFunction.init(functionSpec);
     return anomalyFunction;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
@@ -56,6 +56,7 @@ public class AnomalyFunctionFactory {
       throw new IllegalArgumentException("Unsupported type " + type);
     }
     String className = props.getProperty(type);
+    // TODO: Remove the class PresentationalAnomalyFunction after fixing the issue
     try {
       anomalyFunction = (BaseAnomalyFunction) Class.forName(className).newInstance();
     } catch (ClassNotFoundException e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
@@ -65,6 +65,11 @@ public abstract class BaseAnomalyFunction implements AnomalyFunction {
       Long monitoringWindowEndTime) {
     List<Pair<Long, Long>> startEndTimeIntervals = new ArrayList<>();
     startEndTimeIntervals.add(new Pair<>(monitoringWindowStartTime, monitoringWindowEndTime));
+
+    long baselineOffsetMillis = TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS);
+    startEndTimeIntervals.add(
+        new Pair<>(monitoringWindowStartTime - baselineOffsetMillis, monitoringWindowEndTime - baselineOffsetMillis));
+
     return startEndTimeIntervals;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/PresentationalAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/PresentationalAnomalyFunction.java
@@ -1,0 +1,23 @@
+package com.linkedin.thirdeye.detector.function;
+
+import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
+import java.util.List;
+import org.joda.time.DateTime;
+
+
+/**
+ * A anomaly function that is used to show week-over-week current and baseline values.
+ * This class is used as a backup function when dashboard is unable to construct the corresponding anomaly function
+ * for showing data.
+ */
+public class PresentationalAnomalyFunction extends BaseAnomalyFunction {
+
+  @Override
+  public List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions, MetricTimeSeries timeSeries,
+      DateTime windowStart, DateTime windowEnd, List<RawAnomalyResultDTO> knownAnomalies)
+      throws Exception {
+    return null;
+  }
+}


### PR DESCRIPTION
An unknown exception is thrown when trying to initiate Anomaly function that shows special baseline. We only show week-over-week values for now until we find the problem.