### PR TITLE
Reduce memory usage of anomaly detection workers due to JDBC connections

### DIFF
--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesTool.java
@@ -157,8 +157,8 @@ public class CleanupAndRegenerateAnomaliesTool {
       DateTime currentEnd = currentStart.plus(monitoringWindowSize);
 
       // Make the end time inclusive
-      end = new DateTime(cronExpression.getNextValidTimeAfter(end.toDate()));
-      while (currentEnd.isBefore(end)) {
+      DateTime endBoundary = new DateTime(cronExpression.getNextValidTimeAfter(end.toDate()));
+      while (currentEnd.isBefore(endBoundary)) {
         String monitoringWindowStart = ISODateTimeFormat.dateHourMinute().print(currentStart);
         String monitoringWindowEnd = ISODateTimeFormat.dateHourMinute().print(currentEnd);
 


### PR DESCRIPTION
1. Fix memory leakage due to unclosed PreparedStatement and ResultSet.
2. Fix the end time keeps expanding after each iteration of generating the set of tasks for an anomaly function.