### PR TITLE
Generate v3 segments by default

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -225,7 +225,7 @@ public class CommonConstants {
     public static final String DEFAULT_SEGMENT_LOAD_MAX_RETRY_COUNT = "5";
     public static final String DEFAULT_SEGMENT_LOAD_MIN_RETRY_DELAY_MILLIS = "60000";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.server.segment.fetcher";
-    public static final String DEFAULT_SEGMENT_FORMAT_VERSION = "v1";
+    public static final String DEFAULT_SEGMENT_FORMAT_VERSION = "v3";
     public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "OFF_HEAP";
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -68,7 +68,7 @@ public class SegmentGeneratorConfig {
   private String _segmentCreationTime = null;
   private String _segmentStartTime = null;
   private String _segmentEndTime = null;
-  private SegmentVersion _segmentVersion = SegmentVersion.v1;
+  private SegmentVersion _segmentVersion = SegmentVersion.v3;
   private String _schemaFile = null;
   private Schema _schema = null;
   private String _readerConfigFile = null;
@@ -78,6 +78,7 @@ public class SegmentGeneratorConfig {
   private StarTreeIndexSpec _starTreeIndexSpec = null;
   private String _creatorVersion = null;
   private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
+
   private HllConfig _hllConfig = null;
 
   public SegmentGeneratorConfig() {
@@ -112,6 +113,7 @@ public class SegmentGeneratorConfig {
     _creatorVersion = config._creatorVersion;
     _paddingCharacter = config._paddingCharacter;
     _hllConfig = config._hllConfig;
+    _segmentVersion = config._segmentVersion;
   }
 
   public SegmentGeneratorConfig(Schema schema) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentCreator.java
@@ -27,10 +27,7 @@ import org.apache.commons.configuration.ConfigurationException;
 
 /**
  * Interface for segment creators, which create an index over a set of rows and writes the resulting index to disk.
- *
- * Nov 21, 2014
  */
-
 public interface SegmentCreator {
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentIndexCreationDriver.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentIndexCreationDriver.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.segment.creator;
 
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import java.io.File;
 
 
 /**
@@ -49,4 +50,9 @@ public interface SegmentIndexCreationDriver {
    * @throws Exception
    */
   ColumnStatistics getColumnStatisticsCollector(final String columnName) throws Exception;
+
+  /**
+   * Returns the path of the output directory
+   */
+  File getOutputDirectory();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -52,10 +52,7 @@ import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataK
 
 /**
  * Segment creator which writes data in a columnar form.
- *
- * Nov 9, 2014
  */
-
 public class SegmentColumnarIndexCreator implements SegmentCreator {
   private Logger LOGGER = LoggerFactory.getLogger(SegmentColumnarIndexCreator.class);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.segment.creator.impl;
 
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.segment.index.converter.SegmentFormatConverter;
+import com.linkedin.pinot.core.segment.index.converter.SegmentFormatConverterFactory;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -459,9 +462,35 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
       }
     }
 
+    convertFormatIfNeeded(segmentOutputDir);
     LOGGER.info("Driver, record read time : {}", totalRecordReadTime);
     LOGGER.info("Driver, stats collector time : {}", totalStatsCollectorTime);
     LOGGER.info("Driver, indexing time : {}", totalIndexTime);
+  }
+
+  // Explanation of why we are using format converter:
+  // There are 3 options to correctly generate segments to v3 format
+  // 1. Generate v3 directly: This is efficient but v3 index writer needs to know buffer size upfront.
+  // Inverted, star and raw indexes don't have the index size upfront. This is also least flexible approach
+  // if we add more indexes in future.
+  // 2. Hold data in-memory: One way to work around predeclaring sizes in (1) is to allocate "large" buffer (2GB?)
+  // and hold the data in memory and write the buffer at the end. The memory requirement in this case increases linearly
+  // with the number of columns. Variation of that is to mmap data to separate files...which is what we are doing here
+  // 3. Another option is to generate dictionary and fwd indexes in v3 and generate inverted, star and raw indexes in
+  // separate files. Then add those files to v3 index file. This leads to lot of hodgepodge code to
+  // handle multiple segment formats.
+  // Using converter is similar to option (2), plus it's battle-tested code. We will roll out with
+  // this change to keep changes limited. Once we've migrated we can implement approach (1) with option to
+  // copy for indexes for which we don't know sizes upfront.
+  private void convertFormatIfNeeded(File segmentDirectory)
+      throws Exception {
+    SegmentVersion versionToGenerate = config.getSegmentVersion();
+    if (versionToGenerate.equals(SegmentVersion.v1)) {
+      // v1 by default
+      return;
+    }
+    SegmentFormatConverter converter = SegmentFormatConverterFactory.getConverter(SegmentVersion.v1, SegmentVersion.v3);
+    converter.convert(segmentDirectory);
   }
 
   public ColumnStatistics getColumnStatisticsCollector(final String columnName) throws Exception {
@@ -531,6 +560,14 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
    */
   public String getSegmentName() {
     return segmentName;
+  }
+
+  @Override
+  /**
+   * Returns the path of the output directory
+   */
+  public File getOutputDirectory() {
+    return new File(new File(config.getOutDir()), segmentName);
   }
 
   private GenericRow readNextRowSanitized(GenericRow readRow, GenericRow transformedRow) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentDirectory.java
@@ -107,6 +107,14 @@ public abstract class SegmentDirectory implements AutoCloseable {
     return new SegmentLocalFSDirectory(directory, metadata, readMode);
   }
 
+  public static SegmentDirectory createFromLocalFS(File directory, ReadMode readMode)
+      throws IOException, ConfigurationException {
+    return new SegmentLocalFSDirectory(directory, readMode);
+  }
+  public static SegmentMetadataImpl loadSegmentMetadata(File directory)
+      throws IOException, ConfigurationException {
+    return SegmentLocalFSDirectory.loadSegmentMetadata(directory);
+  }
   /**
    * Get the path/URL for the directory
    * @return

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/store/ColumnIndexDirectoryTestHelper.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/store/ColumnIndexDirectoryTestHelper.java
@@ -105,6 +105,7 @@ public class ColumnIndexDirectoryTestHelper {
   static SegmentMetadataImpl writeMetadata(SegmentVersion version) {
     SegmentMetadataImpl meta = mock(SegmentMetadataImpl.class);
     when(meta.getVersion()).thenReturn(version.toString());
+    when(meta.getSegmentVersion()).thenReturn(version);
     when(meta.getDictionaryFileName(anyString(), anyString()))
         .thenAnswer(new Answer<String>() {
           @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeConverter.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeConverter.java
@@ -16,8 +16,7 @@
 package com.linkedin.pinot.core.startree;
 
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
-import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.store.SegmentDirectoryPaths;
 import java.io.File;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
@@ -47,7 +46,8 @@ public class TestStarTreeConverter {
       throws Exception {
     StarTreeIndexTestSegmentHelper.buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, false);
     _segment = StarTreeIndexTestSegmentHelper.loadSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
-    _indexDir = new File(new File(SEGMENT_DIR_NAME, SEGMENT_NAME), SegmentVersion.v3.toString());
+    // we've v3 segment but giving parent segment name as indexDir. Code should handle this
+    _indexDir = new File(SEGMENT_DIR_NAME, SEGMENT_NAME);
   }
 
   /**
@@ -80,7 +80,7 @@ public class TestStarTreeConverter {
 
   private void assertStarTreeVersion(File indexDir, StarTreeFormatVersion expectedVersion)
       throws IOException {
-    File starTreeFile = new File(_indexDir, V1Constants.STAR_TREE_INDEX_FILE);
+    File starTreeFile = SegmentDirectoryPaths.findStarTreeFile(_indexDir);
     Assert.assertEquals(StarTreeSerDe.getStarTreeVersion(starTreeFile), expectedVersion);
   }
 


### PR DESCRIPTION
Change segment generator default to output v3 segments. Also
correctly set server level segment default to generate v3 segments.
v3 segments are generated by invoking the converter in this step.
This will be replaced with more optimal generator for v3.

Testing: All tests, local segment upload, delete testing with v1 and v3 segments