### PR TITLE
Reorder addition of pinot table views API

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerRestApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerRestApplication.java
@@ -15,21 +15,6 @@
  */
 package com.linkedin.pinot.controller.api;
 
-import com.linkedin.pinot.controller.api.restlet.resources.TableViews;
-import org.restlet.Context;
-import org.restlet.Request;
-import org.restlet.Response;
-import org.restlet.Restlet;
-import org.restlet.data.MediaType;
-import org.restlet.representation.StringRepresentation;
-import org.restlet.resource.Directory;
-import org.restlet.resource.ServerResource;
-import org.restlet.routing.Filter;
-import org.restlet.routing.Redirector;
-import org.restlet.routing.Router;
-import org.restlet.routing.Template;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.common.restlet.PinotRestletApplication;
 import com.linkedin.pinot.common.restlet.swagger.SwaggerResource;
@@ -52,6 +37,21 @@ import com.linkedin.pinot.controller.api.restlet.resources.PinotTenantRestletRes
 import com.linkedin.pinot.controller.api.restlet.resources.PinotVersionRestletResource;
 import com.linkedin.pinot.controller.api.restlet.resources.PqlQueryResource;
 import com.linkedin.pinot.controller.api.restlet.resources.TableSize;
+import com.linkedin.pinot.controller.api.restlet.resources.TableViews;
+import org.restlet.Context;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.Restlet;
+import org.restlet.data.MediaType;
+import org.restlet.representation.StringRepresentation;
+import org.restlet.resource.Directory;
+import org.restlet.resource.ServerResource;
+import org.restlet.routing.Filter;
+import org.restlet.routing.Redirector;
+import org.restlet.routing.Router;
+import org.restlet.routing.Template;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ControllerRestApplication extends PinotRestletApplication {
   private static final Logger LOGGER = LoggerFactory.getLogger(ControllerRestApplication.class);
@@ -94,7 +94,6 @@ public class ControllerRestApplication extends PinotRestletApplication {
     attachRoutesForClass(router, PinotTableSchema.class);
     attachRoutesForClass(router, PinotSegmentRestletResource.class);
     attachRoutesForClass(router, TableSize.class);
-    attachRoutesForClass(router, TableViews.class);
     // PUT
     attachRoutesForClass(router, PinotTableSegmentConfigs.class);
     attachRoutesForClass(router, PinotTableIndexingConfigs.class);
@@ -110,6 +109,9 @@ public class ControllerRestApplication extends PinotRestletApplication {
     attachRoutesForClass(router, LLCSegmentCommit.class);
     attachRoutesForClass(router, LLCSegmentConsumed.class);
 
+    // GET... add it here because it can block visibility of
+    // some of the existing paths (like indexingConfigs) added above
+    attachRoutesForClass(router, TableViews.class);
 
     router.attach("/api", SwaggerResource.class);
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableIndexingConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableIndexingConfigs.java
@@ -48,7 +48,10 @@ public class PinotTableIndexingConfigs extends BasePinotControllerRestletResourc
       setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
       return new StringRepresentation(error);
     }
-
+    if (entity == null) {
+      setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
+      return new StringRepresentation("{\"error\" : \"Request body is required\"}");
+    }
     try {
       return updateIndexingConfig(tableName, entity);
     } catch (final Exception e) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/TableViewsTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/TableViewsTest.java
@@ -111,8 +111,8 @@ public class TableViewsTest extends ControllerTest {
   @DataProvider(name = "stateProvider")
   public Object[][] stateProvider() {
     Object[][] configs = {
-        { "idealstate"},
-        { "externalview"}
+        {TableViews.IDEALSTATE},
+        {TableViews.EXTERNALVIEW}
     };
     return configs;
   }


### PR DESCRIPTION
Move addition of pinot tables views below the existing list.
Keeping it clustered with other GET calls hides existing paths.

Testing: manual