### PR TITLE
Fix auto-creation of segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -117,6 +117,9 @@ public class CommonConstants {
           public static final String ZK_BROKER_URL = "kafka.zk.broker.url";
           public static final String KAFKA_BROKER_LIST = "kafka.broker.list";
 
+          // Consumer properties
+          public static final String AUTO_OFFSET_RESET = "auto.offset.reset";
+
           public static String getDecoderPropertyKeyFor(String key) {
             return StringUtils.join(new String[] { DECODER_PROPS_PREFIX, key }, ".");
           }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -213,7 +213,7 @@ public class PinotTableIdealStateBuilder {
     LOGGER.info("Assigning {} partitions to instances for simple consumer for table {}", nPartitions, realtimeTableName);
 
     segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas,
-        kafkaMetadata.getKafkaConsumerProperties().get("auto.offset.reset"), kafkaMetadata.getBootstrapHosts(),
+        kafkaMetadata.getKafkaConsumerProperties().get(Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET), kafkaMetadata.getBootstrapHosts(),
         idealState, create);
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -665,7 +665,8 @@ public class PinotLLCRealtimeSegmentManager {
           int seqNum = STARTING_SEQUENCE_NUMBER;
           List<String> instances = partitionAssignment.getListField(Integer.toString(curPartition));
           LOGGER.info("Creating CONSUMING segment for {} partition {} with seq {}", realtimeTableName, curPartition, seqNum);
-          long startOffset = getPartitionOffset(kafkaStreamMetadata, "smallest", curPartition);
+          String consumerStartOffsetSpec = kafkaStreamMetadata.getKafkaConsumerProperties().get(CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET);
+          long startOffset = getPartitionOffset(kafkaStreamMetadata, consumerStartOffsetSpec, curPartition);
           LOGGER.info("Found kafka offset {} for table {} for partition {}", startOffset, realtimeTableName, curPartition);
 
           createSegment(realtimeTableName, nReplicas, curPartition, seqNum, instances, startOffset);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -603,8 +603,9 @@ public class PinotLLCRealtimeSegmentManager {
   }
 
   private long getPartitionOffset(final String topicName, final String bootstrapHosts, final String offsetCriteria, int partitionId) {
-    SimpleConsumerWrapper kafkaConsumer = SimpleConsumerWrapper.forPartitionConsumption(new KafkaSimpleConsumerFactoryImpl(),
-        bootstrapHosts, "dummyClientId", topicName, partitionId, KAFKA_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
+    SimpleConsumerWrapper kafkaConsumer = SimpleConsumerWrapper.forPartitionConsumption(
+        new KafkaSimpleConsumerFactoryImpl(), bootstrapHosts, "dummyClientId", topicName, partitionId,
+        KAFKA_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
     final long startOffset;
     try {
       startOffset = kafkaConsumer.fetchPartitionOffset(offsetCriteria, KAFKA_PARTITION_OFFSET_FETCH_TIMEOUT_MILLIS);
@@ -639,7 +640,6 @@ public class PinotLLCRealtimeSegmentManager {
     final int nReplicas = partitionAssignment.getListField("0").size(); // Number of replicas of partition 0
 
     final int nSegments = segmentNames.size();
-    int curPartition = nonConsumingPartitions.get(0);
     // The segment names are sorted in reverse order, so we will have all the segments of the highest partition
     // first, and then the next partition, and so on. In each group, the highest sequence number will appear first.
     // The nonConsumingPartitions list is also sorted in reverse order.
@@ -648,14 +648,17 @@ public class PinotLLCRealtimeSegmentManager {
     // create a CONSUMING segment with STARTING_SEQUENCE_NUMER.
     // If we are done creating a CONSUMING segment for a partition, we remove it from the list of nonConsumingPartitions
     // and set curPartition to the next partition in the list.
-    for (int i = 0; i < nSegments; i++) {
-      final LLCSegmentName segmentName = segmentNames.get(i);
+    int segmentIndex = 0;
+    while (segmentIndex < nSegments && !nonConsumingPartitions.isEmpty()) {
+      final LLCSegmentName segmentName = segmentNames.get(segmentIndex);
       final int segmentPartitionId = segmentName.getPartitionId();
+      final int curPartition = nonConsumingPartitions.get(0);
       try {
         if (segmentPartitionId > curPartition) {
           // The partition we need to look for next is not this one, and could be down below in the list of segments.
           // We need to skip all the segments for higher partitions until we get to curPartition (or lower).
           // Be sure not to remove 'curPartition' from nonConsumingPartitions.
+          segmentIndex++;
           continue;
         } else if (segmentPartitionId < curPartition) {
           // We went past a partition that has no LLC segments. We can create one with STARTING_SEQUENCE_NUMBER
@@ -673,8 +676,14 @@ public class PinotLLCRealtimeSegmentManager {
           LOGGER.info("Creating CONSUMING segment for {} partition {} with seq {}", realtimeTableName, curPartition, nextSeqNum);
           long startOffset = getPartitionOffset(kafkaStreamMetadata, "smallest", curPartition);
           LOGGER.info("Found kafka offset {} for table {} for partition {}", startOffset, realtimeTableName, curPartition);
-
+          final LLCRealtimeSegmentZKMetadata oldSegMetadata = getRealtimeSegmentZKMetadata(realtimeTableName,
+              segmentName.getSegmentName());
+          if (startOffset < oldSegMetadata.getEndOffset()) {
+            startOffset = oldSegMetadata.getEndOffset();
+            LOGGER.info("Choosing newer kafka offset {} for table {} for partition {}", startOffset, realtimeTableName, curPartition);
+          }
           createSegment(realtimeTableName, nReplicas, curPartition, nextSeqNum, instances, startOffset);
+          segmentIndex++;
         }
       } catch (Exception e) {
         LOGGER.error("Exception creating CONSUMING segment for {} partition {}", realtimeTableName, curPartition, e);
@@ -682,10 +691,6 @@ public class PinotLLCRealtimeSegmentManager {
       // We land here only if we have created a CONSUMING segment for 'curPartition'. Remove it from the list, and go on
       // to the next partition (if there is one);
       nonConsumingPartitions.remove(0);
-      if (nonConsumingPartitions.isEmpty()) {
-        break;
-      }
-      curPartition = nonConsumingPartitions.get(0);
     }
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResourceTest.java
@@ -16,18 +16,17 @@
 
 package com.linkedin.pinot.controller.api.restlet.resources;
 
-import com.linkedin.pinot.common.request.helper.ControllerRequestBuilder;
-import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
-import com.linkedin.pinot.controller.helix.ControllerTest;
 import java.io.IOException;
 import java.util.Collections;
 import org.json.JSONObject;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
+import com.linkedin.pinot.common.request.helper.ControllerRequestBuilder;
+import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
+import com.linkedin.pinot.controller.helix.ControllerTest;
+import static com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource;
+import static com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource.Realtime.Kafka;
 import static org.testng.FileAssert.fail;
-import static com.linkedin.pinot.common.utils.CommonConstants.Helix.*;
-import static com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource.Realtime.*;
 
 
 /**
@@ -71,7 +70,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.ZK_BROKER_URL, "fakeUrl");
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.HighLevelConsumer.ZK_CONNECTION_STRING, "potato");
     metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(1234));
-    metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + "auto.offset.reset",
+    metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + Kafka.AUTO_OFFSET_RESET,
         "smallest");
 
     request = ControllerRequestBuilder.buildCreateRealtimeTableJSON("bad__table__name", "default", "default",

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/TableViewsTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/TableViewsTest.java
@@ -15,16 +15,6 @@
  */
 package com.linkedin.pinot.controller.api.restlet.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.linkedin.pinot.common.request.helper.ControllerRequestBuilder;
-import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
-import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
-import com.linkedin.pinot.controller.helix.ControllerTest;
-import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -36,7 +26,16 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.pinot.common.request.helper.ControllerRequestBuilder;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
+import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
+import com.linkedin.pinot.controller.helix.ControllerTest;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
@@ -92,7 +91,7 @@ public class TableViewsTest extends ControllerTest {
     metadata.put(DataSource.STREAM_PREFIX + "." + DataSource.Realtime.Kafka.ZK_BROKER_URL, "fakeUrl");
     metadata.put(DataSource.STREAM_PREFIX + "." + DataSource.Realtime.Kafka.HighLevelConsumer.ZK_CONNECTION_STRING, "potato");
     metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(1234));
-    metadata.put(DataSource.STREAM_PREFIX + "." + DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + "auto.offset.reset",
+    metadata.put(DataSource.STREAM_PREFIX + "." + DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + DataSource.Realtime.Kafka.AUTO_OFFSET_RESET,
         "smallest");
     request = ControllerRequestBuilder.buildCreateRealtimeTableJSON(TABLE_NAME, "default", "default",
         "potato", "DAYS", "DAYS", "5", 2, "BalanceNumSegmentAssignmentStrategy", metadata, "fakeSchema", "fakeColumn",

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -382,6 +382,9 @@ public class ValidationManagerTest {
     Map<String, String> streamConfigs = new HashMap<String, String>(4);
     streamConfigs.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
         CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "highLevel,simple");
+//    streamConfigs.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
+//        CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX,
+//        "auto.offset.reset"), "smallest");
     Field autoCreateOnError = ValidationManager.class.getDeclaredField("_autoCreateOnError");
     autoCreateOnError.setAccessible(true);
     autoCreateOnError.setBoolean(validationManager, false);
@@ -389,13 +392,15 @@ public class ValidationManagerTest {
 
     Assert.assertEquals(validationMetrics.partitionCount, 1);
 
+    // Set partition 0 to have one instance in CONSUMING state, and others in OFFLINE.
+    // we should not flag any partitions to correct.
     helixAdmin.dropResource(HELIX_CLUSTER_NAME, realtimeTableName);
     idealstate.setPartitionState(p0s1.getSegmentName(), S1,
         PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
     idealstate.setPartitionState(p0s1.getSegmentName(), S2,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
+        PinotHelixSegmentOnlineOfflineStateModelGenerator.OFFLINE_STATE);
     idealstate.setPartitionState(p0s1.getSegmentName(), S3,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
+        PinotHelixSegmentOnlineOfflineStateModelGenerator.OFFLINE_STATE);
     helixAdmin.addResource(HELIX_CLUSTER_NAME, realtimeTableName, idealstate);
     validationManager.validateLLCSegments(realtimeTableName, streamConfigs);
     Assert.assertEquals(validationMetrics.partitionCount, 0);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelStreamProviderConfig.java
@@ -57,7 +57,7 @@ public class KafkaHighLevelStreamProviderConfig implements StreamProviderConfig 
     defaultProps.put("rebalance.backoff.ms", "2000");
 
     defaultProps.put("auto.commit.enable", "false");
-    defaultProps.put("auto.offset.reset", "largest");
+    defaultProps.put(Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET, "largest");
 
     // A formatter for time specification that allows time to be specified in days, hours and minutes
     // e.g. 1d2h3m, or 6h5m or simply 5h

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -15,6 +15,22 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.commons.configuration.Configuration;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.broker.broker.BrokerTestUtils;
 import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
 import com.linkedin.pinot.common.data.Schema;
@@ -37,22 +53,6 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderCo
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaMessageDecoder;
 import com.linkedin.pinot.server.starter.helix.DefaultHelixStarterServerConfig;
 import com.linkedin.pinot.server.starter.helix.HelixServerStarter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import org.apache.avro.file.DataFileStream;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.commons.configuration.Configuration;
-import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -226,7 +226,7 @@ public abstract class ClusterTest extends ControllerTest {
     streamConfig.put(DataSource.STREAM_PREFIX + "." + Kafka.ZK_BROKER_URL, kafkaZkUrl);
     streamConfig.put(DataSource.STREAM_PREFIX + "." + Kafka.HighLevelConsumer.ZK_CONNECTION_STRING, kafkaZkUrl);
     streamConfig.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(realtimeSegmentFlushSize));
-    streamConfig.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + "auto.offset.reset",
+    streamConfig.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + Kafka.AUTO_OFFSET_RESET,
         "smallest");
 
     AvroFileSchemaKafkaAvroMessageDecoder.avroFile = avroFile;
@@ -250,7 +250,7 @@ public abstract class ClusterTest extends ControllerTest {
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_BROKER_LIST, kafkaBrokerList);
     metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(1)); // jfim: Invalid value to ensure the test fails if we don't pick the LLC override
     metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + KafkaLowLevelStreamProviderConfig.LLC_PROPERTY_SUFFIX, Integer.toString(realtimeSegmentFlushSize));
-    metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + "auto.offset.reset",
+    metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + Kafka.AUTO_OFFSET_RESET,
         "smallest");
 
     AvroFileSchemaKafkaAvroMessageDecoder.avroFile = avroFile;


### PR DESCRIPTION
Several fixes applied:

The auto-creation loop was skipping over segments if consecutive partitions had missing segments.

The auto-creation logic was always taking the earliest kafka offset (assuming the error is
that of offset not being found), but this may not be the case. So, if we have an older segment whose
end offset is higher than the earliest available kafka offset, we should pick the higher one.

Added tests for these cases.