### PR TITLE
Adding externalDashboardURL field to metricConfigBean

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/MetricConfigResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/MetricConfigResource.java
@@ -25,7 +25,6 @@ import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.bao.DashboardConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DashboardConfigDTO;
-import com.linkedin.thirdeye.datalayer.dto.IngraphMetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.util.JsonResponseUtil;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
@@ -158,6 +157,25 @@ public class MetricConfigResource {
     List<MetricConfigDTO> subList = Utils.sublist(metricConfigDTOs, jtStartIndex, jtPageSize);
     ObjectNode rootNode = JsonResponseUtil.buildResponseJSON(subList);
     return rootNode.toString();
+  }
+
+  @GET
+  @Path("/view")
+  @Produces(MediaType.APPLICATION_JSON)
+  public MetricConfigDTO viewMetricConfigByIdOrName(@QueryParam("id") String id,
+      @QueryParam("dataset") String dataset,
+      @QueryParam("metric") String metric) {
+
+    MetricConfigDTO metricConfigDTO = null;
+    if (StringUtils.isBlank(id) && (StringUtils.isBlank(dataset) || StringUtils.isBlank(metric))) {
+      LOG.error("Must provide either id or metric+dataset {} {} {}", id, metric, dataset);
+    }
+    if (StringUtils.isNotBlank(id)) {
+      metricConfigDTO = metricConfigDao.findById(Long.valueOf(id));
+    } else {
+      metricConfigDTO = metricConfigDao.findByMetricAndDataset(metric, dataset);
+    }
+    return metricConfigDTO;
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
@@ -33,6 +33,8 @@ public class MetricConfigBean extends AbstractBean {
 
   private boolean active = true;
 
+  private String externalDashboardURL;
+
 
   public String getName() {
     return name;
@@ -114,6 +116,15 @@ public class MetricConfigBean extends AbstractBean {
     this.active = active;
   }
 
+
+  public String getExternalDashboardURL() {
+    return externalDashboardURL;
+  }
+
+  public void setExternalDashboardURL(String externalDashboardURL) {
+    this.externalDashboardURL = externalDashboardURL;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof MetricConfigBean)) {
@@ -129,20 +140,21 @@ public class MetricConfigBean extends AbstractBean {
         && Objects.equals(rollupThreshold, mc.getRollupThreshold())
         && Objects.equals(inverseMetric, mc.isInverseMetric())
         && Objects.equals(cellSizeExpression, mc.getCellSizeExpression())
-        && Objects.equals(active, mc.isActive());
+        && Objects.equals(active, mc.isActive())
+        && Objects.equals(externalDashboardURL, mc.getExternalDashboardURL());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), dataset, alias, derived, derivedMetricExpression, rollupThreshold,
-        inverseMetric, cellSizeExpression, active);
+        inverseMetric, cellSizeExpression, active, externalDashboardURL);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("id", getId()).add("dataset", dataset)
+    return MoreObjects.toStringHelper(this).add("id", getId()).add("name", name).add("dataset", dataset)
         .add("alias", alias).add("derived", derived).add("derivedMetricExpression", derivedMetricExpression)
         .add("rollupThreshold", rollupThreshold).add("cellSizeExpression", cellSizeExpression)
-        .add("active", active).toString();
+        .add("active", active).add("externalDashboardURL", externalDashboardURL).toString();
   }
 }


### PR DESCRIPTION
Adding a field for externalDashboardURL to MetricConfigBean, which will be populated by the autoload tools. Created an endpoint for fetching metric by id or metric+name to be used by UI to display URL