### PR TITLE
Remove trailing nulls ('\0') from string values during indexing.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/StringUtil.java
@@ -23,7 +23,34 @@ import org.apache.commons.lang.StringUtils;
 
 public class StringUtil {
 
+  private static final String EMPTY_STRING = "";
+
   public static String join(String seperator, String...keys) {
     return StringUtils.join(keys, seperator);
+  }
+
+  /**
+   * Trim trailing null characters from a string.
+   * @param input Input to trim
+   * @return Trimmed input
+   */
+  public static String trimTrailingNulls(String input) {
+    if (input == null) {
+      return input;
+    }
+
+    int origEnd = input.length() - 1;
+    int end = origEnd;
+    while (end >= 0 && input.charAt(end) == '\0') {
+      end--;
+    }
+
+    if (end == origEnd) {
+      return input;
+    } else if (end < 0) {
+      return EMPTY_STRING;
+    } else {
+      return input.substring(0, end+1);
+    }
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/StringUtilTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/StringUtilTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for StringUtil class
+ */
+public class StringUtilTest {
+
+  private static final int NUM_TRAILING_NULLS = 10;
+  private static final String TEST_STRING = "test_string";
+
+  /**
+   * Test for trimTrailingNulls.
+   */
+  @Test
+  public void testTrimTrailingNulls() {
+    // Input is null
+    String expected = null;
+    String actual = StringUtil.trimTrailingNulls(expected);
+    Assert.assertEquals(actual, expected);
+
+    // Input has no trailing nulls
+    expected = TEST_STRING;
+    actual = StringUtil.trimTrailingNulls(expected);
+    Assert.assertEquals(actual, expected);
+
+    // Input has trailing nulls
+    expected = "abc";
+    String stringToTrim = appendTrailingNulls(expected, NUM_TRAILING_NULLS);
+    actual = StringUtil.trimTrailingNulls(stringToTrim);
+    Assert.assertEquals(actual, expected);
+
+    // Input is empty
+    expected = "";
+    actual = StringUtil.trimTrailingNulls(expected);
+    Assert.assertEquals(actual, expected);
+
+    // Input only has nulls
+    expected = "";
+    stringToTrim = appendTrailingNulls(expected, NUM_TRAILING_NULLS);
+    actual = StringUtil.trimTrailingNulls(stringToTrim);
+    Assert.assertEquals(actual, expected);
+
+    // Input has non-trailing nulls only
+    expected = new String(new byte[] {0, 0, 97, 98, 99, 100, 0, 0, 0, 101, 102, 103});
+    actual = StringUtil.trimTrailingNulls(expected);
+    Assert.assertEquals(actual, expected);
+
+    // Input has non-trailing as well as trailing nulls.
+    expected = new String(new byte[] {0, 0, 97, 98, 99, 100, 0, 0, 0, 101, 102, 103});
+    stringToTrim = appendTrailingNulls(expected, NUM_TRAILING_NULLS);
+    actual = StringUtil.trimTrailingNulls(stringToTrim);
+    Assert.assertEquals(actual, expected);
+
+  }
+
+  /**
+   * Helper method that appends trailing nulls to the given string
+   *
+   * @param input Input string to pad
+   * @param N Number of nulls to append
+   * @return String with nulls appended
+   */
+  private String appendTrailingNulls(String input, int N) {
+    return input + new String(new byte[N]);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
@@ -21,6 +21,7 @@ import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.time.TimeConverter;
 import com.linkedin.pinot.common.utils.time.TimeConverterProvider;
 import com.linkedin.pinot.core.data.GenericRow;
@@ -200,6 +201,12 @@ public class PlainFieldExtractor implements FieldExtractor {
             hasError = true;
             _errorCount.put(column, _errorCount.get(column) + 1);
           }
+        }
+
+        // Null character is the default padding character, we do not allow trailing null chars in strings.
+        // Allowing this can cause multiple values to map to the same padded value, breaking segment generation.
+        if (dest == PinotDataType.STRING) {
+          value = StringUtil.trimTrailingNulls((String) value);
         }
       }
 


### PR DESCRIPTION
NULL ('\0') is the default padding character for string values in
dictionary. If input strings contain trailing null characters, when
padded, different values can map to the same padded string in the
dictionary. This currently triggers an assert in the segment generator,
that in turns stop Kafka consumption in realtime nodes.

Stripping trailing nulls from incoming string values addresses the
issue. This also means that two values 'abc\0' and 'abc' will be
interpreted as the same value 'abc', and this is a behavior we are
choosing to keep.