### PR TITLE
Fixing segment Deletion API

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
@@ -232,12 +232,18 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
 
     JSONArray ret = new JSONArray();
     String tableNameWithType = null;
-    List<String> segmentsToToggle;
+    List<String> segmentsToToggle = new ArrayList<>();
+    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
 
     if (segmentName != null) {
       segmentsToToggle = Collections.singletonList(segmentName);
     } else {
-      segmentsToToggle = _pinotHelixResourceManager.getAllSegmentsForResource(tableName);
+      // Check if there is a realtime table. If there is, remove all segments for realtime
+      if (_pinotHelixResourceManager.hasRealtimeTable(tableName)) {
+        segmentsToToggle.addAll(_pinotHelixResourceManager.getAllSegmentsForResource(realtimeTableName));
+      }
+      segmentsToToggle.addAll(_pinotHelixResourceManager.getAllSegmentsForResource(offlineTableName));
     }
     if ((tableType == null
         && SegmentName.getSegmentType(segmentsToToggle.get(0)).equals(SegmentName.RealtimeSegmentType.UNSUPPORTED)

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
@@ -280,8 +280,14 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
       }
     } else {
       // tableType is null, which means it comes from the get API to toggle all segments
-      segmentsToToggle.addAll(realtimeSegments);
-      segmentsToToggle.addAll(offlineSegments);
+      PinotResourceManagerResponse responseRealtime = toggleSegmentsForTable(realtimeSegments, realtimeTableName, segmentName, state);
+      PinotResourceManagerResponse responseOffline = toggleSegmentsForTable(offlineSegments, offlineTableName, segmentName, state);
+      setStatus(responseRealtime.isSuccessful() && responseOffline.isSuccessful() ? Status.SUCCESS_OK : Status.SERVER_ERROR_INTERNAL);
+      List<PinotResourceManagerResponse> responses = new ArrayList<>();
+      responses.add(responseRealtime);
+      responses.add(responseOffline);
+      ret.put(responses);
+      return new StringRepresentation(ret.toString());
     }
 
     PinotResourceManagerResponse resourceManagerResponse = toggleSegmentsForTable(segmentsToToggle, tableNameWithType, segmentName, state);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
@@ -109,7 +109,11 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
           setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
           return new StringRepresentation(INVALID_STATE_ERROR);
         } else {
-          return toggleSegmentState(tableName, segmentName, state, tableType);
+          if (segmentName != null) {
+            return toggleOneSegmentState(tableName, segmentName, state, tableType);
+          } else {
+            return toggleAllSegmentsState(tableName, state, tableType);
+          }
         }
       } else if (segmentName != null) {
         return getSegmentMetadataForTable(tableName, segmentName, tableType);
@@ -185,7 +189,7 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
   @Summary("Enable, disable or drop a segment from a table")
   @Tags({ "segment", "table" })
   @Paths({ "/tables/{tableName}/segments/{segmentName}", "/tables/{tableName}/segments/{segmentName}/" })
-  public Representation toggleOneSegmentState(
+  private Representation toggleOneSegmentState(
       @Parameter(name = "tableName", in = "path", description = "The name of the table to which segment belongs",
           required = true) String tableName,
       @Parameter(name = "segmentName", in = "path", description = "Segment to enable, disable or drop",
@@ -223,7 +227,7 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
   @Summary("Enable, disable or drop *ALL* segments from a table")
   @Tags({ "segment", "table" })
   @Paths({ "/tables/{tableName}/segments", "/tables/{tableName}/segments/" })
-  public Representation toggleAllSegmentsState(
+  private Representation toggleAllSegmentsState(
         @Parameter(name = "tableName", in = "path", description = "The name of the table to which segment belongs",
             required = true) String tableName,
         @Parameter(name = "state", in = "query", description = "state to set for segment {enable|disable|drop}",

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -27,6 +27,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.Validate;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.joda.time.Interval;
@@ -563,6 +564,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
           required = true) String tableType)
       throws JsonProcessingException, JSONException {
 
+    Validate.notNull(tableType, "tableType can't be null");
     return new PinotSegmentRestletResource().toggleSegmentState(tableName, segmentName, "drop", tableType);
   }
 
@@ -577,6 +579,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
       required = true) String tableType)
       throws JsonProcessingException, JSONException {
 
+    Validate.notNull(tableType, "tableType can't be null");
     return new PinotSegmentRestletResource().toggleSegmentState(tableName, null, "drop", tableType);
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -545,7 +545,11 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
       final String tableType = getReference().getQueryAsForm().getValues(TABLE_TYPE);
 
       LOGGER.info("Getting segment deletion request, tableName: " + tableName + " segmentName: " + segmentName);
-      rep = deleteOneSegment(tableName, segmentName, tableType);
+      if (segmentName != null) {
+        rep = deleteOneSegment(tableName, segmentName, tableType);
+      } else {
+        rep = deleteAllSegments(tableName, tableType);
+      }
     } catch (final Exception e) {
       rep = exceptionToStringRepresentation(e);
       LOGGER.error("Caught exception while processing delete request", e);
@@ -559,7 +563,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   @Summary("Delete a segment from a table")
   @Tags({"segment", "table"})
   @Paths({ "/segments/{tableName}/{segmentName}", "/segments/{tableName}/{segmentName}/" })
-  public Representation deleteOneSegment(
+  private Representation deleteOneSegment(
       @Parameter(name = "tableName", in = "path", description = "The raw table name in which the segment resides",
           required = true) String tableName,
       @Parameter(name = "segmentName", in = "path", description = "The name of the segment to delete",
@@ -577,7 +581,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   @Summary("Delete *ALL* segments from a table")
   @Tags({"segment", "table"})
   @Paths({ "/segments/{tableName}", "/segments/{tableName}/" })
-  public Representation deleteAllSegments(
+  private Representation deleteAllSegments(
       @Parameter(name = "tableName", in = "path", description = "The raw table name in which the segment resides",
           required = true) String tableName,
       @Parameter(name = "type", in = "query", description = "Type of table {offline|realtime}",

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -27,6 +27,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -556,7 +557,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   @Tags({"segment", "table"})
   @Paths({ "/segments/{tableName}/{segmentName}", "/segments/{tableName}/{segmentName}/" })
   private Representation deleteOneSegment(
-      @Parameter(name = "tableName", in = "path", description = "The name of the table in which the segment resides",
+      @Parameter(name = "tableName", in = "path", description = "The raw table name in which the segment resides",
           required = true) String tableName,
       @Parameter(name = "segmentName", in = "path", description = "The name of the segment to delete",
           required = true) String segmentName,
@@ -564,6 +565,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
           required = true) String tableType)
       throws JsonProcessingException, JSONException {
 
+    Validate.isTrue(!StringUtils.containsIgnoreCase(tableName, "_OFFLINE") && !StringUtils.containsIgnoreCase(tableName, "_REALTIME"));
     Validate.notNull(tableType, "tableType can't be null");
     return new PinotSegmentRestletResource().toggleSegmentState(tableName, segmentName, "drop", tableType);
   }
@@ -573,12 +575,13 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   @Tags({"segment", "table"})
   @Paths({ "/segments/{tableName}", "/segments/{tableName}/" })
   private Representation deleteAllSegments(
-      @Parameter(name = "tableName", in = "path", description = "The name of the table in which the segment resides",
+      @Parameter(name = "tableName", in = "path", description = "The raw table name in which the segment resides",
           required = true) String tableName,
       @Parameter(name = "type", in = "query", description = "Type of table {offline|realtime}",
       required = true) String tableType)
       throws JsonProcessingException, JSONException {
 
+    Validate.isTrue(!StringUtils.containsIgnoreCase(tableName, "_OFFLINE") && !StringUtils.containsIgnoreCase(tableName, "_REALTIME"));
     Validate.notNull(tableType, "tableType can't be null");
     return new PinotSegmentRestletResource().toggleSegmentState(tableName, null, "drop", tableType);
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -538,7 +538,10 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
     Representation rep;
     try {
       final String tableName = (String) getRequest().getAttributes().get("tableName");
-      final String segmentName = (String) getRequest().getAttributes().get("segmentName");
+      String segmentName =(String) getRequest().getAttributes().get("segmentName");
+      if (segmentName != null) {
+        segmentName = URLDecoder.decode(segmentName, "UTF-8");
+      }
       final String tableType = getReference().getQueryAsForm().getValues(TABLE_TYPE);
 
       LOGGER.info("Getting segment deletion request, tableName: " + tableName + " segmentName: " + segmentName);
@@ -556,7 +559,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   @Summary("Delete a segment from a table")
   @Tags({"segment", "table"})
   @Paths({ "/segments/{tableName}/{segmentName}", "/segments/{tableName}/{segmentName}/" })
-  private Representation deleteOneSegment(
+  public Representation deleteOneSegment(
       @Parameter(name = "tableName", in = "path", description = "The raw table name in which the segment resides",
           required = true) String tableName,
       @Parameter(name = "segmentName", in = "path", description = "The name of the segment to delete",
@@ -574,7 +577,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   @Summary("Delete *ALL* segments from a table")
   @Tags({"segment", "table"})
   @Paths({ "/segments/{tableName}", "/segments/{tableName}/" })
-  private Representation deleteAllSegments(
+  public Representation deleteAllSegments(
       @Parameter(name = "tableName", in = "path", description = "The raw table name in which the segment resides",
           required = true) String tableName,
       @Parameter(name = "type", in = "query", description = "Type of table {offline|realtime}",

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -590,7 +590,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
 
     Validate.isTrue(!StringUtils.containsIgnoreCase(tableName, "_OFFLINE") && !StringUtils.containsIgnoreCase(tableName, "_REALTIME"));
     Validate.notNull(tableType, "tableType can't be null");
-    return new PinotSegmentRestletResource().toggleSegmentState(tableName, null, "drop", tableType);
+    return new PinotSegmentRestletResource().toggleSegmentState(tableName, null, StateType.DROP.toString(), tableType);
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -537,9 +537,10 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
     try {
       final String tableName = (String) getRequest().getAttributes().get("tableName");
       final String segmentName = (String) getRequest().getAttributes().get("segmentName");
+      final String tableType = getReference().getQueryAsForm().getValues(TABLE_TYPE);
 
       LOGGER.info("Getting segment deletion request, tableName: " + tableName + " segmentName: " + segmentName);
-      rep = deleteOneSegment(tableName, segmentName);
+      rep = deleteOneSegment(tableName, segmentName, tableType);
     } catch (final Exception e) {
       rep = exceptionToStringRepresentation(e);
       LOGGER.error("Caught exception while processing delete request", e);
@@ -557,10 +558,12 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
       @Parameter(name = "tableName", in = "path", description = "The name of the table in which the segment resides",
           required = true) String tableName,
       @Parameter(name = "segmentName", in = "path", description = "The name of the segment to delete",
-          required = true) String segmentName)
+          required = true) String segmentName,
+      @Parameter(name = "type", in = "query", description = "Type of table {offline|realtime}",
+          required = true) String tableType)
       throws JsonProcessingException, JSONException {
 
-    return new PinotSegmentRestletResource().toggleSegmentState(tableName, segmentName, "drop", null);
+    return new PinotSegmentRestletResource().toggleSegmentState(tableName, segmentName, "drop", tableType);
   }
 
   @HttpVerb("delete")
@@ -569,10 +572,12 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   @Paths({ "/segments/{tableName}", "/segments/{tableName}/" })
   private Representation deleteAllSegments(
       @Parameter(name = "tableName", in = "path", description = "The name of the table in which the segment resides",
-          required = true) String tableName)
+          required = true) String tableName,
+      @Parameter(name = "type", in = "query", description = "Type of table {offline|realtime}",
+      required = true) String tableType)
       throws JsonProcessingException, JSONException {
 
-    return new PinotSegmentRestletResource().toggleSegmentState(tableName, null, "drop", null);
+    return new PinotSegmentRestletResource().toggleSegmentState(tableName, null, "drop", tableType);
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.helix;
 
+import java.net.URLEncoder;
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang.StringUtils;
 
@@ -161,4 +162,28 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "datafiles", resourceName, segmentName);
   }
 
+  public String forSegmentDeleteAPI(String tableName, String segmentName, String tableType) throws Exception {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "segments", tableName, URLEncoder.encode(segmentName, "UTF-8") + "?type=" + tableType);
+  }
+
+  public String forSegmentDeleteAllAPI(String tableName, String tableType) throws Exception {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "segments", tableName + "?type=" + tableType);
+  }
+
+  public String forListAllSegments(String tableName) throws Exception {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName, "segments");
+  }
+
+  public String forDeleteTableWithType(String tableName, String tableType) throws Exception {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName + "?type=" + tableType);
+  }
+
+  public String forDeleteSegmentWithGetAPI(String tableName, String segmentName, String tableType) throws Exception {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName, "segments", URLEncoder.encode(segmentName, "UTF-8") + "?state=drop&" + "type=" + tableType);
+  }
+
+  public String forDeleteAllSegmentsWithTypeWithGetAPI(String tableName, String tableType) {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName, "segments" + "?state=drop&" + "type=" + tableType);
+
+  }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
@@ -110,9 +110,8 @@ public class DeleteAPIHybridClusterIntegrationTest extends HybridClusterIntegrat
         ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
     JSONArray offlineSegmentsList = getSegmentsFromJson(segmentList, "offline");
 
-    String response = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+    sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
         forDeleteSegmentWithGetAPI(TABLE_NAME, offlineSegmentsList.get(0).toString(), "offline"));
-    System.out.println(response);
     Thread.sleep(5000);
 
     String postDeleteSegmentList = sendGetRequest(

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DeleteAPIHybridClusterIntegrationTest.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.integration.tests;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.KafkaStarterUtils;
+import junit.framework.Assert;
+
+
+/**
+ * Hybrid cluster integration test that uploads 8 months of data as offline and 6 months of data as realtime (with a
+ * two month overlap) then deletes segments different ways to test delete APIs.
+ *
+ */
+public class DeleteAPIHybridClusterIntegrationTest extends HybridClusterIntegrationTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeClusterIntegrationTest.class);
+  private static final String TABLE_NAME = "mytable";
+  private static final String TENANT_NAME = "TestTenant";
+  private static int nRows;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    super.setUp();
+    org.json.JSONObject response = postQuery("select count(*) from 'mytable'");
+    org.json.JSONArray aggregationResultsArray = response.getJSONArray("aggregationResults");
+    org.json.JSONObject firstAggregationResult = aggregationResultsArray.getJSONObject(0);
+    String pinotValue = firstAggregationResult.getString("value");
+    nRows = Integer.parseInt(pinotValue);
+  }
+
+  private int numRowsReturned() throws Exception{
+    org.json.JSONObject response = postQuery("select count(*) from 'mytable'");
+    org.json.JSONArray aggregationResultsArray = response.getJSONArray("aggregationResults");
+    org.json.JSONObject firstAggregationResult = aggregationResultsArray.getJSONObject(0);
+    String pinotValue = firstAggregationResult.getString("value");
+    return Integer.parseInt(pinotValue);
+  }
+
+  private void waitForTableReady() throws Exception {
+    while (true) {
+      int curOfflineRows = numRowsReturned();
+      if (curOfflineRows != nRows) {
+        Thread.sleep(1000);
+      }
+      else {
+        break;
+      }
+    }
+  }
+
+  // @Test Commenting this out for now because of HLC/LLC
+  public void deleteAllRealtimeSegmentsFromGetAPI() throws Exception{
+    sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+        forDeleteAllSegmentsWithTypeWithGetAPI(TABLE_NAME, "realtime"));
+    Thread.sleep(3000);
+
+    String postDeleteSegmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    Assert.assertEquals(getSegmentsFromJson(postDeleteSegmentList, "realtime").size(), 1);
+    Assert.assertNotSame(getSegmentsFromJson(postDeleteSegmentList, "offline").size(), 0);
+
+    repushRealtimeSegments();
+  }
+
+  @Test
+  public void deleteAllOfflineSegmentsFromGetAPI() throws Exception{
+    sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+        forDeleteAllSegmentsWithTypeWithGetAPI(TABLE_NAME, "offline"));
+    Thread.sleep(3000);
+
+    String postDeleteSegmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    Assert.assertEquals(getSegmentsFromJson(postDeleteSegmentList, "offline"), null);
+    Assert.assertNotSame(getSegmentsFromJson(postDeleteSegmentList, "realtime").size(), 0);
+
+    repushOfflineSegments();
+  }
+
+  @Override
+  public void testHardcodedQuerySet() {}
+
+  @Test
+  public void deleteOfflineSegmentFromGetAPI() throws Exception{
+    String segmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    JSONArray offlineSegmentsList = getSegmentsFromJson(segmentList, "offline");
+
+    String response = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+        forDeleteSegmentWithGetAPI(TABLE_NAME, offlineSegmentsList.get(0).toString(), "offline"));
+    System.out.println(response);
+    Thread.sleep(5000);
+
+    String postDeleteSegmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    JSONArray offlineSegmentsListReturn = getSegmentsFromJson(postDeleteSegmentList, "offline");
+    offlineSegmentsList.remove(0);
+    Assert.assertEquals(offlineSegmentsListReturn, offlineSegmentsList);
+  }
+
+  @Override
+  public void testGeneratedQueriesWithMultiValues() {}
+
+  @Test
+  public void deleteRealtimeSegmentFromGetAPI() throws Exception{
+    String segmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    JSONArray realtimeSegmentsList = getSegmentsFromJson(segmentList, "realtime");
+
+    sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+        forDeleteSegmentWithGetAPI(TABLE_NAME, realtimeSegmentsList.get(0).toString(), "realtime"));
+    Thread.sleep(3000);
+
+    String postDeleteSegmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    JSONArray realtimeSegmentsListReturn = getSegmentsFromJson(postDeleteSegmentList, "realtime");
+    realtimeSegmentsList.remove(0);
+    Assert.assertEquals(realtimeSegmentsListReturn, realtimeSegmentsList);
+  }
+
+  // @Test Commenting this out for now because of HLC/LLC
+  public void deleteAllRealtimeSegmentsFromDeleteAPI() throws Exception{
+    sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+        forSegmentDeleteAllAPI(TABLE_NAME, "realtime"));
+    Thread.sleep(3000);
+
+    String postDeleteSegmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    Assert.assertEquals(getSegmentsFromJson(postDeleteSegmentList, "realtime").size(), 1);
+    Assert.assertNotSame(getSegmentsFromJson(postDeleteSegmentList, "offline").size(), 0);
+
+     repushRealtimeSegments();
+  }
+
+    @Test
+    public void deleteAllOfflineSegmentsFromDeleteAPI() throws Exception{
+      sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+          forSegmentDeleteAllAPI(TABLE_NAME, "offline"));
+      Thread.sleep(3000);
+
+      String postDeleteSegmentList = sendGetRequest(
+          ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+      Assert.assertEquals(getSegmentsFromJson(postDeleteSegmentList, "offline"), null);
+      Assert.assertNotSame(getSegmentsFromJson(postDeleteSegmentList, "realtime").size(), 0);
+
+      repushOfflineSegments();
+    }
+
+    @Test
+    public void deleteOfflineSegmentFromDeleteAPI() throws Exception{
+      String segmentList = sendGetRequest(
+          ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+      JSONArray offlineSegmentsList = getSegmentsFromJson(segmentList, "offline");
+
+      sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+          forSegmentDeleteAPI(TABLE_NAME, offlineSegmentsList.get(0).toString(), "offline"));
+      Thread.sleep(3000);
+
+      String postDeleteSegmentList = sendGetRequest(
+          ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+      JSONArray offlineSegmentsListReturn = getSegmentsFromJson(postDeleteSegmentList, "offline");
+      offlineSegmentsList.remove(0);
+      Assert.assertEquals(offlineSegmentsListReturn, offlineSegmentsList);
+    }
+
+  @Test
+  public void deleteRealtimeSegmentFromDeleteAPI() throws Exception{
+    String segmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    JSONArray realtimeSegmentsList = getSegmentsFromJson(segmentList, "realtime");
+
+    sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).
+        forSegmentDeleteAPI(TABLE_NAME, realtimeSegmentsList.get(0).toString(), "realtime"));
+    Thread.sleep(3000);
+
+    String postDeleteSegmentList = sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forListAllSegments(TABLE_NAME));
+    JSONArray realtimeSegmentsListReturn = getSegmentsFromJson(postDeleteSegmentList, "realtime");
+    realtimeSegmentsList.remove(0);
+    Assert.assertEquals(realtimeSegmentsListReturn, realtimeSegmentsList);
+  }
+
+  private JSONArray getSegmentsFromJson(String json, String type) {
+    if (type.equalsIgnoreCase("realtime")) {
+      com.alibaba.fastjson.JSONObject jsonObject2 = (JSONObject) JSON.parseArray(json).get(0);
+      String jsonObject3 = (String) jsonObject2.get("segments");
+      return (JSONArray) JSON.parseObject(jsonObject3).get("Server_172.21.224.26_8099");
+    } else {
+      com.alibaba.fastjson.JSONObject jsonObject2 = (JSONObject) JSON.parseArray(json).get(1);
+      String jsonObject3 = (String) jsonObject2.get("segments");
+      return (JSONArray) JSON.parseObject(jsonObject3).get("Server_172.21.224.26_8098");
+    }
+  }
+  private void repushOfflineSegments() throws Exception {
+    for (String segmentName : _tarDir.list()) {
+      File file = new File(_tarDir, segmentName);
+      FileUploadUtils.sendSegmentFile("localhost", "8998", segmentName, file, file.length());
+    }
+
+    // Wait for all offline segments to be online
+    waitForTableReady();
+  }
+
+  @Override
+  public void testBrokerDebugOutput() {}
+
+
+  private void repushRealtimeSegments() throws Exception {
+    File schemaFile = getSchemaFile();
+    Schema schema = Schema.fromFile(schemaFile);
+    addSchema(schemaFile, schema.getSchemaName());
+    final List<String> invertedIndexColumns = makeInvertedIndexColumns();
+    final String sortedColumn = makeSortedColumn();
+    final List<File> avroFiles = getAllAvroFiles();
+
+    // delete the realtime table and re-create it
+    sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forDeleteTableWithType(TABLE_NAME, "realtime"));
+    addRealtimeTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", 900, "Days", KafkaStarterUtils.DEFAULT_ZK_STR,
+        KAFKA_TOPIC, schema.getSchemaName(), "TestTenant", "TestTenant",
+        avroFiles.get(0), 1000000, sortedColumn, new ArrayList<String>(), null);
+
+    waitForTableReady();
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -63,7 +63,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
   protected final File _segmentDir = new File("/tmp/HybridClusterIntegrationTest/segmentDir");
   protected final File _tarDir = new File("/tmp/HybridClusterIntegrationTest/tarDir");
   protected static final String KAFKA_TOPIC = "hybrid-integration-test";
-  public static final String TABLE_NAME = "mytable";
+  private static final String TABLE_NAME = "mytable";
 
   private int segmentCount = 12;
   private int offlineSegmentCount = 8;

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -63,7 +63,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
   protected final File _segmentDir = new File("/tmp/HybridClusterIntegrationTest/segmentDir");
   protected final File _tarDir = new File("/tmp/HybridClusterIntegrationTest/tarDir");
   protected static final String KAFKA_TOPIC = "hybrid-integration-test";
-  private static final String TABLE_NAME = "mytable";
+  public static final String TABLE_NAME = "mytable";
 
   private int segmentCount = 12;
   private int offlineSegmentCount = 8;
@@ -205,6 +205,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
     rs.close();
 
     waitForRecordCountToStabilizeToExpectedCount(h2RecordCount, timeInFiveMinutes);
+
   }
 
   protected boolean shouldUseLlc() {
@@ -217,7 +218,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
    *
    * @return sorted column name or null if none is to be used for this run.
    */
-  private String makeSortedColumn() {
+  protected String makeSortedColumn() {
     List<String> dimensions = schema.getDimensionNames();
     final int nDimensions = dimensions.size();
     int ntries = nDimensions;
@@ -248,7 +249,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
    *
    * @return list of inverted index columns or null is no inv index is to be used for this run
    */
-  private List<String> makeInvertedIndexColumns() {
+  protected List<String> makeInvertedIndexColumns() {
     List<String> dimensions = schema.getDimensionNames();
     final int nDimensions = dimensions.size();
     int dimPos = random.nextInt(dimensions.size()+1);


### PR DESCRIPTION
* PINOT-4349
* Previously, if the tableType was null, and the table has both realtime and offline components, we look for the segment in the realtime table, and don't find anything there and throw an error. Now, we check to ensure the table type is correct by looking at the segment metadata.
* Will test with a breakpoint in the integration test & deleting segments in both APIs
