### PR TITLE
Use Travis cache for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ matrix:
     - jdk: oraclejdk8
       env: RUN_INTEGRATION_TESTS=false
 
+cache:
+  directories:
+    - $HOME/.m2
+
+sudo: false
+
 install:
   - ./.travis_install.sh
 

--- a/.travis_test.sh
+++ b/.travis_test.sh
@@ -25,6 +25,9 @@ fi
 # Only run tests for JDK 7
 if [ $TRAVIS_JDK_VERSION != 'oraclejdk7' ]; then
   echo 'Skip tests for version other than oraclejdk7.'
+
+  # Remove Pinot files from local Maven respository to avoid a useless cache rebuild
+  rm -rf ~/.m2/repository/com/linkedin/pinot
   exit 0
 fi
 
@@ -42,3 +45,8 @@ else
 fi
 
 bash <(cat .codecov_bash)
+
+# Remove Pinot files from local Maven respository to avoid a useless cache rebuild
+rm -rf ~/.m2/repository/com/linkedin/pinot
+
+exit 0


### PR DESCRIPTION
Cache the Maven repository between Travis builds, to shorten build
time.