### PR TITLE
Add partial result broker metrics (Based on PR #868)

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
@@ -29,10 +29,10 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   HEALTHCHECK_OK_CALLS("healthcheck", true),
   QUERIES("queries", false),
 
-  // These metrics track the exceptions caught during query execution.
+  // These metrics track the exceptions caught during query execution in broker side.
   // PQL compile phase.
   REQUEST_COMPILATION_EXCEPTIONS("exceptions", true),
-  //Query validation phase.
+  // Query validation phase.
   QUERY_VALIDATION_EXCEPTIONS("exceptions", false),
   // Scatter phase.
   RESOURCE_MISSING_EXCEPTIONS("exceptions", false),
@@ -43,6 +43,14 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   DATA_TABLE_DESERIALIZATION_EXCEPTIONS("exceptions", false),
   // Reduce responses phase.
   RESPONSE_MERGE_EXCEPTIONS("exceptions", false),
+
+  // These metrics track the number of bad broker responses.
+  // This metric track the number of broker responses with processing exceptions inside.
+  // The processing exceptions could be caught from both server side and broker side.
+  BROKER_RESPONSES_WITH_PROCESSING_EXCEPTIONS("badResponses", false),
+  // This metric track the number of broker responses with not all servers responded.
+  // (numServersQueried > numServersResponded)
+  BROKER_RESPONSES_WITH_PARTIAL_SERVERS_RESPONDED("badResponses", false),
 
   // These metrics track the cost of the query.
   DOCUMENTS_SCANNED("documents", false),
@@ -72,8 +80,7 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   // This implies that we have identified an object for which we have not implemented custom ser/de.
   DATA_TABLE_OBJECT_DESERIALIZATION("dataTableObjectDeserialization", true),
 
-  ROUTING_TABLE_REBUILD_FAILURES("failures", false),
-  ;
+  ROUTING_TABLE_REBUILD_FAILURES("failures", false);
 
   private final String brokerMeterName;
   private final String unit;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/BrokerResponse.java
@@ -30,6 +30,20 @@ public interface BrokerResponse {
   void setExceptions(List<ProcessingException> exceptions);
 
   /**
+   * Set the number of servers got queried by the broker.
+   *
+   * @param numServersQueried number of servers got queried.
+   */
+  void setNumServersQueried(int numServersQueried);
+
+  /**
+   * Set the number of servers responded to the broker.
+   *
+   * @param numServersResponded number of servers responded.
+   */
+  void setNumServersResponded(int numServersResponded);
+
+  /**
    * Set the total time used in request handling, into the broker response.
    */
   void setTimeUsedMs(long timeUsedMs);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/broker/BrokerResponseNative.java
@@ -39,7 +39,7 @@ import org.json.JSONObject;
  *
  * Supports serialization via JSON.
  */
-@JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo"})
+@JsonPropertyOrder({"selectionResults", "aggregationResults", "exceptions", "numServersQueried", "numServersResponded", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "totalDocs", "timeUsedMs", "segmentStatistics", "traceInfo"})
 public class BrokerResponseNative implements BrokerResponse {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -47,6 +47,8 @@ public class BrokerResponseNative implements BrokerResponse {
   public static final BrokerResponseNative NO_TABLE_RESULT =
       new BrokerResponseNative(QueryException.BROKER_RESOURCE_MISSING_ERROR);
 
+  private int _numServersQueried = 0;
+  private int _numServersResponded = 0;
   private long _numDocsScanned = 0L;
   private long _numEntriesScannedInFilter = 0L;
   private long _numEntriesScannedPostFilter = 0L;
@@ -110,6 +112,28 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("exceptions")
   public void setProcessingExceptions(List<QueryProcessingException> processingExceptions) {
     _processingExceptions = processingExceptions;
+  }
+
+  @JsonProperty("numServersQueried")
+  public int getNumServersQueried() {
+    return _numServersQueried;
+  }
+
+  @JsonProperty("numServersQueried")
+  @Override
+  public void setNumServersQueried(int numServersQueried) {
+    _numServersQueried = numServersQueried;
+  }
+
+  @JsonProperty("numServersResponded")
+  public int getNumServersResponded() {
+    return _numServersResponded;
+  }
+
+  @JsonProperty("numServersResponded")
+  @Override
+  public void setNumServersResponded(int numServersResponded) {
+    _numServersResponded = numServersResponded;
   }
 
   @JsonProperty("numDocsScanned")

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/plan/CombinePlanNodeTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.plan;
+
+import com.linkedin.pinot.core.common.Operator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import junit.framework.Assert;
+import org.testng.annotations.Test;
+
+
+public class CombinePlanNodeTest {
+  private ExecutorService _executorService = Executors.newFixedThreadPool(10);
+
+  @Test
+  public void testSlowPlanNode() {
+    // Warning: this test is slow (take 10 seconds).
+
+    List<PlanNode> planNodes = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      planNodes.add(new PlanNode() {
+        @Override
+        public Operator run() {
+          try {
+            Thread.sleep(20000);
+          } catch (InterruptedException e) {
+            // Ignored.
+          }
+          return null;
+        }
+
+        @Override
+        public void showTree(String prefix) {
+        }
+      });
+    }
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, null, _executorService, 0);
+    try {
+      combinePlanNode.run();
+    } catch (RuntimeException e) {
+      Assert.assertEquals(e.getCause().toString(), "java.util.concurrent.TimeoutException");
+      return;
+    }
+    // Fail.
+    Assert.fail();
+  }
+
+  @Test
+  public void testPlanNodeThrowException() {
+    List<PlanNode> planNodes = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+      planNodes.add(new PlanNode() {
+        @Override
+        public Operator run() {
+          throw new RuntimeException("Inner exception message.");
+        }
+
+        @Override
+        public void showTree(String prefix) {
+        }
+      });
+    }
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, null, _executorService, 0);
+    try {
+      combinePlanNode.run();
+    } catch (RuntimeException e) {
+      Assert.assertEquals(e.getCause().getMessage(), "java.lang.RuntimeException: Inner exception message.");
+      return;
+    }
+    // Fail.
+    Assert.fail();
+  }
+}

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
@@ -206,4 +206,8 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
   public String getName() {
     return _name;
   }
+
+  public int getNumFutures() {
+    return _futures.size();
+  }
 }


### PR DESCRIPTION
1. Add metrics to track processing exception and partial servers responded.
   2. Add metrics to track entries scanned in/post filter.
   3. Add numServersQueried/Responded into broker response.
   4. Enhance server CombinePlanNode to pass out exceptions.