### PR TITLE
Add retry to segment push.

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategyIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategyIntegrationTest.java
@@ -114,4 +114,9 @@ public class BalanceNumSegmentAssignmentStrategyIntegrationTest extends UploadRe
   public void testRefresh(String tableName, SegmentVersion version) {
     // Ignore this inherited test
   }
+
+  @Test(enabled = false)
+  public void testRetry(String tableName, SegmentVersion version) {
+    // Ignore this inherited test
+  }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
@@ -117,7 +117,7 @@ public class DefaultColumnsClusterIntegrationTest extends BaseClusterIntegration
     // Upload the segments.
     for (String segmentName : TAR_DIR.list()) {
       File file = new File(TAR_DIR, segmentName);
-      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, new FileInputStream(file), file.length());
+      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, file, file.length());
     }
 
     // Wait for all segments to be ONLINE.

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -173,7 +173,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
     for (String segmentName : _tarDir.list()) {
       System.out.println("Uploading segment " + (i++) + " : " + segmentName);
       File file = new File(_tarDir, segmentName);
-      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, new FileInputStream(file), file.length());
+      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, file, file.length());
     }
 
     // Wait for all offline segments to be online

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
@@ -204,7 +204,7 @@ public abstract class HybridClusterScanComparisonIntegrationTest extends HybridC
       i++;
       LOGGER.info("Uploading segment {} : {}", i, segmentName);
       File file = new File(_offlineTarDir, segmentName);
-      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, new FileInputStream(file), file.length());
+      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, file, file.length());
     }
 
     // Wait for all offline segments to be online

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -106,7 +106,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
     for (String segmentName : _tarDir.list()) {
       System.out.println("Uploading segment " + (i++) + " : " + segmentName);
       File file = new File(_tarDir, segmentName);
-      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, new FileInputStream(file), file.length());
+      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, file, file.length());
     }
 
     // Wait for all segments to be online

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -152,7 +152,7 @@ public class StarTreeClusterIntegrationTest extends ClusterTest {
       LOGGER.info("Uploading segment {}", segmentName);
       File file = new File(_tarredSegmentsDir, segmentName);
       FileUploadUtils.sendSegmentFile(ControllerTestUtils.DEFAULT_CONTROLLER_HOST,
-          ControllerTestUtils.DEFAULT_CONTROLLER_API_PORT, segmentName, new FileInputStream(file),
+          ControllerTestUtils.DEFAULT_CONTROLLER_API_PORT, segmentName, file,
           file.length());
     }
   }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -118,12 +118,69 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
 
     for (String segmentFileName : segmentTarDir.list()) {
       File file = new File(segmentTarDir, segmentFileName);
-      FileUploadUtils.sendFile("localhost", "8998", "segments", segmentFileName, new FileInputStream(file), file.length(),
-          FileUploadUtils.SendFileMethod.POST);
+      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentFileName, file, file.length());
     }
 
     avroFile.delete();
     FileUtils.deleteQuietly(segmentTarDir);
+  }
+
+  protected void generateAndUploadRandomSegment1(final String segmentName, int rowCount) throws Exception {
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+    Schema schema = new Schema.Parser().parse(
+        new File(TestUtils.getFileFromResourceUrl(getClass().getClassLoader().getResource("dummy.avsc"))));
+    GenericRecord record = new GenericData.Record(schema);
+    GenericDatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<GenericRecord>(schema);
+    DataFileWriter<GenericRecord> fileWriter = new DataFileWriter<GenericRecord>(datumWriter);
+    final File avroFile = new File(_tmpDir, segmentName + ".avro");
+    fileWriter.create(schema, avroFile);
+
+    for (int i = 0; i < rowCount; i++) {
+      record.put(0, random.nextInt());
+      fileWriter.append(record);
+    }
+
+    fileWriter.close();
+
+    final int segmentIndex = Integer.parseInt(segmentName.split("_")[1]);
+    final String TAR_GZ_FILE_EXTENTION = ".tar.gz";
+    File segmentTarDir = new File(_tarsDir, segmentName);
+    buildSegment(segmentTarDir, avroFile, segmentIndex, segmentName, 0);
+    String segmentFileName = segmentName;
+    for (String name : segmentTarDir.list()) {
+      if (name.endsWith(TAR_GZ_FILE_EXTENTION)) {
+        segmentFileName = name;
+      }
+    }
+    File file = new File(segmentTarDir, segmentFileName);
+    long segmentLength = file.length();
+    final File segmentTarDir1 = new File(_tarsDir, segmentName);
+    FileUtils.deleteQuietly(segmentTarDir);
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          buildSegment(segmentTarDir1, avroFile, segmentIndex, segmentName, 5);
+        } catch (Exception e) {
+        }
+      }
+    }).start();
+
+    FileUploadUtils.sendSegmentFile("localhost", "8998", segmentFileName, file, segmentLength, 5, 5);
+
+    avroFile.delete();
+    FileUtils.deleteQuietly(segmentTarDir);
+  }
+
+  public void buildSegment(File segmentTarDir, File avroFile, int segmentIndex, String segmentName,
+      int sleepTimeSec) throws Exception {
+    Thread.sleep(sleepTimeSec * 1000);
+    ensureDirectoryExistsAndIsEmpty(segmentTarDir);
+    ExecutorService executor = MoreExecutors.sameThreadExecutor();
+    buildSegmentsFromAvro(Collections.singletonList(avroFile), executor, segmentIndex,
+        new File(segmentTarDir, segmentName), segmentTarDir, this.tableName, false, null);
+    executor.shutdown();
+    executor.awaitTermination(1L, TimeUnit.MINUTES);
   }
 
   @DataProvider(name = "configProvider")
@@ -152,6 +209,16 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     generateAndUploadRandomSegment(segment9, nRows3);
     verifyNRows(nRows2, nRows2+nRows3);
   }
+
+  @Test(dataProvider = "configProvider")
+  public void testRetry(String tableName, SegmentVersion version) throws Exception {
+    final String segment6 = "segmentToBeRefreshed_6";
+    final int nRows1 = 69;
+
+    generateAndUploadRandomSegment1(segment6, nRows1);
+    verifyNRows(0, nRows1);
+  }
+
 
   // Verify that the number of rows is either the initial value or the final value but not something else.
   private void verifyNRows(int currentNrows, int finalNrows) throws Exception {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -121,7 +121,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
 
         LOGGER.info("Uploading segment {}", tgzFile.getName());
         FileUploadUtils
-            .sendSegmentFile(_controllerHost, _controllerPort, tgzFile.getName(), new FileInputStream(tgzFile),
+            .sendSegmentFile(_controllerHost, _controllerPort, tgzFile.getName(), tgzFile,
                 tgzFile.length());
       }
     } catch (Exception e) {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -291,7 +291,7 @@ public class PerfBenchmarkDriver {
     for (File indexFile : indexFiles) {
       LOGGER.info("Uploading index segment: {}", indexFile.getAbsolutePath());
       FileUploadUtils.sendSegmentFile(_controllerHost, String.valueOf(_controllerPort), indexFile.getName(),
-          new FileInputStream(indexFile), indexFile.length());
+          indexFile, indexFile.length());
     }
   }
 


### PR DESCRIPTION
This adds retry support for Pinot segment push in FileUploadUtils. This was
tested manually using the UploadRefreshDeleteIntegrationTest and UploadSegment
from pinot-admin. We wait for 60 seconds and retry on failure.