### PR TITLE
Reuse GenericRow instances in realtime indexing

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/GenericRow.java
@@ -29,9 +29,8 @@ import java.util.Set;
 
 
 /**
- * A plain implementation of RowEvent based on HashMap.
- *
- *
+ * A plain implementation of RowEvent based on HashMap. Should be reused as much as possible via
+ * {@link GenericRow#createOrReuseRow(GenericRow)}
  */
 public class GenericRow implements RowEvent {
   private Map<String, Object> _fieldMap = new HashMap<String, Object>();
@@ -113,5 +112,21 @@ public class GenericRow implements RowEvent {
     StringWriter writer = new StringWriter();
     OBJECT_MAPPER.writeValue(writer, _fieldMap);
     return writer.toString().getBytes(Charset.forName("UTF-8"));
+  }
+
+  /**
+   * Creates a new row if the row given is null, otherwise just {@link GenericRow#clear()} the row so that it can be
+   * reused.
+   *
+   * @param row The row to potentially reuse.
+   * @return A cleared or new row.
+   */
+  public static GenericRow createOrReuseRow(GenericRow row) {
+    if (row == null) {
+      return new GenericRow();
+    } else {
+      row.clear();
+      return row;
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -176,13 +176,19 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
         segmentLogger.info("Starting to collect rows");
 
         do {
+          GenericRow readRow = null;
+          GenericRow transformedRow = null;
           GenericRow row = null;
           try {
-            row = kafkaStreamProvider.next();
+            readRow = GenericRow.createOrReuseRow(readRow);
+            readRow = kafkaStreamProvider.next(readRow);
+            row = readRow;
 
-            if (row != null) {
-              row = extractor.transform(row);
-              notFull = realtimeSegment.index(row);
+            if (readRow != null) {
+              transformedRow = GenericRow.createOrReuseRow(transformedRow);
+              transformedRow = extractor.transform(readRow, transformedRow);
+              row = transformedRow;
+              notFull = realtimeSegment.index(transformedRow);
               exceptionSleepMillis = 50L;
             }
           } catch (Exception e) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -286,6 +286,8 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
       int indexedMessageCount = 0;
       int kafkaMessageCount = 0;
       boolean canTakeMore = true;
+      GenericRow decodedRow = null;
+      GenericRow transformedRow = null;
       while (!_shouldStop && !endCriteriaReached() && msgIterator.hasNext()) {
         if (!canTakeMore) {
           // The RealtimeSegmentImpl that we are pushing rows into has indicated that it cannot accept any more
@@ -310,7 +312,8 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
         byte[] array = messageAndOffset.message().payload().array();
         int offset = messageAndOffset.message().payload().arrayOffset();
         int length = messageAndOffset.message().payloadSize();
-        GenericRow row = _messageDecoder.decode(array, offset, length);
+        decodedRow = GenericRow.createOrReuseRow(decodedRow);
+        decodedRow = _messageDecoder.decode(array, offset, length, decodedRow);
 
         // Update lag metric on the first message of each batch
         if (kafkaMessageCount == 0) {
@@ -319,17 +322,28 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
           _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.KAFKA_PARTITION_OFFSET_LAG, offsetDifference);
         }
 
-        if (row != null) {
-          row = _fieldExtractor.transform(row);
+        if (decodedRow != null) {
+          transformedRow = GenericRow.createOrReuseRow(transformedRow);
+          transformedRow = _fieldExtractor.transform(decodedRow, transformedRow);
 
-          if (row != null) {
+          if (transformedRow != null) {
             _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.REALTIME_ROWS_CONSUMED, 1);
             indexedMessageCount++;
           } else {
             _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INVALID_REALTIME_ROWS_DROPPED, 1);
           }
 
-          canTakeMore = _realtimeSegment.index(row);
+          canTakeMore = _realtimeSegment.index(transformedRow);  // Ignore the boolean return
+          if (!canTakeMore) {
+            //TODO
+            // This condition can happen when we are catching up, (due to certain failure scenarios in kafka where
+            // offsets get changed with higher generation numbers for some pinot servers but not others).
+            // Also, it may be that we push in a row into the realtime segment, but it fails to index that row
+            // for some reason., so we may end up with less number of rows in the real segment. Actually, even 0 rows.
+            // In that case, we will see an exception when generating the segment.
+            // TODO We need to come up with how the system behaves in these cases and document/handle them
+            segmentLogger.warn("We got full during indexing");
+          }
         } else {
           _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INVALID_REALTIME_ROWS_DROPPED, 1);
         }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/StreamProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/StreamProvider.java
@@ -38,7 +38,7 @@ public interface StreamProvider {
   /**
    * return GenericRow
    */
-  GenericRow next();
+  GenericRow next(GenericRow destination);
 
   /**
    *

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/FileBasedStreamProviderImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/FileBasedStreamProviderImpl.java
@@ -53,7 +53,7 @@ public class FileBasedStreamProviderImpl implements StreamProvider {
   }
 
   @Override
-  public GenericRow next() {
+  public GenericRow next(GenericRow destination) {
     if (reader.hasNext()) {
       count++;
       return reader.next();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/AvroRecordToPinotRowGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/AvroRecordToPinotRowGenerator.java
@@ -37,8 +37,7 @@ public class AvroRecordToPinotRowGenerator {
     this.indexingSchema = indexingSchema;
   }
 
-  public GenericRow transform(GenericData.Record record, org.apache.avro.Schema schema) {
-    Map<String, Object> rowEntries = new HashMap<String, Object>();
+  public GenericRow transform(GenericData.Record record, org.apache.avro.Schema schema, GenericRow destination) {
     for (String column : indexingSchema.getColumnNames()) {
       Object entry = record.get(column);
       FieldSpec fieldSpec = indexingSchema.getFieldSpecFor(column);
@@ -78,16 +77,13 @@ public class AvroRecordToPinotRowGenerator {
           }
         }
       }
-      rowEntries.put(column, entry);
+      destination.putField(column, entry);
     }
 
-    GenericRow row = new GenericRow();
-    row.init(rowEntries);
-    return row;
+    return destination;
   }
 
-  public GenericRow transform(GenericRecord avroRecord) {
-    Map<String, Object> rowEntries = new HashMap<String, Object>();
+  public GenericRow transform(GenericRecord avroRecord, GenericRow destination) {
     for (String column : indexingSchema.getColumnNames()) {
       Object entry = avroRecord.get(column);
       if (entry instanceof Utf8) {
@@ -99,11 +95,9 @@ public class AvroRecordToPinotRowGenerator {
       if (entry == null && indexingSchema.getFieldSpecFor(column).isSingleValueField()) {
         entry = AvroRecordReader.getDefaultNullValue(indexingSchema.getFieldSpecFor(column));
       }
-      rowEntries.put(column, entry);
+      destination.putField(column, entry);
     }
 
-    GenericRow row = new GenericRow();
-    row.init(rowEntries);
-    return row;
+    return destination;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
@@ -75,12 +75,12 @@ public class KafkaAvroMessageDecoder implements KafkaMessageDecoder {
   }
 
   @Override
-  public GenericRow decode(byte[] payload) {
-    return decode(payload, 0, payload.length);
+  public GenericRow decode(byte[] payload, GenericRow destination) {
+    return decode(payload, 0, payload.length, destination);
   }
 
   @Override
-  public GenericRow decode(byte[] payload, int offset, int length) {
+  public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
     if (payload == null || payload.length == 0 || length == 0) {
       return null;
     }
@@ -105,7 +105,7 @@ public class KafkaAvroMessageDecoder implements KafkaMessageDecoder {
       GenericData.Record avroRecord =
           reader.read(null, decoderFactory.createBinaryDecoder(payload, HEADER_LENGTH + offset,
               length - HEADER_LENGTH, null));
-      return avroRecordConvetrer.transform(avroRecord, schema);
+      return avroRecordConvetrer.transform(avroRecord, schema, destination);
     } catch (IOException e) {
       LOGGER.error("Caught exception while reading message", e);
       return null;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelConsumerStreamProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelConsumerStreamProvider.java
@@ -72,10 +72,10 @@ public class KafkaHighLevelConsumerStreamProvider implements StreamProvider {
   }
 
   @Override
-  public GenericRow next() {
+  public GenericRow next(GenericRow destination) {
     if (kafkaIterator.hasNext()) {
       try {
-        GenericRow row = decoder.decode(kafkaIterator.next().message());
+        destination = decoder.decode(kafkaIterator.next().message(), destination);
         serverMetrics.addMeteredTableValue(tableAndStreamName, ServerMeter.REALTIME_ROWS_CONSUMED, 1L);
         serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_ROWS_CONSUMED, 1L);
         ++currentCount;
@@ -94,7 +94,7 @@ public class KafkaHighLevelConsumerStreamProvider implements StreamProvider {
           lastCount = currentCount;
           lastLogTime = now;
         }
-        return row;
+        return destination;
       } catch (Exception e) {
         INSTANCE_LOGGER.warn("Caught exception while consuming events", e);
         serverMetrics.addMeteredTableValue(tableAndStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaMessageDecoder.java
@@ -35,7 +35,7 @@ public interface KafkaMessageDecoder {
    * @param payload
    * @return
    */
-  GenericRow decode(byte[] payload);
+  GenericRow decode(byte[] payload, GenericRow destination);
 
   /**
    * Decodes a row.
@@ -43,7 +43,8 @@ public interface KafkaMessageDecoder {
    * @param payload The buffer from which to read the row.
    * @param offset The offset into the array from which the row contents starts
    * @param length The length of the row contents in bytes
+   * @param destination The {@link GenericRow} to write the decoded row into
    * @return A new row decoded from the buffer
    */
-  GenericRow decode(byte[] payload, int offset, int length);
+  GenericRow decode(byte[] payload, int offset, int length, GenericRow destination);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -238,8 +238,6 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
       statsCollector.collectRow(transformedRow);
       totalRawDocs++;
       totalDocs++;
-      readRow.clear();
-      transformedRow.clear();
     }
     recordReader.close();
     LOGGER.info("Start building star tree!");
@@ -366,8 +364,6 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
       long stop1 = System.currentTimeMillis();
       totalRecordReadTime += (stop - start);
       totalStatsCollectorTime += (stop1 - stop);
-      readRow.clear();
-      transformedRow.clear();
     }
     buildIndexCreationInfo();
     LOGGER.info("Finished building StatsCollector!");
@@ -387,8 +383,6 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
       long stop1 = System.currentTimeMillis();
       totalRecordReadTime += (stop - start);
       totalIndexTime += (stop1 - stop);
-      readRow.clear();
-      transformedRow.clear();
     }
     recordReader.close();
     LOGGER.info("Finished records indexing in IndexCreator!");
@@ -539,7 +533,9 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
   }
 
   private GenericRow readNextRowSanitized(GenericRow readRow, GenericRow transformedRow) {
+    readRow = GenericRow.createOrReuseRow(readRow);
     readRow = recordReader.next(readRow);
+    transformedRow = GenericRow.createOrReuseRow(transformedRow);
     return extractor.transform(readRow, transformedRow);
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeFileBasedReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeFileBasedReaderTest.java
@@ -84,10 +84,10 @@ public class RealtimeFileBasedReaderTest {
 
     realtimeSegment = new RealtimeSegmentImpl(schema, 100000, tableName, segmentName, AVRO_DATA, new
         ServerMetrics(new MetricsRegistry()));
-    GenericRow row = provider.next();
+    GenericRow row = provider.next(new GenericRow());
     while (row != null) {
       realtimeSegment.index(row);
-      row = provider.next();
+      row = provider.next(row);
     }
 
     provider.shutdown();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -91,11 +91,12 @@ public class RealtimeSegmentTest {
         invertedIdxCols);
     segmentWithoutInvIdx =
         new RealtimeSegmentImpl(schema, 100000, tableName, "noSegment", AVRO_DATA, new ServerMetrics(new MetricsRegistry()));
-    GenericRow row = provider.next();
+    GenericRow row = provider.next(new GenericRow());
     while (row != null) {
       segmentWithInvIdx.index(row);
       segmentWithoutInvIdx.index(row);
-      row = provider.next();
+      row = GenericRow.createOrReuseRow(row);
+      row = provider.next(row);
     }
     provider.shutdown();
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
@@ -279,9 +279,11 @@ public class RealtimeQueriesSentinelTest {
       DataFileStream<GenericRecord> avroReader =
           AvroUtils.getAvroReader(new File(TestUtils.getFileFromResourceUrl(getClass().getClassLoader().getResource(
               AVRO_DATA))));
+      GenericRow genericRow = null;
       while (avroReader.hasNext()) {
         GenericRecord avroRecord = avroReader.next();
-        GenericRow genericRow = AVRO_RECORD_TRANSFORMER.transform(avroRecord);
+        genericRow = GenericRow.createOrReuseRow(genericRow);
+        genericRow = AVRO_RECORD_TRANSFORMER.transform(avroRecord, genericRow);
         // System.out.println(genericRow);
         realtimeSegmentImpl.index(genericRow);
       }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -186,16 +186,16 @@ public abstract class ClusterTest extends ControllerTest {
     }
 
     @Override
-    public GenericRow decode(byte[] payload) {
-      return decode(payload, 0, payload.length);
+    public GenericRow decode(byte[] payload, GenericRow destination) {
+      return decode(payload, 0, payload.length, destination);
     }
 
     @Override
-    public GenericRow decode(byte[] payload, int offset, int length) {
+    public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
       try {
         GenericData.Record avroRecord =
             _reader.read(null, _decoderFactory.binaryDecoder(payload, offset, length, null));
-        return _rowGenerator.transform(avroRecord, _avroSchema);
+        return _rowGenerator.transform(avroRecord, _avroSchema, destination);
       } catch (Exception e) {
         LOGGER.error("Caught exception", e);
         throw new RuntimeException(e);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/FlakyConsumerRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/FlakyConsumerRealtimeClusterIntegrationTest.java
@@ -62,7 +62,7 @@ public class FlakyConsumerRealtimeClusterIntegrationTest extends RealtimeCluster
     }
 
     @Override
-    public GenericRow next() {
+    public GenericRow next(GenericRow destination) {
       // Return a null row every ~1/1000 rows and an exception every ~1/1000 rows
       int randomValue = _random.nextInt(1000);
 
@@ -71,7 +71,7 @@ public class FlakyConsumerRealtimeClusterIntegrationTest extends RealtimeCluster
       } else if (randomValue == 1) {
         throw new RuntimeException("Flaky stream provider exception");
       } else {
-        return _streamProvider.next();
+        return _streamProvider.next(destination);
       }
     }
 


### PR DESCRIPTION
Reuse GenericRow instances in realtime indexing to avoid creating
avoidable garbage for every row indexed.