### PR TITLE
Cache totalDocs and totalRawDocs in SegmentMetadataImpl, instead of fetching from config within getter.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -658,6 +658,12 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       public int getTotalDocs() {
         return docIdSearchableOffset + 1;
       }
+
+      @Override
+      public int getTotalRawDocs() {
+        // In realtime total docs and total raw docs are the same currently.
+        return docIdSearchableOffset + 1;
+      }
     };
   }
 
@@ -665,6 +671,12 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     _segmentMetadata = new SegmentMetadataImpl(segmentMetadata, schema) {
       @Override
       public int getTotalDocs() {
+        return docIdSearchableOffset + 1;
+      }
+
+      @Override
+      public int getTotalRawDocs() {
+        // In realtime total docs and total raw docs are the same currently.
         return docIdSearchableOffset + 1;
       }
     };


### PR DESCRIPTION
In SegmentMetadataImpl, the getters for totalDocs/totalRawDocs fetch the
value from config (which is a hash-lookup). With large number of
segments, these fetches start showing up in the CPU profile. This change
is to fetch the values once in the constructor, and return it in the
getter.