### PR TITLE
Eliminate flaky behavior from Indexed Priority Queue unit tests.

### DIFF
--- a/pinot-core/src/test/java/com/linkedin/pinot/util/IntDoubleIndexedPriorityQueueTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/IntDoubleIndexedPriorityQueueTest.java
@@ -59,9 +59,7 @@ public class IntDoubleIndexedPriorityQueueTest {
    * @param minHeap Min or max mode
    */
   public void test(boolean minHeap) {
-    long seed = System.nanoTime();
-    Random random = new Random(seed);
-    final String randomSeedMsg = "Random seed: " + seed;
+    Random random = new Random(0);
 
     IntDoubleIndexedPriorityQueue pq = new IntDoubleIndexedPriorityQueue(NUM_RECORDS, minHeap);
     Int2DoubleOpenHashMap map = new Int2DoubleOpenHashMap(NUM_RECORDS);
@@ -97,11 +95,11 @@ public class IntDoubleIndexedPriorityQueueTest {
       Pairs.IntDoublePair actual = pq.poll();
       Pairs.IntDoublePair expected = list.get(i++);
 
-      Assert.assertEquals(actual.getIntValue(), expected.getIntValue(), randomSeedMsg);
-      Assert.assertEquals(actual.getDoubleValue(), expected.getDoubleValue(), randomSeedMsg);
+      Assert.assertEquals(actual.getIntValue(), expected.getIntValue());
+      Assert.assertEquals(actual.getDoubleValue(), expected.getDoubleValue());
     }
 
     // Assert that priority queue had expected number of elements.
-    Assert.assertEquals(i, list.size(), randomSeedMsg);
+    Assert.assertEquals(i, list.size());
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/IntObjectIndexedPriorityQueueTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/IntObjectIndexedPriorityQueueTest.java
@@ -61,9 +61,7 @@ public class IntObjectIndexedPriorityQueueTest {
    * @param minHeap Min mode
    */
   public void test(boolean minHeap) {
-    long seed = System.nanoTime();
-    Random random = new Random(seed);
-    final String randomSeedMsg = "Random seed : " + seed;
+    Random random = new Random(0);
 
     IntObjectIndexedPriorityQueue<AvgPair> pq = new IntObjectIndexedPriorityQueue<>(NUM_RECORDS, minHeap);
     Map<Integer, AvgPair> map = new HashMap<>(NUM_RECORDS);
@@ -108,11 +106,11 @@ public class IntObjectIndexedPriorityQueueTest {
       Pairs.IntObjectPair<AvgPair> actual = pq.poll();
       Pairs.IntObjectPair<AvgPair> expected = list.get(i++);
 
-      Assert.assertEquals(actual.getIntValue(), expected.getIntValue(), randomSeedMsg);
-      Assert.assertEquals(actual.getObjectValue(), expected.getObjectValue(), randomSeedMsg);
+      Assert.assertEquals(actual.getIntValue(), expected.getIntValue());
+      Assert.assertEquals(actual.getObjectValue(), expected.getObjectValue());
     }
 
     // Assert that priority queue had expected number of elements.
-    Assert.assertEquals(i, list.size(), randomSeedMsg);
+    Assert.assertEquals(i, list.size());
   }
 }


### PR DESCRIPTION
Depending on the random seed, we might get different groups with same
avg value (upto 10th decimal place in one occasion). Having random seeds
does not add any value to the quality of the tests, so replacing random
seed with '0'.