### PR TITLE
Add API to sync brokerResource with Helix tags

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableTenantConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableTenantConfigs.java
@@ -8,6 +8,8 @@ import com.linkedin.pinot.controller.api.ControllerRestApplication;
 import org.apache.commons.io.FileUtils;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
+import org.restlet.representation.StringRepresentation;
+import org.restlet.resource.Post;
 import org.restlet.resource.Put;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,5 +60,32 @@ public class PinotTableTenantConfigs extends BasePinotControllerRestletResource 
       @Parameter(name = "tableName", in = "path", description = "The name of the table for which to update the tenant configuration", required = true)
       String tableName) {
     throw new UnsupportedOperationException("current tenant config updates are not supported");
+  }
+
+  @Override
+  @Post()
+  public Representation post(Representation entity) {
+    final String tableName = (String) getRequest().getAttributes().get("tableName");
+    try {
+      rebuildBrokerResourceFromHelixTags(tableName);
+      return new StringRepresentation("ok");
+    } catch (Exception e) {
+      setStatus(Status.SERVER_ERROR_INTERNAL);
+      return PinotSegmentUploadRestletResource.exceptionToStringRepresentation(e);
+    }
+  }
+
+  @HttpVerb("post")
+  @Summary("Rebuild broker mapping from Helix tags")
+  @Tags({"table", "tenant"})
+  @Paths({
+      "/tables/{tableName}/rebuildBrokerResourceFromHelixTags"
+  })
+  private Representation rebuildBrokerResourceFromHelixTags(
+      @Parameter(name = "tableName", in = "path", description = "The name of the table for which to rebuild the broker mapping", required = true)
+      String tableName
+  ) {
+    return new StringRepresentation(
+        _pinotHelixResourceManager.rebuildBrokerResourceFromHelixTags(tableName).toString());
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
+import com.google.common.base.Function;
+import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import com.linkedin.pinot.common.utils.retry.RetryPolicy;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -100,6 +103,7 @@ import javax.annotation.Nonnull;
 public class PinotHelixResourceManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotHelixResourceManager.class);
   private static final long DEFAULT_EXTERNAL_VIEW_UPDATE_TIMEOUT_MILLIS = 120_000L; // 2 minutes
+  private static final RetryPolicy DEFAULT_RETRY_POLICY = RetryPolicies.exponentialBackoffRetryPolicy(5, 1000L, 2.0f);
 
   private String _zkBaseUrl;
   private String _helixClusterName;
@@ -449,6 +453,59 @@ public class PinotHelixResourceManager {
     }
     res.status = ResponseStatus.success;
     return res;
+  }
+
+  public PinotResourceManagerResponse rebuildBrokerResourceFromHelixTags(final String tableName) {
+    // Get the broker tag for this table
+    String brokerTag = null;
+    TenantConfig tenantConfig = null;
+
+    try {
+      final TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+      if (tableType == TableType.OFFLINE) {
+        tenantConfig = ZKMetadataProvider.getOfflineTableConfig(getPropertyStore(), tableName).getTenantConfig();
+      } else if (tableType == TableType.REALTIME) {
+        tenantConfig = ZKMetadataProvider.getRealtimeTableConfig(getPropertyStore(), tableName).getTenantConfig();
+      } else {
+        throw new RuntimeException("Don't know how to handle table of type " + tableType);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while rebuilding broker resource from Helix tags for table {}", e, tableName);
+      return new PinotResourceManagerResponse(
+          "Failed to fetch broker tag for table " + tableName + " due to exception: " + e.getMessage(), false);
+    }
+
+    brokerTag = tenantConfig.getBroker();
+
+    // Look for all instances tagged with this broker tag
+    final Set<String> brokerInstances = getAllInstancesForBrokerTenant(brokerTag);
+
+    // Reset ideal state with the instance list
+    try {
+      HelixHelper.updateIdealState(getHelixZkManager(), CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, new Function<IdealState, IdealState>() {
+        @Nullable
+        @Override
+        public IdealState apply(@Nullable IdealState idealState) {
+          Map<String, String> instanceStateMap = idealState.getInstanceStateMap(tableName);
+          if (instanceStateMap != null) {
+            instanceStateMap.clear();
+          }
+
+          for (String brokerInstance : brokerInstances) {
+            idealState.setPartitionState(tableName, brokerInstance, BrokerOnlineOfflineStateModel.ONLINE);
+          }
+
+          return idealState;
+        }
+      }, DEFAULT_RETRY_POLICY);
+
+      LOGGER.info("Successfully rebuilt brokerResource for table {}", tableName);
+      return new PinotResourceManagerResponse("Rebuilt brokerResource for table " + tableName, true);
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while rebuilding broker resource from Helix tags for table {}", e, tableName);
+      return new PinotResourceManagerResponse(
+          "Failed to rebuild brokerResource for table " + tableName + " due to exception: " + e.getMessage(), false);
+    }
   }
 
   private void addInstanceToBrokerIdealState(String brokerTenantTag, String instanceName) {


### PR DESCRIPTION
Add a REST API that syncs the brokerResource for a table with the
brokers specified by Helix tags.