### PR TITLE
Clean up old aggregation functions (Step 3)

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DefaultAggregationExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DefaultAggregationExecutor.java
@@ -96,7 +96,7 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
     Preconditions.checkState(aggregationColumns.length == 1);
     int length = projectionBlock.getNumDocs();
 
-    if (!aggregationFunction.getName().equals(AggregationFunctionFactory.COUNT_AGGREGATION_FUNCTION)) {
+    if (!aggregationFunction.getName().equals(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
       Block dataBlock = projectionBlock.getDataBlock(aggregationColumns[0]);
       ProjectionBlockValSet blockValueSet = (ProjectionBlockValSet) dataBlock.getBlockValueSet();
       aggregationFunction.aggregate(length, resultHolder, blockValueSet);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionFactory.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import javax.annotation.Nonnull;
+
+
 /**
  * Factory class to create instances of aggregation function of the given name.
  */
@@ -22,188 +25,132 @@ public class AggregationFunctionFactory {
   private AggregationFunctionFactory() {
   }
 
-  public static final String COUNT_AGGREGATION_FUNCTION = "count";
-  public static final String MAX_AGGREGATION_FUNCTION = "max";
-  public static final String MIN_AGGREGATION_FUNCTION = "min";
-  public static final String SUM_AGGREGATION_FUNCTION = "sum";
-  public static final String AVG_AGGREGATION_FUNCTION = "avg";
-  public static final String MINMAXRANGE_AGGREGATION_FUNCTION = "minmaxrange";
-  public static final String DISTINCTCOUNT_AGGREGATION_FUNCTION = "distinctcount";
-  public static final String DISTINCTCOUNTHLL_AGGREGATION_FUNCTION = "distinctcounthll";
-  public static final String FASTHLL_AGGREGATION_FUNCTION = "fasthll";
-  public static final String PERCENTILE50_AGGREGATION_FUNCTION = "percentile50";
-  public static final String PERCENTILE90_AGGREGATION_FUNCTION = "percentile90";
-  public static final String PERCENTILE95_AGGREGATION_FUNCTION = "percentile95";
-  public static final String PERCENTILE99_AGGREGATION_FUNCTION = "percentile99";
-  public static final String PERCENTILEEST50_AGGREGATION_FUNCTION = "percentileest50";
-  public static final String PERCENTILEEST90_AGGREGATION_FUNCTION = "percentileest90";
-  public static final String PERCENTILEEST95_AGGREGATION_FUNCTION = "percentileest95";
-  public static final String PERCENTILEEST99_AGGREGATION_FUNCTION = "percentileest99";
+  public enum AggregationFunctionType {
+    // Single-value aggregation functions.
+    COUNT("count"),
+    MIN("min"),
+    MAX("max"),
+    SUM("sum"),
+    AVG("avg"),
+    MINMAXRANGE("minMaxRange"),
+    DISTINCTCOUNT("distinctCount"),
+    DISTINCTCOUNTHLL("distinctCountHLL"),
+    FASTHLL("fastHLL"),
+    PERCENTILE50("percentile50"),
+    PERCENTILE90("percentile90"),
+    PERCENTILE95("percentile95"),
+    PERCENTILE99("percentile99"),
+    PERCENTILEEST50("percentileEst50"),
+    PERCENTILEEST90("percentileEst90"),
+    PERCENTILEEST95("percentileEst95"),
+    PERCENTILEEST99("percentileEst99"),
+    // Multi-value aggregation functions.
+    COUNTMV("countMV"),
+    MINMV("minMV"),
+    MAXMV("maxMV"),
+    SUMMV("sumMV"),
+    AVGMV("avgMV"),
+    MINMAXRANGEMV("minMaxRangeMV"),
+    DISTINCTCOUNTMV("distinctCountMV"),
+    DISTINCTCOUNTHLLMV("distinctCountHLLMV"),
+    FASTHLLMV("fastHLLMV"),
+    PERCENTILE50MV("percentile50MV"),
+    PERCENTILE90MV("percentile90MV"),
+    PERCENTILE95MV("percentile95MV"),
+    PERCENTILE99MV("percentile99MV"),
+    PERCENTILEEST50MV("percentileEst50MV"),
+    PERCENTILEEST90MV("percentileEst90MV"),
+    PERCENTILEEST95MV("percentileEst95MV"),
+    PERCENTILEEST99MV("percentileEst99MV");
 
-  public static final String COUNT_MV_AGGREGATION_FUNCTION = "countmv";
-  public static final String MAX_MV_AGGREGATION_FUNCTION = "maxmv";
-  public static final String MIN_MV_AGGREGATION_FUNCTION = "minmv";
-  public static final String SUM_MV_AGGREGATION_FUNCTION = "summv";
-  public static final String AVG_MV_AGGREGATION_FUNCTION = "avgmv";
-  public static final String MINMAXRANGE_MV_AGGREGATION_FUNCTION = "minmaxrangemv";
-  public static final String DISTINCTCOUNT_MV_AGGREGATION_FUNCTION = "distinctcountmv";
-  public static final String DISTINCTCOUNTHLL_MV_AGGREGATION_FUNCTION = "distinctcounthllmv";
-  public static final String FASTHLL_MV_AGGREGATION_FUNCTION = "fasthllmv";
-  public static final String PERCENTILE50_MV_AGGREGATION_FUNCTION = "percentile50mv";
-  public static final String PERCENTILE90_MV_AGGREGATION_FUNCTION = "percentile90mv";
-  public static final String PERCENTILE95_MV_AGGREGATION_FUNCTION = "percentile95mv";
-  public static final String PERCENTILE99_MV_AGGREGATION_FUNCTION = "percentile99mv";
-  public static final String PERCENTILEEST50_MV_AGGREGATION_FUNCTION = "percentileest50mv";
-  public static final String PERCENTILEEST90_MV_AGGREGATION_FUNCTION = "percentileest90mv";
-  public static final String PERCENTILEEST95_MV_AGGREGATION_FUNCTION = "percentileest95mv";
-  public static final String PERCENTILEEST99_MV_AGGREGATION_FUNCTION = "percentileest99mv";
+    private final String _name;
+
+    AggregationFunctionType(@Nonnull String name) {
+      _name = name;
+    }
+
+    @Nonnull
+    public String getName() {
+      return _name;
+    }
+  }
 
   /**
    * Given the name of aggregation function, create and return a new instance of the corresponding aggregation function.
    */
-  public static AggregationFunction getAggregationFunction(String functionName) {
-    AggregationFunction function;
-    switch (functionName.toLowerCase()) {
-      case COUNT_AGGREGATION_FUNCTION:
-        function = new CountAggregationFunction();
-        break;
-
-      case MIN_AGGREGATION_FUNCTION:
-        function = new MinAggregationFunction();
-        break;
-
-      case MAX_AGGREGATION_FUNCTION:
-        function = new MaxAggregationFunction();
-        break;
-
-      case SUM_AGGREGATION_FUNCTION:
-        function = new SumAggregationFunction();
-        break;
-
-      case AVG_AGGREGATION_FUNCTION:
-        function = new AvgAggregationFunction();
-        break;
-
-      case MINMAXRANGE_AGGREGATION_FUNCTION:
-        function = new MinMaxRangeAggregationFunction();
-        break;
-
-      case DISTINCTCOUNT_AGGREGATION_FUNCTION:
-        function = new DistinctCountAggregationFunction();
-        break;
-
-      case DISTINCTCOUNTHLL_AGGREGATION_FUNCTION:
-        function = new DistinctCountHLLAggregationFunction();
-        break;
-
-      case FASTHLL_AGGREGATION_FUNCTION:
-        function = new FastHLLAggregationFunction();
-        break;
-
-      case PERCENTILE50_AGGREGATION_FUNCTION:
-        function = new PercentileAggregationFunction(50);
-        break;
-
-      case PERCENTILE90_AGGREGATION_FUNCTION:
-        function = new PercentileAggregationFunction(90);
-        break;
-
-      case PERCENTILE95_AGGREGATION_FUNCTION:
-        function = new PercentileAggregationFunction(95);
-        break;
-
-      case PERCENTILE99_AGGREGATION_FUNCTION:
-        function = new PercentileAggregationFunction(99);
-        break;
-
-      case PERCENTILEEST50_AGGREGATION_FUNCTION:
-        function = new PercentileEstAggregationFunction(50);
-        break;
-
-      case PERCENTILEEST90_AGGREGATION_FUNCTION:
-        function = new PercentileEstAggregationFunction(90);
-        break;
-
-      case PERCENTILEEST95_AGGREGATION_FUNCTION:
-        function = new PercentileEstAggregationFunction(95);
-        break;
-
-      case PERCENTILEEST99_AGGREGATION_FUNCTION:
-        function = new PercentileEstAggregationFunction(99);
-        break;
-
-      case COUNT_MV_AGGREGATION_FUNCTION:
-        function = new CountMVAggregationFunction();
-        break;
-
-      case MIN_MV_AGGREGATION_FUNCTION:
-        function = new MinMVAggregationFunction();
-        break;
-
-      case MAX_MV_AGGREGATION_FUNCTION:
-        function = new MaxMVAggregationFunction();
-        break;
-
-      case SUM_MV_AGGREGATION_FUNCTION:
-        function = new SumMVAggregationFunction();
-        break;
-
-      case AVG_MV_AGGREGATION_FUNCTION:
-        function = new AvgMVAggregationFunction();
-        break;
-
-      case MINMAXRANGE_MV_AGGREGATION_FUNCTION:
-        function = new MinMaxRangeMVAggregationFunction();
-        break;
-
-      case DISTINCTCOUNT_MV_AGGREGATION_FUNCTION:
-        function = new DistinctCountMVAggregationFunction();
-        break;
-
-      case DISTINCTCOUNTHLL_MV_AGGREGATION_FUNCTION:
-        function = new DistinctCountHLLMVAggregationFunction();
-        break;
-
-      case FASTHLL_MV_AGGREGATION_FUNCTION:
-        function = new FastHLLMVAggregationFunction();
-        break;
-
-      case PERCENTILE50_MV_AGGREGATION_FUNCTION:
-        function = new PercentileMVAggregationFunction(50);
-        break;
-
-      case PERCENTILE90_MV_AGGREGATION_FUNCTION:
-        function = new PercentileMVAggregationFunction(90);
-        break;
-
-      case PERCENTILE95_MV_AGGREGATION_FUNCTION:
-        function = new PercentileMVAggregationFunction(95);
-        break;
-
-      case PERCENTILE99_MV_AGGREGATION_FUNCTION:
-        function = new PercentileMVAggregationFunction(99);
-        break;
-
-      case PERCENTILEEST50_MV_AGGREGATION_FUNCTION:
-        function = new PercentileEstMVAggregationFunction(50);
-        break;
-
-      case PERCENTILEEST90_MV_AGGREGATION_FUNCTION:
-        function = new PercentileEstMVAggregationFunction(90);
-        break;
-
-      case PERCENTILEEST95_MV_AGGREGATION_FUNCTION:
-        function = new PercentileEstMVAggregationFunction(95);
-        break;
-
-      case PERCENTILEEST99_MV_AGGREGATION_FUNCTION:
-        function = new PercentileEstMVAggregationFunction(99);
-        break;
-
+  @Nonnull
+  public static AggregationFunction getAggregationFunction(@Nonnull String functionName) {
+    switch (AggregationFunctionType.valueOf(functionName.toUpperCase())) {
+      case COUNT:
+        return new CountAggregationFunction();
+      case MIN:
+        return new MinAggregationFunction();
+      case MAX:
+        return new MaxAggregationFunction();
+      case SUM:
+        return new SumAggregationFunction();
+      case AVG:
+        return new AvgAggregationFunction();
+      case MINMAXRANGE:
+        return new MinMaxRangeAggregationFunction();
+      case DISTINCTCOUNT:
+        return new DistinctCountAggregationFunction();
+      case DISTINCTCOUNTHLL:
+        return new DistinctCountHLLAggregationFunction();
+      case FASTHLL:
+        return new FastHLLAggregationFunction();
+      case PERCENTILE50:
+        return new PercentileAggregationFunction(50);
+      case PERCENTILE90:
+        return new PercentileAggregationFunction(90);
+      case PERCENTILE95:
+        return new PercentileAggregationFunction(95);
+      case PERCENTILE99:
+        return new PercentileAggregationFunction(99);
+      case PERCENTILEEST50:
+        return new PercentileEstAggregationFunction(50);
+      case PERCENTILEEST90:
+        return new PercentileEstAggregationFunction(90);
+      case PERCENTILEEST95:
+        return new PercentileEstAggregationFunction(95);
+      case PERCENTILEEST99:
+        return new PercentileEstAggregationFunction(99);
+      case COUNTMV:
+        return new CountMVAggregationFunction();
+      case MINMV:
+        return new MinMVAggregationFunction();
+      case MAXMV:
+        return new MaxMVAggregationFunction();
+      case SUMMV:
+        return new SumMVAggregationFunction();
+      case AVGMV:
+        return new AvgMVAggregationFunction();
+      case MINMAXRANGEMV:
+        return new MinMaxRangeMVAggregationFunction();
+      case DISTINCTCOUNTMV:
+        return new DistinctCountMVAggregationFunction();
+      case DISTINCTCOUNTHLLMV:
+        return new DistinctCountHLLMVAggregationFunction();
+      case FASTHLLMV:
+        return new FastHLLMVAggregationFunction();
+      case PERCENTILE50MV:
+        return new PercentileMVAggregationFunction(50);
+      case PERCENTILE90MV:
+        return new PercentileMVAggregationFunction(90);
+      case PERCENTILE95MV:
+        return new PercentileMVAggregationFunction(95);
+      case PERCENTILE99MV:
+        return new PercentileMVAggregationFunction(99);
+      case PERCENTILEEST50MV:
+        return new PercentileEstMVAggregationFunction(50);
+      case PERCENTILEEST90MV:
+        return new PercentileEstMVAggregationFunction(90);
+      case PERCENTILEEST95MV:
+        return new PercentileEstMVAggregationFunction(95);
+      case PERCENTILEEST99MV:
+        return new PercentileEstMVAggregationFunction(99);
       default:
-        throw new UnsupportedOperationException("Unsupported aggregation function: " + functionName);
+        throw new UnsupportedOperationException();
     }
-
-    return function;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunctionUtils.java
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.linkedin.pinot.core.query.aggregation;
+package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.operator.aggregation.AggregationFunctionContext;
 import com.linkedin.pinot.core.plan.AggregationFunctionInitializer;
 import java.util.List;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -48,5 +49,25 @@ public class AggregationFunctionUtils {
       }
     }
     return aggregationFunctionContexts;
+  }
+
+  @Nonnull
+  public static AggregationFunction[] getAggregationFunctions(@Nonnull List<AggregationInfo> aggregationInfos) {
+    int numAggregationFunctions = aggregationInfos.size();
+    AggregationFunction[] aggregationFunctions = new AggregationFunction[numAggregationFunctions];
+    for (int i = 0; i < numAggregationFunctions; i++) {
+      aggregationFunctions[i] =
+          AggregationFunctionFactory.getAggregationFunction(aggregationInfos.get(i).getAggregationType());
+    }
+    return aggregationFunctions;
+  }
+
+  @Nonnull
+  public static String formatValue(@Nonnull Object value) {
+    if (value instanceof Double) {
+      return String.format(Locale.US, "%1.5f", (Double) value);
+    } else {
+      return value.toString();
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgAggregationFunction.java
@@ -26,18 +26,19 @@ import javax.annotation.Nonnull;
 
 
 public class AvgAggregationFunction implements AggregationFunction<AvgPair, Double> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.AVG.getName();
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.AVG_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.AVG_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgMVAggregationFunction.java
@@ -22,17 +22,18 @@ import javax.annotation.Nonnull;
 
 
 public class AvgMVAggregationFunction extends AvgAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.AVGMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.AVG_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.AVG_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountAggregationFunction.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.common.utils.primitive.MutableLongValue;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.DoubleAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.DoubleGroupByResultHolder;
@@ -25,20 +24,20 @@ import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
-// TODO: use Long as aggregate result type.
-public class CountAggregationFunction implements AggregationFunction<MutableLongValue, Long> {
+public class CountAggregationFunction implements AggregationFunction<Long, Long> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.COUNT.getName();
   private static final double DEFAULT_INITIAL_VALUE = 0.0;
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.COUNT_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.COUNT_AGGREGATION_FUNCTION + "_star";
+    return NAME + "_star";
   }
 
   @Override
@@ -85,22 +84,20 @@ public class CountAggregationFunction implements AggregationFunction<MutableLong
 
   @Nonnull
   @Override
-  public MutableLongValue extractAggregationResult(@Nonnull AggregationResultHolder aggregationResultHolder) {
-    return new MutableLongValue((long) aggregationResultHolder.getDoubleResult());
+  public Long extractAggregationResult(@Nonnull AggregationResultHolder aggregationResultHolder) {
+    return (long) aggregationResultHolder.getDoubleResult();
   }
 
   @Nonnull
   @Override
-  public MutableLongValue extractGroupByResult(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey) {
-    return new MutableLongValue((long) groupByResultHolder.getDoubleResult(groupKey));
+  public Long extractGroupByResult(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey) {
+    return (long) groupByResultHolder.getDoubleResult(groupKey);
   }
 
   @Nonnull
   @Override
-  public MutableLongValue merge(@Nonnull MutableLongValue intermediateResult1,
-      @Nonnull MutableLongValue intermediateResult2) {
-    intermediateResult1.addToValue(intermediateResult2.getValue());
-    return intermediateResult1;
+  public Long merge(@Nonnull Long intermediateResult1, @Nonnull Long intermediateResult2) {
+    return intermediateResult1 + intermediateResult2;
   }
 
   @Nonnull
@@ -111,7 +108,7 @@ public class CountAggregationFunction implements AggregationFunction<MutableLong
 
   @Nonnull
   @Override
-  public Long extractFinalResult(@Nonnull MutableLongValue intermediateResult) {
-    return intermediateResult.getValue();
+  public Long extractFinalResult(@Nonnull Long intermediateResult) {
+    return intermediateResult;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountMVAggregationFunction.java
@@ -22,17 +22,18 @@ import javax.annotation.Nonnull;
 
 
 public class CountMVAggregationFunction extends CountAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.COUNTMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.COUNT_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.COUNT_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountAggregationFunction.java
@@ -26,17 +26,18 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountAggregationFunction implements AggregationFunction<IntOpenHashSet, Integer> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNT.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.DISTINCTCOUNT_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.DISTINCTCOUNT_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -28,17 +28,18 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountHLLAggregationFunction implements AggregationFunction<HyperLogLog, Long> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNTHLL.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.DISTINCTCOUNTHLL_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.DISTINCTCOUNTHLL_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -24,17 +24,18 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNTHLLMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.DISTINCTCOUNTHLL_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.DISTINCTCOUNTHLL_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -23,17 +23,18 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountMVAggregationFunction extends DistinctCountAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNTMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.DISTINCTCOUNT_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.DISTINCTCOUNT_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLAggregationFunction.java
@@ -29,18 +29,20 @@ import javax.annotation.Nonnull;
 
 
 public class FastHLLAggregationFunction implements AggregationFunction<HyperLogLog, Long> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.FASTHLL.getName();
+
   protected int _log2m = HllConstants.DEFAULT_LOG2M;
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.FASTHLL_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.FASTHLL_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   public void setLog2m(int log2m) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLMVAggregationFunction.java
@@ -25,17 +25,18 @@ import javax.annotation.Nonnull;
 
 
 public class FastHLLMVAggregationFunction extends FastHLLAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.FASTHLLMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.FASTHLL_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.FASTHLL_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxAggregationFunction.java
@@ -25,18 +25,19 @@ import javax.annotation.Nonnull;
 
 
 public class MaxAggregationFunction implements AggregationFunction<Double, Double> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MAX.getName();
   private static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.MAX_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.MAX_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxMVAggregationFunction.java
@@ -22,17 +22,18 @@ import javax.annotation.Nonnull;
 
 
 public class MaxMVAggregationFunction extends MaxAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MAXMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.MAX_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.MAX_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinAggregationFunction.java
@@ -25,18 +25,19 @@ import javax.annotation.Nonnull;
 
 
 public class MinAggregationFunction implements AggregationFunction<Double, Double> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MIN.getName();
   private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.MIN_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.MIN_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMVAggregationFunction.java
@@ -22,17 +22,18 @@ import javax.annotation.Nonnull;
 
 
 public class MinMVAggregationFunction extends MinAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MINMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.MIN_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.MIN_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -26,18 +26,19 @@ import javax.annotation.Nonnull;
 
 
 public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMaxRangePair, Double> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MINMAXRANGE.getName();
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.MINMAXRANGE_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.MINMAXRANGE_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -22,17 +22,18 @@ import javax.annotation.Nonnull;
 
 
 public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MINMAXRANGEMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.MINMAXRANGE_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.MINMAXRANGE_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileAggregationFunction.java
@@ -35,16 +35,16 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
   public PercentileAggregationFunction(int percentile) {
     switch (percentile) {
       case 50:
-        _name = AggregationFunctionFactory.PERCENTILE50_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE50.getName();
         break;
       case 90:
-        _name = AggregationFunctionFactory.PERCENTILE90_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE90.getName();
         break;
       case 95:
-        _name = AggregationFunctionFactory.PERCENTILE95_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE95.getName();
         break;
       case 99:
-        _name = AggregationFunctionFactory.PERCENTILE99_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE99.getName();
         break;
       default:
         throw new UnsupportedOperationException(

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstAggregationFunction.java
@@ -34,16 +34,16 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   public PercentileEstAggregationFunction(int percentile) {
     switch (percentile) {
       case 50:
-        _name = AggregationFunctionFactory.PERCENTILEEST50_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST50.getName();
         break;
       case 90:
-        _name = AggregationFunctionFactory.PERCENTILEEST90_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST90.getName();
         break;
       case 95:
-        _name = AggregationFunctionFactory.PERCENTILEEST95_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST95.getName();
         break;
       case 99:
-        _name = AggregationFunctionFactory.PERCENTILEEST99_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST99.getName();
         break;
       default:
         throw new UnsupportedOperationException(

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -29,16 +29,16 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
     super(percentile);
     switch (percentile) {
       case 50:
-        _name = AggregationFunctionFactory.PERCENTILEEST50_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST50MV.getName();
         break;
       case 90:
-        _name = AggregationFunctionFactory.PERCENTILEEST90_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST90MV.getName();
         break;
       case 95:
-        _name = AggregationFunctionFactory.PERCENTILEEST95_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST95MV.getName();
         break;
       case 99:
-        _name = AggregationFunctionFactory.PERCENTILEEST99_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST99MV.getName();
         break;
       default:
         throw new UnsupportedOperationException(

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileMVAggregationFunction.java
@@ -29,16 +29,16 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
     super(percentile);
     switch (percentile) {
       case 50:
-        _name = AggregationFunctionFactory.PERCENTILE50_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE50MV.getName();
         break;
       case 90:
-        _name = AggregationFunctionFactory.PERCENTILE90_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE90MV.getName();
         break;
       case 95:
-        _name = AggregationFunctionFactory.PERCENTILE95_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE95MV.getName();
         break;
       case 99:
-        _name = AggregationFunctionFactory.PERCENTILE99_MV_AGGREGATION_FUNCTION;
+        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE99MV.getName();
         break;
       default:
         throw new UnsupportedOperationException(

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumAggregationFunction.java
@@ -25,18 +25,19 @@ import javax.annotation.Nonnull;
 
 
 public class SumAggregationFunction implements AggregationFunction<Double, Double> {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.SUM.getName();
   private static final double DEFAULT_VALUE = 0.0;
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.SUM_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.SUM_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumMVAggregationFunction.java
@@ -22,17 +22,18 @@ import javax.annotation.Nonnull;
 
 
 public class SumMVAggregationFunction extends SumAggregationFunction {
+  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.SUMMV.getName();
 
   @Nonnull
   @Override
   public String getName() {
-    return AggregationFunctionFactory.SUM_MV_AGGREGATION_FUNCTION;
+    return NAME;
   }
 
   @Nonnull
   @Override
   public String getColumnName(@Nonnull String[] columns) {
-    return AggregationFunctionFactory.SUM_MV_AGGREGATION_FUNCTION + "_" + columns[0];
+    return NAME + "_" + columns[0];
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByTrimmingService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/AggregationGroupByTrimmingService.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.operator.aggregation.groupby;
+
+import com.linkedin.pinot.common.response.broker.GroupByResult;
+import com.linkedin.pinot.core.operator.aggregation.AggregationFunctionContext;
+import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunction;
+import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunctionUtils;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import javax.annotation.Nonnull;
+
+
+/**
+ * The <code>AggregationGroupByTrimmingService</code> class provides trimming service for aggregation group-by query.
+ */
+// TODO: revisit the trim algorithm, implement trim on all Object but not only for Comparable.
+public class AggregationGroupByTrimmingService {
+  public static final String GROUP_KEY_DELIMITER = "\t";
+
+  private final int _numAggregationFunctions;
+  private final boolean[] _minOrders;
+
+  private final int _groupByTopN;
+  // To keep the precision, _trimSize is the larger of (_groupByTopN * 5) or 5000.
+  private final int _trimSize;
+  // To trigger the trimming, number of groups should be larger than _trimThreshold which is (_trimSize * 4).
+  private final int _trimThreshold;
+
+  public AggregationGroupByTrimmingService(@Nonnull AggregationFunctionContext[] aggregationFunctionContexts,
+      int groupByTopN) {
+    _numAggregationFunctions = aggregationFunctionContexts.length;
+    _minOrders = new boolean[_numAggregationFunctions];
+    for (int i = 0; i < _numAggregationFunctions; i++) {
+      String aggregationFunctionName = aggregationFunctionContexts[i].getAggregationFunction().getName();
+      if (aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MIN.getName())
+          || aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MINMV.getName())) {
+        _minOrders[i] = true;
+      }
+    }
+    _groupByTopN = groupByTopN;
+    _trimSize = Math.max(_groupByTopN * 5, 5000);
+    _trimThreshold = _trimSize * 4;
+  }
+
+  public AggregationGroupByTrimmingService(@Nonnull AggregationFunction[] aggregationFunctions, int groupByTopN) {
+    _numAggregationFunctions = aggregationFunctions.length;
+    _minOrders = new boolean[_numAggregationFunctions];
+    for (int i = 0; i < _numAggregationFunctions; i++) {
+      String aggregationFunctionName = aggregationFunctions[i].getName();
+      if (aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MIN.getName())
+          || aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MINMV.getName())) {
+        _minOrders[i] = true;
+      }
+    }
+    _groupByTopN = groupByTopN;
+    _trimSize = Math.max(_groupByTopN * 5, 5000);
+    _trimThreshold = _trimSize * 4;
+  }
+
+  /**
+   * Given a map from group key to the intermediate results for multiple aggregation functions, trim the results to
+   * desired size and put them into a list of maps from group key to intermediate result for each aggregation function.
+   */
+  @Nonnull
+  public List<Map<String, Serializable>> trimIntermediateResultsMap(
+      @Nonnull Map<String, Serializable[]> intermediateResultsMap) {
+    List<Map<String, Serializable>> trimmedResults = new ArrayList<>(_numAggregationFunctions);
+    for (int i = 0; i < _numAggregationFunctions; i++) {
+      trimmedResults.add(new HashMap<String, Serializable>());
+    }
+
+    if (intermediateResultsMap.isEmpty()) {
+      return trimmedResults;
+    }
+
+    if (intermediateResultsMap.size() > _trimThreshold) {
+      // Need to trim.
+
+      // Construct the priority queues.
+      @SuppressWarnings("unchecked")
+      PriorityQueue<GroupKeyResultPair>[] priorityQueues = new PriorityQueue[_numAggregationFunctions];
+      Serializable[] sampleResults = intermediateResultsMap.values().iterator().next();
+      for (int i = 0; i < _numAggregationFunctions; i++) {
+        if (sampleResults[i] instanceof Comparable) {
+          priorityQueues[i] = new PriorityQueue<>(_trimSize + 1, getGroupKeyResultPairComparator(_minOrders[i]));
+        }
+      }
+
+      // Fill results into the priority queues.
+      for (Map.Entry<String, Serializable[]> entry : intermediateResultsMap.entrySet()) {
+        String groupKey = entry.getKey();
+        Serializable[] intermediateResults = entry.getValue();
+        for (int i = 0; i < _numAggregationFunctions; i++) {
+          PriorityQueue<GroupKeyResultPair> priorityQueue = priorityQueues[i];
+          if (priorityQueue == null) {
+            trimmedResults.get(i).put(groupKey, intermediateResults[i]);
+          } else {
+            priorityQueue.add(new GroupKeyResultPair(groupKey, (Comparable) intermediateResults[i]));
+            if (priorityQueue.size() > _trimSize) {
+              priorityQueue.poll();
+            }
+          }
+        }
+      }
+
+      // Fill trimmed results into the maps.
+      for (int i = 0; i < _numAggregationFunctions; i++) {
+        PriorityQueue<GroupKeyResultPair> priorityQueue = priorityQueues[i];
+        if (priorityQueue != null) {
+          while (!priorityQueue.isEmpty()) {
+            GroupKeyResultPair groupKeyResultPair = priorityQueue.poll();
+            trimmedResults.get(i).put(groupKeyResultPair._groupKey, (Serializable) groupKeyResultPair._result);
+          }
+        }
+      }
+    } else {
+      // No need to trim.
+      for (Map.Entry<String, Serializable[]> entry : intermediateResultsMap.entrySet()) {
+        String groupKey = entry.getKey();
+        Serializable[] intermediateResults = entry.getValue();
+        for (int i = 0; i < _numAggregationFunctions; i++) {
+          trimmedResults.get(i).put(groupKey, intermediateResults[i]);
+        }
+      }
+    }
+
+    return trimmedResults;
+  }
+
+  /**
+   * Given an array of maps from group key to final result for each aggregation function, trim the results to topN size.
+   */
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  public List<GroupByResult>[] trimFinalResults(@Nonnull Map<String, Object>[] finalResultMaps) {
+    List<GroupByResult>[] trimmedResults = new List[_numAggregationFunctions];
+
+    for (int i = 0; i < _numAggregationFunctions; i++) {
+      LinkedList<GroupByResult> groupByResults = new LinkedList<>();
+      trimmedResults[i] = groupByResults;
+      Map<String, Object> finalResultMap = finalResultMaps[i];
+      if (finalResultMap.isEmpty()) {
+        continue;
+      }
+
+      // Construct the priority queues.
+      PriorityQueue<GroupKeyResultPair> priorityQueue =
+          new PriorityQueue<>(_groupByTopN + 1, getGroupKeyResultPairComparator(_minOrders[i]));
+
+      // Fill results into the priority queues.
+      for (Map.Entry<String, Object> entry : finalResultMap.entrySet()) {
+        String groupKey = entry.getKey();
+        Object finalResult = entry.getValue();
+        priorityQueue.add(new GroupKeyResultPair(groupKey, (Comparable) finalResult));
+        if (priorityQueue.size() > _groupByTopN) {
+          priorityQueue.poll();
+        }
+      }
+
+      // Fill trimmed results into the list.
+      while (!priorityQueue.isEmpty()) {
+        GroupKeyResultPair groupKeyResultPair = priorityQueue.poll();
+        GroupByResult groupByResult = new GroupByResult();
+        groupByResult.setGroup(Arrays.asList(groupKeyResultPair._groupKey.split(GROUP_KEY_DELIMITER)));
+        groupByResult.setValue(AggregationFunctionUtils.formatValue(groupKeyResultPair._result));
+        groupByResults.addFirst(groupByResult);
+      }
+    }
+
+    return trimmedResults;
+  }
+
+  private static class GroupKeyResultPair {
+    public String _groupKey;
+    public Comparable _result;
+
+    public GroupKeyResultPair(@Nonnull String groupKey, @Nonnull Comparable result) {
+      _groupKey = groupKey;
+      _result = result;
+    }
+  }
+
+  private static Comparator<GroupKeyResultPair> getGroupKeyResultPairComparator(boolean minOrder) {
+    if (minOrder) {
+      return new Comparator<GroupKeyResultPair>() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public int compare(GroupKeyResultPair o1, GroupKeyResultPair o2) {
+          return o2._result.compareTo(o1._result);
+        }
+      };
+    } else {
+      return new Comparator<GroupKeyResultPair>() {
+        @SuppressWarnings("unchecked")
+        @Override
+        public int compare(GroupKeyResultPair o1, GroupKeyResultPair o2) {
+          return o1._result.compareTo(o2._result);
+        }
+      };
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupByExecutor.java
@@ -142,7 +142,7 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
     Preconditions.checkState(aggregationColumns.length == 1);
     int length = projectionBlock.getNumDocs();
 
-    if (!aggregationFunction.getName().equals(AggregationFunctionFactory.COUNT_AGGREGATION_FUNCTION)) {
+    if (!aggregationFunction.getName().equals(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
       Block dataBlock = projectionBlock.getDataBlock(aggregationColumns[0]);
       ProjectionBlockValSet blockValueSet = (ProjectionBlockValSet) dataBlock.getBlockValueSet();
       if (_hasMVGroupByColumns) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/DefaultGroupKeyGenerator.java
@@ -19,7 +19,6 @@ import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockMetadata;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
-import com.linkedin.pinot.core.query.aggregation.groupby.GroupByConstants;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -703,7 +702,7 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
       StringBuilder builder = new StringBuilder(_dictionaries[0].get(groupKey % cardinality).toString());
       groupKey /= cardinality;
       for (int i = 1; i < _numGroupByColumns; i++) {
-        builder.append(GroupByConstants.GroupByDelimiter.groupByMultiDelimeter);
+        builder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
         cardinality = _cardinalities[i];
         builder.append(_dictionaries[i].get(groupKey % cardinality));
         groupKey /= cardinality;
@@ -730,7 +729,7 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
       StringBuilder builder = new StringBuilder(_dictionaries[0].get((int) (rawKey % cardinality)).toString());
       rawKey /= cardinality;
       for (int i = 1; i < _numGroupByColumns; i++) {
-        builder.append(GroupByConstants.GroupByDelimiter.groupByMultiDelimeter);
+        builder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
         cardinality = _cardinalities[i];
         builder.append(_dictionaries[i].get((int) (rawKey % cardinality)));
         rawKey /= cardinality;
@@ -751,7 +750,7 @@ public class DefaultGroupKeyGenerator implements GroupKeyGenerator {
     int[] rawKeyArray = rawKey.elements();
     StringBuilder builder = new StringBuilder(_dictionaries[0].get(rawKeyArray[0]).toString());
     for (int i = 1; i < _numGroupByColumns; i++) {
-      builder.append(GroupByConstants.GroupByDelimiter.groupByMultiDelimeter);
+      builder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
       builder.append(_dictionaries[i].get(rawKeyArray[i]).toString());
     }
     return builder.toString();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/NoDictionaryGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/groupby/NoDictionaryGroupKeyGenerator.java
@@ -20,7 +20,6 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
 import com.linkedin.pinot.core.operator.blocks.ProjectionColumnBlock;
-import com.linkedin.pinot.core.query.aggregation.groupby.GroupByConstants;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -115,7 +114,7 @@ public class NoDictionaryGroupKeyGenerator implements GroupKeyGenerator {
         }
 
         if (j < (numGroupByColumns - 1)) {
-          stringBuilder.append(GroupByConstants.GroupByDelimiter.groupByMultiDelimeter);
+          stringBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
         }
       }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -22,12 +22,9 @@ import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
-import com.linkedin.pinot.core.operator.aggregation.AggregationFunctionContext;
-import com.linkedin.pinot.core.operator.aggregation.AggregationOperator;
 import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunctionUtils;
 import com.linkedin.pinot.core.operator.aggregation.groupby.AggregationGroupByOperator;
-import com.linkedin.pinot.core.operator.aggregation.groupby.DefaultGroupByExecutor;
-import com.linkedin.pinot.core.query.aggregation.AggregationFunctionUtils;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -65,7 +62,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
     Set<String> aggregationGroupByRelatedColumns = new HashSet<>();
     for (AggregationInfo aggregationInfo : _aggregationInfos) {
       if (!aggregationInfo.getAggregationType()
-          .equalsIgnoreCase(AggregationFunctionFactory.COUNT_AGGREGATION_FUNCTION)) {
+          .equalsIgnoreCase(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
         String columns = aggregationInfo.getAggregationParams().get("column").trim();
         aggregationGroupByRelatedColumns.addAll(Arrays.asList(columns.split(",")));
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationPlanNode.java
@@ -21,10 +21,9 @@ import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
-import com.linkedin.pinot.core.operator.aggregation.AggregationFunctionContext;
 import com.linkedin.pinot.core.operator.aggregation.AggregationOperator;
 import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunctionFactory;
-import com.linkedin.pinot.core.query.aggregation.AggregationFunctionUtils;
+import com.linkedin.pinot.core.operator.aggregation.function.AggregationFunctionUtils;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -57,7 +56,7 @@ public class AggregationPlanNode implements PlanNode {
     Set<String> aggregationRelatedColumns = new HashSet<>();
     for (AggregationInfo aggregationInfo : _aggregationInfos) {
       if (!aggregationInfo.getAggregationType()
-          .equalsIgnoreCase(AggregationFunctionFactory.COUNT_AGGREGATION_FUNCTION)) {
+          .equalsIgnoreCase(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
         String columns = aggregationInfo.getAggregationParams().get("column").trim();
         aggregationRelatedColumns.addAll(Arrays.asList(columns.split(",")));
       }

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/aggregation/NoDictionaryGroupKeyGeneratorTest.java
@@ -19,7 +19,6 @@ import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.segment.ReadMode;
-import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.readers.RecordReader;
@@ -29,12 +28,12 @@ import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
 import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
+import com.linkedin.pinot.core.operator.aggregation.groupby.AggregationGroupByTrimmingService;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupKeyGenerator;
 import com.linkedin.pinot.core.operator.aggregation.groupby.NoDictionaryGroupKeyGenerator;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
 import com.linkedin.pinot.core.operator.filter.MatchEntireSegmentOperator;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
-import com.linkedin.pinot.core.query.aggregation.groupby.GroupByConstants;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.core.segment.index.loader.Loaders;
 import java.io.File;
@@ -160,7 +159,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
         }
         stringBuilder.append(map.get(column));
         if (j++ < NUM_COLUMNS - 1) {
-          stringBuilder.append(GroupByConstants.GroupByDelimiter.groupByMultiDelimeter);
+          stringBuilder.append(AggregationGroupByTrimmingService.GROUP_KEY_DELIMITER);
         }
       }
       keys.add(stringBuilder.toString());

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.queries;
 
-import com.linkedin.pinot.common.utils.primitive.MutableLongValue;
 import com.linkedin.pinot.core.operator.ExecutionStatistics;
 import com.linkedin.pinot.core.operator.aggregation.AggregationOperator;
 import com.linkedin.pinot.core.operator.aggregation.groupby.AggregationGroupByOperator;
@@ -55,10 +54,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 400000L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
     List<Serializable> aggregationResult = resultsBlock.getAggregationResult();
-    Assert.assertEquals(((MutableLongValue) aggregationResult.get(0)).getValue(), 100000L);
-    Assert.assertEquals(((Double) aggregationResult.get(1)).longValue(), 100991525475000L);
-    Assert.assertEquals(((Double) aggregationResult.get(2)).intValue(), 2147434110);
-    Assert.assertEquals(((Double) aggregationResult.get(3)).intValue(), 1182655);
+    Assert.assertEquals(((Number) aggregationResult.get(0)).longValue(), 100000L);
+    Assert.assertEquals(((Number) aggregationResult.get(1)).longValue(), 100991525475000L);
+    Assert.assertEquals(((Number) aggregationResult.get(2)).intValue(), 2147434110);
+    Assert.assertEquals(((Number) aggregationResult.get(3)).intValue(), 1182655);
     AvgAggregationFunction.AvgPair avgResult = (AvgAggregationFunction.AvgPair) aggregationResult.get(4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 83439903673981L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 100000L);
@@ -72,10 +71,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 62480L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
     aggregationResult = resultsBlock.getAggregationResult();
-    Assert.assertEquals(((MutableLongValue) aggregationResult.get(0)).getValue(), 15620L);
-    Assert.assertEquals(((Double) aggregationResult.get(1)).longValue(), 17287754700747L);
-    Assert.assertEquals(((Double) aggregationResult.get(2)).intValue(), 999943053);
-    Assert.assertEquals(((Double) aggregationResult.get(3)).intValue(), 1182655);
+    Assert.assertEquals(((Number) aggregationResult.get(0)).longValue(), 15620L);
+    Assert.assertEquals(((Number) aggregationResult.get(1)).longValue(), 17287754700747L);
+    Assert.assertEquals(((Number) aggregationResult.get(2)).intValue(), 999943053);
+    Assert.assertEquals(((Number) aggregationResult.get(3)).intValue(), 1182655);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationResult.get(4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 11017594448983L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 15620L);
@@ -94,10 +93,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 200000L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
     List<Serializable> aggregationResult = resultsBlock.getAggregationResult();
-    Assert.assertEquals(((MutableLongValue) aggregationResult.get(0)).getValue(), 106688L);
-    Assert.assertEquals(((Double) aggregationResult.get(1)).longValue(), 107243218420671L);
-    Assert.assertEquals(((Double) aggregationResult.get(2)).intValue(), 2147483647);
-    Assert.assertEquals(((Double) aggregationResult.get(3)).intValue(), 201);
+    Assert.assertEquals(((Number) aggregationResult.get(0)).longValue(), 106688L);
+    Assert.assertEquals(((Number) aggregationResult.get(1)).longValue(), 107243218420671L);
+    Assert.assertEquals(((Number) aggregationResult.get(2)).intValue(), 2147483647);
+    Assert.assertEquals(((Number) aggregationResult.get(3)).intValue(), 201);
     AvgAggregationFunction.AvgPair avgResult = (AvgAggregationFunction.AvgPair) aggregationResult.get(4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 121081150452570L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 106688L);
@@ -111,10 +110,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 31240L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 100000L);
     aggregationResult = resultsBlock.getAggregationResult();
-    Assert.assertEquals(((MutableLongValue) aggregationResult.get(0)).getValue(), 15620L);
-    Assert.assertEquals(((Double) aggregationResult.get(1)).longValue(), 28567975886777L);
-    Assert.assertEquals(((Double) aggregationResult.get(2)).intValue(), 2147483647);
-    Assert.assertEquals(((Double) aggregationResult.get(3)).intValue(), 203);
+    Assert.assertEquals(((Number) aggregationResult.get(0)).longValue(), 15620L);
+    Assert.assertEquals(((Number) aggregationResult.get(1)).longValue(), 28567975886777L);
+    Assert.assertEquals(((Number) aggregationResult.get(2)).intValue(), 2147483647);
+    Assert.assertEquals(((Number) aggregationResult.get(3)).intValue(), 203);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationResult.get(4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 28663153397978L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 15620L);
@@ -137,12 +136,11 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "201");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(),
-        26L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(),
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 26L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(),
         32555949195L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 2100941020);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 117939666);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 2100941020);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 117939666);
     AvgAggregationFunction.AvgPair avgResult =
         (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 23061775005L);
@@ -159,10 +157,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "203");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 1L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 185436225L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 987549258);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 674022574);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 1L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 185436225L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 987549258);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 674022574);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 674022574L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 1L);
@@ -185,10 +183,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "w\t3836469\t204");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 1L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1415527660L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1747635671);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1298457813);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 1L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1415527660L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1747635671);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1298457813);
     AvgAggregationFunction.AvgPair avgResult =
         (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 1235208236L);
@@ -205,10 +203,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "L\t1483645\t2147483647");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 1L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 650650103L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 108417107);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 674022574);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 1L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 650650103L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 108417107);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 674022574);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 674022574L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 1L);
@@ -232,10 +230,10 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(),
         "1118965780\t1848116124\t8599\t504\t1597666851\t675163196\t607034543");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 1L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1118965780L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1848116124);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1597666851);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 1L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1118965780L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1848116124);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1597666851);
     AvgAggregationFunction.AvgPair avgResult =
         (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 675163196L);
@@ -253,12 +251,11 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(),
         "949960647\t238753654\t2147483647\t2147483647\t674022574\t674022574\t674022574");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 2L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1899921294L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 238753654);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 674022574);
-    avgResult =
-        (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 2L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1899921294L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 238753654);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 674022574);
+    avgResult = (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 1348045148L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 2L);
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.queries;
 
-import com.linkedin.pinot.common.utils.primitive.MutableLongValue;
 import com.linkedin.pinot.core.operator.ExecutionStatistics;
 import com.linkedin.pinot.core.operator.aggregation.AggregationOperator;
 import com.linkedin.pinot.core.operator.aggregation.groupby.AggregationGroupByOperator;
@@ -53,10 +52,10 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 120000L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
     List<Serializable> aggregationResult = resultsBlock.getAggregationResult();
-    Assert.assertEquals(((MutableLongValue) aggregationResult.get(0)).getValue(), 30000L);
-    Assert.assertEquals(((Double) aggregationResult.get(1)).longValue(), 32317185437847L);
-    Assert.assertEquals(((Double) aggregationResult.get(2)).intValue(), 2147419555);
-    Assert.assertEquals(((Double) aggregationResult.get(3)).intValue(), 1689277);
+    Assert.assertEquals(((Number) aggregationResult.get(0)).longValue(), 30000L);
+    Assert.assertEquals(((Number) aggregationResult.get(1)).longValue(), 32317185437847L);
+    Assert.assertEquals(((Number) aggregationResult.get(2)).intValue(), 2147419555);
+    Assert.assertEquals(((Number) aggregationResult.get(3)).intValue(), 1689277);
     AvgAggregationFunction.AvgPair avgResult = (AvgAggregationFunction.AvgPair) aggregationResult.get(4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 28175373944314L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 30000L);
@@ -70,10 +69,10 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 24516L);
     Assert.assertEquals(executionStatistics.getNumTotalRawDocs(), 30000L);
     aggregationResult = resultsBlock.getAggregationResult();
-    Assert.assertEquals(((MutableLongValue) aggregationResult.get(0)).getValue(), 6129L);
-    Assert.assertEquals(((Double) aggregationResult.get(1)).longValue(), 6875947596072L);
-    Assert.assertEquals(((Double) aggregationResult.get(2)).intValue(), 999813884);
-    Assert.assertEquals(((Double) aggregationResult.get(3)).intValue(), 1980174);
+    Assert.assertEquals(((Number) aggregationResult.get(0)).longValue(), 6129L);
+    Assert.assertEquals(((Number) aggregationResult.get(1)).longValue(), 6875947596072L);
+    Assert.assertEquals(((Number) aggregationResult.get(2)).intValue(), 999813884);
+    Assert.assertEquals(((Number) aggregationResult.get(3)).intValue(), 1980174);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationResult.get(4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 4699510391301L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 6129L);
@@ -96,10 +95,10 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "11270");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 1L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 815409257L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1215316262);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1328642550);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 1L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 815409257L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1215316262);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1328642550);
     AvgAggregationFunction.AvgPair avgResult =
         (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 788414092L);
@@ -116,10 +115,10 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "242920");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 3L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 4348938306L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 407993712);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 296467636);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 3L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 4348938306L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 407993712);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 296467636);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 5803888725L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 3L);
@@ -142,10 +141,10 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "1577638897\tP\tKrNxpdycSiwoRohEiTIlLqDHnx");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 5L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1211410535L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1720170285);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1585725369);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 5L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1211410535L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 1720170285);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 1585725369);
     AvgAggregationFunction.AvgPair avgResult =
         (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 8398774425L);
@@ -162,11 +161,11 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(), "1096298724\tP\tKrNxpdycSiwoRohEiTIlLqDHnx");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 7L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(),
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 7L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(),
         13531749490L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 478007592);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 394608493);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 478007592);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 394608493);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 1229066783L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 7L);
@@ -190,10 +189,10 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(),
         "1784773968\t204243323\t628170461\t1985159279\t296467636\tP\tHEuxNvH\t402773817\t2047180536");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 1L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1784773968L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 204243323);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 628170461);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 1L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1784773968L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 204243323);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 628170461);
     AvgAggregationFunction.AvgPair avgResult =
         (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 1985159279L);
@@ -211,10 +210,10 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
     Assert.assertEquals(firstGroupKey.getStringKey(),
         "1361199163\t178133991\t296467636\t788414092\t1719301234\tP\tMaztCmmxxgguBUxPti\t1284373442\t752388855");
-    Assert.assertEquals(((MutableLongValue) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).getValue(), 1L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1361199163L);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 178133991);
-    Assert.assertEquals(((Double) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 296467636);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 0)).longValue(), 1L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 1)).longValue(), 1361199163L);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 2)).intValue(), 178133991);
+    Assert.assertEquals(((Number) aggregationGroupByResult.getResultForKey(firstGroupKey, 3)).intValue(), 296467636);
     avgResult = (AvgAggregationFunction.AvgPair) aggregationGroupByResult.getResultForKey(firstGroupKey, 4);
     Assert.assertEquals(avgResult.getFirst().longValue(), 788414092L);
     Assert.assertEquals(avgResult.getSecond().longValue(), 1L);


### PR DESCRIPTION
Move all broker side code to use new agrgegation functions.
1. Add AggregationGroupByTrimmingService class to perform trimming.
2. Refactor BrokerReduceService to use new aggregation functions and trimming service.
3. Change the intermediate data type in COUNT from MutableLong to Long.