### PR TITLE
Add internal API to get the service status

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -47,6 +47,7 @@ import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.utils.ServiceStatus;
 
 
 /**
@@ -120,6 +121,11 @@ public class HelixBrokerStarter {
     _helixManager.connect();
     _helixAdmin = _helixManager.getClusterManagmentTool();
     addInstanceTagIfNeeded(helixClusterName, brokerId);
+
+
+    // Register the service status handler
+    ServiceStatus.setServiceStatusCallback(
+        new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixAdmin, helixClusterName, brokerId));
 
     ClusterChangeMediator clusterChangeMediator = new ClusterChangeMediator(_helixExternalViewBasedRouting,
         _brokerServerBuilder.getBrokerMetrics());

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Utility class to obtain the status of the Pinot instance running in this JVM.
+ */
+public class ServiceStatus {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceStatus.class);
+
+  public enum Status {
+    STARTING,
+    GOOD,
+    BAD
+  }
+
+  /**
+   * Callback that returns the status of the service.
+   */
+  public interface ServiceStatusCallback {
+    Status getServiceStatus();
+  }
+
+  private static ServiceStatusCallback serviceStatusCallback = null;
+
+  public static void setServiceStatusCallback(ServiceStatusCallback serviceStatusCallback) {
+    ServiceStatus.serviceStatusCallback = serviceStatusCallback;
+  }
+
+  public static Status getServiceStatus() {
+    if (serviceStatusCallback == null) {
+      return Status.STARTING;
+    } else {
+      try {
+        return serviceStatusCallback.getServiceStatus();
+      } catch (Exception e) {
+        LOGGER.warn("Caught exception while reading the service status", e);
+        return Status.BAD;
+      }
+    }
+  }
+
+  /**
+   * Service status callback that reports starting until all resources relevant to this instance have a matching
+   * external view and ideal state. This callback considers the ERROR state in the external view to be equivalent to the
+   * ideal state value.
+   */
+  public static class IdealStateAndExternalViewMatchServiceStatusCallback implements ServiceStatusCallback {
+    private HelixAdmin _helixAdmin;
+    private String _clusterName;
+    private String _instanceName;
+    private List<String> _resourcesToMonitor;
+    private boolean _finishedStartingUp = false;
+
+    public IdealStateAndExternalViewMatchServiceStatusCallback(HelixAdmin helixAdmin, String clusterName,
+        String instanceName) {
+      _helixAdmin = helixAdmin;
+      _clusterName = clusterName;
+      _instanceName = instanceName;
+
+      // Make a list of the resources to monitor
+      _resourcesToMonitor = new ArrayList<>();
+
+      for (String resource : _helixAdmin.getResourcesInCluster(_clusterName)) {
+        final IdealState idealState = _helixAdmin.getResourceIdealState(_clusterName, resource);
+        for (String partitionInResource : idealState.getPartitionSet()) {
+          if (idealState.getInstanceSet(partitionInResource).contains(_instanceName)) {
+            _resourcesToMonitor.add(resource);
+            break;
+          }
+        }
+      }
+
+      LOGGER.info("Monitoring resources {} for start up of instance {}", _resourcesToMonitor, _instanceName);
+    }
+
+    public IdealStateAndExternalViewMatchServiceStatusCallback(HelixAdmin helixAdmin, String clusterName,
+        String instanceName, List<String> resourcesToMonitor) {
+      _helixAdmin = helixAdmin;
+      _clusterName = clusterName;
+      _instanceName = instanceName;
+      _resourcesToMonitor = resourcesToMonitor;
+
+      LOGGER.info("Monitoring resources {} for start up of instance {}", _resourcesToMonitor, _instanceName);
+    }
+
+    @Override
+    public Status getServiceStatus() {
+      if(_finishedStartingUp) {
+        return Status.GOOD;
+      }
+
+      for (String resourceToMonitor : _resourcesToMonitor) {
+        IdealState idealState = _helixAdmin.getResourceIdealState(_clusterName, resourceToMonitor);
+        ExternalView externalView = _helixAdmin.getResourceExternalView(_clusterName, resourceToMonitor);
+
+        if (idealState == null || externalView == null) {
+          return Status.STARTING;
+        }
+
+        for (String partition : idealState.getPartitionSet()) {
+          String idealStateStatus = idealState.getInstanceStateMap(partition).get(_instanceName);
+          String externalViewStatus = externalView.getStateMap(partition).get(_instanceName);
+
+          // Skip this partition if it is not assigned to this instance
+          if (idealStateStatus == null) {
+            continue;
+          }
+
+          // If this instance state is not in the external view, then it hasn't finished starting up
+          if (externalViewStatus == null) {
+            return Status.STARTING;
+          }
+
+          // If the instance state is not ERROR and is not the same as what's expected from the ideal state, then it
+          // hasn't finished starting up
+          if (!externalViewStatus.equals("ERROR") && !externalViewStatus.equals(idealStateStatus)) {
+            return Status.STARTING;
+          }
+        }
+      }
+
+      LOGGER.info("Instance {} has finished starting up", _instanceName);
+      _finishedStartingUp = true;
+      return Status.GOOD;
+    }
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -16,10 +16,14 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.ServiceStatus;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.helix.ControllerTestUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -27,13 +31,22 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.manager.zk.ZNRecordSerializer;
+import org.apache.helix.manager.zk.ZkClient;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
 
 /**
  * Integration test that converts Avro data for 12 segments and runs queries against it.
@@ -44,6 +57,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
   private final File _tmpDir = new File("/tmp/OfflineClusterIntegrationTest");
   private final File _segmentDir = new File("/tmp/OfflineClusterIntegrationTest/segmentDir");
   private final File _tarDir = new File("/tmp/OfflineClusterIntegrationTest/tarDir");
+  private ServiceStatus.ServiceStatusCallback _brokerServiceStatusCallback;
+  private ServiceStatus.ServiceStatusCallback _serverServiceStatusCallback;
 
   private static final int SEGMENT_COUNT = 12;
 
@@ -85,6 +100,32 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
 
     createTable();
 
+    // Get the list of instances through the REST API
+    URL url = new URL("http://" + ControllerTestUtils.DEFAULT_CONTROLLER_HOST + ":"
+        + ControllerTestUtils.DEFAULT_CONTROLLER_API_PORT + "/instances");
+    InputStream inputStream = url.openConnection().getInputStream();
+    String instanceApiResponseString = IOUtils.toString(inputStream);
+    IOUtils.closeQuietly(inputStream);
+    JSONObject instanceApiResponse = new JSONObject(instanceApiResponseString);
+    JSONArray instanceArray = instanceApiResponse.getJSONArray("instances");
+
+    HelixAdmin helixAdmin = new ZKHelixAdmin(new ZkClient(ZkStarter.DEFAULT_ZK_STR, 10000, 10000, new ZNRecordSerializer()));
+    for (int i = 0; i < instanceArray.length(); i++) {
+      String instance = instanceArray.getString(i);
+
+      if (instance.startsWith("Server_")) {
+        _serverServiceStatusCallback =
+            new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(helixAdmin, getHelixClusterName(),
+                instance);
+      }
+
+      if (instance.startsWith("Broker_")) {
+        _brokerServiceStatusCallback =
+            new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(helixAdmin, getHelixClusterName(),
+                instance, Collections.singletonList("brokerResource"));
+      }
+    }
+
     // Load data into H2
     ExecutorService executor = Executors.newCachedThreadPool();
     setupH2AndInsertAvro(avroFiles, executor);
@@ -122,6 +163,15 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
         Assert.fail("Segments were not completely loaded within two minutes");
       }
     }
+  }
+
+  @Test
+  public void testInstancesStarted() {
+    assertEquals(_serverServiceStatusCallback.getServiceStatus(), ServiceStatus.Status.GOOD,
+        "Server status is not GOOD");
+
+    assertEquals(_brokerServiceStatusCallback.getServiceStatus(), ServiceStatus.Status.GOOD,
+        "Broker status is not GOOD");
   }
 
   /**

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -45,6 +45,7 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.MmapUtils;
 import com.linkedin.pinot.common.utils.NetUtil;
+import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.common.utils.ZkUtils;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentMetadataLoader;
 import com.linkedin.pinot.server.conf.ServerConf;
@@ -141,6 +142,11 @@ public class HelixServerStarter {
             _serverInstance.getServerMetrics().addMeteredGlobalValue(ServerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L);
           }
         });
+
+    // Register the service status handler
+    ServiceStatus.setServiceStatusCallback(
+        new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixAdmin, _helixClusterName,
+            _instanceId));
 
     ControllerLeaderLocator.create(_helixManager);
 


### PR DESCRIPTION
Add internal API to get the service status

Add an internal API to get the service status (starting, good or bad)
and a simple implementation for controller, broker and server. This can
be leveraged to determine the state of instances and expose the status
to deployment and monitoring infrastructures.