### PR TITLE
Use Kafka topic/id/zk as consumer manager key

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
@@ -49,7 +49,7 @@ public class KafkaHighLevelStreamProviderConfig implements StreamProviderConfig 
     // Rebalance retries will take up to 1 mins to fail.
     defaultProps.put("rebalance.max.retries", "30");
     defaultProps.put("rebalance.backoff.ms", "2000");
-    
+
     defaultProps.put("auto.commit.enable", "false");
     defaultProps.put("auto.offset.reset", "largest");
   }
@@ -203,6 +203,14 @@ public class KafkaHighLevelStreamProviderConfig implements StreamProviderConfig 
   @Override
   public long getTimeThresholdToFlushSegment() {
     return segmentTimeInMillis;
+  }
+
+  String getGroupId() {
+    return groupId;
+  }
+
+  String getZkString() {
+    return zkString;
   }
 
   @Override

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -165,8 +165,8 @@
       <artifactId>testng</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -286,9 +286,9 @@
         <version>1.2</version>
       </dependency>
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>2.6</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.5</version>
       </dependency>
       <dependency>
         <groupId>commons-configuration</groupId>


### PR DESCRIPTION
Use the Kafka topic name, consumer ID and ZK connection string as the
consumer manager key instead of the kafka stream config. This prevents
duplicate consumers being created when stream configurations change
between segments.