### PR TITLE
Display test execution duration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,7 @@
             <systemPropertyVariables>
               <zookeeper.forceSync>no</zookeeper.forceSync>
             </systemPropertyVariables>
+            <reportFormat>plain</reportFormat>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Display the wall time used by the unit tests and integration tests
in the Maven test execution summary, so that we can optimize the ones
that have the longest execution time.