### PR TITLE
Add max weight limitation to ResultSetGroup cache

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
@@ -121,10 +121,11 @@ public class ThirdEyeCacheRegistry {
     // ResultSetGroup Cache. The size of this cache is limited by the total number of buckets in all ResultSetGroup.
     // We estimate that 1 bucket (including overhead) consumes 1KB and this cache is allowed to use up to 50% of max
     // heap space.
+    long maxBucketNumber = getApproximateMaxBucketNumber(DEFAULT_HEAP_PERCENTAGE_FOR_RESULTSETGROUP_CACHE);
     LoadingCache<PinotQuery, ResultSetGroup> resultSetGroupCache = CacheBuilder.newBuilder()
         .removalListener(listener)
         .expireAfterAccess(1, TimeUnit.HOURS)
-        .maximumWeight(getApproximateMaxBucketNumber(DEFAULT_HEAP_PERCENTAGE_FOR_RESULTSETGROUP_CACHE))
+        .maximumWeight(maxBucketNumber)
         .weigher((pinotQuery, resultSetGroup) -> {
           int resultSetCount = resultSetGroup.getResultSetCount();
           int weight = 0;
@@ -136,6 +137,7 @@ public class ThirdEyeCacheRegistry {
         })
         .build(new ResultSetGroupCacheLoader(pinotThirdeyeClientConfig));
     cacheRegistry.registerResultSetGroupCache(resultSetGroupCache);
+    LOGGER.info("Max bucket number for ResultSetGroup cache is set to {}", maxBucketNumber);
 
     // CollectionMaxDataTime Cache
     LoadingCache<String, Long> collectionMaxDataTimeCache = CacheBuilder.newBuilder()


### PR DESCRIPTION
The approximate weight is calculated by following rules:
  1. We estimate that a bucket, including its overhead, occupies 1 KB. The value is estimated from previous heap dumps.
  2. Cache size (in bytes) = JVM's max heap space * percentage
  3. We also bound the cache size between 100MB and 8GB if max heap size is unavailable.
  4. Weight (number of buckets) = cache size / 1KB.

Tested using a JVM with 2GB heap space and 5 working threads keep pulling data from Pinot. ResultSetGroup starts to be expired once the heap space reaches 2.24GB. The test lasts about 9 hours without Out-Of-Memory exception.
