### PR TITLE
Modify ForwardIndexCreatorTest to only use ascii strings.

### DIFF
--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/ForwardIndexCreatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/ForwardIndexCreatorTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Random;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.testng.Assert;
@@ -107,9 +108,11 @@ public class ForwardIndexCreatorTest {
 
     String[] expected = new String[NUM_ROWS];
     final List<GenericRow> rows = new ArrayList<>();
+    Random random = new Random();
+
     for (int row = 0; row < NUM_ROWS; row++) {
       HashMap<String, Object> map = new HashMap<>();
-      String value = RandomStringUtils.random(MAX_STRING_LENGTH);
+      String value = RandomStringUtils.randomAscii(1 + random.nextInt(MAX_STRING_LENGTH));
       expected[row] = value;
 
       for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {


### PR DESCRIPTION
1. Test will now only use ascii strings, to avoid any potential non UTF8 characters.
2. Strings will now be variable length, instead of fixed length.