### PR TITLE
Set default supported segmnet format version for servers to v3.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
@@ -118,6 +118,7 @@ public class TableDataManagerConfig {
     _tableDataManagerConfig.setProperty(IndexLoadingConfigMetadata.KEY_OF_STAR_TREE_FORMAT_VERSION,
         indexingConfig.getStarTreeFormat());
     String segmentVersionKey = IndexLoadingConfigMetadata.KEY_OF_SEGMENT_FORMAT_VERSION;
+
     // Server configuration is always to DEFAULT or configured value
     // Apply table configuration only if the server configuration is set with table config
     // overriding server config
@@ -126,10 +127,12 @@ public class TableDataManagerConfig {
     // security from inadvertent changes as both config will need to be enabled for the
     // change to take effect
     SegmentVersion tableConfigVersion =
-        SegmentVersion.fromStringOrDefault(indexingConfig.getSegmentFormatVersion());
-    SegmentVersion serverConfigVersion =
-        SegmentVersion.fromStringOrDefault(_tableDataManagerConfig.getString(
-            IndexLoadingConfigMetadata.KEY_OF_SEGMENT_FORMAT_VERSION));
+        SegmentVersion.fromString(indexingConfig.getSegmentFormatVersion(), SegmentVersion.DEFAULT_TABLE_VERSION);
+
+    SegmentVersion serverConfigVersion = SegmentVersion.fromString(
+        _tableDataManagerConfig.getString(IndexLoadingConfigMetadata.KEY_OF_SEGMENT_FORMAT_VERSION),
+        SegmentVersion.DEFAULT_SERVER_VERSION);
+
     // override server based configuration with table level configuration iff table configuration
     // is less than server configuration
     if (SegmentVersion.compare(tableConfigVersion, serverConfigVersion) < 0) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -95,7 +95,7 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
     super();
     _realtimeTableDataManager = realtimeTableDataManager;
     final String segmentVersionStr = tableConfig.getIndexingConfig().getSegmentFormatVersion();
-    _segmentVersion = SegmentVersion.fromStringOrDefault(segmentVersionStr);
+    _segmentVersion = SegmentVersion.fromString(segmentVersionStr, SegmentVersion.DEFAULT_TABLE_VERSION);
     this.schema = schema;
     this.extractor = (PlainFieldExtractor) FieldExtractorFactory.getPlainFieldExtractor(schema);
     this.serverMetrics =serverMetrics;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -663,7 +663,8 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
     _resourceDataDir = resourceDataDir;
     _schema = schema;
     _serverMetrics = serverMetrics;
-    _segmentVersion = SegmentVersion.fromStringOrDefault(tableConfig.getIndexingConfig().getSegmentFormatVersion());
+    _segmentVersion = SegmentVersion.fromString(tableConfig.getIndexingConfig().getSegmentFormatVersion(),
+        SegmentVersion.DEFAULT_TABLE_VERSION);
     _instance = _realtimeTableDataManager.getServerInstance();
     _protocolHandler = new ServerSegmentCompletionProtocolHandler(_instance);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentVersion.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentVersion.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.indexsegment.generator;
 
-import com.linkedin.pinot.common.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +29,10 @@ public enum SegmentVersion {
   v3 (3);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentVersion.class);
+
+  public static SegmentVersion DEFAULT_TABLE_VERSION = SegmentVersion.v1;
+  public static SegmentVersion DEFAULT_SERVER_VERSION = SegmentVersion.v3;
+
   int versionNumber;
   SegmentVersion(int versionNum) {
     this.versionNumber = versionNum;
@@ -47,21 +50,21 @@ public enum SegmentVersion {
   }
 
   /**
-   * This is null-safe version of valueOf method
-   * @param inputVersion
-   * @return
+   * Get the segment format version from string or return the default value
+   * @param inputVersion input segment format version to read
+   * @param defaultVal default value to use
+   * @return SegmentVersion for inputVersion of defaultVal if inputVersion is empty or bad value
    */
-  public static SegmentVersion fromStringOrDefault(String inputVersion) {
-    String version = inputVersion;
+  public static SegmentVersion fromString(String inputVersion, SegmentVersion defaultVal) {
     if (inputVersion == null) {
-      version = CommonConstants.Server.DEFAULT_SEGMENT_FORMAT_VERSION;
+      return defaultVal;
     }
     try {
-      return SegmentVersion.valueOf(version);
+      return SegmentVersion.valueOf(inputVersion);
     } catch (IllegalArgumentException e) {
-      LOGGER.error("Invalid argument for segment version, input: {}, Returning default version: {}",
-          inputVersion, CommonConstants.Server.DEFAULT_SEGMENT_FORMAT_VERSION, e);
-      return SegmentVersion.valueOf(CommonConstants.Server.DEFAULT_SEGMENT_FORMAT_VERSION);
+      LOGGER.error("Invalid argument for segment version input: {}, Returning default value: {}",
+          inputVersion, defaultVal);
+      return defaultVal;
     }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/Loaders.java
@@ -122,10 +122,10 @@ public class Loaders {
 
     private static SegmentVersion getSegmentVersionToLoad(IndexLoadingConfigMetadata indexLoadingConfigMetadata) {
       if (indexLoadingConfigMetadata == null) {
-        return SegmentVersion.fromStringOrDefault(CommonConstants.Server.DEFAULT_SEGMENT_FORMAT_VERSION);
+        return SegmentVersion.DEFAULT_TABLE_VERSION;
       }
       String versionName = indexLoadingConfigMetadata.segmentVersionToLoad();
-      return SegmentVersion.fromStringOrDefault(versionName);
+      return SegmentVersion.fromString(versionName, SegmentVersion.DEFAULT_TABLE_VERSION);
     }
 
     /**

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/SegmentVersionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/SegmentVersionTest.java
@@ -16,28 +16,27 @@
 
 package com.linkedin.pinot.core.indexsegment;
 
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 
 
 public class SegmentVersionTest {
   @Test
   public void test1() {
     SegmentVersion version;
-    version = SegmentVersion.fromStringOrDefault("v1");
+    version = SegmentVersion.fromString("v1", SegmentVersion.v3);
     Assert.assertEquals(version, SegmentVersion.v1);
-    version = SegmentVersion.fromStringOrDefault("v2");
+    version = SegmentVersion.fromString("v2", SegmentVersion.v1);
     Assert.assertEquals(version, SegmentVersion.v2);
-    version = SegmentVersion.fromStringOrDefault("v3");
+    version = SegmentVersion.fromString("v3", SegmentVersion.v1);
     Assert.assertEquals(version, SegmentVersion.v3);
-    version = SegmentVersion.fromStringOrDefault("badString");
-    Assert.assertEquals(version.toString(), (CommonConstants.Server.DEFAULT_SEGMENT_FORMAT_VERSION));
-    version = SegmentVersion.fromStringOrDefault(null);
-    Assert.assertEquals(version.toString(), CommonConstants.Server.DEFAULT_SEGMENT_FORMAT_VERSION);
-    version = SegmentVersion.fromStringOrDefault("");
-    Assert.assertEquals(version.toString(), CommonConstants.Server.DEFAULT_SEGMENT_FORMAT_VERSION);
+    version = SegmentVersion.fromString("badString", SegmentVersion.v1);
+    Assert.assertEquals(version, SegmentVersion.v1);
+    version = SegmentVersion.fromString(null, SegmentVersion.v3);
+    Assert.assertEquals(version, SegmentVersion.v3);
+    version = SegmentVersion.fromString("", SegmentVersion.DEFAULT_SERVER_VERSION);
+    Assert.assertEquals(version, SegmentVersion.DEFAULT_SERVER_VERSION);
 
     Assert.assertTrue(SegmentVersion.v1.compareTo(SegmentVersion.v2) < 0);
     Assert.assertTrue(SegmentVersion.v2.compareTo(SegmentVersion.v2) == 0);

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -50,6 +50,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public static final String READ_MODE = "readMode";
   // Key of the segment format this server can read
   public static final String SEGMENT_FORMAT_VERSION = "segment.format.version";
+
   // Key of whether to enable default columns
   private static final String ENABLE_DEFAULT_COLUMNS = "enable.default.columns";
 


### PR DESCRIPTION
Set the default segment format version for servers to v3. This will allow
using v3 format for tables by only configuring the segmentFormatVersion in
table configuration. We still retain ability to go back to v1 on a server
by explicitly setting the format version value in server configuration to v1.
Table level default is still v1.