### PR TITLE
Making Projection/Aggregation/GroupBy independent of Datasource

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MProjectionOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MProjectionOperator.java
@@ -38,11 +38,11 @@ public class MProjectionOperator extends BaseOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MProjectionOperator.class);
 
   private final BReusableFilteredDocIdSetOperator _docIdSetOperator;
-  private final Map<String, DataSource> _columnToDataSourceMap;
+  private final Map<String, BaseOperator> _columnToDataSourceMap;
   private ProjectionBlock _currentBlock = null;
   private Map<String, Block> _blockMap;
 
-  public MProjectionOperator(Map<String, DataSource> dataSourceMap, BReusableFilteredDocIdSetOperator docIdSetOperator) {
+  public MProjectionOperator(Map<String, BaseOperator> dataSourceMap, BReusableFilteredDocIdSetOperator docIdSetOperator) {
     _docIdSetOperator = docIdSetOperator;
     _columnToDataSourceMap = dataSourceMap;
     _blockMap = new HashMap<>();
@@ -94,8 +94,12 @@ public class MProjectionOperator extends BaseOperator {
     return _currentBlock;
   }
 
-  public DataSource getDataSource(String column) {
+  public BaseOperator getDataSource(String column) {
     return _columnToDataSourceMap.get(column);
+  }
+  
+  public Map<String, BaseOperator> getDataSourceMap() {
+    return _columnToDataSourceMap;
   }
 
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationFunctionContext.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationFunctionContext.java
@@ -33,8 +33,8 @@ public class AggregationFunctionContext {
    * @param aggFuncName
    * @param aggrColumns
    */
-  public AggregationFunctionContext(String aggFuncName, String[] aggrColumns, SegmentMetadata segmentMetadata) {
-    _aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggFuncName, segmentMetadata);
+  public AggregationFunctionContext(String aggFuncName, String[] aggrColumns) {
+    _aggregationFunction = AggregationFunctionFactory.getAggregationFunction(aggFuncName);
     _aggrColumns = aggrColumns;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationOperator.java
@@ -44,10 +44,11 @@ public class AggregationOperator extends BaseOperator {
   private List<AggregationInfo> _aggregationInfoList;
   private MProjectionOperator _projectionOperator;
 
-  private IndexSegment _indexSegment;
   private int _nextBlockCallCounter = 0;
 
   private int[] _reusableDocIdSet;
+
+  private final long _totalRawDocs;
 
   /**
    * Constructor for the class.
@@ -56,17 +57,15 @@ public class AggregationOperator extends BaseOperator {
    * @param aggregationsInfoList List of AggregationInfo (contains context for applying aggregation functions).
    * @param projectionOperator Projection
    */
-  public AggregationOperator(IndexSegment indexSegment, List<AggregationInfo> aggregationsInfoList,
-      MProjectionOperator projectionOperator) {
+  public AggregationOperator(List<AggregationInfo> aggregationsInfoList, MProjectionOperator projectionOperator, long totalRawDocs) {
 
-    Preconditions.checkNotNull(indexSegment);
     Preconditions.checkArgument((aggregationsInfoList != null) && (aggregationsInfoList.size() > 0));
     Preconditions.checkNotNull(projectionOperator);
 
-    _indexSegment = indexSegment;
     _aggregationInfoList = aggregationsInfoList;
     _projectionOperator = projectionOperator;
-    _aggregationExecutor = new DefaultAggregationExecutor(indexSegment, _aggregationInfoList);
+    _aggregationExecutor = new DefaultAggregationExecutor(projectionOperator, _aggregationInfoList);
+    _totalRawDocs = totalRawDocs;
   }
 
   /**
@@ -106,7 +105,7 @@ public class AggregationOperator extends BaseOperator {
             aggregationResults);
 
     resultBlock.setNumDocsScanned(numDocsScanned);
-    resultBlock.setTotalRawDocs(_indexSegment.getSegmentMetadata().getTotalRawDocs());
+    resultBlock.setTotalRawDocs(_totalRawDocs);
     resultBlock.setTimeUsedMs(System.currentTimeMillis() - startTimeMillis);
 
     return resultBlock;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionFactory.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
-import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.core.startree.hll.HllConstants;
 
 
 /**
@@ -64,7 +64,7 @@ public class AggregationFunctionFactory {
    * @param functionName
    * @return
    */
-  public static AggregationFunction getAggregationFunction(String functionName, SegmentMetadata segmentMetadata) {
+  public static AggregationFunction getAggregationFunction(String functionName) {
     switch (functionName.toLowerCase()) {
       case COUNT_AGGREGATION_FUNCTION:
         return new CountAggregationFunction();
@@ -91,7 +91,8 @@ public class AggregationFunctionFactory {
         return new DistinctCountHLLAggregationFunction();
 
       case FASTHLL_AGGREGATION_FUNCTION:
-        return new FastHllAggregationFunction(segmentMetadata.getHllLog2m());
+        // TODO: Add support for configurable hll per segment.
+        return new FastHllAggregationFunction(HllConstants.DEFAULT_LOG2M);
 
       case PERCENTILE50_AGGREGATION_FUNCTION:
         return new PercentileAggregationFunction(50);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByOperator.java
@@ -44,32 +44,31 @@ public class AggregationGroupByOperator extends BaseOperator {
   GroupByExecutor _groupByExecutor;
   private List<AggregationInfo> _aggregationInfoList;
   private MProjectionOperator _projectionOperator;
-  private IndexSegment _indexSegment;
   private int _nextBlockCallCounter = 0;
 
   private int[] _reusableDocIdSet;
+  private final long _totalRawDocs;
 
   /**
    * Constructor for the class.
    *
-   * @param indexSegment Index on which aggregation group by is to be performed.
    * @param aggregationsInfoList List of AggregationInfo (contains context for applying aggregation functions).
    * @param groupBy GroupBy to perform
    * @param projectionOperator Projection
    * @param numGroupsLimit Limit on number of aggregation groups returned in the result
    */
-  public AggregationGroupByOperator(IndexSegment indexSegment, List<AggregationInfo> aggregationsInfoList,
-      GroupBy groupBy, MProjectionOperator projectionOperator, int numGroupsLimit) {
+  public AggregationGroupByOperator(List<AggregationInfo> aggregationsInfoList,
+      GroupBy groupBy, MProjectionOperator projectionOperator, int numGroupsLimit, long totalRawDocs) {
 
-    Preconditions.checkNotNull(indexSegment);
     Preconditions.checkArgument((aggregationsInfoList != null) && (aggregationsInfoList.size() > 0));
     Preconditions.checkNotNull(groupBy);
     Preconditions.checkNotNull(projectionOperator);
 
-    _indexSegment = indexSegment;
     _aggregationInfoList = aggregationsInfoList;
     _projectionOperator = projectionOperator;
-    _groupByExecutor = new DefaultGroupByExecutor(indexSegment, aggregationsInfoList, groupBy, numGroupsLimit);
+    this._totalRawDocs = totalRawDocs;
+    _groupByExecutor = new DefaultGroupByExecutor(projectionOperator, aggregationsInfoList, groupBy, numGroupsLimit);
+
   }
 
   /**
@@ -106,7 +105,7 @@ public class AggregationGroupByOperator extends BaseOperator {
             aggregationGroupByResult);
 
     resultBlock.setNumDocsScanned(numDocsScanned);
-    resultBlock.setTotalRawDocs(_indexSegment.getSegmentMetadata().getTotalRawDocs());
+    resultBlock.setTotalRawDocs(_totalRawDocs);
     resultBlock.setTimeUsedMs(System.currentTimeMillis() - startTimeMillis);
 
     return resultBlock;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByOperatorPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByOperatorPlanNode.java
@@ -36,6 +36,7 @@ import com.linkedin.pinot.core.query.aggregation.AggregationFunctionUtils;
  * AggregationGroupByOperatorPlanNode takes care of how to apply multiple aggregation
  * functions and groupBy query to an IndexSegment.
  */
+@Deprecated
 public class AggregationGroupByOperatorPlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger("QueryPlanLog");
   private final IndexSegment _indexSegment;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ColumnarDataSourcePlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ColumnarDataSourcePlanNode.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.operator.BaseOperator;
 
 
 /**
@@ -43,7 +44,7 @@ public class ColumnarDataSourcePlanNode implements PlanNode {
   }
 
   @Override
-  public Operator run() {
+  public BaseOperator run() {
     DataSource dataSource = _indexSegment.getDataSource(_columnName);
     return dataSource;
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/DataFetcherTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/DataFetcherTest.java
@@ -23,11 +23,13 @@ import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.core.segment.index.loader.Loaders;
 import com.linkedin.pinot.util.TestDataRecordReader;
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
@@ -100,8 +102,12 @@ public class DataFetcherTest {
 
     IndexSegment indexSegment = Loaders.IndexSegment.load(new File(INDEX_DIR_PATH, SEGMENT_NAME), ReadMode.heap);
 
+    Map<String, BaseOperator> dataSourceMap = new HashMap<>();
+    for (String column : indexSegment.getColumnNames()) {
+      dataSourceMap.put(column, indexSegment.getDataSource(column));
+    }
     // Get a data fetcher for the index segment.
-    _dataFetcher = new DataFetcher(indexSegment);
+    _dataFetcher = new DataFetcher(dataSourceMap);
   }
 
   @Test

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllIndexCreationTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllIndexCreationTest.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.common.DataFetcher;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
 import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -31,7 +32,9 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.Configuration;
@@ -127,7 +130,11 @@ public class HllIndexCreationTest {
       for (int i = 0; i < maxDocLength; i++) {
         docIdSet[i] = i;
       }
-      DataBlockCache blockCache = new DataBlockCache(new DataFetcher(indexSegment));
+      Map<String, BaseOperator> dataSourceMap = new HashMap<>();
+      for (String column : indexSegment.getColumnNames()) {
+        dataSourceMap.put(column, indexSegment.getDataSource(column));
+      }
+      DataBlockCache blockCache = new DataBlockCache(new DataFetcher(dataSourceMap));
       blockCache.initNewBlock(docIdSet, 0, maxDocLength);
 
       String[] strings = blockCache.getStringValueArrayForColumn("column1_hll");

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/DefaultGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/DefaultGroupKeyGeneratorTest.java
@@ -23,6 +23,7 @@ import com.linkedin.pinot.core.common.DataFetcher;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.aggregation.groupby.DefaultGroupKeyGenerator;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupKeyGenerator;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -114,7 +115,11 @@ public class DefaultGroupKeyGeneratorTest {
     IndexSegment indexSegment = Loaders.IndexSegment.load(new File(INDEX_DIR_PATH, SEGMENT_NAME), ReadMode.heap);
 
     // Get a data fetcher for the index segment.
-    _dataFetcher = new DataFetcher(indexSegment);
+    Map<String, BaseOperator> dataSourceMap = new HashMap<>();
+    for (String column : indexSegment.getColumnNames()) {
+      dataSourceMap.put(column, indexSegment.getDataSource(column));
+    }
+    _dataFetcher = new DataFetcher(dataSourceMap);
 
     // Generate a random test doc id set.
     int num1 = _random.nextInt(50);

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByOperatorForMultiValueTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByOperatorForMultiValueTest.java
@@ -56,6 +56,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.UReplicatedProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -182,7 +183,7 @@ public class AggregationGroupByOperatorForMultiValueTest {
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
 
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
 
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
@@ -210,7 +211,7 @@ public class AggregationGroupByOperatorForMultiValueTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
 
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
@@ -236,7 +237,7 @@ public class AggregationGroupByOperatorForMultiValueTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -269,7 +270,7 @@ public class AggregationGroupByOperatorForMultiValueTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -294,7 +295,7 @@ public class AggregationGroupByOperatorForMultiValueTest {
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
 
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -567,8 +568,8 @@ public class AggregationGroupByOperatorForMultiValueTest {
     return aggregationsInfo;
   }
 
-  private static Map<String, DataSource> getDataSourceMap() {
-    final Map<String, DataSource> dataSourceMap = new HashMap<String, DataSource>();
+  private static Map<String, BaseOperator> getDataSourceMap() {
+    final Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
     dataSourceMap.put("column1", _indexSegment.getDataSource("column1"));
     dataSourceMap.put("column2", _indexSegment.getDataSource("column2"));
     dataSourceMap.put("column3", _indexSegment.getDataSource("column3"));

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByOperatorTest.java
@@ -36,6 +36,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.UReplicatedProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -182,7 +183,7 @@ public class AggregationGroupByOperatorTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
 
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
@@ -210,7 +211,7 @@ public class AggregationGroupByOperatorTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
 
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
@@ -236,7 +237,7 @@ public class AggregationGroupByOperatorTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -270,7 +271,7 @@ public class AggregationGroupByOperatorTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -294,7 +295,7 @@ public class AggregationGroupByOperatorTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -584,8 +585,8 @@ public class AggregationGroupByOperatorTest {
     return aggregationsInfo;
   }
 
-  private static Map<String, DataSource> getDataSourceMap() {
-    final Map<String, DataSource> dataSourceMap = new HashMap<String, DataSource>();
+  private static Map<String, BaseOperator> getDataSourceMap() {
+    final Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
     dataSourceMap.put("column11", _indexSegment.getDataSource("column11"));
     dataSourceMap.put("column12", _indexSegment.getDataSource("column12"));
     dataSourceMap.put("met_impressionCount", _indexSegment.getDataSource("met_impressionCount"));

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryAndTrieTreeOperatorMultiValueTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryAndTrieTreeOperatorMultiValueTest.java
@@ -36,6 +36,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.UReplicatedProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -187,7 +188,7 @@ public class AggregationGroupByWithDictionaryAndTrieTreeOperatorMultiValueTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -503,8 +504,8 @@ public class AggregationGroupByWithDictionaryAndTrieTreeOperatorMultiValueTest {
     return aggregationsInfo;
   }
 
-  private static Map<String, DataSource> getDataSourceMap() {
-    final Map<String, DataSource> dataSourceMap = new HashMap<String, DataSource>();
+  private static Map<String, BaseOperator> getDataSourceMap() {
+    final Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
     dataSourceMap.put("column1", _indexSegment.getDataSource("column1"));
     dataSourceMap.put("column2", _indexSegment.getDataSource("column2"));
     dataSourceMap.put("column3", _indexSegment.getDataSource("column3"));

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryAndTrieTreeOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryAndTrieTreeOperatorTest.java
@@ -36,6 +36,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.UReplicatedProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -187,7 +188,7 @@ public class AggregationGroupByWithDictionaryAndTrieTreeOperatorTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -517,8 +518,8 @@ public class AggregationGroupByWithDictionaryAndTrieTreeOperatorTest {
     return aggregationsInfo;
   }
 
-  private static Map<String, DataSource> getDataSourceMap() {
-    final Map<String, DataSource> dataSourceMap = new HashMap<String, DataSource>();
+  private static Map<String, BaseOperator> getDataSourceMap() {
+    final Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
     dataSourceMap.put("column11", _indexSegment.getDataSource("column11"));
     dataSourceMap.put("column12", _indexSegment.getDataSource("column12"));
     dataSourceMap.put("met_impressionCount", _indexSegment.getDataSource("met_impressionCount"));

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryOperatorForMultiValueTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryOperatorForMultiValueTest.java
@@ -56,6 +56,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.UReplicatedProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -190,7 +191,7 @@ public class AggregationGroupByWithDictionaryOperatorForMultiValueTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -224,7 +225,7 @@ public class AggregationGroupByWithDictionaryOperatorForMultiValueTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -255,7 +256,7 @@ public class AggregationGroupByWithDictionaryOperatorForMultiValueTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -280,7 +281,7 @@ public class AggregationGroupByWithDictionaryOperatorForMultiValueTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -558,8 +559,8 @@ public class AggregationGroupByWithDictionaryOperatorForMultiValueTest {
     return aggregationsInfo;
   }
 
-  private static Map<String, DataSource> getDataSourceMap() {
-    final Map<String, DataSource> dataSourceMap = new HashMap<String, DataSource>();
+  private static Map<String, BaseOperator> getDataSourceMap() {
+    final Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
     dataSourceMap.put("column1", _indexSegment.getDataSource("column1"));
     dataSourceMap.put("column2", _indexSegment.getDataSource("column2"));
     dataSourceMap.put("column3", _indexSegment.getDataSource("column3"));

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationGroupByWithDictionaryOperatorTest.java
@@ -57,6 +57,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.UReplicatedProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -184,7 +185,7 @@ public class AggregationGroupByWithDictionaryOperatorTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -213,7 +214,7 @@ public class AggregationGroupByWithDictionaryOperatorTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -239,7 +240,7 @@ public class AggregationGroupByWithDictionaryOperatorTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -274,7 +275,7 @@ public class AggregationGroupByWithDictionaryOperatorTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -299,7 +300,7 @@ public class AggregationGroupByWithDictionaryOperatorTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -582,8 +583,8 @@ public class AggregationGroupByWithDictionaryOperatorTest {
     return aggregationsInfo;
   }
 
-  private static Map<String, DataSource> getDataSourceMap() {
-    final Map<String, DataSource> dataSourceMap = new HashMap<String, DataSource>();
+  private static Map<String, BaseOperator> getDataSourceMap() {
+    final Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
     dataSourceMap.put("column11", _indexSegment.getDataSource("column11"));
     dataSourceMap.put("column12", _indexSegment.getDataSource("column12"));
     dataSourceMap.put("met_impressionCount", _indexSegment.getDataSource("met_impressionCount"));

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/AggregationQueriesTest.java
@@ -35,6 +35,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.UReplicatedProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -172,7 +173,7 @@ public class AggregationQueriesTest {
     Operator filterOperator = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator =
         new BReusableFilteredDocIdSetOperator(filterOperator, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
 
     final MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
 
@@ -203,7 +204,7 @@ public class AggregationQueriesTest {
     Operator filterOperator1 = new MatchEntireSegmentOperator(_indexSegment.getSegmentMetadata().getTotalDocs());
     final BReusableFilteredDocIdSetOperator docIdSetOperator1 =
         new BReusableFilteredDocIdSetOperator(filterOperator1, _indexSegment.getSegmentMetadata().getTotalDocs(), 5000);
-    final Map<String, DataSource> dataSourceMap1 = getDataSourceMap();
+    final Map<String, BaseOperator> dataSourceMap1 = getDataSourceMap();
     final MProjectionOperator projectionOperator1 = new MProjectionOperator(dataSourceMap1, docIdSetOperator1);
 
     for (int i = 0; i < _numAggregations; ++i) {
@@ -368,8 +369,8 @@ public class AggregationQueriesTest {
     return aggregationsInfo;
   }
 
-  private static Map<String, DataSource> getDataSourceMap() {
-    final Map<String, DataSource> dataSourceMap = new HashMap<String, DataSource>();
+  private static Map<String, BaseOperator> getDataSourceMap() {
+    final Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
     dataSourceMap.put("column11", _indexSegment.getDataSource("column11"));
     dataSourceMap.put("column12", _indexSegment.getDataSource("column12"));
     dataSourceMap.put("met_impressionCount", _indexSegment.getDataSource("met_impressionCount"));

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/selection/BaseSelectionQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/selection/BaseSelectionQueriesTest.java
@@ -23,6 +23,7 @@ import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
 import com.linkedin.pinot.core.operator.filter.MatchEntireSegmentOperator;
@@ -63,7 +64,7 @@ public abstract class BaseSelectionQueriesTest {
    *
    * @return data source map for the tests.
    */
-  abstract Map<String, DataSource> getDataSourceMap();
+  abstract Map<String, BaseOperator> getDataSourceMap();
 
   /**
    * Get the selection ONLY query.
@@ -109,7 +110,7 @@ public abstract class BaseSelectionQueriesTest {
   public void testSelectionOnlyIteration()
       throws Exception {
     IndexSegment indexSegment = getIndexSegment();
-    Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     Selection selectionOnlyQuery = getSelectionOnlyQuery();
 
     // Get selection result block.
@@ -146,7 +147,7 @@ public abstract class BaseSelectionQueriesTest {
   public void testSelectionOrderByIteration()
       throws Exception {
     IndexSegment indexSegment = getIndexSegment();
-    Map<String, DataSource> dataSourceMap = getDataSourceMap();
+    Map<String, BaseOperator> dataSourceMap = getDataSourceMap();
     Selection selectionOrderByQuery = getSelectionOrderByQuery();
 
     // Get selection result block.

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionQueriesMVTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionQueriesMVTest.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
@@ -45,7 +46,7 @@ public class SelectionQueriesMVTest extends BaseSelectionQueriesTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "SelectionQueriesMVTest");
 
   private IndexSegment _indexSegment;
-  private Map<String, DataSource> _dataSourceMap;
+  private Map<String, BaseOperator> _dataSourceMap;
   private Selection _selectionOnlyQuery;
   private Selection _selectionOrderByQuery;
 
@@ -103,7 +104,7 @@ public class SelectionQueriesMVTest extends BaseSelectionQueriesTest {
   }
 
   @Override
-  Map<String, DataSource> getDataSourceMap() {
+  Map<String, BaseOperator> getDataSourceMap() {
     return _dataSourceMap;
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionQueriesSVTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionQueriesSVTest.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
@@ -45,7 +46,7 @@ public class SelectionQueriesSVTest extends BaseSelectionQueriesTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "SelectionQueriesSVTest");
 
   private IndexSegment _indexSegment;
-  private Map<String, DataSource> _dataSourceMap;
+  private Map<String, BaseOperator> _dataSourceMap;
   private Selection _selectionOnlyQuery;
   private Selection _selectionOrderByQuery;
 
@@ -103,7 +104,7 @@ public class SelectionQueriesSVTest extends BaseSelectionQueriesTest {
   }
 
   @Override
-  Map<String, DataSource> getDataSourceMap() {
+  Map<String, BaseOperator> getDataSourceMap() {
     return _dataSourceMap;
   }
 


### PR DESCRIPTION
First phase of removing explicit use of data source and indexsegment from projection/groupby/aggregation operators.

Pending clean up of selection and filter operators.

This is setting up the code to implement transform operator and remove the need for dictionary for all columns