### PR TITLE
Update broker resource rebuild endpoint

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -471,7 +471,7 @@ public class PinotHelixResourceManager {
       } else if (tableType == TableType.REALTIME) {
         tenantConfig = ZKMetadataProvider.getRealtimeTableConfig(getPropertyStore(), tableName).getTenantConfig();
       } else {
-        throw new RuntimeException("Don't know how to handle table of type " + tableType);
+        return new PinotResourceManagerResponse("Table " + tableName + " does not have a table type", false);
       }
     } catch (Exception e) {
       LOGGER.warn("Caught exception while rebuilding broker resource from Helix tags for table {}", e, tableName);


### PR DESCRIPTION
Update broker resource rebuild endpoint

Update the broker resource rebuild endpoint to specify that it
requires the table type suffix (eg. myTable_OFFLINE or
myTable_REALTIME). Update the endpoint to return status messages. Set
the HTTP status code to not be 200 on error.