### PR TITLE
Fix the error message for difference summary when summary cannot be generated successfully

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/SummaryResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/SummaryResource.java
@@ -25,10 +25,8 @@ import com.linkedin.thirdeye.client.diffsummary.Dimensions;
 import com.linkedin.thirdeye.client.diffsummary.OLAPDataBaseClient;
 import com.linkedin.thirdeye.client.diffsummary.PinotThirdEyeSummaryClient;
 import com.linkedin.thirdeye.dashboard.Utils;
-import com.linkedin.thirdeye.dashboard.configs.CollectionConfig;
 import com.linkedin.thirdeye.dashboard.views.diffsummary.Summary;
 import com.linkedin.thirdeye.dashboard.views.diffsummary.SummaryResponse;
-import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 
 @Path(value = "/dashboard")
@@ -60,16 +58,7 @@ public class SummaryResource {
     if (summarySize < 1) summarySize = 1;
 
     SummaryResponse response = null;
-//    String derivedMetricName = null;
     try {
-//      CollectionConfig collectionConfig = CACHE_REGISTRY_INSTANCE.getCollectionConfigCache().getIfPresent(collection);
-//      if (collectionConfig != null && collectionConfig.getDerivedMetrics() != null
-//          && collectionConfig.getDerivedMetrics().containsKey(metric)) {
-//        derivedMetricName = collectionConfig.getDerivedMetrics().get(metric);
-//      } else {
-//        derivedMetricName = metric;
-//      }
-//      List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(derivedMetricName, MetricAggFunction.SUM,collection);
     List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metric, MetricAggFunction.SUM,collection);
 
       OLAPDataBaseClient olapClient = new PinotThirdEyeSummaryClient(CACHE_REGISTRY_INSTANCE.getQueryCache());
@@ -100,6 +89,7 @@ public class SummaryResource {
     } catch (Exception e) {
       LOG.error("Exception while generating difference summary", e);
       response = SummaryResponse.buildNotAvailableResponse();
+      response.setMetricName(metric);
     }
     return OBJECT_MAPPER.writeValueAsString(response);
   }
@@ -121,12 +111,6 @@ public class SummaryResource {
 
     SummaryResponse response = null;
     try {
-//      collection = ThirdEyeUtils.getCollectionFromAlias(collection);
-//      CollectionConfig collectionConfig = CACHE_REGISTRY_INSTANCE.getCollectionConfigCache().getIfPresent(collection);
-//      if (collectionConfig != null && collectionConfig.getDerivedMetrics() != null
-//          && collectionConfig.getDerivedMetrics().containsKey(metric)) {
-//        metric = collectionConfig.getDerivedMetrics().get(metric);
-//      }
       List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metric, MetricAggFunction.SUM, collection);
 
       OLAPDataBaseClient olapClient = new PinotThirdEyeSummaryClient(CACHE_REGISTRY_INSTANCE.getQueryCache());

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
@@ -290,18 +290,17 @@ function renderD3heatmap(data, tab, templatePlaceHolder) {
 }
 
 function renderHeatMapSummary(summaryData){
-
-    if (summaryData.responseRows == 0) {
-
-        var warning = $('<div></div>', { class: 'uk-alert uk-alert-warning' })
-        warning.append($('<p></p>', { html: 'There is no data available for this request.'  }))
-        $("#difference-summary" + summaryData.metricName).html(warning)
-        return
-    }
-
     var data = {summaryData : summaryData}
     var result_treemap_summary_template = HandleBarsTemplates.template_treemap_summary(data)
-    $("#difference-summary-" + summaryData.metricName).html(result_treemap_summary_template);
+    if (summaryData.responseRows == 0) {
+        var warning = $('<div></div>', { class: 'uk-alert uk-alert-warning' })
+        warning.append($('<p></p>', { html: 'Data is not complete (e.g., Pinot segment is missing)'
+        + ' in order to explain the difference.'}))
+        $("#difference-summary-" + summaryData.metricName).html(
+            result_treemap_summary_template).append(warning)
+    } else {
+        $("#difference-summary-" + summaryData.metricName).html(result_treemap_summary_template);
+    }
 
     //Create dataTable instance of summary table
     $("#heat-map-" + summaryData.metricName +"-difference-summary-table").DataTable({


### PR DESCRIPTION
The error message was overlapped by a spinning wheel when the summary is not generated successfully.

The fix returns an empty summary when an error occurs. The empty summary will remove the spinning wheel and hence the error message is shown properly.

Tested on a dataset which has missing Pinot segments and the error message is shown properly.