### PR TITLE
Move alert filter from metric level to function level

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -49,6 +50,9 @@ public class AnomalyFunctionBean extends AbstractBean {
   private String filters;
 
   private long metricId;
+
+  private Map<String, String> alertFilter;
+
 
   public long getMetricId() {
     return metricId;
@@ -199,6 +203,14 @@ public class AnomalyFunctionBean extends AbstractBean {
     this.isActive = isActive;
   }
 
+  public Map<String, String> getAlertFilter() {
+    return alertFilter;
+  }
+
+  public void setAlertFilter(Map<String, String> alertFilter) {
+    this.alertFilter = alertFilter;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof AnomalyFunctionBean)) {
@@ -217,14 +229,15 @@ public class AnomalyFunctionBean extends AbstractBean {
         && Objects.equals(windowDelay, af.getWindowDelay())
         && Objects.equals(windowDelayUnit, af.getWindowDelayUnit())
         && Objects.equals(exploreDimensions, af.getExploreDimensions())
-        && Objects.equals(filters, af.getFilters());
+        && Objects.equals(filters, af.getFilters())
+        && Objects.equals(alertFilter, af.getAlertFilter());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), collection, metric, metricFunction, type, isActive, cron,
         properties, bucketSize, bucketUnit, windowSize, windowUnit, windowDelay, windowDelayUnit,
-        exploreDimensions, filters);
+        exploreDimensions, filters, alertFilter);
   }
 
   @Override
@@ -235,6 +248,6 @@ public class AnomalyFunctionBean extends AbstractBean {
         .add("bucketSize", bucketSize).add("bucketUnit", bucketUnit).add("windowSize", windowSize)
         .add("windowUnit", windowUnit).add("windowDelay", windowDelay)
         .add("windowDelayUnit", windowDelayUnit).add("exploreDimensions", exploreDimensions)
-        .add("filters", filters).toString();
+        .add("filters", filters).add("alertFilter", alertFilter).toString();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
@@ -38,8 +38,6 @@ public class MetricConfigBean extends AbstractBean {
 
   private Map<String, String> extSourceLinkInfo;
 
-  private Map<String, String> alertFilterInfo;
-
 
   public String getName() {
     return name;
@@ -129,14 +127,6 @@ public class MetricConfigBean extends AbstractBean {
     this.extSourceLinkInfo = extSourceLinkInfo;
   }
 
-  public Map<String, String> getAlertFilterInfo() {
-    return alertFilterInfo;
-  }
-
-  public void setAlertFilterInfo(Map<String, String> alertFilterInfo) {
-    this.alertFilterInfo = alertFilterInfo;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof MetricConfigBean)) {
@@ -153,14 +143,13 @@ public class MetricConfigBean extends AbstractBean {
         && Objects.equals(inverseMetric, mc.isInverseMetric())
         && Objects.equals(cellSizeExpression, mc.getCellSizeExpression())
         && Objects.equals(active, mc.isActive())
-        && Objects.equals(extSourceLinkInfo, mc.getExtSourceLinkInfo())
-        && Objects.equals(alertFilterInfo, mc.getAlertFilterInfo());
+        && Objects.equals(extSourceLinkInfo, mc.getExtSourceLinkInfo());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), dataset, alias, derived, derivedMetricExpression, rollupThreshold,
-        inverseMetric, cellSizeExpression, active, extSourceLinkInfo, alertFilterInfo);
+        inverseMetric, cellSizeExpression, active, extSourceLinkInfo);
   }
 
   @Override
@@ -168,6 +157,6 @@ public class MetricConfigBean extends AbstractBean {
     return MoreObjects.toStringHelper(this).add("id", getId()).add("name", name).add("dataset", dataset)
         .add("alias", alias).add("derived", derived).add("derivedMetricExpression", derivedMetricExpression)
         .add("rollupThreshold", rollupThreshold).add("cellSizeExpression", cellSizeExpression).add("active", active)
-        .add("extSourceLinkInfo", extSourceLinkInfo).add("alertFilterInfo", alertFilterInfo).toString();
+        .add("extSourceLinkInfo", extSourceLinkInfo).toString();
   }
 }


### PR DESCRIPTION
Changing alert filter from metric level to function has two advantages:

First, us could give anomaly function and its counter function different filters. 
Second, we could try out different function settings on the same metric.

Tested on local machines.
