### PR TITLE
Enhance SelectionOperatorUtils/Service to allow rows with type compatible data schema to merge.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -257,6 +257,66 @@ public abstract class FieldSpec {
       return this.ordinal() < BYTE_ARRAY.ordinal();
     }
 
+    public DataType toMultiValue() {
+      switch (this) {
+        case BYTE:
+          return BYTE_ARRAY;
+        case CHAR:
+          return CHAR_ARRAY;
+        case INT:
+          return INT_ARRAY;
+        case LONG:
+          return LONG_ARRAY;
+        case FLOAT:
+          return FLOAT_ARRAY;
+        case DOUBLE:
+          return DOUBLE_ARRAY;
+        case STRING:
+          return STRING_ARRAY;
+        default:
+          throw new UnsupportedOperationException("Unsupported toMultiValue for data type: " + this);
+      }
+    }
+
+    public DataType toSingleValue() {
+      switch (this) {
+        case BYTE_ARRAY:
+          return BYTE;
+        case CHAR_ARRAY:
+          return CHAR;
+        case INT_ARRAY:
+          return INT;
+        case LONG_ARRAY:
+          return LONG;
+        case FLOAT_ARRAY:
+          return FLOAT;
+        case DOUBLE_ARRAY:
+          return DOUBLE;
+        case STRING_ARRAY:
+          return STRING;
+        default:
+          throw new UnsupportedOperationException("Unsupported toSingleValue for data type: " + this);
+      }
+    }
+
+    public boolean isCompatible(DataType anotherDataType) {
+      // Single-value is not compatible with multi-value.
+      if (isSingleValue() != anotherDataType.isSingleValue()) {
+        return false;
+      }
+      // Number is not compatible with String.
+      if (isSingleValue()) {
+        if (isNumber() != anotherDataType.isNumber()) {
+          return false;
+        }
+      } else {
+        if (toSingleValue().isNumber() != anotherDataType.toSingleValue().isNumber()) {
+          return false;
+        }
+      }
+      return true;
+    }
+
     /**
      * Return the {@link DataType} stored in pinot.
      */
@@ -321,7 +381,8 @@ public abstract class FieldSpec {
       }
     }
 
-    public JSONObject toJSONSchemaFor(String column) throws JSONException {
+    public JSONObject toJSONSchemaFor(String column)
+        throws JSONException {
       final JSONObject ret = new JSONObject();
       ret.put("name", column);
       ret.put("doc", "data sample from load generator");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -175,7 +175,7 @@ public class IntermediateResultsBlock implements Block {
   }
 
   private DataTable getSelectionResultDataTable() throws Exception {
-    return attachMetadataToDataTable(SelectionOperatorUtils.getDataTableFromRowSet(_selectionResult, _dataSchema));
+    return attachMetadataToDataTable(SelectionOperatorUtils.getDataTableFromRows(_selectionResult, _dataSchema));
   }
 
   public DataTable getAggregationResultDataTable() throws Exception {
@@ -251,6 +251,13 @@ public class IntermediateResultsBlock implements Block {
 
   public void setExceptionsList(List<ProcessingException> processingExceptions) {
     _processingExceptions = processingExceptions;
+  }
+
+  public void addToExceptionsList(ProcessingException processingException) {
+    if (_processingExceptions == null) {
+      _processingExceptions = new ArrayList<>();
+    }
+    _processingExceptions.add(processingException);
   }
 
   public void setNumDocsScanned(long numDocsScanned) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
@@ -32,6 +32,7 @@ import com.linkedin.pinot.core.query.selection.SelectionOperatorUtils;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,24 +48,21 @@ public class MSelectionOnlyOperator extends BaseOperator {
 
   private final IndexSegment _indexSegment;
   private final MProjectionOperator _projectionOperator;
-  private final Selection _selection;
   private final DataSchema _dataSchema;
   private final Block[] _blocks;
-  private final String[] _selectionColumns;
   private final int _limitDocs;
   private final Collection<Serializable[]> _rowEvents;
   private ExecutionStatistics _executionStatistics;
 
   public MSelectionOnlyOperator(IndexSegment indexSegment, Selection selection, Operator projectionOperator) {
     _indexSegment = indexSegment;
-    _selection = selection;
-    _limitDocs = _selection.getSize();
+    _limitDocs = selection.getSize();
     _projectionOperator = (MProjectionOperator) projectionOperator;
-
-    _selectionColumns = SelectionOperatorUtils.extractSelectionRelatedColumns(_selection, _indexSegment);
-    _dataSchema = SelectionOperatorUtils.extractDataSchema(_selectionColumns, indexSegment);
-    _blocks = new Block[_selectionColumns.length];
-    _rowEvents = new ArrayList<Serializable[]>();
+    List<String> selectionColumns =
+        SelectionOperatorUtils.getSelectionColumns(selection.getSelectionColumns(), indexSegment);
+    _dataSchema = SelectionOperatorUtils.extractDataSchema(null, selectionColumns, indexSegment);
+    _blocks = new Block[selectionColumns.size()];
+    _rowEvents = new ArrayList<>();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOrderByOperator.java
@@ -107,7 +107,7 @@ public class MSelectionOrderByOperator extends BaseOperator {
             numTotalRawDocs);
 
     IntermediateResultsBlock resultBlock = new IntermediateResultsBlock();
-    resultBlock.setSelectionResult(_selectionOperatorService.getRowEventsSet());
+    resultBlock.setSelectionResult(_selectionOperatorService.getRows());
     resultBlock.setSelectionDataSchema(_selectionOperatorService.getDataSchema());
     return resultBlock;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/SelectionPlanNode.java
@@ -53,7 +53,8 @@ public class SelectionPlanNode implements PlanNode {
 
   @Override
   public Operator run() {
-    if (_selection.isSetSelectionSortSequence()) {
+    // Use selection order-by operator only if there are sorting columns and selection size is not 0.
+    if (_selection.isSetSelectionSortSequence() && (_selection.getSize() != 0)) {
       return new MSelectionOrderByOperator(_indexSegment, _selection, _projectionPlanNode.run());
     } else {
       return new MSelectionOnlyOperator(_indexSegment, _selection, _projectionPlanNode.run());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorService.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.query.selection;
 
-import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.request.Selection;
 import com.linkedin.pinot.common.request.SelectionSort;
 import com.linkedin.pinot.common.response.ServerInstance;
@@ -31,10 +30,13 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 
@@ -64,124 +66,167 @@ import javax.annotation.Nonnull;
  * </ul>
  */
 public class SelectionOperatorService {
-
   private final List<String> _selectionColumns;
   private final List<SelectionSort> _sortSequence;
   private final DataSchema _dataSchema;
   private final int _selectionOffset;
-  private final int _maxRowSize;
-  private final PriorityQueue<Serializable[]> _rowEventsSet;
+  private final int _maxNumRows;
+  private final PriorityQueue<Serializable[]> _rows;
 
   private long _numDocsScanned = 0;
 
   /**
-   * Constructor for <code>SelectionOperatorService</code> with {@link IndexSegment}. (Server side)
+   * Constructor for <code>SelectionOperatorService</code> with {@link IndexSegment}. (Inner segment)
    *
    * @param selection selection query.
    * @param indexSegment index segment.
    */
   public SelectionOperatorService(@Nonnull Selection selection, @Nonnull IndexSegment indexSegment) {
     _selectionColumns = SelectionOperatorUtils.getSelectionColumns(selection.getSelectionColumns(), indexSegment);
-    _sortSequence = selection.getSelectionSortSequence();
-    // For highest performance, only allow selection queries with ORDER BY.
-    Preconditions.checkState(_sortSequence != null && !_sortSequence.isEmpty());
+    _sortSequence = getSortSequence(selection.getSelectionSortSequence());
     _dataSchema = SelectionOperatorUtils.extractDataSchema(_sortSequence, _selectionColumns, indexSegment);
-
-    // TODO: selectionSize should never be 0 on this layer, address LIMIT 0 selection queries on upper layer.
-    int selectionSize = selection.getSize();
-    if (selectionSize == 0) {
-      // No need to select any row.
-      _selectionOffset = 0;
-      _maxRowSize = 0;
-      _rowEventsSet = new PriorityQueue<>(1);
-    } else {
-      // Select rows from offset to offset + size.
-      _selectionOffset = selection.getOffset();
-      _maxRowSize = _selectionOffset + selectionSize;
-      _rowEventsSet = new PriorityQueue<>(_maxRowSize, getComparator());
-    }
+    // Select rows from offset to offset + size.
+    _selectionOffset = selection.getOffset();
+    _maxNumRows = _selectionOffset + selection.getSize();
+    _rows = new PriorityQueue<>(_maxNumRows, getStrictComparator());
   }
 
   /**
-   * Constructor for <code>SelectionOperatorService</code> with {@link DataSchema}. (Broker side)
+   * Constructor for <code>SelectionOperatorService</code> with {@link DataSchema}. (Inter segment)
    *
    * @param selection selection query.
    * @param dataSchema data schema.
    */
   public SelectionOperatorService(@Nonnull Selection selection, @Nonnull DataSchema dataSchema) {
     _selectionColumns = SelectionOperatorUtils.getSelectionColumns(selection.getSelectionColumns(), dataSchema);
-    _sortSequence = selection.getSelectionSortSequence();
-    // For highest performance, only allow selection queries with ORDER BY.
-    Preconditions.checkState(_sortSequence != null && !_sortSequence.isEmpty());
+    _sortSequence = getSortSequence(selection.getSelectionSortSequence());
     _dataSchema = dataSchema;
-
-    // TODO: selectionSize should never be 0 on this layer, address LIMIT 0 selection queries on upper layer.
-    int selectionSize = selection.getSize();
-    if (selectionSize == 0) {
-      // No need to select any row.
-      _selectionOffset = 0;
-      _maxRowSize = 0;
-      _rowEventsSet = new PriorityQueue<>(1);
-    } else {
-      // Select rows from offset to offset + size.
-      _selectionOffset = selection.getOffset();
-      _maxRowSize = _selectionOffset + selectionSize;
-      _rowEventsSet = new PriorityQueue<>(_maxRowSize, getComparator());
-    }
+    // Select rows from offset to offset + size.
+    _selectionOffset = selection.getOffset();
+    _maxNumRows = _selectionOffset + selection.getSize();
+    _rows = new PriorityQueue<>(_maxNumRows, getTypeCompatibleComparator());
   }
 
   /**
-   * Helper method to get the {@link Comparator} for selection rows.
+   * Helper method to handle duplicate sort columns.
    *
-   * @return {@link Comparator} for selection rows.
+   * @return de-duplicated list of sort sequences.
    */
-  private Comparator<Serializable[]> getComparator() {
+  @Nonnull
+  private List<SelectionSort> getSortSequence(List<SelectionSort> selectionSorts) {
+    List<SelectionSort> deDupedSelectionSorts = new ArrayList<>();
+    Set<String> sortColumns = new HashSet<>();
+    for (SelectionSort selectionSort : selectionSorts) {
+      String sortColumn = selectionSort.getColumn();
+      if (!sortColumns.contains(sortColumn)) {
+        deDupedSelectionSorts.add(selectionSort);
+        sortColumns.add(sortColumn);
+      }
+    }
+    return deDupedSelectionSorts;
+  }
+
+  /**
+   * Helper method to get the strict {@link Comparator} for selection rows. (Inner segment)
+   * <p>Strict comparator does not allow any schema mismatch (more performance driven).
+   *
+   * @return strict {@link Comparator} for selection rows.
+   */
+  @Nonnull
+  private Comparator<Serializable[]> getStrictComparator() {
     return new Comparator<Serializable[]>() {
       @Override
       public int compare(Serializable[] o1, Serializable[] o2) {
         int numSortColumns = _sortSequence.size();
         for (int i = 0; i < numSortColumns; i++) {
           int ret = 0;
+          SelectionSort selectionSort = _sortSequence.get(i);
+          Serializable v1 = o1[i];
+          Serializable v2 = o2[i];
+
           // Only compare single-value columns.
           switch (_dataSchema.getColumnType(i)) {
             case INT:
-              if (!_sortSequence.get(i).isIsAsc()) {
-                ret = ((Integer) o1[i]).compareTo((Integer) o2[i]);
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Integer) v1).compareTo((Integer) v2);
               } else {
-                ret = ((Integer) o2[i]).compareTo((Integer) o1[i]);
+                ret = ((Integer) v2).compareTo((Integer) v1);
               }
               break;
             case LONG:
-              if (!_sortSequence.get(i).isIsAsc()) {
-                ret = ((Long) o1[i]).compareTo((Long) o2[i]);
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Long) v1).compareTo((Long) v2);
               } else {
-                ret = ((Long) o2[i]).compareTo((Long) o1[i]);
+                ret = ((Long) v2).compareTo((Long) v1);
               }
               break;
             case FLOAT:
-              if (!_sortSequence.get(i).isIsAsc()) {
-                ret = ((Float) o1[i]).compareTo((Float) o2[i]);
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Float) v1).compareTo((Float) v2);
               } else {
-                ret = ((Float) o2[i]).compareTo((Float) o1[i]);
+                ret = ((Float) v2).compareTo((Float) v1);
               }
               break;
             case DOUBLE:
-              if (!_sortSequence.get(i).isIsAsc()) {
-                ret = ((Double) o1[i]).compareTo((Double) o2[i]);
+              if (!selectionSort.isIsAsc()) {
+                ret = ((Double) v1).compareTo((Double) v2);
               } else {
-                ret = ((Double) o2[i]).compareTo((Double) o1[i]);
+                ret = ((Double) v2).compareTo((Double) v1);
               }
               break;
             case STRING:
-              if (!_sortSequence.get(i).isIsAsc()) {
-                ret = ((String) o1[i]).compareTo((String) o2[i]);
+              if (!selectionSort.isIsAsc()) {
+                ret = ((String) v1).compareTo((String) v2);
               } else {
-                ret = ((String) o2[i]).compareTo((String) o1[i]);
+                ret = ((String) v2).compareTo((String) v1);
               }
               break;
             default:
               break;
           }
+
+          if (ret != 0) {
+            return ret;
+          }
+        }
+        return 0;
+      }
+    };
+  }
+
+  /**
+   * Helper method to get the type-compatible {@link Comparator} for selection rows. (Inter segment)
+   * <p>Type-compatible comparator allows compatible types to compare with each other.
+   *
+   * @return flexible {@link Comparator} for selection rows.
+   */
+  @Nonnull
+  private Comparator<Serializable[]> getTypeCompatibleComparator() {
+    return new Comparator<Serializable[]>() {
+      @Override
+      public int compare(Serializable[] o1, Serializable[] o2) {
+        int numSortColumns = _sortSequence.size();
+        for (int i = 0; i < numSortColumns; i++) {
+          int ret = 0;
+          SelectionSort selectionSort = _sortSequence.get(i);
+          Serializable v1 = o1[i];
+          Serializable v2 = o2[i];
+
+          // Only compare single-value columns.
+          if (v1 instanceof Number) {
+            if (!selectionSort.isIsAsc()) {
+              ret = Double.compare(((Number) v1).doubleValue(), ((Number) v2).doubleValue());
+            } else {
+              ret = Double.compare(((Number) v2).doubleValue(), ((Number) v1).doubleValue());
+            }
+          } else if (v1 instanceof String) {
+            if (!selectionSort.isIsAsc()) {
+              ret = ((String) v1).compareTo((String) v2);
+            } else {
+              ret = ((String) v2).compareTo((String) v1);
+            }
+          }
+
           if (ret != 0) {
             return ret;
           }
@@ -196,6 +241,7 @@ public class SelectionOperatorService {
    *
    * @return data schema.
    */
+  @Nonnull
   public DataSchema getDataSchema() {
     return _dataSchema;
   }
@@ -205,12 +251,13 @@ public class SelectionOperatorService {
    *
    * @return selection results.
    */
-  public PriorityQueue<Serializable[]> getRowEventsSet() {
-    return _rowEventsSet;
+  @Nonnull
+  public PriorityQueue<Serializable[]> getRows() {
+    return _rows;
   }
 
   /**
-   * Get number of documents scanned.
+   * Get number of documents scanned. (Inner segment)
    *
    * @return number of documents scanned.
    */
@@ -220,99 +267,104 @@ public class SelectionOperatorService {
 
   /**
    * Iterate over {@link Block}s, extract values from them and merge the values to the selection results for selection
-   * queries with <code>ORDER BY</code>. (Server side)
+   * queries with <code>ORDER BY</code>. (Inner segment)
    *
    * @param blockDocIdIterator block document id iterator.
    * @param blocks {@link Block} array.
    */
   public void iterateOnBlocksWithOrdering(@Nonnull BlockDocIdIterator blockDocIdIterator, @Nonnull Block[] blocks) {
-    if (_maxRowSize > 0) {
-      Comparator<Integer> rowDocIdComparator = new CompositeDocIdValComparator(_sortSequence, blocks);
-      PriorityQueue<Integer> rowDocIdPriorityQueue = new PriorityQueue<>(_maxRowSize, rowDocIdComparator);
-      int docId;
-      while ((docId = blockDocIdIterator.next()) != Constants.EOF) {
-        _numDocsScanned++;
-        addToPriorityQueue(docId, rowDocIdPriorityQueue);
-      }
-
-      SelectionFetcher selectionFetcher = new SelectionFetcher(blocks, _dataSchema);
-      Collection<Serializable[]> rowEventsSet = new ArrayList<>(rowDocIdPriorityQueue.size());
-      for (int rowDocId : rowDocIdPriorityQueue) {
-        rowEventsSet.add(selectionFetcher.getRow(rowDocId));
-      }
-      mergeWithOrdering(_rowEventsSet, rowEventsSet);
+    Comparator<Integer> rowDocIdComparator = new CompositeDocIdValComparator(_sortSequence, blocks);
+    PriorityQueue<Integer> rowDocIdPriorityQueue = new PriorityQueue<>(_maxNumRows, rowDocIdComparator);
+    int docId;
+    while ((docId = blockDocIdIterator.next()) != Constants.EOF) {
+      _numDocsScanned++;
+      SelectionOperatorUtils.addToPriorityQueue(docId, rowDocIdPriorityQueue, _maxNumRows);
     }
+
+    SelectionFetcher selectionFetcher = new SelectionFetcher(blocks, _dataSchema);
+    Collection<Serializable[]> rows = new ArrayList<>(rowDocIdPriorityQueue.size());
+    for (int rowDocId : rowDocIdPriorityQueue) {
+      rows.add(selectionFetcher.getRow(rowDocId));
+    }
+    SelectionOperatorUtils.mergeWithOrdering(_rows, rows, _maxNumRows);
   }
 
   /**
-   * Merge two partial results for selection queries with <code>ORDER BY</code>. (Server side)
-   *
-   * @param mergedRowEventsSet partial results 1.
-   * @param toMergeRowEventsSet partial results 2.
-   */
-  public void mergeWithOrdering(@Nonnull Collection<Serializable[]> mergedRowEventsSet,
-      @Nonnull Collection<Serializable[]> toMergeRowEventsSet) {
-    if (_maxRowSize > 0) {
-      PriorityQueue<Serializable[]> mergedPriorityQueue = (PriorityQueue<Serializable[]>) mergedRowEventsSet;
-      for (Serializable[] row : toMergeRowEventsSet) {
-        addToPriorityQueue(row, mergedPriorityQueue);
-      }
-    }
-  }
-
-  /**
-   * Reduce a collection of {@link DataTable}s to selection results for selection queries with <code>ORDER BY</code>.
+   * Reduce a collection of {@link DataTable}s to selection rows for selection queries with <code>ORDER BY</code>.
    * (Broker side)
    *
    * @param selectionResults {@link Map} from {@link ServerInstance} to {@link DataTable}.
-   * @return reduced results.
    */
-  public PriorityQueue<Serializable[]> reduceWithOrdering(@Nonnull Map<ServerInstance, DataTable> selectionResults) {
-    if (_maxRowSize > 0) {
-      for (DataTable dataTable : selectionResults.values()) {
-        int numRows = dataTable.getNumberOfRows();
-        for (int rowId = 0; rowId < numRows; rowId++) {
-          Serializable[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
-          addToPriorityQueue(row, _rowEventsSet);
-        }
+  public void reduceWithOrdering(@Nonnull Map<ServerInstance, DataTable> selectionResults) {
+    for (DataTable dataTable : selectionResults.values()) {
+      int numRows = dataTable.getNumberOfRows();
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        Serializable[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
+        SelectionOperatorUtils.addToPriorityQueue(row, _rows, _maxNumRows);
       }
     }
-    return _rowEventsSet;
   }
 
   /**
-   * Render the final selection results to a {@link SelectionResults} object for selection queries with
+   * Render the unformatted selection rows to a formatted {@link SelectionResults} object for selection queries with
    * <code>ORDER BY</code>. (Broker side)
-   * <p>{@link SelectionResults} object will be used in building the BrokerResponse.
+   * <p>{@link SelectionResults} object will be used to build the broker response.
+   * <p>Should be called after method "reduceWithOrdering()".
    *
-   * @param finalResults final selection results.
    * @return {@link SelectionResults} object results.
    */
-  public SelectionResults renderSelectionResultsWithOrdering(@Nonnull Collection<Serializable[]> finalResults) {
-    LinkedList<Serializable[]> rowEventsSet = new LinkedList<>();
+  @Nonnull
+  public SelectionResults renderSelectionResultsWithOrdering() {
+    LinkedList<Serializable[]> rowsInSelectionResults = new LinkedList<>();
 
-    PriorityQueue<Serializable[]> finalResultsPriorityQueue = (PriorityQueue<Serializable[]>) finalResults;
-    while (finalResultsPriorityQueue.size() > _selectionOffset) {
-      rowEventsSet.addFirst(
-          SelectionOperatorUtils.getFormattedRow(finalResultsPriorityQueue.poll(), _selectionColumns, _dataSchema));
+    int[] columnIndices = getColumnIndices();
+    while (_rows.size() > _selectionOffset) {
+      rowsInSelectionResults.addFirst(getFormattedRowWithOrdering(_rows.poll(), columnIndices));
     }
 
-    return new SelectionResults(_selectionColumns, rowEventsSet);
+    return new SelectionResults(_selectionColumns, rowsInSelectionResults);
   }
 
   /**
-   * Helper method to add a value to a {@link PriorityQueue}.
+   * Helper method to get each selection column index in data schema.
    *
-   * @param value value to be added.
-   * @param queue priority queue.
-   * @param <T> type for the value.
+   * @return column indices.
    */
-  private <T> void addToPriorityQueue(@Nonnull T value, @Nonnull PriorityQueue<T> queue) {
-    if (queue.size() < _maxRowSize) {
-      queue.add(value);
-    } else if (queue.comparator().compare(queue.peek(), value) < 0) {
-      queue.poll();
-      queue.add(value);
+  private int[] getColumnIndices() {
+    int numSelectionColumns = _selectionColumns.size();
+    int[] columnIndices = new int[numSelectionColumns];
+
+    Map<String, Integer> dataSchemaIndices = new HashMap<>();
+    int numColumnsInDataSchema = _dataSchema.size();
+    for (int i = 0; i < numColumnsInDataSchema; i++) {
+      dataSchemaIndices.put(_dataSchema.getColumnName(i), i);
     }
+
+    for (int i = 0; i < numSelectionColumns; i++) {
+      columnIndices[i] = dataSchemaIndices.get(_selectionColumns.get(i));
+    }
+
+    return columnIndices;
+  }
+
+  /**
+   * Helper method to format a selection row, make all values string or string array type based on data schema passed in
+   * for selection queries with <code>ORDER BY</code>. (Broker side)
+   * <p>Formatted row is used to build the {@link SelectionResults}.
+   *
+   * @param row selection row to be formatted.
+   * @param columnIndices column indices of original rows.
+   * @return formatted selection row.
+   */
+  @Nonnull
+  private Serializable[] getFormattedRowWithOrdering(@Nonnull Serializable[] row, @Nonnull int[] columnIndices) {
+    int numColumns = columnIndices.length;
+    Serializable[] formattedRow = new Serializable[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      int columnIndex = columnIndices[i];
+      formattedRow[i] =
+          SelectionOperatorUtils.getFormattedValue(row[columnIndex], _dataSchema.getColumnType(columnIndex));
+    }
+    return formattedRow;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -23,7 +23,6 @@ import com.linkedin.pinot.common.response.broker.SelectionResults;
 import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.common.utils.DataTableBuilder;
 import com.linkedin.pinot.common.utils.DataTableBuilder.DataSchema;
-import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import java.io.Serializable;
@@ -33,12 +32,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.PriorityQueue;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -46,7 +45,7 @@ import javax.annotation.Nullable;
 
 /**
  * The <code>SelectionOperatorUtils</code> class provides the utility methods for selection queries without
- * <code>ORDER BY</code>.
+ * <code>ORDER BY</code> and {@link SelectionOperatorService}.
  * <p>Expected behavior:
  * <ul>
  *   <li>
@@ -67,88 +66,24 @@ public class SelectionOperatorUtils {
   private SelectionOperatorUtils() {
   }
 
-  private static final Map<DataType, DecimalFormat> DEFAULT_FORMAT_STRING_MAP = new HashMap<>();
-
-  static {
-    DEFAULT_FORMAT_STRING_MAP.put(DataType.INT,
-        new DecimalFormat("##########", DecimalFormatSymbols.getInstance(Locale.US)));
-    DEFAULT_FORMAT_STRING_MAP.put(DataType.LONG,
-        new DecimalFormat("####################", DecimalFormatSymbols.getInstance(Locale.US)));
-    DEFAULT_FORMAT_STRING_MAP.put(DataType.FLOAT,
-        new DecimalFormat("#########0.0####", DecimalFormatSymbols.getInstance(Locale.US)));
-    DEFAULT_FORMAT_STRING_MAP.put(DataType.DOUBLE,
-        new DecimalFormat("###################0.0#########", DecimalFormatSymbols.getInstance(Locale.US)));
-  }
-
-  /**
-   * Merge two partial results for selection queries without <code>ORDER BY</code>. (Server side)
-   *
-   * @param mergedRowEventsSet partial results 1.
-   * @param toMergeRowEventsSet partial results 2.
-   * @param maxRowSize maximum number of rows in merged result.
-   */
-  public static void mergeWithoutOrdering(@Nonnull Collection<Serializable[]> mergedRowEventsSet,
-      @Nonnull Collection<Serializable[]> toMergeRowEventsSet, int maxRowSize) {
-    Iterator<Serializable[]> iterator = toMergeRowEventsSet.iterator();
-    while (mergedRowEventsSet.size() < maxRowSize && iterator.hasNext()) {
-      mergedRowEventsSet.add(iterator.next());
-    }
-  }
-
-  /**
-   * Reduce a collection of {@link DataTable}s to selection results for selection queries without <code>ORDER BY</code>.
-   * (Broker side)
-   *
-   * @param selectionResults {@link Map} from {@link ServerInstance} to {@link DataTable}.
-   * @param maxRowSize maximum number of rows in reduced result.
-   * @return reduced results.
-   */
-  public static Collection<Serializable[]> reduceWithoutOrdering(
-      @Nonnull Map<ServerInstance, DataTable> selectionResults, int maxRowSize) {
-    Collection<Serializable[]> rowEventsSet = new ArrayList<>(maxRowSize);
-    for (DataTable dataTable : selectionResults.values()) {
-      int numRows = dataTable.getNumberOfRows();
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (rowEventsSet.size() < maxRowSize) {
-          rowEventsSet.add(extractRowFromDataTable(dataTable, rowId));
-        } else {
-          break;
-        }
-      }
-    }
-    return rowEventsSet;
-  }
-
-  /**
-   * Render the final selection results to a {@link SelectionResults} object for selection queries without
-   * <code>ORDER BY</code>. (Broker side)
-   * <p>{@link SelectionResults} object will be used in building the BrokerResponse.
-   *
-   * @param finalResults final selection results.
-   * @param selectionColumns selection columns.
-   * @param dataSchema data schema.
-   * @return {@link SelectionResults} object results.
-   */
-  public static SelectionResults renderSelectionResultsWithoutOrdering(@Nonnull Collection<Serializable[]> finalResults,
-      @Nonnull List<String> selectionColumns, @Nonnull DataSchema dataSchema) {
-    selectionColumns = getSelectionColumns(selectionColumns, dataSchema);
-
-    List<Serializable[]> rowEvents = new ArrayList<>();
-    for (Serializable[] row : finalResults) {
-      rowEvents.add(getFormattedRow(row, selectionColumns, dataSchema));
-    }
-
-    return new SelectionResults(selectionColumns, rowEvents);
-  }
+  private static final DecimalFormat INT_FORMAT =
+      new DecimalFormat("##########", DecimalFormatSymbols.getInstance(Locale.US));
+  private static final DecimalFormat LONG_FORMAT =
+      new DecimalFormat("####################", DecimalFormatSymbols.getInstance(Locale.US));
+  private static final DecimalFormat FLOAT_FORMAT =
+      new DecimalFormat("#########0.0####", DecimalFormatSymbols.getInstance(Locale.US));
+  private static final DecimalFormat DOUBLE_FORMAT =
+      new DecimalFormat("###################0.0#########", DecimalFormatSymbols.getInstance(Locale.US));
 
   /**
    * Expand <code>'SELECT *'</code> to select all columns with {@link IndexSegment}, order all columns alphabatically.
-   * (Server side)
+   * (Inner segment)
    *
    * @param selectionColumns unexpanded selection columns (may contain '*').
    * @param indexSegment index segment.
    * @return expanded selection columns.
    */
+  @Nonnull
   public static List<String> getSelectionColumns(@Nonnull List<String> selectionColumns,
       @Nonnull IndexSegment indexSegment) {
     if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
@@ -161,13 +96,80 @@ public class SelectionOperatorUtils {
   }
 
   /**
+   * Extract all related columns for a selection query with {@link IndexSegment}. (Inner segment)
+   *
+   * @param selection selection query.
+   * @param indexSegment index segment.
+   * @return all related columns.
+   */
+  @Nonnull
+  public static String[] extractSelectionRelatedColumns(@Nonnull Selection selection,
+      @Nonnull IndexSegment indexSegment) {
+    Set<String> selectionColumns = new HashSet<>(getSelectionColumns(selection.getSelectionColumns(), indexSegment));
+    if (selection.getSelectionSortSequence() != null) {
+      for (SelectionSort selectionSort : selection.getSelectionSortSequence()) {
+        selectionColumns.add(selectionSort.getColumn());
+      }
+    }
+    return selectionColumns.toArray(new String[selectionColumns.size()]);
+  }
+
+  /**
+   * Extract the {@link DataSchema} from sort sequence, selection columns and {@link IndexSegment}. (Inner segment)
+   * <p>Inside data schema, we just store each column once (de-duplicated).
+   *
+   * @param sortSequence sort sequence.
+   * @param selectionColumns selection columns.
+   * @param indexSegment index segment.
+   * @return data schema.
+   */
+  @Nonnull
+  public static DataSchema extractDataSchema(@Nullable List<SelectionSort> sortSequence,
+      @Nonnull List<String> selectionColumns, @Nonnull IndexSegment indexSegment) {
+    List<String> columnList = new ArrayList<>();
+    Set<String> columnSet = new HashSet<>();
+
+    if (sortSequence != null) {
+      for (SelectionSort selectionSort : sortSequence) {
+        String column = selectionSort.getColumn();
+        columnList.add(column);
+        columnSet.add(column);
+      }
+    }
+
+    for (String column : selectionColumns) {
+      if (!columnSet.contains(column)) {
+        columnList.add(column);
+        columnSet.add(column);
+      }
+    }
+
+    int numColumns = columnList.size();
+    String[] columns = new String[numColumns];
+    DataType[] dataTypes = new DataType[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      String column = columnList.get(i);
+      columns[i] = column;
+      DataSourceMetadata columnMetadata = indexSegment.getDataSource(column).getDataSourceMetadata();
+      if (columnMetadata.isSingleValue()) {
+        dataTypes[i] = columnMetadata.getDataType();
+      } else {
+        dataTypes[i] = columnMetadata.getDataType().toMultiValue();
+      }
+    }
+
+    return new DataSchema(columns, dataTypes);
+  }
+
+  /**
    * Expand <code>'SELECT *'</code> to select all columns with {@link DataSchema}, order all columns alphabatically.
-   * (Broker side)
+   * (Inter segment)
    *
    * @param selectionColumns unexpanded selection columns (may contain '*').
    * @param dataSchema data schema.
    * @return expanded selection columns.
    */
+  @Nonnull
   public static List<String> getSelectionColumns(@Nonnull List<String> selectionColumns,
       @Nonnull DataSchema dataSchema) {
     if ((selectionColumns.size() == 1) && selectionColumns.get(0).equals("*")) {
@@ -184,183 +186,158 @@ public class SelectionOperatorUtils {
   }
 
   /**
-   * Extract all related columns for a selection query with {@link IndexSegment}. (Server side)
+   * Merge two partial results for selection queries without <code>ORDER BY</code>. (Server side)
    *
-   * @param selection selection query.
-   * @param indexSegment index segment.
-   * @return all related columns.
+   * @param mergedRows partial results 1.
+   * @param rowsToMerge partial results 2.
+   * @param selectionSize size of the selection.
    */
-  public static String[] extractSelectionRelatedColumns(@Nonnull Selection selection,
-      @Nonnull IndexSegment indexSegment) {
-    Set<String> selectionColumns = new HashSet<>(getSelectionColumns(selection.getSelectionColumns(), indexSegment));
-    if (selection.getSelectionSortSequence() != null) {
-      for (SelectionSort selectionSort : selection.getSelectionSortSequence()) {
-        selectionColumns.add(selectionSort.getColumn());
-      }
+  public static void mergeWithoutOrdering(@Nonnull Collection<Serializable[]> mergedRows,
+      @Nonnull Collection<Serializable[]> rowsToMerge, int selectionSize) {
+    Iterator<Serializable[]> iterator = rowsToMerge.iterator();
+    while (mergedRows.size() < selectionSize && iterator.hasNext()) {
+      mergedRows.add(iterator.next());
     }
-    return selectionColumns.toArray(new String[selectionColumns.size()]);
   }
 
   /**
-   * Extract the {@link DataSchema} from selection columns and {@link IndexSegment}.
+   * Merge two partial results for selection queries with <code>ORDER BY</code>. (Server side)
    *
-   * @param selectionColumns selection columns.
-   * @param indexSegment index segment.
-   * @return data schema.
+   * @param mergedRows partial results 1.
+   * @param rowsToMerge partial results 2.
+   * @param maxNumRows maximum number of rows need to be stored.
    */
-  public static DataSchema extractDataSchema(@Nonnull String[] selectionColumns, @Nonnull IndexSegment indexSegment) {
-    return extractDataSchema(null, Arrays.asList(selectionColumns), indexSegment);
+  public static void mergeWithOrdering(@Nonnull PriorityQueue<Serializable[]> mergedRows,
+      @Nonnull Collection<Serializable[]> rowsToMerge, int maxNumRows) {
+    for (Serializable[] row : rowsToMerge) {
+      addToPriorityQueue(row, mergedRows, maxNumRows);
+    }
   }
 
   /**
-   * Extract the {@link DataSchema} from sort sequence, selection columns and {@link IndexSegment}.
+   * Build a {@link DataTable} from a {@link Collection} of selection rows with {@link DataSchema}. (Server side)
+   * <p>The passed in data schema stored the column data type that can cover all actual data types for that column.
+   * <p>The actual data types for each column in rows can be different but must be compatible with each other.
+   * <p>Before write each row into the data table, first convert it to match the data types in data schema.
    *
-   * @param sortSequence sort sequence.
-   * @param selectionColumns selection columns.
-   * @param indexSegment index segment.
-   * @return data schema.
-   */
-  public static DataSchema extractDataSchema(@Nullable List<SelectionSort> sortSequence,
-      @Nonnull List<String> selectionColumns, @Nonnull IndexSegment indexSegment) {
-    List<String> columns = new ArrayList<>();
-
-    if (sortSequence != null) {
-      for (SelectionSort selectionSort : sortSequence) {
-        columns.add(selectionSort.getColumn());
-      }
-    }
-
-    String[] selectionColumnArray = selectionColumns.toArray(new String[selectionColumns.size()]);
-    Arrays.sort(selectionColumnArray);
-    for (String selectionColumn : selectionColumnArray) {
-      if (!columns.contains(selectionColumn)) {
-        columns.add(selectionColumn);
-      }
-    }
-
-    int numColumns = columns.size();
-    DataType[] dataTypes = new DataType[numColumns];
-    for (int i = 0; i < dataTypes.length; ++i) {
-      DataSource ds = indexSegment.getDataSource(columns.get(i));
-      DataSourceMetadata m = ds.getDataSourceMetadata();
-      dataTypes[i] = m.getDataType();
-      if (!m.isSingleValue()) {
-        dataTypes[i] = DataType.valueOf(dataTypes[i] + "_ARRAY");
-      }
-    }
-
-    return new DataSchema(columns.toArray(new String[numColumns]), dataTypes);
-  }
-
-  /**
-   * Format a selection row to make all values {@link String} type.
-   *
-   * @param row selection row.
-   * @param selectionColumns selection columns.
+   * @param rows {@link Collection} of selection rows.
    * @param dataSchema data schema.
-   * @return formatted selection row.
+   * @return data table.
+   * @throws Exception
    */
-  public static Serializable[] getFormattedRow(@Nonnull Serializable[] row, @Nonnull List<String> selectionColumns,
-      @Nonnull DataSchema dataSchema) {
-    int numColumns = selectionColumns.size();
-    Serializable[] formattedRow = new Serializable[numColumns];
-    Map<String, Integer> columnToIdxMapping = buildColumnToIdxMappingForDataSchema(dataSchema);
+  @Nonnull
+  public static DataTable getDataTableFromRows(@Nonnull Collection<Serializable[]> rows, @Nonnull DataSchema dataSchema)
+      throws Exception {
+    int numColumns = dataSchema.size();
 
-    for (int i = 0; i < numColumns; i++) {
-      String column = selectionColumns.get(i);
-      if (columnToIdxMapping.containsKey(column)) {
-        int idxInDataSchema = columnToIdxMapping.get(selectionColumns.get(i));
-        DataType columnType = dataSchema.getColumnType(idxInDataSchema);
-
-        if (columnType.isSingleValue()) {
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
+    dataTableBuilder.open();
+    for (Serializable[] row : rows) {
+      dataTableBuilder.startRow();
+      for (int i = 0; i < numColumns; i++) {
+        Serializable columnValue = row[i];
+        DataType columnType = dataSchema.getColumnType(i);
+        switch (columnType) {
           // Single-value column.
-          if (columnType == DataType.STRING) {
-            formattedRow[i] = row[idxInDataSchema];
-          } else {
-            formattedRow[i] =
-                DEFAULT_FORMAT_STRING_MAP.get(dataSchema.getColumnType(idxInDataSchema)).format(row[idxInDataSchema]);
-          }
-        } else {
-          // Multi-value column.
-          String[] multiValues;
-          int numValues;
+          case INT:
+            dataTableBuilder.setColumn(i, ((Number) columnValue).intValue());
+            break;
+          case LONG:
+            dataTableBuilder.setColumn(i, ((Number) columnValue).longValue());
+            break;
+          case FLOAT:
+            dataTableBuilder.setColumn(i, ((Number) columnValue).floatValue());
+            break;
+          case DOUBLE:
+            dataTableBuilder.setColumn(i, ((Number) columnValue).doubleValue());
+            break;
+          case STRING:
+            dataTableBuilder.setColumn(i, ((String) columnValue));
+            break;
 
-          switch (columnType) {
-            case INT_ARRAY:
-              int[] intValues = (int[]) row[idxInDataSchema];
-              numValues = intValues.length;
-              multiValues = new String[numValues];
-              for (int j = 0; j < numValues; j++) {
-                multiValues[j] = DEFAULT_FORMAT_STRING_MAP.get(DataType.INT).format(intValues[j]);
+          // Multi-value column.
+          case INT_ARRAY:
+            dataTableBuilder.setColumn(i, (int[]) columnValue);
+            break;
+          case LONG_ARRAY:
+            // LONG_ARRAY type covers INT_ARRAY and LONG_ARRAY.
+            if (columnValue instanceof int[]) {
+              int[] ints = (int[]) columnValue;
+              int length = ints.length;
+              long[] longs = new long[length];
+              for (int j = 0; j < length; j++) {
+                longs[j] = ints[j];
               }
-              break;
-            case LONG_ARRAY:
-              long[] longValues = (long[]) row[idxInDataSchema];
-              numValues = longValues.length;
-              multiValues = new String[numValues];
-              for (int j = 0; j < numValues; j++) {
-                multiValues[j] = DEFAULT_FORMAT_STRING_MAP.get(DataType.LONG).format(longValues[j]);
+              dataTableBuilder.setColumn(i, longs);
+            } else {
+              dataTableBuilder.setColumn(i, (long[]) columnValue);
+            }
+            break;
+          case FLOAT_ARRAY:
+            dataTableBuilder.setColumn(i, (float[]) columnValue);
+            break;
+          case DOUBLE_ARRAY:
+            // DOUBLE_ARRAY type covers INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY and DOUBLE_ARRAY.
+            if (columnValue instanceof int[]) {
+              int[] ints = (int[]) columnValue;
+              int length = ints.length;
+              double[] doubles = new double[length];
+              for (int j = 0; j < length; j++) {
+                doubles[j] = ints[j];
               }
-              break;
-            case FLOAT_ARRAY:
-              float[] floatValues = (float[]) row[idxInDataSchema];
-              numValues = floatValues.length;
-              multiValues = new String[numValues];
-              for (int j = 0; j < numValues; j++) {
-                multiValues[j] = DEFAULT_FORMAT_STRING_MAP.get(DataType.FLOAT).format(floatValues[j]);
+              dataTableBuilder.setColumn(i, doubles);
+            } else if (columnValue instanceof long[]) {
+              long[] longs = (long[]) columnValue;
+              int length = longs.length;
+              double[] doubles = new double[length];
+              for (int j = 0; j < length; j++) {
+                doubles[j] = longs[j];
               }
-              break;
-            case DOUBLE_ARRAY:
-              double[] doubleValues = (double[]) row[idxInDataSchema];
-              numValues = doubleValues.length;
-              multiValues = new String[numValues];
-              for (int j = 0; j < numValues; j++) {
-                multiValues[j] = DEFAULT_FORMAT_STRING_MAP.get(DataType.DOUBLE).format(doubleValues[j]);
+              dataTableBuilder.setColumn(i, doubles);
+            } else if (columnValue instanceof float[]) {
+              float[] floats = (float[]) columnValue;
+              int length = floats.length;
+              double[] doubles = new double[length];
+              for (int j = 0; j < length; j++) {
+                doubles[j] = floats[j];
               }
-              break;
-            case STRING_ARRAY:
-              multiValues = (String[]) row[idxInDataSchema];
-              break;
-            default:
-              throw new RuntimeException(
-                  "Unsupported data type " + columnType + " for column " + dataSchema.getColumnName(idxInDataSchema));
-          }
-          formattedRow[i] = multiValues;
+              dataTableBuilder.setColumn(i, doubles);
+            } else {
+              dataTableBuilder.setColumn(i, (double[]) columnValue);
+            }
+            break;
+          case STRING_ARRAY:
+            dataTableBuilder.setColumn(i, (String[]) columnValue);
+            break;
+
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported data type: " + columnType + " for column: " + dataSchema.getColumnName(i));
         }
       }
+      dataTableBuilder.finishRow();
     }
-    return formattedRow;
+    dataTableBuilder.seal();
+
+    return dataTableBuilder.build();
   }
 
   /**
-   * Build a {@link Map} from column name to column index in {@link DataSchema}.
-   *
-   * @param dataSchema data schema.
-   * @return {@link Map} from column name to column index.
-   */
-  private static Map<String, Integer> buildColumnToIdxMappingForDataSchema(@Nonnull DataSchema dataSchema) {
-    Map<String, Integer> columnToIdxMapping = new HashMap<>();
-    int numColumns = dataSchema.size();
-    for (int i = 0; i < numColumns; i++) {
-      columnToIdxMapping.put(dataSchema.getColumnName(i), i);
-    }
-    return columnToIdxMapping;
-  }
-
-  /**
-   * Extract a selection row from {@link DataTable}.
+   * Extract a selection row from {@link DataTable}. (Broker side)
    *
    * @param dataTable data table.
    * @param rowId row id.
    * @return selection row.
    */
+  @Nonnull
   public static Serializable[] extractRowFromDataTable(@Nonnull DataTable dataTable, int rowId) {
     DataSchema dataSchema = dataTable.getDataSchema();
-    int numRows = dataSchema.size();
+    int numColumns = dataSchema.size();
 
-    Serializable[] row = new Serializable[numRows];
-    for (int i = 0; i < numRows; i++) {
-      switch (dataSchema.getColumnType(i)) {
+    Serializable[] row = new Serializable[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      DataType columnType = dataSchema.getColumnType(i);
+      switch (columnType) {
         // Single-value column.
         case INT:
           row[i] = dataTable.getInt(rowId, i);
@@ -394,142 +371,188 @@ public class SelectionOperatorUtils {
         case STRING_ARRAY:
           row[i] = dataTable.getStringArray(rowId, i);
           break;
+
         default:
-          throw new RuntimeException(
-              "Unsupported data type " + dataSchema.getColumnType(i) + " for column " + dataSchema.getColumnName(i));
+          throw new UnsupportedOperationException(
+              "Unsupported data type: " + columnType + " for column: " + dataSchema.getColumnName(i));
       }
     }
+
     return row;
   }
 
   /**
-   * Build a {@link DataTable} from a {@link Collection} of selection rows with {@link DataSchema}.
+   * Reduce a collection of {@link DataTable}s to selection rows for selection queries without <code>ORDER BY</code>.
+   * (Broker side)
    *
-   * @param rowEventsSet {@link Collection} of selection rows.
-   * @param dataSchema data schema.
-   * @return data table.
-   * @throws Exception
+   * @param selectionResults {@link Map} from {@link ServerInstance} to {@link DataTable}.
+   * @param selectionSize size of the selection.
+   * @return reduced results.
    */
-  public static DataTable getDataTableFromRowSet(@Nonnull Collection<Serializable[]> rowEventsSet,
-      @Nonnull DataSchema dataSchema)
-      throws Exception {
-    DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
-    dataTableBuilder.open();
-    int numRows = dataSchema.size();
-
-    for (Serializable[] row : rowEventsSet) {
-      dataTableBuilder.startRow();
-      for (int i = 0; i < numRows; i++) {
-        switch (dataSchema.getColumnType(i)) {
-          // Single-value column.
-          case INT:
-            dataTableBuilder.setColumn(i, ((Integer) row[i]).intValue());
-            break;
-          case LONG:
-            dataTableBuilder.setColumn(i, ((Long) row[i]).longValue());
-            break;
-          case FLOAT:
-            dataTableBuilder.setColumn(i, ((Float) row[i]).floatValue());
-            break;
-          case DOUBLE:
-            dataTableBuilder.setColumn(i, ((Double) row[i]).doubleValue());
-            break;
-          case STRING:
-            dataTableBuilder.setColumn(i, ((String) row[i]));
-            break;
-
-          // Multi-value column.
-          case INT_ARRAY:
-            dataTableBuilder.setColumn(i, (int[]) row[i]);
-            break;
-          case LONG_ARRAY:
-            dataTableBuilder.setColumn(i, (long[]) row[i]);
-            break;
-          case FLOAT_ARRAY:
-            dataTableBuilder.setColumn(i, (float[]) row[i]);
-            break;
-          case DOUBLE_ARRAY:
-            dataTableBuilder.setColumn(i, (double[]) row[i]);
-            break;
-          case STRING_ARRAY:
-            dataTableBuilder.setColumn(i, (String[]) row[i]);
-            break;
-          default:
-            throw new RuntimeException(
-                "Unsupported data type " + dataSchema.getColumnType(i) + " for column " + dataSchema.getColumnName(i));
+  @Nonnull
+  public static List<Serializable[]> reduceWithoutOrdering(@Nonnull Map<ServerInstance, DataTable> selectionResults,
+      int selectionSize) {
+    List<Serializable[]> rows = new ArrayList<>(selectionSize);
+    for (DataTable dataTable : selectionResults.values()) {
+      int numRows = dataTable.getNumberOfRows();
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (rows.size() < selectionSize) {
+          rows.add(extractRowFromDataTable(dataTable, rowId));
+        } else {
+          return rows;
         }
       }
-      dataTableBuilder.finishRow();
     }
-    dataTableBuilder.seal();
-    return dataTableBuilder.build();
+    return rows;
   }
 
   /**
-   * Get a {@link String} representation of a selection row.
+   * Render the unformatted selection rows to a formatted {@link SelectionResults} object for selection queries without
+   * <code>ORDER BY</code>. (Broker side)
+   * <p>{@link SelectionResults} object will be used to build the broker response.
+   * <p>Should be called after method "reduceWithoutOrdering()".
    *
-   * @param row selection row.
+   * @param rows unformatted selection rows.
    * @param dataSchema data schema.
-   * @return {@link String} representation of the selection row.
+   * @param selectionColumns selection columns.
+   * @return {@link SelectionResults} object results.
    */
-  public static String getRowStringFromSerializable(@Nonnull Serializable[] row, @Nonnull DataSchema dataSchema) {
-    StringBuilder rowStringBuilder = new StringBuilder();
-    int numColumns = dataSchema.size();
-    for (int i = 0; i < numColumns; ++i) {
-      if (i != 0) {
-        rowStringBuilder.append(" : ");
-      }
-      DataType columnType = dataSchema.getColumnType(i);
-      if (columnType.isSingleValue()) {
-        // Single-value column.
-        rowStringBuilder.append(row[i]);
-      } else {
-        // Multi-value column.
-        rowStringBuilder.append("[ ");
-        int arrayLength;
-        switch (columnType) {
-          case INT_ARRAY:
-            int[] intValues = (int[]) row[i];
-            arrayLength = intValues.length;
-            for (int j = 0; j < arrayLength; j++) {
-              rowStringBuilder.append(intValues[j]).append(' ');
-            }
-            break;
-          case LONG_ARRAY:
-            long[] longValues = (long[]) row[i];
-            arrayLength = longValues.length;
-            for (int j = 0; j < arrayLength; j++) {
-              rowStringBuilder.append(longValues[j]).append(' ');
-            }
-            break;
-          case FLOAT_ARRAY:
-            float[] floatValues = (float[]) row[i];
-            arrayLength = floatValues.length;
-            for (int j = 0; j < arrayLength; j++) {
-              rowStringBuilder.append(floatValues[j]).append(' ');
-            }
-            break;
-          case DOUBLE_ARRAY:
-            double[] doubleValues = (double[]) row[i];
-            arrayLength = doubleValues.length;
-            for (int j = 0; j < arrayLength; j++) {
-              rowStringBuilder.append(doubleValues[j]).append(' ');
-            }
-            break;
-          case STRING_ARRAY:
-            String[] stringValues = (String[]) row[i];
-            arrayLength = stringValues.length;
-            for (int j = 0; j < arrayLength; j++) {
-              rowStringBuilder.append(stringValues[j]).append(' ');
-            }
-            break;
-          default:
-            throw new RuntimeException(
-                "Unsupported data type " + dataSchema.getColumnType(i) + " for column " + dataSchema.getColumnName(i));
-        }
-        rowStringBuilder.append(']');
-      }
+  @Nonnull
+  public static SelectionResults renderSelectionResultsWithoutOrdering(@Nonnull List<Serializable[]> rows,
+      @Nonnull DataSchema dataSchema, @Nonnull List<String> selectionColumns) {
+    for (Serializable[] row : rows) {
+      formatRowWithoutOrdering(row, dataSchema);
     }
-    return rowStringBuilder.toString();
+    return new SelectionResults(selectionColumns, rows);
+  }
+
+  /**
+   * Helper method to format a selection row, make all values string or string array type based on data schema passed in
+   * for selection queries without <code>ORDER BY</code>. (Broker side)
+   * <p>Formatted row is used to build the {@link SelectionResults}.
+   *
+   * @param row selection row to be formatted.
+   * @param dataSchema data schema.
+   */
+  private static void formatRowWithoutOrdering(@Nonnull Serializable[] row, @Nonnull DataSchema dataSchema) {
+    int numColumns = row.length;
+    for (int i = 0; i < numColumns; i++) {
+      row[i] = getFormattedValue(row[i], dataSchema.getColumnType(i));
+    }
+  }
+
+  /**
+   * Format a {@link Serializable} value into a {@link String} or {@link String} array based on the data type.
+   * (Broker side)
+   * <p>Actual value type can be different with data type passed in, but they must be type compatible.
+   *
+   * @param value value to be formatted.
+   * @param dataType data type.
+   * @return formatted value.
+   */
+  @Nonnull
+  public static Serializable getFormattedValue(@Nonnull Serializable value, @Nonnull DataType dataType) {
+    switch (dataType) {
+      // Single-value column.
+      case INT:
+        return INT_FORMAT.format(((Number) value).intValue());
+      case LONG:
+        return LONG_FORMAT.format(((Number) value).longValue());
+      case FLOAT:
+        return FLOAT_FORMAT.format(((Number) value).floatValue());
+      case DOUBLE:
+        return DOUBLE_FORMAT.format(((Number) value).doubleValue());
+
+      // Multi-value column.
+      case INT_ARRAY:
+        int[] ints = (int[]) value;
+        int length = ints.length;
+        String[] formattedValue = new String[length];
+        for (int i = 0; i < length; i++) {
+          formattedValue[i] = INT_FORMAT.format(ints[i]);
+        }
+        return formattedValue;
+      case LONG_ARRAY:
+        // LONG_ARRAY type covers INT_ARRAY and LONG_ARRAY.
+        if (value instanceof int[]) {
+          ints = (int[]) value;
+          length = ints.length;
+          formattedValue = new String[length];
+          for (int i = 0; i < length; i++) {
+            formattedValue[i] = LONG_FORMAT.format(ints[i]);
+          }
+        } else {
+          long[] longs = (long[]) value;
+          length = longs.length;
+          formattedValue = new String[length];
+          for (int i = 0; i < length; i++) {
+            formattedValue[i] = LONG_FORMAT.format(longs[i]);
+          }
+        }
+        return formattedValue;
+      case FLOAT_ARRAY:
+        float[] floats = (float[]) value;
+        length = floats.length;
+        formattedValue = new String[length];
+        for (int i = 0; i < length; i++) {
+          formattedValue[i] = FLOAT_FORMAT.format(floats[i]);
+        }
+        return formattedValue;
+      case DOUBLE_ARRAY:
+        // DOUBLE_ARRAY type covers INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY and DOUBLE_ARRAY.
+        if (value instanceof int[]) {
+          ints = (int[]) value;
+          length = ints.length;
+          formattedValue = new String[length];
+          for (int i = 0; i < length; i++) {
+            formattedValue[i] = DOUBLE_FORMAT.format((double) ints[i]);
+          }
+          return formattedValue;
+        } else if (value instanceof long[]) {
+          long[] longs = (long[]) value;
+          length = longs.length;
+          formattedValue = new String[length];
+          for (int i = 0; i < length; i++) {
+            formattedValue[i] = DOUBLE_FORMAT.format((double) longs[i]);
+          }
+          return formattedValue;
+        } else if (value instanceof float[]) {
+          floats = (float[]) value;
+          length = floats.length;
+          formattedValue = new String[length];
+          for (int i = 0; i < length; i++) {
+            formattedValue[i] = DOUBLE_FORMAT.format(floats[i]);
+          }
+          return formattedValue;
+        } else {
+          double[] doubles = (double[]) value;
+          length = doubles.length;
+          formattedValue = new String[length];
+          for (int i = 0; i < length; i++) {
+            formattedValue[i] = DOUBLE_FORMAT.format(doubles[i]);
+          }
+          return formattedValue;
+        }
+      default:
+        // For STRING and STRING_ARRAY, no need to format.
+        return value;
+    }
+  }
+
+  /**
+   * Helper method to add a value to a {@link PriorityQueue}.
+   *
+   * @param value value to be added.
+   * @param queue priority queue.
+   * @param maxNumValues maximum number of values in the priority queue.
+   * @param <T> type for the value.
+   */
+  public static <T> void addToPriorityQueue(@Nonnull T value, @Nonnull PriorityQueue<T> queue, int maxNumValues) {
+    if (queue.size() < maxNumValues) {
+      queue.add(value);
+    } else if (queue.comparator().compare(queue.peek(), value) < 0) {
+      queue.poll();
+      queue.offer(value);
+    }
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/SelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/SelectionSingleValueQueriesTest.java
@@ -94,7 +94,7 @@ public class SelectionSingleValueQueriesTest extends BaseSingleValueQueriesTest 
     DataTableBuilder.DataSchema selectionDataSchema = resultsBlock.getSelectionDataSchema();
     Assert.assertEquals(selectionDataSchema.size(), 3);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
-    Assert.assertEquals(selectionDataSchema.getColumnName(1), "column11");
+    Assert.assertEquals(selectionDataSchema.getColumnName(2), "column11");
     Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
     List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
@@ -102,7 +102,7 @@ public class SelectionSingleValueQueriesTest extends BaseSingleValueQueriesTest 
     Serializable[] firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 3);
     Assert.assertEquals(((Integer) firstRow[0]).intValue(), 1578964907);
-    Assert.assertEquals((String) firstRow[1], "P");
+    Assert.assertEquals((String) firstRow[2], "P");
 
     // Test query with filter.
     selectionOnlyOperator = getOperatorForQueryWithFilter(query);
@@ -115,7 +115,7 @@ public class SelectionSingleValueQueriesTest extends BaseSingleValueQueriesTest 
     selectionDataSchema = resultsBlock.getSelectionDataSchema();
     Assert.assertEquals(selectionDataSchema.size(), 3);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
-    Assert.assertEquals(selectionDataSchema.getColumnName(1), "column11");
+    Assert.assertEquals(selectionDataSchema.getColumnName(2), "column11");
     Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
     Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
     selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
@@ -123,7 +123,7 @@ public class SelectionSingleValueQueriesTest extends BaseSingleValueQueriesTest 
     firstRow = selectionResult.get(0);
     Assert.assertEquals(firstRow.length, 3);
     Assert.assertEquals(((Integer) firstRow[0]).intValue(), 351823652);
-    Assert.assertEquals((String) firstRow[1], "t");
+    Assert.assertEquals((String) firstRow[2], "t");
   }
 
   @Test

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionOperatorServiceTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.query.selection;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.request.Selection;
+import com.linkedin.pinot.common.request.SelectionSort;
+import com.linkedin.pinot.common.response.broker.SelectionResults;
+import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.common.utils.DataTableBuilder;
+import com.linkedin.pinot.core.query.selection.SelectionOperatorService;
+import com.linkedin.pinot.core.query.selection.SelectionOperatorUtils;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * The <code>SelectionOperatorServiceTest</code> class provides unit tests for {@link SelectionOperatorUtils} and
+ * {@link SelectionOperatorService}.
+ */
+public class SelectionOperatorServiceTest {
+  private final String[] _columnNames =
+      {"int", "long", "float", "double", "string", "int_array", "long_array", "float_array", "double_array", "string_array"};
+  private final FieldSpec.DataType[] _dataTypes =
+      {FieldSpec.DataType.INT, FieldSpec.DataType.LONG, FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.STRING, FieldSpec.DataType.INT_ARRAY, FieldSpec.DataType.LONG_ARRAY, FieldSpec.DataType.FLOAT_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.STRING_ARRAY};
+  private final DataTableBuilder.DataSchema _dataSchema = new DataTableBuilder.DataSchema(_columnNames, _dataTypes);
+  private final FieldSpec.DataType[] _compatibleDataTypes =
+      {FieldSpec.DataType.LONG, FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.INT, FieldSpec.DataType.STRING, FieldSpec.DataType.LONG_ARRAY, FieldSpec.DataType.FLOAT_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.INT_ARRAY, FieldSpec.DataType.STRING_ARRAY};
+  private final DataTableBuilder.DataSchema _compatibleDataSchema =
+      new DataTableBuilder.DataSchema(_columnNames, _compatibleDataTypes);
+  private final FieldSpec.DataType[] _upgradedDataTypes =
+      new FieldSpec.DataType[]{FieldSpec.DataType.LONG, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.STRING, FieldSpec.DataType.LONG_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.STRING_ARRAY};
+  private final DataTableBuilder.DataSchema _upgradedDataSchema =
+      new DataTableBuilder.DataSchema(_columnNames, _upgradedDataTypes);
+  private final Serializable[] _row1 =
+      {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}};
+  private final Serializable[] _row2 =
+      {10, 11L, 12.0F, 13.0, "14", new int[]{15}, new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new String[]{"19"}};
+  private final Serializable[] _compatibleRow1 =
+      {1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"}};
+  private final Serializable[] _compatibleRow2 =
+      {11L, 12.0F, 13.0, 14, "15", new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new int[]{19}, new String[]{"20"}};
+  private final Selection _selectionOrderBy = new Selection();
+
+  @BeforeClass
+  public void setUp() {
+    // SELECT * FROM table ORDER BY int DESC LIMIT 1, 2.
+    _selectionOrderBy.setSelectionColumns(Arrays.asList(_columnNames));
+    SelectionSort selectionSort = new SelectionSort();
+    selectionSort.setColumn("int");
+    selectionSort.setIsAsc(false);
+    _selectionOrderBy.setSelectionSortSequence(Collections.singletonList(selectionSort));
+    _selectionOrderBy.setSize(2);
+    _selectionOrderBy.setOffset(1);
+  }
+
+  @Test
+  public void testGetSelectionColumns() {
+    List<String> selectionColumns =
+        SelectionOperatorUtils.getSelectionColumns(Collections.singletonList("*"), _dataSchema);
+    // Alphabetical.
+    List<String> expectedSelectionColumns =
+        Arrays.asList("double", "double_array", "float", "float_array", "int", "int_array", "long", "long_array",
+            "string", "string_array");
+    Assert.assertEquals(selectionColumns, expectedSelectionColumns);
+  }
+
+  @Test
+  public void testCompatibleRowsMergeWithoutOrdering() {
+    ArrayList<Serializable[]> mergedRows = new ArrayList<>(2);
+    mergedRows.add(_row1.clone());
+    mergedRows.add(_row2.clone());
+    Collection<Serializable[]> rowsToMerge = new ArrayList<>(2);
+    rowsToMerge.add(_compatibleRow1.clone());
+    rowsToMerge.add(_compatibleRow2.clone());
+    SelectionOperatorUtils.mergeWithoutOrdering(mergedRows, rowsToMerge, 3);
+    Assert.assertEquals(mergedRows.size(), 3);
+    Assert.assertEquals(mergedRows.get(0), _row1);
+    Assert.assertEquals(mergedRows.get(1), _row2);
+    Assert.assertEquals(mergedRows.get(2), _compatibleRow1);
+  }
+
+  @Test
+  public void testCompatibleRowsMergeWithOrdering() {
+    SelectionOperatorService selectionOperatorService = new SelectionOperatorService(_selectionOrderBy, _dataSchema);
+    PriorityQueue<Serializable[]> mergedRows = selectionOperatorService.getRows();
+    Collection<Serializable[]> rowsToMerge1 = new ArrayList<>(2);
+    rowsToMerge1.add(_row1.clone());
+    rowsToMerge1.add(_row2.clone());
+    Collection<Serializable[]> rowsToMerge2 = new ArrayList<>(2);
+    rowsToMerge2.add(_compatibleRow1.clone());
+    rowsToMerge2.add(_compatibleRow2.clone());
+    int maxNumRows = _selectionOrderBy.getOffset() + _selectionOrderBy.getSize();
+    SelectionOperatorUtils.mergeWithOrdering(mergedRows, rowsToMerge1, maxNumRows);
+    SelectionOperatorUtils.mergeWithOrdering(mergedRows, rowsToMerge2, maxNumRows);
+    Assert.assertEquals(mergedRows.size(), 3);
+    Assert.assertEquals(mergedRows.poll(), _compatibleRow1);
+    Assert.assertEquals(mergedRows.poll(), _row2);
+    Assert.assertEquals(mergedRows.poll(), _compatibleRow2);
+  }
+
+  @Test
+  public void testCompatibleRowsDataTableTransformation()
+      throws Exception {
+    Collection<Serializable[]> rows = new ArrayList<>(2);
+    rows.add(_row1.clone());
+    rows.add(_compatibleRow1.clone());
+    DataTableBuilder.DataSchema dataSchema = _dataSchema.clone();
+    Assert.assertTrue(dataSchema.isTypeCompatibleWith(_compatibleDataSchema));
+    dataSchema.upgradeToCover(_compatibleDataSchema);
+    Assert.assertEquals(dataSchema, _upgradedDataSchema);
+    DataTable dataTable = SelectionOperatorUtils.getDataTableFromRows(rows, dataSchema);
+    Serializable[] expectedRow1 =
+        {0L, 1.0, 2.0, 3.0, "4", new long[]{5L}, new double[]{6.0}, new double[]{7.0}, new double[]{8.0}, new String[]{"9"}};
+    Serializable[] expectedCompatibleRow1 =
+        {1L, 2.0, 3.0, 4.0, "5", new long[]{6L}, new double[]{7.0}, new double[]{8.0}, new double[]{9.0}, new String[]{"10"}};
+    Assert.assertEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 0), expectedRow1);
+    Assert.assertEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 1), expectedCompatibleRow1);
+  }
+
+  @Test
+  public void testCompatibleRowsRenderSelectionResultsWithoutOrdering() {
+    List<Serializable[]> rows = new ArrayList<>(2);
+    rows.add(_row1.clone());
+    rows.add(_compatibleRow1.clone());
+    SelectionResults selectionResults =
+        SelectionOperatorUtils.renderSelectionResultsWithoutOrdering(rows, _upgradedDataSchema,
+            Arrays.asList(_columnNames));
+    List<Serializable[]> formattedRows = selectionResults.getRows();
+    Serializable[] expectedFormattedRow1 = {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
+    Serializable[] expectedFormattedRow2 = {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
+    Assert.assertEquals(formattedRows.get(0), expectedFormattedRow1);
+    Assert.assertEquals(formattedRows.get(1), expectedFormattedRow2);
+  }
+
+  @Test
+  public void testCompatibleRowsRenderSelectionResultsWithOrdering() {
+    SelectionOperatorService selectionOperatorService =
+        new SelectionOperatorService(_selectionOrderBy, _upgradedDataSchema);
+    PriorityQueue<Serializable[]> rows = selectionOperatorService.getRows();
+    rows.offer(_row1.clone());
+    rows.offer(_compatibleRow1.clone());
+    rows.offer(_compatibleRow2.clone());
+    SelectionResults selectionResults = selectionOperatorService.renderSelectionResultsWithOrdering();
+    List<Serializable[]> formattedRows = selectionResults.getRows();
+    Serializable[] expectedFormattedRow1 = {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
+    Serializable[] expectedFormattedRow2 = {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
+    Assert.assertEquals(formattedRows.get(0), expectedFormattedRow1);
+    Assert.assertEquals(formattedRows.get(1), expectedFormattedRow2);
+  }
+}


### PR DESCRIPTION
1. Solve the problem of segments with not identical but type compatible data schema cannot merge.
2. All numbers are type compatible, but not type compatible with other types.
3. For selection order-by with limit 0, use SelectionOnly operator to improve performance.
4. Optimize the logic of selection only (data schema should be the same as selection columns).
5. Fix the bug of throwing exception when order by the same column multiple times.
6. Fix the behavior of swallow merge exceptions in server side.