### PR TITLE
[PINOT-4312] Fix NPE in ValidationManager

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -169,6 +169,8 @@ public class ValidationManager {
             LOGGER.warn("Cannot get realtime tableconfig for {}", tableName);
           } else if (streamMetadata == null) {
             LOGGER.warn("Cannot get streamconfig for {}", tableName);
+          } else {
+            LOGGER.error("Exception while validating table {}", tableName, e);
           }
         }
       } else {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.ControllerStarter;
+import com.linkedin.pinot.controller.validation.ValidationManager;
 
 
 /**
@@ -137,6 +138,11 @@ public abstract class ControllerTest {
 
   protected void startController() {
     startController(false);
+  }
+
+  protected ValidationManager getControllerValidationManager() throws Exception {
+    assert _controllerStarter != null;
+    return _controllerStarter.getValidationManager();
   }
 
   /**


### PR DESCRIPTION
Moved the instantiation of ValidationManager to to be after that of PinotLLCRealtimeSegmentManager
so that it can get a handle to the right instance of the latter.

Added an integration test to make sure that a ValidationManager run fixes offline partitions