### PR TITLE
Set the flush threshold on a per-segment basis

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/RealtimeSegmentZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/RealtimeSegmentZKMetadata.java
@@ -31,6 +31,7 @@ import static com.linkedin.pinot.common.utils.EqualityUtils.isNullOrNotSameClass
 public class RealtimeSegmentZKMetadata extends SegmentZKMetadata {
 
   private Status _status = null;
+  private int _sizeThresholdToFlushSegment = -1;
 
   public RealtimeSegmentZKMetadata() {
     setSegmentType(SegmentType.REALTIME);
@@ -40,6 +41,7 @@ public class RealtimeSegmentZKMetadata extends SegmentZKMetadata {
     super(znRecord);
     setSegmentType(SegmentType.REALTIME);
     _status = Status.valueOf(znRecord.getSimpleField(CommonConstants.Segment.Realtime.STATUS));
+    _sizeThresholdToFlushSegment = znRecord.getIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, -1);
   }
 
   public Status getStatus() {
@@ -69,6 +71,7 @@ public class RealtimeSegmentZKMetadata extends SegmentZKMetadata {
   public ZNRecord toZNRecord() {
     ZNRecord znRecord = super.toZNRecord();
     znRecord.setSimpleField(CommonConstants.Segment.Realtime.STATUS, _status.toString());
+    znRecord.setLongField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, _sizeThresholdToFlushSegment);
     return znRecord;
   }
 
@@ -83,13 +86,17 @@ public class RealtimeSegmentZKMetadata extends SegmentZKMetadata {
     }
 
     RealtimeSegmentZKMetadata metadata = (RealtimeSegmentZKMetadata) segmentMetadata;
-    return super.equals(metadata) && isEqual(_status, metadata._status);
+    return super.equals(metadata) &&
+        isEqual(_status, metadata._status) &&
+        isEqual(_sizeThresholdToFlushSegment, metadata._sizeThresholdToFlushSegment);
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-    return hashCodeOf(result, _status);
+    result = hashCodeOf(result, _status);
+    result = hashCodeOf(result, _sizeThresholdToFlushSegment);
+    return result;
   }
 
   @Override
@@ -97,6 +104,15 @@ public class RealtimeSegmentZKMetadata extends SegmentZKMetadata {
     Map<String, String> configMap = super.toMap();
     configMap.put(CommonConstants.Segment.Realtime.STATUS, _status.toString());
     configMap.put(CommonConstants.Segment.SEGMENT_TYPE, SegmentType.REALTIME.toString());
+    configMap.put(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, Integer.toString(_sizeThresholdToFlushSegment));
     return configMap;
+  }
+
+  public void setSizeThresholdToFlushSegment(int sizeThresholdToFlushSegment) {
+    _sizeThresholdToFlushSegment = sizeThresholdToFlushSegment;
+  }
+
+  public int getSizeThresholdToFlushSegment() {
+    return _sizeThresholdToFlushSegment;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -26,6 +26,7 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
 import static com.linkedin.pinot.common.utils.EqualityUtils.isEqual;
 import static com.linkedin.pinot.common.utils.EqualityUtils.hashCodeOf;
+import static com.linkedin.pinot.common.utils.EqualityUtils.isEqualIgnoreOrder;
 import static com.linkedin.pinot.common.utils.EqualityUtils.isSameReference;
 import static com.linkedin.pinot.common.utils.EqualityUtils.isNullOrNotSameClass;
 
@@ -44,7 +45,6 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
   private long _totalRawDocs = -1;
   private long _crc = -1;
   private long _creationTime = -1;
-  private int _sizeThresholdToFlushSegment = -1;
 
   public SegmentZKMetadata() {
   }
@@ -63,7 +63,6 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     _totalRawDocs = znRecord.getLongField(CommonConstants.Segment.TOTAL_DOCS, -1);
     _crc = znRecord.getLongField(CommonConstants.Segment.CRC, -1);
     _creationTime = znRecord.getLongField(CommonConstants.Segment.CREATION_TIME, -1);
-    _sizeThresholdToFlushSegment = znRecord.getIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, -1);
   }
 
   public String getSegmentName() {
@@ -223,9 +222,5 @@ public abstract class SegmentZKMetadata implements ZKMetadata {
     configMap.put(CommonConstants.Segment.CRC, Long.toString(_crc));
     configMap.put(CommonConstants.Segment.CREATION_TIME, Long.toString(_creationTime));
     return configMap;
-  }
-
-  public int getSizeThresholdToFlushSegment() {
-    return _sizeThresholdToFlushSegment;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -93,7 +93,21 @@ public class CommonConstants {
         public static final String STREAM_TYPE = "streamType";
         // Time threshold that will keep the realtime segment open for before we convert it into an offline segment
         public static final String REALTIME_SEGMENT_FLUSH_TIME = "realtime.segment.flush.threshold.time";
-        // Num records threshold in the realtime segment
+        /**
+         * Row count flush threshold for realtime segments. This behaves in a similar way for HLC and LLC. For HLC,
+         * since there is only one consumer per server, this size is used as the size of the consumption buffer and
+         * determines after how many rows we flush to disk. For example, if this threshold is set to two million rows,
+         * then a high level consumer would have a buffer size of two million.
+         *
+         * For LLC, this size is divided across all the segments assigned to a given server and is set on a per segment
+         * basis. Assuming a low level consumer server is assigned four Kafka partitions to consume from and a flush
+         * size of two million, then each consuming segment would have a flush size of five hundred thousand rows, for a
+         * total of two million rows in memory.
+         *
+         * Keep in mind that this NOT a hard threshold, as other tables can also be assigned to this server, and that in
+         * certain conditions (eg. if the number of servers, replicas of Kafka partitions changes) where Kafka partition
+         * to server assignment changes, it's possible to end up with more (or less) than this number of rows in memory.
+         */
         public static final String REALTIME_SEGMENT_FLUSH_SIZE = "realtime.segment.flush.threshold.size";
 
         public static enum StreamType {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
@@ -77,6 +77,7 @@ public class SegmentZKMetadataTest {
     record.setLongField(CommonConstants.Segment.TOTAL_DOCS, 10000);
     record.setLongField(CommonConstants.Segment.CRC, 1234);
     record.setLongField(CommonConstants.Segment.CREATION_TIME, 3000);
+    record.setIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, 1234);
     return record;
   }
 
@@ -93,6 +94,7 @@ public class SegmentZKMetadataTest {
     realtimeSegmentMetadata.setTotalRawDocs(10000);
     realtimeSegmentMetadata.setCrc(1234);
     realtimeSegmentMetadata.setCreationTime(3000);
+    realtimeSegmentMetadata.setSizeThresholdToFlushSegment(1234);
     return realtimeSegmentMetadata;
   }
 
@@ -110,6 +112,7 @@ public class SegmentZKMetadataTest {
     record.setLongField(CommonConstants.Segment.TOTAL_DOCS, -1);
     record.setLongField(CommonConstants.Segment.CRC, -1);
     record.setLongField(CommonConstants.Segment.CREATION_TIME, 1000);
+    record.setIntField(CommonConstants.Segment.FLUSH_THRESHOLD_SIZE, 1234);
     return record;
   }
 
@@ -126,6 +129,7 @@ public class SegmentZKMetadataTest {
     realtimeSegmentMetadata.setTotalRawDocs(-1);
     realtimeSegmentMetadata.setCrc(-1);
     realtimeSegmentMetadata.setCreationTime(1000);
+    realtimeSegmentMetadata.setSizeThresholdToFlushSegment(1234);
     return realtimeSegmentMetadata;
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -212,7 +213,7 @@ public class PinotTableIdealStateBuilder {
 
     segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas,
         kafkaMetadata.getKafkaConsumerProperties().get(Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET), kafkaMetadata.getBootstrapHosts(),
-        idealState, create);
+        idealState, create, PinotLLCRealtimeSegmentManager.getRealtimeTableFlushSize(realtimeTableConfig));
   }
 
   public static int getPartitionCount(KafkaStreamMetadata kafkaMetadata) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.controller.helix.core.realtime;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -96,7 +97,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     segmentManager.setupHelixEntries(topic, rtTableName, nPartitions, instances, nReplicas, startOffset, DUMMY_HOST,
-        null, true);
+        null, true, 1000000);
 
     Map<String, List<String>> assignmentMap = segmentManager._partitionAssignment.getListFields();
     Assert.assertEquals(assignmentMap.size(), nPartitions);
@@ -144,7 +145,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     IdealState  idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, nReplicas);
     segmentManager.setupHelixEntries(topic, rtTableName, nPartitions, instances, nReplicas, startOffset,
-        DUMMY_HOST, idealState, !existingIS);
+        DUMMY_HOST, idealState, !existingIS, 1000000);
 
     final String actualRtTableName = segmentManager._realtimeTableName;
     final Map<String, List<String>> idealStateEntries = segmentManager._idealStateEntries;
@@ -207,14 +208,16 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     IdealState  idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, 10);
     try {
-      segmentManager.setupHelixEntries(topic, rtTableName, 8, instances, 3, startOffset, DUMMY_HOST, idealState, false);
+      segmentManager.setupHelixEntries(topic, rtTableName, 8, instances, 3, startOffset, DUMMY_HOST, idealState, false,
+          10000);
       Assert.fail("Did not get expected exception when setting up helix with existing segments in propertystore");
     } catch (RuntimeException e) {
       // Expected
     }
 
     try {
-      segmentManager.setupHelixEntries(topic, rtTableName, 8, instances, 3, startOffset, DUMMY_HOST, idealState, true);
+      segmentManager.setupHelixEntries(topic, rtTableName, 8, instances, 3, startOffset, DUMMY_HOST, idealState, true,
+          10000);
       Assert.fail("Did not get expected exception when setting up helix with existing segments in propertystore");
     } catch (RuntimeException e) {
       // Expected
@@ -237,7 +240,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     IdealState  idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, nReplicas);
     segmentManager.setupHelixEntries(topic, rtTableName, nPartitions, instances, nReplicas, startOffset, DUMMY_HOST, idealState,
-        !existingIS);
+        !existingIS, 10000);
     // Now commit the first segment of partition 6.
     final int committingPartition = 6;
     final long nextOffset = 3425666L;
@@ -345,7 +348,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     // Setup initial entries
     segmentManager.setupHelixEntries(topic, rtTableName, nKafkaPartitions, instances, nReplicas, startOffset, DUMMY_HOST,
-        null, true);
+        null, true, 1000);
 
     ZNRecord partitionAssignment = segmentManager._partitionAssignment;
     segmentManager._currentKafkaPartitionCount = nKafkaPartitions;
@@ -418,7 +421,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     IdealState  idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName,
         nReplicas);
     segmentManager.setupHelixEntries(topic, rtTableName, nPartitions, instances, nReplicas, startOffset, DUMMY_HOST,
-        idealState, false);
+        idealState, false, 10000);
     // Add another segment for each partition
     long now = System.currentTimeMillis();
     List<String> existingSegments = new ArrayList<>(segmentManager._idealStateEntries.keySet());
@@ -564,7 +567,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
       final String startOffset = KAFKA_OFFSET;
 
       FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(false, null);
-      segmentManager.setupHelixEntries(topic, realtimeTableName, nPartitions, instances, nReplicas, startOffset, DUMMY_HOST, idealState, false);
+      segmentManager.setupHelixEntries(topic, realtimeTableName, nPartitions, instances, nReplicas, startOffset,
+          DUMMY_HOST, idealState, false, 10000);
       ZNRecord partitionAssignment = segmentManager.getKafkaPartitionAssignment(realtimeTableName);
 
       for (int p = 0; p < nPartitions; p++) {
@@ -669,12 +673,12 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     @Override
     protected void setupInitialSegments(String realtimeTableName, ZNRecord partitionAssignment, String topicName, String startOffset, String bootstrapHostList,
-        IdealState idealState, boolean create, int nReplicas) {
+        IdealState idealState, boolean create, int nReplicas, int flushSize) {
       _realtimeTableName = realtimeTableName;
       _partitionAssignment = partitionAssignment;
       _startOffset = startOffset;
       if (_setupInitialSegments) {
-        super.setupInitialSegments(realtimeTableName, partitionAssignment, topicName, startOffset, bootstrapHostList, idealState, create, nReplicas);
+        super.setupInitialSegments(realtimeTableName, partitionAssignment, topicName, startOffset, bootstrapHostList, idealState, create, nReplicas, flushSize);
       }
     }
 
@@ -752,6 +756,11 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
+    protected int getRealtimeTableFlushSizeForTable(String tableName) {
+      return 1000;
+    }
+
+    @Override
     protected IdealState getTableIdealState(String realtimeTableName) {
       return _tableIdealState;
     }
@@ -764,6 +773,87 @@ public class PinotLLCRealtimeSegmentManagerTest {
     @Override
     protected int getKafkaPartitionCount(KafkaStreamMetadata metadata) {
       return _currentKafkaPartitionCount;
+    }
+  }
+
+  private String makeFakeSegmentName(int id) {
+    return new LLCSegmentName("fakeTable_REALTIME", id, 0, 1234L).getSegmentName();
+  }
+
+  @Test
+  public void testUpdateFlushThresholdForSegmentMetadata() {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager = new FakePinotLLCRealtimeSegmentManager(false,
+        Collections.<String>emptyList());
+
+    ZNRecord partitionAssignment = new ZNRecord("fakeTable_REALTIME");
+    // 4 partitions assigned to 4 servers, 4 replicas => the segments should have 250k rows each (1M / 4)
+    for(int segmentId = 1; segmentId <= 4; ++segmentId) {
+      List<String> instances = new ArrayList<>();
+
+      for(int replicaId = 1; replicaId <= 4; ++replicaId) {
+        instances.add("Server_1.2.3.4_123" + replicaId);
+      }
+
+      partitionAssignment.setListField(Integer.toString(segmentId), instances);
+    }
+
+    // Check that each segment has 250k rows each
+    for(int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 250000);
+    }
+
+    // 4 partitions assigned to 4 servers, 2 partitions/server => the segments should have 500k rows each (1M / 2)
+    partitionAssignment.getListFields().clear();
+    for(int segmentId = 1; segmentId <= 4; ++segmentId) {
+      List<String> instances = new ArrayList<>();
+
+      for(int replicaId = 1; replicaId <= 2; ++replicaId) {
+        instances.add("Server_1.2.3.4_123" + ((replicaId + segmentId) % 4));
+      }
+
+      partitionAssignment.setListField(Integer.toString(segmentId), instances);
+    }
+
+    // Check that each segment has 500k rows each
+    for(int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
+    }
+
+    // 4 partitions assigned to 4 servers, 1 partition/server => the segments should have 1M rows each (1M / 1)
+    partitionAssignment.getListFields().clear();
+    for(int segmentId = 1; segmentId <= 4; ++segmentId) {
+      List<String> instances = new ArrayList<>();
+      instances.add("Server_1.2.3.4_123" + segmentId);
+      partitionAssignment.setListField(Integer.toString(segmentId), instances);
+    }
+
+    // Check that each segment has 1M rows each
+    for(int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 1000000);
+    }
+
+    // Assign another partition to all servers => the servers should have 500k rows each (1M / 2)
+    List<String> instances = new ArrayList<>();
+    for(int replicaId = 1; replicaId <= 4; ++replicaId) {
+      instances.add("Server_1.2.3.4_123" + replicaId);
+    }
+    partitionAssignment.setListField("5", instances);
+
+    // Check that each segment has 500k rows each
+    for(int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -248,8 +248,7 @@ public abstract class ClusterTest extends ControllerTest {
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.DECODER_CLASS,
         AvroFileSchemaKafkaAvroMessageDecoder.class.getName());
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_BROKER_LIST, kafkaBrokerList);
-    metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(1)); // jfim: Invalid value to ensure the test fails if we don't pick the LLC override
-    metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + KafkaLowLevelStreamProviderConfig.LLC_PROPERTY_SUFFIX, Integer.toString(realtimeSegmentFlushSize));
+    metadata.put(DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, Integer.toString(realtimeSegmentFlushSize));
     metadata.put(DataSource.STREAM_PREFIX + "." + Kafka.KAFKA_CONSUMER_PROPS_PREFIX + "." + Kafka.AUTO_OFFSET_RESET,
         "smallest");
 


### PR DESCRIPTION
Set the LLC realtime segment flush threshold on a per-segment basis
according to the maximum number of partitions consumed by replicas. For
example, if some replicas for a new segment are consuming three
partitions and some are consuming four, the new segment will have a
flush threshold equal to the per-table row flush threshold divided by
four.

This ensures that even if the number of Kafka partitions increases,
there is still an upper bound on the number of rows held in memory
before being flushed to disk.