### PR TITLE
Fix DST problem in TimeOverTime, Heatmap, and TimeSeries view

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -241,12 +241,20 @@ public class DashboardResource {
         currentEnd = currentEnd - delta;
         baselineEnd = baselineEnd - delta;
       }
+
+      // The input start and end time (i.e., currentStart, currentEnd, baselineStart, and
+      // baselineEnd) are given in millisecond since epoch, which is timezone insensitive. On the
+      // other hand, the start and end time of the request to be sent to backend database (e.g.,
+      // Pinot) could be converted to SimpleDateFormat, which is timezone sensitive. Therefore,
+      // we need to store user's start and end time in DateTime objects with data's timezone
+      // in order to ensure that the conversion to SimpleDateFormat is always correct regardless
+      // user and server's timezone, including daylight saving time.
       DateTimeZone timeZoneForCollection = Utils.getDataTimeZone(collection);
-//      DateTimeZone timeZoneForCollection = DateTimeZone.forID(timeZone);
       request.setBaselineStart(new DateTime(baselineStart, timeZoneForCollection));
       request.setBaselineEnd(new DateTime(baselineEnd, timeZoneForCollection));
       request.setCurrentStart(new DateTime(currentStart, timeZoneForCollection));
       request.setCurrentEnd(new DateTime(currentEnd, timeZoneForCollection));
+
       if (filterJson != null && !filterJson.isEmpty()) {
         filterJson = URLDecoder.decode(filterJson, "UTF-8");
         request.setFilters(ThirdEyeUtils.convertToMultiMap(filterJson));
@@ -291,10 +299,14 @@ public class DashboardResource {
       currentEnd = currentEnd - delta;
       baselineEnd = baselineEnd - delta;
     }
-    request.setBaselineStart(new DateTime(baselineStart, DateTimeZone.forID(timeZone)));
-    request.setBaselineEnd(new DateTime(baselineEnd, DateTimeZone.forID(timeZone)));
-    request.setCurrentStart(new DateTime(currentStart, DateTimeZone.forID(timeZone)));
-    request.setCurrentEnd(new DateTime(currentEnd, DateTimeZone.forID(timeZone)));
+
+    // See {@link #getDashboardData} for the reason that the start and end time are stored in a
+    // DateTime object with data's timezone.
+    DateTimeZone timeZoneForCollection = Utils.getDataTimeZone(collection);
+    request.setBaselineStart(new DateTime(baselineStart, timeZoneForCollection));
+    request.setBaselineEnd(new DateTime(baselineEnd, timeZoneForCollection));
+    request.setCurrentStart(new DateTime(currentStart, timeZoneForCollection));
+    request.setCurrentEnd(new DateTime(currentEnd, timeZoneForCollection));
     // filter
     if (filterJson != null && !filterJson.isEmpty()) {
       filterJson = URLDecoder.decode(filterJson, "UTF-8");
@@ -340,10 +352,14 @@ public class DashboardResource {
       baselineEnd = baselineEnd - delta;
     }
 
-    request.setBaselineStart(new DateTime(baselineStart, DateTimeZone.forID(timeZone)));
-    request.setBaselineEnd(new DateTime(baselineEnd, DateTimeZone.forID(timeZone)));
-    request.setCurrentStart(new DateTime(currentStart, DateTimeZone.forID(timeZone)));
-    request.setCurrentEnd(new DateTime(currentEnd, DateTimeZone.forID(timeZone)));
+    // See {@link #getDashboardData} for the reason that the start and end time are stored in a
+    // DateTime object with data's timezone.
+    DateTimeZone timeZoneForCollection = Utils.getDataTimeZone(collection);
+    request.setBaselineStart(new DateTime(baselineStart, timeZoneForCollection));
+    request.setBaselineEnd(new DateTime(baselineEnd, timeZoneForCollection));
+    request.setCurrentStart(new DateTime(currentStart, timeZoneForCollection));
+    request.setCurrentEnd(new DateTime(currentEnd, timeZoneForCollection));
+
     if (filterJson != null && !filterJson.isEmpty()) {
       filterJson = URLDecoder.decode(filterJson, "UTF-8");
       request.setFilters(ThirdEyeUtils.convertToMultiMap(filterJson));
@@ -389,10 +405,14 @@ public class DashboardResource {
       currentEnd = currentEnd - delta;
       baselineEnd = baselineEnd - delta;
     }
-    request.setBaselineStart(new DateTime(baselineStart, DateTimeZone.forID(timeZone)));
-    request.setBaselineEnd(new DateTime(baselineEnd, DateTimeZone.forID(timeZone)));
-    request.setCurrentStart(new DateTime(currentStart, DateTimeZone.forID(timeZone)));
-    request.setCurrentEnd(new DateTime(currentEnd, DateTimeZone.forID(timeZone)));
+
+    // See {@link #getDashboardData} for the reason that the start and end time are stored in a
+    // DateTime object with data's timezone.
+    DateTimeZone timeZoneForCollection = Utils.getDataTimeZone(collection);
+    request.setBaselineStart(new DateTime(baselineStart, timeZoneForCollection));
+    request.setBaselineEnd(new DateTime(baselineEnd, timeZoneForCollection));
+    request.setCurrentStart(new DateTime(currentStart, timeZoneForCollection));
+    request.setCurrentEnd(new DateTime(currentEnd, timeZoneForCollection));
 
     if (filterJson != null && !filterJson.isEmpty()) {
       filterJson = URLDecoder.decode(filterJson, "UTF-8");
@@ -432,8 +452,12 @@ public class DashboardResource {
 
     TimeSeriesRequest request = new TimeSeriesRequest();
     request.setCollectionName(collection);
-    request.setStart(new DateTime(start, DateTimeZone.forID(timeZone)));
-    request.setEnd(new DateTime(end, DateTimeZone.forID(timeZone)));
+
+    // See {@link #getDashboardData} for the reason that the start and end time are stored in a
+    // DateTime object with data's timezone.
+    DateTimeZone timeZoneForCollection = Utils.getDataTimeZone(collection);
+    request.setStart(new DateTime(start, timeZoneForCollection));
+    request.setEnd(new DateTime(end, timeZoneForCollection));
 
     if (groupByDimensions != null && !groupByDimensions.isEmpty()) {
       request.setGroupByDimensions(Arrays.asList(groupByDimensions.trim().split(",")));


### PR DESCRIPTION
The time over time comparison is not showing correctly if the dataset uses SimpleDateFormat and the baseline includes the day when daylight saving time starts or ends. For instance, TimeOverTime comparison shows nothing when comparing the week 11/13 - 11/19 with 11/06 - 11/12.

Fix: Ensure the start and end time given by user are stored with DateTime object with data's timezone. Hence, the conversion to SimpleTimeFormat always honors data's timezone.

Test in 2 steps:
1. We use a dataset that uses SimpleTimeFormat as the timestamp: We compare the time series of the week that contains the day when daylight saving time ends with the time series of the previous week. We make sure that the trend of the time series remains the same. Note that if the conversion to SimpleTimeFormat is incorrect, the entire time series would shift one day due to daylight saving time.

2. Once TimeOverTime shows correct data, we use it as the golden data to compare with the data we get from TimeSeries view and Heatmap view.