### PR TITLE
Reduce anomaly detection latency

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobScheduler.java
@@ -37,6 +37,9 @@ import com.linkedin.thirdeye.datalayer.dto.EmailConfigurationDTO;
 public class AlertJobScheduler implements JobScheduler, Runnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(AlertJobScheduler.class);
+  public static final int DEFAULT_ALERT_DELAY = 10;
+  public static final TimeUnit DEFAULT_ALERT_DELAY_UNIT = TimeUnit.MINUTES;
+
   private SchedulerFactory schedulerFactory;
   private Scheduler quartzScheduler;
   private ScheduledExecutorService scheduledExecutorService;
@@ -72,7 +75,7 @@ public class AlertJobScheduler implements JobScheduler, Runnable {
   public void start() throws SchedulerException {
     quartzScheduler.start();
 
-    scheduledExecutorService.scheduleWithFixedDelay(this, 0, 30, TimeUnit.MINUTES);
+    scheduledExecutorService.scheduleWithFixedDelay(this, 0, DEFAULT_ALERT_DELAY, DEFAULT_ALERT_DELAY_UNIT);
   }
 
   public void run() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/SeverityComputationUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/SeverityComputationUtil.java
@@ -42,11 +42,16 @@ public class SeverityComputationUtil {
     List<Pair<DateTime, DateTime>> intervals =
         getHistoryIntervals(currentWindowStart, currentWindowEnd, seasonalPeriod, seasonCount);
     double baselineSum = 0;
+    int count = 0;
     for (Pair<DateTime, DateTime> pair : intervals) {
       thirdEyeRequest = createThirdEyeRequest(pair.getLeft().getMillis(), pair.getRight().getMillis());
-      baselineSum += getSum(thirdEyeRequest);
+      double sum = getSum(thirdEyeRequest);
+      if (sum != 0d) {
+        ++count;
+        baselineSum += sum;
+      }
     }
-    double baselineSumAvg = baselineSum / intervals.size();
+    double baselineSumAvg = baselineSum / count;
     double weight = (currentSum - baselineSumAvg) / baselineSumAvg;
     HashMap<String, Object> hashMap = Maps.newHashMap();
     hashMap.put("weight", weight);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -232,15 +232,16 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
     }
     Assert.assertTrue(completedCount > 0);
 
-    // check if anomalies present
+    // Raw anomalies of the same function and dimensions should have been merged by the worker, so we
+    // check if any raw anomalies present, whose existence means the worker fails the synchronous merge.
     List<RawAnomalyResultDTO> rawAnomalies = rawResultDAO.findUnmergedByFunctionId(functionId);
-    Assert.assertTrue(rawAnomalies.size() > 0);
+    Assert.assertTrue(rawAnomalies.size() == 0);
 
     // start merge
-    startMerger();
+    // startMerger();
 
     // check merged anomalies
-    Thread.sleep(4000);
+    // Thread.sleep(4000);
     List<MergedAnomalyResultDTO> mergedAnomalies = mergedResultDAO.findByFunctionId(functionId);
     Assert.assertTrue(mergedAnomalies.size() > 0);
 


### PR DESCRIPTION
1. Reduce alert fixed delay.
2. Perform synchronous merge, which is a light merge, right after each anomaly detection.
3. Improve the accuracy of severity calculation utility.