### PR TITLE
Upgrade restlet version to 2.3.4

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -50,22 +50,18 @@
     <!-- Jetty -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-webapp</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.restlet.jse</groupId>
+      <artifactId>org.restlet.ext.jetty</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <!-- End jetty -->
-    
+
     <dependency>
       <groupId>com.linkedin.pinot</groupId>
       <artifactId>pinot-transport</artifactId>

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/SwaggerResource.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/SwaggerResource.java
@@ -25,12 +25,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import java.util.Set;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.restlet.Restlet;
-import org.restlet.engine.header.Header;
+import org.restlet.data.Header;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.Finder;
@@ -109,12 +108,7 @@ public class SwaggerResource extends ServerResource {
       StringRepresentation representation = new StringRepresentation(swagger.toString());
 
       // Set up CORS
-      Series<Header> responseHeaders = (Series<Header>) getResponse().getAttributes().get("org.restlet.http.headers");
-      if (responseHeaders == null) {
-        responseHeaders = new Series(Header.class);
-        getResponse().getAttributes().put("org.restlet.http.headers", responseHeaders);
-      }
-      responseHeaders.add(new Header("Access-Control-Allow-Origin", "*"));
+      getResponse().getHeaders().add(new Header("Access-Control-Allow-Origin", "*"));
       return representation;
     } catch (JSONException e) {
       return new StringRepresentation(e.toString());

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/SwaggerResource.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/restlet/swagger/SwaggerResource.java
@@ -40,7 +40,6 @@ import org.restlet.routing.Route;
 import org.restlet.routing.Router;
 import org.restlet.routing.TemplateRoute;
 import org.restlet.util.RouteList;
-import org.restlet.util.Series;
 
 
 /**

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -86,10 +86,6 @@
       <artifactId>jackson-mapper-asl</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-    </dependency>
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/BasePinotControllerRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/BasePinotControllerRestletResource.java
@@ -12,9 +12,8 @@ import java.util.concurrent.Executor;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.restlet.Response;
+import org.restlet.data.Header;
 import org.restlet.data.MediaType;
-import org.restlet.engine.header.Header;
-import org.restlet.engine.header.HeaderConstants;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.ServerResource;
 import org.restlet.util.Series;
@@ -115,11 +114,7 @@ public class BasePinotControllerRestletResource extends ServerResource {
   }
 
   public static void addExtraHeaders(Response response) {
-    Series<Header> responseHeaders = (Series<Header>)response.getAttributes().get(HeaderConstants.ATTRIBUTE_HEADERS);
-    if (responseHeaders == null) {
-      responseHeaders = new Series(Header.class);
-      response.getAttributes().put(HeaderConstants.ATTRIBUTE_HEADERS, responseHeaders);
-    }
+    Series<Header> responseHeaders = response.getHeaders();
 
     responseHeaders.add(new Header(HDR_CONTROLLER_HOST, getHostName()));
     responseHeaders.add(new Header(HDR_CONTROLLER_VERSION, getControllerVersion()));

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
     <jackson.version>2.8.0</jackson.version>
     <async-http-client.version>1.9.21</async-http-client.version>
     <jersey.version>2.23</jersey.version>
+    <restlet.version>2.3.4</restlet.version>
     <!-- Sets the VM argument line used when unit tests are run. -->
     <argLine> -Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g </argLine>
   </properties>
@@ -243,22 +244,22 @@
       <dependency>
         <groupId>org.restlet.jse</groupId>
         <artifactId>org.restlet</artifactId>
-        <version>2.2.1</version>
+        <version>${restlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.restlet.jee</groupId>
         <artifactId>org.restlet.ext.jackson</artifactId>
-        <version>2.2.1</version>
+        <version>${restlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.restlet.jee</groupId>
         <artifactId>org.restlet.ext.fileupload</artifactId>
-        <version>2.2.1</version>
+        <version>${restlet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.restlet.jse</groupId>
         <artifactId>org.restlet.ext.jetty</artifactId>
-        <version>2.2.1</version>
+        <version>${restlet.version}</version>
       </dependency>
       <dependency>
         <groupId>xml-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,8 @@
     <async-http-client.version>1.9.21</async-http-client.version>
     <jersey.version>2.23</jersey.version>
     <restlet.version>2.3.4</restlet.version>
+    <!-- The jetty version needs to match with the one transitively imported from restlet -->
+    <jetty.version>9.2.6.v20141205</jetty.version>
     <!-- Sets the VM argument line used when unit tests are run. -->
     <argLine> -Xms4g -Xmx4g -XX:MaxPermSize=512m -XX:MaxDirectMemorySize=10g </argLine>
   </properties>
@@ -371,26 +373,26 @@
         <artifactId>libthrift</artifactId>
         <version>0.9.1</version>
       </dependency>
-      <dependency>
+      <!-- <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>8.1.8.v20121106</version>
-      </dependency>
+      </dependency> -->
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>3.0.1</version>
         <scope>compile</scope>
       </dependency>
-      <dependency>
+      <!-- <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-servlet</artifactId>
         <version>8.1.8.v20121106</version>
-      </dependency>
+      </dependency> -->
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>8.1.8.v20121106</version>
+        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>


### PR DESCRIPTION
Upgrade the version number of restlet to 2.3.4 from 2.2.1. Since we
use Jetty with restlet and 2.2.1 depends on Jetty 8 (which has been
EOL'ed for two years), upgrade to a version which uses a non-EOL'ed
Jetty.