### PR TITLE
Add routing table builder for large clusters

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/ServerInstance.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/ServerInstance.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
  * local hostname.
  */
 public class ServerInstance implements Comparable<ServerInstance> {
-
   protected static final Logger LOGGER = LoggerFactory.getLogger(ServerInstance.class);
 
   public static final String NAME_PORT_DELIMITER = ":";
@@ -64,8 +63,8 @@ public class ServerInstance implements Comparable<ServerInstance> {
   }
 
   public ServerInstance(String name, int port, int seq) {
-    super();
     InetAddress ipAddr = null;
+
     try {
       ipAddr = InetAddress.getByName(name);
     } catch (UnknownHostException e) {

--- a/pinot-transport/pom.xml
+++ b/pinot-transport/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId> 
+      <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/AbstractRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/AbstractRoutingTableBuilder.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.routing.builder;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+
+
+/**
+ * Utility class to share common utility methods between routing table builders.
+ */
+public abstract class AbstractRoutingTableBuilder implements RoutingTableBuilder {
+  /**
+   * Picks a random replica, inversely weighted by the number of segments already assigned to each replica. See a longer
+   * description of the probabilities used in
+   * {@link KafkaLowLevelConsumerRoutingTableBuilder#computeRoutingTableFromExternalView(String, ExternalView, List)}
+   *
+   * @param validReplicaSet The list of valid replicas from which to pick a replica
+   * @param instanceToSegmentSetMap A map containing the segments already assigned to each replica for routing
+   * @param random The random number generator to use
+   * @return The instance name of a replica that was chosen
+   */
+  protected String pickWeightedRandomReplica(Set<String> validReplicaSet,
+      Map<String, Set<String>> instanceToSegmentSetMap, Random random) {
+
+    // No replicas?
+    if (validReplicaSet.isEmpty()) {
+      return null;
+    }
+
+    // Only one valid replica?
+    if (validReplicaSet.size() == 1) {
+      return validReplicaSet.iterator().next();
+    }
+
+    // Find maximum segment count assigned to a replica
+    String[] replicas = validReplicaSet.toArray(new String[validReplicaSet.size()]);
+    int[] replicaSegmentCounts = new int[validReplicaSet.size()];
+
+    int maxSegmentCount = 0;
+    for (int i = 0; i < replicas.length; i++) {
+      String replica = replicas[i];
+      int replicaSegmentCount = 0;
+
+      if (instanceToSegmentSetMap.containsKey(replica)) {
+        replicaSegmentCount = instanceToSegmentSetMap.get(replica).size();
+      }
+
+      replicaSegmentCounts[i] = replicaSegmentCount;
+
+      if (maxSegmentCount < replicaSegmentCount) {
+        maxSegmentCount = replicaSegmentCount;
+      }
+    }
+
+    // Compute replica weights
+    int[] replicaWeights = new int[validReplicaSet.size()];
+    int totalReplicaWeights = 0;
+    for (int i = 0; i < replicas.length; i++) {
+      int replicaWeight = maxSegmentCount - replicaSegmentCounts[i];
+      replicaWeights[i] = replicaWeight;
+      totalReplicaWeights += replicaWeight;
+    }
+
+    // If all replicas are equal, just pick a random replica
+    if (totalReplicaWeights == 0) {
+      return replicas[random.nextInt(replicas.length)];
+    }
+
+    // Pick the proper replica given their respective weights
+    int randomValue = random.nextInt(totalReplicaWeights);
+    int i = 0;
+    while(replicaWeights[i] == 0 || replicaWeights[i] <= randomValue) {
+      randomValue -= replicaWeights[i];
+      ++i;
+    }
+
+    return replicas[i];
+  }
+}

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
@@ -43,9 +43,10 @@ import com.linkedin.pinot.routing.ServerToSegmentSetMap;
 /**
  * Routing table builder for the Kafka low level consumer.
  */
-public class KafkaLowLevelConsumerRoutingTableBuilder implements RoutingTableBuilder {
+public class KafkaLowLevelConsumerRoutingTableBuilder extends AbstractRoutingTableBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaLowLevelConsumerRoutingTableBuilder.class);
   private static final int routingTableCount = 10;
+  private final Random _random = new Random();
 
   @Override
   public void init(Configuration configuration) {
@@ -241,7 +242,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilder implements RoutingTableBui
         String segment = segmentAndValidReplicaSet.getKey();
         Set<String> validReplicaSet = segmentAndValidReplicaSet.getValue();
 
-        String replica = pickWeightedRandomReplica(validReplicaSet, instanceToSegmentSetMap);
+        String replica = pickWeightedRandomReplica(validReplicaSet, instanceToSegmentSetMap, _random);
         if (replica != null) {
           Set<String> segmentsForInstance = instanceToSegmentSetMap.get(replica);
 
@@ -258,64 +259,5 @@ public class KafkaLowLevelConsumerRoutingTableBuilder implements RoutingTableBui
     }
 
     return routingTables;
-  }
-
-  private String pickWeightedRandomReplica(Set<String> validReplicaSet,
-      Map<String, Set<String>> instanceToSegmentSetMap) {
-    Random random = new Random();
-
-    // No replicas?
-    if (validReplicaSet.isEmpty()) {
-      return null;
-    }
-
-    // Only one valid replica?
-    if (validReplicaSet.size() == 1) {
-      return validReplicaSet.iterator().next();
-    }
-
-    // Find maximum segment count assigned to a replica
-    String[] replicas = validReplicaSet.toArray(new String[validReplicaSet.size()]);
-    int[] replicaSegmentCounts = new int[validReplicaSet.size()];
-
-    int maxSegmentCount = 0;
-    for (int i = 0; i < replicas.length; i++) {
-      String replica = replicas[i];
-
-      if (!instanceToSegmentSetMap.containsKey(replica)) {
-        instanceToSegmentSetMap.put(replica, new HashSet<String>());
-      }
-
-      int replicaSegmentCount = instanceToSegmentSetMap.get(replica).size();
-      replicaSegmentCounts[i] = replicaSegmentCount;
-
-      if (maxSegmentCount < replicaSegmentCount) {
-        maxSegmentCount = replicaSegmentCount;
-      }
-    }
-
-    // Compute replica weights
-    int[] replicaWeights = new int[validReplicaSet.size()];
-    int totalReplicaWeights = 0;
-    for (int i = 0; i < replicas.length; i++) {
-      int replicaWeight = maxSegmentCount - replicaSegmentCounts[i];
-      replicaWeights[i] = replicaWeight;
-      totalReplicaWeights += replicaWeight;
-    }
-
-    // If all replicas are equal, just pick a random replica
-    if (totalReplicaWeights == 0) {
-      return replicas[random.nextInt(replicas.length)];
-    }
-
-    // Pick the proper replica given their respective weights
-    int randomValue = random.nextInt(totalReplicaWeights);
-    int i = 0;
-    while(replicaWeights[i] == 0 || replicaWeights[i] <= randomValue) {
-      randomValue -= replicaWeights[i];
-      ++i;
-    }
-
-    return replicas[i];
   }
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
@@ -1,0 +1,321 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.routing.builder;
+
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Routing table builder for large offline clusters (over 20-30 servers) that avoids having each request go to every server.
+ */
+public class LargeClusterRoutingTableBuilder extends AbstractRoutingTableBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LargeClusterRoutingTableBuilder.class);
+
+  /** Number of servers to hit for each query (this is a soft limit, not a hard limit) */
+  private int TARGET_SERVER_COUNT_PER_QUERY = 20;
+
+  /** Number of routing tables to keep */
+  private static final int ROUTING_TABLE_COUNT = 500;
+
+  /** Number of routing tables to generate during the optimization phase */
+  private static final int ROUTING_TABLE_GENERATION_COUNT = 1000;
+
+  private final Random random;
+
+  public LargeClusterRoutingTableBuilder() {
+    random = new Random();
+  }
+
+  LargeClusterRoutingTableBuilder(Random random) {
+    this.random = random;
+  }
+
+  private class RoutingTableGenerator {
+    private Map<String, Set<String>> segmentToInstanceMap = new HashMap<>();
+    private Map<String, Set<String>> instanceToSegmentMap = new HashMap<>();
+    private Set<String> segmentsWithAtLeastOneOnlineReplica = new HashSet<>();
+    private Set<String> allValidInstancesSet;
+    private String[] instanceArray;
+    private Map<String, String[]> segmentToInstanceArrayMap;
+
+    private void init(ExternalView externalView, List<InstanceConfig> instanceConfigList) {
+      RoutingTableInstancePruner pruner = new RoutingTableInstancePruner(instanceConfigList);
+
+      // Compute the inverse of the external view
+      for (String segment : externalView.getPartitionSet()) {
+        Set<String> instancesForSegment = new HashSet<>();
+        segmentToInstanceMap.put(segment, instancesForSegment);
+
+        for (Map.Entry<String, String> instanceAndState : externalView.getStateMap(segment).entrySet()) {
+          String instance = instanceAndState.getKey();
+          String state = instanceAndState.getValue();
+
+          // Only consider partitions that are ONLINE
+          if (!CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE.equals(state)) {
+            continue;
+          }
+
+          // Skip instances that are disabled
+          if (pruner.isInactive(instance)) {
+            continue;
+          }
+
+          // Add to the instance -> segments map
+          Set<String> segmentsForInstance = instanceToSegmentMap.get(instance);
+
+          if (segmentsForInstance == null) {
+            segmentsForInstance = new HashSet<>();
+            instanceToSegmentMap.put(instance, segmentsForInstance);
+          }
+
+          segmentsForInstance.add(segment);
+
+          // Add to the segment -> instances map
+          instancesForSegment.add(instance);
+
+          // Add to the valid segments map
+          segmentsWithAtLeastOneOnlineReplica.add(segment);
+        }
+      }
+
+      allValidInstancesSet = instanceToSegmentMap.keySet();
+      instanceArray = allValidInstancesSet.toArray(new String[allValidInstancesSet.size()]);
+
+      segmentToInstanceArrayMap = new HashMap<>();
+    }
+
+    private Map<String, Set<String>> generateRoutingTable() {
+      // List of segments that have no instance serving them
+      Set<String> segmentsNotHandledByServers = new HashSet<>(segmentsWithAtLeastOneOnlineReplica);
+
+      // List of servers in this routing table
+      Set<String> instancesInRoutingTable = new HashSet<>(TARGET_SERVER_COUNT_PER_QUERY);
+
+      // If there are not enough instances, add them all
+      if (instanceArray.length <= TARGET_SERVER_COUNT_PER_QUERY) {
+        instancesInRoutingTable.addAll(allValidInstancesSet);
+        segmentsNotHandledByServers.clear();
+      } else {
+        // Otherwise add TARGET_SERVER_COUNT_PER_QUERY instances
+        while (instancesInRoutingTable.size() < TARGET_SERVER_COUNT_PER_QUERY) {
+          String randomInstance = instanceArray[random.nextInt(instanceArray.length)];
+          instancesInRoutingTable.add(randomInstance);
+          segmentsNotHandledByServers.removeAll(instanceToSegmentMap.get(randomInstance));
+        }
+      }
+
+      // If there are segments that have no instance that can serve them, add a server to serve them
+      while (!segmentsNotHandledByServers.isEmpty()) {
+        // Get the instances in array format
+        String segmentNotHandledByServers = segmentsNotHandledByServers.iterator().next();
+
+        String[] instancesArrayForThisSegment = segmentToInstanceArrayMap.get(segmentNotHandledByServers);
+
+        if (instancesArrayForThisSegment == null) {
+          Set<String> instanceSet = segmentToInstanceMap.get(segmentNotHandledByServers);
+          instancesArrayForThisSegment = instanceSet.toArray(new String[instanceSet.size()]);
+          segmentToInstanceArrayMap.put(segmentNotHandledByServers, instancesArrayForThisSegment);
+        }
+
+        // Pick a random instance that can serve this segment
+        String instance = instancesArrayForThisSegment[random.nextInt(instancesArrayForThisSegment.length)];
+        instancesInRoutingTable.add(instance);
+        segmentsNotHandledByServers.removeAll(instanceToSegmentMap.get(instance));
+      }
+
+      // Sort all the segments to be used during assignment in ascending order of replicas
+      int segmentCount = Math.max(segmentsWithAtLeastOneOnlineReplica.size(), 1);
+      PriorityQueue<Pair<String, Set<String>>> segmentToReplicaSetQueue = new PriorityQueue<>(segmentCount,
+          new Comparator<Pair<String, Set<String>>>() {
+            @Override
+            public int compare(Pair<String, Set<String>> firstPair, Pair<String, Set<String>> secondPair) {
+              return Integer.compare(firstPair.getRight().size(), secondPair.getRight().size());
+            }
+          });
+
+      for (String segment : segmentsWithAtLeastOneOnlineReplica) {
+        // Instances for this segment is the intersection of all instances for this segment and the instances that we
+        // have in this routing table
+        Set<String> instancesForThisSegment = new HashSet<>(segmentToInstanceMap.get(segment));
+        instancesForThisSegment.retainAll(instancesInRoutingTable);
+
+        segmentToReplicaSetQueue.add(new ImmutablePair<>(segment, instancesForThisSegment));
+      }
+
+      // Create the routing table from the segment -> instances priority queue
+      Map<String, Set<String>> instanceToSegmentSetMap = new HashMap<>();
+      int[] replicas = new int[10];
+      while(!segmentToReplicaSetQueue.isEmpty()) {
+        Pair<String, Set<String>> segmentAndReplicaSet = segmentToReplicaSetQueue.poll();
+        String segment = segmentAndReplicaSet.getKey();
+        Set<String> replicaSet = segmentAndReplicaSet.getValue();
+        replicas[replicaSet.size() - 1]++;
+
+        String instance = pickWeightedRandomReplica(replicaSet, instanceToSegmentSetMap, random);
+        if (instance != null) {
+          Set<String> segmentsAssignedToInstance = instanceToSegmentSetMap.get(instance);
+
+          if (segmentsAssignedToInstance == null) {
+            segmentsAssignedToInstance = new HashSet<>();
+            instanceToSegmentSetMap.put(instance, segmentsAssignedToInstance);
+          }
+
+          segmentsAssignedToInstance.add(segment);
+        } else {
+          LOGGER.error("null replica while trying to find replicas for segment {}, this shouldn't happen", segment);
+        }
+      }
+
+      return instanceToSegmentSetMap;
+    }
+  }
+
+  @Override
+  public void init(Configuration configuration) {
+    // TODO jfim This is a broker-level configuration for now, until we refactor the configuration of the routing table to allow per-table routing settings
+    if (configuration.containsKey("targetServerCountPerQuery")) {
+      final String targetServerCountPerQuery = configuration.getString("targetServerCountPerQuery");
+      try {
+        TARGET_SERVER_COUNT_PER_QUERY = Integer.parseInt(targetServerCountPerQuery);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Could not get the target server count per query from configuration value {}, keeping default value {}",
+            targetServerCountPerQuery, TARGET_SERVER_COUNT_PER_QUERY, e);
+      }
+    }
+  }
+
+  @Override
+  public List<ServerToSegmentSetMap> computeRoutingTableFromExternalView(String tableName, ExternalView externalView,
+      List<InstanceConfig> instanceConfigList) {
+    // The default routing table algorithm tries to balance all available segments across all servers, so that each
+    // server is hit on every query. This works fine with small clusters (say less than 20 servers) but for larger
+    // clusters, this adds up to significant overhead (one request must be enqueued for each server, processed,
+    // returned, deserialized, aggregated, etc.).
+    //
+    // For large clusters, we want to avoid hitting every server, as this also has an adverse effect on client tail
+    // latency. This is due to the fact that a query cannot return until it has received a response from each server,
+    // and the greater the number of servers that are hit, the more likely it is that one of the servers will be a
+    // straggler (eg. due to contention for query processing threads, GC, etc.). We also want to balance the segments
+    // within any given routing table so that each server in the routing table has approximately the same number of
+    // segments to process.
+    //
+    // To do so, we have a routing table generator that generates routing tables by picking a random subset of servers.
+    // With this set of servers, we check if the set of segments served by these servers is complete. If the set of
+    // segments served does not cover all of the segments, we compute the list of missing segments and pick a random
+    // server that serves these missing segments until we have complete coverage of all the segments.
+    //
+    // We then order the segments in ascending number of replicas within our server set, in order to allocate the
+    // segments with fewer replicas first. This ensures that segments that are 'easier' to allocate are more likely to
+    // end up on a replica with fewer segments.
+    //
+    // Then, we pick a random replica for each segment, iterating from fewest replicas to most replicas, inversely
+    // weighted by the number of segments already assigned to that replica. This ensures that we build a routing table
+    // that's as even as possible.
+    //
+    // The algorithm to generate a routing table is thus:
+    // 1. Compute the inverse external view, a mapping of servers to segments
+    // 2. For each routing table to generate:
+    //   a) Pick TARGET_SERVER_COUNT_PER_QUERY distinct servers
+    //   b) Check if the server set covers all the segments; if not, add additional servers until it does.
+    //   c) Order the segments in our server set in ascending order of number of replicas present in our server set
+    //   d) For each segment, pick a random replica with proper weighting
+    //   e) Return that routing table
+    //
+    // Given that we can generate routing tables at will, we then generate many routing tables and use them to optimize
+    // according to two criteria: the variance in workload per server for any individual table as well as the variance
+    // in workload per server across all the routing tables. To do so, we generate an initial set of routing tables
+    // according to a per-routing table metric and discard the worst routing tables.
+
+    RoutingTableGenerator routingTableGenerator = new RoutingTableGenerator();
+    routingTableGenerator.init(externalView, instanceConfigList);
+
+    PriorityQueue<Pair<Map<String, Set<String>>, Float>> topRoutingTables = new PriorityQueue<>(ROUTING_TABLE_COUNT, new Comparator<Pair<Map<String, Set<String>>, Float>>() {
+      @Override
+      public int compare(Pair<Map<String, Set<String>>, Float> left, Pair<Map<String, Set<String>>, Float> right) {
+        // Float.compare sorts in ascending order and we want a max heap, so we need to return the negative of the comparison
+        return -Float.compare(left.getValue(), right.getValue());
+      }
+    });
+
+    for (int i = 0; i < ROUTING_TABLE_COUNT; i++) {
+      topRoutingTables.add(generateRoutingTableWithMetric(routingTableGenerator));
+    }
+
+    // Generate routing more tables and keep the ROUTING_TABLE_COUNT top ones
+    for(int i = 0; i < (ROUTING_TABLE_GENERATION_COUNT - ROUTING_TABLE_COUNT); ++i) {
+      Pair<Map<String, Set<String>>, Float> newRoutingTable = generateRoutingTableWithMetric(routingTableGenerator);
+      Pair<Map<String, Set<String>>, Float> worstRoutingTable = topRoutingTables.peek();
+
+      // If the new routing table is better than the worst one, keep it
+      if (newRoutingTable.getRight() < worstRoutingTable.getRight()) {
+        topRoutingTables.poll();
+        topRoutingTables.add(newRoutingTable);
+      }
+    }
+
+    // Return the best routing tables
+    List<ServerToSegmentSetMap> routingTables = new ArrayList<>(topRoutingTables.size());
+    while(!topRoutingTables.isEmpty()) {
+      Pair<Map<String, Set<String>>, Float> routingTableWithMetric = topRoutingTables.poll();
+      routingTables.add(new ServerToSegmentSetMap(routingTableWithMetric.getKey()));
+    }
+
+    return routingTables;
+  }
+
+  private Pair<Map<String, Set<String>>, Float> generateRoutingTableWithMetric(RoutingTableGenerator routingTableGenerator) {
+    Map<String, Set<String>> routingTable = routingTableGenerator.generateRoutingTable();
+    int segmentCount = 0;
+    int serverCount = 0;
+
+    // Compute the number of segments and servers (for the average part of the variance)
+    for (Set<String> segmentsForServer : routingTable.values()) {
+      int segmentCountForServer = segmentsForServer.size();
+      segmentCount += segmentCountForServer;
+      serverCount++;
+    }
+
+    // Compute the variance of the number of segments allocated per server
+    float averageSegmentCount = ((float) segmentCount) / serverCount;
+    float variance = 0.0f;
+    for (Set<String> segmentsForServer : routingTable.values()) {
+      int segmentCountForServer = segmentsForServer.size();
+      float difference = segmentCountForServer - averageSegmentCount;
+      variance += difference * difference;
+    }
+
+    return new ImmutablePair<>(routingTable, variance);
+  }
+}

--- a/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilderTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilderTest.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.routing.builder;
+
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Test for the large cluster routing table builder.
+ */
+public class LargeClusterRoutingTableBuilderTest {
+  private static final boolean EXHAUSTIVE = false;
+  private static final long RANDOM_SEED = System.currentTimeMillis();
+  private LargeClusterRoutingTableBuilder _largeClusterRoutingTableBuilder =
+      new LargeClusterRoutingTableBuilder(new Random(RANDOM_SEED));
+
+  private interface RoutingTableValidator {
+    boolean isRoutingTableValid(ServerToSegmentSetMap routingTable, ExternalView externalView,
+        List<InstanceConfig> instanceConfigs);
+  }
+
+  @Test
+  public void setUp() {
+    System.out.println("RANDOM_SEED = " + RANDOM_SEED);
+  }
+
+  @Test
+  public void testRoutingTableCoversAllSegmentsExactlyOnce() {
+    validateAssertionOverMultipleRoutingTables(new RoutingTableValidator() {
+      @Override
+      public boolean isRoutingTableValid(ServerToSegmentSetMap routingTable, ExternalView externalView,
+          List<InstanceConfig> instanceConfigs) {
+        Set<String> unassignedSegments = new HashSet<>();
+        unassignedSegments.addAll(externalView.getPartitionSet());
+
+        for (String server : routingTable.getServerSet()) {
+          final Set<String> serverSegmentSet = routingTable.getSegmentSet(server);
+
+          if (!unassignedSegments.containsAll(serverSegmentSet)) {
+            // A segment is already assigned to another server and/or doesn't exist in external view
+            return false;
+          }
+
+          unassignedSegments.removeAll(serverSegmentSet);
+        }
+
+        return unassignedSegments.isEmpty();
+      }
+    }, "Routing table should contain all segments exactly once");
+  }
+
+  @Test
+  public void testRoutingTableExcludesDisabledAndRebootingInstances() {
+    final String tableName = "fakeTable_OFFLINE";
+    final int segmentCount = 100;
+    final int replicationFactor = 6;
+    final int instanceCount = 50;
+
+    ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
+    List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
+
+    final InstanceConfig disabledHelixInstance = instanceConfigs.get(0);
+    final String disabledHelixInstanceName = disabledHelixInstance.getInstanceName();
+    disabledHelixInstance.setInstanceEnabled(false);
+
+    final InstanceConfig shuttingDownInstance = instanceConfigs.get(1);
+    final String shuttingDownInstanceName = shuttingDownInstance.getInstanceName();
+    shuttingDownInstance.getRecord().setSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(true));
+
+    validateAssertionForOneRoutingTable(new RoutingTableValidator() {
+      @Override
+      public boolean isRoutingTableValid(ServerToSegmentSetMap routingTable, ExternalView externalView,
+          List<InstanceConfig> instanceConfigs) {
+        for (String server : routingTable.getServerSet()) {
+          // These servers should not appear in the routing table
+          if (server.equals(disabledHelixInstanceName) || server.equals(shuttingDownInstanceName)) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+    }, "Routing table should not contain disabled instances", externalView, instanceConfigs, tableName);
+  }
+
+  @Test
+  public void testRoutingTableSizeGenerallyHasConfiguredServerCount() {
+    final String tableName = "fakeTable_OFFLINE";
+    final int segmentCount = 100;
+    final int replicationFactor = 10;
+    final int instanceCount = 50;
+    final int desiredServerCount = 20;
+
+    ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
+    List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
+
+    List<ServerToSegmentSetMap> routingTables =
+        _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+
+    int routingTableCount = 0;
+    int largerThanDesiredRoutingTableCount = 0;
+
+    for (ServerToSegmentSetMap routingTable : routingTables) {
+      routingTableCount++;
+      if (desiredServerCount < routingTable.getServerSet().size()) {
+        largerThanDesiredRoutingTableCount++;
+      }
+    }
+
+    assertTrue(largerThanDesiredRoutingTableCount / 0.6 < routingTableCount,
+        "More than 60% of routing tables exceed the desired routing table size, RANDOM_SEED = " + RANDOM_SEED);
+  }
+
+  @Test
+  public void testRoutingTableServerLoadIsRelativelyEqual() {
+    final String tableName = "fakeTable_OFFLINE";
+    final int segmentCount = 300;
+    final int replicationFactor = 10;
+    final int instanceCount = 50;
+
+    ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
+    List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
+
+    List<ServerToSegmentSetMap> routingTables =
+        _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+
+    Map<String, Integer> segmentCountPerServer = new HashMap<>();
+
+    // Count number of segments assigned per server
+    for (ServerToSegmentSetMap routingTable : routingTables) {
+      for (String server : routingTable.getServerSet()) {
+        Integer segmentCountForServer = segmentCountPerServer.get(server);
+
+        if (segmentCountForServer == null) {
+          segmentCountForServer = 0;
+        }
+
+        segmentCountForServer += routingTable.getSegmentSet(server).size();
+        segmentCountPerServer.put(server, segmentCountForServer);
+      }
+    }
+
+    int minNumberOfSegmentsAssignedPerServer = Integer.MAX_VALUE;
+    int maxNumberOfSegmentsAssignedPerServer = 0;
+
+    for (Integer segmentCountForServer : segmentCountPerServer.values()) {
+      if (segmentCountForServer < minNumberOfSegmentsAssignedPerServer) {
+        minNumberOfSegmentsAssignedPerServer = segmentCountForServer;
+      }
+
+      if (maxNumberOfSegmentsAssignedPerServer < segmentCountForServer) {
+        maxNumberOfSegmentsAssignedPerServer = segmentCountForServer;
+      }
+    }
+
+    assertTrue(maxNumberOfSegmentsAssignedPerServer < minNumberOfSegmentsAssignedPerServer * 1.5,
+        "At least one server has more than 150% of the load of the least loaded server, minNumberOfSegmentsAssignedPerServer = "
+            + minNumberOfSegmentsAssignedPerServer + " maxNumberOfSegmentsAssignedPerServer = "
+            + maxNumberOfSegmentsAssignedPerServer + " RANDOM_SEED = " + RANDOM_SEED);
+  }
+
+  private String buildInstanceName(int instanceId) {
+    return "Server_127.0.0.1_" + instanceId;
+  }
+
+  private ExternalView createExternalView(String tableName, int segmentCount, int replicationFactor,
+      int instanceCount) {
+    ExternalView externalView = new ExternalView(tableName);
+
+    String[] instanceNames = new String[instanceCount];
+    for (int i = 0; i < instanceCount; i++) {
+      instanceNames[i] = buildInstanceName(i);
+    }
+
+    int assignmentCount = 0;
+    for (int i = 0; i < segmentCount; i++) {
+      String segmentName = tableName + "_" + i;
+      for (int j = 0; j < replicationFactor; j++) {
+        externalView.setState(segmentName, instanceNames[assignmentCount % instanceCount], "ONLINE");
+        ++assignmentCount;
+      }
+    }
+
+    return externalView;
+  }
+
+  private void validateAssertionOverMultipleRoutingTables(RoutingTableValidator routingTableValidator,
+      String message) {
+    if (EXHAUSTIVE) {
+      for (int instanceCount = 1; instanceCount < 100; instanceCount += 1) {
+        for (int replicationFactor = 1; replicationFactor < 10; replicationFactor++) {
+          for (int segmentCount = 0; segmentCount < 300; segmentCount += 10) {
+            validateAssertionForOneRoutingTable(routingTableValidator, message, instanceCount, replicationFactor,
+                segmentCount);
+          }
+        }
+      }
+    } else {
+      validateAssertionForOneRoutingTable(routingTableValidator, message, 50, 6, 200);
+    }
+  }
+
+  private void validateAssertionForOneRoutingTable(RoutingTableValidator routingTableValidator, String message,
+      int instanceCount, int replicationFactor, int segmentCount) {
+    final String tableName = "fakeTable_OFFLINE";
+
+    ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
+    List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
+
+    validateAssertionForOneRoutingTable(routingTableValidator, message, externalView, instanceConfigs, tableName);
+  }
+
+  private void validateAssertionForOneRoutingTable(RoutingTableValidator routingTableValidator, String message,
+      ExternalView externalView, List<InstanceConfig> instanceConfigs, String tableName) {
+    List<ServerToSegmentSetMap> routingTables =
+        _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+
+    for (ServerToSegmentSetMap routingTable : routingTables) {
+      boolean isValid = routingTableValidator.isRoutingTableValid(routingTable, externalView, instanceConfigs);
+
+      if (!isValid) {
+        System.out.println("externalView = " + externalView);
+        System.out.println("routingTable = " + routingTable);
+        System.out.println("RANDOM_SEED = " + RANDOM_SEED);
+      }
+
+      assertTrue(isValid, message);
+    }
+  }
+
+  private List<InstanceConfig> createInstanceConfigs(int instanceCount) {
+    List<InstanceConfig> instanceConfigs = new ArrayList<>();
+
+    for (int i = 0; i < instanceCount; i++) {
+      InstanceConfig instanceConfig = new InstanceConfig(buildInstanceName(i));
+      instanceConfig.setInstanceEnabled(true);
+      instanceConfigs.add(instanceConfig);
+    }
+
+    return instanceConfigs;
+  }
+}


### PR DESCRIPTION
Add a new strategy to build routing tables for large clusters, as to
avoid high tail latencies with large clusters.