### PR TITLE
Remove spuriously emitted LLC routing metrics

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestHandler.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/requestHandler/BrokerRequestHandler.java
@@ -295,22 +295,17 @@ public class BrokerRequestHandler {
   private List<String> getMatchedTables(BrokerRequest request) {
     List<String> matchedTables = new ArrayList<String>();
     String tableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(request.getQuerySource().getTableName());
-    Map<ServerInstance, SegmentIdSet> routingMap = _routingTable.findServers(
-        new RoutingTableLookupRequest(tableName, extractRoutingOptionsFromBrokerRequest(request)));
-    if (routingMap != null && !routingMap.isEmpty()) {
+    if (_routingTable.routingTableExists(tableName)) {
       matchedTables.add(tableName);
     }
     tableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(request.getQuerySource().getTableName());
-    routingMap = _routingTable.findServers(
-        new RoutingTableLookupRequest(tableName, extractRoutingOptionsFromBrokerRequest(request)));
-    if (routingMap != null && !routingMap.isEmpty()) {
+    if (_routingTable.routingTableExists(tableName)) {
       matchedTables.add(tableName);
     }
     // For backward compatible
     if (matchedTables.isEmpty()) {
       tableName = request.getQuerySource().getTableName();
-      if (_routingTable.findServers(
-          new RoutingTableLookupRequest(tableName, extractRoutingOptionsFromBrokerRequest(request))) != null) {
+      if (_routingTable.routingTableExists(tableName)) {
         matchedTables.add(tableName);
       }
     }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/CfgBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/CfgBasedRouting.java
@@ -51,6 +51,12 @@ public class CfgBasedRouting implements RoutingTable {
   }
 
   @Override
+  public boolean routingTableExists(String tableName) {
+    Map<ServerInstance, SegmentIdSet> routingTableEntry = findServers(new RoutingTableLookupRequest(tableName, null));
+    return routingTableEntry != null && !routingTableEntry.isEmpty();
+  }
+
+  @Override
   public void start() {
     // Nothing to be done here
   }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
@@ -137,6 +137,12 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
     return serverToSegmentSetMaps.get(_random.nextInt(serverToSegmentSetMaps.size())).getRouting();
   }
 
+  @Override
+  public boolean routingTableExists(String tableName) {
+    return (_brokerRoutingTable.containsKey(tableName) && !_brokerRoutingTable.get(tableName).isEmpty()) ||
+        (_llcBrokerRoutingTable.containsKey(tableName) && !_llcBrokerRoutingTable.get(tableName).isEmpty());
+  }
+
   private List<ServerToSegmentSetMap> routeToLLC(String tableName) {
     if (_brokerMetrics != null) {
       _brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.LLC_QUERY_COUNT, 1);

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTable.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTable.java
@@ -32,6 +32,14 @@ public interface RoutingTable {
   Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request);
 
   /**
+   * Returns whether or not a routing table exists and is not empty for a given table.
+   *
+   * @param tableName The table name for which to check if a routing table exists
+   * @return true if the routing table exists and isn't empty
+   */
+  boolean routingTableExists(String tableName);
+
+  /**
    * Initialize and start the Routing table population
    */
   void start();


### PR DESCRIPTION
When receiving a query, we check which tables exist in the routing
table by issuing a routing request to the routing table. To determine
whether or not a table has an offline part and a realtime part, we
check both the realtime and offline names for existence in the routing
table.

If a table does not have a routing table entry in the normal routing
table, we assume it is an LLC request and route it as an LLC query.
This unconditionally increments a counter for the number of queries
sent to LLC.

Those two behaviors put together mean that for every query to any
table, we increment the LLC query count, even if that table is
offline-only, has the "_OFFLINE" suffix or even if it does not exist.

This removes these spuriously emitted LLC metrics by adding a method
to check if a table has a non-empty entry in the routing table and
using it to determine if this is a single table query or a federated
query.