### PR TITLE
Fix path name used for deleting expired segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -90,7 +90,8 @@ public class ZKMetadataProvider {
   }
 
   public static boolean isSegmentExisted(ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceNameForResource, String segmentName) {
-    return propertyStore.exists(constructPropertyStorePathForSegment(resourceNameForResource, segmentName), AccessOption.PERSISTENT);
+    return propertyStore.exists(constructPropertyStorePathForSegment(resourceNameForResource, segmentName),
+        AccessOption.PERSISTENT);
   }
 
   public static void removeResourceSegmentsFromPropertyStore(ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
@@ -131,7 +132,7 @@ public class ZKMetadataProvider {
     return new OfflineSegmentZKMetadata(propertyStore.get(constructPropertyStorePathForSegment(offlineTableName, segmentName), null, AccessOption.PERSISTENT));
   }
 
-  public static RealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName, String segmentName) {
+  public static @Nullable RealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName, String segmentName) {
     String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
     ZNRecord znRecord = propertyStore
         .get(constructPropertyStorePathForSegment(realtimeTableName, segmentName), null, AccessOption.PERSISTENT);
@@ -148,7 +149,8 @@ public class ZKMetadataProvider {
 
   public static @Nullable AbstractTableConfig getOfflineTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
     String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
-    ZNRecord znRecord = propertyStore.get(constructPropertyStorePathForResourceConfig(offlineTableName), null, AccessOption.PERSISTENT);
+    ZNRecord znRecord = propertyStore.get(constructPropertyStorePathForResourceConfig(offlineTableName), null,
+        AccessOption.PERSISTENT);
     if (znRecord == null) {
       return null;
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -135,6 +135,10 @@ public class ZKMetadataProvider {
     String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
     ZNRecord znRecord = propertyStore
         .get(constructPropertyStorePathForSegment(realtimeTableName, segmentName), null, AccessOption.PERSISTENT);
+    // It is possible that the segment metadata has just been deleted due to retention.
+    if (znRecord == null) {
+      return null;
+    }
     if (SegmentName.isHighLevelConsumerSegmentName(segmentName)) {
       return new RealtimeSegmentZKMetadata(znRecord);
     } else {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -138,13 +138,14 @@ public class SegmentDeletionManager {
       if (_localDiskDir != null) {
         File fileToMove = new File(new File(_localDiskDir, rawTableName), segmentId);
         if (fileToMove.exists()) {
-          File deletedDir = new File(_localDiskDir, DELETED_SEGMENTS);
+          File targetDir = new File(new File(_localDiskDir, DELETED_SEGMENTS), rawTableName);
           try {
-            FileUtils.moveFileToDirectory(fileToMove, deletedDir, true);
-            LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(), deletedDir.getAbsolutePath());
+            FileUtils.moveFileToDirectory(fileToMove, targetDir, true);
+            LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(),
+                targetDir.getAbsolutePath());
           } catch (IOException e) {
             LOGGER.warn("Could not move segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(),
-                deletedDir.getAbsolutePath(), e);
+                targetDir.getAbsolutePath(), e);
           }
         } else {
           CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -16,12 +16,12 @@
 package com.linkedin.pinot.controller.helix.core;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
@@ -29,9 +29,10 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.SegmentName;
 
 
 /**
@@ -48,6 +49,7 @@ public class SegmentDeletionManager {
   private final String _helixClusterName;
   private final HelixAdmin _helixAdmin;
   private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final String DELETED_SEGMENTS = "Deleted_Segments";
 
   SegmentDeletionManager(String localDiskDir, HelixAdmin helixAdmin, String helixClusterName, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _localDiskDir = localDiskDir;
@@ -132,25 +134,35 @@ public class SegmentDeletionManager {
         return;
       }
 
-      switch (TableNameBuilder.getTableTypeFromTableName(tableName)) {
-        case OFFLINE:
-          if (_localDiskDir != null) {
-            File fileToDelete = new File(new File(_localDiskDir, tableName), segmentId);
-            if (fileToDelete.exists()) {
-              FileUtils.deleteQuietly(fileToDelete);
-              LOGGER.info("Delete segment : " + segmentId + " from local directory : " + fileToDelete.getAbsolutePath());
-            } else {
-              LOGGER.warn("Not found local segment file for segment : " + segmentId);
-            }
-          } else {
-            LOGGER.info("localDiskDir is not configured, won't delete anything from disk");
+      final String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+      if (_localDiskDir != null) {
+        File fileToMove = new File(new File(_localDiskDir, rawTableName), segmentId);
+        if (fileToMove.exists()) {
+          File deletedDir = new File(_localDiskDir, DELETED_SEGMENTS);
+          try {
+            FileUtils.moveFileToDirectory(fileToMove, deletedDir, true);
+            LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(), deletedDir.getAbsolutePath());
+          } catch (IOException e) {
+            LOGGER.warn("Could not move segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(),
+                deletedDir.getAbsolutePath(), e);
           }
-          break;
-        case REALTIME:
-          LOGGER.info("No local segment file for RealtimeSegment in Controller");
-          break;
-        default:
-          throw new UnsupportedOperationException("Not support ResourceType for semgnet - " + segmentId);
+        } else {
+          CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+          switch (tableType) {
+            case OFFLINE:
+              LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
+              break;
+            case REALTIME:
+              if (SegmentName.isLowLevelConsumerSegmentName(segmentId)) {
+                LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
+              }
+              break;
+            default:
+              LOGGER.warn("Unsupported table type {} when deleting segment {}", tableType, segmentId);
+          }
+        }
+      } else {
+        LOGGER.info("localDiskDir is not configured, won't delete segment {} from disk", segmentId);
       }
     } else {
       long effectiveDeletionDelay = Math.min(deletionDelay * 2, MAX_DELETION_DELAY_SECONDS);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -191,6 +191,10 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
               RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = ZKMetadataProvider
                   .getRealtimeSegmentZKMetadata(_pinotHelixResourceManager.getPropertyStore(), segName.getTableName(),
                       partition);
+              if (realtimeSegmentZKMetadata == null) {
+                // Segment was deleted by retention manager.
+                continue;
+              }
               if (realtimeSegmentZKMetadata.getStatus() == Status.IN_PROGRESS) {
                 instancesToAssignRealtimeSegment.removeAll(state.getInstanceSet(partition));
               }
@@ -337,6 +341,10 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
                 RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = ZKMetadataProvider
                     .getRealtimeSegmentZKMetadata(_pinotHelixResourceManager.getPropertyStore(),
                         abstractTableConfig.getTableName(), segmentName);
+                if (realtimeSegmentZKMetadata == null) {
+                  // The segment got deleted by retention manager
+                  continue;
+                }
                 if (realtimeSegmentZKMetadata.getStatus() == Status.IN_PROGRESS) {
                   LOGGER.info("Setting data change watch for real-time segment currently being consumed: {}",
                       segmentPath);


### PR DESCRIPTION
We are currently not deleting any segments from the controller store because we
look for the segment in the directory tableName_OFFLINE (or tableName_REALTIME)
whereas the segment is actually in the directory tableName (without the type
extension).

This change moves the segments to another directory under _localDiskDir, from which
segments can be deleted periodically as needed to reclaim space.