### PR TITLE
Optimize get string without padding.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
@@ -55,14 +55,13 @@ public class StringDictionary extends ImmutableDictionaryReader {
     if ((dictionaryId == -1) || (dictionaryId >= length())) {
       return "null";
     }
-    String val = getString(dictionaryId);
-    byte[] bytes = val.getBytes(UTF_8);
-    for (int i = 0; i < lengthofMaxEntry; i++) {
-      if (bytes[i] == paddingChar) {
-        return new String(bytes, 0, i, UTF_8);
+    byte[] bytes = dataFileReader.getBytes(dictionaryId, 0);
+    for (int i = lengthofMaxEntry - 1; i >= 0; i--) {
+      if (bytes[i] != paddingChar) {
+        return new String(bytes, 0, i + 1, UTF_8);
       }
     }
-    return val;
+    return "";
   }
 
   @Override


### PR DESCRIPTION
Remove the step of converting byte array to String back to byte array.
Search padding from right to left to avoid problem of padding character in the middle.