### PR TITLE
Populate correct known anomalies to anomaly detection functions

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import java.util.List;
 
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -8,6 +9,8 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   List<MergedAnomalyResultDTO> getAllByTimeEmailIdAndNotifiedFalse(long startTime, long endTime,
       long emailId);
+
+  List<MergedAnomalyResultDTO> findAllConflictByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd);
 
   List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
       String metric, String dimensions, long startTime, long endTime);
@@ -19,6 +22,8 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
       long endTime);
 
   MergedAnomalyResultDTO findLatestByFunctionIdDimensions(Long functionId, String dimensions);
+
+  MergedAnomalyResultDTO findLatestConflictByFunctionIdDimensions(Long functionId, String dimensions, long conflictWindowStart, long conflictWindowEnd);
 
   MergedAnomalyResultDTO findLatestByFunctionIdOnly(Long functionId);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RawAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RawAnomalyResultManagerImpl.java
@@ -81,13 +81,7 @@ public class RawAnomalyResultManagerImpl extends AbstractManagerImpl<RawAnomalyR
     Predicate functionIdPredicate = Predicate.EQ("functionId", functionId);
     Predicate finalPredicate =
         Predicate.AND(functionIdPredicate, Predicate.OR(endTimeTimePredicate, startTimePredicate));
-    List<RawAnomalyResultBean> list =
-        genericPojoDao.get(finalPredicate, RawAnomalyResultBean.class);
-    List<RawAnomalyResultDTO> result = new ArrayList<>();
-    for (RawAnomalyResultBean bean : list) {
-      result.add(createRawAnomalyDTOFromBean(bean));
-    }
-    return result;
+    return findByPredicate(finalPredicate);
   }
 
   public List<RawAnomalyResultDTO> findUnmergedByFunctionId(Long functionId) {
@@ -99,16 +93,15 @@ public class RawAnomalyResultManagerImpl extends AbstractManagerImpl<RawAnomalyR
         Predicate.EQ("merged", false), //
         Predicate.EQ("dataMissing", false) //
     );
-    List<RawAnomalyResultBean> list = genericPojoDao.get(predicate, RawAnomalyResultBean.class);
-    List<RawAnomalyResultDTO> result = new ArrayList<>();
-    for (RawAnomalyResultBean bean : list) {
-      result.add(createRawAnomalyDTOFromBean(bean));
-    }
-    return result;
+    return findByPredicate(predicate);
   }
 
   public List<RawAnomalyResultDTO> findByFunctionId(Long functionId) {
     Predicate predicate = Predicate.EQ("functionId", functionId);
+    return findByPredicate(predicate);
+  }
+
+  private List<RawAnomalyResultDTO> findByPredicate(Predicate predicate) {
     List<RawAnomalyResultBean> list = genericPojoDao.get(predicate, RawAnomalyResultBean.class);
     List<RawAnomalyResultDTO> result = new ArrayList<>();
     for (RawAnomalyResultBean bean : list) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.detector.function;
 
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.List;
 
 import org.joda.time.DateTime;
@@ -32,7 +33,7 @@ public interface AnomalyFunction {
    *         A list of anomalies that were not previously known.
    */
   List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions, MetricTimeSeries timeSeries,
-      DateTime windowStart, DateTime windowEnd, List<RawAnomalyResultDTO> knownAnomalies)
+      DateTime windowStart, DateTime windowEnd, List<MergedAnomalyResultDTO> knownAnomalies)
       throws Exception;
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.detector.function;
 
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -37,7 +38,7 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
   @Override
   public List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions,
       MetricTimeSeries timeSeries, DateTime windowStart, DateTime windowEnd,
-      List<RawAnomalyResultDTO> knownAnomalies) throws Exception {
+      List<MergedAnomalyResultDTO> knownAnomalies) throws Exception {
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
     // Parse function properties
     Properties props = getProperties();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/WeekOverWeekRuleFunction.java
@@ -4,6 +4,7 @@ import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.dashboard.views.TimeBucket;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.io.IOException;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class WeekOverWeekRuleFunction extends BaseAnomalyFunction {
 
   @Override
   public List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions, MetricTimeSeries timeSeries,
-      DateTime windowStart, DateTime windowEnd, List<RawAnomalyResultDTO> knownAnomalies)
+      DateTime windowStart, DateTime windowEnd, List<MergedAnomalyResultDTO> knownAnomalies)
       throws Exception {
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
 


### PR DESCRIPTION
1. Correct known anomalies are passed to anomaly detection function for constructing history data.

2. Fix the issue that same raw anomalies cannot be regenerated multiple times and hence duplicate raw anomalies exists.

TODO: Fix the calculate of severity for merged anomalies; currently calculation does not consider history data.