### PR TITLE
Add routing deferral latency metric

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -117,7 +117,8 @@ public class HelixBrokerStarter {
     _helixAdmin = _helixManager.getClusterManagmentTool();
     addInstanceTagIfNeeded(helixClusterName, brokerId);
 
-    ClusterChangeMediator clusterChangeMediator = new ClusterChangeMediator(_helixExternalViewBasedRouting);
+    ClusterChangeMediator clusterChangeMediator = new ClusterChangeMediator(_helixExternalViewBasedRouting,
+        _brokerServerBuilder.getBrokerMetrics());
     _helixManager.addExternalViewChangeListener(clusterChangeMediator);
     _helixManager.addInstanceConfigChangeListener(clusterChangeMediator);
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerTimer.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerTimer.java
@@ -23,7 +23,8 @@ import com.linkedin.pinot.common.Utils;
 *
 */
 public enum BrokerTimer implements AbstractMetrics.Timer {
-  ROUTING_TABLE_UPDATE_TIME(true);
+  ROUTING_TABLE_UPDATE_TIME(true),
+  ROUTING_TABLE_UPDATE_QUEUE_TIME(true);
   private final String timerName;
   private final boolean global;
 


### PR DESCRIPTION
Add a metric that tracks how long a deferred routing table update has
been sitting enqueued before being processed.