### PR TITLE
[PINOT-4172] Fix LLC segment cleanup when conumer type is changed

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -63,7 +63,6 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactoryImp
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
-import javax.annotation.Nullable;
 
 
 public class PinotLLCRealtimeSegmentManager {
@@ -213,41 +212,19 @@ public class PinotLLCRealtimeSegmentManager {
     // If there are any completions in the pipeline we let them commit.
     Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
 
-    // Remove segments from propertystore.
-    final List<String> segmentNames = getExistingSegments(realtimeTableName);
-    final List<String> znodesToDelete = new ArrayList<>(segmentNames.size());
-    for (String segmentName : segmentNames) {
+    IdealState idealState = HelixHelper.getTableIdealState(_helixManager, realtimeTableName);
+    final List<String> segmentsToRemove = new ArrayList<String>();
+    Set<String> allSegments = idealState.getPartitionSet();
+    int removeCount = 0;
+    for (String segmentName : allSegments) {
       if (SegmentName.isLowLevelConsumerSegmentName(segmentName)) {
-        final String znodePath = ZKMetadataProvider.constructPropertyStorePathForSegment(realtimeTableName, segmentName);
-        znodesToDelete.add(znodePath);
+        segmentsToRemove.add(segmentName);
+        removeCount++;
       }
     }
-    _propertyStore.remove(znodesToDelete, AccessOption.PERSISTENT);
-    LOGGER.info("Removed {} LLC segments from PROPERTYSTORE for {}", znodesToDelete.size(), realtimeTableName);
+    LOGGER.info("Attempting to remove {} LLC segments of table {}", removeCount, realtimeTableName);
 
-    // Remove segments from IdealState. The segments in the idealstate should be the same as that in propertystore,
-    // but it is better to take what idealstate reports and remove the llc segments from there.
-    HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
-      @Nullable
-      @Override
-      public IdealState apply(@Nullable IdealState idealState) {
-        Set<String> allSegments = idealState.getPartitionSet();
-        List<String> segmentsToRemove = new ArrayList<String>(allSegments.size());
-        int removedCount = 0;
-        for (String segmentName : allSegments) {
-          if (SegmentName.isLowLevelConsumerSegmentName(segmentName)) {
-            segmentsToRemove.add(segmentName);
-            removedCount++;
-          }
-        }
-        LOGGER.info("Attempting to remove {} LLC segments from IDEALSTATE for {}", removedCount, realtimeTableName);
-        for (String segmentName : segmentsToRemove) {
-          idealState.getPartitionSet().remove(segmentName);
-        }
-        return idealState;
-      }
-    }, RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0f));
-    LOGGER.info("Removed LLC segments from IDEALSTATE (if any) for {}", realtimeTableName);
+    _helixResourceManager.deleteSegments(realtimeTableName, segmentsToRemove);
   }
 
   protected void writeKafkaPartitionAssignemnt(final String realtimeTableName, ZNRecord znRecord) {


### PR DESCRIPTION
When consumer type is changed from "highLevel,simple" to "highLevel" for any reason
we need to delete the segments on disk as well. Going through the deletion manager
deletes from idealstate, and also from propertystore and disk

Tested by contriving a case in LLCRealtimeClusterIntegrationTests