### PR TITLE
Add metrics for time spent and timeouts in broker waiting for a connection.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
@@ -32,6 +32,8 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   REQUEST_FETCH_EXCEPTIONS("exceptions", false),
   REQUEST_DESERIALIZATION_EXCEPTIONS("exceptions", false),
   DOCUMENTS_SCANNED("documents", false),
+  REQUEST_CONNECTION_TIMEOUTS("timeouts", false),
+  REQUEST_CONNECTION_WAIT_TIME_IN_MILLIS("waits", false),
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
 
   // This metric tracks the number of requests dropped by the broker after we get a connection to the server.


### PR DESCRIPTION
This metric will give an idea of the amount of time spent in the broker
waiting for a server connection to help us provision better.