### PR TITLE
Add explicit dataset suffix to queries, to avoid realtime being queried by default

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
@@ -50,16 +50,16 @@ public class CollectionMaxDataTimeCacheLoader extends CacheLoader<String, Long> 
     try {
       DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(collection);
       // By default, query only offline, unless dataset has been marked as realtime
-      String datasetWithSuffix = ThirdEyeUtils.getDatasetWithOfflineRealtimeSuffix(collection);
+      String tableName = ThirdEyeUtils.computeTableName(collection);
       TimeSpec timeSpec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
       long prevMaxDataTime = getPrevMaxDataTime(collection, timeSpec);
-      String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), datasetWithSuffix,
+      String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), tableName,
           timeSpec.getColumnName(), prevMaxDataTime);
-      PinotQuery maxTimePinotQuery = new PinotQuery(maxTimePql, datasetWithSuffix);
+      PinotQuery maxTimePinotQuery = new PinotQuery(maxTimePql, tableName);
       resultSetGroupCache.refresh(maxTimePinotQuery);
       ResultSetGroup resultSetGroup = resultSetGroupCache.get(maxTimePinotQuery);
       if (resultSetGroup.getResultSetCount() == 0 || resultSetGroup.getResultSet(0).getRowCount() == 0) {
-        LOGGER.info("resultSetGroup is Empty for collection {} is {}", datasetWithSuffix, resultSetGroup);
+        LOGGER.info("resultSetGroup is Empty for collection {} is {}", tableName, resultSetGroup);
         this.collectionToPrevMaxDataTimeMap.remove(collection);
       } else {
         long endTime = new Double(resultSetGroup.getResultSet(0).getDouble(0)).longValue();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
@@ -2,11 +2,12 @@ package com.linkedin.thirdeye.client.cache;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -22,6 +23,7 @@ import com.linkedin.thirdeye.client.pinot.PinotQuery;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 public class CollectionMaxDataTimeCacheLoader extends CacheLoader<String, Long> {
@@ -47,15 +49,17 @@ public class CollectionMaxDataTimeCacheLoader extends CacheLoader<String, Long> 
     long maxTime = 0;
     try {
       DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(collection);
+      // By default, query only offline, unless dataset has been marked as realtime
+      String datasetWithSuffix = ThirdEyeUtils.getDatasetWithOfflineRealtimeSuffix(collection);
       TimeSpec timeSpec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
       long prevMaxDataTime = getPrevMaxDataTime(collection, timeSpec);
-      String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), collection, timeSpec.getColumnName(),
-          prevMaxDataTime);
-      PinotQuery maxTimePinotQuery = new PinotQuery(maxTimePql, collection);
+      String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), datasetWithSuffix,
+          timeSpec.getColumnName(), prevMaxDataTime);
+      PinotQuery maxTimePinotQuery = new PinotQuery(maxTimePql, datasetWithSuffix);
       resultSetGroupCache.refresh(maxTimePinotQuery);
       ResultSetGroup resultSetGroup = resultSetGroupCache.get(maxTimePinotQuery);
       if (resultSetGroup.getResultSetCount() == 0 || resultSetGroup.getResultSet(0).getRowCount() == 0) {
-        LOGGER.info("resultSetGroup is Empty for collection {} is {}", collection, resultSetGroup);
+        LOGGER.info("resultSetGroup is Empty for collection {} is {}", datasetWithSuffix, resultSetGroup);
         this.collectionToPrevMaxDataTimeMap.remove(collection);
       } else {
         long endTime = new Double(resultSetGroup.getResultSet(0).getDouble(0)).longValue();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -113,19 +113,19 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
     List<ResultSetGroup> resultSetGroups = new ArrayList<>();
 
     // By default, query only offline, unless dataset has been marked as realtime
-    String datasetWithSuffix = ThirdEyeUtils.getDatasetWithOfflineRealtimeSuffix(request.getCollection());
+    String tableName = ThirdEyeUtils.computeTableName(request.getCollection());
 
     if (datasetConfig.isMetricAsDimension()) {
        List<String> pqls = PqlUtils.getMetricAsDimensionPqls(request, dataTimeSpec, datasetConfig);
        for (String pql : pqls) {
          LOG.debug("PQL isMetricAsDimension : {}", pql);
-         ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache().get(new PinotQuery(pql, datasetWithSuffix));
+         ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache().get(new PinotQuery(pql, tableName));
          resultSetGroups.add(result);
        }
     } else {
       String sql = PqlUtils.getPql(request, dataTimeSpec);
       LOG.debug("PQL: {}", sql);
-      ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache().get(new PinotQuery(sql, datasetWithSuffix));
+      ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache().get(new PinotQuery(sql, tableName));
       resultSetGroups.add(result);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Result for: {} {}", sql, format(result));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -29,6 +29,7 @@ import com.linkedin.thirdeye.client.ThirdEyeClient;
 import com.linkedin.thirdeye.client.ThirdEyeRequest;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 public class PinotThirdEyeClient implements ThirdEyeClient {
@@ -111,20 +112,20 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
     List<String> dimensionNames = datasetConfig.getDimensions();
     List<ResultSetGroup> resultSetGroups = new ArrayList<>();
 
+    // By default, query only offline, unless dataset has been marked as realtime
+    String datasetWithSuffix = ThirdEyeUtils.getDatasetWithOfflineRealtimeSuffix(request.getCollection());
+
     if (datasetConfig.isMetricAsDimension()) {
        List<String> pqls = PqlUtils.getMetricAsDimensionPqls(request, dataTimeSpec, datasetConfig);
        for (String pql : pqls) {
          LOG.debug("PQL isMetricAsDimension : {}", pql);
-         ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache()
-             .get(new PinotQuery(pql, request.getCollection()));
+         ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache().get(new PinotQuery(pql, datasetWithSuffix));
          resultSetGroups.add(result);
        }
     } else {
-
       String sql = PqlUtils.getPql(request, dataTimeSpec);
       LOG.debug("PQL: {}", sql);
-      ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache()
-          .get(new PinotQuery(sql, request.getCollection()));
+      ResultSetGroup result = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache().get(new PinotQuery(sql, datasetWithSuffix));
       resultSetGroups.add(result);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Result for: {} {}", sql, format(result));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -100,7 +100,9 @@ public class PqlUtils {
     StringBuilder sb = new StringBuilder();
     String selectionClause = getMetricAsDimensionSelectionClause(metricFunction, metricValuesColumn);
 
-    sb.append("SELECT ").append(selectionClause).append(" FROM ").append(collection);
+    String tableName = ThirdEyeUtils.computeTableName(collection);
+
+    sb.append("SELECT ").append(selectionClause).append(" FROM ").append(tableName);
     String betweenClause = getBetweenClause(startTime, endTimeExclusive, dataTimeSpec, collection);
     sb.append(" WHERE ").append(betweenClause);
 
@@ -127,9 +129,9 @@ public class PqlUtils {
     StringBuilder sb = new StringBuilder();
     String selectionClause = getSelectionClause(metricFunctions);
 
-    String datasetWithSuffix = ThirdEyeUtils.getDatasetWithOfflineRealtimeSuffix(collection);
+    String tableName = ThirdEyeUtils.computeTableName(collection);
 
-    sb.append("SELECT ").append(selectionClause).append(" FROM ").append(datasetWithSuffix);
+    sb.append("SELECT ").append(selectionClause).append(" FROM ").append(tableName);
     String betweenClause = getBetweenClause(startTime, endTimeExclusive, dataTimeSpec, collection);
     sb.append(" WHERE ").append(betweenClause);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PqlUtils.java
@@ -2,13 +2,10 @@ package com.linkedin.thirdeye.client.pinot;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-
-import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -28,6 +25,7 @@ import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 /**
  * Util class for generated PQL queries (pinot).
@@ -129,7 +127,9 @@ public class PqlUtils {
     StringBuilder sb = new StringBuilder();
     String selectionClause = getSelectionClause(metricFunctions);
 
-    sb.append("SELECT ").append(selectionClause).append(" FROM ").append(collection);
+    String datasetWithSuffix = ThirdEyeUtils.getDatasetWithOfflineRealtimeSuffix(collection);
+
+    sb.append("SELECT ").append(selectionClause).append(" FROM ").append(datasetWithSuffix);
     String betweenClause = getBetweenClause(startTime, endTimeExclusive, dataTimeSpec, collection);
     sb.append(" WHERE ").append(betweenClause);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -13,6 +13,7 @@ import com.linkedin.thirdeye.api.TimeSpec;
 public class DatasetConfigBean extends AbstractBean {
 
   public static String DEFAULT_PREAGGREGATED_DIMENSION_VALUE = "all";
+  public static String DATASET_OFFLINE_PREFIX = "_OFFLINE";
 
   private String dataset;
 
@@ -44,6 +45,8 @@ public class DatasetConfigBean extends AbstractBean {
   private String preAggregatedKeyword = DEFAULT_PREAGGREGATED_DIMENSION_VALUE;
   private Integer nonAdditiveBucketSize;
   private String nonAdditiveBucketUnit;
+
+  private boolean realtime = false;
 
   public String getDataset() {
     return dataset;
@@ -182,6 +185,15 @@ public class DatasetConfigBean extends AbstractBean {
     this.nonAdditiveBucketUnit = nonAdditiveBucketUnit;
   }
 
+
+  public boolean isRealtime() {
+    return realtime;
+  }
+
+  public void setRealtime(boolean realtime) {
+    this.realtime = realtime;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof DatasetConfigBean)) {
@@ -205,14 +217,15 @@ public class DatasetConfigBean extends AbstractBean {
         && Objects.equals(dimensionsHaveNoPreAggregation, dc.getDimensionsHaveNoPreAggregation())
         && Objects.equals(preAggregatedKeyword, dc.getPreAggregatedKeyword())
         && Objects.equals(nonAdditiveBucketUnit, dc.getNonAdditiveBucketUnit())
-        && Objects.equals(nonAdditiveBucketSize, dc.getNonAdditiveBucketSize());
+        && Objects.equals(nonAdditiveBucketSize, dc.getNonAdditiveBucketSize())
+        && Objects.equals(realtime, dc.isRealtime());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), dataset, dimensions, timeColumn, timeUnit, timeDuration, timeFormat, timezone,
         metricAsDimension, metricNamesColumn, metricValuesColumn, autoDiscoverMetrics, active, additive,
-        dimensionsHaveNoPreAggregation, preAggregatedKeyword, nonAdditiveBucketSize, nonAdditiveBucketUnit);
+        dimensionsHaveNoPreAggregation, preAggregatedKeyword, nonAdditiveBucketSize, nonAdditiveBucketUnit, realtime);
   }
 
   @Override
@@ -224,6 +237,6 @@ public class DatasetConfigBean extends AbstractBean {
         .add("autoDiscoverMetrics", autoDiscoverMetrics).add("active", active).add("additive", additive)
         .add("dimensionsHaveNoPreAggregation", dimensionsHaveNoPreAggregation)
         .add("preAggregatedKeyword", preAggregatedKeyword).add("nonAdditiveBucketSize", nonAdditiveBucketSize)
-        .add("nonAdditiveBucketUnit", nonAdditiveBucketUnit).toString();
+        .add("nonAdditiveBucketUnit", nonAdditiveBucketUnit).add("offlineOnly", realtime).toString();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -186,7 +186,7 @@ public class DatasetConfigBean extends AbstractBean {
   }
 
 
-  public boolean isRealtime() {
+  public boolean queryRealtime() {
     return realtime;
   }
 
@@ -218,7 +218,7 @@ public class DatasetConfigBean extends AbstractBean {
         && Objects.equals(preAggregatedKeyword, dc.getPreAggregatedKeyword())
         && Objects.equals(nonAdditiveBucketUnit, dc.getNonAdditiveBucketUnit())
         && Objects.equals(nonAdditiveBucketSize, dc.getNonAdditiveBucketSize())
-        && Objects.equals(realtime, dc.isRealtime());
+        && Objects.equals(realtime, dc.queryRealtime());
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -320,12 +320,12 @@ public abstract class ThirdEyeUtils {
   }
 
   //By default, query only offline, unless dataset has been marked as realtime
-  public static String getDatasetWithOfflineRealtimeSuffix(String collection) {
+  public static String computeTableName(String collection) {
     String dataset = null;
     try {
       DatasetConfigDTO datasetConfig = CACHE_REGISTRY.getDatasetConfigCache().get(collection);
       dataset = collection + DatasetConfigBean.DATASET_OFFLINE_PREFIX;
-      if (datasetConfig.isRealtime()) {
+      if (datasetConfig.queryRealtime()) {
         dataset = collection;
       }
     } catch (ExecutionException e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -44,6 +44,7 @@ import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.pojo.DashboardConfigBean;
+import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
 
 
@@ -316,6 +317,21 @@ public abstract class ThirdEyeUtils {
   public static String getDefaultDashboardName(String dataset) {
     String dashboardName = DashboardConfigBean.DEFAULT_DASHBOARD_PREFIX + dataset;
     return dashboardName;
+  }
+
+  //By default, query only offline, unless dataset has been marked as realtime
+  public static String getDatasetWithOfflineRealtimeSuffix(String collection) {
+    String dataset = null;
+    try {
+      DatasetConfigDTO datasetConfig = CACHE_REGISTRY.getDatasetConfigCache().get(collection);
+      dataset = collection + DatasetConfigBean.DATASET_OFFLINE_PREFIX;
+      if (datasetConfig.isRealtime()) {
+        dataset = collection;
+      }
+    } catch (ExecutionException e) {
+      LOG.error("Exception in getting dataset name {}", collection, e);
+    }
+    return dataset;
   }
 
 }


### PR DESCRIPTION
Realtime data gets displayed by default, and we aren't fully equipped to handle it yet. This is resulting in undesirable results in certain datasets. Adding realtime as a mode to the dataset, disabled by default, so that we only consider realtime if explicitly set