### PR TITLE
Optimize logic to refresh watches for realtime table and fix error handling

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/AbstractTableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/AbstractTableConfig.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.commons.configuration.ConfigurationRuntimeException;
 import org.apache.helix.ZNRecord;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.JsonNode;
@@ -70,8 +71,13 @@ public abstract class AbstractTableConfig {
         loadIndexingConfig(new ObjectMapper().readTree(tableJson.getJSONObject("tableIndexConfig").toString()));
     QuotaConfig quotaConfig = null;
     if (tableJson.has(QuotaConfig.QUOTA_SECTION_NAME)) {
-      quotaConfig = loadQuotaConfig(new ObjectMapper().readTree(
-          tableJson.getJSONObject(QuotaConfig.QUOTA_SECTION_NAME).toString()));
+      try {
+        quotaConfig = loadQuotaConfig(
+            new ObjectMapper().readTree(tableJson.getJSONObject(QuotaConfig.QUOTA_SECTION_NAME).toString()));
+      } catch(ConfigurationRuntimeException e) {
+        LOGGER.error("Invalid quota configuration value for table: {}", tableName);
+        throw e;
+      }
     }
 
     if (tableType.equals("offline")) {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.common.config;
 
 import java.io.IOException;
+import org.apache.commons.configuration.ConfigurationRuntimeException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -49,6 +50,14 @@ public class QuotaConfigTest {
       Assert.assertNotNull(quotaConfig.getStorage());
       Assert.assertEquals(quotaConfig.storageSizeBytes(), -1);
     }
+  }
+
+  @Test(expectedExceptions = ConfigurationRuntimeException.class)
+  public void testBadConfig()
+      throws IOException {
+    String quotaConfigStr = "{\"storage\":\"-1M\"}";
+    QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+    quotaConfig.validate();
   }
 
 }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
@@ -87,7 +87,13 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
     String rawTenantName = tenantName.replaceAll("_OFFLINE", "").replace("_REALTIME", "");
     int nRebalances = 0;
     for (ZNRecord znRecord : tableConfigs) {
-      AbstractTableConfig tableConfig = AbstractTableConfig.fromZnRecord(znRecord);
+      AbstractTableConfig tableConfig;
+      try {
+        tableConfig = AbstractTableConfig.fromZnRecord(znRecord);
+      } catch (Exception e) {
+        LOGGER.warn("Failed to parse table configuration for ZnRecord id: {}. Skipping", znRecord.getId());
+        continue;
+      }
       if (tableConfig.getTenantConfig().getServer().equals(rawTenantName)) {
         LOGGER.info(tableConfig.getTableName() + ":" + tableConfig.getTenantConfig().getServer());
         nRebalances++;

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -519,16 +520,16 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
 
     // Remove table from all instances
     synchronized (_tablesForInstance) {
-      for (String instanceName : _brokerRoutingTable.keySet()) {
-        Set<String> tablesForCurrentInstance = _tablesForInstance.get(instanceName);
-        if (tablesForCurrentInstance.contains(tableName)) {
-          tablesForCurrentInstance.remove(tableName);
-        }
-
-        if (tablesForCurrentInstance.isEmpty()) {
-          _lastKnownInstanceConfigs.remove(instanceName);
+      Iterator<Map.Entry<String, Set<String>>> iterator = _tablesForInstance.entrySet().iterator();
+      while (iterator.hasNext()) {
+        Map.Entry<String, Set<String>> entry = iterator.next();
+        entry.getValue().remove(tableName);
+        if (entry.getValue().isEmpty()) {
+          _lastKnownInstanceConfigs.remove(entry.getKey());
+          iterator.remove();
         }
       }
+
     }
   }
 


### PR DESCRIPTION
During refresh watches, check if a table is realtime based on zn record id
before converting the record to table configuration. Also, handle all possible
exceptions to continue with as many tables as it can. This reduces the
impact of bad configurations of a table on other tables