### PR TITLE
Add support for per-segment realtime flush size

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -44,6 +44,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
   private long _totalRawDocs = -1;
   private long _crc = -1;
   private long _creationTime = -1;
+  private int _sizeThresholdToFlushSegment = -1;
 
   public SegmentZKMetadata() {
   }
@@ -62,6 +63,7 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     _totalRawDocs = znRecord.getLongField(CommonConstants.Segment.TOTAL_DOCS, -1);
     _crc = znRecord.getLongField(CommonConstants.Segment.CRC, -1);
     _creationTime = znRecord.getLongField(CommonConstants.Segment.CREATION_TIME, -1);
+    _sizeThresholdToFlushSegment = znRecord.getIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, -1);
   }
 
   public String getSegmentName() {
@@ -221,5 +223,9 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     configMap.put(CommonConstants.Segment.CRC, Long.toString(_crc));
     configMap.put(CommonConstants.Segment.CREATION_TIME, Long.toString(_creationTime));
     return configMap;
+  }
+
+  public int getSizeThresholdToFlushSegment() {
+    return _sizeThresholdToFlushSegment;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -246,6 +246,7 @@ public class CommonConstants {
     public static final String TOTAL_DOCS = "segment.total.docs";
     public static final String CRC = "segment.crc";
     public static final String CREATION_TIME = "segment.creation.time";
+    public static final String FLUSH_THRESHOLD_SIZE = "segment.flush.threshold.size";
 
     public static enum SegmentType {
       OFFLINE,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -678,7 +678,6 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
     _segmentNameStr = _segmentZKMetadata.getSegmentName();
     _segmentName = new LLCSegmentName(_segmentNameStr);
     _kafkaPartitionId = _segmentName.getPartitionId();
-    _segmentMaxRowCount = kafkaStreamProviderConfig.getSizeThresholdToFlushSegment();
     _tableName = _tableConfig.getTableName();
     _metricKeyName = _tableName + "-" + _kafkaTopic + "-" + _kafkaPartitionId;
     segmentLogger = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class.getName() +
@@ -709,6 +708,16 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
     if (_sortedColumn != null && !invertedIndexColumns.contains(_sortedColumn)) {
       invertedIndexColumns.add(_sortedColumn);
     }
+
+    // Read the max number of rows
+    int segmentMaxRowCount = kafkaStreamProviderConfig.getSizeThresholdToFlushSegment();
+
+    if (0 < segmentZKMetadata.getSizeThresholdToFlushSegment()) {
+      segmentMaxRowCount = segmentZKMetadata.getSizeThresholdToFlushSegment();
+    }
+
+    _segmentMaxRowCount = segmentMaxRowCount;
+
     // Start new realtime segment
     _realtimeSegment = new RealtimeSegmentImpl(schema, _segmentMaxRowCount, tableConfig.getTableName(),
         segmentZKMetadata.getSegmentName(), _kafkaTopic, _serverMetrics, invertedIndexColumns);


### PR DESCRIPTION
Add support for per-segment realtime flush size threshold, so that
individual segments can have a realtime flush size that is configured
by the controller instead of having a per-table setting.