### PR TITLE
Performance improvement for StarTree index generation.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/OffHeapStarTreeBuilder.java
@@ -28,6 +28,7 @@ import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.utils.Pairs.IntPair;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.io.BufferedOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -574,7 +575,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
 
     StarTreeDataTable dataSorter =
         new StarTreeDataTable(file, dimensionSizeBytes, metricSizeBytes, getSortOrder());
-    dataSorter.sort(startDocId, endDocId, 0, dimensionSizeBytes);
+    dataSorter.sort(startDocId, endDocId);
     if (debugMode) {
       LOG.info("AFTER SORTING");
       printFile(file, startDocId, endDocId);
@@ -807,8 +808,7 @@ public class OffHeapStarTreeBuilder implements StarTreeBuilder {
    * @param file
    * @return
    */
-  private Map<Integer, IntPair> groupBy(int startDocId, int endDocId, Integer dimension,
-      File file) {
+  private Int2ObjectMap<IntPair> groupBy(int startDocId, int endDocId, Integer dimension, File file) {
     StarTreeDataTable dataSorter =
         new StarTreeDataTable(file, dimensionSizeBytes, metricSizeBytes, getSortOrder());
     return dataSorter.groupByIntColumnCount(startDocId, endDocId, dimension);


### PR DESCRIPTION
Removed inefficiencies from code to sort records before generating
StarTree index. More improvements to follow:

1. Replaced Java maps with fastUtil map to be able to use primitive int's as key.
2. Avoid creating garbage when copy data out of Mmap buffer. This required handling
   endianess as Java is Big Endian, whereas MMapBuffer (xerial) can be Little Endian.
3. For an avro of size 3.6GB, reduced peak memory usage from > 3.5 GB to ~1 GB. This also improves
   CPU time from 660s to 500s (~25%).