### PR TITLE
Greatly reduce object allocation in realtime path

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
@@ -25,6 +25,7 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -39,6 +40,10 @@ public class GenericRow implements RowEvent {
   @Override
   public void init(Map<String, Object> field) {
     _fieldMap = field;
+  }
+
+  public Set<Map.Entry<String, Object>> getEntrySet() {
+    return _fieldMap.entrySet();
   }
 
   @Override
@@ -84,6 +89,15 @@ public class GenericRow implements RowEvent {
     }
     GenericRow r = (GenericRow) o;
     return _fieldMap.equals(r._fieldMap);
+  }
+
+  /**
+   * Empties the values of this generic row, keeping the keys and hash map nodes to minimize object allocation.
+   */
+  public void clear() {
+    for (Map.Entry<String, Object> mapEntry : getEntrySet()) {
+      mapEntry.setValue(null);
+    }
   }
 
   static TypeReference typeReference = new TypeReference<Map<String, Object>>() {};

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/FieldExtractor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/FieldExtractor.java
@@ -32,4 +32,6 @@ public interface FieldExtractor {
   Schema getSchema();
 
   GenericRow transform(GenericRow row);
+
+  GenericRow transform(GenericRow row, GenericRow destinationRow);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
@@ -124,7 +124,11 @@ public class PlainFieldExtractor implements FieldExtractor {
 
   @Override
   public GenericRow transform(GenericRow row) {
-    Map<String, Object> fieldMap = new HashMap<>();
+    return transform(row, new GenericRow());
+  }
+
+  @Override
+  public GenericRow transform(GenericRow row, GenericRow destinationRow) {
     boolean hasError = false;
     boolean hasNull = false;
     boolean hasConversion = false;
@@ -221,7 +225,7 @@ public class PlainFieldExtractor implements FieldExtractor {
         }
       }
 
-      fieldMap.put(column, value);
+      destinationRow.putField(column, value);
     }
 
     if (hasError) {
@@ -234,8 +238,7 @@ public class PlainFieldExtractor implements FieldExtractor {
       _totalConversions++;
     }
 
-    row.init(fieldMap);
-    return row;
+    return destinationRow;
   }
 
   public Map<String, Integer> getErrorCount() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/CSVRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/CSVRecordReader.java
@@ -82,8 +82,12 @@ public class CSVRecordReader extends BaseRecordReader {
 
   @Override
   public GenericRow next() {
+    return next(new GenericRow());
+  }
+
+  @Override
+  public GenericRow next(GenericRow row) {
     CSVRecord record = _iterator.next();
-    Map<String, Object> fieldMap = new HashMap<String, Object>();
 
     for (final FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
       String column = fieldSpec.getName();
@@ -100,12 +104,10 @@ public class CSVRecordReader extends BaseRecordReader {
         value = RecordReaderUtils.convertToDataTypeArray(tokens, fieldSpec.getDataType());
       }
 
-      fieldMap.put(column, value);
+      row.putField(column, value);
     }
 
-    GenericRow genericRow = new GenericRow();
-    genericRow.init(fieldMap);
-    return genericRow;
+    return row;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/JSONRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/JSONRecordReader.java
@@ -69,8 +69,12 @@ public class JSONRecordReader extends BaseRecordReader {
 
   @Override
   public GenericRow next() {
+    return next(new GenericRow());
+  }
+
+  @Override
+  public GenericRow next(GenericRow row) {
     Map<String, Object> record = _iterator.next();
-    Map<String, Object> fieldMap = new HashMap<String, Object>();
 
     for (final FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
       String column = fieldSpec.getName();
@@ -87,12 +91,10 @@ public class JSONRecordReader extends BaseRecordReader {
         value = convertToDataTypeArray(data, fieldSpec.getDataType());
       }
 
-      fieldMap.put(column, value);
+      row.putField(column, value);
     }
 
-    GenericRow genericRow = new GenericRow();
-    genericRow.init(fieldMap);
-    return genericRow;
+    return row;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/PinotSegmentRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/PinotSegmentRecordReader.java
@@ -231,17 +231,20 @@ public class PinotSegmentRecordReader extends BaseRecordReader {
 
   @Override
   public GenericRow next() {
-    Map<String, Object> fields = new HashMap<>();
+    return next(new GenericRow());
+  }
 
+  @Override
+  public GenericRow next(GenericRow row) {
     for (String column : columns) {
       Dictionary dictionary = pinotDictionaryBufferMap.get(column);
 
       if (isSingleValueMap.get(column)) {
         // Single-value column.
         if (!isSortedMap.get(column)) {
-          fields.put(column, dictionary.get(singleValueReaderMap.get(column).getInt(docNumber)));
+          row.putField(column, dictionary.get(singleValueReaderMap.get(column).getInt(docNumber)));
         } else {
-          fields.put(column, dictionary.get(singleValueSortedReaderMap.get(column).getInt(docNumber)));
+          row.putField(column, dictionary.get(singleValueSortedReaderMap.get(column).getInt(docNumber)));
         }
       } else {
         // Multi-value column.
@@ -252,11 +255,10 @@ public class PinotSegmentRecordReader extends BaseRecordReader {
         for (int i = 0; i < numValues; i++) {
           objectArray[i] = dictionary.get(dictionaryIdArray[i]);
         }
-        fields.put(column, objectArray);
+        row.putField(column, objectArray);
       }
     }
-    GenericRow row = new GenericRow();
-    row.init(fields);
+
     docNumber++;
 
     return row;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/RecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/RecordReader.java
@@ -65,6 +65,12 @@ public interface RecordReader {
   public GenericRow next();
 
   /**
+   *
+   * @return
+   */
+  public GenericRow next(GenericRow row);
+
+  /**
    * Get the map of fields that have null values.
    */
   public Map<String, MutableLong> getNullCountMap();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/RealtimeSegment.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/RealtimeSegment.java
@@ -48,7 +48,7 @@ public interface RealtimeSegment extends MutableIndexSegment {
    * @param docId
    * @return
    */
-  public GenericRow getRawValueRowAt(int docId);
+  public GenericRow getRawValueRowAt(int docId, GenericRow row);
 
   /**
    * this will return the total number of documents that have been indexed to far,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
@@ -85,13 +85,18 @@ public class RealtimeSegmentRecordReader extends BaseRecordReader {
 
   @Override
   public GenericRow next() {
+    return next(new GenericRow());
+  }
+
+  @Override
+  public GenericRow next(GenericRow row) {
     if (docIdIterator == null) {
-      GenericRow row = realtimeSegment.getRawValueRowAt(counter);
+      row = realtimeSegment.getRawValueRowAt(counter, row);
       counter++;
       return row;
     }
     int docId = docIdIterator.next();
-    return realtimeSegment.getRawValueRowAt(docId);
+    return realtimeSegment.getRawValueRowAt(docId, row);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -598,16 +598,13 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   }
 
   @Override
-  public GenericRow getRawValueRowAt(int docId) {
-    GenericRow row = new GenericRow();
-    Map<String, Object> rowValues = new HashMap<String, Object>();
-
+  public GenericRow getRawValueRowAt(int docId, GenericRow row) {
     for (String dimension : dataSchema.getDimensionNames()) {
       if (dataSchema.getFieldSpecFor(dimension).isSingleValueField()) {
         int dicId =
             ((FixedByteSingleColumnSingleValueReaderWriter) columnIndexReaderWriterMap.get(dimension)).getInt(docId);
         Object rawValue = dictionaryMap.get(dimension).get(dicId);
-        rowValues.put(dimension, rawValue);
+        row.putField(dimension, rawValue);
       } else {
         int[] dicIds = new int[maxNumberOfMultivaluesMap.get(dimension)];
         int len =
@@ -617,7 +614,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
         for (int i = 0; i < len; i++) {
           rawValues[i] = dictionaryMap.get(dimension).get(dicIds[i]);
         }
-        rowValues.put(dimension, rawValues);
+        row.putField(dimension, rawValues);
       }
     }
 
@@ -627,32 +624,30 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       switch (dataSchema.getFieldSpecFor(metric).getDataType()) {
       case INT:
         int intValue = dictionaryMap.get(metric).getIntValue(dicId);
-        rowValues.put(metric, intValue);
+        row.putField(metric, intValue);
         break;
       case FLOAT:
         float floatValue = dictionaryMap.get(metric).getFloatValue(dicId);
-        rowValues.put(metric, floatValue);
+        row.putField(metric, floatValue);
         break;
       case LONG:
         long longValue = dictionaryMap.get(metric).getLongValue(dicId);
-        rowValues.put(metric, longValue);
+        row.putField(metric, longValue);
         break;
       case DOUBLE:
         double doubleValue = dictionaryMap.get(metric).getDoubleValue(dicId);
-        rowValues.put(metric, doubleValue);
+        row.putField(metric, doubleValue);
         break;
       default:
         throw new UnsupportedOperationException("unsopported metric data type");
       }
     }
 
-    rowValues.put(
+    row.putField(
         outgoingTimeColumnName,
         dictionaryMap.get(outgoingTimeColumnName).get(
             ((FixedByteSingleColumnSingleValueReaderWriter) columnIndexReaderWriterMap.get(outgoingTimeColumnName))
                 .getInt(docId)));
-
-    row.init(rowValues);
 
     return row;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleMutableDictionary.java
@@ -35,7 +35,7 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
     }
 
     if (rawValue instanceof String) {
-      Double entry = new Double(Double.parseDouble(rawValue.toString()));
+      Double entry = Double.parseDouble((String) rawValue);
       addToDictionaryBiMap(entry);
       updateMinMax(entry);
       return;
@@ -50,15 +50,15 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
     if (rawValue instanceof Object[]) {
       for (Object o : (Object[]) rawValue) {
         if (o instanceof String) {
-          addToDictionaryBiMap(new Double(Double.parseDouble(o.toString())));
-          updateMinMax(new Double(Double.parseDouble(o.toString())));
+          final Double doubleValue = Double.parseDouble(o.toString());
+          addToDictionaryBiMap(doubleValue);
+          updateMinMax(doubleValue);
           continue;
         }
 
         if (o instanceof Double) {
           addToDictionaryBiMap(o);
           updateMinMax((Double) o);
-          continue;
         }
       }
     }
@@ -79,7 +79,7 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
       return hasNull;
     }
     if (rawValue instanceof String) {
-      return dictionaryIdBiMap.inverse().containsKey(new Double(Double.parseDouble(rawValue.toString())));
+      return dictionaryIdBiMap.inverse().containsKey(Double.parseDouble(rawValue.toString()));
     }
     return dictionaryIdBiMap.inverse().containsKey(rawValue);
   }
@@ -87,7 +87,7 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getIndexOfFromBiMap(new Double(Double.parseDouble(rawValue.toString())));
+      return getIndexOfFromBiMap(Double.parseDouble(rawValue.toString()));
     }
     return getIndexOfFromBiMap(rawValue);
   }
@@ -104,7 +104,7 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public double getDoubleValue(int dictionaryId) {
-    return ((Double) getRawValueFromBiMap(dictionaryId)).doubleValue();
+    return (Double) getRawValueFromBiMap(dictionaryId);
   }
 
   @Override
@@ -119,7 +119,7 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public String toString(int dictionaryId) {
-    return ((Double) getRawValueFromBiMap(dictionaryId)).toString();
+    return (getRawValueFromBiMap(dictionaryId)).toString();
   }
 
   @Override
@@ -162,7 +162,7 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
   }
 
   private double getDouble(int dictionaryId) {
-    return ((Double) dictionaryIdBiMap.get(new Integer(dictionaryId))).doubleValue();
+    return (Double) dictionaryIdBiMap.get(dictionaryId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatMutableDictionary.java
@@ -34,7 +34,7 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
       return;
     }
     if (rawValue instanceof String) {
-      Float e = new Float(Float.parseFloat(rawValue.toString()));
+      Float e = Float.parseFloat(rawValue.toString());
       addToDictionaryBiMap(e);
       updateMinMax(e);
       return;
@@ -50,15 +50,15 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
 
       for (Object o : (Object[]) rawValue) {
         if (o instanceof String) {
-          addToDictionaryBiMap(new Float(Float.parseFloat(o.toString())));
-          updateMinMax(new Float(Float.parseFloat(o.toString())));
+          final Float floatValue = Float.parseFloat(o.toString());
+          addToDictionaryBiMap(floatValue);
+          updateMinMax(floatValue);
           continue;
         }
 
         if (o instanceof Float) {
           addToDictionaryBiMap(o);
           updateMinMax((Float) o);
-          continue;
         }
       }
     }
@@ -79,7 +79,7 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
       return hasNull;
     }
     if (rawValue instanceof String) {
-      return dictionaryIdBiMap.inverse().containsKey(new Float(Float.parseFloat(rawValue.toString())));
+      return dictionaryIdBiMap.inverse().containsKey(Float.parseFloat(rawValue.toString()));
     }
     return dictionaryIdBiMap.inverse().containsKey(rawValue);
   }
@@ -87,7 +87,7 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getIndexOfFromBiMap(new Float(Float.parseFloat(rawValue.toString())));
+      return getIndexOfFromBiMap(Float.parseFloat(rawValue.toString()));
     }
     return getIndexOfFromBiMap(rawValue);
   }
@@ -119,7 +119,7 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public String toString(int dictionaryId) {
-    return ((Float) getRawValueFromBiMap(dictionaryId)).toString();
+    return (getRawValueFromBiMap(dictionaryId)).toString();
   }
 
   @Override
@@ -158,11 +158,11 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public String getStringValue(int dictionaryId) {
-    return ((Double) getRawValueFromBiMap(dictionaryId)).toString();
+    return (getRawValueFromBiMap(dictionaryId)).toString();
   }
 
   private float getFloat(int dictionaryId) {
-    return ((Float) dictionaryIdBiMap.get(new Integer(dictionaryId))).floatValue();
+    return (Float) dictionaryIdBiMap.get(dictionaryId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntMutableDictionary.java
@@ -35,7 +35,7 @@ public class IntMutableDictionary extends MutableDictionaryReader {
     }
 
     if (rawValue instanceof String) {
-      Integer entry = new Integer(Integer.parseInt(rawValue.toString()));
+      Integer entry = Integer.parseInt(rawValue.toString());
       addToDictionaryBiMap(entry);
       updateMinMax(entry);
       return;
@@ -53,7 +53,7 @@ public class IntMutableDictionary extends MutableDictionaryReader {
       for (int i = 0; i < multivalues.length; i++) {
 
         if (multivalues[i] instanceof String) {
-          addToDictionaryBiMap(new Integer(Integer.parseInt(multivalues[i].toString())));
+          addToDictionaryBiMap(Integer.parseInt(multivalues[i].toString()));
           updateMinMax(Integer.parseInt(multivalues[i].toString()));
           continue;
         }
@@ -82,7 +82,7 @@ public class IntMutableDictionary extends MutableDictionaryReader {
       return hasNull;
     }
     if (rawValue instanceof String) {
-      return dictionaryIdBiMap.inverse().containsKey(new Integer(Integer.parseInt(rawValue.toString())));
+      return dictionaryIdBiMap.inverse().containsKey(Integer.parseInt(rawValue.toString()));
     }
     return dictionaryIdBiMap.inverse().containsKey(rawValue);
   }
@@ -90,7 +90,7 @@ public class IntMutableDictionary extends MutableDictionaryReader {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getIndexOfFromBiMap(new Integer(Integer.parseInt(rawValue.toString())));
+      return getIndexOfFromBiMap(Integer.parseInt(rawValue.toString()));
     }
     return getIndexOfFromBiMap(rawValue);
   }
@@ -174,7 +174,7 @@ public class IntMutableDictionary extends MutableDictionaryReader {
   }
 
   public int getInt(int dictionaryId) {
-    return ((Integer) dictionaryIdBiMap.get(new Integer(dictionaryId))).intValue();
+    return (Integer) dictionaryIdBiMap.get(dictionaryId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
@@ -35,7 +35,7 @@ public class LongMutableDictionary extends MutableDictionaryReader {
     }
 
     if (rawValue instanceof String) {
-      Long e = new Long(Long.parseLong(rawValue.toString()));
+      Long e = Long.parseLong(rawValue.toString());
       addToDictionaryBiMap(e);
       updateMinMax(e);
       return;
@@ -50,15 +50,15 @@ public class LongMutableDictionary extends MutableDictionaryReader {
     if (rawValue instanceof Object[]) {
       for (Object o : (Object[]) rawValue) {
         if (o instanceof String) {
-          addToDictionaryBiMap(new Long(Long.parseLong(o.toString())));
-          updateMinMax(new Long(Long.parseLong(o.toString())));
+          final Long longValue = Long.parseLong(o.toString());
+          addToDictionaryBiMap(longValue);
+          updateMinMax(longValue);
           continue;
         }
 
         if (o instanceof Long) {
           addToDictionaryBiMap(o);
           updateMinMax((Long) o);
-          continue;
         }
       }
     }
@@ -79,7 +79,7 @@ public class LongMutableDictionary extends MutableDictionaryReader {
       return hasNull;
     }
     if (rawValue instanceof String) {
-      return dictionaryIdBiMap.inverse().containsKey(new Long(Long.parseLong(rawValue.toString())));
+      return dictionaryIdBiMap.inverse().containsKey(Long.parseLong((String) rawValue));
     }
     return dictionaryIdBiMap.inverse().containsKey(rawValue);
   }
@@ -87,7 +87,7 @@ public class LongMutableDictionary extends MutableDictionaryReader {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getIndexOfFromBiMap(new Long(Long.parseLong(rawValue.toString())));
+      return getIndexOfFromBiMap(Long.parseLong(rawValue.toString()));
     }
     return getIndexOfFromBiMap(rawValue);
   }
@@ -99,7 +99,7 @@ public class LongMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public long getLongValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).longValue();
+    return (Long) getRawValueFromBiMap(dictionaryId);
   }
 
   @Override
@@ -159,11 +159,11 @@ public class LongMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public String getStringValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).toString();
+    return getRawValueFromBiMap(dictionaryId).toString();
   }
 
   private long getLong(int dictionaryId) {
-    return ((Long) dictionaryIdBiMap.get(new Integer(dictionaryId))).longValue();
+    return (Long) dictionaryIdBiMap.get(dictionaryId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
@@ -36,8 +36,7 @@ public abstract class MutableDictionaryReader implements Dictionary {
 
   protected void addToDictionaryBiMap(Object val) {
     if (!dictionaryIdBiMap.inverse().containsKey(val)) {
-      dictionaryIdBiMap.put(new Integer(dictionaryIdGenerator.incrementAndGet()), val);
-      return;
+      dictionaryIdBiMap.put(dictionaryIdGenerator.incrementAndGet(), val);
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
@@ -136,7 +136,7 @@ public class StringMutableDictionary extends MutableDictionaryReader {
   }
 
   private String getString(int dictionaryId) {
-    return dictionaryIdBiMap.get(new Integer(dictionaryId)).toString();
+    return dictionaryIdBiMap.get(dictionaryId).toString();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/AbstractColumnStatisticsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/AbstractColumnStatisticsCollector.java
@@ -150,25 +150,4 @@ public abstract class AbstractColumnStatisticsCollector implements  ColumnStatis
     }
     return entry;
   }
-
-  public Object addressNull(Object entry) {
-    System.out.println("******* calling ");
-    if (entry == null) {
-
-      System.out.println("entry is null");
-      if (entry instanceof String || entry instanceof Boolean || entry instanceof Utf8) {
-        entry = V1Constants.Str.NULL_STRING;
-        System.out.println("^^^^^^^^^^^^^^^^^^^ : " + entry);
-      } else if (entry instanceof Double) {
-        entry = V1Constants.Numbers.NULL_DOUBLE;
-      } else if (entry instanceof Float) {
-        entry = V1Constants.Numbers.NULL_FLOAT;
-      } else if (entry instanceof Long) {
-        entry = V1Constants.Numbers.NULL_LONG;
-      } else if (entry instanceof Integer) {
-        entry = V1Constants.Numbers.NULL_INT;
-      }
-    }
-    return entry;
-  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -89,12 +89,15 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
 
   @Override
   public void collectRow(GenericRow row, boolean isAggregated) throws Exception {
-    for (final String column : row.getFieldNames()) {
-      if (columnStatsCollectorMap.containsKey(column)) {
+    for (Map.Entry<String, Object> columnNameAndValue : row.getEntrySet()) {
+      final String columnName = columnNameAndValue.getKey();
+      final Object value = columnNameAndValue.getValue();
+
+      if (columnStatsCollectorMap.containsKey(columnName)) {
         try {
-          columnStatsCollectorMap.get(column).collect(row.getValue(column), isAggregated);
+          columnStatsCollectorMap.get(columnName).collect(value, isAggregated);
         } catch (Exception e) {
-          LOGGER.error("Exception while collecting stats for column:{} in row:{}", column, row);
+          LOGGER.error("Exception while collecting stats for column:{} in row:{}", columnName, row);
           throw e;
         }
       }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractorTest.java
@@ -77,7 +77,7 @@ public class PlainFieldExtractorTest {
     fieldMap.put("timeInt", currentDaysSinceEpoch);
 
     row.init(fieldMap);
-    plainFieldExtractor.transform(row);
+    row = plainFieldExtractor.transform(row);
 
     Assert.assertTrue(row.getValue("svDimensionInt") instanceof Integer);
     Assert.assertEquals(row.getValue("svDimensionInt"), 5);
@@ -236,7 +236,7 @@ public class PlainFieldExtractorTest {
     long currentDaysSinceEpoch = System.currentTimeMillis() / 1000 / 60 / 60 / 24;
     fieldMap.put("incoming", currentDaysSinceEpoch);
     row.init(fieldMap);
-    plainFieldExtractor.transform(row);
+    row = plainFieldExtractor.transform(row);
 
     Assert.assertNull(row.getValue("incoming"));
     Assert.assertTrue(row.getValue("outgoing") instanceof Long);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/TestRecordReader.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/TestRecordReader.java
@@ -70,6 +70,11 @@ public class TestRecordReader extends BaseRecordReader {
   }
 
   @Override
+  public GenericRow next(GenericRow row) {
+    return next();
+  }
+
+  @Override
   public void close() throws Exception {
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
@@ -158,6 +158,11 @@ public class StarTreeIndexTestSegmentHelper {
       }
 
       @Override
+      public GenericRow next(GenericRow row) {
+        return next();
+      }
+
+      @Override
       public void init()
           throws Exception {
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/DefaultAggregationExecutorTest.java
@@ -322,6 +322,11 @@ public class DefaultAggregationExecutorTest {
       }
 
       @Override
+      public GenericRow next(GenericRow row) {
+        return next();
+      }
+
+      @Override
       public void init()
           throws Exception {
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/TestDataRecordReader.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/TestDataRecordReader.java
@@ -59,6 +59,11 @@ public class TestDataRecordReader implements RecordReader {
   }
 
   @Override
+  public GenericRow next(GenericRow row) {
+    return next();
+  }
+
+  @Override
   public Map<String, MutableLong> getNullCountMap() {
     return null;
   }

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/StringDictionaryPerfTest.java
@@ -156,6 +156,11 @@ public class StringDictionaryPerfTest {
       }
 
       @Override
+      public GenericRow next(GenericRow row) {
+        return next();
+      }
+
+      @Override
       public void init()
           throws Exception {
       }


### PR DESCRIPTION
Significantly reduce object allocation in realtime indexing and
realtime segment flush:

- Reuse GenericRows during realtime segment flush
- Reduce boxing/unboxing in mutable dictionaries
- Reuse small Integers instead of allocating new ones
- Avoid turning GenericRow field names into a String[] for each row