### PR TITLE
Enhance merged anomaly calculation

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.anomaly;
 
 import com.linkedin.thirdeye.dashboard.resources.AnomalyFunctionResource;
 
+import com.linkedin.thirdeye.util.SeverityComputationUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -92,9 +93,13 @@ public class ThirdEyeAnomalyApplication
           .register(new AlertJobResource(alertJobScheduler, emailConfigurationDAO));
         }
         if (config.isMerger()) {
+          // anomalyFunctionFactory might have initiated if current machine is also a worker
+          if (anomalyFunctionFactory == null) {
+            anomalyFunctionFactory = new AnomalyFunctionFactory(config.getFunctionConfigPath());
+          }
           ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
           anomalyMergeExecutor =
-              new AnomalyMergeExecutor(executorService);
+              new AnomalyMergeExecutor(executorService, anomalyFunctionFactory);
           anomalyMergeExecutor.start();
         }
         if (config.isAutoload()) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobResource.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.anomaly.detection;
 import java.util.List;
 
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -75,7 +76,7 @@ public class DetectionJobResource {
   @POST
   @Path("/{id}/backfill")
   public Response backfill(@PathParam("id") Long id, @QueryParam("start") String startTimeIso,
-      @QueryParam("end") String endTimeIso) throws Exception {
+      @QueryParam("end") String endTimeIso, @DefaultValue("false") @QueryParam("force") boolean force) throws Exception {
     DateTime startTime = null;
     DateTime endTime = null;
     if (StringUtils.isNotBlank(startTimeIso)) {
@@ -92,7 +93,7 @@ public class DetectionJobResource {
       new Thread(new Runnable() {
         @Override
         public void run() {
-          detectionJobScheduler.runBackfill(id, innerStartTime, innerEndTime);
+          detectionJobScheduler.runBackfill(id, innerStartTime, innerEndTime, force);
         }
       }).start();
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -9,6 +9,7 @@ import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -36,8 +37,6 @@ public class DetectionTaskRunner implements TaskRunner {
   private static final Logger LOG = LoggerFactory.getLogger(DetectionTaskRunner.class);
   public static final String BACKFILL_PREFIX = "adhoc_";
 
-  private TimeSeriesResponseConverter timeSeriesResponseConverter;
-
   private MergedAnomalyResultManager mergedResultDAO;
   private RawAnomalyResultManager rawAnomalyDAO;
 
@@ -48,14 +47,8 @@ public class DetectionTaskRunner implements TaskRunner {
   private List<RawAnomalyResultDTO> existingRawAnomalies;
   private BaseAnomalyFunction anomalyFunction;
   private DatasetConfigManager datasetConfigDAO;
-  private AnomalyMergeExecutor syncAnomalyMergeExecutor;
 
   public DetectionTaskRunner() {
-    timeSeriesResponseConverter = TimeSeriesResponseConverter.getInstance();
-    // syncAnomalyMergeExecutor is supposed to perform lightweight merge (i.e., anomalies that have the same function
-    // id and at the same dimensions) after each detection task. Consequently, a null thread pool is passed the merge
-    // executor on purpose in order to prevent unwanted
-    syncAnomalyMergeExecutor = new AnomalyMergeExecutor(null);
   }
 
   public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
@@ -82,8 +75,10 @@ public class DetectionTaskRunner implements TaskRunner {
     knownMergedAnomalies = getKnownMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
     existingRawAnomalies = getExistingRawAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
 
+    List<Pair<Long, Long>> startEndTimeRanges =
+        anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis());
     TimeSeriesResponse finalResponse =
-        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
+        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
 
     exploreDimensionsAndAnalyze(finalResponse);
 
@@ -92,6 +87,10 @@ public class DetectionTaskRunner implements TaskRunner {
     String jobName = taskContext.getJobDAO().getJobNameByJobId(detectionTaskInfo.getJobExecutionId());
     if (jobName != null && jobName.toLowerCase().startsWith(BACKFILL_PREFIX)) {
       boolean isNotified = true;
+      // syncAnomalyMergeExecutor is supposed to perform lightweight merge (i.e., anomalies that have the same function
+      // id and at the same dimensions) after each detection task. Consequently, a null thread pool is passed the merge
+      // executor on purpose in order to prevent unwanted
+      AnomalyMergeExecutor syncAnomalyMergeExecutor = new AnomalyMergeExecutor(null, anomalyFunctionFactory);
       syncAnomalyMergeExecutor.performSynchronousMergeBasedOnFunctionIdAndDimension(anomalyFunctionSpec, isNotified);
     }
 
@@ -101,7 +100,7 @@ public class DetectionTaskRunner implements TaskRunner {
   private void exploreDimensionsAndAnalyze(TimeSeriesResponse finalResponse) {
     int anomalyCounter = 0;
     Map<DimensionKey, MetricTimeSeries> res =
-        timeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
+        TimeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
 
     // Sort the known anomalies by their dimension names
     ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> dimensionNamesToKnownMergedAnomalies = ArrayListMultimap.create();
@@ -125,13 +124,19 @@ public class DetectionTaskRunner implements TaskRunner {
 
       // Get current entry's knownMergedAnomalies, which should have the same explored dimensions
       List<MergedAnomalyResultDTO> knownMergedAnomaliesOfAnEntry = dimensionNamesToKnownMergedAnomalies.get(exploredDimensions);
-      List<MergedAnomalyResultDTO> historyMergedAnomalies = retainHistoryMergedAnomalies(windowStart.getMillis(), knownMergedAnomaliesOfAnEntry);
 
       try {
         // Run algorithm
         MetricTimeSeries metricTimeSeries = entry.getValue();
         LOG.info("Analyzing anomaly function with explored dimensions: {}, windowStart: {}, windowEnd: {}",
             exploredDimensions, windowStart, windowEnd);
+
+        List<MergedAnomalyResultDTO> historyMergedAnomalies;
+        if (anomalyFunction.useHistoryAnomaly()) {
+          historyMergedAnomalies = retainHistoryMergedAnomalies(windowStart.getMillis(), knownMergedAnomaliesOfAnEntry);
+        } else {
+          historyMergedAnomalies = Collections.emptyList();
+        }
 
         List<RawAnomalyResultDTO> resultsOfAnEntry = anomalyFunction
             .analyze(exploredDimensions, metricTimeSeries, windowStart, windowEnd, historyMergedAnomalies);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -77,10 +77,10 @@ public class DetectionTaskRunner implements TaskRunner {
 
     List<Pair<Long, Long>> startEndTimeRanges =
         anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis());
-    TimeSeriesResponse finalResponse =
-        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
+    Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap =
+        TimeSeriesUtil.getTimeSeriesForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
 
-    exploreDimensionsAndAnalyze(finalResponse);
+    exploreDimensionsAndAnalyze(dimensionKeyMetricTimeSeriesMap);
 
     // If the current job is a backfill (adhoc) detection job, then perform a lightweight merge right after the
     // detection. Moreover, set notified flag to true so the merged anomalies do not induce alerts and emails.
@@ -97,10 +97,8 @@ public class DetectionTaskRunner implements TaskRunner {
     return taskResult;
   }
 
-  private void exploreDimensionsAndAnalyze(TimeSeriesResponse finalResponse) {
+  private void exploreDimensionsAndAnalyze(Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap) {
     int anomalyCounter = 0;
-    Map<DimensionKey, MetricTimeSeries> res =
-        TimeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
 
     // Sort the known anomalies by their dimension names
     ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> dimensionNamesToKnownMergedAnomalies = ArrayListMultimap.create();
@@ -113,7 +111,7 @@ public class DetectionTaskRunner implements TaskRunner {
       dimensionNamesToKnownRawAnomalies.put(existingRawAnomaly.getDimensions(), existingRawAnomaly);
     }
 
-    for (Map.Entry<DimensionKey, MetricTimeSeries> entry : res.entrySet()) {
+    for (Map.Entry<DimensionKey, MetricTimeSeries> entry : dimensionKeyMetricTimeSeriesMap.entrySet()) {
       DimensionKey dimensionKey = entry.getKey();
       DimensionMap exploredDimensions = DimensionMap.fromDimensionKey(dimensionKey, collectionDimensions);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
@@ -3,28 +3,32 @@ package com.linkedin.thirdeye.anomaly.detection;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.linkedin.pinot.pql.parsers.utils.Pair;
-import com.linkedin.thirdeye.anomaly.views.function.AnomalyTimeSeriesView;
+import com.linkedin.thirdeye.api.DimensionKey;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.client.MetricExpression;
 import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesHandler;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesRequest;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesResponse;
+import com.linkedin.thirdeye.client.timeseries.TimeSeriesResponseConverter;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesRow;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
-import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.quartz.JobExecutionException;
@@ -42,20 +46,16 @@ public abstract class TimeSeriesUtil {
   /**
    * Returns the time series that are needed by the given anomaly function for detecting anomalies.
    *
-   * @param anomalyFunction the anomaly function for detecting anomalies
-   * @param monitoringWindowStart inclusive
-   * @param monitoringWindowEnd exclusive
+   * @param anomalyFunctionSpec spec of the anomaly function
+   * @param startEndTimeRanges the time ranges to retrieve the data for constructing the time series
+   *
    * @return the data that is needed by the anomaly function for detecting anomalies.
    * @throws JobExecutionException
    * @throws ExecutionException
    */
-  public static TimeSeriesResponse getTimeSeriesResponseForAnomalyDetection(BaseAnomalyFunction anomalyFunction,
-      long monitoringWindowStart, long monitoringWindowEnd)
+  public static TimeSeriesResponse getTimeSeriesResponseForAnomalyDetection(AnomalyFunctionDTO anomalyFunctionSpec,
+      List<Pair<Long, Long>> startEndTimeRanges)
       throws JobExecutionException, ExecutionException {
-    AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunction.getSpec();
-
-    List<Pair<Long, Long>> startEndTimeRanges =
-        anomalyFunction.getDataRangeIntervals(monitoringWindowStart, monitoringWindowEnd);
 
     String filterString = anomalyFunctionSpec.getFilters();
     Multimap<String, String> filters;
@@ -82,23 +82,20 @@ public abstract class TimeSeriesUtil {
   /**
    * Returns the time series that were used by the given anomaly function for detecting the anomaly.
    *
-   * @param anomalyTimeSeriesView the time series view for presenting the current and baseline values for the anomaly
+   * @param anomalyFunctionSpec spec of the anomaly function
+   * @param startEndTimeRanges the time ranges to retrieve the data for constructing the time series
    * @param dimensionMap a dimension map that is used to construct the filter for retrieving the corresponding data
    *                     that was used to detected the anomaly
-   * @param timeGranularity time granularity for the frontend
-   * @param viewWindowStart inclusive
-   * @param viewWindowEnd exclusive
-   * @return the time series that were used by the given anomaly function for detecting the anomaly
+   * @param timeGranularity time granularity of the time series
+   *
+   * @return the time series in the same format as those used by the given anomaly function for anomaly detection
+   *
    * @throws JobExecutionException
    * @throws ExecutionException
    */
-  public static TimeSeriesResponse getTimeSeriesResponseForPresentation(AnomalyTimeSeriesView anomalyTimeSeriesView,
-      DimensionMap dimensionMap, TimeGranularity timeGranularity, long viewWindowStart, long viewWindowEnd)
+  public static MetricTimeSeries getTimeSeriesResponseForPresentation(AnomalyFunctionDTO anomalyFunctionSpec,
+      List<Pair<Long, Long>> startEndTimeRanges, DimensionMap dimensionMap, TimeGranularity timeGranularity)
       throws JobExecutionException, ExecutionException {
-
-    AnomalyFunctionDTO anomalyFunctionSpec = anomalyTimeSeriesView.getSpec();
-    List<Pair<Long, Long>> startEndTimeRanges =
-        anomalyTimeSeriesView.getDataRangeIntervals(viewWindowStart, viewWindowEnd);
 
     // Get the original filter
     Multimap<String, String> filters;
@@ -129,7 +126,63 @@ public abstract class TimeSeriesUtil {
       groupByDimensions = Arrays.asList(anomalyFunctionSpec.getExploreDimensions().trim().split(","));
     }
 
-    return getTimeSeriesResponseImpl(anomalyFunctionSpec, startEndTimeRanges, timeGranularity, filters, groupByDimensions);
+    TimeSeriesResponse response =
+        getTimeSeriesResponseImpl(anomalyFunctionSpec, startEndTimeRanges, timeGranularity, filters, groupByDimensions);
+    try {
+      Map<DimensionKey, MetricTimeSeries> metricTimeSeriesMap = TimeSeriesResponseConverter.toMap(response,
+          Utils.getSchemaDimensionNames(anomalyFunctionSpec.getCollection()));
+      return extractMetricTimeSeriesForPresentation(metricTimeSeriesMap);
+    } catch (Exception e) {
+      LOG.warn("Unable to get schema dimension name for retrieving metric time series: {}", e.toString());
+      return null;
+    }
+  }
+
+  /**
+   * Extract current and baseline values from the parsed Pinot results. There are two possible time series for presenting
+   * the time series after anomaly detection: 1. the time series with a specific dimension and 2. the time series for
+   * OTHER dimension.
+   *
+   * For case 1, the input map should contain only one time series and hence we can just return it. For case 2, the
+   * input map would contain all combination of explored dimension and hence we need to filter out the one for OTHER
+   * dimension.
+   *
+   * @param metricTimeSeriesMap
+   *
+   * @return the time series when the anomaly is detected
+   */
+  private static MetricTimeSeries extractMetricTimeSeriesForPresentation(Map<DimensionKey, MetricTimeSeries> metricTimeSeriesMap) {
+    MetricTimeSeries metricTimeSeries = null;
+    if (MapUtils.isNotEmpty(metricTimeSeriesMap)) {
+      // For most anomalies, there should be only one time series due to its dimensions. The exception is the OTHER
+      // dimension, in which time series of different dimensions are returned due to the calculation of OTHER dimension.
+      // Therefore, we need to get the time series of OTHER dimension manually.
+      if (metricTimeSeriesMap.size() == 1) {
+        Iterator<MetricTimeSeries> ite = metricTimeSeriesMap.values().iterator();
+        if (ite.hasNext()) {
+          metricTimeSeries = ite.next();
+        }
+      } else { // Retrieve the time series of OTHER dimension
+        Iterator<Map.Entry<DimensionKey, MetricTimeSeries>> ite = metricTimeSeriesMap.entrySet().iterator();
+        while (ite.hasNext()) {
+          Map.Entry<DimensionKey, MetricTimeSeries> entry = ite.next();
+          DimensionKey dimensionKey = entry.getKey();
+          boolean foundOTHER = false;
+          for (String dimensionValue : dimensionKey.getDimensionValues()) {
+
+            if (dimensionValue.equalsIgnoreCase("OTHER")) {
+              metricTimeSeries = entry.getValue();
+              foundOTHER = true;
+              break;
+            }
+          }
+          if (foundOTHER) {
+            break;
+          }
+        }
+      }
+    }
+    return metricTimeSeries;
   }
 
   private static TimeSeriesResponse getTimeSeriesResponseImpl(AnomalyFunctionDTO anomalyFunctionSpec,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -1,9 +1,11 @@
 package com.linkedin.thirdeye.anomaly.merge;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
+import com.linkedin.pinot.pql.parsers.utils.Pair;
+import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
+import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -15,31 +17,21 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.client.DAORegistry;
-import com.linkedin.thirdeye.client.MetricExpression;
 import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
-import com.linkedin.thirdeye.client.cache.MetricDataset;
 import com.linkedin.thirdeye.client.cache.QueryCache;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesHandler;
-import com.linkedin.thirdeye.client.timeseries.TimeSeriesRequest;
-import com.linkedin.thirdeye.client.timeseries.TimeSeriesResponse;
-import com.linkedin.thirdeye.client.timeseries.TimeSeriesRow;
-import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
-import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
-import com.linkedin.thirdeye.detector.function.AnomalyFunctionUtils;
-import com.linkedin.thirdeye.util.ThirdEyeUtils;
+
 
 /**
  * finds raw anomalies grouped by a strategy and merges them with an existing (in the same group) or
@@ -50,6 +42,7 @@ public class AnomalyMergeExecutor implements Runnable {
   private final RawAnomalyResultManager anomalyResultDAO;
   private final AnomalyFunctionManager anomalyFunctionDAO;
   private final ScheduledExecutorService executorService;
+  private final AnomalyFunctionFactory anomalyFunctionFactory;
 
   private final QueryCache queryCache;
   private final TimeSeriesHandler timeSeriesHandler;
@@ -59,13 +52,14 @@ public class AnomalyMergeExecutor implements Runnable {
 
   private final static Logger LOG = LoggerFactory.getLogger(AnomalyMergeExecutor.class);
 
-  public AnomalyMergeExecutor(ScheduledExecutorService executorService) {
+  public AnomalyMergeExecutor(ScheduledExecutorService executorService, AnomalyFunctionFactory anomalyFunctionFactory) {
     this.mergedResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
     this.anomalyResultDAO = DAO_REGISTRY.getRawAnomalyResultDAO();
     this.anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
     this.executorService = executorService;
     this.queryCache = CACHE_REGISTRY_INSTANCE.getQueryCache();
     this.timeSeriesHandler = new TimeSeriesHandler(queryCache);
+    this.anomalyFunctionFactory = anomalyFunctionFactory;
   }
 
   public void start() {
@@ -184,128 +178,53 @@ public class AnomalyMergeExecutor implements Runnable {
     }
   }
 
-  // TODO: Update severity according to history data
   private void updateMergedSeverity(MergedAnomalyResultDTO anomalyMergedResult) throws Exception {
     AnomalyFunctionDTO anomalyFunctionSpec = anomalyMergedResult.getFunction();
+    BaseAnomalyFunction anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
 
-    // create time series request
-    TimeSeriesRequest timeSeriesRequest = new TimeSeriesRequest();
-    timeSeriesRequest.setCollectionName(anomalyFunctionSpec.getCollection());
+    List<Pair<Long, Long>> startEndTimeRanges =
+        anomalyFunction.getDataRangeIntervals(anomalyMergedResult.getStartTime(), anomalyMergedResult.getEndTime());
 
-    List<MetricExpression> metricExpressions = Utils
-        .convertToMetricExpressions(anomalyFunctionSpec.getMetric(),
-            anomalyFunctionSpec.getMetricFunction(), anomalyFunctionSpec.getCollection());
-
-    timeSeriesRequest.setMetricExpressions(metricExpressions);
-    TimeGranularity timeBucket = new TimeGranularity(anomalyFunctionSpec.getBucketSize(),
+    TimeGranularity timeGranularity = new TimeGranularity(anomalyFunctionSpec.getBucketSize(),
         anomalyFunctionSpec.getBucketUnit());
-    timeSeriesRequest.setAggregationTimeGranularity(timeBucket);
 
-    timeSeriesRequest.setEndDateInclusive(false);
+    MetricTimeSeries metricTimeSeries =
+        TimeSeriesUtil.getTimeSeriesResponseForPresentation(anomalyFunctionSpec, startEndTimeRanges,
+            anomalyMergedResult.getDimensions(), timeGranularity);
 
-    Multimap<String, String> filters = ArrayListMultimap.create();
-    if (StringUtils.isNotBlank(anomalyFunctionSpec.getFilters())) {
-      filters.putAll(ThirdEyeUtils.getFilterSet(anomalyFunctionSpec.getFilters()));
+    if (metricTimeSeries != null) {
+      List<MergedAnomalyResultDTO> knownAnomalies = null;
+      if (anomalyFunction.useHistoryAnomaly()) {
+        knownAnomalies = getKnownMergedAnomalies(anomalyFunction, anomalyMergedResult.getStartTime(),
+            anomalyMergedResult.getEndTime());
+      }
+      anomalyFunction.updateMergedAnomalyInfo(anomalyMergedResult, metricTimeSeries, knownAnomalies);
     }
-
-    String exploreDimensions = anomalyFunctionSpec.getExploreDimensions();
-    if (StringUtils.isNotBlank(exploreDimensions)) {
-      // Decorate filters according to dimensionMap
-      DimensionMap exploredDimensions = anomalyMergedResult.getDimensions();
-      filters = ThirdEyeUtils.getFilterSetFromDimensionMap(exploredDimensions, filters);
-    }
-
-    LOG.info("Applying final filter : {}", filters.toString());
-    // Set filters including anomaly-dimension
-    timeSeriesRequest.setFilterSet(filters);
-
-    // TODO : fix the pinot query interface to accept time in millis
-    // Fetch current time series data
-    timeSeriesRequest.setStart(new DateTime(anomalyMergedResult.getStartTime()));
-    timeSeriesRequest.setEnd(new DateTime(anomalyMergedResult.getEndTime()));
-    TimeSeriesResponse responseCurrent = timeSeriesHandler.handle(timeSeriesRequest);
-
-    LOG.info("printing current start end millis : {} {}, joda {} {}", anomalyMergedResult.getStartTime(),
-        anomalyMergedResult.getEndTime(), new DateTime(anomalyMergedResult.getStartTime()),
-        new DateTime(anomalyMergedResult.getEndTime()));
-
-    // Fetch baseline time series data
-    long baselineOffset = AnomalyFunctionUtils.getBaselineOffset(anomalyFunctionSpec);
-    timeSeriesRequest.setStart(new DateTime(anomalyMergedResult.getStartTime() - baselineOffset));
-    timeSeriesRequest.setEnd(new DateTime(anomalyMergedResult.getEndTime() - baselineOffset));
-    TimeSeriesResponse responseBaseline = timeSeriesHandler.handle(timeSeriesRequest);
-
-    LOG.info("printing baseline start end millis : {} {}, joda {} {}", anomalyMergedResult.getStartTime() - baselineOffset,
-        anomalyMergedResult.getEndTime() - baselineOffset, new DateTime(anomalyMergedResult.getStartTime() - baselineOffset),
-        new DateTime(anomalyMergedResult.getEndTime() - baselineOffset));
-
-    Double currentValue;
-    Double baselineValue;
-
-
-    MetricDataset metricDataset =
-        new MetricDataset(anomalyFunctionSpec.getMetric(), anomalyFunctionSpec.getCollection());
-    MetricConfigDTO metricConfig = CACHE_REGISTRY_INSTANCE.getMetricConfigCache().get(metricDataset);
-    if (metricConfig.isDerived()) {
-
-      LOG.info("Found derived metric [{}], assigning avg value per bucket in the message",
-          anomalyFunctionSpec.getMetric());
-      currentValue = getAvgMetricValuePerBucket(responseCurrent, anomalyFunctionSpec.getMetric());
-      baselineValue = getAvgMetricValuePerBucket(responseBaseline, anomalyFunctionSpec.getMetric());
-    } else {
-      LOG.info("Assigning total value in the message for metric : [{}]",
-          anomalyFunctionSpec.getMetric());
-      currentValue = getMetricValueSum(responseCurrent, anomalyFunctionSpec.getMetric());
-      baselineValue = getMetricValueSum(responseBaseline, anomalyFunctionSpec.getMetric());
-    }
-
-    Double severity;
-    if (baselineValue != 0) {
-      severity = (currentValue - baselineValue) / baselineValue;
-      anomalyMergedResult.setWeight(severity);
-    } else {
-      LOG.error("Could not recompute severity for merged anomaly [{}], assigning weighted avg",
-          anomalyMergedResult.toString());
-    }
-    anomalyMergedResult
-        .setMessage(createMessage(anomalyMergedResult.getWeight(), currentValue, baselineValue));
   }
 
-  private Double getMetricValueSum(TimeSeriesResponse response, String metricName) {
-    Double totalVal = 0.0;
-    for (int i = 0; i < response.getNumRows(); i++) {
-      for (TimeSeriesRow.TimeSeriesMetric metricData : response.getRow(i).getMetrics()) {
-        if (metricName.equals(metricData.getMetricName())) {
-          totalVal += metricData.getValue();
-        }
-      }
-    }
-    return totalVal;
-  }
+  private List<MergedAnomalyResultDTO> getKnownMergedAnomalies(BaseAnomalyFunction anomalyFunction,
+      long monitoringWindowStart, long monitoringWindowEnd) {
 
-  /**
-   * Returns average metrics value (per bucket) for given time series
-   *
-   * @param response
-   * @param metricName
-   *
-   * @return
-   */
-  private Double getAvgMetricValuePerBucket(TimeSeriesResponse response, String metricName) {
-    Double totalVal = 0.0;
-    int numBuckets = 0;
-    for (int i = 0; i < response.getNumRows(); i++) {
-      for (TimeSeriesRow.TimeSeriesMetric metricData : response.getRow(i).getMetrics()) {
-        if (metricName.equals(metricData.getMetricName())) {
-          totalVal += metricData.getValue();
-          numBuckets++;
-        }
+    List<Pair<Long, Long>> startEndTimeRanges =
+        anomalyFunction.getDataRangeIntervals(monitoringWindowStart, monitoringWindowEnd);
+
+    List<MergedAnomalyResultDTO> results = new ArrayList<>();
+    for (Pair<Long, Long> startEndTimeRange : startEndTimeRanges) {
+      // we don't need the known anomalies on current window; we only need those on history data
+      if (monitoringWindowStart <= startEndTimeRange.getFirst()
+          && startEndTimeRange.getSecond() <= monitoringWindowEnd) {
+        continue;
+      }
+      try {
+        results.addAll(
+            mergedResultDAO.findAllConflictByFunctionId(anomalyFunction.getSpec().getId(), startEndTimeRange.getFirst(),
+                startEndTimeRange.getSecond()));
+      } catch (Exception e) {
+        LOG.error("Exception in getting existing anomalies", e);
       }
     }
-    if (numBuckets == 0) {
-      return totalVal;
-    }
-    return totalVal / numBuckets;
+
+    return results;
   }
 
   private void performMergeBasedOnFunctionId(AnomalyFunctionDTO function,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -190,7 +190,7 @@ public class AnomalyMergeExecutor implements Runnable {
         anomalyFunctionSpec.getBucketUnit());
 
     MetricTimeSeries metricTimeSeries =
-        TimeSeriesUtil.getTimeSeriesResponseForPresentation(anomalyFunctionSpec, startEndTimeRanges,
+        TimeSeriesUtil.getTimeSeriesByDimension(anomalyFunctionSpec, startEndTimeRanges,
             anomalyMergedResult.getDimensions(), timeGranularity);
 
     if (metricTimeSeries != null) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/DetectionResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/DetectionResourceHttpUtils.java
@@ -37,10 +37,10 @@ public class DetectionResourceHttpUtils extends AbstractResourceHttpUtils {
     return callJobEndpoint(req);
   }
 
-  public String runBackfillAnomalyFunction(String id, String startTimeIso, String endTimeIso)
+  public String runBackfillAnomalyFunction(String id, String startTimeIso, String endTimeIso, boolean forceBackfill)
       throws ClientProtocolException, IOException {
     HttpPost req = new HttpPost(
-        DETECTION_JOB_ENDPOINT + id + BACKFILL + "?start=" + startTimeIso + "&end=" + endTimeIso);
+        DETECTION_JOB_ENDPOINT + id + BACKFILL + "?start=" + startTimeIso + "&end=" + endTimeIso + "&force=" + forceBackfill);
     return callJobEndpoint(req);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesResponseConverter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesResponseConverter.java
@@ -41,7 +41,7 @@ public class TimeSeriesResponseConverter {
    * within the response input. The metrics returned in the MetricTimeSeries instances correspond to
    * the metric names as opposed to the full metric function (eg __COUNT instead of SUM(__COUNT))
    */
-  public Map<DimensionKey, MetricTimeSeries> toMap(TimeSeriesResponse response,
+  public static Map<DimensionKey, MetricTimeSeries> toMap(TimeSeriesResponse response,
       List<String> schemaDimensions) {
     DimensionKeyGenerator dimensionKeyGenerator = new DimensionKeyGenerator(schemaDimensions);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.dashboard.resources;
 
+import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
 import com.linkedin.thirdeye.api.DimensionKey;
 import com.linkedin.thirdeye.api.DimensionMap;
@@ -46,8 +47,6 @@ public class AnomalyFunctionResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(AnomalyFunctionResource.class);
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
-  private static final TimeSeriesResponseConverter timeSeriesResponseConverter =
-      TimeSeriesResponseConverter.getInstance();
 
   private final Map<String, Object> anomalyFunctionMetadata = new HashMap<>();
   private final AnomalyFunctionFactory anomalyFunctionFactory;
@@ -114,16 +113,18 @@ public class AnomalyFunctionResource {
       throws Exception {
     // TODO: replace this with Job/Task framework and job tracker page
     BaseAnomalyFunction anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
+
+    List<Pair<Long, Long>> startEndTimeRanges = anomalyFunction.getDataRangeIntervals(startTime, endTime);
+
     TimeSeriesResponse finalResponse =
-        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunction, startTime, endTime);
+        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
 
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
     List<RawAnomalyResultDTO> results = new ArrayList<>();
     List<String> collectionDimensions = DAO_REGISTRY.getDatasetConfigDAO()
         .findByDataset(anomalyFunctionSpec.getCollection()).getDimensions();
 
-    Map<DimensionKey, MetricTimeSeries> res =
-        timeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
+    Map<DimensionKey, MetricTimeSeries> res = TimeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
     for (Map.Entry<DimensionKey, MetricTimeSeries> entry : res.entrySet()) {
       DimensionKey dimensionKey = entry.getKey();
       DimensionMap dimensionMap = DimensionMap.fromDimensionKey(dimensionKey, collectionDimensions);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -116,16 +116,15 @@ public class AnomalyFunctionResource {
 
     List<Pair<Long, Long>> startEndTimeRanges = anomalyFunction.getDataRangeIntervals(startTime, endTime);
 
-    TimeSeriesResponse finalResponse =
-        TimeSeriesUtil.getTimeSeriesResponseForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
+    Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap =
+        TimeSeriesUtil.getTimeSeriesForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
 
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
     List<RawAnomalyResultDTO> results = new ArrayList<>();
     List<String> collectionDimensions = DAO_REGISTRY.getDatasetConfigDAO()
         .findByDataset(anomalyFunctionSpec.getCollection()).getDimensions();
 
-    Map<DimensionKey, MetricTimeSeries> res = TimeSeriesResponseConverter.toMap(finalResponse, collectionDimensions);
-    for (Map.Entry<DimensionKey, MetricTimeSeries> entry : res.entrySet()) {
+    for (Map.Entry<DimensionKey, MetricTimeSeries> entry : dimensionKeyMetricTimeSeriesMap.entrySet()) {
       DimensionKey dimensionKey = entry.getKey();
       DimensionMap dimensionMap = DimensionMap.fromDimensionKey(dimensionKey, collectionDimensions);
       if (entry.getValue().getTimeWindowSet().size() < 2) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.dashboard.resources;
 
+import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
 import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
 import com.linkedin.thirdeye.anomaly.views.function.AnomalyTimeSeriesView;
@@ -568,72 +569,37 @@ public class AnomalyResource {
     // ThirdEye backend is end time exclusive, so one more bucket is appended to make end time inclusive for frontend.
     viewWindowEndTime += bucketMillis;
 
-    TimeSeriesResponse timeSeriesResponse =
-        TimeSeriesUtil.getTimeSeriesResponseForPresentation(anomalyTimeSeriesView, dimensions, timeGranularity,
-            viewWindowStartTime, viewWindowEndTime);
+    List<Pair<Long, Long>> startEndTimeRanges =
+        anomalyTimeSeriesView.getDataRangeIntervals(viewWindowStartTime, viewWindowEndTime);
 
-    TimeSeriesResponseConverter timeSeriesResponseConverter = TimeSeriesResponseConverter.getInstance();
-    Map<DimensionKey, MetricTimeSeries> res = timeSeriesResponseConverter.toMap(timeSeriesResponse,
-        Utils.getSchemaDimensionNames(anomalyResult.getFunction().getCollection()));
+    MetricTimeSeries metricTimeSeries =
+        TimeSeriesUtil.getTimeSeriesResponseForPresentation(anomalyFunctionSpec, startEndTimeRanges, dimensions, timeGranularity);
 
-    if (MapUtils.isNotEmpty(res)) {
-      // Currently, we assume that we get time series for one metric at a time
-      String metricName = anomalyFunctionSpec.getMetric();
-
-      // For most anomalies, there should be only one time series due to its dimensions. The exception is the OTHER
-      // dimension, in which time series of different dimensions are returned due to the calculation of OTHER dimension.
-      // Therefore, we need to get the time series of OTHER dimension manually.
-      MetricTimeSeries metricTimeSeries = null;
-      if (res.size() == 1) {
-        Iterator<MetricTimeSeries> ite = res.values().iterator();
-        if (ite.hasNext()) {
-          metricTimeSeries = ite.next();
-        }
-      } else { // Retrieve the time series of OTHER dimension
-        Iterator<Map.Entry<DimensionKey, MetricTimeSeries>> ite = res.entrySet().iterator();
-        while (ite.hasNext()) {
-          Map.Entry<DimensionKey, MetricTimeSeries> entry = ite.next();
-          DimensionKey dimensionKey = entry.getKey();
-          boolean foundOTHER = false;
-          for (String dimensionValue : dimensionKey.getDimensionValues()) {
-            if (dimensionValue.equalsIgnoreCase("OTHER")) {
-              metricTimeSeries = entry.getValue();
-              foundOTHER = true;
-              break;
-            }
-          }
-          if (foundOTHER) {
-            break;
-          }
-        }
-        // Check if something goes wrong when we try to get the time series for OTHER dimension; in that case, we
-        // return an empty time series
-        if (metricTimeSeries == null) {
-          return new AnomalyTimelinesView();
-        }
-      }
-
-      AnomalyTimelinesView anomalyTimelinesView =
-          anomalyTimeSeriesView.getTimeSeriesView(metricTimeSeries, bucketMillis, metricName, viewWindowStartTime, viewWindowEndTime, null);
-
-      // Generate summary for frontend
-      List<TimeBucket> timeBuckets = anomalyTimelinesView.getTimeBuckets();
-      if (timeBuckets.size() > 0) {
-        TimeBucket firstBucket = timeBuckets.get(0);
-        anomalyTimelinesView.addSummary("currentStart", Long.toString(firstBucket.getCurrentStart()));
-        anomalyTimelinesView.addSummary("baselineStart", Long.toString(firstBucket.getBaselineStart()));
-
-        TimeBucket lastBucket = timeBuckets.get(timeBuckets.size()-1);
-        anomalyTimelinesView.addSummary("currentEnd", Long.toString(lastBucket.getCurrentStart()));
-        anomalyTimelinesView.addSummary("baselineEnd", Long.toString(lastBucket.getBaselineEnd()));
-      }
-
-      return anomalyTimelinesView;
-    } else {
+    if (metricTimeSeries == null) {
       // If this case happened, there was something wrong with anomaly detection because we are not able to retrieve
       // the timeseries for the given anomaly
       return new AnomalyTimelinesView();
     }
+
+    // Known anomalies are ignored (the null parameter) because 1. we can reduce users' waiting time and 2. presentation
+    // data does not need to be as accurate as the one used for detecting anomalies
+    AnomalyTimelinesView anomalyTimelinesView =
+        anomalyTimeSeriesView.getTimeSeriesView(metricTimeSeries, bucketMillis, anomalyFunctionSpec.getMetric(),
+            viewWindowStartTime, viewWindowEndTime, null);
+
+    // Generate summary for frontend
+    List<TimeBucket> timeBuckets = anomalyTimelinesView.getTimeBuckets();
+    if (timeBuckets.size() > 0) {
+      TimeBucket firstBucket = timeBuckets.get(0);
+      anomalyTimelinesView.addSummary("currentStart", Long.toString(firstBucket.getCurrentStart()));
+      anomalyTimelinesView.addSummary("baselineStart", Long.toString(firstBucket.getBaselineStart()));
+
+      TimeBucket lastBucket = timeBuckets.get(timeBuckets.size()-1);
+      anomalyTimelinesView.addSummary("currentEnd", Long.toString(lastBucket.getCurrentStart()));
+      anomalyTimelinesView.addSummary("baselineEnd", Long.toString(lastBucket.getBaselineEnd()));
+    }
+
+    return anomalyTimelinesView;
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -5,11 +5,8 @@ import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
 import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
 import com.linkedin.thirdeye.anomaly.views.function.AnomalyTimeSeriesView;
 import com.linkedin.thirdeye.anomaly.views.function.AnomalyTimeSeriesViewFactory;
-import com.linkedin.thirdeye.api.DimensionKey;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
-import com.linkedin.thirdeye.client.timeseries.TimeSeriesResponse;
-import com.linkedin.thirdeye.client.timeseries.TimeSeriesResponseConverter;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.dashboard.views.TimeBucket;
 
@@ -18,9 +15,7 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -35,7 +30,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
@@ -573,7 +567,7 @@ public class AnomalyResource {
         anomalyTimeSeriesView.getDataRangeIntervals(viewWindowStartTime, viewWindowEndTime);
 
     MetricTimeSeries metricTimeSeries =
-        TimeSeriesUtil.getTimeSeriesResponseForPresentation(anomalyFunctionSpec, startEndTimeRanges, dimensions, timeGranularity);
+        TimeSeriesUtil.getTimeSeriesByDimension(anomalyFunctionSpec, startEndTimeRanges, dimensions, timeGranularity);
 
     if (metricTimeSeries == null) {
       // If this case happened, there was something wrong with anomaly detection because we are not able to retrieve

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -1,7 +1,9 @@
 package com.linkedin.thirdeye.dashboard.resources;
 
+import com.linkedin.thirdeye.client.pinot.PinotThirdEyeClient;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
 
+import com.linkedin.thirdeye.util.SeverityComputationUtil;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
@@ -10,22 +12,27 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import javax.ws.rs.core.Response;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -557,5 +564,30 @@ public class DashboardResource {
       }
     }
     return response;
+  }
+
+  @POST
+  @Path("/severity")
+  public Response computeSeverity(@NotNull @QueryParam("collection") String collectionName,
+      @NotNull @QueryParam("metric") String metricName,
+      @NotNull @QueryParam("start") String startTimeIso, @NotNull @QueryParam("end") String endTimeIso)
+      throws Exception {
+    DateTime startTime = null;
+    DateTime endTime = null;
+    if (StringUtils.isNotBlank(startTimeIso)) {
+      startTime = ISODateTimeFormat.dateTimeParser().parseDateTime(startTimeIso);
+    }
+    if (StringUtils.isNotBlank(endTimeIso)) {
+      endTime = ISODateTimeFormat.dateTimeParser().parseDateTime(endTimeIso);
+    }
+    PinotThirdEyeClient thirdEyeClient = PinotThirdEyeClient.getDefaultTestClient();
+    SeverityComputationUtil util = new SeverityComputationUtil(thirdEyeClient, collectionName, metricName);
+    long currentWindowStart = startTime.getMillis();
+    long currentWindowEnd = endTime.getMillis();
+    String compareMode = "WO3WMean";
+
+    Map<String, Object> severity = util.computeSeverity(currentWindowStart, currentWindowEnd, compareMode);
+
+    return Response.ok(severity.toString(), MediaType.TEXT_PLAIN_TYPE).build();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -1,6 +1,6 @@
 package com.linkedin.thirdeye.dashboard.resources;
 
-import com.linkedin.thirdeye.client.pinot.PinotThirdEyeClient;
+import com.linkedin.thirdeye.client.ThirdEyeClient;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
 
 import com.linkedin.thirdeye.util.SeverityComputationUtil;
@@ -566,6 +566,7 @@ public class DashboardResource {
     return response;
   }
 
+  // TODO: Move to AnomalyResources
   @POST
   @Path("/severity")
   public Response computeSeverity(@NotNull @QueryParam("collection") String collectionName,
@@ -580,11 +581,11 @@ public class DashboardResource {
     if (StringUtils.isNotBlank(endTimeIso)) {
       endTime = ISODateTimeFormat.dateTimeParser().parseDateTime(endTimeIso);
     }
-    PinotThirdEyeClient thirdEyeClient = PinotThirdEyeClient.getDefaultTestClient();
+    ThirdEyeClient thirdEyeClient = CACHE_REGISTRY_INSTANCE.getQueryCache().getClient();
     SeverityComputationUtil util = new SeverityComputationUtil(thirdEyeClient, collectionName, metricName);
     long currentWindowStart = startTime.getMillis();
     long currentWindowEnd = endTime.getMillis();
-    String compareMode = "WO3WMean";
+    String compareMode = "WO4WMean";
 
     Map<String, Object> severity = util.computeSeverity(currentWindowStart, currentWindowEnd, compareMode);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -1,11 +1,9 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.linkedin.thirdeye.api.DimensionMap;
-import com.linkedin.thirdeye.datalayer.entity.MergedAnomalyResultIndex;
 import java.util.List;
 import java.util.Objects;
 import org.apache.commons.lang.ObjectUtils;
-import org.modelmapper.PropertyMap;
 
 
 public class MergedAnomalyResultBean extends AbstractBean
@@ -116,8 +114,7 @@ public class MergedAnomalyResultBean extends AbstractBean
   }
 
   /**
-   * Weight is Severity
-   * @return
+   * Weight is change ratio. The absolute value of weight is severity.
    */
   public double getWeight() {
     return weight;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
@@ -49,7 +49,8 @@ public interface AnomalyFunction {
       throws Exception;
 
   /**
-   * Computes the severity according to the current and baseline of the given timeSeries
+   * Computes the score and severity according to the current and baseline of the given timeSeries and stores the
+   * information to the merged anomaly. The start and end time of the time series is provided
    *
    * @param anomalyToUpdated
    *          the merged anomaly to be updated.
@@ -62,7 +63,7 @@ public interface AnomalyFunction {
    * @return the severity according to the current and baseline of the given timeSeries
    */
   void updateMergedAnomalyInfo(MergedAnomalyResultDTO anomalyToUpdated, MetricTimeSeries timeSeries,
-      List<MergedAnomalyResultDTO> knownAnomalies)
+      DateTime windowStart, DateTime windowEnd, List<MergedAnomalyResultDTO> knownAnomalies)
       throws Exception;
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunction.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.detector.function;
 
+import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.List;
@@ -18,6 +19,17 @@ public interface AnomalyFunction {
   AnomalyFunctionDTO getSpec();
 
   /**
+   * Returns the time ranges of data that is used by this anomaly function. This method is useful when multiple time
+   * intervals are needed for fetching current vs baseline data
+   *
+   * @param monitoringWindowStartTime inclusive
+   * @param monitoringWindowEndTime exclusive
+   *
+   * @return the time ranges of data that is used by this anomaly function
+   */
+   List<Pair<Long, Long>> getDataRangeIntervals(Long monitoringWindowStartTime, Long monitoringWindowEndTime);
+
+  /**
    * Analyzes a metric time series and returns any anomalous points / intervals.
    * @param exploredDimensions
    *          Pairs of dimension value and name corresponding to timeSeries.
@@ -34,6 +46,23 @@ public interface AnomalyFunction {
    */
   List<RawAnomalyResultDTO> analyze(DimensionMap exploredDimensions, MetricTimeSeries timeSeries,
       DateTime windowStart, DateTime windowEnd, List<MergedAnomalyResultDTO> knownAnomalies)
+      throws Exception;
+
+  /**
+   * Computes the severity according to the current and baseline of the given timeSeries
+   *
+   * @param anomalyToUpdated
+   *          the merged anomaly to be updated.
+   * @param timeSeries
+   *          The metric time series data.
+   * @param knownAnomalies
+   *          Any known anomalies in the time range.
+   * @return
+   *         A list of anomalies that were not previously known.
+   * @return the severity according to the current and baseline of the given timeSeries
+   */
+  void updateMergedAnomalyInfo(MergedAnomalyResultDTO anomalyToUpdated, MetricTimeSeries timeSeries,
+      List<MergedAnomalyResultDTO> knownAnomalies)
       throws Exception;
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Properties;
 
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +38,14 @@ public abstract class BaseAnomalyFunction implements AnomalyFunction {
     return props;
   }
 
+  @Override
+  public List<Pair<Long, Long>> getDataRangeIntervals(Long monitoringWindowStartTime,
+      Long monitoringWindowEndTime) {
+    List<Pair<Long, Long>> startEndTimeIntervals = new ArrayList<>();
+    startEndTimeIntervals.add(new Pair<>(monitoringWindowStartTime, monitoringWindowEndTime));
+    return startEndTimeIntervals;
+  }
+
   /**
    * Returns unit change from baseline value
    * @param currentValue
@@ -50,22 +57,10 @@ public abstract class BaseAnomalyFunction implements AnomalyFunction {
   }
 
   /**
-   * Useful when multiple time intervals are needed for fetching current vs baseline data
-   *
-   * @param monitoringWindowStartTime inclusive
-   * @param monitoringWindowEndTime exclusive
-   *
-   * @return
+   * Returns true if this anomaly function uses the information of history anomalies
+   * @return true if this anomaly function uses the information of history anomalies
    */
-  public List<Pair<Long, Long>> getDataRangeIntervals(Long monitoringWindowStartTime,
-      Long monitoringWindowEndTime) {
-    List<Pair<Long, Long>> startEndTimeIntervals = new ArrayList<>();
-    startEndTimeIntervals.add(new Pair<>(monitoringWindowStartTime, monitoringWindowEndTime));
-
-    long baselineOffsetMillis = TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS);
-    startEndTimeIntervals.add(
-        new Pair<>(monitoringWindowStartTime - baselineOffsetMillis, monitoringWindowEndTime - baselineOffsetMillis));
-
-    return startEndTimeIntervals;
+  public boolean useHistoryAnomaly() {
+    return false;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.detector.function;
 
+import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.ArrayList;
@@ -29,10 +30,17 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
   public static final String DEFAULT_MESSAGE_TEMPLATE = "change : %.2f %%, currentVal : %.2f, min : %.2f, max : %.2f";
   public static final String MIN_VAL = "min";
   public static final String MAX_VAL = "max";
-  private static final Joiner CSV = Joiner.on(",");
 
   public static String[] getPropertyKeys() {
     return new String [] {MIN_VAL, MAX_VAL};
+  }
+
+  @Override
+  public List<Pair<Long, Long>> getDataRangeIntervals(Long monitoringWindowStartTime,
+      Long monitoringWindowEndTime) {
+    List<Pair<Long, Long>> startEndTimeIntervals = new ArrayList<>();
+    startEndTimeIntervals.add(new Pair<>(monitoringWindowStartTime, monitoringWindowEndTime));
+    return startEndTimeIntervals;
   }
 
   @Override
@@ -91,13 +99,61 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
         }
         anomalyResults.add(anomalyResult);
       }
-    } return anomalyResults;
+    }
+    return anomalyResults;
+  }
+
+  @Override
+  public void updateMergedAnomalyInfo(MergedAnomalyResultDTO anomalyToUpdated, MetricTimeSeries timeSeries,
+      List<MergedAnomalyResultDTO> knownAnomalies)
+      throws Exception {
+
+    // Get min / max props
+    Properties props = getProperties();
+    Double min = null;
+    if (props.containsKey(MIN_VAL)) {
+      min = Double.valueOf(props.getProperty(MIN_VAL));
+    }
+
+    Double max = null;
+    if (props.containsKey(MAX_VAL)) {
+      max = Double.valueOf(props.getProperty(MAX_VAL));
+    }
+
+    String metric = getSpec().getMetric();
+    long currentWindowStart = anomalyToUpdated.getStartTime();
+    long currentWindowEnd = anomalyToUpdated.getEndTime();
+
+    double currentAverageValue = 0d;
+    int currentBucketCount = 0;
+    double deviationFromThreshold = 0d;
+    for (long time : timeSeries.getTimeWindowSet()) {
+      double value = timeSeries.get(time, metric).doubleValue();
+      if (value != 0d) {
+        if (currentWindowStart <= time && time <= currentWindowEnd) {
+          currentAverageValue += value;
+          ++currentBucketCount;
+          deviationFromThreshold += getDeviationFromThreshold(value, min, max);
+        } // else ignore unknown time key
+      }
+    }
+
+    if (currentBucketCount != 0d) {
+      currentAverageValue /= currentBucketCount;
+      deviationFromThreshold /= currentBucketCount;
+    }
+    anomalyToUpdated.setScore(currentAverageValue);
+    anomalyToUpdated.setWeight(deviationFromThreshold);
+
+    String message =
+        String.format(DEFAULT_MESSAGE_TEMPLATE, deviationFromThreshold, currentAverageValue, min, max);
+    anomalyToUpdated.setMessage(message);
   }
 
   private double getDeviationFromThreshold(double currentValue, Double min, Double max) {
-    if ((min != null && currentValue < min)) {
+    if ((min != null && currentValue < min && min != 0d)) {
       return calculateChange(currentValue, min);
-    } else if (max != null && currentValue > max) {
+    } else if (max != null && currentValue > max && max != 0d) {
       return calculateChange(currentValue, max);
     }
     return 0;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/MinMaxThresholdFunction.java
@@ -9,11 +9,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Joiner;
-import com.linkedin.thirdeye.api.DimensionKey;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 
@@ -105,7 +101,7 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
 
   @Override
   public void updateMergedAnomalyInfo(MergedAnomalyResultDTO anomalyToUpdated, MetricTimeSeries timeSeries,
-      List<MergedAnomalyResultDTO> knownAnomalies)
+      DateTime windowStart, DateTime windowEnd, List<MergedAnomalyResultDTO> knownAnomalies)
       throws Exception {
 
     // Get min / max props
@@ -121,8 +117,8 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
     }
 
     String metric = getSpec().getMetric();
-    long currentWindowStart = anomalyToUpdated.getStartTime();
-    long currentWindowEnd = anomalyToUpdated.getEndTime();
+    long windowStartInMillis = windowStart.getMillis();
+    long windowEndInMillis = windowEnd.getMillis();
 
     double currentAverageValue = 0d;
     int currentBucketCount = 0;
@@ -130,7 +126,7 @@ public class MinMaxThresholdFunction extends BaseAnomalyFunction {
     for (long time : timeSeries.getTimeWindowSet()) {
       double value = timeSeries.get(time, metric).doubleValue();
       if (value != 0d) {
-        if (currentWindowStart <= time && time <= currentWindowEnd) {
+        if (windowStartInMillis <= time && time <= windowEndInMillis) {
           currentAverageValue += value;
           ++currentBucketCount;
           deviationFromThreshold += getDeviationFromThreshold(value, min, max);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/SeverityComputationUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/SeverityComputationUtil.java
@@ -1,0 +1,107 @@
+package com.linkedin.thirdeye.util;
+
+import com.linkedin.thirdeye.client.MetricExpression;
+import com.linkedin.thirdeye.dashboard.Utils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import java.util.concurrent.ExecutionException;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import com.google.common.collect.Maps;
+import com.linkedin.thirdeye.client.ThirdEyeRequest;
+import com.linkedin.thirdeye.client.ThirdEyeRequest.ThirdEyeRequestBuilder;
+import com.linkedin.thirdeye.client.ThirdEyeResponseRow;
+import com.linkedin.thirdeye.client.pinot.PinotThirdEyeClient;
+import com.linkedin.thirdeye.client.pinot.PinotThirdEyeResponse;
+import com.linkedin.thirdeye.constant.MetricAggFunction;
+
+public class SeverityComputationUtil {
+
+  private PinotThirdEyeClient pinotThirdEyeClient;
+  private String collectionName;
+  private String metricName;
+
+  public SeverityComputationUtil(PinotThirdEyeClient pinotThirdEyeClient, String collectionName, String metricName) {
+    this.pinotThirdEyeClient = pinotThirdEyeClient;
+    this.collectionName = collectionName;
+    this.metricName = metricName;
+  }
+
+  public Map<String, Object> computeSeverity(long currentWindowStart, long currentWindowEnd, String compareMode) throws Exception {
+    // CURRENT
+    ThirdEyeRequest thirdEyeRequest = createThirdEyeRequest(currentWindowStart, currentWindowEnd);
+    double currentSum = getSum(thirdEyeRequest);
+
+    List<Pair<DateTime, DateTime>> intervals = getIntervals(currentWindowStart, currentWindowEnd, compareMode);
+    double baselineSum = 0;
+    for (Pair<DateTime, DateTime> pair : intervals) {
+      thirdEyeRequest = createThirdEyeRequest(pair.getLeft().getMillis(), pair.getRight().getMillis());
+      baselineSum += getSum(thirdEyeRequest);
+    }
+    double baselineSumAvg = baselineSum / intervals.size();
+    double severity = (currentSum - baselineSumAvg) / baselineSumAvg;
+    HashMap<String, Object> hashMap = Maps.newHashMap();
+    hashMap.put("severity", severity);
+    hashMap.put("currentSum", currentSum);
+    hashMap.put("baselineSumAvg", baselineSumAvg);
+    return hashMap;
+  }
+
+  private double getSum(ThirdEyeRequest thirdEyeRequest) throws Exception {
+    double sum = 0;
+    PinotThirdEyeResponse response = pinotThirdEyeClient.execute(thirdEyeRequest);
+    if (response.getNumRows() == 1) {
+      ThirdEyeResponseRow row = response.getRow(0);
+      sum = row.getMetrics().get(0);
+    }
+    return sum;
+  }
+
+  private ThirdEyeRequest createThirdEyeRequest(long currentWindowStart, long currentWindowEnd)
+      throws ExecutionException {
+    ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
+    requestBuilder.setCollection(collectionName);
+    requestBuilder.setStartTimeInclusive(new DateTime(currentWindowStart));
+    requestBuilder.setEndTimeExclusive(new DateTime(currentWindowEnd));
+    // requestBuilder.setFilterSet(comparisonRequest.getFilterSet());
+    // requestBuilder.addGroupBy(comparisonRequest.getGroupByDimensions());
+    requestBuilder.setGroupByTimeGranularity(null);
+
+    List<MetricExpression> metricExpressions =
+        Utils.convertToMetricExpressions(metricName, MetricAggFunction.SUM, collectionName);
+    requestBuilder.setMetricFunctions(metricExpressions.get(0).computeMetricFunctions());
+
+    ThirdEyeRequest thirdEyeRequest = requestBuilder.build("test-" + System.currentTimeMillis());
+    return thirdEyeRequest;
+  }
+
+  private List<Pair<DateTime, DateTime>> getIntervals(long currentWindowStart, long currentWindowEnd, String compareMode) {
+    if (compareMode.equals("WO3WMean")) {
+      List<Pair<DateTime, DateTime>> intervals = new ArrayList<>();
+      intervals.add(ImmutablePair.of(new DateTime(currentWindowStart).minusDays(7), new DateTime(currentWindowEnd).minusDays(7)));
+      intervals.add(ImmutablePair.of(new DateTime(currentWindowStart).minusDays(14), new DateTime(currentWindowEnd).minusDays(14)));
+      intervals.add(ImmutablePair.of(new DateTime(currentWindowStart).minusDays(21), new DateTime(currentWindowEnd).minusDays(21)));
+      return intervals;
+    }
+    return Collections.emptyList();
+
+  }
+
+  public static void main(String[] args) throws Exception {
+    PinotThirdEyeClient thirdEyeClient = PinotThirdEyeClient.getDefaultTestClient();
+//    SeverityComputationUtil util = new SeverityComputationUtil(thirdEyeClient, "mny-ads-su-kpi-alerts", "id542749");
+    SeverityComputationUtil util = new SeverityComputationUtil(thirdEyeClient, "mny-ads-su-kpi-alerts", "SU_Impression_Count_on_iOS");
+    long currentWindowStart = new DateTime(2016, 11, 02, 0, 0, DateTimeZone.UTC).getMillis();
+    long currentWindowEnd = new DateTime(2016, 11, 02, 4, 0, DateTimeZone.UTC).getMillis();
+    String compareMode = "WO3WMean";
+    Map<String, Object> severity = util.computeSeverity(currentWindowStart, currentWindowEnd, compareMode);
+    System.out.println(severity);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TestTimeSeriesResponseUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TestTimeSeriesResponseUtils.java
@@ -23,13 +23,11 @@ import com.linkedin.thirdeye.client.timeseries.TimeSeriesRow.TimeSeriesMetric;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
 
 public class TestTimeSeriesResponseUtils {
-  private static final TimeSeriesResponseConverter converter =
-      TimeSeriesResponseConverter.getInstance();
 
   @Test(dataProvider = "toMapProvider")
   public void toMap(String testName, TimeSeriesResponse response, List<String> schemaDimensions,
       Map<DimensionKey, MetricTimeSeries> expected) {
-    Map<DimensionKey, MetricTimeSeries> actual = converter.toMap(response, schemaDimensions);
+    Map<DimensionKey, MetricTimeSeries> actual = TimeSeriesResponseConverter.toMap(response, schemaDimensions);
     Assert.assertEquals(actual, expected);
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -252,7 +252,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
 
   private void startMerger() throws Exception {
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-    anomalyMergeExecutor = new AnomalyMergeExecutor(executorService);
+    anomalyMergeExecutor = new AnomalyMergeExecutor(executorService, null);
     executorService.scheduleWithFixedDelay(anomalyMergeExecutor, 0, 3, TimeUnit.SECONDS);
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesConfig.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesConfig.java
@@ -17,6 +17,8 @@ public class CleanupAndRegenerateAnomaliesConfig {
   // datasets to cleanup/regenerate if functionIds not provided.
   // will be ignored if functionIds provided
   private String datasets;
+  // forceBackfill previous backfill job if there exists any
+  private String forceBackfill;
 
   public String getPersistenceFile() {
     return persistenceFile;
@@ -60,6 +62,11 @@ public class CleanupAndRegenerateAnomaliesConfig {
   public void setFunctionIds(String functionIds) {
     this.functionIds = functionIds;
   }
-
+  public String getForceBackfill() {
+    return forceBackfill;
+  }
+  public void setForceBackfill(String forceBackfill) {
+    this.forceBackfill = forceBackfill;
+  }
 
 }


### PR DESCRIPTION
1. Add force backfill flag, which indicate this backfill session does not want to resume from any previous backfill sessions.

2. Create a method that uses anomaly function specific method to update weight, whose absolute value is severity, of merged anomalies. If the update is failed, then the average of its raw anomalies is used.