### PR TITLE
Make toString on segment names work as expected

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/HLCSegmentName.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/HLCSegmentName.java
@@ -140,4 +140,9 @@ public class HLCSegmentName extends SegmentName {
   public RealtimeSegmentType getSegmentType() {
     return _segmentType;
   }
+
+  @Override
+  public String toString() {
+    return getSegmentName();
+  }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/LLCSegmentName.java
@@ -153,4 +153,9 @@ public class LLCSegmentName extends SegmentName implements Comparable {
     result = 31 * result + (_segmentName != null ? _segmentName.hashCode() : 0);
     return result;
   }
+
+  @Override
+  public String toString() {
+    return getSegmentName();
+  }
 }


### PR DESCRIPTION
Make toString on segment names return a segment name instead of the
default java.lang.Object#toString()