### PR TITLE
Re-design Projection operator to perform actual projection.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
@@ -28,6 +28,30 @@ public interface BlockValSet {
   DataType getValueType();
 
   /**
+   * Get values for single-valued column.
+   *
+   * @param <T> Return type
+   * @return Values for single-valued column.
+   */
+  <T> T getSingleValues();
+
+  /**
+   * Get values for multi-valued column.
+   *
+   * @param <T> Return type
+   * @return Values for multi-valued column.
+   *
+   * TODO: Re-visit batch reading of multi-valued columns.
+   */
+  <T> T getMultiValues();
+
+  /**
+   * Get the dictionary ids for all docs of this block.
+   * This version is for single-valued columns.
+   */
+  int[] getDictionaryIds();
+
+  /**
    * Copies the dictionaryIds for the input range DocIds.
    * Expects that the out array is properly sized
    * @param inDocIds input set of doc ids for which to read dictionaryIds
@@ -38,7 +62,18 @@ public interface BlockValSet {
    * @param outStartPos starting index position in outDictionaryIds. Indexes will
    *                    be copied starting at this position.
    *                    outDictionaryIds must be atleast (outStartPos + inDocIdsSize) in size
+   * TODO: Remove arguments from this api, as ProjectionBlock has all the required info.
    */
-  void readIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos);
+  void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos);
 
+  /**
+   * Fills dictionary id's of multi-valued column for the current doc id in the passed in array,
+   * and returns the total number of multi-values read.
+   * Caller responsible to ensure that the passed in array is large enough to store the result.
+   *
+   * @param docId Doc id for which to get the dictionary ids.
+   * @param outputDictIds int array where the resulting dictionary ids will be stored.
+   * @return Total number of multi-valued columns.
+   */
+  int getDictionaryIdsForDocId(int docId, int[] outputDictIds);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationExecutor.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.aggregation;
 
+import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -37,11 +38,9 @@ public interface AggregationExecutor {
    * Performs the actual aggregation on the given docId's of a segment.
    * Asserts that 'init' has been called before calling this method.
    *
-   * @param docIdSet
-   * @param startIndex
-   * @param length
+   * @param projectionBlock Projection block on which to perform aggregation.
    */
-  void aggregate(int[] docIdSet, int startIndex, int length);
+  void aggregate(ProjectionBlock projectionBlock);
 
   /**
    * Post processing (if any) to be done after all docIdSets have been processed, and

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/AggregationOperator.java
@@ -54,7 +54,7 @@ public class AggregationOperator extends BaseOperator {
     Preconditions.checkArgument((aggregationsInfoList != null) && (aggregationsInfoList.size() > 0));
     Preconditions.checkNotNull(projectionOperator);
 
-    _aggregationExecutor = new DefaultAggregationExecutor(projectionOperator, aggregationsInfoList);
+    _aggregationExecutor = new DefaultAggregationExecutor(aggregationsInfoList);
     _aggregationInfoList = aggregationsInfoList;
     _projectionOperator = projectionOperator;
     _numTotalRawDocs = numTotalRawDocs;
@@ -85,10 +85,8 @@ public class AggregationOperator extends BaseOperator {
     _aggregationExecutor.init();
     ProjectionBlock projectionBlock;
     while ((projectionBlock = (ProjectionBlock) _projectionOperator.nextBlock()) != null) {
-      DocIdSetBlock docIdSetBlock = projectionBlock.getDocIdSetBlock();
-      int searchableLength = docIdSetBlock.getSearchableLength();
-      numDocsScanned += searchableLength;
-      _aggregationExecutor.aggregate(docIdSetBlock.getDocIdSet(), 0, searchableLength);
+      numDocsScanned += projectionBlock.getNumDocs();
+      _aggregationExecutor.aggregate(projectionBlock);
     }
     _aggregationExecutor.finish();
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DataBlockCache.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DataBlockCache.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.core.operator.aggregation;
 
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockMetadata;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -91,7 +93,7 @@ public class DataBlockCache {
    * @param column column name.
    * @return dictionary id array associated with this column.
    */
-  private int[] getDictIdArrayForColumn(String column) {
+  public int[] getDictIdArrayForColumn(String column) {
     int[] dictIds = _columnToDictIdsMap.get(column);
     if (!_columnDictIdLoaded.contains(column)) {
       if (dictIds == null) {
@@ -292,4 +294,32 @@ public class DataBlockCache {
     return stringsArray;
   }
 
+  /**
+   * Returns the data type of the specified column.
+   *
+   * @param column Column for which to return the data type.
+   * @return Data type of the column.
+   */
+  public FieldSpec.DataType getDataType(String column) {
+    return _dataFetcher.getDataType(column);
+  }
+
+  /**
+   * Returns the block metadata for the given column.
+   *
+   * @param column Column for which to get the metadata
+   * @return Metadata for the column
+   */
+  public BlockMetadata getMetadataFor(String column) {
+    return _dataFetcher.getBlockMetadataFor(column);
+  }
+
+  /**
+   * Returns the data fetcher
+   *
+   * @return Data fetcher
+   */
+  public DataFetcher getDataFetcher() {
+    return _dataFetcher;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupByExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupByExecutor.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.groupby;
 
+import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+
+
 /**
  * Interface class for executing the actual group-by operation.
  */
@@ -26,13 +29,11 @@ public interface GroupByExecutor {
   void init();
 
   /**
-   * Performs the actual group-by aggregation on the given docId's.
+   * Performs the actual group-by aggregation on the given projection block.
    *
-   * @param docIdSet
-   * @param startIndex
-   * @param length
+   * @param projectionBlock Projection block to process
    */
-  void process(int[] docIdSet, int startIndex, int length);
+  void process(ProjectionBlock projectionBlock);
 
   /**
    * Post processing (if any) to be done after all docIdSets have been processed, and
@@ -44,7 +45,7 @@ public interface GroupByExecutor {
    * Returns the result of group-by aggregation, ensures that 'finish' has been
    * called before calling getResult().
    *
-   * @return
+   * @return Result of aggregation group-by.
    */
   AggregationGroupByResult getResult();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupKeyGenerator.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.groupby;
 
+import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
 import com.linkedin.pinot.core.query.utils.Pair;
 import java.util.Iterator;
-import java.util.List;
 
 
 /**
@@ -45,24 +45,20 @@ public interface GroupKeyGenerator {
    * Generate group keys for a given docId set and return the mapping in the passed in docIdToGroupKey array.
    * This interface is for situation where all the group-by columns are single valued.
    *
-   * @param docIdSet document id set.
-   * @param startIndex start index.
-   * @param length length.
+   * @param projectionBlock Projection block for which to generate keys.
    * @param docIdToGroupKey buffer to return the results.
    */
-  void generateKeysForDocIdSet(int[] docIdSet, int startIndex, int length, int[] docIdToGroupKey);
+  void generateKeysForBlock(ProjectionBlock projectionBlock, int[] docIdToGroupKey);
 
   /**
    * Generate group keys for the given docId set and return a mapping from docId to group keys(int[]) in the passed in
    * docIdToGroupKeys array.
    * This interface is for situation where at least one group-by columns are multi valued.
    *
-   * @param docIdSet document id set.
-   * @param startIndex start index.
-   * @param length length.
+   * @param projectionBlock Projection block for which to generate keys
    * @param docIdToGroupKeys buffer to return the results.
    */
-  void generateKeysForDocIdSet(int[] docIdSet, int startIndex, int length, int[][] docIdToGroupKeys);
+  void generateKeysForBlock(ProjectionBlock projectionBlock, int[][] docIdToGroupKeys);
 
   /**
    * Get the current upper bound of the group key. All group keys already generated should be less than this value. This

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/ProjectionBlock.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
+import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
 import java.util.Map;
 
 import com.linkedin.pinot.core.common.Block;
@@ -27,16 +28,19 @@ import com.linkedin.pinot.core.common.Predicate;
 
 /**
  * ProjectionBlock holds a column name to Block Map.
- * It provides DocIdSetBlock and DataBlock for a given column.
+ * It provides DocIdSetBlock and ProjectionColumnBlock for a given column.
  */
 public class ProjectionBlock implements Block {
 
   private final Map<String, Block> _blockMap;
   private final DocIdSetBlock _docIdSetBlock;
+  private final DataBlockCache _dataBlockCache;
 
-  public ProjectionBlock(Map<String, Block> blockMap, DocIdSetBlock docIdSetBlock) {
+  public ProjectionBlock(Map<String, Block> blockMap, DataBlockCache dataBlockCache, DocIdSetBlock docIdSetBlock) {
     _blockMap = blockMap;
     _docIdSetBlock = docIdSetBlock;
+    _dataBlockCache = dataBlockCache;
+    _dataBlockCache.initNewBlock(docIdSetBlock.getDocIdSet(), 0, docIdSetBlock.getSearchableLength());
   }
 
   @Override
@@ -73,7 +77,15 @@ public class ProjectionBlock implements Block {
     return _blockMap.get(column);
   }
 
+  public Block getDataBlock(String column) {
+    return new ProjectionColumnBlock(_dataBlockCache, column);
+  }
+
   public DocIdSetBlock getDocIdSetBlock() {
     return _docIdSetBlock;
+  }
+
+  public int getNumDocs() {
+    return _docIdSetBlock.getSearchableLength();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/ProjectionColumnBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/ProjectionColumnBlock.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.operator.blocks;
+
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockDocIdSet;
+import com.linkedin.pinot.core.common.BlockDocIdValueSet;
+import com.linkedin.pinot.core.common.BlockId;
+import com.linkedin.pinot.core.common.BlockMetadata;
+import com.linkedin.pinot.core.common.BlockValSet;
+import com.linkedin.pinot.core.common.Predicate;
+import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
+import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
+
+
+/**
+ * Class to represent projection block for a specified column.
+ */
+public class ProjectionColumnBlock implements Block {
+  private final DataBlockCache _dataBlockCache;
+  private final String _column;
+
+  public ProjectionColumnBlock(DataBlockCache dataBlockCache, String column) {
+    _column = column;
+    _dataBlockCache = dataBlockCache;
+  }
+
+  @Override
+  public BlockId getId() {
+    throw new UnsupportedOperationException("Operation getId() not supported on ProjectionColumnBlock.");
+  }
+
+  @Override
+  public boolean applyPredicate(Predicate predicate) {
+    throw new UnsupportedOperationException("Operation applyPredicate() not support on ProjectionColumnBlock.");
+  }
+
+  @Override
+  public BlockDocIdSet getBlockDocIdSet() {
+    throw new UnsupportedOperationException("Operation getBlockDocIdSet() not supported on ProjectionColumnBlock.");
+  }
+
+  @Override
+  public BlockValSet getBlockValueSet() {
+    return new ProjectionBlockValSet(_dataBlockCache, _column);
+  }
+
+  @Override
+  public BlockDocIdValueSet getBlockDocIdValueSet() {
+    throw new UnsupportedOperationException("Operation getBlockDocIdValueSet() not supported on ProjectionColumnBlock.");
+  }
+
+  @Override
+  public BlockMetadata getMetadata() {
+    return _dataBlockCache.getMetadataFor(_column);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/MultiValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/MultiValueSet.java
@@ -33,6 +33,16 @@ public final class MultiValueSet implements BlockValSet {
   }
 
   @Override
+  public <T> T getSingleValues() {
+    throw new UnsupportedOperationException("Reading a batch of values is not supported for multi-value BlockValSet.");
+  }
+
+  @Override
+  public <T> T getMultiValues() {
+    throw new UnsupportedOperationException("Reading a batch of values is not supported for multi-value BlockValSet.");
+  }
+
+  @Override
   public BlockValIterator iterator() {
     return new MultiValueIterator(mVReader, columnMetadata);
   }
@@ -43,8 +53,17 @@ public final class MultiValueSet implements BlockValSet {
   }
 
   @Override
-  public void readIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
     throw new UnsupportedOperationException("Reading a batch of values is not supported for multi-value BlockValSet");
   }
 
+  @Override
+  public int[] getDictionaryIds() {
+    throw new UnsupportedOperationException("Reading a batch of dictionary id is not supported for multi-value BlockValSet");
+  }
+
+  @Override
+  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    throw new UnsupportedOperationException("Reading a single values is not supported for multi-value BlockValSet");
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.operator.docvalsets;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockMultiValIterator;
+import com.linkedin.pinot.core.common.BlockValIterator;
+import com.linkedin.pinot.core.common.BlockValSet;
+import com.linkedin.pinot.core.operator.MProjectionOperator;
+import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
+
+
+/**
+ * This class represents the BlockValSet for a projection block.
+ * It provides api's to access data for a specified projection column.
+ * It uses {@link DataBlockCache} to cache the projection data.
+ */
+public class ProjectionBlockValSet implements BlockValSet {
+
+  private DataBlockCache _dataBlockCache;
+  private final BlockValIterator _blockValIterator;
+  private final FieldSpec.DataType _columnDataType;
+  private String _column;
+
+  /**
+
+
+   * Constructor for the class.
+   * The dataBlockCache argument is initialized in {@link com.linkedin.pinot.core.operator.MProjectionOperator},
+   * so that it can be reused across multiple calls to {@link MProjectionOperator#getNextBlock()}.
+   *
+   * @param dataBlockCache data block cache
+   * @param column Projection column.
+   */
+  public ProjectionBlockValSet(DataBlockCache dataBlockCache, String column) {
+    _dataBlockCache = dataBlockCache;
+    _column = column;
+    _columnDataType = _dataBlockCache.getDataType(column);
+    _blockValIterator = _dataBlockCache.getDataFetcher().getBlockValIteratorForColumn(column);
+  }
+
+  /**
+   * Returns an array of single values for the given doc Ids.
+   * Caller chooses T based on data type.
+   *
+   * @param <T> Return type.
+   * @return Array of single-values from dataBlockCache.
+   */
+  @Override
+  public <T> T getSingleValues() {
+    return getValues(false);
+  }
+
+  /**
+   * Returns an array of multi-values for the given doc Ids.
+   * Caller chooses T based on data type.
+   *
+   * @param <T> Return type.
+   * @return Array of multi-values from dataBlockCache.
+   */
+  @Override
+  public <T> T getMultiValues() {
+    return getValues(true);
+  }
+
+  @Override
+  public BlockValIterator iterator() {
+    throw new UnsupportedOperationException("iterator() not supported on ProjectionBlockValSet.");
+  }
+
+  @Override
+  public FieldSpec.DataType getValueType() {
+    return _columnDataType;
+  }
+
+  // TODO: Remove arguments from interface, as projection block will have the information.
+  @Override
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds,
+      int outStartPos) {
+    getDictionaryIds();
+  }
+
+  @Override
+  public int[] getDictionaryIds() {
+    return _dataBlockCache.getDictIdArrayForColumn(_column);
+  }
+
+  @Override
+  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    BlockMultiValIterator blockValIterator = (BlockMultiValIterator) _blockValIterator;
+    blockValIterator.skipTo(docId);
+    return blockValIterator.nextIntVal(outputDictIds);
+  }
+
+  /**
+   * Returns array containing hash codes for values of the single-valued projection column, for the filtered docIds.
+   * @return Array of hash codes for values of the projection column
+   */
+  public double[] getSVHashCodeArray() {
+    return _dataBlockCache.getHashCodeArrayForColumn(_column);
+  }
+
+  /**
+   * Returns array containing hash codes for values of the multi-valued projection column, for the filtered docIds.
+   * @return Array of hash codes for values of the projection column
+   */
+  public double[][] getMVHashCodeArray() {
+    return _dataBlockCache.getHashCodesArrayForColumn(_column);
+  }
+
+  /**
+   * Returns an array containing number of MV entries for the filtered docIds of the projection column.
+   * @return Array of number of MV entries
+   */
+  public int[] getNumberOfMVEntriesArray() {
+    return _dataBlockCache.getNumberOfEntriesArrayForColumn(_column);
+  }
+
+  /**
+   * Helper method to get SV/MV values for the projection column.
+   *
+   * @param multiValued True for multi-valued columns, False for single-valued columns.
+   * @param <T> Return data type
+   * @return Values for the projection column.
+   */
+  @SuppressWarnings("unchecked")
+  private <T> T getValues(boolean multiValued) {
+    switch (_columnDataType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        return (T) ((multiValued) ? _dataBlockCache.getDoubleValuesArrayForColumn(_column)
+            : _dataBlockCache.getDoubleValueArrayForColumn(_column));
+
+      case STRING:
+        return (T) ((multiValued) ? _dataBlockCache.getStringValuesArrayForColumn(_column)
+            : _dataBlockCache.getStringValueArrayForColumn(_column));
+
+      case OBJECT:
+        return (T) ((multiValued) ? _dataBlockCache.getHashCodesArrayForColumn(_column)
+            : _dataBlockCache.getHashCodeArrayForColumn(_column));
+
+      default:
+        throw new RuntimeException("Data type " + _columnDataType + " not supported in ProjectionBlockValSet.");
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeMultiValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeMultiValueSet.java
@@ -23,7 +23,7 @@ import com.linkedin.pinot.core.operator.docvaliterators.RealtimeMultiValueIterat
 
 public final class RealtimeMultiValueSet implements BlockValSet {
   /**
-   * 
+   *
    */
   private SingleColumnMultiValueReader reader;
   private int length;
@@ -37,6 +37,18 @@ public final class RealtimeMultiValueSet implements BlockValSet {
   }
 
   @Override
+  public <T> T getSingleValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for realtime multi-value BlockValSet.");
+  }
+
+  @Override
+  public <T> T getMultiValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for realtime multi-value BlockValSet.");
+  }
+
+  @Override
   public BlockValIterator iterator() {
     return new RealtimeMultiValueIterator(reader, length, dataType);
   }
@@ -47,7 +59,19 @@ public final class RealtimeMultiValueSet implements BlockValSet {
   }
 
   @Override
-  public void readIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
     throw new UnsupportedOperationException("Reading batch of multi-values in not implemented for realtime multivalue set");
+  }
+
+  @Override
+  public int[] getDictionaryIds() {
+    throw new UnsupportedOperationException(
+        "Reading batch of multi-values in not implemented for realtime multi-value set");
+  }
+
+  @Override
+  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    throw new UnsupportedOperationException(
+        "Reading value for a given docId in not implemented for realtime multi-value set");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeSingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeSingleValueSet.java
@@ -36,6 +36,18 @@ public final class RealtimeSingleValueSet implements BlockValSet {
   }
 
   @Override
+  public <T> T getSingleValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for realtime single-value BlockValSet.");
+  }
+
+  @Override
+  public <T> T getMultiValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for realtime single-value BlockValSet.");
+  }
+
+  @Override
   public BlockValIterator iterator() {
     return new RealtimeSingleValueIterator(reader, length, dataType);
   }
@@ -46,11 +58,23 @@ public final class RealtimeSingleValueSet implements BlockValSet {
   }
 
   @Override
-  public void readIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
     int endPos = inStartPos + inDocIdsSize;
     for (int iter = inStartPos; iter < endPos; ++iter) {
       int row = inDocIds[iter];
       outDictionaryIds[outStartPos++] = reader.getInt(row);
     }
+  }
+
+  @Override
+  public int[] getDictionaryIds() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation 'getDictionaryIds' for realtime single-value BlockValSet.");
+  }
+
+  @Override
+  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    throw new UnsupportedOperationException(
+        "Reading value for a given docId is not supported in realtime single-value set");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SortedSingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SortedSingleValueSet.java
@@ -23,11 +23,23 @@ import com.linkedin.pinot.core.io.reader.impl.SortedValueReaderContext;
 import com.linkedin.pinot.core.operator.docvaliterators.SortedSingleValueIterator;
 
 public final class SortedSingleValueSet implements BlockValSet {
- 
+
   private SortedForwardIndexReader sVReader;
 
   public SortedSingleValueSet(SortedForwardIndexReader sVReader) {
     this.sVReader = sVReader;
+  }
+
+  @Override
+  public <T> T getSingleValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for sorted single -value BlockValSet.");
+  }
+
+  @Override
+  public <T> T getMultiValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for sorted single -value BlockValSet.");
   }
 
   @Override
@@ -42,12 +54,24 @@ public final class SortedSingleValueSet implements BlockValSet {
   }
 
   @Override
-  public void readIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
     SortedValueReaderContext readerContext = sVReader.createContext();
     int endPos = inStartPos + inDocIdsSize;
     for (int iter = inStartPos; iter < endPos; iter++) {
       int row = inDocIds[iter];
       outDictionaryIds[outStartPos++] = sVReader.getInt(row, readerContext);
     }
+  }
+
+  @Override
+  public int[] getDictionaryIds() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation 'getDictionaryIds()' for sorted single-value BlockValSet.");
+  }
+
+  @Override
+  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    throw new UnsupportedOperationException(
+        "Reading value for a given docId is not supported for sorted single-value BlockValSet");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/UnSortedSingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/UnSortedSingleValueSet.java
@@ -34,6 +34,18 @@ public final class UnSortedSingleValueSet implements BlockValSet {
   }
 
   @Override
+  public <T> T getSingleValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for unsorted single-value BlockValSet.");
+  }
+
+  @Override
+  public <T> T getMultiValues() {
+    throw new UnsupportedOperationException(
+        "Reading a batch of values is not supported for unsorted single-value BlockValSet.");
+  }
+
+  @Override
   public BlockValIterator iterator() {
     return new UnSortedSingleValueIterator(sVReader, columnMetadata);
   }
@@ -44,7 +56,19 @@ public final class UnSortedSingleValueSet implements BlockValSet {
   }
 
   @Override
-  public void readIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
     sVReader.readValues(inDocIds, inStartPos, inDocIdsSize, outDictionaryIds, outStartPos);
+  }
+
+  @Override
+  public int[] getDictionaryIds() {
+    throw new UnsupportedOperationException(
+        "Unsupported operation 'getDictionaryIds' for unsorted single-value BlockValSet.");
+  }
+
+  @Override
+  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    throw new UnsupportedOperationException(
+        "Reading value for a given docId not supported for unsorted single-value BlockValset.");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -106,7 +106,7 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
     while (current < docIdLength) {
       int pending = (docIdLength - current);
       int batchLimit = (pending > vectorSize) ? vectorSize : pending;
-      blockValueSet.readIntValues(docIds, current, batchLimit, dictIds, 0);
+      blockValueSet.getDictionaryIds(docIds, current, batchLimit, dictIds, 0);
       dictionaryReader.readDoubleValues(dictIds, 0, batchLimit, values, 0);
       for (int vi = 0; vi < batchLimit; vi++) {
         ret += values[vi];

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/DefaultAggregationExecutorTest.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.readers.RecordReader;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
@@ -30,6 +31,7 @@ import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.aggregation.AggregationExecutor;
 import com.linkedin.pinot.core.operator.aggregation.DefaultAggregationExecutor;
 import com.linkedin.pinot.core.operator.blocks.MatchEntireSegmentDocIdSetBlock;
+import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
 import com.linkedin.pinot.core.operator.filter.MatchEntireSegmentOperator;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.core.segment.index.loader.Loaders;
@@ -131,9 +133,10 @@ public class DefaultAggregationExecutorTest {
     MatchEntireSegmentOperator matchEntireSegmentOperator = new MatchEntireSegmentOperator(totalRawDocs);
     BReusableFilteredDocIdSetOperator docIdSetOperator = new BReusableFilteredDocIdSetOperator(matchEntireSegmentOperator,totalRawDocs, 10000);
     MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
-    AggregationExecutor aggregationExecutor = new DefaultAggregationExecutor(projectionOperator, _aggregationInfoList);
+    ProjectionBlock projectionBlock = (ProjectionBlock) projectionOperator.nextBlock();
+    AggregationExecutor aggregationExecutor = new DefaultAggregationExecutor(_aggregationInfoList);
     aggregationExecutor.init();
-    aggregationExecutor.aggregate(_docIdSet, 0, NUM_ROWS);
+    aggregationExecutor.aggregate(projectionBlock);
     aggregationExecutor.finish();
 
     List<Serializable> result = aggregationExecutor.getResult();


### PR DESCRIPTION
In the existing implementation projection operator is just a pass through that passes
filtered docIds from the filter operator to operators above it. This PR re-designs the
projection operator to also perform data fetch.
- DataFetcher/DataCacheBlock are now within projection operator, clients don't need to use them
  to fetch values. They can fetch values from projection block instead.
- Added ProjectionColumnBlock which is a projection block for a specific column.
- Enhanced BlockValSet interface to get SV/MV values, apart from dictionary ids.
- Added ProjectionBlockValSet (implementation of BlockValSet) that provides access to data for
  projection columns.
- Modified AggregationOperator/DefaultAggregationExecutor to use this new design, instead of fetching the data itself.
  Other parts of the code will be migrated in following PR's.