### PR TITLE
Refactor: Change AggregationFunction api's to take BlockValSet instead of ProjectionBlockValSet.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BaseBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BaseBlockValSet.java
@@ -58,12 +58,53 @@ public abstract class BaseBlockValSet implements BlockValSet {
   }
 
   @Override
-  public <T> T getSingleValues() {
+  public int[] getIntValuesSV() {
+    throw new UnsupportedOperationException();
+
+  }
+
+  @Override
+  public int[][] getIntValuesMV() {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public <T> T getMultiValues() {
+  public long[] getLongValuesSV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long[][] getLongValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float[] getFloatValuesSV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float[][] getFloatValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double[] getDoubleValuesSV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double[][] getDoubleValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String[] getStringValuesSV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String[][] getStringValuesMV() {
     throw new UnsupportedOperationException();
   }
 
@@ -80,6 +121,11 @@ public abstract class BaseBlockValSet implements BlockValSet {
 
   @Override
   public int getDictionaryIdsForDocId(int docId, int[] outputDictIds) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int[] getNumberOfMVEntriesArray(){
     throw new UnsupportedOperationException();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockValSet.java
@@ -82,22 +82,72 @@ public interface BlockValSet {
   void getStringValues(int[] inDocIds, int inStartPos, int inDocIdsSize, String[] outValues, int outStartPos);
 
   /**
-   * Get values for single-valued column.
-   *
-   * @param <T> Return type
-   * @return Values for single-valued column.
+   * Get int values for a single-valued column.
+   * @return int values
    */
-  <T> T getSingleValues();
+  int[] getIntValuesSV();
 
   /**
-   * Get values for multi-valued column.
+   * Get int values for a multi-valued column.
+   * @return int values
+   */
+  int[][] getIntValuesMV();
+
+  /**
+   * Get long values for a single-valued column.
+   * @return long values
+   */
+  long[] getLongValuesSV();
+
+  /**
+   * Get long values for a single-valued column.
+   * @return long values
+   */
+  long[][] getLongValuesMV();
+
+  /**
+   * Get float values for a single-valued column.
+   * @return float values
+   */
+  float[] getFloatValuesSV();
+
+  /**
+   * Get int values for a single-valued column.
+   * @return int values
+   */
+  float[][] getFloatValuesMV();
+
+  /**
+   * Get double values for single-valued column.
    *
-   * @param <T> Return type
+   * @return Values for single-valued column.
+   */
+  double[] getDoubleValuesSV();
+
+  /**
+   * Get double values for multi-valued column.
+   *
    * @return Values for multi-valued column.
    *
    * TODO: Re-visit batch reading of multi-valued columns.
    */
-  <T> T getMultiValues();
+  double[][] getDoubleValuesMV();
+
+  /**
+   * Get String values for single-valued column.
+   *
+   * @return Values for single-valued column.
+   */
+  String[] getStringValuesSV();
+
+  /**
+   * Get String values for multi-valued column.
+   *
+   * @return Values for multi-valued column.
+   *
+   * TODO: Re-visit batch reading of multi-valued columns.
+   */
+  String[][] getStringValuesMV();
 
   /**
    * Get the dictionary ids for all docs of this block.
@@ -130,4 +180,10 @@ public interface BlockValSet {
    * @return Total number of multi-valued columns.
    */
   int getDictionaryIdsForDocId(int docId, int[] outputDictIds);
+
+  /**
+   * Returns an array containing number of MV entries for each docId in the BlockValSet.
+   * @return Array of number of MV entries
+   */
+  int[] getNumberOfMVEntriesArray();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
@@ -365,50 +365,6 @@ public class DataFetcher {
   }
 
   /**
-   * Fetch the hash code values for a single value column.
-   *
-   * @param column column name.
-   * @param inDocIds doc Id array.
-   * @param inStartPos input start position.
-   * @param length input length.
-   * @param outValues value array buffer.
-   * @param outStartPos output start position.
-   */
-  public void fetchHashCodes(String column, int[] inDocIds, int inStartPos, int length, int[] outValues, int outStartPos) {
-    Dictionary dictionary = getDictionaryForColumn(column);
-    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
-
-    for (int i = 0; i < length; i++, outStartPos++) {
-      outValues[outStartPos] = dictionary.get(_reusableDictIds[i]).hashCode();
-    }
-  }
-
-  /**
-   * Fetch the hash code values for a single value column.
-   *
-   * @param column column name.
-   * @param inDocIds doc Id array.
-   * @param inStartPos input start position.
-   * @param length input length.
-   * @param outValues value array buffer.
-   * @param outStartPos output start position.
-   */
-  public void fetchHashCodes(String column, int[] inDocIds, int inStartPos, int length, int[][] outValues, int outStartPos) {
-    Dictionary dictionary = getDictionaryForColumn(column);
-    BlockMultiValIterator iterator = (BlockMultiValIterator) getBlockValIteratorForColumn(column);
-
-    int inEndPos = inStartPos + length;
-    for (int i = inStartPos; i < inEndPos; i++, outStartPos++) {
-      iterator.skipTo(inDocIds[i]);
-      int numValues = iterator.nextIntVal(_reusableMVDictIds);
-      outValues[outStartPos] = new int[numValues];
-      for (int j = 0; j < numValues; j++) {
-        outValues[outStartPos][j] = dictionary.get(_reusableMVDictIds[j]).hashCode();
-      }
-    }
-  }
-
-  /**
    * Returns the data type for the specified column.
    *
    * @param column Name of column for which to return the data type.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DataBlockCache.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/DataBlockCache.java
@@ -43,14 +43,12 @@ public class DataBlockCache {
   /** _columnToXXsMap must be defined accordingly */
   private final Map<String, int[]> _columnToDictIdsMap = new HashMap<>();
   private final Map<String, Object> _columnToValuesMap = new HashMap<>();
-  private final Map<String, int[]> _columnToHashCodesMap = new HashMap<>();
   private final Map<String, String[]> _columnToStringsMap = new HashMap<>();
 
   private final Map<String, int[]> _columnToNumberOfEntriesMap = new HashMap<>();
 
   private final Map<String, int[][]> _columnToDictIdsArrayMap = new HashMap<>();
   private final Map<String, Object> _columnToValuesArrayMap = new HashMap<>();
-  private final Map<String, int[][]> _columnToHashCodesArrayMap = new HashMap<>();
   private final Map<String, String[][]> _columnToStringsArrayMap = new HashMap<>();
 
   private final Map<String, int[]> _columnToTempDictIdsMap = new HashMap<>();
@@ -143,14 +141,15 @@ public class DataBlockCache {
    * @return value array associated with this column.
    */
   public int[] getIntValueArrayForColumn(String column) {
-    int[] intValues = (int []) _columnToValuesMap.get(column);
-    if (!_columnValueLoaded.contains(column)) {
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.INT);
+    int[] intValues = (int []) _columnToValuesMap.get(key);
+    if (!_columnValueLoaded.contains(key)) {
       if (intValues == null) {
         intValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-        _columnToValuesMap.put(column, intValues);
+        _columnToValuesMap.put(key, intValues);
       }
       _dataFetcher.fetchIntValues(column, _docIds, _startPos, _length, intValues, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return intValues;
   }
@@ -162,16 +161,17 @@ public class DataBlockCache {
    * @return int values array associated with this column.
    */
   public int[][] getIntValuesArrayForColumn(String column) {
-    int[][] intValues = (int[][]) _columnToValuesArrayMap.get(column);
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.INT_ARRAY);
+    int[][] intValues = (int[][]) _columnToValuesArrayMap.get(key);
 
-    if (!_columnValueLoaded.contains(column)) {
+    if (!_columnValueLoaded.contains(key)) {
       if (intValues == null) {
         intValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
-        _columnToValuesArrayMap.put(column, intValues);
+        _columnToValuesArrayMap.put(key, intValues);
       }
 
       _dataFetcher.fetchIntValues(column, _docIds, _startPos, _length, intValues, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return intValues;
   }
@@ -183,14 +183,15 @@ public class DataBlockCache {
    * @return value array associated with this column.
    */
   public long[] getLongValueArrayForColumn(String column) {
-    long[] longValues = (long []) _columnToValuesMap.get(column);
-    if (!_columnValueLoaded.contains(column)) {
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.LONG);
+    long[] longValues = (long []) _columnToValuesMap.get(key);
+    if (!_columnValueLoaded.contains(key)) {
       if (longValues == null) {
         longValues = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-        _columnToValuesMap.put(column, longValues);
+        _columnToValuesMap.put(key, longValues);
       }
       _dataFetcher.fetchLongValues(column, _docIds, _startPos, _length, longValues, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return longValues;
   }
@@ -202,16 +203,17 @@ public class DataBlockCache {
    * @return long values array associated with this column.
    */
   public long[][] getLongValuesArrayForColumn(String column) {
-    long[][] longValues = (long[][]) _columnToValuesArrayMap.get(column);
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.LONG_ARRAY);
+    long[][] longValues = (long[][]) _columnToValuesArrayMap.get(key);
 
-    if (!_columnValueLoaded.contains(column)) {
+    if (!_columnValueLoaded.contains(key)) {
       if (longValues == null) {
         longValues = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
-        _columnToValuesArrayMap.put(column, longValues);
+        _columnToValuesArrayMap.put(key, longValues);
       }
 
       _dataFetcher.fetchLongValues(column, _docIds, _startPos, _length, longValues, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return longValues;
   }
@@ -223,14 +225,15 @@ public class DataBlockCache {
    * @return value array associated with this column.
    */
   public float[] getFloatValueArrayForColumn(String column) {
-    float[] floatValues = (float []) _columnToValuesMap.get(column);
-    if (!_columnValueLoaded.contains(column)) {
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.FLOAT);
+    float[] floatValues = (float []) _columnToValuesMap.get(key);
+    if (!_columnValueLoaded.contains(key)) {
       if (floatValues == null) {
         floatValues = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-        _columnToValuesMap.put(column, floatValues);
+        _columnToValuesMap.put(key, floatValues);
       }
       _dataFetcher.fetchFloatValues(column, _docIds, _startPos, _length, floatValues, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return floatValues;
   }
@@ -242,16 +245,17 @@ public class DataBlockCache {
    * @return long values array associated with this column.
    */
   public float[][] getFloatValuesArrayForColumn(String column) {
-    float[][] floatValues = (float[][]) _columnToValuesArrayMap.get(column);
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.FLOAT_ARRAY);
+    float[][] floatValues = (float[][]) _columnToValuesArrayMap.get(key);
 
-    if (!_columnValueLoaded.contains(column)) {
+    if (!_columnValueLoaded.contains(key)) {
       if (floatValues == null) {
         floatValues = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
-        _columnToValuesArrayMap.put(column, floatValues);
+        _columnToValuesArrayMap.put(key, floatValues);
       }
 
       _dataFetcher.fetchFloatValues(column, _docIds, _startPos, _length, floatValues, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return floatValues;
   }
@@ -263,14 +267,15 @@ public class DataBlockCache {
    * @return value array associated with this column.
    */
   public double[] getDoubleValueArrayForColumn(String column) {
-    double[] doubleValues = (double []) _columnToValuesMap.get(column);
-    if (!_columnValueLoaded.contains(column)) {
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.DOUBLE);
+    double[] doubleValues = (double []) _columnToValuesMap.get(key);
+    if (!_columnValueLoaded.contains(key)) {
       if (doubleValues == null) {
         doubleValues = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-        _columnToValuesMap.put(column, doubleValues);
+        _columnToValuesMap.put(key, doubleValues);
       }
       _dataFetcher.fetchDoubleValues(column, _docIds, _startPos, _length, doubleValues, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return doubleValues;
   }
@@ -282,61 +287,19 @@ public class DataBlockCache {
    * @return double values array associated with this column.
    */
   public double[][] getDoubleValuesArrayForColumn(String column) {
-    double[][] doubleValuesArray = (double[][]) _columnToValuesArrayMap.get(column);
+    String key = getKeyForColumnAndType(column, FieldSpec.DataType.DOUBLE_ARRAY);
+    double[][] doubleValuesArray = (double[][]) _columnToValuesArrayMap.get(key);
 
-    if (!_columnValueLoaded.contains(column)) {
+    if (!_columnValueLoaded.contains(key)) {
       if (doubleValuesArray == null) {
         doubleValuesArray = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
-        _columnToValuesArrayMap.put(column, doubleValuesArray);
+        _columnToValuesArrayMap.put(key, doubleValuesArray);
       }
 
       _dataFetcher.fetchDoubleValues(column, _docIds, _startPos, _length, doubleValuesArray, 0);
-      _columnValueLoaded.add(column);
+      _columnValueLoaded.add(key);
     }
     return doubleValuesArray;
-  }
-
-  /**
-   * Get hash code array for a given column for the specific block initialized in the initNewBlock.
-   *
-   * @param column column name.
-   * @return hash code array associated with this column.
-   */
-  public int[] getHashCodeArrayForColumn(String column) {
-    int[] hashCodes = _columnToHashCodesMap.get(column);
-    if (!_columnHashCodeLoaded.contains(column)) {
-      if (hashCodes == null) {
-        hashCodes = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-        _columnToHashCodesMap.put(column, hashCodes);
-      }
-      _dataFetcher.fetchHashCodes(column, _docIds, _startPos, _length, hashCodes, 0);
-      _columnHashCodeLoaded.add(column);
-    }
-    return hashCodes;
-  }
-
-  /**
-   * Get hash code array for a given column for the specific block initialized in the initNewBlock.
-   *
-   * @param column column name.
-   * @return hash codes array associated with this column.
-   */
-  public int[][] getHashCodesArrayForColumn(String column) {
-    int[][] hashCodesArray = _columnToHashCodesArrayMap.get(column);
-    if (!_columnHashCodeLoaded.contains(column)) {
-      if (hashCodesArray == null) {
-        hashCodesArray = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
-        _columnToHashCodesArrayMap.put(column, hashCodesArray);
-      }
-
-      int maxNumberOfEntriesForColumn = _dataFetcher.getMaxNumberOfEntriesForColumn(column);
-      for (int pos = 0; pos < _length; ++pos) {
-        hashCodesArray[pos] = new int[maxNumberOfEntriesForColumn];
-      }
-      _dataFetcher.fetchHashCodes(column, _docIds, _startPos, _length, hashCodesArray, 0);
-      _columnHashCodeLoaded.add(column);
-    }
-    return hashCodesArray;
   }
 
   /**
@@ -427,5 +390,20 @@ public class DataBlockCache {
    */
   public DataFetcher getDataFetcher() {
     return _dataFetcher;
+  }
+
+  /**
+   * Helper method that generates a key for {@link #_columnToValuesMap} using column name and data type
+   * to be fetched for the column.
+   *
+   * @param column Column Name
+   * @param dataType Data Type
+   * @return Key of column name and data type
+   */
+  private String getKeyForColumnAndType(String column, FieldSpec.DataType dataType) {
+    StringBuilder builder = new StringBuilder(column);
+    builder.append("_");
+    builder.append(dataType);
+    return builder.toString();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AggregationFunction.java
@@ -16,9 +16,9 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 
@@ -64,25 +64,22 @@ public interface AggregationFunction<IntermediateResult extends Serializable, Fi
   /**
    * Perform aggregation on the given projection block value sets.
    */
-  // TODO: after adding all support in BlockValSet, change ProjectionBlockValSet to BlockValSet.
   void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets);
+      @Nonnull BlockValSet... blockValSets);
 
   /**
    * Perform group-by on the given group key array and projection block value sets.
    * <p>This method is for all single-value group-by columns case, where each docId has only one group key.
    */
-  // TODO: after adding all support in BlockValSet, change ProjectionBlockValSet to BlockValSet.
   void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray, @Nonnull GroupByResultHolder groupByResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets);
+      @Nonnull BlockValSet... blockValSets);
 
   /**
    * Perform group-by on the given group keys array and projection block value sets.
    * <p>This method is for multi-value group by columns case, where each docId can have multiple group keys.
    */
-  // TODO: after adding all support in BlockValSet, change ProjectionBlockValSet to BlockValSet.
   void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray, @Nonnull GroupByResultHolder groupByResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets);
+      @Nonnull BlockValSet... blockValSets);
 
   /**
    * Extract aggregation result from the aggregation result holder.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import com.linkedin.pinot.core.query.aggregation.function.AvgAggregationFunction.AvgPair;
 import javax.annotation.Nonnull;
 
@@ -60,8 +60,8 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     double sum = 0.0;
     for (int i = 0; i < length; i++) {
       sum += valueArray[i];
@@ -83,9 +83,8 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
-    ;
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       setGroupByResult(groupKeyArray[i], groupByResultHolder, valueArray[i], 1L);
     }
@@ -93,8 +92,8 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/AvgMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -38,8 +38,8 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     double sum = 0.0;
     long count = 0L;
     for (int i = 0; i < length; i++) {
@@ -54,8 +54,8 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       aggregateOnGroupKey(groupKeyArray[i], groupByResultHolder, valuesArray[i]);
     }
@@ -63,8 +63,8 @@ public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.DoubleAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.DoubleGroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -59,13 +59,13 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
+      @Nonnull BlockValSet... blockValSets) {
     aggregationResultHolder.setValue(aggregationResultHolder.getDoubleResult() + length);
   }
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + 1);
@@ -74,7 +74,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
     for (int i = 0; i < length; i++) {
       for (int groupKey : groupKeysArray[i]) {
         groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + 1);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/CountMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -38,8 +38,8 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getNumberOfMVEntriesArray();
+      @Nonnull BlockValSet... blockValSets) {
+    int[] valueArray = blockValSets[0].getNumberOfMVEntriesArray();
     long count = 0L;
     for (int i = 0; i < length; i++) {
       count += valueArray[i];
@@ -49,8 +49,8 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getNumberOfMVEntriesArray();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    int[] valueArray = blockValSets[0].getNumberOfMVEntriesArray();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + valueArray[i]);
@@ -59,8 +59,8 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getNumberOfMVEntriesArray();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    int[] valueArray = blockValSets[0].getNumberOfMVEntriesArray();
     for (int i = 0; i < length; i++) {
       int value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import javax.annotation.Nonnull;
 
@@ -59,47 +59,152 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getSVHashCodeArray();
+      @Nonnull BlockValSet... blockValSets) {
     IntOpenHashSet valueSet = aggregationResultHolder.getResult();
     if (valueSet == null) {
       valueSet = new IntOpenHashSet();
       aggregationResultHolder.setValue(valueSet);
     }
-    for (int i = 0; i < length; i++) {
-      valueSet.add(valueArray[i]);
+
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSets[0].getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          valueSet.add(intValues[i]);
+        }
+        break;
+
+      case LONG:
+        long[] longValues = blockValSets[0].getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          valueSet.add(Long.valueOf(longValues[i]).hashCode());
+        }
+        break;
+
+      case FLOAT:
+        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          valueSet.add(Float.valueOf(floatValues[i]).hashCode());
+        }
+        break;
+
+      case DOUBLE:
+        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          valueSet.add(Double.valueOf(doubleValues[i]).hashCode());
+        }
+        break;
+
+      case STRING:
+        String[] stringValues = blockValSets[0].getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          valueSet.add(stringValues[i].hashCode());
+        }
+        break;
+
+      default:
+        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getSVHashCodeArray();
-    for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      IntOpenHashSet valueSet = groupByResultHolder.getResult(groupKey);
-      if (valueSet == null) {
-        valueSet = new IntOpenHashSet();
-        groupByResultHolder.setValueForKey(groupKey, valueSet);
-      }
-      valueSet.add(valueArray[i]);
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSets[0].getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          // Hashcode for int is the same as its value.
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], intValues[i]);
+        }
+        break;
+
+      case LONG:
+        long[] longValues = blockValSets[0].getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = Long.valueOf(longValues[i]).hashCode();
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], hashCode);
+        }
+        break;
+
+      case FLOAT:
+        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = Float.valueOf(floatValues[i]).hashCode();
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], hashCode);
+        }
+        break;
+
+      case DOUBLE:
+        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = Double.valueOf(doubleValues[i]).hashCode();
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], hashCode);
+        }
+        break;
+
+      case STRING:
+        String[] stringValues = blockValSets[0].getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = stringValues[i].hashCode();
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], hashCode);
+        }
+        break;
+
+      default:
+        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getSVHashCodeArray();
-    for (int i = 0; i < length; i++) {
-      int value = valueArray[i];
-      for (int groupKey : groupKeysArray[i]) {
-        IntOpenHashSet valueSet = groupByResultHolder.getResult(groupKey);
-        if (valueSet == null) {
-          valueSet = new IntOpenHashSet();
-          groupByResultHolder.setValueForKey(groupKey, valueSet);
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSets[0].getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
         }
-        valueSet.add(value);
-      }
+        break;
+
+      case LONG:
+        long[] longValues = blockValSets[0].getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = Long.valueOf(longValues[i]).hashCode();
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], hashCode);
+        }
+        break;
+
+      case FLOAT:
+        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = Float.valueOf(floatValues[i]).hashCode();
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], hashCode);
+        }
+        break;
+
+      case DOUBLE:
+        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = Double.valueOf(doubleValues[i]).hashCode();
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], hashCode);
+        }
+        break;
+
+      case STRING:
+        String[] stringValues = blockValSets[0].getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = stringValues[i].hashCode();
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], hashCode);
+        }
+        break;
+
+      default:
+        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
     }
   }
 
@@ -143,5 +248,34 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
   @Override
   public Integer extractFinalResult(@Nonnull IntOpenHashSet intermediateResult) {
     return intermediateResult.size();
+  }
+
+  /**
+   * Helper method to set value for a groupKey into the result holder.
+   *
+   * @param groupByResultHolder Result holder
+   * @param groupKey Group-key for which to set the value
+   * @param value Value for the group key
+   */
+  private void setValueForGroupKey(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey, int value) {
+    IntOpenHashSet valueSet = groupByResultHolder.getResult(groupKey);
+    if (valueSet == null) {
+      valueSet = new IntOpenHashSet();
+      groupByResultHolder.setValueForKey(groupKey, valueSet);
+    }
+    valueSet.add(value);
+  }
+
+  /**
+   * Helper method to set values for a given array of groupKeys, into the result holder.
+   *
+   * @param groupByResultHolder Result holder
+   * @param groupKeys Array of group keys for which to set the value
+   * @param value Value to be set
+   */
+  private void setValueForGroupKeys(@Nonnull GroupByResultHolder groupByResultHolder, int[] groupKeys, int value) {
+    for (int groupKey : groupKeys) {
+      setValueForGroupKey(groupByResultHolder, groupKey, value);
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -18,11 +18,11 @@ package com.linkedin.pinot.core.operator.aggregation.function;
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
 import javax.annotation.Nonnull;
 
@@ -61,47 +61,150 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getSVHashCodeArray();
+      @Nonnull BlockValSet... blockValSets) {
+
     HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
     if (hyperLogLog == null) {
       hyperLogLog = new HyperLogLog(HllConstants.DEFAULT_LOG2M);
       aggregationResultHolder.setValue(hyperLogLog);
     }
-    for (int i = 0; i < length; i++) {
-      hyperLogLog.offer(valueArray[i]);
+
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSets[0].getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          hyperLogLog.offer(intValues[i]);
+        }
+        break;
+
+      case LONG:
+        long[] longValues = blockValSets[0].getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          hyperLogLog.offer(Long.valueOf(longValues[i]).hashCode());
+        }
+        break;
+
+      case FLOAT:
+        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          hyperLogLog.offer(Float.valueOf(floatValues[i]).hashCode());
+        }
+        break;
+
+      case DOUBLE:
+        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          hyperLogLog.offer(Double.valueOf(doubleValues[i]).hashCode());
+        }
+        break;
+
+      case STRING:
+        String[] stringValues = blockValSets[0].getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          hyperLogLog.offer(stringValues[i]);
+        }
+        break;
+
+      default:
+        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getSVHashCodeArray();
-    for (int i = 0; i < length; i++) {
-      int groupKey = groupKeyArray[i];
-      HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
-      if (hyperLogLog == null) {
-        hyperLogLog = new HyperLogLog(HllConstants.DEFAULT_LOG2M);
-        groupByResultHolder.setValueForKey(groupKey, hyperLogLog);
-      }
-      hyperLogLog.offer(valueArray[i]);
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSets[0].getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], intValues[i]);
+        }
+        break;
+
+      case LONG:
+        long[] longValues = blockValSets[0].getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], Long.valueOf(longValues[i]).hashCode());
+        }
+        break;
+
+      case FLOAT:
+        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKey(groupByResultHolder, groupKeyArray[i], Float.valueOf(floatValues[i]).hashCode());
+        }
+        break;
+
+      case DOUBLE:
+        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          int groupKey = groupKeyArray[i];
+          setValueForGroupKey(groupByResultHolder, groupKey, Double.valueOf(doubleValues[i]).hashCode());
+        }
+        break;
+
+      case STRING:
+        String[] stringValues = blockValSets[0].getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          int groupKey = groupKeyArray[i];
+          setValueForGroupKey(groupByResultHolder, groupKey, stringValues[i].hashCode());
+        }
+        break;
+
+      default:
+        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
     }
   }
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    int[] valueArray = projectionBlockValSets[0].getSVHashCodeArray();
-    for (int i = 0; i < length; i++) {
-      int value = valueArray[i];
-      for (int groupKey : groupKeysArray[i]) {
-        HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
-        if (hyperLogLog == null) {
-          hyperLogLog = new HyperLogLog(HllConstants.DEFAULT_LOG2M);
-          groupByResultHolder.setValueForKey(groupKey, hyperLogLog);
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+
+    FieldSpec.DataType valueType = blockValSets[0].getValueType();
+    switch (valueType) {
+      case INT:
+        int[] intValues = blockValSets[0].getIntValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], intValues[i]);
         }
-        hyperLogLog.offer(value);
-      }
+        break;
+
+      case LONG:
+        long[] longValues = blockValSets[0].getLongValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Long.valueOf(longValues[i]).hashCode());
+        }
+        break;
+
+      case FLOAT:
+        float[] floatValues = blockValSets[0].getFloatValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Float.valueOf(floatValues[i]).hashCode());
+        }
+        break;
+
+      case DOUBLE:
+        double[] doubleValues = blockValSets[0].getDoubleValuesSV();
+        for (int i = 0; i < length; i++) {
+          setValueForGroupKeys(groupByResultHolder, groupKeysArray[i], Double.valueOf(doubleValues[i]).hashCode());
+        }
+        break;
+
+      case STRING:
+        String[] singleValues = blockValSets[0].getStringValuesSV();
+        for (int i = 0; i < length; i++) {
+          int hashCode = singleValues[i].hashCode();
+          for (int groupKey : groupKeysArray[i]) {
+            setValueForGroupKey(groupByResultHolder, groupKey, hashCode);
+          }
+        }
+        break;
+
+      default:
+        throw new IllegalArgumentException("Illegal data type for distinct count aggregation function: " + valueType);
     }
   }
 
@@ -148,5 +251,33 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
   @Override
   public Long extractFinalResult(@Nonnull HyperLogLog intermediateResult) {
     return intermediateResult.cardinality();
+  }
+
+  /**
+   * Helper method to set value for a groupKey into the result holder.
+   *
+   * @param groupByResultHolder Result holder
+   * @param groupKey Group-key for which to set the value
+   * @param value Value for the group key
+   */
+  private void setValueForGroupKey(@Nonnull GroupByResultHolder groupByResultHolder, int groupKey, int value) {
+    HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
+    if (hyperLogLog == null) {
+      hyperLogLog = new HyperLogLog(HllConstants.DEFAULT_LOG2M);
+      groupByResultHolder.setValueForKey(groupKey, hyperLogLog);
+    }
+    hyperLogLog.offer(value);
+  }
+
+  /**
+   * Helper method to set value for a given array of group keys.
+   * @param groupByResultHolder Result Holder
+   * @param groupKeys Group keys for which to set the value
+   * @param value Value to set
+   */
+  private void setValueForGroupKeys(@Nonnull GroupByResultHolder groupByResultHolder, int[] groupKeys, int value) {
+    for (int groupKey : groupKeys) {
+      setValueForGroupKey(groupByResultHolder, groupKey, value);
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLAggregationFunction.java
@@ -18,11 +18,11 @@ package com.linkedin.pinot.core.operator.aggregation.function;
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
 import com.linkedin.pinot.core.startree.hll.HllUtil;
 import javax.annotation.Nonnull;
@@ -68,8 +68,8 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    String[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    String[] valueArray = blockValSets[0].getStringValuesSV();
     HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
     if (hyperLogLog == null) {
       hyperLogLog = new HyperLogLog(_log2m);
@@ -86,8 +86,8 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    String[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    String[] valueArray = blockValSets[0].getStringValuesSV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
@@ -105,8 +105,8 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    String[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    String[] valueArray = blockValSets[0].getStringValuesSV();
     for (int i = 0; i < length; i++) {
       String value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/FastHLLMVAggregationFunction.java
@@ -17,9 +17,9 @@ package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import com.linkedin.pinot.core.startree.hll.HllUtil;
 import javax.annotation.Nonnull;
 
@@ -41,8 +41,8 @@ public class FastHLLMVAggregationFunction extends FastHLLAggregationFunction {
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    String[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    String[][] valuesArray = blockValSets[0].getStringValuesMV();
     HyperLogLog hyperLogLog = aggregationResultHolder.getResult();
     if (hyperLogLog == null) {
       hyperLogLog = new HyperLogLog(_log2m);
@@ -61,8 +61,8 @@ public class FastHLLMVAggregationFunction extends FastHLLAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    String[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    String[][] valuesArray = blockValSets[0].getStringValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       HyperLogLog hyperLogLog = groupByResultHolder.getResult(groupKey);
@@ -82,8 +82,8 @@ public class FastHLLMVAggregationFunction extends FastHLLAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    String[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    String[][] valuesArray = blockValSets[0].getStringValuesMV();
     for (int i = 0; i < length; i++) {
       String[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.DoubleAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.DoubleGroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -59,8 +59,8 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     double max = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
@@ -73,8 +73,8 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       int groupKey = groupKeyArray[i];
@@ -86,8 +86,8 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MaxMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -38,8 +38,8 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     double max = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -53,8 +53,8 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       double max = groupByResultHolder.getDoubleResult(groupKey);
@@ -69,8 +69,8 @@ public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.DoubleAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.DoubleGroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -59,8 +59,8 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     double min = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
@@ -73,8 +73,8 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       int groupKey = groupKeyArray[i];
@@ -86,8 +86,8 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -38,8 +38,8 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     double min = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -53,8 +53,8 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       double min = groupByResultHolder.getDoubleResult(groupKey);
@@ -69,8 +69,8 @@ public class MinMVAggregationFunction extends MinAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import com.linkedin.pinot.core.query.aggregation.function.MinMaxRangeAggregationFunction.MinMaxRangePair;
 import javax.annotation.Nonnull;
 
@@ -60,8 +60,8 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
     for (int i = 0; i < length; i++) {
@@ -94,8 +94,8 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       setGroupByResult(groupKeyArray[i], groupByResultHolder, value, value);
@@ -104,8 +104,8 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -38,8 +38,8 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     double min = Double.POSITIVE_INFINITY;
     double max = Double.NEGATIVE_INFINITY;
     for (int i = 0; i < length; i++) {
@@ -58,8 +58,8 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       aggregateOnGroupKey(groupKeyArray[i], groupByResultHolder, valuesArray[i]);
     }
@@ -67,8 +67,8 @@ public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunc
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.util.Collections;
 import javax.annotation.Nonnull;
@@ -84,8 +84,8 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     DoubleArrayList doubleArrayList = aggregationResultHolder.getResult();
     if (doubleArrayList == null) {
       doubleArrayList = new DoubleArrayList();
@@ -98,8 +98,8 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       DoubleArrayList doubleArrayList = groupByResultHolder.getResult(groupKey);
@@ -113,8 +113,8 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import com.linkedin.pinot.core.query.aggregation.function.quantile.digest.QuantileDigest;
 import javax.annotation.Nonnull;
 
@@ -83,8 +83,8 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     QuantileDigest quantileDigest = aggregationResultHolder.getResult();
     if (quantileDigest == null) {
       quantileDigest = new QuantileDigest(DEFAULT_MAX_ERROR);
@@ -97,8 +97,8 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       QuantileDigest quantileDigest = groupByResultHolder.getResult(groupKey);
@@ -112,8 +112,8 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import com.linkedin.pinot.core.query.aggregation.function.quantile.digest.QuantileDigest;
 import javax.annotation.Nonnull;
 
@@ -60,8 +60,8 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     QuantileDigest quantileDigest = aggregationResultHolder.getResult();
     if (quantileDigest == null) {
       quantileDigest = new QuantileDigest(DEFAULT_MAX_ERROR);
@@ -76,8 +76,8 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       QuantileDigest quantileDigest = groupByResultHolder.getResult(groupKey);
@@ -93,8 +93,8 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/PercentileMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import javax.annotation.Nonnull;
 
@@ -60,8 +60,8 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     DoubleArrayList doubleArrayList = aggregationResultHolder.getResult();
     if (doubleArrayList == null) {
       doubleArrayList = new DoubleArrayList();
@@ -76,8 +76,8 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       DoubleArrayList doubleArrayList = groupByResultHolder.getResult(groupKey);
@@ -93,8 +93,8 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumAggregationFunction.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.core.operator.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.DoubleAggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.DoubleGroupByResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -59,8 +59,8 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     double sum = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       sum += valueArray[i];
@@ -70,8 +70,8 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + valueArray[i]);
@@ -80,8 +80,8 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[] valueArray = projectionBlockValSets[0].getSingleValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[] valueArray = blockValSets[0].getDoubleValuesSV();
     for (int i = 0; i < length; i++) {
       double value = valueArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/aggregation/function/SumMVAggregationFunction.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.operator.aggregation.function;
 
+import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.operator.aggregation.groupby.GroupByResultHolder;
-import com.linkedin.pinot.core.operator.docvalsets.ProjectionBlockValSet;
 import javax.annotation.Nonnull;
 
 
@@ -38,8 +38,8 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregate(int length, @Nonnull AggregationResultHolder aggregationResultHolder,
-      @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     double sum = aggregationResultHolder.getDoubleResult();
     for (int i = 0; i < length; i++) {
       for (double value : valuesArray[i]) {
@@ -51,8 +51,8 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregateGroupBySV(int length, @Nonnull int[] groupKeyArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       int groupKey = groupKeyArray[i];
       double sum = groupByResultHolder.getDoubleResult(groupKey);
@@ -65,8 +65,8 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
 
   @Override
   public void aggregateGroupByMV(int length, @Nonnull int[][] groupKeysArray,
-      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull ProjectionBlockValSet... projectionBlockValSets) {
-    double[][] valuesArray = projectionBlockValSets[0].getMultiValues();
+      @Nonnull GroupByResultHolder groupByResultHolder, @Nonnull BlockValSet... blockValSets) {
+    double[][] valuesArray = blockValSets[0].getDoubleValuesMV();
     for (int i = 0; i < length; i++) {
       double[] values = valuesArray[i];
       for (int groupKey : groupKeysArray[i]) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -52,28 +52,67 @@ public class ProjectionBlockValSet extends BaseBlockValSet {
     _blockValIterator = _dataBlockCache.getDataFetcher().getBlockValIteratorForColumn(column);
   }
 
+  @Override
+  public int[] getIntValuesSV() {
+    return _dataBlockCache.getIntValueArrayForColumn(_column);
+  }
+
+  @Override
+  public int[][] getIntValuesMV() {
+    return _dataBlockCache.getIntValuesArrayForColumn(_column);
+  }
+
+  @Override
+  public long[] getLongValuesSV() {
+    return _dataBlockCache.getLongValueArrayForColumn(_column);
+  }
+
+  @Override
+  public long[][] getLongValuesMV() {
+    return _dataBlockCache.getLongValuesArrayForColumn(_column);
+  }
+
+  @Override
+  public float[] getFloatValuesSV() {
+    return _dataBlockCache.getFloatValueArrayForColumn(_column);
+  }
+
+  @Override
+  public float[][] getFloatValuesMV() {
+    return _dataBlockCache.getFloatValuesArrayForColumn(_column);
+  }
+
   /**
    * Returns an array of single values for the given doc Ids.
    * Caller chooses T based on data type.
    *
-   * @param <T> Return type.
    * @return Array of single-values from dataBlockCache.
    */
   @Override
-  public <T> T getSingleValues() {
-    return getValues(false);
+  public double[] getDoubleValuesSV() {
+    return _dataBlockCache.getDoubleValueArrayForColumn(_column);
   }
 
   /**
    * Returns an array of multi-values for the given doc Ids.
    * Caller chooses T based on data type.
    *
-   * @param <T> Return type.
    * @return Array of multi-values from dataBlockCache.
    */
   @Override
-  public <T> T getMultiValues() {
-    return getValues(true);
+  public double[][] getDoubleValuesMV() {
+    return _dataBlockCache.getDoubleValuesArrayForColumn(_column);
+  }
+
+
+  @Override
+  public String[] getStringValuesSV() {
+    return _dataBlockCache.getStringValueArrayForColumn(_column);
+  }
+
+  @Override
+  public String[][] getStringValuesMV() {
+    return _dataBlockCache.getStringValuesArrayForColumn(_column);
   }
 
   @Override
@@ -100,57 +139,8 @@ public class ProjectionBlockValSet extends BaseBlockValSet {
     return blockValIterator.nextIntVal(outputDictIds);
   }
 
-  /**
-   * Returns array containing hash codes for values of the single-valued projection column, for the filtered docIds.
-   * @return Array of hash codes for values of the projection column
-   */
-  public int[] getSVHashCodeArray() {
-    return _dataBlockCache.getHashCodeArrayForColumn(_column);
-  }
-
-  /**
-   * Returns array containing hash codes for values of the multi-valued projection column, for the filtered docIds.
-   * @return Array of hash codes for values of the projection column
-   */
-  public int[][] getMVHashCodeArray() {
-    return _dataBlockCache.getHashCodesArrayForColumn(_column);
-  }
-
-  /**
-   * Returns an array containing number of MV entries for the filtered docIds of the projection column.
-   * @return Array of number of MV entries
-   */
+  @Override
   public int[] getNumberOfMVEntriesArray() {
     return _dataBlockCache.getNumberOfEntriesArrayForColumn(_column);
-  }
-
-  /**
-   * Helper method to get SV/MV values for the projection column.
-   *
-   * @param multiValued True for multi-valued columns, False for single-valued columns.
-   * @param <T> Return data type
-   * @return Values for the projection column.
-   */
-  @SuppressWarnings("unchecked")
-  private <T> T getValues(boolean multiValued) {
-    switch (_columnDataType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        return (T) ((multiValued) ? _dataBlockCache.getDoubleValuesArrayForColumn(_column)
-            : _dataBlockCache.getDoubleValueArrayForColumn(_column));
-
-      case STRING:
-        return (T) ((multiValued) ? _dataBlockCache.getStringValuesArrayForColumn(_column)
-            : _dataBlockCache.getStringValueArrayForColumn(_column));
-
-      case OBJECT:
-        return (T) ((multiValued) ? _dataBlockCache.getHashCodesArrayForColumn(_column)
-            : _dataBlockCache.getHashCodeArrayForColumn(_column));
-
-      default:
-        throw new RuntimeException("Data type " + _columnDataType + " not supported in ProjectionBlockValSet.");
-    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/DefaultExpressionEvaluator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/DefaultExpressionEvaluator.java
@@ -87,7 +87,7 @@ public class DefaultExpressionEvaluator implements TransformExpressionEvaluator 
       if (column != null) {
         Block dataBlock = projectionBlock.getDataBlock(column);
         ProjectionBlockValSet blockValSet = (ProjectionBlockValSet) dataBlock.getBlockValueSet();
-        double[] values = blockValSet.getSingleValues();
+        double[] values = blockValSet.getDoubleValuesSV();
         return new DoubleArrayTransformResult(values);
       } else {
         throw new RuntimeException("Literals not supported in transforms yet");

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/DataFetcherTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/DataFetcherTest.java
@@ -190,22 +190,6 @@ public class DataFetcherTest {
     }
   }
 
-  @Test
-  public void testFetchSingleHashCodes() {
-    int[] docIds = new int[NUM_ROWS];
-    int length = 0;
-    for (int i = _random.nextInt(MAX_STEP_LENGTH); i < NUM_ROWS; i += _random.nextInt(MAX_STEP_LENGTH) + 1) {
-      docIds[length++] = i;
-    }
-
-    int[] hashCodes = new int[length];
-    _dataFetcher.fetchHashCodes(DIMENSION_NAME, docIds, 0, length, hashCodes, 0);
-
-    for (int i = 0; i < length; i++) {
-      Assert.assertEquals(hashCodes[i], _dimensionValues[docIds[i]].hashCode(), _errorMessage);
-    }
-  }
-
   @AfterClass
   public void cleanUp() {
     FileUtils.deleteQuietly(new File(INDEX_DIR_PATH));

--- a/pinot-core/src/test/java/com/linkedin/pinot/util/TestUtils.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/util/TestUtils.java
@@ -85,6 +85,9 @@ public class TestUtils {
         errorRate = Math.abs((actual - estimate) / actual);
       }
       LOGGER.debug("estimate: " + estimate + " actual: " + actual + " error (in rate): " + errorRate);
+      if (errorRate >= precision) {
+        System.out.println("Found it: " + actual + " " +  estimate);
+      }
       Assert.assertTrue(errorRate < precision);
     }
   }

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/RawIndexBenchmark.java
@@ -227,7 +227,7 @@ public class RawIndexBenchmark {
     while ((projectionBlock = (ProjectionBlock) projectionOperator.nextBlock()) != null) {
       Block dataBlock = projectionBlock.getDataBlock(column);
       ProjectionBlockValSet blockValueSet = (ProjectionBlockValSet) dataBlock.getBlockValueSet();
-      blockValueSet.getSingleValues();
+      blockValueSet.getDoubleValuesSV();
     }
     return (System.currentTimeMillis() - start);
   }


### PR DESCRIPTION
1. Eliminated api's from ProjectionBlockValSet to get SV/MV hash codes,
moved the logic to compute hash codes within aggregation functions.

2. Changed AggregationFunction api's to take BlockValSet instead of
ProjectionBlockValSet.