### PR TITLE
Add support LLC-specific config overrides

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -53,7 +53,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaMessageDecoder;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactoryImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
@@ -646,8 +646,8 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   }
 
   // TODO Make this a factory class.
-  protected KafkaHighLevelStreamProviderConfig createStreamProviderConfig() {
-    return new KafkaHighLevelStreamProviderConfig();
+  protected KafkaLowLevelStreamProviderConfig createStreamProviderConfig() {
+    return new KafkaLowLevelStreamProviderConfig();
   }
 
   // Assume that this is called only on OFFLINE to CONSUMING transition.
@@ -667,7 +667,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
 
     // TODO Validate configs
     IndexingConfig indexingConfig = _tableConfig.getIndexingConfig();
-    KafkaHighLevelStreamProviderConfig kafkaStreamProviderConfig = createStreamProviderConfig();
+    KafkaLowLevelStreamProviderConfig kafkaStreamProviderConfig = createStreamProviderConfig();
     kafkaStreamProviderConfig.init(tableConfig, instanceZKMetadata, schema);
     final String bootstrapNodes = indexingConfig.getStreamConfigs()
         .get(CommonConstants.Helix.DataSource.STREAM_PREFIX + "." + CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamProviderConfig.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.impl.kafka;
+
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import java.util.Map;
+
+
+/**
+ * Low level stream config, adds some overrides for llc-specific properties.
+ */
+public class KafkaLowLevelStreamProviderConfig extends KafkaHighLevelStreamProviderConfig {
+  private static final int NOT_DEFINED = Integer.MIN_VALUE;
+
+  private long llcSegmentTimeInMillis = NOT_DEFINED;
+  private int llcRealtimeRecordsThreshold = NOT_DEFINED;
+  public static final String LLC_PROPERTY_SUFFIX = ".llc";
+
+  @Override
+  public void init(AbstractTableConfig tableConfig, InstanceZKMetadata instanceMetadata, Schema schema) {
+    super.init(tableConfig, instanceMetadata, schema);
+
+    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX)) {
+      llcRealtimeRecordsThreshold =
+          Integer.parseInt(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX));
+    }
+
+    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX)) {
+      llcSegmentTimeInMillis =
+          Long.parseLong(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX));
+    }
+  }
+
+  @Override
+  public void init(Map<String, String> properties, Schema schema) {
+    super.init(properties, schema);
+
+    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX)) {
+      llcRealtimeRecordsThreshold =
+          Integer.parseInt(properties.get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX));
+    }
+
+    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX)) {
+      llcSegmentTimeInMillis =
+          Long.parseLong(properties.get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX));
+    }
+  }
+
+  @Override
+  public int getSizeThresholdToFlushSegment() {
+    if (llcRealtimeRecordsThreshold != NOT_DEFINED) {
+      return llcRealtimeRecordsThreshold;
+    } else {
+      return super.getSizeThresholdToFlushSegment();
+    }
+  }
+
+  @Override
+  public long getTimeThresholdToFlushSegment() {
+    if (llcSegmentTimeInMillis != NOT_DEFINED) {
+      return llcSegmentTimeInMillis;
+    } else {
+      return super.getTimeThresholdToFlushSegment();
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -32,7 +32,7 @@ import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import junit.framework.Assert;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -535,8 +535,8 @@ public class LLRealtimeSegmentDataManagerTest {
     }
 
     @Override
-    protected KafkaHighLevelStreamProviderConfig createStreamProviderConfig() {
-      KafkaHighLevelStreamProviderConfig config = mock(KafkaHighLevelStreamProviderConfig.class);
+    protected KafkaLowLevelStreamProviderConfig createStreamProviderConfig() {
+      KafkaLowLevelStreamProviderConfig config = mock(KafkaLowLevelStreamProviderConfig.class);
       Mockito.doNothing().when(config).init(any(AbstractTableConfig.class), any(InstanceZKMetadata.class), any(Schema.class));
       when(config.getTopicName()).thenReturn(_topicName);
       when(config.getStreamName()).thenReturn(_topicName);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -33,6 +33,7 @@ import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.indexsegment.utils.AvroUtils;
 import com.linkedin.pinot.core.realtime.impl.kafka.AvroRecordToPinotRowGenerator;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaMessageDecoder;
 import com.linkedin.pinot.server.starter.helix.DefaultHelixStarterServerConfig;
 import com.linkedin.pinot.server.starter.helix.HelixServerStarter;
@@ -247,7 +248,8 @@ public abstract class ClusterTest extends ControllerTest {
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.DECODER_CLASS,
         AvroFileSchemaKafkaAvroMessageDecoder.class.getName());
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_BROKER_LIST, kafkaBrokerList);
-    metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(realtimeSegmentFlushSize));
+    metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(1)); // jfim: Invalid value to ensure the test fails if we don't pick the LLC override
+    metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + KafkaLowLevelStreamProviderConfig.LLC_PROPERTY_SUFFIX, Integer.toString(realtimeSegmentFlushSize));
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + "auto.offset.reset",
         "smallest");
 


### PR DESCRIPTION
Add support for LLC-specific consumer configuration overrides for
segment flush thresholds by adding a ".llc" suffix.