### PR TITLE
Exclude jsr311 lib from swagger jersey2 library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -613,6 +613,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
     </dependencies>


### PR DESCRIPTION
swagger-jersey2-jaxrs brings jsr311 library which has conflicting
APIs with jersey2 we are using.