### PR TITLE
Fix direct memory usage tracking.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/MmapUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/MmapUtils.java
@@ -245,6 +245,7 @@ public class MmapUtils {
     try {
       byteBuffer = ByteBuffer.allocateDirect(capacity);
     } catch (OutOfMemoryError e) {
+      DIRECT_BYTE_BUFFER_USAGE.addAndGet(-capacity);
       LOGGER.error("Ran out of direct memory while trying to allocate {} bytes (context {})", capacity, context, e);
       LOGGER.error("Allocation status {}", getTrackedAllocationStatus());
       Utils.rethrowException(e);


### PR DESCRIPTION
Failed direct memory allocations are not be accounted for correctly. This shows
up as monitonically increasing direct memory usage after first failure.
This PR fixes this accounting error.