### PR TITLE
Fix the issue of duplicate alert

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -166,7 +166,9 @@ public class AnomalyMergeExecutor implements Runnable {
           throw new IllegalArgumentException("Merge strategy " + mergeConfig.getMergeStrategy() + " not supported");
       }
       for (MergedAnomalyResultDTO mergedAnomalyResultDTO : output) {
-        mergedAnomalyResultDTO.setNotified(isBackfill);
+        if (isBackfill) {
+          mergedAnomalyResultDTO.setNotified(isBackfill);
+        } // else notified flag is left as is
         updateMergedScoreAndPersist(mergedAnomalyResultDTO, mergeConfig);
       }
       return output.size();


### PR DESCRIPTION
The case happens when the events are executed in the following order:
1. A merged anomaly is generated, whose notified flag is false.
2. An alert for this anomaly is sent. The anomaly's notified flag is set to true.
3. A new raw anomaly is merged to the anomaly and set its flag to false.
4. A duplicate alert is sent.

The fix leaves the flag as is when a raw anomaly is merged to an alerted anomaly.