### PR TITLE
Add a metric that reflects the highes offset consumed by a server for a partition

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -25,7 +25,7 @@ import com.linkedin.pinot.common.Utils;
 public enum ServerGauge implements AbstractMetrics.Gauge {
   DOCUMENT_COUNT("documents", false),
   SEGMENT_COUNT("segments", false),
-  HIGHEST_KAFKA_OFFSET_CONSUMED("seconds", false),
+  HIGHEST_KAFKA_OFFSET_CONSUMED("messages", false),
   LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_INITIAL_CONSUMPTION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_CATCHUP_DURATION_SECONDS("seconds", false),

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -25,6 +25,7 @@ import com.linkedin.pinot.common.Utils;
 public enum ServerGauge implements AbstractMetrics.Gauge {
   DOCUMENT_COUNT("documents", false),
   SEGMENT_COUNT("segments", false),
+  HIGHEST_KAFKA_OFFSET_CONSUMED("seconds", false),
   LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_INITIAL_CONSUMPTION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_CATCHUP_DURATION_SECONDS("seconds", false),

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -342,6 +342,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
       if (kafkaMessageCount != 0) {
         segmentLogger.debug("Indexed {} messages ({} messages read from Kafka) current offset {}", indexedMessageCount,
             kafkaMessageCount, _currentOffset);
+        _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.HIGHEST_KAFKA_OFFSET_CONSUMED, _currentOffset);
       } else {
         // If there were no messages to be fetched from Kafka, wait for a little bit as to avoid hammering the
         // Kafka broker
@@ -466,6 +467,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
         segmentLogger.error("Exception while in work", e);
         postStopConsumedMsg(e.getClass().getName());
         _state = State.ERROR;
+        _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.HIGHEST_KAFKA_OFFSET_CONSUMED, 0L);
         return;
       }
 


### PR DESCRIPTION
With this metric in a graph, we can immediately indentify whether a host is stuck
at a particular offset, or is moving forward, or has completely stopped consuming.