### PR TITLE
Add multiple or equality predicate optimization

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestOptimizer.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestOptimizer.java
@@ -25,7 +25,8 @@ import com.linkedin.pinot.common.utils.request.RequestUtils;
 
 public class BrokerRequestOptimizer {
   private static final List<? extends FilterQueryTreeOptimizer> FILTER_QUERY_TREE_OPTIMIZERS = Arrays.asList(
-      new FlattenNestedPredicatesFilterQueryTreeOptimizer()
+      new FlattenNestedPredicatesFilterQueryTreeOptimizer(),
+      new MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer()
   );
 
   /**

--- a/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.requestHandler;
+
+import com.google.common.base.Splitter;
+import com.linkedin.pinot.common.request.FilterOperator;
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+
+/**
+ * Optimizer that collapses multiple OR clauses to IN clauses. For example, <code>a = 1 OR a = 2 OR a =
+ * 3</code> gets turned to <code>a IN (1, 2, 3)</code>.
+ */
+public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer implements FilterQueryTreeOptimizer {
+  @Override
+  public FilterQueryTree optimize(FilterQueryTree filterQueryTree) {
+    return optimize(filterQueryTree, null);
+  }
+
+  private FilterQueryTree optimize(FilterQueryTree filterQueryTree, FilterQueryTree parent) {
+    if (filterQueryTree.getOperator() == FilterOperator.OR) {
+      Map<String, Set<String>> columnToValues = new HashMap<>();
+      List<FilterQueryTree> nonEqualityOperators = new ArrayList<>();
+
+      // Collect all equality/in values and non-equality operators
+      boolean containsDuplicates = collectChildOperators(filterQueryTree, columnToValues, nonEqualityOperators);
+
+      // If we have at least one column to return
+      if (!columnToValues.isEmpty()) {
+        // We can eliminate the OR node if there is only one column with multiple values
+        if (columnToValues.size() == 1 && nonEqualityOperators.isEmpty()) {
+          Map.Entry<String, Set<String>> columnAndValues = columnToValues.entrySet().iterator().next();
+
+          return buildFilterQueryTreeForColumnAndValues(columnAndValues);
+        }
+
+        // Check if we need to rebuild the predicate
+        boolean rebuildRequired = isRebuildRequired(columnToValues, containsDuplicates);
+
+        if (!rebuildRequired) {
+          // No mutation needed, so just return the same tree
+          return filterQueryTree;
+        } else {
+          // Rebuild the predicates
+          return rebuildFilterPredicate(columnToValues, nonEqualityOperators);
+        }
+      }
+    } else if (filterQueryTree.getChildren() != null){
+      // Optimize the child nodes, if any
+      applyOptimizationToChildNodes(filterQueryTree);
+    }
+
+    return filterQueryTree;
+  }
+
+  private void applyOptimizationToChildNodes(FilterQueryTree filterQueryTree) {
+    Iterator<FilterQueryTree> childTreeIterator = filterQueryTree.getChildren().iterator();
+    List<FilterQueryTree> childrenToAdd = null;
+
+    while (childTreeIterator.hasNext()) {
+      FilterQueryTree childQueryTree = childTreeIterator.next();
+      FilterQueryTree optimizedChildQueryTree = optimize(childQueryTree, filterQueryTree);
+      if (childQueryTree != optimizedChildQueryTree) {
+        childTreeIterator.remove();
+        if (childrenToAdd == null) {
+          childrenToAdd = new ArrayList<>();
+        }
+        childrenToAdd.add(optimizedChildQueryTree);
+      }
+    }
+
+    if (childrenToAdd != null) {
+      filterQueryTree.getChildren().addAll(childrenToAdd);
+    }
+  }
+
+  private boolean collectChildOperators(FilterQueryTree filterQueryTree, Map<String, Set<String>> columnToValues,
+      List<FilterQueryTree> nonEqualityOperators) {
+    boolean containsDuplicates = false;
+
+    for (FilterQueryTree childQueryTree : filterQueryTree.getChildren()) {
+      if (childQueryTree.getOperator() == FilterOperator.EQUALITY || childQueryTree.getOperator() == FilterOperator.IN) {
+        List<String> childValues = valueDoubleTabListToElements(childQueryTree.getValue());
+
+        if (!columnToValues.containsKey(childQueryTree.getColumn())) {
+          TreeSet<String> value = new TreeSet<>(childValues);
+          columnToValues.put(childQueryTree.getColumn(), value);
+          if (!containsDuplicates && value.size() != childValues.size()) {
+            containsDuplicates = true;
+          }
+        } else {
+           Set<String> currentValues = columnToValues.get(childQueryTree.getColumn());
+          for (String childValue : childValues) {
+            if (!containsDuplicates && currentValues.contains(childValue)) {
+              containsDuplicates = true;
+            } else {
+              currentValues.add(childValue);
+            }
+          }
+        }
+      } else {
+        nonEqualityOperators.add(childQueryTree);
+      }
+    }
+
+    return containsDuplicates;
+  }
+
+  private boolean isRebuildRequired(Map<String, Set<String>> columnToValues, boolean containsDuplicates) {
+    // We need to rebuild the predicate if there were duplicate values detected (eg. a = 1 OR a = 1) or if there is
+    // more than one value for a column (eg. a = 1 OR a = 2)
+    boolean rebuildRequired = containsDuplicates;
+
+    if (!rebuildRequired) {
+      for (Set<String> columnValues : columnToValues.values()) {
+        if (1 < columnValues.size()) {
+          rebuildRequired = true;
+          break;
+        }
+      }
+    }
+    return rebuildRequired;
+  }
+
+  private FilterQueryTree rebuildFilterPredicate(Map<String, Set<String>> columnToValues,
+      List<FilterQueryTree> nonEqualityOperators) {
+    ArrayList<FilterQueryTree> newChildren = new ArrayList<>();
+    for (Map.Entry<String, Set<String>> columnAndValues : columnToValues.entrySet()) {
+      newChildren.add(buildFilterQueryTreeForColumnAndValues(columnAndValues));
+    }
+    newChildren.addAll(nonEqualityOperators);
+    return new FilterQueryTree(null, null, FilterOperator.OR, newChildren);
+  }
+
+  private FilterQueryTree buildFilterQueryTreeForColumnAndValues(Map.Entry<String, Set<String>> columnAndValues) {
+    // If there's only one value, turn it into an equality, otherwise turn it into an IN clause
+    if (columnAndValues.getValue().size() == 1) {
+      Set<String> Values = columnAndValues.getValue();
+      return new FilterQueryTree(columnAndValues.getKey(),
+          elementListToDoubleTabSingletonList(columnAndValues.getValue()), FilterOperator.EQUALITY, null);
+    } else {
+      return new FilterQueryTree(columnAndValues.getKey(),
+          elementListToDoubleTabSingletonList(columnAndValues.getValue()), FilterOperator.IN, null);
+    }
+  }
+
+  private List<String> elementListToDoubleTabSingletonList(Collection<String> elementList) {
+    return Collections.singletonList(StringUtil.join("\t\t", elementList.toArray(new String[elementList.size()])));
+  }
+
+  private List<String> valueDoubleTabListToElements(List<String> doubleTabSeparatedElements) {
+    Splitter valueSplitter = Splitter.on("\t\t");
+    List<String> valueElements = new ArrayList<>();
+
+    for (String value : doubleTabSeparatedElements) {
+      valueElements.addAll(valueSplitter.splitToList(value));
+    }
+
+    return valueElements;
+  }
+
+  private List<String> valueDoubleTabListToElements(String doubleTabSeparatedElements) {
+    Splitter valueSplitter = Splitter.on("\t\t");
+    return valueSplitter.splitToList(doubleTabSeparatedElements);
+  }
+}

--- a/pinot-transport/src/test/java/com/linkedin/pinot/requestHandler/FilterOptimizerTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/requestHandler/FilterOptimizerTest.java
@@ -74,7 +74,7 @@ public class FilterOptimizerTest {
     }
 
     // 3-level test case
-    req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 OR D = 9)) OR (C=7)) OR D=8");
+    req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 OR D = 9)) OR (C=7)) OR E=8");
     tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
     Assert.assertEquals(tree.getChildren().size(), 5);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
@@ -84,7 +84,7 @@ public class FilterOptimizerTest {
     }
 
     // Mixed case.
-    req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 AND D = 9)) OR (C=7)) OR D=8");
+    req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 AND D = 9)) OR (C=7)) OR E=8");
     tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
     Assert.assertEquals(tree.getChildren().size(), 4);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
@@ -155,7 +155,7 @@ public class FilterOptimizerTest {
     if (depth == 1) {
       return "(A = " + depth + ")";
     } else {
-      return "(A = " + depth + " " + operator + " " + constructWhereClause(operator, depth-1) + ")";
+      return "(A" + depth + " = " + depth + " " + operator + " " + constructWhereClause(operator, depth-1) + ")";
     }
   }
 }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/requestHandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/requestHandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.requestHandler;
+
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test for MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.
+ */
+public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
+  @Test
+  public void testSimpleOrCase() {
+    // a = 1 OR a = 2 OR a = 3 should be rewritten to a IN (1, 2, 3)
+    checkForIdenticalFilterQueryTrees(
+        "select * from a where a = 1 OR a = 2 OR a = 3",
+        "select * from a where a IN (1, 2, 3)"
+    );
+  }
+
+  @Test
+  public void testWithOtherClause() {
+    // a = 1 OR a = 2 OR (a = 3 AND b = 4) -> a IN (1, 2) OR (a = 3 AND b = 4)
+    checkForIdenticalFilterQueryTrees(
+        "select * from a where a = 1 OR a = 2 OR a = 3 AND b = 4",
+        "select * from a where a IN (1, 2) OR (a = 3 AND b = 4)"
+    );
+  }
+
+  @Test
+  public void testTwoOrClauses() {
+    // a = 1 OR a = 2 OR a = 3 OR b = 4 OR b = 5 OR b = 6 -> a IN (1,2,3) OR b IN (4,5,6)
+    checkForIdenticalFilterQueryTrees(
+        "select * from a where a = 1 OR a = 2 OR a = 3 OR b = 4 OR b = 5 OR b = 6",
+        "select * from a where a IN (1,2,3) OR b IN (4,5,6)"
+    );
+  }
+
+  @Test
+  public void testMultipleOutOfOrderClauses() {
+    // a = 1 OR a = 2 OR a = 3 OR b = 4 OR b = 5 OR b = 6 -> a IN (1,2,3) OR b IN (4,5,6)
+    checkForIdenticalFilterQueryTrees(
+        "select * from a where a = 1 OR b = 4 OR a = 2 OR b = 5 OR a = 3 OR b = 6",
+        "select * from a where a IN (1,2,3) OR b IN (4,5,6)"
+    );
+  }
+
+  @Test
+  public void testDuplicatesAndPullup() {
+    // a = 1 OR a = 1 -> a = 1 (equality predicate, not IN clause, eg. a IN (1))
+    // This should also remove the OR node
+    checkForIdenticalFilterQueryTrees(
+        "select * from a where a = 1 OR a = 1",
+        "select * from a where a = 1"
+    );
+
+    // (a = 1 OR a = 1) AND b = 2 -> a = 1 AND b = 2 (no OR node either)
+    // These are reordered due to an implementation detail
+    checkOptimizedFilterQueryTreeForQuery(
+        "select * from a where (a = 1 OR a = 1) AND b = 2",
+        "AND\n" +
+            " b EQUALITY [2]\n" +
+            " a EQUALITY [1]"
+    );
+  }
+
+  @Test
+  public void testEqualityAndInMerge() {
+    // a = 1 OR a IN (2,3,4) -> a IN (1,2,3,4)
+    checkForIdenticalFilterQueryTrees(
+        "select * from a where a = 1 OR a IN (2,3,4)",
+        "select * from a where a IN (1,2,3,4)"
+    );
+  }
+
+  @Test
+  public void testSingularInClauseDedupeAndCollapse() {
+    // a IN (1,1) -> a = 1
+    checkForIdenticalFilterQueryTrees(
+        "select * from a where a IN (1, 1) OR a = 1",
+        "select * from a where a = 1"
+    );
+  }
+
+  private static final Pql2Compiler COMPILER = new Pql2Compiler();
+  public static final BrokerRequestOptimizer OPTIMIZER = new BrokerRequestOptimizer();
+
+  private String stripIds(String filterQueryTree) {
+    String[] lines = filterQueryTree.split("\n");
+
+    // Strip all FilterQueryTree ids
+    for (int i = 0; i < lines.length; i++) {
+      lines[i] = lines[i].replaceAll(" \\(.*", "");
+    }
+
+    return StringUtil.join("\n", lines);
+  }
+
+  private String filterQueryTreeForQuery(String query) {
+    BrokerRequest brokerRequest = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(query));
+    return RequestUtils.generateFilterQueryTree(brokerRequest).toString();
+  }
+
+  private void checkOptimizedFilterQueryTreeForQuery(String query, String optimizedFilterQueryTree) {
+    String queryFilterTree = stripIds(filterQueryTreeForQuery(query));
+    Assert.assertEquals(queryFilterTree, stripIds(optimizedFilterQueryTree), "Optimized filter query trees are different for query " + query);
+  }
+
+  private void checkForIdenticalFilterQueryTrees(String query, String optimizedQuery) {
+    String queryFilterTree = stripIds(filterQueryTreeForQuery(query));
+    String optimizedFilterQueryTree = stripIds(filterQueryTreeForQuery(optimizedQuery));
+
+    Assert.assertEquals(queryFilterTree, stripIds(optimizedFilterQueryTree), "Optimized filter query trees are different for query " + query);
+  }
+}


### PR DESCRIPTION
Optimize query predicates where multiple equality and IN clauses are
linked by OR operators. For example, this rewrites the query predicate
a = 1 OR a = 2 into a IN (1, 2).

This optimization removes redundant OR operators ("pull-up") if the
OR node contains a single predicate. It removes duplicate values
across linked predicates (eg. a = 1 OR a = 1 is collapsed to a single
equality statement). Equality predicates of different types are
joined (eg. a = 1 OR a IN (2,3) becomes a IN (1,2,3)). Singular
predicates are turned into equality predicates (eg. a IN (1) OR
a = 1 becomes a = 1).