### PR TITLE
Change holiday scaling model: Apply scaling factor to baseline

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -9,7 +9,6 @@ import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
-import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 
 import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
@@ -19,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Properties;
 import org.apache.commons.collections.CollectionUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -166,7 +166,11 @@ public class DetectionTaskRunner implements TaskRunner {
         AnomalyUtils.logAnomaliesOverlapWithWindow(windowStart, windowEnd, historyMergedAnomalies);
 
         // Scaling time series according to the scaling factor
-        MetricTransfer.rescaleMetric(metricTimeSeries, metricName, scalingFactors);
+        if (CollectionUtils.isNotEmpty(scalingFactors)) {
+          Properties properties = anomalyFunction.getProperties();
+          MetricTransfer.rescaleMetric(metricTimeSeries, windowStart.getMillis(), scalingFactors,
+              metricName, properties);
+        }
 
         List<RawAnomalyResultDTO> resultsOfAnEntry = anomalyFunction
             .analyze(exploredDimensions, metricTimeSeries, windowStart, windowEnd, historyMergedAnomalies);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -7,7 +7,6 @@ import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
-import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
@@ -17,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -283,7 +284,11 @@ public class AnomalyMergeExecutor implements Runnable {
           .getTimeSeriesScalingFactors(overrideConfigDAO, anomalyFunctionSpec.getCollection(),
               anomalyFunctionSpec.getMetric(), anomalyFunctionSpec.getId(), anomalyFunction
                   .getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
-      MetricTransfer.rescaleMetric(metricTimeSeries, anomalyFunctionSpec.getMetric(), scalingFactors);
+      if (CollectionUtils.isNotEmpty(scalingFactors)) {
+        Properties properties = anomalyFunction.getProperties();
+        MetricTransfer.rescaleMetric(metricTimeSeries, windowStart.getMillis(), scalingFactors,
+            anomalyFunctionSpec.getMetric(), properties);
+      }
 
       anomalyFunction.updateMergedAnomalyInfo(anomalyMergedResult, metricTimeSeries, windowStart, windowEnd,
           knownAnomalies);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -31,5 +31,8 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   List<MergedAnomalyResultDTO> findByFunctionId(Long functionId);
 
+  List<MergedAnomalyResultDTO> findByStartTimeInRangeAndFunctionId(long startTime, long endTime,
+      long functionId);
+
   void updateAnomalyFeedback(MergedAnomalyResultDTO entity);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -147,6 +147,16 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
+  public List<MergedAnomalyResultDTO> findByStartTimeInRangeAndFunctionId(long startTime, long
+      endTime, long functionId) {
+    Predicate predicate =
+        Predicate.AND(Predicate.GE("startTime", startTime), Predicate.LT("startTime", endTime),
+            Predicate.EQ("functionId", functionId));
+    List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
+    return batchConvertMergedAnomalyBean2DTO(list, true);
+  }
+
+  @Override
   public List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
       String metric, String dimensions, long startTime, long endTime, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
@@ -27,7 +27,7 @@ public abstract class BaseAnomalyFunction implements AnomalyFunction {
     return spec;
   }
 
-  protected Properties getProperties() throws IOException {
+  public Properties getProperties() throws IOException {
     Properties props = new Properties();
     if (spec.getProperties() != null) {
       String[] tokens = spec.getProperties().split(";");

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
@@ -3,10 +3,11 @@ package com.linkedin.thirdeye.detector.metric.transfer;
 import com.linkedin.thirdeye.api.MetricSchema;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.api.MetricType;
-import com.linkedin.thirdeye.api.TimeRange;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 
@@ -23,44 +24,51 @@ public class testMetricTransfer {
     List<MetricType> types = Collections.nCopies(names.size(), MetricType.DOUBLE);
     MetricSchema metricSchema = new MetricSchema(names, types);
     MetricTimeSeries metrics = new MetricTimeSeries(metricSchema);
+    // the last three values are current values; the rest values are baseline values
     double [] m0 = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
     for (long i=0l; i<=5l; i++) {
       metrics.set(i, mName, 1.0);
     }
 
     // create a list of mock scaling factors
-    ScalingFactor sf0 = new ScalingFactor(2l, 4l, 0.8);
+    ScalingFactor sf0 = new ScalingFactor(2l, 6l, 0.8);
     List<ScalingFactor> sfList0 = new ArrayList<>();
     sfList0.add(sf0);
 
-    MetricTransfer.rescaleMetric(metrics, mName, sfList0);
-    double [] m1_expected = {1.0, 1.0, 0.8, 0.8, 1.0, 1.0};
+    Properties properties = new Properties();
+    properties.put(MetricTransfer.SEASONAL_SIZE, "3");
+    properties.put(MetricTransfer.SEASONAL_UNIT, TimeUnit.MILLISECONDS.toString());
+    properties.put(MetricTransfer.BASELINE_SEASONAL_PERIOD, "2"); // mistakenly set 2 on purpose
+
+    MetricTransfer.rescaleMetric(metrics, 3, sfList0, mName, properties);
+    double [] m1_expected = {0.8, 0.8, 0.0, 1.0, 1.0, 1.0};
     double [] m_actual = new double[6];
     for (int i=0; i<=5; i++) {
       m_actual[i]= metrics.get(i, mName).doubleValue();
     }
     Assert.assertEquals(m_actual, m1_expected);
 
-    // revert to the original cases
-    ScalingFactor _sf0 = new ScalingFactor(2l, 4l, 1.25);
-    // no points in time range and no change
-    sfList0.remove(0);
-    Assert.assertEquals(sfList0.size(), 0);
-    sfList0.add(_sf0);
-    MetricTransfer.rescaleMetric(metrics, mName, sfList0);
-    for (int i=0; i<=5; i++) {
-      m_actual[i]= metrics.get(i, mName).doubleValue();
-    }
-    Assert.assertEquals(m_actual, m0);
+//    // revert to the original cases
+//    ScalingFactor _sf0 = new ScalingFactor(2l, 4l, 1.25);
+//    // no points in time range and no change
+//    sfList0.remove(0);
+//    Assert.assertEquals(sfList0.size(), 0);
+//    sfList0.add(_sf0);
+//    MetricTransfer.rescaleMetric(metrics, , sfList0, mName);
+//    for (int i=0; i<=5; i++) {
+//      m_actual[i]= metrics.get(i, mName).doubleValue();
+//    }
+//    Assert.assertEquals(m_actual, m0);
 
     //should not affect
     sfList0.remove(0);
     ScalingFactor sf1 = new ScalingFactor(12l, 14l, 0.8);
     sfList0.add(sf1);
+    MetricTransfer.rescaleMetric(metrics, 3, sfList0, mName, properties);
     for (int i=0; i<=5; i++) {
       m_actual[i]= metrics.get(i, mName).doubleValue();
     }
-    Assert.assertEquals(m_actual, m0);
+    Assert.assertEquals(m_actual, m1_expected);
 
   }
 


### PR DESCRIPTION
This PR has two changes:
1. Change holiday scaling model which applies scaling factor to baseline instead of current values.
2. Add time range specified deletion for existing anomalies.

Tested using unit test and performed an integration test on local setup.