### PR TITLE
[PINOT-4062] Auto-create segments in CONSUMING state if we do not see one in a partition

### DIFF
--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -360,8 +360,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
       fixedPartitionSegmentName = new LLCSegmentName(segmentManager._paths.get(1));
     }
 
-    Assert.assertEquals(emptyPartitionSegmentName.getSequenceNumber(), PinotLLCRealtimeSegmentManager.STARTING_SEQUENCE_NULMBER);
-    Assert.assertEquals(fixedPartitionSegmentName.getSequenceNumber(), PinotLLCRealtimeSegmentManager.STARTING_SEQUENCE_NULMBER+1);
+    Assert.assertEquals(emptyPartitionSegmentName.getSequenceNumber(), PinotLLCRealtimeSegmentManager.STARTING_SEQUENCE_NUMBER);
+    Assert.assertEquals(fixedPartitionSegmentName.getSequenceNumber(), PinotLLCRealtimeSegmentManager.STARTING_SEQUENCE_NUMBER
+        +1);
 
     for (ZNRecord znRecord : segmentManager._records) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata(znRecord);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.controller.validation;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.yammer.metrics.core.MetricsRegistry;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,8 +46,10 @@ import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ValidationMetrics;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.StarTreeMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
@@ -57,7 +60,6 @@ import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegment
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
-import javax.annotation.Nullable;
 
 
 /**
@@ -376,7 +378,13 @@ public class ValidationManagerTest {
     FakeValidationMetrics validationMetrics = new FakeValidationMetrics();
 
     ValidationManager validationManager = new ValidationManager(validationMetrics, _pinotHelixResourceManager, new ControllerConf());
-    validationManager.validateLLCSegments(realtimeTableName);
+    Map<String, String> streamConfigs = new HashMap<String, String>(4);
+    streamConfigs.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "highLevel,simple");
+    Field autoCreateOnError = ValidationManager.class.getDeclaredField("_autoCreateOnError");
+    autoCreateOnError.setAccessible(true);
+    autoCreateOnError.setBoolean(validationManager, false);
+    validationManager.validateLLCSegments(realtimeTableName, streamConfigs);
 
     Assert.assertEquals(validationMetrics.partitionCount, 1);
 
@@ -388,7 +396,7 @@ public class ValidationManagerTest {
     idealstate.setPartitionState(p0s1.getSegmentName(), S3,
         PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
     helixAdmin.addResource(HELIX_CLUSTER_NAME, realtimeTableName, idealstate);
-    validationManager.validateLLCSegments(realtimeTableName);
+    validationManager.validateLLCSegments(realtimeTableName, streamConfigs);
     Assert.assertEquals(validationMetrics.partitionCount, 0);
 
     helixAdmin.dropResource(HELIX_CLUSTER_NAME, realtimeTableName);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -15,9 +15,6 @@
  */
 package com.linkedin.pinot.controller.validation;
 
-import com.linkedin.pinot.common.data.MetricFieldSpec;
-import com.linkedin.pinot.common.metrics.ControllerMetrics;
-import com.yammer.metrics.core.MetricsRegistry;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,9 +37,11 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.common.metrics.ValidationMetrics;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.StarTreeMetadata;
@@ -60,6 +59,8 @@ import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegment
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
+import com.yammer.metrics.core.MetricsRegistry;
+import javax.annotation.Nullable;
 
 
 /**


### PR DESCRIPTION
This feature is useful to fix kafka consumer errors (e.g. offset not found). In this condition
the segments will still show up as being in CONSUMING state, except that the servers
have stopped consuming, and are waiting for some other server to commit the segment so that
they can get the right segment. If each server thinks they are the only one that is having
a problem, then consumption will stall.

We have a metric for number of bytes consumed, which should drop to zero.

In this case, the operator can just remove the segment in CONSUMING state for that partition,
and we will auto-create the segment on the next run of ValidationManager.

It may be useful to run this functionality more than once in an hour, TBD.