### PR TITLE
Remove hardcoded Thread.sleep() in unit tests

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -1237,12 +1237,16 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
   protected long getCurrentServingNumDocs(String tableName) {
     ensurePinotConnectionIsCreated();
-    com.linkedin.pinot.client.ResultSetGroup resultSetGroup =
-        _pinotConnection.execute("SELECT COUNT(*) from " + tableName + " LIMIT 0");
-    if (resultSetGroup.getResultSetCount() > 0) {
-      return resultSetGroup.getResultSet(0).getInt(0);
+    try {
+      com.linkedin.pinot.client.ResultSetGroup resultSetGroup =
+          _pinotConnection.execute("SELECT COUNT(*) from " + tableName + " LIMIT 0");
+      if (resultSetGroup.getResultSetCount() > 0) {
+        return resultSetGroup.getResultSet(0).getInt(0);
+      }
+      return 0;
+    } catch (Exception e) {
+      return -1L;
     }
-    return 0;
   }
 
   protected int getGeneratedQueryCount() {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.utils.FileUploadUtils;
 import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
@@ -76,7 +75,6 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     this.tableName = (String) args[0];
     SegmentVersion version = (SegmentVersion) args[1];
     addOfflineTable("DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, this.tableName, version);
-    Uninterruptibles.sleepUninterruptibly(200, TimeUnit.MILLISECONDS);
     ensureDirectoryExistsAndIsEmpty(_tmpDir);
     ensureDirectoryExistsAndIsEmpty(_segmentsDir);
     ensureDirectoryExistsAndIsEmpty(_tarsDir);


### PR DESCRIPTION
Some unit tests are using Thread.sleep() as a mechanism to ensure
that the cluster gets to a given state, this replaces these hardcoded
sleep statements by polling the cluster state until it reaches the
desired state.