### PR TITLE
Group By support for columns without dictionary.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
@@ -198,6 +198,27 @@ public class DataFetcher {
   }
 
   /**
+   * Fetch the int values for a multi-valued column.
+   *
+   * @param column column name.
+   * @param inDocIds dictionary Id array.
+   * @param inStartPos input start position.
+   * @param length input length.
+   * @param outValues value array buffer.
+   * @param outStartPos output start position.
+   */
+  public void fetchIntValues(String column, int[] inDocIds, int inStartPos, int length, int[][] outValues, int outStartPos) {
+    Dictionary dictionary = getDictionaryForColumn(column);
+
+    int inEndPos = inStartPos + length;
+    for (int i = inStartPos; i < inEndPos; i++, outStartPos++) {
+      int numValues = fetchDictIdsForDocId(column, inDocIds[i], _reusableMVDictIds);
+      outValues[outStartPos] = new int[numValues];
+      dictionary.readIntValues(_reusableMVDictIds, 0, numValues, outValues[outStartPos], 0);
+    }
+  }
+
+  /**
    * Fetch the values for a single long value column.
    *
    * @param column column name.
@@ -214,6 +235,27 @@ public class DataFetcher {
   }
 
   /**
+   * Fetch the long values for a multi-valued column.
+   *
+   * @param column column name.
+   * @param inDocIds dictionary Id array.
+   * @param inStartPos input start position.
+   * @param length input length.
+   * @param outValues value array buffer.
+   * @param outStartPos output start position.
+   */
+  public void fetchLongValues(String column, int[] inDocIds, int inStartPos, int length, long[][] outValues, int outStartPos) {
+    Dictionary dictionary = getDictionaryForColumn(column);
+
+    int inEndPos = inStartPos + length;
+    for (int i = inStartPos; i < inEndPos; i++, outStartPos++) {
+      int numValues = fetchDictIdsForDocId(column, inDocIds[i], _reusableMVDictIds);
+      outValues[outStartPos] = new long[numValues];
+      dictionary.readLongValues(_reusableMVDictIds, 0, numValues, outValues[outStartPos], 0);
+    }
+  }
+
+  /**
    * Fetch the values for a single float value column.
    *
    * @param column column name.
@@ -227,6 +269,27 @@ public class DataFetcher {
     Dictionary dictionary = getDictionaryForColumn(column);
     fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
     dictionary.readFloatValues(_reusableDictIds, 0, length, outValues, outStartPos);
+  }
+
+  /**
+   * Fetch the float values for a multi-valued column.
+   *
+   * @param column column name.
+   * @param inDocIds dictionary Id array.
+   * @param inStartPos input start position.
+   * @param length input length.
+   * @param outValues value array buffer.
+   * @param outStartPos output start position.
+   */
+  public void fetchFloatValues(String column, int[] inDocIds, int inStartPos, int length, float[][] outValues, int outStartPos) {
+    Dictionary dictionary = getDictionaryForColumn(column);
+
+    int inEndPos = inStartPos + length;
+    for (int i = inStartPos; i < inEndPos; i++, outStartPos++) {
+      int numValues = fetchDictIdsForDocId(column, inDocIds[i], _reusableMVDictIds);
+      outValues[outStartPos] = new float[numValues];
+      dictionary.readFloatValues(_reusableMVDictIds, 0, numValues, outValues[outStartPos], 0);
+    }
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DataBlockCache.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DataBlockCache.java
@@ -30,6 +30,7 @@ import java.util.Set;
  * data multiple times. This class allocate resources on demand, and reuse them as much as possible to prevent garbage
  * collection.
  */
+@SuppressWarnings("Duplicates")
 public class DataBlockCache {
   private final DataFetcher _dataFetcher;
 
@@ -41,14 +42,14 @@ public class DataBlockCache {
 
   /** _columnToXXsMap must be defined accordingly */
   private final Map<String, int[]> _columnToDictIdsMap = new HashMap<>();
-  private final Map<String, double[]> _columnToValuesMap = new HashMap<>();
+  private final Map<String, Object> _columnToValuesMap = new HashMap<>();
   private final Map<String, double[]> _columnToHashCodesMap = new HashMap<>();
   private final Map<String, String[]> _columnToStringsMap = new HashMap<>();
 
   private final Map<String, int[]> _columnToNumberOfEntriesMap = new HashMap<>();
 
   private final Map<String, int[][]> _columnToDictIdsArrayMap = new HashMap<>();
-  private final Map<String, double[][]> _columnToValuesArrayMap = new HashMap<>();
+  private final Map<String, Object> _columnToValuesArrayMap = new HashMap<>();
   private final Map<String, double[][]> _columnToHashCodesArrayMap = new HashMap<>();
   private final Map<String, String[][]> _columnToStringsArrayMap = new HashMap<>();
 
@@ -136,13 +137,133 @@ public class DataBlockCache {
   }
 
   /**
+   * Get int value array for a given column for the specific block initialized in the initNewBlock.
+   *
+   * @param column column name.
+   * @return value array associated with this column.
+   */
+  public int[] getIntValueArrayForColumn(String column) {
+    int[] intValues = (int []) _columnToValuesMap.get(column);
+    if (!_columnValueLoaded.contains(column)) {
+      if (intValues == null) {
+        intValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        _columnToValuesMap.put(column, intValues);
+      }
+      _dataFetcher.fetchIntValues(column, _docIds, _startPos, _length, intValues, 0);
+      _columnValueLoaded.add(column);
+    }
+    return intValues;
+  }
+
+  /**
+   * Get double value array for a given column for the specific block initialized in the initNewBlock.
+   *
+   * @param column column name.
+   * @return int values array associated with this column.
+   */
+  public int[][] getIntValuesArrayForColumn(String column) {
+    int[][] intValues = (int[][]) _columnToValuesArrayMap.get(column);
+
+    if (!_columnValueLoaded.contains(column)) {
+      if (intValues == null) {
+        intValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        _columnToValuesArrayMap.put(column, intValues);
+      }
+
+      _dataFetcher.fetchIntValues(column, _docIds, _startPos, _length, intValues, 0);
+      _columnValueLoaded.add(column);
+    }
+    return intValues;
+  }
+
+  /**
+   * Get long value array for a given column for the specific block initialized in the initNewBlock.
+   *
+   * @param column column name.
+   * @return value array associated with this column.
+   */
+  public long[] getLongValueArrayForColumn(String column) {
+    long[] longValues = (long []) _columnToValuesMap.get(column);
+    if (!_columnValueLoaded.contains(column)) {
+      if (longValues == null) {
+        longValues = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        _columnToValuesMap.put(column, longValues);
+      }
+      _dataFetcher.fetchLongValues(column, _docIds, _startPos, _length, longValues, 0);
+      _columnValueLoaded.add(column);
+    }
+    return longValues;
+  }
+
+  /**
+   * Get long value array for a given column for the specific block initialized in the initNewBlock.
+   *
+   * @param column column name.
+   * @return long values array associated with this column.
+   */
+  public long[][] getLongValuesArrayForColumn(String column) {
+    long[][] longValues = (long[][]) _columnToValuesArrayMap.get(column);
+
+    if (!_columnValueLoaded.contains(column)) {
+      if (longValues == null) {
+        longValues = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        _columnToValuesArrayMap.put(column, longValues);
+      }
+
+      _dataFetcher.fetchLongValues(column, _docIds, _startPos, _length, longValues, 0);
+      _columnValueLoaded.add(column);
+    }
+    return longValues;
+  }
+
+  /**
+   * Get long value array for a given column for the specific block initialized in the initNewBlock.
+   *
+   * @param column column name.
+   * @return value array associated with this column.
+   */
+  public float[] getFloatValueArrayForColumn(String column) {
+    float[] floatValues = (float []) _columnToValuesMap.get(column);
+    if (!_columnValueLoaded.contains(column)) {
+      if (floatValues == null) {
+        floatValues = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        _columnToValuesMap.put(column, floatValues);
+      }
+      _dataFetcher.fetchFloatValues(column, _docIds, _startPos, _length, floatValues, 0);
+      _columnValueLoaded.add(column);
+    }
+    return floatValues;
+  }
+
+  /**
+   * Get long value array for a given column for the specific block initialized in the initNewBlock.
+   *
+   * @param column column name.
+   * @return long values array associated with this column.
+   */
+  public float[][] getFloatValuesArrayForColumn(String column) {
+    float[][] floatValues = (float[][]) _columnToValuesArrayMap.get(column);
+
+    if (!_columnValueLoaded.contains(column)) {
+      if (floatValues == null) {
+        floatValues = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        _columnToValuesArrayMap.put(column, floatValues);
+      }
+
+      _dataFetcher.fetchFloatValues(column, _docIds, _startPos, _length, floatValues, 0);
+      _columnValueLoaded.add(column);
+    }
+    return floatValues;
+  }
+
+  /**
    * Get double value array for a given column for the specific block initialized in the initNewBlock.
    *
    * @param column column name.
    * @return value array associated with this column.
    */
   public double[] getDoubleValueArrayForColumn(String column) {
-    double[] doubleValues = _columnToValuesMap.get(column);
+    double[] doubleValues = (double []) _columnToValuesMap.get(column);
     if (!_columnValueLoaded.contains(column)) {
       if (doubleValues == null) {
         doubleValues = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
@@ -161,7 +282,7 @@ public class DataBlockCache {
    * @return double values array associated with this column.
    */
   public double[][] getDoubleValuesArrayForColumn(String column) {
-    double[][] doubleValuesArray = _columnToValuesArrayMap.get(column);
+    double[][] doubleValuesArray = (double[][]) _columnToValuesArrayMap.get(column);
 
     if (!_columnValueLoaded.contains(column)) {
       if (doubleValuesArray == null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
@@ -55,8 +55,6 @@ import java.util.NoSuchElementException;
  * All the logic is maintained internally, and to the outside world, the group keys are always int type.
  */
 public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
-  private static final int INVALID_ID = -1;
-
   public enum StorageType {
     ARRAY_BASED,
     LONG_MAP_BASED,
@@ -68,7 +66,6 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
   private final int[] _cardinalities;
   private long _cardinalityProduct = 1L;
   private final boolean[] _isSingleValueGroupByColumn;
-  private boolean _hasMultiValueGroupByColumn = false;
   private final StorageType _storageType;
 
   private final Dictionary[] _dictionaries;
@@ -149,9 +146,6 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
       // Store single/multi value group-by columns, allocate reusable resources based on that.
       boolean isSingleValueGroupByColumn = blockMetadata.isSingleValue();
       _isSingleValueGroupByColumn[i] = isSingleValueGroupByColumn;
-      if (!isSingleValueGroupByColumn) {
-        _hasMultiValueGroupByColumn = true;
-      }
 
       if (!isSingleValueGroupByColumn) {
         maxNumMultiValues = Math.max(maxNumMultiValues, blockMetadata.getMaxNumberOfMultiValues());
@@ -196,14 +190,6 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
     } else {
       return (int) _cardinalityProduct;
     }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public boolean hasMultiValueGroupByColumn() {
-    return _hasMultiValueGroupByColumn;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/GroupKeyGenerator.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
  * Interface for generating group keys.
  */
 public interface GroupKeyGenerator {
+  int INVALID_ID = -1;
+
   /**
    * Get the global upper bound of the group key. All group keys generated or will be generated should be less than this
    * value. This interface can be called before generating group keys to determine the type and size of the value result
@@ -32,14 +34,6 @@ public interface GroupKeyGenerator {
    * @return global upper bound of the group key.
    */
   int getGlobalGroupKeyUpperBound();
-
-  /**
-   * Return whether there are any multi value group-by columns. This interface can be used to determine using which
-   * interface to generate the group keys.
-   *
-   * @return whether there are multi value group-by columns.
-   */
-  boolean hasMultiValueGroupByColumn();
 
   /**
    * Generate group keys for a given docId set and return the mapping in the passed in docIdToGroupKey array.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/NoDictionaryGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/NoDictionaryGroupKeyGenerator.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.operator.aggregation.groupby;
+
+import com.clearspring.analytics.util.Preconditions;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
+import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.blocks.ProjectionColumnBlock;
+import com.linkedin.pinot.core.query.aggregation.groupby.GroupByConstants;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+
+/**
+ * Implementation of {@link GroupKeyGenerator} interface using actual string based
+ * group keys, instead of dictionary ids. This implementation is used for group-by key
+ * generation when one or more of the group-by columns do not have dictionary.
+ *
+ * TODO:
+ * 1. Add support for multi-valued group-by columns.
+ * 2. Add support for trimming group-by results.
+ */
+public class NoDictionaryGroupKeyGenerator implements GroupKeyGenerator {
+
+  private String[] _groupByColumns;
+  Map<String, Integer> _groupKeyMap;
+  private int _numGroupKeys = 0;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param groupByColumns Columns for which to generate group-by keys
+   */
+  public NoDictionaryGroupKeyGenerator(String[] groupByColumns) {
+    _groupByColumns = groupByColumns;
+    _groupKeyMap = new HashMap<>();
+  }
+
+  @Override
+  public int getGlobalGroupKeyUpperBound() {
+    // Since there's no dictionary, we cannot find the cardinality
+    return Integer.MAX_VALUE;
+  }
+
+  @Override
+  public void generateKeysForBlock(ProjectionBlock projectionBlock, int[] docIdToGroupKey) {
+    int numGroupByColumns = _groupByColumns.length;
+    int numDocs = projectionBlock.getNumDocs();
+
+    Object[] values = new Object[numGroupByColumns];
+    FieldSpec.DataType[] dataTypes = new FieldSpec.DataType[numGroupByColumns];
+
+    for (int i = 0; i < numGroupByColumns; i++) {
+      ProjectionColumnBlock dataBlock = (ProjectionColumnBlock) projectionBlock.getDataBlock(_groupByColumns[i]);
+      BlockValSet blockValSet = dataBlock.getBlockValueSet();
+
+      // This method is only for single-valued columns, there's a separate method for multi-valued columns.
+      Preconditions.checkState(dataBlock.getMetadata().isSingleValue(),
+          "Multi-valued column specified in single valued group key generator: " + _groupByColumns[i]);
+
+      dataTypes[i] = blockValSet.getValueType();
+      values[i] = blockValSet.getSingleValues();
+    }
+
+    StringBuilder stringBuilder = new StringBuilder();
+    for (int i = 0; i < numDocs; i++) {
+      stringBuilder.setLength(0);
+
+      for (int j = 0; j < numGroupByColumns; j++) {
+        double[] doubleValues;
+
+        // BlockValSet.getSingleValues() always returns double currently, as all aggregation functions assume
+        // data type to be double.
+
+        switch (dataTypes[j]) {
+          case INT:
+            doubleValues = (double[]) values[j];
+            stringBuilder.append((int) doubleValues[i]);
+            break;
+
+          case LONG:
+            doubleValues = (double[]) values[j];
+            stringBuilder.append((long) doubleValues[i]);
+            break;
+
+          case FLOAT:
+            doubleValues = (double[]) values[j];
+            stringBuilder.append((float) doubleValues[i]);
+            break;
+
+          case DOUBLE:
+            doubleValues = (double[]) values[j];
+            stringBuilder.append(doubleValues[i]);
+            break;
+
+          default:
+            Object[] objects = (Object[]) values[j];
+            stringBuilder.append(objects[i].toString());
+            break;
+        }
+
+        if (j < (numGroupByColumns - 1)) {
+          stringBuilder.append(GroupByConstants.GroupByDelimiter.groupByMultiDelimeter);
+        }
+      }
+
+      docIdToGroupKey[i] = getGroupIdForKey(stringBuilder.toString());
+    }
+  }
+
+  @Override
+  public void generateKeysForBlock(ProjectionBlock projectionBlock, int[][] docIdToGroupKeys) {
+    // TODO: Support generating keys for multi-valued columns.
+    throw new UnsupportedOperationException("Operation not supported");
+  }
+
+  @Override
+  public int getCurrentGroupKeyUpperBound() {
+    return _groupKeyMap.size();
+  }
+
+  @Override
+  public Iterator<GroupKey> getUniqueGroupKeys() {
+    return new GroupKeyIterator(_groupKeyMap);
+  }
+
+  @Override
+  public void purgeKeys(int[] keysToPurge) {
+    // TODO: Implement purging.
+    throw new UnsupportedOperationException("Purging keys not yet supported in GroupKeyGenerator without dictionary.");
+  }
+
+  /**
+   * Helper method to get or create group-id for a group key.
+   *
+   * @param key Group key for which to generate group id
+   * @return Group id
+   */
+  private int getGroupIdForKey(String key) {
+    int groupId;
+
+    if (!_groupKeyMap.containsKey(key)) {
+      _groupKeyMap.put(key, _numGroupKeys);
+      groupId = _numGroupKeys++;
+    } else {
+      groupId = _groupKeyMap.get(key);
+    }
+
+    return groupId;
+  }
+
+  /**
+   * Iterator for {Group-Key, Group-id) pair.
+   */
+  class GroupKeyIterator implements Iterator<GroupKey> {
+    Iterator<Map.Entry<String, Integer>> _iterator;
+    GroupKey _groupKey;
+
+    public GroupKeyIterator(Map<String, Integer> map) {
+      _iterator = map.entrySet().iterator();
+      _groupKey = new GroupKey(INVALID_ID, null);
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _iterator.hasNext();
+    }
+
+    @Override
+    public GroupKey next() {
+      Map.Entry<String, Integer> entry = _iterator.next();
+      _groupKey.setFirst(entry.getValue());
+      _groupKey.setSecond(entry.getKey());
+      return _groupKey;
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/BlockMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/BlockMetadataImpl.java
@@ -71,7 +71,7 @@ public final class BlockMetadataImpl implements BlockMetadata {
 
   @Override
   public boolean hasDictionary() {
-    return true;
+    return columnMetadata.hasDictionary();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/ProjectionBlock.java
@@ -15,9 +15,6 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
-import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
-import java.util.Map;
-
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
@@ -25,6 +22,8 @@ import com.linkedin.pinot.core.common.BlockId;
 import com.linkedin.pinot.core.common.BlockMetadata;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
+import com.linkedin.pinot.core.operator.aggregation.DataBlockCache;
+import java.util.Map;
 
 /**
  * ProjectionBlock holds a column name to Block Map.
@@ -77,6 +76,7 @@ public class ProjectionBlock implements Block {
     return _blockMap.get(column);
   }
 
+  // TODO: getDataBlock should replace getBlock, this requires changing selection code to use projection block to fetch data.
   public Block getDataBlock(String column) {
     return new ProjectionColumnBlock(_dataBlockCache, column);
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/DefaultGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/DefaultGroupKeyGeneratorTest.java
@@ -152,7 +152,6 @@ public class DefaultGroupKeyGeneratorTest {
     DefaultGroupKeyGenerator defaultGroupKeyGenerator = new DefaultGroupKeyGenerator(_projectionBlock, groupByColumns);
     Assert.assertEquals(defaultGroupKeyGenerator.getGlobalGroupKeyUpperBound(), UNIQUE_ROWS, _errorMessage);
     Assert.assertEquals(defaultGroupKeyGenerator.getCurrentGroupKeyUpperBound(), UNIQUE_ROWS, _errorMessage);
-    Assert.assertEquals(defaultGroupKeyGenerator.hasMultiValueGroupByColumn(), false, _errorMessage);
 
     // Test group key generation.
     defaultGroupKeyGenerator.generateKeysForBlock(_projectionBlock, _singleValueGroupKeyBuffer);
@@ -171,7 +170,6 @@ public class DefaultGroupKeyGeneratorTest {
     DefaultGroupKeyGenerator defaultGroupKeyGenerator = new DefaultGroupKeyGenerator(_projectionBlock, groupByColumns);
     Assert.assertEquals(defaultGroupKeyGenerator.getGlobalGroupKeyUpperBound(), expected, _errorMessage);
     Assert.assertEquals(defaultGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
-    Assert.assertEquals(defaultGroupKeyGenerator.hasMultiValueGroupByColumn(), false, _errorMessage);
 
     // Test group key generation.
     defaultGroupKeyGenerator.generateKeysForBlock(_projectionBlock, _singleValueGroupKeyBuffer);
@@ -189,7 +187,6 @@ public class DefaultGroupKeyGeneratorTest {
     DefaultGroupKeyGenerator defaultGroupKeyGenerator = new DefaultGroupKeyGenerator(_projectionBlock, groupByColumns);
     Assert.assertEquals(defaultGroupKeyGenerator.getGlobalGroupKeyUpperBound(), Integer.MAX_VALUE, _errorMessage);
     Assert.assertEquals(defaultGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
-    Assert.assertEquals(defaultGroupKeyGenerator.hasMultiValueGroupByColumn(), false, _errorMessage);
 
     // Test group key generation.
     defaultGroupKeyGenerator.generateKeysForBlock(_projectionBlock, _singleValueGroupKeyBuffer);
@@ -221,7 +218,6 @@ public class DefaultGroupKeyGeneratorTest {
     DefaultGroupKeyGenerator defaultGroupKeyGenerator = new DefaultGroupKeyGenerator(_projectionBlock, groupByColumns);
     int groupKeyUpperBound = defaultGroupKeyGenerator.getGlobalGroupKeyUpperBound();
     Assert.assertEquals(defaultGroupKeyGenerator.getCurrentGroupKeyUpperBound(), groupKeyUpperBound, _errorMessage);
-    Assert.assertEquals(defaultGroupKeyGenerator.hasMultiValueGroupByColumn(), true, _errorMessage);
 
     // Test group key generation.
     defaultGroupKeyGenerator.generateKeysForBlock(_projectionBlock, _multiValueGroupKeyBuffer);
@@ -239,7 +235,6 @@ public class DefaultGroupKeyGeneratorTest {
     // Test initial status.
     DefaultGroupKeyGenerator defaultGroupKeyGenerator = new DefaultGroupKeyGenerator(_projectionBlock, groupByColumns);
     Assert.assertEquals(defaultGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
-    Assert.assertEquals(defaultGroupKeyGenerator.hasMultiValueGroupByColumn(), true, _errorMessage);
 
     // Test group key generation.
     defaultGroupKeyGenerator.generateKeysForBlock(_projectionBlock, _multiValueGroupKeyBuffer);
@@ -257,7 +252,6 @@ public class DefaultGroupKeyGeneratorTest {
     // Test initial status.
     DefaultGroupKeyGenerator defaultGroupKeyGenerator = new DefaultGroupKeyGenerator(_projectionBlock, groupByColumns);
     Assert.assertEquals(defaultGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
-    Assert.assertEquals(defaultGroupKeyGenerator.hasMultiValueGroupByColumn(), true, _errorMessage);
 
     // Test group key generation.
     defaultGroupKeyGenerator.generateKeysForBlock(_projectionBlock, _multiValueGroupKeyBuffer);

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/NoDictionaryGroupKeyGeneratorTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.operator.aggregation;
+
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.DataSource;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.readers.RecordReader;
+import com.linkedin.pinot.core.data.readers.TestRecordReader;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
+import com.linkedin.pinot.core.operator.BaseOperator;
+import com.linkedin.pinot.core.operator.MProjectionOperator;
+import com.linkedin.pinot.core.operator.aggregation.groupby.GroupKeyGenerator;
+import com.linkedin.pinot.core.operator.aggregation.groupby.NoDictionaryGroupKeyGenerator;
+import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.filter.MatchEntireSegmentOperator;
+import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
+import com.linkedin.pinot.core.query.aggregation.groupby.GroupByConstants;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.linkedin.pinot.core.segment.index.loader.Loaders;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link NoDictionaryGroupKeyGenerator}
+ */
+public class NoDictionaryGroupKeyGeneratorTest {
+  private static final String SEGMENT_DIR_NAME = System.getProperty("java.io.tmpdir") + File.separator + "rawIndexPerf";
+  private static final String SEGMENT_NAME = "perfTestSegment";
+  private static final int NUM_COLUMNS = 2;
+  private static final int NUM_ROWS = 10000;
+
+  /**
+   * This test builds a segment with two columns, one without dictionary, and the other with dictionary.
+   * It then uses {@link NoDictionaryGroupKeyGenerator} to ensure that all group keys are generated correctly.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void test()
+      throws Exception {
+    Set<String> expectedGroupKeys = buildSegment();
+
+    // Load the segment.
+    File segment = new File(SEGMENT_DIR_NAME, SEGMENT_NAME);
+    IndexSegment indexSegment = Loaders.IndexSegment.load(segment, ReadMode.heap);
+
+    // Build the group key generator.
+    GroupKeyGenerator groupKeyGenerator = new NoDictionaryGroupKeyGenerator(indexSegment.getColumnNames());
+
+    // Build the data source map
+    Map<String, BaseOperator> dataSourceMap = new HashMap<>();
+    for (String column : indexSegment.getColumnNames()) {
+      DataSource dataSource = indexSegment.getDataSource(column);
+      dataSourceMap.put(column, dataSource);
+    }
+
+    // Build the projection operator.
+    MatchEntireSegmentOperator matchEntireSegmentOperator = new MatchEntireSegmentOperator(NUM_ROWS);
+    BReusableFilteredDocIdSetOperator docIdSetOperator =
+        new BReusableFilteredDocIdSetOperator(matchEntireSegmentOperator, NUM_ROWS, 10000);
+    MProjectionOperator projectionOperator = new MProjectionOperator(dataSourceMap, docIdSetOperator);
+
+    // Iterator over all projection blocks and generate group keys.
+    ProjectionBlock projectionBlock;
+    int[] docIdToGroupKeys = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+
+    while ((projectionBlock = (ProjectionBlock) projectionOperator.nextBlock()) != null) {
+      groupKeyGenerator.generateKeysForBlock(projectionBlock, docIdToGroupKeys);
+    }
+
+    // Assert total number of group keys is as expected
+    Assert.assertEquals(groupKeyGenerator.getCurrentGroupKeyUpperBound(), expectedGroupKeys.size(),
+        "Number of group keys mis-match.");
+
+    // Assert all group key values are as expected
+    Iterator<GroupKeyGenerator.GroupKey> uniqueGroupKeys = groupKeyGenerator.getUniqueGroupKeys();
+    while (uniqueGroupKeys.hasNext()) {
+      GroupKeyGenerator.GroupKey groupKey = uniqueGroupKeys.next();
+      String actual = groupKey.getStringKey();
+      Assert.assertTrue(expectedGroupKeys.contains(actual), "Unexpected group key: " + actual);
+    }
+  }
+
+  /**
+   * Helper method to build a segment as follows:
+   * <ul>
+   *   <li> One string column without dictionary. </li>
+   *   <li> One integer column with dictionary. </li>
+   * </ul>
+   *
+   * It also computes the unique group keys while it generates the index.
+   *
+   * @return Set containing unique group keys from the created segment.
+   *
+   * @throws Exception
+   */
+  private Set<String> buildSegment()
+      throws Exception {
+    Schema schema = new Schema();
+
+    for (int i = 0; i < NUM_COLUMNS; i++) {
+      String column = "column_" + i;
+      FieldSpec.DataType dataType = ((i & 0x1) == 1) ? FieldSpec.DataType.STRING : FieldSpec.DataType.INT;
+      DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec(column, dataType, true);
+      schema.addField(dimensionFieldSpec);
+    }
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setRawIndexCreationColumns(Collections.singletonList("column_1"));
+
+    config.setOutDir(SEGMENT_DIR_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    Set<String> keys = new HashSet<>(NUM_ROWS);
+    StringBuilder stringBuilder = new StringBuilder();
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Map<String, Object> map = new HashMap<>(NUM_COLUMNS);
+
+      int j = 0;
+      stringBuilder.setLength(0);
+      for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+        String column = fieldSpec.getName();
+
+        if (fieldSpec.getDataType() == FieldSpec.DataType.STRING) {
+          map.put(column, "value_" + i);
+        } else {
+          map.put(column, NUM_ROWS - i - 1);
+        }
+        stringBuilder.append(map.get(column));
+        if (j++ < NUM_COLUMNS - 1) {
+          stringBuilder.append(GroupByConstants.GroupByDelimiter.groupByMultiDelimeter);
+        }
+      }
+      keys.add(stringBuilder.toString());
+
+      GenericRow genericRow = new GenericRow();
+      genericRow.init(map);
+      rows.add(genericRow);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    RecordReader recordReader = new TestRecordReader(rows, schema);
+
+    driver.init(config, recordReader);
+    driver.build();
+
+    return keys;
+  }
+}

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -165,5 +166,19 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
       }
       driver.addSegment(segmentMetadata);
     }
+  }
+
+  /**
+   * Main method for the class.
+   *
+   * @param args Arguments for the converter
+   * @throws Exception
+   */
+  public static void main(String[] args)
+      throws Exception {
+    PerfBenchmarkRunner perfBenchmarkRunner = new PerfBenchmarkRunner();
+    CmdLineParser parser = new CmdLineParser(perfBenchmarkRunner);
+    parser.parseArgument(args);
+    perfBenchmarkRunner.execute();
   }
 }


### PR DESCRIPTION
1. Added a new GroupKeyGenerator that works without dictionary, ie using
actual values for keys, instead of dictionary id's.
2. Integrated the NoDictionaryGroupKeyGenerator into the group-by
executor.
3. Enhanced PerfBenchmarkRunner to be invoked from IDE (added main that
parses args4j args).