### PR TITLE
Log an error and update metric when zookeeper updates fail

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
@@ -45,6 +45,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   CONTROLLER_REALTIME_TABLE_SEGMENT_ASSIGNMENT_ERROR("errors", true),
   LLC_STATE_MACHINE_ABORTS("aborts", false),
   LLC_AUTO_CREATED_PARTITIONS("creates", false),
+  LLC_ZOOKEPER_UPDATE_FAILURES("failures", false),
   LLC_KAFKA_DATA_LOSS("dataLoss", false);
 
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -356,7 +356,7 @@ public class PinotLLCRealtimeSegmentManager {
           }
         }, RetryPolicies.fixedDelayRetryPolicy(10, 500L));
       } catch (Exception e) {
-        LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+        LOGGER.error("Failed to update idealstate for table {} entries {}", realtimeTableName, idealStateEntries, e);
         _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
         throw e;
       }
@@ -374,7 +374,8 @@ public class PinotLLCRealtimeSegmentManager {
         }
       }, RetryPolicies.fixedDelayRetryPolicy(10, 500L));
     } catch (Exception e) {
-      LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+      LOGGER.error("Failed to update idealstate for table {}, old segment {}, new segment {}, newInstances {}",
+          realtimeTableName, oldSegmentNameStr, newSegmentNameStr, newInstances, e);
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
       throw e;
     }
@@ -433,7 +434,7 @@ public class PinotLLCRealtimeSegmentManager {
     try {
       _propertyStore.setChildren(paths, records, AccessOption.PERSISTENT);
     } catch (Exception e) {
-      LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+      LOGGER.error("Failed to update idealstate for table {} for paths {}", realtimeTableName, paths, e);
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
       throw e;
     }
@@ -862,7 +863,7 @@ public class PinotLLCRealtimeSegmentManager {
         }
       }, RetryPolicies.fixedDelayRetryPolicy(10, 500L));
     } catch (Exception e) {
-      LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+      LOGGER.error("Failed to update idealstate for table {} instance {} segment {}", realtimeTableName, instance, segmentNameStr, e);
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
       throw e;
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -299,7 +299,7 @@ public class PinotLLCRealtimeSegmentManager {
       records.add(record);
     }
 
-    writeSegmentsToPropertyStore(paths, records);
+    writeSegmentsToPropertyStore(paths, records, realtimeTableName);
     LOGGER.info("Added {} segments to propertyStore for table {}", paths.size(), realtimeTableName);
 
     updateHelixIdealState(idealState, realtimeTableName, idealStateEntries, create, nReplicas);
@@ -347,25 +347,37 @@ public class PinotLLCRealtimeSegmentManager {
       addLLCRealtimeSegmentsInIdealState(idealState, idealStateEntries);
       _helixAdmin.addResource(_clusterName, realtimeTableName, idealState);
     } else {
-      HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
-        @Override
-        public IdealState apply(IdealState idealState) {
-          idealState.setReplicas(Integer.toString(nReplicas));
-          return addLLCRealtimeSegmentsInIdealState(idealState, idealStateEntries);
-        }
-      }, RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0f));
+      try {
+        HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
+          @Override
+          public IdealState apply(IdealState idealState) {
+            idealState.setReplicas(Integer.toString(nReplicas));
+            return addLLCRealtimeSegmentsInIdealState(idealState, idealStateEntries);
+          }
+        }, RetryPolicies.fixedDelayRetryPolicy(10, 500L));
+      } catch (Exception e) {
+        LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+        _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
+        throw e;
+      }
     }
   }
 
   // Update the helix state when an old segment commits and a new one is to be started.
   protected void updateHelixIdealState(final String realtimeTableName, final List<String> newInstances,
       final String oldSegmentNameStr, final String newSegmentNameStr) {
-    HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
-      @Override
-      public IdealState apply(IdealState idealState) {
-        return updateForNewRealtimeSegment(idealState, newInstances, oldSegmentNameStr, newSegmentNameStr);
-      }
-    }, RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0f));
+    try {
+      HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
+        @Override
+        public IdealState apply(IdealState idealState) {
+          return updateForNewRealtimeSegment(idealState, newInstances, oldSegmentNameStr, newSegmentNameStr);
+        }
+      }, RetryPolicies.fixedDelayRetryPolicy(10, 500L));
+    } catch (Exception e) {
+      LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
+      throw e;
+    }
   }
 
   protected static IdealState updateForNewRealtimeSegment(IdealState idealState,
@@ -417,8 +429,14 @@ public class PinotLLCRealtimeSegmentManager {
 
   }
 
-  protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records) {
-    _propertyStore.setChildren(paths, records, AccessOption.PERSISTENT);
+  protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records, final String realtimeTableName) {
+    try {
+      _propertyStore.setChildren(paths, records, AccessOption.PERSISTENT);
+    } catch (Exception e) {
+      LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
+      throw e;
+    }
   }
 
   protected List<String> getAllRealtimeTables() {
@@ -508,7 +526,7 @@ public class PinotLLCRealtimeSegmentManager {
      * If the controller fails after step-2, we are fine because the idealState has the new segments.
      * If the controller fails before step-1, the server will see this as an upload failure, and will re-try.
      */
-    writeSegmentsToPropertyStore(paths, records);
+    writeSegmentsToPropertyStore(paths, records, realtimeTableName);
 
     // TODO Introduce a controller failure here for integration testing
 
@@ -800,7 +818,7 @@ public class PinotLLCRealtimeSegmentManager {
     propStorePaths.add(newZnodePath);
     propStoreEntries.add(newZnRecord);
 
-    writeSegmentsToPropertyStore(propStorePaths, propStoreEntries);
+    writeSegmentsToPropertyStore(propStorePaths, propStoreEntries, realtimeTableName);
 
     updateHelixIdealState(realtimeTableName, serverInstances, null, newSegmentNameStr);
 
@@ -826,22 +844,28 @@ public class PinotLLCRealtimeSegmentManager {
    * Mark the state of the segment to be OFFLINE in idealstate.
    * When all replicas of this segment are marked offline, the ValidationManager, in its next
    * run, will auto-create a new segment with the appropriate offset.
-   * See {@link #createConsumingSegment(String, List, List, AbstractTableConfig)}
+   * See {@link #createConsumingSegment(String, Set, List, AbstractTableConfig)}
   */
   public void segmentStoppedConsuming(final LLCSegmentName segmentName, final String instance) {
     String rawTableName = segmentName.getTableName();
     String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(rawTableName);
     final String segmentNameStr = segmentName.getSegmentName();
-    HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
-      @Override
-      public IdealState apply(IdealState idealState) {
-        idealState.setPartitionState(segmentNameStr, instance,
-            CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.OFFLINE);
-        Map<String, String> instanceStateMap = idealState.getInstanceStateMap(segmentNameStr);
-        LOGGER.info("Attempting to mark {} offline. Current map:{}", segmentNameStr, instanceStateMap.toString());
-        return idealState;
-      }
-    }, RetryPolicies.exponentialBackoffRetryPolicy(5, 500L, 2.0f));
+    try {
+      HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {
+        @Override
+        public IdealState apply(IdealState idealState) {
+          idealState.setPartitionState(segmentNameStr, instance,
+              CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.OFFLINE);
+          Map<String, String> instanceStateMap = idealState.getInstanceStateMap(segmentNameStr);
+          LOGGER.info("Attempting to mark {} offline. Current map:{}", segmentNameStr, instanceStateMap.toString());
+          return idealState;
+        }
+      }, RetryPolicies.fixedDelayRetryPolicy(10, 500L));
+    } catch (Exception e) {
+      LOGGER.error("Failed to update idealstate for table {}", realtimeTableName, e);
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.LLC_ZOOKEPER_UPDATE_FAILURES, 1);
+      throw e;
+    }
     LOGGER.info("Successfully marked {} offline for instance {} since it stopped consuming", segmentNameStr, instance);
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -715,7 +715,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records) {
+    protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records, String realtimeTableName) {
       _paths.addAll(paths);
       _records.addAll(records);
       for (int i = 0; i < paths.size(); i++) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -463,7 +463,7 @@ public class SegmentCompletionTest {
     }
 
     @Override
-    protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records) {
+    protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records, String realtimeTableName) {
       _segmentMetadata = new LLCRealtimeSegmentZKMetadata(records.get(0));  // Updated record that we are writing to ZK
     }
 


### PR DESCRIPTION
We have retries for helix updates, but if an update fails even after multiple retries
(as has been seen sometimes), we need to know about it.

Changed the retry policy to a linear fixed-delay policy with max 10 retries, attempting
an update every 1/2 second. (earlier we had exponential back-off with 5 max attempts).
This places a maximum time delay of 5 seconds to update zookeeper. Hopefully, zk is not
busy for more than 5 seconds.

Should an update fail after all these retries, we bump a metric, that we can alert on.
If this alert files, some manual repair of zookeeper may be needed, production experience
will tell better.