### PR TITLE
Improve query engine benchmark setup

### DIFF
--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>1.10.4</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/PerfBenchmarkDriver.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/PerfBenchmarkDriver.java
@@ -334,8 +334,16 @@ public class PerfBenchmarkDriver {
   }
 
   public JSONObject postQuery(String query) throws Exception {
+    return postQuery(query, null);
+  }
+
+  public JSONObject postQuery(String query, String optimizationFlags) throws Exception {
     final JSONObject json = new JSONObject();
     json.put("pql", query);
+
+    if (optimizationFlags != null && !optimizationFlags.isEmpty()) {
+      json.put("debugOptions", "optimizationFlags=" + optimizationFlags);
+    }
 
     final long start = System.currentTimeMillis();
     final URLConnection conn = new URL(brokerBaseApiUrl + "/query").openConnection();

--- a/pinot-perf/src/main/resources/log4j.properties
+++ b/pinot-perf/src/main/resources/log4j.properties
@@ -14,21 +14,21 @@
 # limitations under the License.
 #
 
-log4j.rootLogger=INFO, stdout
-log4j.logger.com.linkedin.pinot=INFO
+log4j.rootLogger=WARN, stdout
+log4j.logger.com.linkedin.pinot=WARN
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 
-log4j.logger.com.linkedin.pinot.perf=INFO, stdout
+log4j.logger.com.linkedin.pinot.perf=WARN, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.additivity.com.linkedin.pinot.perf = false
 
-log4j.logger.com.linkedin.pinot.controller=INFO, controllerLog
-log4j.logger.com.linkedin.pinot.broker=INFO, brokerLog
-log4j.logger.com.linkedin.pinot.server=INFO, serverLog
+log4j.logger.com.linkedin.pinot.controller=WARN, controllerLog
+log4j.logger.com.linkedin.pinot.broker=WARN, brokerLog
+log4j.logger.com.linkedin.pinot.server=WARN, serverLog
 
 log4j.appender.controllerLog=org.apache.log4j.FileAppender
 log4j.appender.controllerLog.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Improve the query engine benchmark setup to allow running benchmarks
with some optimizations toggled on and off. Poll the external view to
wait until segments are loaded instead of having a fixed timeout. Add
support for multiple query strings in the benchmark, doing a cross
product of optimization flags and queries. Add option to output
profiling information. Update the version of JMH.
