### PR TITLE
Fix closing of index without dictionary.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/IndexSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/IndexSegmentImpl.java
@@ -105,19 +105,24 @@ public class IndexSegmentImpl implements IndexSegment {
   public void destroy() {
     LOGGER.info("Trying to destroy segment : {}", this.getSegmentName());
     for (String column : indexContainerMap.keySet()) {
+      ColumnIndexContainer columnIndexContainer = indexContainerMap.get(column);
+
       try {
-        indexContainerMap.get(column).getDictionary().close();
+        if (columnIndexContainer.hasDictionary()) {
+          ImmutableDictionaryReader dictionary = columnIndexContainer.getDictionary();
+          dictionary.close();
+        }
       } catch (Exception e) {
         LOGGER.error("Error when close dictionary index for column : " + column, e);
       }
       try {
-        indexContainerMap.get(column).getForwardIndex().close();
+        columnIndexContainer.getForwardIndex().close();
       } catch (Exception e) {
         LOGGER.error("Error when close forward index for column : " + column, e);
       }
       try {
-        if (indexContainerMap.get(column).getInvertedIndex() != null) {
-          indexContainerMap.get(column).getInvertedIndex().close();
+        if (columnIndexContainer.getInvertedIndex() != null) {
+          columnIndexContainer.getInvertedIndex().close();
         }
       } catch (Exception e) {
         LOGGER.error("Error when close inverted index for column : " + column, e);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
@@ -160,6 +160,11 @@ public abstract class ColumnIndexContainer {
   public abstract DataFileReader getForwardIndex();
 
   /**
+   * @return True if index has dictionary, false otherwise
+   */
+  public abstract boolean hasDictionary();
+
+  /**
    * @return
    */
   public abstract ImmutableDictionaryReader getDictionary();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/SortedSVColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/SortedSVColumnIndexContainer.java
@@ -54,6 +54,11 @@ public class SortedSVColumnIndexContainer extends ColumnIndexContainer {
   }
 
   @Override
+  public boolean hasDictionary() {
+    return columnMetadata.hasDictionary();
+  }
+
+  @Override
   public ImmutableDictionaryReader getDictionary() {
     return dictionaryReader;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/UnSortedMVColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/UnSortedMVColumnIndexContainer.java
@@ -57,6 +57,11 @@ public class UnSortedMVColumnIndexContainer extends ColumnIndexContainer {
   }
 
   @Override
+  public boolean hasDictionary() {
+    return columnMetadata.hasDictionary();
+  }
+
+  @Override
   public ImmutableDictionaryReader getDictionary() {
     return dictionary;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/UnsortedSVColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/UnsortedSVColumnIndexContainer.java
@@ -62,6 +62,11 @@ public class UnsortedSVColumnIndexContainer extends ColumnIndexContainer {
   }
 
   @Override
+  public boolean hasDictionary() {
+    return columnMetadata.hasDictionary();
+  }
+
+  @Override
   public ColumnMetadata getColumnMetadata() {
     return columnMetadata;
   }


### PR DESCRIPTION
1. Added method 'hasDictionary' to the interface ColumnIndexContainer.
2. Destory on segment checks presence of dictionary before closing it to
avoid NPE.