### PR TITLE
Fix IndexOutOfBoundException when doing group-key trimming on non-comparable objects.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/ResultHolderFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/ResultHolderFactory.java
@@ -20,28 +20,23 @@ import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunction
 import com.linkedin.pinot.core.operator.aggregation.groupby.DoubleGroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * Factory class to create ResultHolder appropriate for a given function.
- * Supports both, AggregationResultHolder as well as GroupByResultHolder.
+ * The <code>ResultHolderFactory</code> class is the factory to create {@link AggregationResultHolder} and
+ * {@link GroupByResultHolder} that appropriate for a given function.
  */
 public class ResultHolderFactory {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ResultHolderFactory.class);
-
   private ResultHolderFactory() {
   }
 
   public static final int MAX_INITIAL_RESULT_HOLDER_CAPACITY = 10_000;
 
   /**
-   * Creates and returns the appropriate implementation of AggregationResultHolder,
-   * based on aggregation function.
+   * Get the appropriate implementation of {@link AggregationResultHolder} based on the aggregation function.
    *
-   * @param function Aggregation function
-   * @return Appropriate aggregation result holder
+   * @param function aggregation function.
+   * @return appropriate aggregation result holder.
    */
   public static AggregationResultHolder getAggregationResultHolder(AggregationFunction function) {
     String functionName = function.getName();
@@ -63,14 +58,15 @@ public class ResultHolderFactory {
   }
 
   /**
-   * Creates and returns the appropriate implementation of GroupByResultHolder,
-   * based on aggregation function.
+   * Get the appropriate implementation of {@link GroupByResultHolder} based on the aggregation function.
    *
-   * @param function Aggregation function
-   * @param capacityCap Max number of results
-   * @return Appropriate group by result holder
+   * @param function aggregation function.
+   * @param capacityCap maximum result holder capacity needed.
+   * @param trimSize maximum number of groups returned after trimming.
+   * @return appropriate group-by result holder.
    */
-  public static GroupByResultHolder getGroupByResultHolder(AggregationFunction function, int capacityCap) {
+  public static GroupByResultHolder getGroupByResultHolder(AggregationFunction function, int capacityCap,
+      int trimSize) {
     String functionName = function.getName();
 
     int initialCapacity = Math.min(capacityCap, MAX_INITIAL_RESULT_HOLDER_CAPACITY);
@@ -82,16 +78,16 @@ public class ResultHolderFactory {
       case AggregationFunctionFactory.COUNT_MV_AGGREGATION_FUNCTION:
       case AggregationFunctionFactory.MAX_MV_AGGREGATION_FUNCTION:
       case AggregationFunctionFactory.SUM_MV_AGGREGATION_FUNCTION:
-        return new DoubleGroupByResultHolder(initialCapacity, capacityCap, function.getDefaultValue(),
+        return new DoubleGroupByResultHolder(initialCapacity, capacityCap, trimSize, function.getDefaultValue(),
             false /* minOrder */);
 
       case AggregationFunctionFactory.MIN_AGGREGATION_FUNCTION:
       case AggregationFunctionFactory.MIN_MV_AGGREGATION_FUNCTION:
-        return new DoubleGroupByResultHolder(initialCapacity, capacityCap, function.getDefaultValue(),
+        return new DoubleGroupByResultHolder(initialCapacity, capacityCap, trimSize, function.getDefaultValue(),
             true /* minOrder */);
 
       default:
-        return new ObjectGroupByResultHolder(initialCapacity, capacityCap);
+        return new ObjectGroupByResultHolder(initialCapacity, capacityCap, trimSize);
     }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupByResultHolder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupByResultHolder.java
@@ -75,8 +75,7 @@ public interface GroupByResultHolder {
 
   /**
    * Trim the results to a pre-specified size.
-   * @param targetSize Target size to trim the result set to.
    * @return List of group keys that were removed.
    */
-  int[] trimResults(int targetSize);
+  int[] trimResults();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/ObjectGroupByResultHolder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/ObjectGroupByResultHolder.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.groupby;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.Pairs.IntObjectPair;
 import com.linkedin.pinot.core.util.IntObjectIndexedPriorityQueue;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -24,12 +25,13 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
  * Result Holder implemented using ObjectArray.
  */
 public class ObjectGroupByResultHolder implements GroupByResultHolder {
-  private Object[] _resultArray;
-  private int _resultHolderCapacity;
-  private int _maxCapacity;
+  private final int _maxCapacity;
+  private final int _trimSize;
   private final boolean _minHeap;
 
+  private int _resultHolderCapacity;
   private StorageMode _storageMode;
+  private Object[] _resultArray;
   private Int2ObjectOpenHashMap _resultMap;
   private IntObjectIndexedPriorityQueue _priorityQueue;
 
@@ -38,13 +40,15 @@ public class ObjectGroupByResultHolder implements GroupByResultHolder {
    *
    * @param initialCapacity Initial capacity of result holder
    * @param maxCapacity Max capacity of result holder
+   * @param trimSize maximum number of groups returned after trimming.
    * @param minOrder Min ordering for trim (in case of min aggregation functions)
    */
-  public ObjectGroupByResultHolder(int initialCapacity, int maxCapacity, boolean minOrder) {
+  public ObjectGroupByResultHolder(int initialCapacity, int maxCapacity, int trimSize, boolean minOrder) {
     _resultArray = new Object[initialCapacity];
     _resultHolderCapacity = initialCapacity;
     _storageMode = StorageMode.ARRAY_STORAGE;
     _maxCapacity = maxCapacity;
+    _trimSize = trimSize;
     _minHeap = !minOrder; // Max order requires minHeap for trimming results, and vice-versa
 
     _resultMap = null;
@@ -55,9 +59,10 @@ public class ObjectGroupByResultHolder implements GroupByResultHolder {
    *
    * @param initialCapacity Initial capacity of result holder
    * @param maxCapacity Max capacity of result holder
+   * @param trimSize maximum number of groups returned after trimming.
    */
-  public ObjectGroupByResultHolder(int initialCapacity, int maxCapacity) {
-    this(initialCapacity, maxCapacity, false /* minOrdering */);
+  public ObjectGroupByResultHolder(int initialCapacity, int maxCapacity, int trimSize) {
+    this(initialCapacity, maxCapacity, trimSize, false /* minOrdering */);
   }
 
   /**
@@ -67,15 +72,15 @@ public class ObjectGroupByResultHolder implements GroupByResultHolder {
    */
   @Override
   public void ensureCapacity(int capacity) {
+    Preconditions.checkArgument(capacity <= _maxCapacity);
+
     // Nothing to be done for map mode.
     if (_storageMode == StorageMode.MAP_STORAGE) {
       return;
     }
 
-    // TODO: if object is not comparable, result holder capacity might not be enough and might throw ArrayIndexOutOfBoundsException.
-    // TODO: need to revisit the logic because Set and HyperLogLog will not be comparable.
     // If object is not comparable, we cannot use a priority queue and cannot compare.
-    if (capacity > _maxCapacity && (_resultArray[0] instanceof Comparable)) {
+    if (capacity > _trimSize && (_resultArray[0] instanceof Comparable)) {
       switchToMapMode(capacity);
       return;
     }
@@ -141,24 +146,17 @@ public class ObjectGroupByResultHolder implements GroupByResultHolder {
   /**
    * {@inheritDoc}
    *
-   * Keys with 'lowest' values (as per the sort order) are trimmed away to reduce the
-   * size to _maxCapacity.
+   * Keys with 'lowest' values (as per the sort order) are trimmed away to reduce the size to _trimSize.
    *
-   * @param targetSize Target size to trim the result set to.
    * @return Array of keys that were trimmed.
    */
   @Override
-  public int[] trimResults(int targetSize) {
+  public int[] trimResults() {
     if (_storageMode == StorageMode.ARRAY_STORAGE) {
       return EMPTY_ARRAY; // Still in array mode, trimming has not kicked in yet.
     }
 
-    int size = _resultMap.size();
-    if (size <= _maxCapacity) {
-      return EMPTY_ARRAY;
-    }
-
-    int numKeysToRemove = size - targetSize;
+    int numKeysToRemove = _resultMap.size() - _trimSize;
     int[] removedGroupKeys = new int[numKeysToRemove];
 
     for (int i = 0; i < numKeysToRemove; i++) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -40,16 +40,18 @@ import org.slf4j.LoggerFactory;
 public class InstancePlanMakerImplV2 implements PlanMaker {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstancePlanMakerImplV2.class);
 
+  // TODO: Fix the runtime trimming and add back the number of aggregation groups limit.
+  // TODO: Need to revisit the runtime trimming solution. Current solution will remove group keys that should not be removed.
   // Limit on number of groups, beyond which results are truncated.
-  private static final String NUM_AGGR_GROUPS_LIMIT = "num.aggr.groups.limit";
-  private static final int DEFAULT_NUM_AGGR_GROUPS_LIMIT = 100_000;
-  private final int _numAggrGroupsLimit;
+  // private static final String NUM_AGGR_GROUPS_LIMIT = "num.aggr.groups.limit";
+  // private static final int DEFAULT_NUM_AGGR_GROUPS_LIMIT = 100_000;
+  private final int _numAggrGroupsLimit = Integer.MAX_VALUE;
 
   /**
    * Default constructor.
    */
   public InstancePlanMakerImplV2() {
-    _numAggrGroupsLimit = DEFAULT_NUM_AGGR_GROUPS_LIMIT;
+//    _numAggrGroupsLimit = DEFAULT_NUM_AGGR_GROUPS_LIMIT;
   }
 
   /**
@@ -61,9 +63,9 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
    * @param queryExecutorConfig query executor configuration.
    */
   public InstancePlanMakerImplV2(QueryExecutorConfig queryExecutorConfig) {
-    // Read the limit on number of aggregation groups in query result from config.
-    _numAggrGroupsLimit = queryExecutorConfig.getConfig().getInt(NUM_AGGR_GROUPS_LIMIT, DEFAULT_NUM_AGGR_GROUPS_LIMIT);
-    LOGGER.info("Maximum number of allowed groups for group-by query results: '{}'", _numAggrGroupsLimit);
+    // TODO: Read the limit on number of aggregation groups in query result from config.
+    // _numAggrGroupsLimit = queryExecutorConfig.getConfig().getInt(NUM_AGGR_GROUPS_LIMIT, DEFAULT_NUM_AGGR_GROUPS_LIMIT);
+    // LOGGER.info("Maximum number of allowed groups for group-by query results: '{}'", _numAggrGroupsLimit);
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/groupby/result/DoubleGroupByResultHolderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/groupby/result/DoubleGroupByResultHolderTest.java
@@ -62,7 +62,8 @@ public class DoubleGroupByResultHolderTest {
    */
   @Test
   void testSetValueForKey() {
-    GroupByResultHolder resultHolder = new DoubleGroupByResultHolder(INITIAL_CAPACITY, MAX_CAPACITY, DEFAULT_VALUE);
+    GroupByResultHolder resultHolder =
+        new DoubleGroupByResultHolder(INITIAL_CAPACITY, MAX_CAPACITY, MAX_CAPACITY, DEFAULT_VALUE);
 
     for (int i = 0; i < INITIAL_CAPACITY; i++) {
       resultHolder.setValueForKey(i, _expected[i]);
@@ -79,7 +80,8 @@ public class DoubleGroupByResultHolderTest {
    */
   @Test
   void testEnsureCapacity() {
-    GroupByResultHolder resultHolder = new DoubleGroupByResultHolder(INITIAL_CAPACITY, MAX_CAPACITY, DEFAULT_VALUE);
+    GroupByResultHolder resultHolder =
+        new DoubleGroupByResultHolder(INITIAL_CAPACITY, MAX_CAPACITY, MAX_CAPACITY, DEFAULT_VALUE);
 
     for (int i = 0; i < INITIAL_CAPACITY; i++) {
       resultHolder.setValueForKey(i, _expected[i]);
@@ -139,7 +141,7 @@ public class DoubleGroupByResultHolderTest {
    */
   void testTrimResults(final boolean minOrder) {
     GroupByResultHolder resultHolder =
-        new DoubleGroupByResultHolder(INITIAL_CAPACITY, INITIAL_CAPACITY, DEFAULT_VALUE, minOrder);
+        new DoubleGroupByResultHolder(INITIAL_CAPACITY, MAX_CAPACITY, INITIAL_CAPACITY, DEFAULT_VALUE, minOrder);
     List<IntDoublePair> expected = new ArrayList<>(MAX_CAPACITY);
 
     for (int i = 0; i < INITIAL_CAPACITY; i++) {
@@ -155,8 +157,8 @@ public class DoubleGroupByResultHolderTest {
       expected.add(new IntDoublePair(i, _expected[i]));
     }
 
-    // Trim the results to INITIAL_CAPACITY.
-    resultHolder.trimResults(INITIAL_CAPACITY);
+    // Trim the results.
+    resultHolder.trimResults();
 
     // Sort the input
     Collections.sort(expected, new IntDoubleComparator(!minOrder));

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/groupby/result/ObjectGroupByResultHolderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/groupby/result/ObjectGroupByResultHolderTest.java
@@ -60,7 +60,8 @@ public class ObjectGroupByResultHolderTest {
   private void testTrimResults(final boolean minOrder) {
     Random random = new Random(0);
 
-    GroupByResultHolder resultHolder = new ObjectGroupByResultHolder(INITIAL_CAPACITY, INITIAL_CAPACITY, minOrder);
+    GroupByResultHolder resultHolder =
+        new ObjectGroupByResultHolder(INITIAL_CAPACITY, MAX_CAPACITY, INITIAL_CAPACITY, minOrder);
     List<IntObjectPair> expected = new ArrayList<>(MAX_CAPACITY);
 
     for (int i = 0; i < INITIAL_CAPACITY; i++) {
@@ -84,8 +85,8 @@ public class ObjectGroupByResultHolderTest {
 
     Collections.sort(expected, new Pairs.IntObjectComparator(!minOrder));
 
-    // Trim the results to INITIAL_CAPACITY.
-    resultHolder.trimResults(INITIAL_CAPACITY);
+    // Trim the results.
+    resultHolder.trimResults();
 
     // Ensure that all the correct group keys survive after trimming.
     for (int i = 0; i < INITIAL_CAPACITY; i++) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/AggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/AggregationMultiValueQueriesTest.java
@@ -216,10 +216,7 @@ public class AggregationMultiValueQueriesTest extends BaseMultiValueQueriesTest 
 
   @Test
   public void testLargeAggregationGroupBy() {
-    // TODO: make AVG work on trimming, and add AVG back to the test.
-    // String query = "SELECT" + AGGREGATION + " FROM testTable" + LARGE_GROUP_BY;
-
-    String query = "SELECT COUNT(*), SUM(column1), MAX(column2), MIN(column8) FROM testTable" + LARGE_GROUP_BY;
+    String query = "SELECT" + AGGREGATION + " FROM testTable" + LARGE_GROUP_BY;
 
     // NOTE: here we assume the first group key returned from the iterator is constant.
 
@@ -239,10 +236,10 @@ public class AggregationMultiValueQueriesTest extends BaseMultiValueQueriesTest 
     Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1118965780L);
     Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1848116124);
     Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1597666851);
-//    AvgAggregationFunction.AvgPair avgResult =
-//        (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
-//    Assert.assertEquals(avgResult.getFirst().longValue(), toBeAdded);
-//    Assert.assertEquals(avgResult.getSecond().longValue(), toBeAdded);
+    AvgAggregationFunction.AvgPair avgResult =
+        (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
+    Assert.assertEquals(avgResult.getFirst().longValue(), 675163196L);
+    Assert.assertEquals(avgResult.getSecond().longValue(), 1L);
 
     // Test query with filter.
     aggregationGroupByOperator = getOperatorForQueryWithFilter(query);
@@ -260,9 +257,9 @@ public class AggregationMultiValueQueriesTest extends BaseMultiValueQueriesTest 
     Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1899921294L);
     Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 238753654);
     Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 674022574);
-//    avgResult =
-//        (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
-//    Assert.assertEquals(avgResult.getFirst().longValue(), toBeAdded);
-//    Assert.assertEquals(avgResult.getSecond().longValue(), toBeAdded);
+    avgResult =
+        (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
+    Assert.assertEquals(avgResult.getFirst().longValue(), 1348045148L);
+    Assert.assertEquals(avgResult.getSecond().longValue(), 2L);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/function/MaxAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/function/MaxAggregationFunctionTest.java
@@ -97,7 +97,7 @@ public class MaxAggregationFunctionTest {
 
     MaxAggregationFunction maxAggregationFunction = new MaxAggregationFunction();
     GroupByResultHolder resultHolder =
-        ResultHolderFactory.getGroupByResultHolder(maxAggregationFunction, MAX_NUM_GROUP_KEYS);
+        ResultHolderFactory.getGroupByResultHolder(maxAggregationFunction, MAX_NUM_GROUP_KEYS, MAX_NUM_GROUP_KEYS);
 
     maxAggregationFunction.aggregateGroupBySV(NUM_VALUES_TO_AGGREGATE, groupKeysForValues, resultHolder, valuesToAggregate);
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/function/MinAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/function/MinAggregationFunctionTest.java
@@ -97,7 +97,7 @@ public class MinAggregationFunctionTest {
 
     MinAggregationFunction minAggregationFunction = new MinAggregationFunction();
     GroupByResultHolder resultHolder =
-        ResultHolderFactory.getGroupByResultHolder(minAggregationFunction, MAX_NUM_GROUP_KEYS);
+        ResultHolderFactory.getGroupByResultHolder(minAggregationFunction, MAX_NUM_GROUP_KEYS, MAX_NUM_GROUP_KEYS);
 
     minAggregationFunction.aggregateGroupBySV(NUM_VALUES_TO_AGGREGATE, groupKeysForValues, resultHolder,
         valuesToAggregate);

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/function/SumAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/function/SumAggregationFunctionTest.java
@@ -96,7 +96,7 @@ public class SumAggregationFunctionTest {
 
     SumAggregationFunction sumAggregationFunction = new SumAggregationFunction();
     GroupByResultHolder resultHolder =
-        ResultHolderFactory.getGroupByResultHolder(sumAggregationFunction, MAX_NUM_GROUP_KEYS);
+        ResultHolderFactory.getGroupByResultHolder(sumAggregationFunction, MAX_NUM_GROUP_KEYS, MAX_NUM_GROUP_KEYS);
 
     sumAggregationFunction.aggregateGroupBySV(NUM_VALUES_TO_AGGREGATE, groupKeysForValues, resultHolder,
         valuesToAggregate);


### PR DESCRIPTION
Disable the group-key trimming because trimming will break the multi-aggregation group-by use case.