### PR TITLE
Handle removing index for V3 format silently.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/LoaderUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/LoaderUtils.java
@@ -24,13 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class LoaderUtils {
-  private static final Logger LOGGER = LoggerFactory.getLogger(LoaderUtils.class);
-
   private LoaderUtils() {
   }
 
@@ -51,20 +47,15 @@ public class LoaderUtils {
     try {
       if (segmentWriter.hasIndexFor(column, indexType)) {
         // Index already exists, try to reuse it.
-
         buffer = segmentWriter.getIndexFor(column, indexType);
         if (buffer.size() != fileLength) {
           // Existed index size is not equal to index file size.
           // Throw exception to drop and re-download the segment.
-
-          String failureMessage =
-              "V3 format segment already has " + indexType + " for column: " + column + " that cannot be removed.";
-          LOGGER.error(failureMessage);
-          throw new IllegalStateException(failureMessage);
+          throw new V3RemoveIndexException(
+              "V3 format segment already has " + indexType + " for column: " + column + " that cannot be reused.");
         }
       } else {
         // Index does not exist, create a new buffer for that.
-
         buffer = segmentWriter.newIndexFor(column, indexType, fileLength);
       }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/V3RemoveIndexException.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/V3RemoveIndexException.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.loader;
+
+/**
+ * The <code>V3RemoveIndexException</code> class extends {@link RuntimeException} and should be thrown out when trying
+ * to remove an index from Pinot V3 format segment.
+ */
+public class V3RemoveIndexException extends RuntimeException {
+  public V3RemoveIndexException(String message) {
+    super(message);
+  }
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.server.starter.helix;
 
 import com.linkedin.pinot.common.utils.SchemaUtils;
+import com.linkedin.pinot.core.segment.index.loader.V3RemoveIndexException;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -124,8 +125,15 @@ public class SegmentFetcherAndLoader {
               // TODO Update zk metadata with CRC for this instance
               return;
             }
+          } catch (V3RemoveIndexException e) {
+            LOGGER.info(
+                "Unable to remove local index from V3 format segment: {}, table: {}, try to reload it from controller.",
+                segmentId, tableName, e);
+            FileUtils.deleteQuietly(new File(localSegmentDir));
+            localSegmentMetadata = null;
           } catch (Exception e) {
-            LOGGER.error("Failed to load {} of table {} from local, will try to reload it from controller!", segmentId, tableName, e);
+            LOGGER.error("Failed to load {} of table {} from local, will try to reload it from controller!", segmentId,
+                tableName, e);
             FileUtils.deleteQuietly(new File(localSegmentDir));
             localSegmentMetadata = null;
           }


### PR DESCRIPTION
We handle removing index for V3 format by throwing out exception and download from controller.
The exception here is expected, and should not be logged as ERROR.