### PR TITLE
Add passive refresh for max data time

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
@@ -121,6 +121,7 @@ public class ThirdEyeCacheRegistry {
 
         // CollectionMaxDataTime Cache
     LoadingCache<String, Long> collectionMaxDataTimeCache = CacheBuilder.newBuilder()
+        .refreshAfterWrite(5, TimeUnit.MINUTES)
         .build(new CollectionMaxDataTimeCacheLoader(resultSetGroupCache, datasetConfigDAO));
     cacheRegistry.registerCollectionMaxDataTimeCache(collectionMaxDataTimeCache);
 
@@ -186,7 +187,7 @@ public class ThirdEyeCacheRegistry {
           LOGGER.error("Exception while loading collections", e);
         }
       }
-    }, 5, 5, TimeUnit.MINUTES);
+    }, 30, 30, TimeUnit.MINUTES);
 
     ScheduledExecutorService hourlyService = Executors.newSingleThreadScheduledExecutor();
     hourlyService.scheduleAtFixedRate(new Runnable() {


### PR DESCRIPTION
If a max data time is being read and last refreshing happens more than 5 minutes ago, then the cache will refresh the max data time asynchronously: The read that triggers the update may or may not get the latest value, but the next subsequent reads will get the refreshed value when the refreshing is done.

All data time is actively refreshed every 30 minutes.