### PR TITLE
Refactor: Modify BlockValSet interface to support filtered as well as unfiltered blocks.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BaseBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BaseBlockValSet.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.common;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+
+
+/**
+ * Abstract base class implementation for BlockValSet
+ */
+public abstract class BaseBlockValSet implements BlockValSet {
+  @Override
+  public BlockValIterator iterator() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public FieldSpec.DataType getValueType() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T getSingleValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T getMultiValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int[] getDictionaryIds() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds,
+      int outStartPos) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
@@ -28,6 +28,60 @@ public interface BlockValSet {
   DataType getValueType();
 
   /**
+   * Get Integer values for the given docIds.
+   *
+   * @param inDocIds Input docIds
+   * @param inStartPos Start index in inDocIds
+   * @param inDocIdsSize Number of input doc ids
+   * @param outValues Output array
+   * @param outStartPos Start position in outValues
+   */
+  void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos);
+
+  /**
+   * Get long values for the given docIds.
+   *
+   * @param inDocIds Input docIds
+   * @param inStartPos Start index in inDocIds
+   * @param inDocIdsSize Number of input doc ids
+   * @param outValues Output array
+   * @param outStartPos Start position in outValues
+   */
+  void getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos);
+
+  /**
+   * Get float values for the given docIds.
+   *
+   * @param inDocIds Input docIds
+   * @param inStartPos Start index in inDocIds
+   * @param inDocIdsSize Number of input doc ids
+   * @param outValues Output array
+   * @param outStartPos Start position in outValues
+   */
+  void getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos);
+
+  /**
+   *
+   * @param inDocIds Input docIds
+   * @param inStartPos Start index in inDocIds
+   * @param inDocIdsSize Number of input doc ids
+   * @param outValues Output array
+   * @param outStartPos Start position in outValues
+   */
+  void getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos);
+
+  /**
+   * Get string values for the given docIds.
+   *
+   * @param inDocIds Input docIds
+   * @param inStartPos Start index in inDocIds
+   * @param inDocIdsSize Number of input doc ids
+   * @param outValues Output array
+   * @param outStartPos Start position in outValues
+   */
+  void getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos);
+
+  /**
    * Get values for single-valued column.
    *
    * @param <T> Return type

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
@@ -17,12 +17,14 @@ package com.linkedin.pinot.core.common;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+
 
 /**
  * DataFetcher is a higher level abstraction for data fetching. Given an index segment, DataFetcher can manage the
@@ -33,11 +35,19 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 public class DataFetcher {
   private static final BlockId BLOCK_ZERO = new BlockId(0);
 
-  private final Map<String, BaseOperator> _columnToDataSourceMap;
   private final Map<String, Dictionary> _columnToDictionaryMap;
   private final Map<String, BlockValSet> _columnToBlockValSetMap;
   private final Map<String, BlockValIterator> _columnToBlockValIteratorMap;
   private final Map<String, BlockMetadata> _columnToBlockMetadataMap;
+
+  // Map from MV column name to max number of entries for the column.
+  private final Map<String, Integer> _columnToMaxNumMultiValuesMap;
+
+  // Re-usable array for all dictionary ids in the block, of a single valued column
+  private final int[] _reusableDictIds;
+
+  // Re-usable array to store MV dictionary id's for a given docId
+  private final int[] _reusableMVDictIds;
 
   /**
    * Constructor for DataFetcher.
@@ -45,32 +55,32 @@ public class DataFetcher {
    * @param columnToDataSourceMap Map from column name to data source
    */
   public DataFetcher(Map<String, BaseOperator> columnToDataSourceMap) {
-    _columnToDataSourceMap = columnToDataSourceMap;
     _columnToDictionaryMap = new HashMap<>();
     _columnToBlockValSetMap = new HashMap<>();
     _columnToBlockValIteratorMap = new HashMap<>();
     _columnToBlockMetadataMap = new HashMap<>();
 
-    for (String column : columnToDataSourceMap.keySet()) {
-      BaseOperator baseOperator = columnToDataSourceMap.get(column);
-      Block block = baseOperator.nextBlock(BLOCK_ZERO);
-      _columnToDictionaryMap.put(column, block.getMetadata().getDictionary());
+    _reusableDictIds = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    _columnToMaxNumMultiValuesMap = new HashMap<>();
 
-      BlockValSet blockValSet = block.getBlockValueSet();
+    int reusableMVDictIdSize = 0;
+    for (String column : columnToDataSourceMap.keySet()) {
+      BaseOperator dataSource = columnToDataSourceMap.get(column);
+      Block dataSourceBlock = dataSource.nextBlock(BLOCK_ZERO);
+      BlockMetadata metadata = dataSourceBlock.getMetadata();
+      _columnToDictionaryMap.put(column, metadata.getDictionary());
+
+      BlockValSet blockValSet = dataSourceBlock.getBlockValueSet();
       _columnToBlockValSetMap.put(column, blockValSet);
       _columnToBlockValIteratorMap.put(column, blockValSet.iterator());
-      _columnToBlockMetadataMap.put(column, block.getMetadata());
-    }
-  }
+      _columnToBlockMetadataMap.put(column, metadata);
 
-  /**
-   * Given a column, fetch its data source.
-   *
-   * @param column column name.
-   * @return data source associated with this column.
-   */
-  public BaseOperator getDataSourceForColumn(String column) {
-    return _columnToDataSourceMap.get(column);
+      int maxNumberOfMultiValues = metadata.getMaxNumberOfMultiValues();
+      _columnToMaxNumMultiValuesMap.put(column, maxNumberOfMultiValues);
+      reusableMVDictIdSize = Math.max(reusableMVDictIdSize, maxNumberOfMultiValues);
+    }
+
+    _reusableMVDictIds = new int[reusableMVDictIdSize];
   }
 
   /**
@@ -106,6 +116,7 @@ public class DataFetcher {
   public BlockMetadata getBlockMetadataFor(String column) {
     return _columnToBlockMetadataMap.get(column);
   }
+
   /**
    * Fetch the dictionary Ids for a single value column.
    *
@@ -136,12 +147,28 @@ public class DataFetcher {
   public void fetchMultiValueDictIds(String column, int[] inDocIds, int inStartPos, int length, int[][] outDictIdsArray, int outStartPos,
       int[] tempDictIdArray) {
     BlockMultiValIterator iterator = (BlockMultiValIterator) getBlockValSetForColumn(column).iterator();
-    for (int i = inStartPos; i < inStartPos + length; ++i) {
+    for (int i = inStartPos; i < inStartPos + length; i++, outStartPos++) {
       iterator.skipTo(inDocIds[i]);
       int dictIdLength = iterator.nextIntVal(tempDictIdArray);
-      outDictIdsArray[outStartPos++] = Arrays.copyOfRange(tempDictIdArray, 0, dictIdLength);
+      outDictIdsArray[outStartPos] = Arrays.copyOfRange(tempDictIdArray, 0, dictIdLength);
     }
   }
+
+  /**
+   * Fetches dictionary ids for a given docId of a multi-valued column.
+   * Expects outDictIds to be sufficiently large to accommodate all values.
+   *
+   * @param column Column name
+   * @param inDocId Input docId
+   * @param outDictIds output array
+   * @return Dictionary ids for all multi-values for the given docId
+   */
+  public int fetchDictIdsForDocId(String column, int inDocId, int[] outDictIds) {
+    BlockMultiValIterator iterator = (BlockMultiValIterator) getBlockValSetForColumn(column).iterator();
+    iterator.skipTo(inDocId);
+    return iterator.nextIntVal(outDictIds);
+  }
+
 
   /**
    * For a given multi-value column, trying to get the max number of
@@ -151,99 +178,164 @@ public class DataFetcher {
    * @return max number of entries for a given column.
    */
   public int getMaxNumberOfEntriesForColumn(String column) {
-    return getDataSourceForColumn(column).nextBlock(BLOCK_ZERO).getMetadata().getMaxNumberOfMultiValues();
+    return _columnToMaxNumMultiValuesMap.get(column);
   }
 
   /**
    * Fetch the values for a single int value column.
    *
    * @param column column name.
-   * @param inDictIds dictionary Id array.
+   * @param inDocIds doc Id array.
    * @param inStartPos input start position.
    * @param length input length.
    * @param outValues value array buffer.
    * @param outStartPos output start position.
    */
-  public void fetchSingleIntValues(String column, int[] inDictIds, int inStartPos, int length, int[] outValues, int outStartPos) {
+  public void fetchIntValues(String column, int[] inDocIds, int inStartPos, int length, int[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    dictionary.readIntValues(inDictIds, inStartPos, length, outValues, outStartPos);
+    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+    dictionary.readIntValues(_reusableDictIds, 0, length, outValues, outStartPos);
   }
 
   /**
    * Fetch the values for a single long value column.
    *
    * @param column column name.
-   * @param inDictIds dictionary Id array.
+   * @param inDocIds doc Id array.
    * @param inStartPos input start position.
    * @param length input length.
    * @param outValues value array buffer.
    * @param outStartPos output start position.
    */
-  public void fetchSingleLongValues(String column, int[] inDictIds, int inStartPos, int length, long[] outValues, int outStartPos) {
+  public void fetchLongValues(String column, int[] inDocIds, int inStartPos, int length, long[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    dictionary.readLongValues(inDictIds, inStartPos, length, outValues, outStartPos);
+    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+    dictionary.readLongValues(_reusableDictIds, 0, length, outValues, outStartPos);
   }
 
   /**
    * Fetch the values for a single float value column.
    *
    * @param column column name.
-   * @param inDictIds dictionary Id array.
+   * @param inDocIds doc Id array.
    * @param inStartPos input start position.
    * @param length input length.
    * @param outValues value array buffer.
    * @param outStartPos output start position.
    */
-  public void fetchSingleFloatValues(String column, int[] inDictIds, int inStartPos, int length, float[] outValues, int outStartPos) {
+  public void fetchFloatValues(String column, int[] inDocIds, int inStartPos, int length, float[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    dictionary.readFloatValues(inDictIds, inStartPos, length, outValues, outStartPos);
+    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+    dictionary.readFloatValues(_reusableDictIds, 0, length, outValues, outStartPos);
   }
 
   /**
    * Fetch the values for a single double value column.
    *
    * @param column column name.
-   * @param inDictIds dictionary Id array.
+   * @param inDocIds dictionary Id array.
    * @param inStartPos input start position.
    * @param length input length.
    * @param outValues value array buffer.
    * @param outStartPos output start position.
    */
-  public void fetchSingleDoubleValues(String column, int[] inDictIds, int inStartPos, int length, double[] outValues, int outStartPos) {
+  public void fetchDoubleValues(String column, int[] inDocIds, int inStartPos, int length, double[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    dictionary.readDoubleValues(inDictIds, inStartPos, length, outValues, outStartPos);
+    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+    dictionary.readDoubleValues(_reusableDictIds, 0, length, outValues, outStartPos);
   }
 
   /**
-   * Fetch the values for a single String value column.
+   * Fetch the double values for a multi-valued column.
    *
    * @param column column name.
-   * @param inDictIds dictionary Id array.
+   * @param inDocIds dictionary Id array.
    * @param inStartPos input start position.
    * @param length input length.
    * @param outValues value array buffer.
    * @param outStartPos output start position.
    */
-  public void fetchSingleStringValues(String column, int[] inDictIds, int inStartPos, int length, String[] outValues, int outStartPos) {
+  public void fetchDoubleValues(String column, int[] inDocIds, int inStartPos, int length, double[][] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    dictionary.readStringValues(inDictIds, inStartPos, length, outValues, outStartPos);
+
+    int inEndPos = inStartPos + length;
+    for (int i = inStartPos; i < inEndPos; i++, outStartPos++) {
+      int numValues = fetchDictIdsForDocId(column, inDocIds[i], _reusableMVDictIds);
+      outValues[outStartPos] = new double[numValues];
+      dictionary.readDoubleValues(_reusableMVDictIds, 0, numValues, outValues[outStartPos], 0);
+    }
+  }
+
+  /**
+   *
+   * @param column Column for which to fetch the values
+   * @param inDocIds Array of docIds for which to fetch the values
+   * @param outValues Array of strings where output will be written
+   * @param length Length of input docIds
+   */
+  public void fetchStringValues(String column, int[] inDocIds, int inStartPos, int length, String[] outValues, int outStartPos) {
+    Dictionary dictionary = getDictionaryForColumn(column);
+    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+    dictionary.readStringValues(_reusableDictIds, 0, length, outValues, outStartPos);
+  }
+
+  /**
+   *
+   * @param column Column for which to fetch the values
+   * @param inDocIds Array of docIds for which to fetch the values
+   * @param outValues Array of strings where output will be written
+   * @param length Length of input docIds
+   */
+  public void fetchStringValues(String column, int[] inDocIds, int inStartPos, int length, String[][] outValues, int outStartPos) {
+    Dictionary dictionary = getDictionaryForColumn(column);
+
+    int inEndPos = inStartPos + length;
+    for (int i = inStartPos; i < inEndPos; i++, outStartPos++) {
+      int numValues = fetchDictIdsForDocId(column, inDocIds[i], _reusableMVDictIds);
+      outValues[outStartPos] = new String[numValues];
+      dictionary.readStringValues(_reusableMVDictIds, 0, numValues, outValues[outStartPos], 0);
+    }
   }
 
   /**
    * Fetch the hash code values for a single value column.
    *
    * @param column column name.
-   * @param inDictIds dictionary Id array.
+   * @param inDocIds doc Id array.
    * @param inStartPos input start position.
    * @param length input length.
    * @param outValues value array buffer.
    * @param outStartPos output start position.
    */
-  public void fetchSingleHashCodes(String column, int[] inDictIds, int inStartPos, int length, double[] outValues, int outStartPos) {
+  public void fetchHashCodes(String column, int[] inDocIds, int inStartPos, int length, double[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
+    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+
+    for (int i = 0; i < length; i++, outStartPos++) {
+      outValues[outStartPos] = dictionary.get(_reusableDictIds[i]).hashCode();
+    }
+  }
+
+  /**
+   * Fetch the hash code values for a single value column.
+   *
+   * @param column column name.
+   * @param inDocIds doc Id array.
+   * @param inStartPos input start position.
+   * @param length input length.
+   * @param outValues value array buffer.
+   * @param outStartPos output start position.
+   */
+  public void fetchHashCodes(String column, int[] inDocIds, int inStartPos, int length, double[][] outValues, int outStartPos) {
+    Dictionary dictionary = getDictionaryForColumn(column);
+
     int inEndPos = inStartPos + length;
-    for (int i = inStartPos; i < inEndPos; i++) {
-      outValues[outStartPos++] = dictionary.get(inDictIds[i]).hashCode();
+    for (int i = inStartPos; i < inEndPos; i++, outStartPos++) {
+      int numValues = fetchDictIdsForDocId(column, inDocIds[i], _reusableMVDictIds);
+      outValues[outStartPos] = new double[numValues];
+      for (int j = 0; j < numValues; j++) {
+        outValues[outStartPos][j] = dictionary.get(_reusableMVDictIds[j]).hashCode();
+      }
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/MultiValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/MultiValueSet.java
@@ -16,13 +16,14 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockValIterator;
-import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.io.reader.SingleColumnMultiValueReader;
 import com.linkedin.pinot.core.operator.docvaliterators.MultiValueIterator;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 
-public final class MultiValueSet implements BlockValSet {
+
+public final class MultiValueSet extends BaseBlockValSet {
   private ColumnMetadata columnMetadata;
   private SingleColumnMultiValueReader mVReader;
 
@@ -33,16 +34,6 @@ public final class MultiValueSet implements BlockValSet {
   }
 
   @Override
-  public <T> T getSingleValues() {
-    throw new UnsupportedOperationException("Reading a batch of values is not supported for multi-value BlockValSet.");
-  }
-
-  @Override
-  public <T> T getMultiValues() {
-    throw new UnsupportedOperationException("Reading a batch of values is not supported for multi-value BlockValSet.");
-  }
-
-  @Override
   public BlockValIterator iterator() {
     return new MultiValueIterator(mVReader, columnMetadata);
   }
@@ -50,20 +41,5 @@ public final class MultiValueSet implements BlockValSet {
   @Override
   public DataType getValueType() {
     return columnMetadata.getDataType();
-  }
-
-  @Override
-  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
-    throw new UnsupportedOperationException("Reading a batch of values is not supported for multi-value BlockValSet");
-  }
-
-  @Override
-  public int[] getDictionaryIds() {
-    throw new UnsupportedOperationException("Reading a batch of dictionary id is not supported for multi-value BlockValSet");
-  }
-
-  @Override
-  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
-    throw new UnsupportedOperationException("Reading a single values is not supported for multi-value BlockValSet");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -16,9 +16,9 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockMultiValIterator;
 import com.linkedin.pinot.core.common.BlockValIterator;
-import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
 
@@ -28,7 +28,7 @@ import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
  * It provides api's to access data for a specified projection column.
  * It uses {@link DataBlockCache} to cache the projection data.
  */
-public class ProjectionBlockValSet implements BlockValSet {
+public class ProjectionBlockValSet extends BaseBlockValSet {
 
   private DataBlockCache _dataBlockCache;
   private final BlockValIterator _blockValIterator;
@@ -74,11 +74,6 @@ public class ProjectionBlockValSet implements BlockValSet {
   @Override
   public <T> T getMultiValues() {
     return getValues(true);
-  }
-
-  @Override
-  public BlockValIterator iterator() {
-    throw new UnsupportedOperationException("iterator() not supported on ProjectionBlockValSet.");
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeMultiValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeMultiValueSet.java
@@ -16,12 +16,13 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockValIterator;
-import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.io.reader.SingleColumnMultiValueReader;
 import com.linkedin.pinot.core.operator.docvaliterators.RealtimeMultiValueIterator;
 
-public final class RealtimeMultiValueSet implements BlockValSet {
+
+public final class RealtimeMultiValueSet extends BaseBlockValSet {
   /**
    *
    */
@@ -37,18 +38,6 @@ public final class RealtimeMultiValueSet implements BlockValSet {
   }
 
   @Override
-  public <T> T getSingleValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for realtime multi-value BlockValSet.");
-  }
-
-  @Override
-  public <T> T getMultiValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for realtime multi-value BlockValSet.");
-  }
-
-  @Override
   public BlockValIterator iterator() {
     return new RealtimeMultiValueIterator(reader, length, dataType);
   }
@@ -56,22 +45,5 @@ public final class RealtimeMultiValueSet implements BlockValSet {
   @Override
   public DataType getValueType() {
     return dataType;
-  }
-
-  @Override
-  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
-    throw new UnsupportedOperationException("Reading batch of multi-values in not implemented for realtime multivalue set");
-  }
-
-  @Override
-  public int[] getDictionaryIds() {
-    throw new UnsupportedOperationException(
-        "Reading batch of multi-values in not implemented for realtime multi-value set");
-  }
-
-  @Override
-  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
-    throw new UnsupportedOperationException(
-        "Reading value for a given docId in not implemented for realtime multi-value set");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeSingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeSingleValueSet.java
@@ -16,35 +16,23 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockValIterator;
-import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.operator.docvaliterators.RealtimeSingleValueIterator;
 
-public final class RealtimeSingleValueSet implements BlockValSet {
+
+public final class RealtimeSingleValueSet extends BaseBlockValSet {
 
   private SingleColumnSingleValueReader reader;
   private int length;
   private DataType dataType;
 
-  public RealtimeSingleValueSet(SingleColumnSingleValueReader reader, int length,
-      DataType dataType) {
+  public RealtimeSingleValueSet(SingleColumnSingleValueReader reader, int length, DataType dataType) {
     super();
     this.reader = reader;
     this.length = length;
     this.dataType = dataType;
-  }
-
-  @Override
-  public <T> T getSingleValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for realtime single-value BlockValSet.");
-  }
-
-  @Override
-  public <T> T getMultiValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for realtime single-value BlockValSet.");
   }
 
   @Override
@@ -58,23 +46,12 @@ public final class RealtimeSingleValueSet implements BlockValSet {
   }
 
   @Override
-  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds,
+      int outStartPos) {
     int endPos = inStartPos + inDocIdsSize;
     for (int iter = inStartPos; iter < endPos; ++iter) {
       int row = inDocIds[iter];
       outDictionaryIds[outStartPos++] = reader.getInt(row);
     }
-  }
-
-  @Override
-  public int[] getDictionaryIds() {
-    throw new UnsupportedOperationException(
-        "Unsupported operation 'getDictionaryIds' for realtime single-value BlockValSet.");
-  }
-
-  @Override
-  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
-    throw new UnsupportedOperationException(
-        "Reading value for a given docId is not supported in realtime single-value set");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SortedSingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SortedSingleValueSet.java
@@ -16,30 +16,19 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockValIterator;
-import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.io.reader.impl.SortedForwardIndexReader;
 import com.linkedin.pinot.core.io.reader.impl.SortedValueReaderContext;
 import com.linkedin.pinot.core.operator.docvaliterators.SortedSingleValueIterator;
 
-public final class SortedSingleValueSet implements BlockValSet {
+
+public final class SortedSingleValueSet extends BaseBlockValSet {
 
   private SortedForwardIndexReader sVReader;
 
   public SortedSingleValueSet(SortedForwardIndexReader sVReader) {
     this.sVReader = sVReader;
-  }
-
-  @Override
-  public <T> T getSingleValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for sorted single -value BlockValSet.");
-  }
-
-  @Override
-  public <T> T getMultiValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for sorted single -value BlockValSet.");
   }
 
   @Override
@@ -54,24 +43,13 @@ public final class SortedSingleValueSet implements BlockValSet {
   }
 
   @Override
-  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds,
+      int outStartPos) {
     SortedValueReaderContext readerContext = sVReader.createContext();
     int endPos = inStartPos + inDocIdsSize;
     for (int iter = inStartPos; iter < endPos; iter++) {
       int row = inDocIds[iter];
       outDictionaryIds[outStartPos++] = sVReader.getInt(row, readerContext);
     }
-  }
-
-  @Override
-  public int[] getDictionaryIds() {
-    throw new UnsupportedOperationException(
-        "Unsupported operation 'getDictionaryIds()' for sorted single-value BlockValSet.");
-  }
-
-  @Override
-  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
-    throw new UnsupportedOperationException(
-        "Reading value for a given docId is not supported for sorted single-value BlockValSet");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/UnSortedSingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/UnSortedSingleValueSet.java
@@ -16,33 +16,21 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.core.common.BaseBlockValSet;
 import com.linkedin.pinot.core.common.BlockValIterator;
-import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.operator.docvaliterators.UnSortedSingleValueIterator;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 
-public final class UnSortedSingleValueSet implements BlockValSet {
+
+public final class UnSortedSingleValueSet extends BaseBlockValSet {
   final SingleColumnSingleValueReader sVReader;
   final ColumnMetadata columnMetadata;
 
-  public UnSortedSingleValueSet(SingleColumnSingleValueReader sVReader,
-      ColumnMetadata columnMetadata) {
+  public UnSortedSingleValueSet(SingleColumnSingleValueReader sVReader, ColumnMetadata columnMetadata) {
     super();
     this.sVReader = sVReader;
     this.columnMetadata = columnMetadata;
-  }
-
-  @Override
-  public <T> T getSingleValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for unsorted single-value BlockValSet.");
-  }
-
-  @Override
-  public <T> T getMultiValues() {
-    throw new UnsupportedOperationException(
-        "Reading a batch of values is not supported for unsorted single-value BlockValSet.");
   }
 
   @Override
@@ -56,19 +44,8 @@ public final class UnSortedSingleValueSet implements BlockValSet {
   }
 
   @Override
-  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds, int outStartPos) {
+  public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds,
+      int outStartPos) {
     sVReader.readValues(inDocIds, inStartPos, inDocIdsSize, outDictionaryIds, outStartPos);
-  }
-
-  @Override
-  public int[] getDictionaryIds() {
-    throw new UnsupportedOperationException(
-        "Unsupported operation 'getDictionaryIds' for unsorted single-value BlockValSet.");
-  }
-
-  @Override
-  public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
-    throw new UnsupportedOperationException(
-        "Reading value for a given docId not supported for unsorted single-value BlockValset.");
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/DataFetcherTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/DataFetcherTest.java
@@ -118,11 +118,8 @@ public class DataFetcherTest {
       docIds[length++] = i;
     }
 
-    int[] dictIds = new int[length];
     int[] intValues = new int[length];
-
-    _dataFetcher.fetchSingleDictIds(INT_METRIC_NAME, docIds, 0, length, dictIds, 0);
-    _dataFetcher.fetchSingleIntValues(INT_METRIC_NAME, dictIds, 0, length, intValues, 0);
+    _dataFetcher.fetchIntValues(INT_METRIC_NAME, docIds, 0, length, intValues, 0);
 
     for (int i = 0; i < length; i++) {
       Assert.assertEquals(intValues[i], _intMetricValues[docIds[i]], _errorMessage);
@@ -137,11 +134,8 @@ public class DataFetcherTest {
       docIds[length++] = i;
     }
 
-    int[] dictIds = new int[length];
     long[] longValues = new long[length];
-
-    _dataFetcher.fetchSingleDictIds(LONG_METRIC_NAME, docIds, 0, length, dictIds, 0);
-    _dataFetcher.fetchSingleLongValues(LONG_METRIC_NAME, dictIds, 0, length, longValues, 0);
+    _dataFetcher.fetchLongValues(LONG_METRIC_NAME, docIds, 0, length, longValues, 0);
 
     for (int i = 0; i < length; i++) {
       Assert.assertEquals(longValues[i], _longMetricValues[docIds[i]], _errorMessage);
@@ -156,11 +150,8 @@ public class DataFetcherTest {
       docIds[length++] = i;
     }
 
-    int[] dictIds = new int[length];
     float[] floatValues = new float[length];
-
-    _dataFetcher.fetchSingleDictIds(FLOAT_METRIC_NAME, docIds, 0, length, dictIds, 0);
-    _dataFetcher.fetchSingleFloatValues(FLOAT_METRIC_NAME, dictIds, 0, length, floatValues, 0);
+    _dataFetcher.fetchFloatValues(FLOAT_METRIC_NAME, docIds, 0, length, floatValues, 0);
 
     for (int i = 0; i < length; i++) {
       Assert.assertEquals(floatValues[i], _floatMetricValues[docIds[i]], _errorMessage);
@@ -175,11 +166,8 @@ public class DataFetcherTest {
       docIds[length++] = i;
     }
 
-    int[] dictIds = new int[length];
     double[] doubleValues = new double[length];
-
-    _dataFetcher.fetchSingleDictIds(DOUBLE_METRIC_NAME, docIds, 0, length, dictIds, 0);
-    _dataFetcher.fetchSingleDoubleValues(DOUBLE_METRIC_NAME, dictIds, 0, length, doubleValues, 0);
+    _dataFetcher.fetchDoubleValues(DOUBLE_METRIC_NAME, docIds, 0, length, doubleValues, 0);
 
     for (int i = 0; i < length; i++) {
       Assert.assertEquals(doubleValues[i], _doubleMetricValues[docIds[i]], _errorMessage);
@@ -194,11 +182,8 @@ public class DataFetcherTest {
       docIds[length++] = i;
     }
 
-    int[] dictIds = new int[length];
     String[] stringValues = new String[length];
-
-    _dataFetcher.fetchSingleDictIds(DIMENSION_NAME, docIds, 0, length, dictIds, 0);
-    _dataFetcher.fetchSingleStringValues(DIMENSION_NAME, dictIds, 0, length, stringValues, 0);
+    _dataFetcher.fetchStringValues(DIMENSION_NAME, docIds, 0, length, stringValues, 0);
 
     for (int i = 0; i < length; i++) {
       Assert.assertEquals(stringValues[i], _dimensionValues[docIds[i]], _errorMessage);
@@ -213,11 +198,8 @@ public class DataFetcherTest {
       docIds[length++] = i;
     }
 
-    int[] dictIds = new int[length];
     double[] hashCodes = new double[length];
-
-    _dataFetcher.fetchSingleDictIds(DIMENSION_NAME, docIds, 0, length, dictIds, 0);
-    _dataFetcher.fetchSingleHashCodes(DIMENSION_NAME, dictIds, 0, length, hashCodes, 0);
+    _dataFetcher.fetchHashCodes(DIMENSION_NAME, docIds, 0, length, hashCodes, 0);
 
     for (int i = 0; i < length; i++) {
       Assert.assertEquals((int) hashCodes[i], _dimensionValues[docIds[i]].hashCode(), _errorMessage);


### PR DESCRIPTION
Refactor: Modify BlockValSet interface to support filtered as well as unfiltered
blocks.
1. Added api's to get values for a specific set of docIds. This is
required to support fetching values from DataSource block, which does
not have docIds of its own (as opposed to Projection block).
2. Pushed down responsibility to get dictionary id's for docId's, from
DataBlockCache to DataFetcher. This is in preparation for no-dictionary
support.