### PR TITLE
Add scaling factor logic to detection and merge task runner

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -3,13 +3,17 @@ package com.linkedin.thirdeye.anomaly.detection;
 import com.google.common.collect.ArrayListMultimap;
 import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeExecutor;
+import com.linkedin.thirdeye.anomaly.override.OverrideConfigHelper;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 
 import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
+import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,11 +43,13 @@ public class DetectionTaskRunner implements TaskRunner {
 
   private MergedAnomalyResultManager mergedResultDAO;
   private RawAnomalyResultManager rawAnomalyDAO;
+  private OverrideConfigManager overrideConfigDAO;
 
   private List<String> collectionDimensions;
   private DateTime windowStart;
   private DateTime windowEnd;
   private List<MergedAnomalyResultDTO> knownMergedAnomalies;
+  private List<OverrideConfigDTO> overrideConfigs;
   private List<RawAnomalyResultDTO> existingRawAnomalies;
   private BaseAnomalyFunction anomalyFunction;
   private DatasetConfigManager datasetConfigDAO;
@@ -58,6 +64,7 @@ public class DetectionTaskRunner implements TaskRunner {
     mergedResultDAO = taskContext.getMergedResultDAO();
     rawAnomalyDAO = taskContext.getResultDAO();
     datasetConfigDAO = taskContext.getDatasetConfigDAO();
+    overrideConfigDAO = taskContext.getOverrideConfigDAO();
     AnomalyFunctionFactory anomalyFunctionFactory = taskContext.getAnomalyFunctionFactory();
     AnomalyFunctionDTO anomalyFunctionSpec = detectionTaskInfo.getAnomalyFunctionSpec();
     anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
@@ -90,6 +97,10 @@ public class DetectionTaskRunner implements TaskRunner {
         anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis());
     Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap =
         TimeSeriesUtil.getTimeSeriesForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
+
+    overrideConfigs = OverrideConfigHelper.getTimeSeriesOverrideConfigs(
+        anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()),
+        overrideConfigDAO);
 
     exploreDimensionsAndAnalyze(dimensionKeyMetricTimeSeriesMap);
 
@@ -124,6 +135,23 @@ public class DetectionTaskRunner implements TaskRunner {
       dimensionNamesToKnownRawAnomalies.put(existingRawAnomaly.getDimensions(), existingRawAnomaly);
     }
 
+    // The parameters are used by scaling factor of time series
+    AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunction.getSpec();
+    String metricName = anomalyFunctionSpec.getMetric();
+
+    // timeSeriesTargetLevel is used for check if the scaling factor should be apply on THIS
+    // collection, metric, and function id
+    Map<String, String> timeSeriesTargetLevel = OverrideConfigHelper
+        .getEntityTargetLevel(anomalyFunctionSpec.getCollection(), metricName, anomalyFunctionSpec.getId());
+
+    // Convert override config to scaling factor
+    List<ScalingFactor> scalingFactors = OverrideConfigHelper
+        .convertToScalingFactors(overrideConfigs, timeSeriesTargetLevel);
+
+    LOG.info("Found {} scaling-factor rules for collection {}, metric {}, function {}",
+        scalingFactors.size(), anomalyFunctionSpec.getCollection(), anomalyFunctionSpec.getMetric(),
+        anomalyFunctionSpec.getId());
+
     for (Map.Entry<DimensionKey, MetricTimeSeries> entry : dimensionKeyMetricTimeSeriesMap.entrySet()) {
       DimensionKey dimensionKey = entry.getKey();
       DimensionMap exploredDimensions = DimensionMap.fromDimensionKey(dimensionKey, collectionDimensions);
@@ -152,13 +180,9 @@ public class DetectionTaskRunner implements TaskRunner {
         LOG.info("Checking if any known anomalies overlap with the monitoring window of anomaly detection, which could result in unwanted holes in current values.");
         AnomalyUtils.logAnomaliesOverlapWithWindow(windowStart, windowEnd, historyMergedAnomalies);
 
-        String metricName = anomalyFunction.getSpec().getMetric();
-        // The following is just a place holder here
-        // Need to get a list of ScalingFactors from database (same way as get anomaly histories)
-        // Passed this as the last input parameter replace null
-        MetricTransfer.rescaleMetric(metricTimeSeries, metricName, null);
+        // Scaling time series according to the scaling factor
+        MetricTransfer.rescaleMetric(metricTimeSeries, metricName, scalingFactors);
 
-        // Rescale the TimeSeriesMetric
         List<RawAnomalyResultDTO> resultsOfAnEntry = anomalyFunction
             .analyze(exploredDimensions, metricTimeSeries, windowStart, windowEnd, historyMergedAnomalies);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -2,11 +2,16 @@ package com.linkedin.thirdeye.anomaly.merge;
 
 import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
+import com.linkedin.thirdeye.anomaly.override.OverrideConfigHelper;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
+import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
+import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
+import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,6 +46,7 @@ public class AnomalyMergeExecutor implements Runnable {
   private final MergedAnomalyResultManager mergedResultDAO;
   private final RawAnomalyResultManager anomalyResultDAO;
   private final AnomalyFunctionManager anomalyFunctionDAO;
+  private final OverrideConfigManager overrideConfigDAO;
   private final ScheduledExecutorService executorService;
   private final AnomalyFunctionFactory anomalyFunctionFactory;
 
@@ -69,6 +75,7 @@ public class AnomalyMergeExecutor implements Runnable {
     this.mergedResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
     this.anomalyResultDAO = DAO_REGISTRY.getRawAnomalyResultDAO();
     this.anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
+    this.overrideConfigDAO = DAO_REGISTRY.getOverrideConfigDAO();
     this.executorService = executorService;
     this.anomalyFunctionFactory = anomalyFunctionFactory;
   }
@@ -250,6 +257,7 @@ public class AnomalyMergeExecutor implements Runnable {
 
       List<MergedAnomalyResultDTO> knownAnomalies = Collections.emptyList();
 
+      // Retrieve history merged anomalies
       if (anomalyFunction.useHistoryAnomaly()) {
         switch (mergeConfig.getMergeStrategy()) {
           case FUNCTION:
@@ -269,6 +277,29 @@ public class AnomalyMergeExecutor implements Runnable {
           AnomalyUtils.logAnomaliesOverlapWithWindow(windowStart, windowEnd, knownAnomalies);
         }
       }
+
+      // Transform Time Series
+      // timeSeriesTargetLevel is used for check if the scaling factor should be apply on THIS
+      // collection, metric, and function id
+      Map<String, String> timeSeriesTargetLevel = OverrideConfigHelper
+          .getEntityTargetLevel(anomalyFunctionSpec.getCollection(), anomalyFunctionSpec.getMetric(),
+              anomalyFunctionSpec.getId());
+
+      // Get override configs
+      List<OverrideConfigDTO> overrideConfigDTOs = OverrideConfigHelper
+          .getTimeSeriesOverrideConfigs(anomalyFunction.getDataRangeIntervals(windowStart
+              .getMillis(), windowEnd.getMillis()), overrideConfigDAO);
+
+      // Convert override config to scaling factor
+      List<ScalingFactor> scalingFactors =
+          OverrideConfigHelper.convertToScalingFactors(overrideConfigDTOs, timeSeriesTargetLevel);
+
+      LOG.info("Found {} scaling-factor rules for collection {}, metric {}, function {}",
+          scalingFactors.size(), anomalyFunctionSpec.getCollection(), anomalyFunctionSpec.getMetric(),
+          anomalyFunctionSpec.getId());
+
+      // Scaling time series according to the scaling factor
+      MetricTransfer.rescaleMetric(metricTimeSeries, anomalyFunctionSpec.getMetric(), scalingFactors);
 
       anomalyFunction.updateMergedAnomalyInfo(anomalyMergedResult, metricTimeSeries, windowStart, windowEnd,
           knownAnomalies);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -279,26 +279,10 @@ public class AnomalyMergeExecutor implements Runnable {
       }
 
       // Transform Time Series
-      // timeSeriesTargetLevel is used for check if the scaling factor should be apply on THIS
-      // collection, metric, and function id
-      Map<String, String> timeSeriesTargetLevel = OverrideConfigHelper
-          .getEntityTargetLevel(anomalyFunctionSpec.getCollection(), anomalyFunctionSpec.getMetric(),
-              anomalyFunctionSpec.getId());
-
-      // Get override configs
-      List<OverrideConfigDTO> overrideConfigDTOs = OverrideConfigHelper
-          .getTimeSeriesOverrideConfigs(anomalyFunction.getDataRangeIntervals(windowStart
-              .getMillis(), windowEnd.getMillis()), overrideConfigDAO);
-
-      // Convert override config to scaling factor
-      List<ScalingFactor> scalingFactors =
-          OverrideConfigHelper.convertToScalingFactors(overrideConfigDTOs, timeSeriesTargetLevel);
-
-      LOG.info("Found {} scaling-factor rules for collection {}, metric {}, function {}",
-          scalingFactors.size(), anomalyFunctionSpec.getCollection(), anomalyFunctionSpec.getMetric(),
-          anomalyFunctionSpec.getId());
-
-      // Scaling time series according to the scaling factor
+      List<ScalingFactor> scalingFactors = OverrideConfigHelper
+          .getTimeSeriesScalingFactors(overrideConfigDAO, anomalyFunctionSpec.getCollection(),
+              anomalyFunctionSpec.getMetric(), anomalyFunctionSpec.getId(), anomalyFunction
+                  .getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
       MetricTransfer.rescaleMetric(metricTimeSeries, anomalyFunctionSpec.getMetric(), scalingFactors);
 
       anomalyFunction.updateMergedAnomalyInfo(anomalyMergedResult, metricTimeSeries, windowStart, windowEnd,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/override/OverrideConfigHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/override/OverrideConfigHelper.java
@@ -124,7 +124,7 @@ public class OverrideConfigHelper {
         if (MapUtils.isNotEmpty(overrideConfigDTO.getOverrideProperties())) {
           try {
             double scalingFactor =
-                Double.parseDouble(overrideConfigDTO.getOverrideProperties().get("scalingFactor"));
+                Double.parseDouble(overrideConfigDTO.getOverrideProperties().get(ScalingFactor.SCALING_FACTOR));
             ScalingFactor sf = new ScalingFactor(startTime, endTime, scalingFactor);
             results.add(sf);
           } catch (Exception e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskContext.java
@@ -5,6 +5,7 @@ import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.JobManager;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
@@ -18,6 +19,7 @@ public class TaskContext {
   private AnomalyFunctionFactory anomalyFunctionFactory;
   private DatasetConfigManager datasetConfigDAO;
   private MetricConfigManager metricConfigDAO;
+  private OverrideConfigManager overrideConfigDAO;
   private ThirdEyeAnomalyConfiguration thirdEyeAnomalyConfiguration;
 
   public ThirdEyeAnomalyConfiguration getThirdEyeAnomalyConfiguration() {
@@ -85,4 +87,11 @@ public class TaskContext {
     this.metricConfigDAO = metricConfigDAO;
   }
 
+  public OverrideConfigManager getOverrideConfigDAO() {
+    return overrideConfigDAO;
+  }
+
+  public void setOverrideConfigDAO(OverrideConfigManager overrideConfigDAO) {
+    this.overrideConfigDAO = overrideConfigDAO;
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
@@ -57,6 +57,7 @@ public class TaskDriver {
     taskContext.setMergedResultDAO(DAO_REGISTRY.getMergedAnomalyResultDAO());
     taskContext.setDatasetConfigDAO(DAO_REGISTRY.getDatasetConfigDAO());
     taskContext.setMetricConfigDAO(DAO_REGISTRY.getMetricConfigDAO());
+    taskContext.setOverrideConfigDAO(DAO_REGISTRY.getOverrideConfigDAO());
     taskContext.setThirdEyeAnomalyConfiguration(thirdEyeAnomalyConfiguration);
     allowedOldTaskStatus.add(TaskStatus.FAILED);
     allowedOldTaskStatus.add(TaskStatus.WAITING);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/MetricTransfer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/MetricTransfer.java
@@ -1,10 +1,16 @@
 package com.linkedin.thirdeye.detector.metric.transfer;
 
 import com.linkedin.thirdeye.api.MetricTimeSeries;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MetricTransfer {
+  private static final Logger LOG = LoggerFactory.getLogger(MetricTransfer.class);
+  private static final boolean DEBUG = true;
 
   /**
    * Use the scaling factor to normalize the input time series
@@ -16,19 +22,70 @@ public class MetricTransfer {
    */
   public static void rescaleMetric(MetricTimeSeries metricsToModify, String metricName,
       List<ScalingFactor> scalingFactorList) {
-    if (scalingFactorList == null || scalingFactorList.size() < 1) {
+    if (CollectionUtils.isEmpty(scalingFactorList)) {
       return;  // no transformation if there is no scaling factor in
     }
+
+    List<ScaledValue> scaledValues = null;
+    if (DEBUG) {
+      scaledValues = new ArrayList<>();
+    }
+
     // Went over the List of Scaling Factors and Rescale the timestamps with in the time range
     // get the metric name
     for (long ts : metricsToModify.getTimeWindowSet()) {
       for (ScalingFactor sf: scalingFactorList) {
-        if (sf.getTimeWindow().contains(ts)) {
-          //update the metric value
-          metricsToModify.set(ts, metricName, metricsToModify.get(ts, metricName).doubleValue() * sf.getScalingFactor());
+        if (sf.isInTimeWindow(ts)) {
+          double originalValue = metricsToModify.get(ts, metricName).doubleValue();
+          double scaledValue = originalValue * sf.getScalingFactor();
+          metricsToModify.set(ts, metricName, scaledValue);
+          if (DEBUG) {
+            scaledValues.add(new ScaledValue(ts, originalValue, scaledValue));
+          }
         }
       }
     }
+    if (DEBUG) {
+      if (CollectionUtils.isNotEmpty(scaledValues)) {
+        Collections.sort(scaledValues);
+        StringBuilder sb = new StringBuilder();
+        String separator = "";
+        for (ScaledValue scaledValue : scaledValues) {
+          sb.append(separator).append(scaledValue.toString());
+          separator = ", ";
+        }
+        LOG.info("Transformed values: {}", sb.toString());
+      }
+    }
+  }
 
+  /**
+   * This class is used to store debugging information, which is used to show the status of the
+   * transformed time series.
+   */
+  private static class ScaledValue implements Comparable<ScaledValue> {
+    long timestamp;
+    double originalValue;
+    double scaledValue;
+
+    public ScaledValue(long timestamp, double originalValue, double scaledValue) {
+      this.timestamp = timestamp;
+      this.originalValue = originalValue;
+      this.scaledValue = scaledValue;
+    }
+
+    /**
+     * Used to sort ScaledValue by the natural order of their timestamp
+     */
+    @Override
+    public int compareTo(ScaledValue o) {
+      return Long.compare(timestamp, o.timestamp);
+    }
+
+    @Override
+    public String toString() {
+      return "ScaledValue{" + "timestamp=" + timestamp + ", originalValue=" + originalValue
+          + ", scaledValue=" + scaledValue + ", scale=" + scaledValue / originalValue + '}';
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/ScalingFactor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/ScalingFactor.java
@@ -7,6 +7,8 @@ package com.linkedin.thirdeye.detector.metric.transfer;
  */
 public class ScalingFactor {
 
+  public static final String SCALING_FACTOR = "scalingFactor";
+
   /** The time range of the scaling window */
   private final long windowStart; // inclusive
   private final long windowEnd; // exclusive

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/ScalingFactor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/ScalingFactor.java
@@ -1,8 +1,5 @@
 package com.linkedin.thirdeye.detector.metric.transfer;
 
-import com.linkedin.thirdeye.api.TimeRange;
-
-
 /**
  * Scaling factor to rescale the metric within a time window
  * For any ts within tht timeWindow the value will be modified as
@@ -11,13 +8,22 @@ import com.linkedin.thirdeye.api.TimeRange;
 public class ScalingFactor {
 
   /** The time range of the scaling window */
-  private final TimeRange timeWindow;
+  private final long windowStart; // inclusive
+  private final long windowEnd; // exclusive
 
   /** Scaling factor during the scaling window */
   private final double scalingFactor;
 
-  public ScalingFactor(TimeRange timeWindow, double scalingFactor) {
-    this.timeWindow = timeWindow;
+  /**
+   * Construct a scaling factor with the given window start, inclusive, and window end,
+   * exclusive, and scaling factor.
+   * @param windowStart the start time of the window, inclusive
+   * @param windowEnd the end time of the window, exclusive
+   * @param scalingFactor the scaling factor
+   */
+  public ScalingFactor(long windowStart, long windowEnd, double scalingFactor) {
+    this.windowStart = windowStart;
+    this.windowEnd = windowEnd;
     this.scalingFactor = scalingFactor;
   }
 
@@ -25,8 +31,14 @@ public class ScalingFactor {
     return scalingFactor;
   }
 
-  public TimeRange getTimeWindow() {
-    return timeWindow;
+  /**
+   * Checks if the given timestamp is located between the start, inclusive, and end, exclusive,
+   * window of this scaling.
+   *
+   * @param timestamp the timestamp to check
+   * @return true if the timestamp is located between start and end window
+   */
+  public boolean isInTimeWindow(long timestamp) {
+    return windowStart <= timestamp && timestamp < windowEnd;
   }
-
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -6,6 +6,7 @@ import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
 
+import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
@@ -273,7 +274,7 @@ public abstract class AbstractManagerTestBase {
     overrideConfigDTO.setActive(true);
 
     Map<String, String> overrideProperties = new HashMap<>();
-    overrideProperties.put("scalingFactor", "1.2");
+    overrideProperties.put(ScalingFactor.SCALING_FACTOR, "1.2");
     overrideConfigDTO.setOverrideProperties(overrideProperties);
 
     Map<String, List<String>> overrideTarget = new HashMap<>();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -273,7 +273,7 @@ public abstract class AbstractManagerTestBase {
     overrideConfigDTO.setActive(true);
 
     Map<String, String> overrideProperties = new HashMap<>();
-    overrideProperties.put("scaling_factor", "1.2");
+    overrideProperties.put("scalingFactor", "1.2");
     overrideConfigDTO.setOverrideProperties(overrideProperties);
 
     Map<String, List<String>> overrideTarget = new HashMap<>();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestOverrideConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestOverrideConfigManager.java
@@ -49,18 +49,18 @@ public class TestOverrideConfigManager extends AbstractManagerTestBase {
     OverrideConfigDTO overrideConfigDTO = overrideConfigDAO.findById(overrideConfigId1);
     Assert.assertNotNull(overrideConfigDTO);
     Assert.assertNotNull(overrideConfigDTO.getOverrideProperties());
-    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get("scaling_factor"));
-    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get("scaling_factor"), "1.2");
+    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get("scalingFactor"));
+    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get("scalingFactor"), "1.2");
     Map<String, String> newOverrideProperties = new HashMap<>();
-    newOverrideProperties.put("scaling_factor", "0.8");
+    newOverrideProperties.put("scalingFactor", "0.8");
     overrideConfigDTO.setOverrideProperties(newOverrideProperties);
     overrideConfigDAO.update(overrideConfigDTO);
 
     overrideConfigDTO = overrideConfigDAO.findById(overrideConfigId1);
     Assert.assertNotNull(overrideConfigDTO);
     Assert.assertNotNull(overrideConfigDTO.getOverrideProperties());
-    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get("scaling_factor"));
-    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get("scaling_factor"), "0.8");
+    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get("scalingFactor"));
+    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get("scalingFactor"), "0.8");
 
     // Test update of target level
     overrideConfigDTO = overrideConfigDAO.findById(overrideConfigId1);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestOverrideConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestOverrideConfigManager.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.datalayer.bao;
 
 import com.linkedin.thirdeye.anomaly.override.OverrideConfigHelper;
 import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
+import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -49,18 +50,18 @@ public class TestOverrideConfigManager extends AbstractManagerTestBase {
     OverrideConfigDTO overrideConfigDTO = overrideConfigDAO.findById(overrideConfigId1);
     Assert.assertNotNull(overrideConfigDTO);
     Assert.assertNotNull(overrideConfigDTO.getOverrideProperties());
-    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get("scalingFactor"));
-    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get("scalingFactor"), "1.2");
+    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get(ScalingFactor.SCALING_FACTOR));
+    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get(ScalingFactor.SCALING_FACTOR), "1.2");
     Map<String, String> newOverrideProperties = new HashMap<>();
-    newOverrideProperties.put("scalingFactor", "0.8");
+    newOverrideProperties.put(ScalingFactor.SCALING_FACTOR, "0.8");
     overrideConfigDTO.setOverrideProperties(newOverrideProperties);
     overrideConfigDAO.update(overrideConfigDTO);
 
     overrideConfigDTO = overrideConfigDAO.findById(overrideConfigId1);
     Assert.assertNotNull(overrideConfigDTO);
     Assert.assertNotNull(overrideConfigDTO.getOverrideProperties());
-    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get("scalingFactor"));
-    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get("scalingFactor"), "0.8");
+    Assert.assertNotNull(overrideConfigDTO.getOverrideProperties().get(ScalingFactor.SCALING_FACTOR));
+    Assert.assertEquals(overrideConfigDTO.getOverrideProperties().get(ScalingFactor.SCALING_FACTOR), "0.8");
 
     // Test update of target level
     overrideConfigDTO = overrideConfigDAO.findById(overrideConfigId1);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
@@ -29,12 +29,12 @@ public class testMetricTransfer {
     }
 
     // create a list of mock scaling factors
-    ScalingFactor sf0 = new ScalingFactor(new TimeRange(2l, 4l), 0.8);
+    ScalingFactor sf0 = new ScalingFactor(2l, 4l, 0.8);
     List<ScalingFactor> sfList0 = new ArrayList<>();
     sfList0.add(sf0);
 
     MetricTransfer.rescaleMetric(metrics, mName, sfList0);
-    double [] m1_expected = {1.0, 1.0, 0.8, 0.8, 0.8, 1.0};
+    double [] m1_expected = {1.0, 1.0, 0.8, 0.8, 1.0, 1.0};
     double [] m_actual = new double[6];
     for (int i=0; i<=5; i++) {
       m_actual[i]= metrics.get(i, mName).doubleValue();
@@ -42,7 +42,7 @@ public class testMetricTransfer {
     Assert.assertEquals(m_actual, m1_expected);
 
     // revert to the original cases
-    ScalingFactor _sf0 = new ScalingFactor(new TimeRange(2l, 4l), 1.25);
+    ScalingFactor _sf0 = new ScalingFactor(2l, 4l, 1.25);
     // no points in time range and no change
     sfList0.remove(0);
     Assert.assertEquals(sfList0.size(), 0);
@@ -55,7 +55,7 @@ public class testMetricTransfer {
 
     //should not affect
     sfList0.remove(0);
-    ScalingFactor sf1 = new ScalingFactor(new TimeRange(12l, 14l), 0.8);
+    ScalingFactor sf1 = new ScalingFactor(12l, 14l, 0.8);
     sfList0.add(sf1);
     for (int i=0; i<=5; i++) {
       m_actual[i]= metrics.get(i, mName).doubleValue();


### PR DESCRIPTION
Add transformation of time series before anomaly detection tasks and merge tasks.

Tested on local setup and made sure both anomaly detector and merger can get the scaling factor when detecting anomaly and computing the weight of merged anomalies.