### PR TITLE
Optimizing anomaly results pageload

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -6,21 +6,21 @@ import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 
 public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomalyResultDTO> {
 
+  MergedAnomalyResultDTO findById(Long id, boolean loadRawAnomalies);
+
   List<MergedAnomalyResultDTO> getAllByTimeEmailIdAndNotifiedFalse(long startTime, long endTime,
       long emailId);
 
   List<MergedAnomalyResultDTO> findAllConflictByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd);
 
   List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
-      String metric, String dimensions, long startTime, long endTime);
+      String metric, String dimensions, long startTime, long endTime, boolean loadRawAnomalies);
 
   List<MergedAnomalyResultDTO> findByCollectionMetricTime(String collection, String metric,
-      long startTime, long endTime);
+      long startTime, long endTime, boolean loadRawAnomalies);
 
   List<MergedAnomalyResultDTO> findByCollectionTime(String collection, long startTime,
-      long endTime);
-
-  MergedAnomalyResultDTO findLatestByFunctionIdDimensions(Long functionId, String dimensions);
+      long endTime, boolean loadRawAnomalies);
 
   MergedAnomalyResultDTO findLatestConflictByFunctionIdDimensions(Long functionId, String dimensions,
       long conflictWindowStart, long conflictWindowEnd, long sequentialAllowedGap);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -43,9 +43,6 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
   private static final String FIND_BY_FUNCTION_ID = "where functionId=:functionId";
 
-  private static final String FIND_BY_FUNCTION_AND_DIMENSIONS =
-      "where functionId=:functionId " + "and dimensions=:dimensions order by endTime desc limit 1";
-
   private static final String FIND_LATEST_CONFLICT_BY_FUNCTION_AND_DIMENSIONS =
       "where functionId=:functionId " + "and dimensions=:dimensions "
         + "and (startTime < :endTime and endTime > :startTime) " + "order by endTime desc limit 1";
@@ -85,17 +82,19 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
       return genericPojoDao.update(mergeAnomalyBean);
     }
   }
-
-  public MergedAnomalyResultDTO findById(Long id) {
-    MergedAnomalyResultBean mergedAnomalyResultBean =
-        genericPojoDao.get(id, MergedAnomalyResultBean.class);
+  public MergedAnomalyResultDTO findById(Long id, boolean loadRawAnomalies) {
+    MergedAnomalyResultBean mergedAnomalyResultBean = genericPojoDao.get(id, MergedAnomalyResultBean.class);
     if (mergedAnomalyResultBean != null) {
       MergedAnomalyResultDTO mergedAnomalyResultDTO;
-      mergedAnomalyResultDTO = convertMergedAnomalyBean2DTO(mergedAnomalyResultBean);
+      mergedAnomalyResultDTO = convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, loadRawAnomalies);
       return mergedAnomalyResultDTO;
     } else {
       return null;
     }
+  }
+
+  public MergedAnomalyResultDTO findById(Long id) {
+    return findById(id, true);
   }
 
   @Override
@@ -116,7 +115,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     );
     List<MergedAnomalyResultBean> list =
         genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return batchConvertMergedAnomalyBean2DTO(list);
+    return batchConvertMergedAnomalyBean2DTO(list, true);
   }
 
   @Override
@@ -125,7 +124,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
         Predicate.AND(Predicate.LE("startTime", conflictWindowEnd), Predicate.GE("endTime", conflictWindowStart),
             Predicate.EQ("functionId", functionId));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return batchConvertMergedAnomalyBean2DTO(list);
+    return batchConvertMergedAnomalyBean2DTO(list, true);
   }
 
   @Override
@@ -135,12 +134,12 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(FIND_BY_FUNCTION_ID,
         filterParams, MergedAnomalyResultBean.class);
-    return batchConvertMergedAnomalyBean2DTO(list);
+    return batchConvertMergedAnomalyBean2DTO(list, true);
   }
 
   @Override
   public List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
-      String metric, String dimensions, long startTime, long endTime) {
+      String metric, String dimensions, long startTime, long endTime, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("collection", collection);
     filterParams.put("metric", metric);
@@ -150,13 +149,13 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(
         FIND_BY_COLLECTION_METRIC_DIMENSIONS_TIME, filterParams, MergedAnomalyResultBean.class);
-    return batchConvertMergedAnomalyBean2DTO(list);
+    return batchConvertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
 
   @Override
   public List<MergedAnomalyResultDTO> findByCollectionMetricTime(String collection, String metric,
-      long startTime, long endTime) {
+      long startTime, long endTime, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("collection", collection);
     filterParams.put("metric", metric);
@@ -165,12 +164,12 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(
         FIND_BY_COLLECTION_METRIC_TIME, filterParams, MergedAnomalyResultBean.class);
-    return batchConvertMergedAnomalyBean2DTO(list);
+    return batchConvertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
   public List<MergedAnomalyResultDTO> findByCollectionTime(String collection, long startTime,
-      long endTime) {
+      long endTime, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("collection", collection);
     filterParams.put("startTime", startTime);
@@ -178,24 +177,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(
         FIND_BY_COLLECTION_TIME, filterParams, MergedAnomalyResultBean.class);
-    return batchConvertMergedAnomalyBean2DTO(list);
-  }
-
-
-  @Override
-  public MergedAnomalyResultDTO findLatestByFunctionIdDimensions(Long functionId,
-      String dimensions) {
-    Map<String, Object> filterParams = new HashMap<>();
-    filterParams.put("functionId", functionId);
-    filterParams.put("dimensions", dimensions);
-
-    List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(
-        FIND_BY_FUNCTION_AND_DIMENSIONS, filterParams, MergedAnomalyResultBean.class);
-    if (CollectionUtils.isNotEmpty(list)) {
-      MergedAnomalyResultDTO mergedAnomalyResultDTO = convertMergedAnomalyBean2DTO(list.get(0));
-      return mergedAnomalyResultDTO;
-    }
-    return null;
+    return batchConvertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
@@ -212,7 +194,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     if (CollectionUtils.isNotEmpty(list)) {
       MergedAnomalyResultBean mostRecentConflictMergedAnomalyResultBean = list.get(0);
-      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean);
+      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean, true);
     }
 
     return null;
@@ -225,7 +207,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(
         FIND_BY_FUNCTION_AND_NULL_DIMENSION, filterParams, MergedAnomalyResultBean.class);
-    List<MergedAnomalyResultDTO> result = batchConvertMergedAnomalyBean2DTO(list);
+    List<MergedAnomalyResultDTO> result = batchConvertMergedAnomalyBean2DTO(list, true);
     // TODO: Check list size instead of result size?
     if (result.size() > 0) {
       return result.get(0);
@@ -261,7 +243,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   protected MergedAnomalyResultDTO convertMergedAnomalyBean2DTO(
-      MergedAnomalyResultBean mergedAnomalyResultBean) {
+      MergedAnomalyResultBean mergedAnomalyResultBean, boolean loadRawAnomalies) {
     MergedAnomalyResultDTO mergedAnomalyResultDTO;
     mergedAnomalyResultDTO =
         MODEL_MAPPER.map(mergedAnomalyResultBean, MergedAnomalyResultDTO.class);
@@ -279,7 +261,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
           MODEL_MAPPER.map(anomalyFeedbackBean, AnomalyFeedbackDTO.class);
       mergedAnomalyResultDTO.setFeedback(anomalyFeedbackDTO);
     }
-    if (mergedAnomalyResultBean.getRawAnomalyIdList() != null
+    if (loadRawAnomalies && mergedAnomalyResultBean.getRawAnomalyIdList() != null
         && !mergedAnomalyResultBean.getRawAnomalyIdList().isEmpty()) {
       List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
       List<RawAnomalyResultBean> list = genericPojoDao
@@ -294,11 +276,11 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   protected List<MergedAnomalyResultDTO> batchConvertMergedAnomalyBean2DTO(
-      List<MergedAnomalyResultBean> mergedAnomalyResultBeanList) {
+      List<MergedAnomalyResultBean> mergedAnomalyResultBeanList, boolean loadRawAnomalies) {
     List<Future<MergedAnomalyResultDTO>> mergedAnomalyResultDTOFutureList = new ArrayList<>(mergedAnomalyResultBeanList.size());
     for (MergedAnomalyResultBean mergedAnomalyResultBean : mergedAnomalyResultBeanList) {
       Future<MergedAnomalyResultDTO> future =
-          executorService.submit(() -> convertMergedAnomalyBean2DTO(mergedAnomalyResultBean));
+          executorService.submit(() -> convertMergedAnomalyBean2DTO(mergedAnomalyResultBean, loadRawAnomalies));
       mergedAnomalyResultDTOFutureList.add(future);
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/anomalies.js
@@ -73,7 +73,7 @@ function getAnomalies(tab) {
         } else {
             getTimeseriesData();
         }
-        
+
         function getTimeseriesData(anomalyData) {
           if(anomalyData) {
              var anomalyMetric = true;
@@ -87,7 +87,7 @@ function getAnomalies(tab) {
           }
           delete hash.anomalyFunctionId;
           delete hash.fnCompareWeeks;
-          
+
 //            if(anomalyData){
 //                var anomalyMetric = true;
 //            }
@@ -569,11 +569,32 @@ function renderAnomalyThumbnails(data, tab) {
      function requestLineChart(i) {
          var startTime = data[i]["startTime"];
          var endTime = data[i]["endTime"];
-         var aggTimeGranularity = calcAggregateGranularity(hash.currentStart,hash.currentEnd);
+
+         var viewWindowStart = startTime;
+         var viewWindowEnd = endTime;
+
+         var aggTimeGranularity = calcAggregateGranularity(startTime, endTime);
+
+         var extensionWindowMillis;
+         switch (aggTimeGranularity) {
+             case "DAYS":
+                 extensionWindowMillis = 86400000;
+                 break;
+             case "HOURS":
+             default:
+                 var viewWindowSize = viewWindowEnd - viewWindowStart;
+                 var multiplier = Math.max(2, parseInt(viewWindowSize / 3600000));
+                 extensionWindowMillis = 3600000 * multiplier;
+         }
+
+         viewWindowStart -= extensionWindowMillis;
+         viewWindowEnd += extensionWindowMillis;
+
+
          var anomalyId = data[i]["id"]
          var placeholder= "#d3charts-" + i;
          var timeSeriesUrl = "/dashboard/anomaly-merged-result/timeseries/" + anomalyId
-             + "?aggTimeGranularity=" + aggTimeGranularity + "&start=" + hash.currentStart + "&end=" + hash.currentEnd;
+             + "?aggTimeGranularity=" + aggTimeGranularity + "&start=" + viewWindowStart + "&end=" + viewWindowEnd;
          var tab = hash.view;
 
         getDataCustomCallback(timeSeriesUrl, tab).done(function (timeSeriesData) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies-tab/anomalies.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies-tab/anomalies.ftl
@@ -20,7 +20,8 @@
 
                         </div>
                         <div>
-                            <a class="anomaly-details-link blue" data-id="{{anomalyData/id}}"># {{anomalyData/id}}</a>
+                            <!--a class="anomaly-details-link blue" data-id="{{anomalyData/id}}">TODO: fix this link</a-->
+                          # {{anomalyData/id}}
                         </div>
                         <div>
                             <h3 style="margin-top:0px;">

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
@@ -62,7 +62,7 @@ public class TestMergedAnomalyResultManager extends AbstractManagerTestBase {
 
     List<MergedAnomalyResultDTO> mergedResultsByMetricDimensionsTime = mergedResultDAO
         .findByCollectionMetricDimensionsTime(mergedResult.getCollection(), mergedResult.getMetric(),
-            mergedResult.getDimensions().toString(), 0, System.currentTimeMillis());
+            mergedResult.getDimensions().toString(), 0, System.currentTimeMillis(), true);
 
     Assert.assertEquals(mergedResultsByMetricDimensionsTime.get(0), mergedResult);
   }


### PR DESCRIPTION
- disabled anomaly detail page till we fix the anomaly results load delay
- rendering anomaly chart with time range selection of individual merged anomaly instead of entire time range selection from the left panel.
- not loading raw anomalies for the calls coming from front end.
