### PR TITLE
Handle errors in Dynamic Broker selection

### DIFF
--- a/pinot-api/pom.xml
+++ b/pinot-api/pom.xml
@@ -57,5 +57,9 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-api/src/main/java/com/linkedin/pinot/client/DynamicBrokerSelector.java
+++ b/pinot-api/src/main/java/com/linkedin/pinot/client/DynamicBrokerSelector.java
@@ -23,10 +23,11 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
+import javax.annotation.Nullable;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.serialize.BytesPushThroughSerializer;
+
 import static com.linkedin.pinot.client.ExternalViewReader.OFFLINE_SUFFIX;
 import static com.linkedin.pinot.client.ExternalViewReader.REALTIME_SUFFIX;
 
@@ -61,10 +62,14 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
   }
 
   @Override
-  public String selectBroker(String table) {
+  public @Nullable String selectBroker(String table) {
     if (table == null) {
       List<String> list = allBrokerListRef.get();
-      return list.get(_random.nextInt(list.size()));
+      if (list != null && !list.isEmpty()) {
+        return list.get(_random.nextInt(list.size()));
+      } else {
+        return null;
+      }
     }
     String tableName = table.replace(OFFLINE_SUFFIX, "").replace(REALTIME_SUFFIX, "");
     List<String> list = tableToBrokerListMapRef.get().get(tableName);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.utils.FileUploadUtils;
 import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
@@ -75,6 +76,7 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     this.tableName = (String) args[0];
     SegmentVersion version = (SegmentVersion) args[1];
     addOfflineTable("DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, this.tableName, version);
+    Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
     ensureDirectoryExistsAndIsEmpty(_tmpDir);
     ensureDirectoryExistsAndIsEmpty(_segmentsDir);
     ensureDirectoryExistsAndIsEmpty(_tarsDir);


### PR DESCRIPTION
Correctly handle empty or null broker list in
dynamic broker selector if table name is not supplied. This
spawned strage exception message from java.lang.Random.

This also fixes flaky UploadRefreshDeleteIntegrationTest by
introducing some sleep after table creation.

Testing: Reproduce issue/flakiness by lowering sleepTime in
verifyNRows. Verified that a series of runs after this fix
pass.