### PR TITLE
Make v3 format as default segment format

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentVersion.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentVersion.java
@@ -30,7 +30,7 @@ public enum SegmentVersion {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentVersion.class);
 
-  public static SegmentVersion DEFAULT_TABLE_VERSION = SegmentVersion.v1;
+  public static SegmentVersion DEFAULT_TABLE_VERSION = SegmentVersion.v3;
   public static SegmentVersion DEFAULT_SERVER_VERSION = SegmentVersion.v3;
 
   int versionNumber;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -133,7 +133,9 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
 
         for (String column : allColumns) {
           LOGGER.debug("Converting segment: {} , column: {}", v2Directory, column);
-          copyDictionary(v2DataReader, v3DataWriter, column);
+          if (v2Metadata.hasDictionary(column)) {
+            copyDictionary(v2DataReader, v3DataWriter, column);
+          }
           copyForwardIndex(v2DataReader, v3DataWriter, column);
         }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
@@ -68,6 +68,10 @@ public class SegmentDirectoryPaths {
     Preconditions.checkNotNull(indexDir);
     Preconditions.checkArgument(indexDir.exists(), "Path %s does not exist", indexDir);
 
+    if (! indexDir.isDirectory()) {
+      return indexDir;
+    }
+
     File v1File = new File(indexDir, fileName);
     if (v1File.exists()) {
       return v1File;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectoryPaths.java
@@ -48,22 +48,7 @@ public class SegmentDirectoryPaths {
   }
 
   public static @Nullable File findMetadataFile(@Nonnull File indexDir) {
-    Preconditions.checkNotNull(indexDir);
-    Preconditions.checkArgument(indexDir.exists(), "Path: %s does not exist", indexDir);
-    if (! indexDir.isDirectory()) {
-      return indexDir;
-    }
-    File metadataFile = new File(indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
-    if (metadataFile.exists()) {
-      return metadataFile;
-    }
-
-    File v3Dir = segmentDirectoryFor(indexDir, SegmentVersion.v3);
-    metadataFile = new File(v3Dir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
-    if (metadataFile.exists()) {
-      return metadataFile;
-    }
-    return null;
+    return findFormatFile(indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
   }
 
   /**
@@ -73,18 +58,25 @@ public class SegmentDirectoryPaths {
    * @return creation metadata file or null if the file is not found
    */
   public static @Nullable File findCreationMetaFile(@Nonnull File indexDir) {
+    return findFormatFile(indexDir, V1Constants.SEGMENT_CREATION_META);
+  }
+
+  public static @Nullable File findStarTreeFile(@Nonnull File indexDir) {
+    return findFormatFile(indexDir, V1Constants.STAR_TREE_INDEX_FILE);
+  }
+  private static @Nullable File findFormatFile(@Nonnull File indexDir, String fileName) {
     Preconditions.checkNotNull(indexDir);
     Preconditions.checkArgument(indexDir.exists(), "Path %s does not exist", indexDir);
 
-    File creationMetaFile = new File(indexDir, V1Constants.SEGMENT_CREATION_META);
-    if (creationMetaFile.exists()) {
-      return creationMetaFile;
+    File v1File = new File(indexDir, fileName);
+    if (v1File.exists()) {
+      return v1File;
     }
 
     File v3Dir = segmentDirectoryFor(indexDir, SegmentVersion.v3);
-    creationMetaFile = new File(v3Dir, V1Constants.SEGMENT_CREATION_META);
-    if (creationMetaFile.exists()) {
-      return creationMetaFile;
+    File v3File = new File(v3Dir, V1Constants.SEGMENT_CREATION_META);
+    if (v3File.exists()) {
+      return v3File;
     }
 
     return null;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoadersTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoadersTest.java
@@ -94,19 +94,21 @@ public class LoadersTest {
       throws Exception {
     SegmentMetadataImpl originalMetadata = new SegmentMetadataImpl(segmentDirectory);
     Assert.assertEquals(originalMetadata.getSegmentVersion(), SegmentVersion.v1);
+    // note: ordering of these two test blocks matters
     {
-      // with this code and converter in place, make sure we still load original version
-      // by default. We require specific configuration for v3.
-      IndexSegment indexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap);
-      Assert.assertEquals(indexSegment.getSegmentMetadata().getVersion(), originalMetadata.getVersion());
-      Assert.assertFalse(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
-    }
-    {
-      // Same as above but with explicit indexLoadingConfigMetadata passed to load v1
+      // Explicitly pass v1 format since we will convert by default to v3
       IndexSegment indexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v1LoadingConfig);
       Assert.assertEquals(indexSegment.getSegmentMetadata().getVersion(), originalMetadata.getVersion());
       Assert.assertFalse(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
     }
+    {
+      // with this code and converter in place, make sure we still load original version
+      // by default. We require specific configuration for v3.
+      IndexSegment indexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap);
+      Assert.assertEquals(indexSegment.getSegmentMetadata().getVersion(), SegmentVersion.v3.toString());
+      Assert.assertTrue(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
+    }
+
   }
 
 
@@ -123,8 +125,8 @@ public class LoadersTest {
 
     {
       IndexSegment indexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap);
-      Assert.assertEquals(indexSegment.getSegmentMetadata().getVersion(), originalMetadata.getVersion());
-      Assert.assertFalse(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
+      Assert.assertEquals(indexSegment.getSegmentMetadata().getVersion(), SegmentVersion.v3.toString());
+      Assert.assertTrue(SegmentDirectoryPaths.segmentDirectoryFor(segmentDirectory, SegmentVersion.v3).exists());
     }
     {
       IndexSegment indexSegment = Loaders.IndexSegment.load(segmentDirectory, ReadMode.mmap, v3LoadingConfig);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeConverter.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeConverter.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.startree;
 
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.File;
 import java.io.IOException;
@@ -46,8 +47,7 @@ public class TestStarTreeConverter {
       throws Exception {
     StarTreeIndexTestSegmentHelper.buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, false);
     _segment = StarTreeIndexTestSegmentHelper.loadSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
-    _indexDir = new File(SEGMENT_DIR_NAME, SEGMENT_NAME);
-
+    _indexDir = new File(new File(SEGMENT_DIR_NAME, SEGMENT_NAME), SegmentVersion.v3.toString());
   }
 
   /**
@@ -80,7 +80,7 @@ public class TestStarTreeConverter {
 
   private void assertStarTreeVersion(File indexDir, StarTreeFormatVersion expectedVersion)
       throws IOException {
-    File starTreeFile = new File(indexDir, V1Constants.STAR_TREE_INDEX_FILE);
+    File starTreeFile = new File(_indexDir, V1Constants.STAR_TREE_INDEX_FILE);
     Assert.assertEquals(StarTreeSerDe.getStarTreeVersion(starTreeFile), expectedVersion);
   }
 


### PR DESCRIPTION
All servers will convert all segments to v3 format by default.
Tables can be explicitly configured to use v1 format. Segment
generation is still in v1 format. This commit is first step towards
making v3 format as default.