### PR TITLE
Add metric for allocation failure count

### DIFF
--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -171,7 +171,13 @@ public class HelixServerStarter {
               }
             });
 
-
+    _serverInstance.getServerMetrics().addCallbackGauge(
+        "memory.allocationFailureCount", new Callable<Long>() {
+              @Override
+              public Long call() throws Exception {
+                return (long) MmapUtils.getAllocationFailureCount();
+              }
+            });
   }
 
   private void updateInstanceConfigInHelix(int adminApiPort, boolean shuttingDown) {


### PR DESCRIPTION
Add a metric that tracks the number of direct memory and mmap buffers
allocation failures, so that an alert can be raised if it ever goes
above zero.