### PR TITLE
Limit number of servers hit per query for LLC

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/GeneratorBasedRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/GeneratorBasedRoutingTableBuilder.java
@@ -1,0 +1,297 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.routing.builder;
+
+import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Routing table builder that uses a random routing table generator to create multiple routing tables. See a more
+ * detailed explanation of the algorithm in {@link KafkaLowLevelConsumerRoutingTableBuilder} and
+ * {@link LargeClusterRoutingTableBuilder}.
+ */
+public abstract class GeneratorBasedRoutingTableBuilder extends AbstractRoutingTableBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GeneratorBasedRoutingTableBuilder.class);
+
+  /** Number of routing tables to keep */
+  protected static final int ROUTING_TABLE_COUNT = 500;
+
+  /** Number of routing tables to generate during the optimization phase */
+  protected static final int ROUTING_TABLE_GENERATION_COUNT = 1000;
+
+  /**
+   * Generates a routing table, decorated with a metric.
+   *
+   * @param routingTableGenerator The routing table generator to use to generate routing tables.
+   * @return A pair of a routing table and its associated metric.
+   */
+  private Pair<Map<String, Set<String>>, Float> generateRoutingTableWithMetric(RoutingTableGenerator routingTableGenerator) {
+    Map<String, Set<String>> routingTable = routingTableGenerator.generateRoutingTable();
+    int segmentCount = 0;
+    int serverCount = 0;
+
+    // Compute the number of segments and servers (for the average part of the variance)
+    for (Set<String> segmentsForServer : routingTable.values()) {
+      int segmentCountForServer = segmentsForServer.size();
+      segmentCount += segmentCountForServer;
+      serverCount++;
+    }
+
+    // Compute the variance of the number of segments allocated per server
+    float averageSegmentCount = ((float) segmentCount) / serverCount;
+    float variance = 0.0f;
+    for (Set<String> segmentsForServer : routingTable.values()) {
+      int segmentCountForServer = segmentsForServer.size();
+      float difference = segmentCountForServer - averageSegmentCount;
+      variance += difference * difference;
+    }
+
+    return new ImmutablePair<>(routingTable, variance);
+  }
+
+  interface RoutingTableGenerator {
+    void init(ExternalView externalView, List<InstanceConfig> instanceConfigList);
+    Map<String, Set<String>> generateRoutingTable();
+  }
+
+  abstract class BaseRoutingTableGenerator implements RoutingTableGenerator {
+    private final int TARGET_SERVER_COUNT_PER_QUERY;
+    private final Random random;
+
+    protected BaseRoutingTableGenerator(int target_server_count_per_query, Random random) {
+      TARGET_SERVER_COUNT_PER_QUERY = target_server_count_per_query;
+      this.random = random;
+    }
+
+    /**
+     * Set of segments to assign during routing table generation.
+     */
+    protected abstract Set<String> getSegmentSet();
+
+    /**
+     * Array of instance names to use during assignment.
+     */
+    protected abstract String[] getInstanceArray();
+
+    /**
+     * Set of instances to use during assignment.
+     */
+    protected abstract Set<String> getInstanceSet();
+
+    /**
+     * Map from instance name to segment set.
+     */
+    protected abstract Map<String,Set<String>> getInstanceToSegmentMap();
+
+    /**
+     * Map from segment name to instance name array.
+     */
+    protected abstract Map<String, String[]> getSegmentToInstanceArrayMap();
+
+    /**
+     * Map from segment name to instance set.
+     */
+    protected abstract Map<String,Set<String>> getSegmentToInstanceMap();
+
+    public Map<String, Set<String>> generateRoutingTable() {
+      Set<String> segmentSet = getSegmentSet();
+      Set<String> instanceSet = getInstanceSet();
+      String[] instanceArray = getInstanceArray();
+      Map<String, Set<String>> instanceToSegmentMap = getInstanceToSegmentMap();
+      Map<String, String[]> segmentToInstanceArrayMap = getSegmentToInstanceArrayMap();
+      Map<String, Set<String>> segmentToInstanceMap = getSegmentToInstanceMap();
+
+      // List of segments that have no instance serving them
+      Set<String> segmentsNotHandledByServers = new HashSet<>(segmentSet);
+
+      // List of servers in this routing table
+      Set<String> instancesInRoutingTable = new HashSet<>(TARGET_SERVER_COUNT_PER_QUERY);
+
+      // If there are not enough instances, add them all
+      if (instanceArray.length <= TARGET_SERVER_COUNT_PER_QUERY) {
+        instancesInRoutingTable.addAll(instanceSet);
+        segmentsNotHandledByServers.clear();
+      } else {
+        // Otherwise add TARGET_SERVER_COUNT_PER_QUERY instances
+        while (instancesInRoutingTable.size() < TARGET_SERVER_COUNT_PER_QUERY) {
+          String randomInstance = instanceArray[random.nextInt(instanceArray.length)];
+          instancesInRoutingTable.add(randomInstance);
+          segmentsNotHandledByServers.removeAll(instanceToSegmentMap.get(randomInstance));
+        }
+      }
+
+      // If there are segments that have no instance that can serve them, add a server to serve them
+      while (!segmentsNotHandledByServers.isEmpty()) {
+        // Get the instances in array format
+        String segmentNotHandledByServers = segmentsNotHandledByServers.iterator().next();
+
+        String[] instancesArrayForThisSegment = segmentToInstanceArrayMap.get(segmentNotHandledByServers);
+
+        if (instancesArrayForThisSegment == null) {
+          Set<String> segmentInstanceSet = segmentToInstanceMap.get(segmentNotHandledByServers);
+          instancesArrayForThisSegment = segmentInstanceSet.toArray(new String[segmentInstanceSet.size()]);
+          segmentToInstanceArrayMap.put(segmentNotHandledByServers, instancesArrayForThisSegment);
+        }
+
+        // Pick a random instance that can serve this segment
+        String instance = instancesArrayForThisSegment[random.nextInt(instancesArrayForThisSegment.length)];
+        instancesInRoutingTable.add(instance);
+        segmentsNotHandledByServers.removeAll(instanceToSegmentMap.get(instance));
+      }
+
+      // Sort all the segments to be used during assignment in ascending order of replicas
+      int segmentCount = Math.max(segmentSet.size(), 1);
+      PriorityQueue<Pair<String, Set<String>>> segmentToReplicaSetQueue = new PriorityQueue<>(segmentCount,
+          new Comparator<Pair<String, Set<String>>>() {
+            @Override
+            public int compare(Pair<String, Set<String>> firstPair, Pair<String, Set<String>> secondPair) {
+              return Integer.compare(firstPair.getRight().size(), secondPair.getRight().size());
+            }
+          });
+
+      for (String segment : segmentSet) {
+        // Instances for this segment is the intersection of all instances for this segment and the instances that we
+        // have in this routing table
+        Set<String> instancesForThisSegment = new HashSet<>(segmentToInstanceMap.get(segment));
+        instancesForThisSegment.retainAll(instancesInRoutingTable);
+
+        segmentToReplicaSetQueue.add(new ImmutablePair<>(segment, instancesForThisSegment));
+      }
+
+      // Create the routing table from the segment -> instances priority queue
+      Map<String, Set<String>> instanceToSegmentSetMap = new HashMap<>();
+      while(!segmentToReplicaSetQueue.isEmpty()) {
+        Pair<String, Set<String>> segmentAndReplicaSet = segmentToReplicaSetQueue.poll();
+        String segment = segmentAndReplicaSet.getKey();
+        Set<String> replicaSet = segmentAndReplicaSet.getValue();
+
+        String instance = pickWeightedRandomReplica(replicaSet, instanceToSegmentSetMap, random);
+        if (instance != null) {
+          Set<String> segmentsAssignedToInstance = instanceToSegmentSetMap.get(instance);
+
+          if (segmentsAssignedToInstance == null) {
+            segmentsAssignedToInstance = new HashSet<>();
+            instanceToSegmentSetMap.put(instance, segmentsAssignedToInstance);
+          }
+
+          segmentsAssignedToInstance.add(segment);
+        } else {
+          LOGGER.error("null replica while trying to find replicas for segment {}, this shouldn't happen", segment);
+        }
+      }
+
+      return instanceToSegmentSetMap;
+    }
+  }
+
+  protected abstract RoutingTableGenerator buildRoutingTableGenerator();
+
+  @Override
+  public List<ServerToSegmentSetMap> computeRoutingTableFromExternalView(String tableName, ExternalView externalView,
+      List<InstanceConfig> instanceConfigList) {
+    // The default routing table algorithm tries to balance all available segments across all servers, so that each
+    // server is hit on every query. This works fine with small clusters (say less than 20 servers) but for larger
+    // clusters, this adds up to significant overhead (one request must be enqueued for each server, processed,
+    // returned, deserialized, aggregated, etc.).
+    //
+    // For large clusters, we want to avoid hitting every server, as this also has an adverse effect on client tail
+    // latency. This is due to the fact that a query cannot return until it has received a response from each server,
+    // and the greater the number of servers that are hit, the more likely it is that one of the servers will be a
+    // straggler (eg. due to contention for query processing threads, GC, etc.). We also want to balance the segments
+    // within any given routing table so that each server in the routing table has approximately the same number of
+    // segments to process.
+    //
+    // To do so, we have a routing table generator that generates routing tables by picking a random subset of servers.
+    // With this set of servers, we check if the set of segments served by these servers is complete. If the set of
+    // segments served does not cover all of the segments, we compute the list of missing segments and pick a random
+    // server that serves these missing segments until we have complete coverage of all the segments.
+    //
+    // We then order the segments in ascending number of replicas within our server set, in order to allocate the
+    // segments with fewer replicas first. This ensures that segments that are 'easier' to allocate are more likely to
+    // end up on a replica with fewer segments.
+    //
+    // Then, we pick a random replica for each segment, iterating from fewest replicas to most replicas, inversely
+    // weighted by the number of segments already assigned to that replica. This ensures that we build a routing table
+    // that's as even as possible.
+    //
+    // The algorithm to generate a routing table is thus:
+    // 1. Compute the inverse external view, a mapping of servers to segments
+    // 2. For each routing table to generate:
+    //   a) Pick TARGET_SERVER_COUNT_PER_QUERY distinct servers
+    //   b) Check if the server set covers all the segments; if not, add additional servers until it does.
+    //   c) Order the segments in our server set in ascending order of number of replicas present in our server set
+    //   d) For each segment, pick a random replica with proper weighting
+    //   e) Return that routing table
+    //
+    // Given that we can generate routing tables at will, we then generate many routing tables and use them to optimize
+    // according to two criteria: the variance in workload per server for any individual table as well as the variance
+    // in workload per server across all the routing tables. To do so, we generate an initial set of routing tables
+    // according to a per-routing table metric and discard the worst routing tables.
+
+    RoutingTableGenerator routingTableGenerator = buildRoutingTableGenerator();
+    routingTableGenerator.init(externalView, instanceConfigList);
+
+    PriorityQueue<Pair<Map<String, Set<String>>, Float>>
+        topRoutingTables = new PriorityQueue<>(ROUTING_TABLE_COUNT, new Comparator<Pair<Map<String, Set<String>>, Float>>() {
+      @Override
+      public int compare(Pair<Map<String, Set<String>>, Float> left, Pair<Map<String, Set<String>>, Float> right) {
+        // Float.compare sorts in ascending order and we want a max heap, so we need to return the negative of the comparison
+        return -Float.compare(left.getValue(), right.getValue());
+      }
+    });
+
+    for (int i = 0; i < ROUTING_TABLE_COUNT; i++) {
+      topRoutingTables.add(generateRoutingTableWithMetric(routingTableGenerator));
+    }
+
+    // Generate routing more tables and keep the ROUTING_TABLE_COUNT top ones
+    for(int i = 0; i < (ROUTING_TABLE_GENERATION_COUNT - ROUTING_TABLE_COUNT); ++i) {
+      Pair<Map<String, Set<String>>, Float> newRoutingTable = generateRoutingTableWithMetric(routingTableGenerator);
+      Pair<Map<String, Set<String>>, Float> worstRoutingTable = topRoutingTables.peek();
+
+      // If the new routing table is better than the worst one, keep it
+      if (newRoutingTable.getRight() < worstRoutingTable.getRight()) {
+        topRoutingTables.poll();
+        topRoutingTables.add(newRoutingTable);
+      }
+    }
+
+    // Return the best routing tables
+    List<ServerToSegmentSetMap> routingTables = new ArrayList<>(topRoutingTables.size());
+    while(!topRoutingTables.isEmpty()) {
+      Pair<Map<String, Set<String>>, Float> routingTableWithMetric = topRoutingTables.poll();
+      routingTables.add(new ServerToSegmentSetMap(routingTableWithMetric.getKey()));
+    }
+
+    return routingTables;
+  }
+}

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
@@ -43,19 +43,34 @@ import com.linkedin.pinot.routing.ServerToSegmentSetMap;
 /**
  * Routing table builder for the Kafka low level consumer.
  */
-public class KafkaLowLevelConsumerRoutingTableBuilder extends AbstractRoutingTableBuilder {
+public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRoutingTableBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaLowLevelConsumerRoutingTableBuilder.class);
-  private static final int routingTableCount = 10;
   private final Random _random = new Random();
+  private int TARGET_SERVER_COUNT_PER_QUERY = 8;
 
   @Override
   public void init(Configuration configuration) {
-    // No configuration at the moment
+    // TODO jfim This is a broker-level configuration for now, until we refactor the configuration of the routing table to allow per-table routing settings
+    if (configuration.containsKey("realtimeTargetServerCountPerQuery")) {
+      final String targetServerCountPerQuery = configuration.getString("realtimeTargetServerCountPerQuery");
+      try {
+        TARGET_SERVER_COUNT_PER_QUERY = Integer.parseInt(targetServerCountPerQuery);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Could not get the target server count per query from configuration value {}, keeping default value {}",
+            targetServerCountPerQuery, TARGET_SERVER_COUNT_PER_QUERY, e);
+      }
+    } else {
+      LOGGER.info("Using default value for target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
+    }
   }
 
   @Override
-  public List<ServerToSegmentSetMap> computeRoutingTableFromExternalView(String tableName, ExternalView externalView,
-      List<InstanceConfig> instanceConfigList) {
+  protected RoutingTableGenerator buildRoutingTableGenerator() {
+    return new KafkaLowLevelConsumerRoutingTableGenerator();
+  }
+
+  private class KafkaLowLevelConsumerRoutingTableGenerator extends BaseRoutingTableGenerator {
     // We build the routing table based off the external view here. What we want to do is to make sure that we uphold
     // the guarantees clients expect (no duplicate records, eventual consistency) and spreading the load as equally as
     // possible between the servers.
@@ -100,164 +115,188 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends AbstractRoutingTab
     // 3. Sort all the segments to be used during assignment in ascending order of replicas
     // 4. For each segment to be used during assignment, pick a random replica, weighted by the number of segments
     //    assigned to each replica.
+    //
+    // The upstream code in BaseRoutingTableGenerator will generate routing tables based on taking a subset of servers
+    // if the cluster is large enough as well as ensure that the best routing tables are used for routing.
 
-    // 1. Gather all segments and group them by Kafka partition, sorted by sequence number
-    Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition = new HashMap<String, SortedSet<SegmentName>>();
-    for (String helixPartitionName : externalView.getPartitionSet()) {
-      // Ignore segments that are not low level consumer segments
-      if (!SegmentName.isLowLevelConsumerSegmentName(helixPartitionName)) {
-        continue;
-      }
+    private Set<String> segmentSet = new HashSet<>();
+    private Set<String> instanceSet = new HashSet<>();
+    private Map<String, Set<String>> segmentToInstanceMap = new HashMap<>();
+    private Map<String, String[]> segmentToInstanceArrayMap = new HashMap<>();
+    private Map<String, Set<String>> instanceToSegmentMap = new HashMap<>();
+    private String[] instanceArray;
 
-      final LLCSegmentName segmentName = new LLCSegmentName(helixPartitionName);
-      String kafkaPartitionName = segmentName.getPartitionRange();
-      SortedSet<SegmentName> segmentsForPartition = sortedSegmentsByKafkaPartition.get(kafkaPartitionName);
-
-      // Create sorted set if necessary
-      if (segmentsForPartition == null) {
-        segmentsForPartition = new TreeSet<SegmentName>();
-
-        sortedSegmentsByKafkaPartition.put(kafkaPartitionName, segmentsForPartition);
-      }
-
-      segmentsForPartition.add(segmentName);
+    protected KafkaLowLevelConsumerRoutingTableGenerator() {
+      super(TARGET_SERVER_COUNT_PER_QUERY, _random);
     }
 
-    // 2. Ensure that for each Kafka partition, we have at most one Helix partition (Pinot segment) in consuming state
-    Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition = new HashMap<String, SegmentName>();
-    for (String kafkaPartition : sortedSegmentsByKafkaPartition.keySet()) {
-      SortedSet<SegmentName> sortedSegmentsForKafkaPartition = sortedSegmentsByKafkaPartition.get(kafkaPartition);
-      SegmentName lastAllowedSegmentInConsumingState = null;
+    @Override
+    public void init(ExternalView externalView, List<InstanceConfig> instanceConfigList) {
+      // 1. Gather all segments and group them by Kafka partition, sorted by sequence number
+      Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition = new HashMap<String, SortedSet<SegmentName>>();
+      for (String helixPartitionName : externalView.getPartitionSet()) {
+        // Ignore segments that are not low level consumer segments
+        if (!SegmentName.isLowLevelConsumerSegmentName(helixPartitionName)) {
+          continue;
+        }
 
-      for (SegmentName segmentName : sortedSegmentsForKafkaPartition) {
-        Map<String, String> helixPartitionState = externalView.getStateMap(segmentName.getSegmentName());
-        boolean allInConsumingState = true;
-        int replicasInConsumingState = 0;
+        final LLCSegmentName segmentName = new LLCSegmentName(helixPartitionName);
+        String kafkaPartitionName = segmentName.getPartitionRange();
+        SortedSet<SegmentName> segmentsForPartition = sortedSegmentsByKafkaPartition.get(kafkaPartitionName);
 
-        // Only keep the segment if all replicas have it in CONSUMING state
-        for (String externalViewState : helixPartitionState.values()) {
-          // Ignore ERROR state
-          if (externalViewState.equalsIgnoreCase(
-              CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ERROR)) {
-            continue;
+        // Create sorted set if necessary
+        if (segmentsForPartition == null) {
+          segmentsForPartition = new TreeSet<SegmentName>();
+
+          sortedSegmentsByKafkaPartition.put(kafkaPartitionName, segmentsForPartition);
+        }
+
+        segmentsForPartition.add(segmentName);
+      }
+
+      // 2. Ensure that for each Kafka partition, we have at most one Helix partition (Pinot segment) in consuming state
+      Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition = new HashMap<String, SegmentName>();
+      for (String kafkaPartition : sortedSegmentsByKafkaPartition.keySet()) {
+        SortedSet<SegmentName> sortedSegmentsForKafkaPartition = sortedSegmentsByKafkaPartition.get(kafkaPartition);
+        SegmentName lastAllowedSegmentInConsumingState = null;
+
+        for (SegmentName segmentName : sortedSegmentsForKafkaPartition) {
+          Map<String, String> helixPartitionState = externalView.getStateMap(segmentName.getSegmentName());
+          boolean allInConsumingState = true;
+          int replicasInConsumingState = 0;
+
+          // Only keep the segment if all replicas have it in CONSUMING state
+          for (String externalViewState : helixPartitionState.values()) {
+            // Ignore ERROR state
+            if (externalViewState.equalsIgnoreCase(
+                CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ERROR)) {
+              continue;
+            }
+
+            // Not all segments are in CONSUMING state, therefore don't consider the last segment assignable to CONSUMING
+            // replicas
+            if (externalViewState.equalsIgnoreCase(
+                CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+              allInConsumingState = false;
+              break;
+            }
+
+            // Otherwise count the replica as being in CONSUMING state
+            if (externalViewState.equalsIgnoreCase(
+                CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+              replicasInConsumingState++;
+            }
           }
 
-          // Not all segments are in CONSUMING state, therefore don't consider the last segment assignable to CONSUMING
-          // replicas
-          if (externalViewState.equalsIgnoreCase(
-              CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
-            allInConsumingState = false;
+          // If all replicas have this segment in consuming state (and not all of them are in ERROR state), then pick this
+          // segment to be the last allowed segment to be in CONSUMING state
+          if (allInConsumingState && 0 < replicasInConsumingState) {
+            lastAllowedSegmentInConsumingState = segmentName;
             break;
           }
+        }
 
-          // Otherwise count the replica as being in CONSUMING state
-          if (externalViewState.equalsIgnoreCase(
-              CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
-            replicasInConsumingState++;
+        if (lastAllowedSegmentInConsumingState != null) {
+          allowedSegmentInConsumingStateByKafkaPartition.put(kafkaPartition, lastAllowedSegmentInConsumingState);
+        }
+      }
+
+      // 3. Sort all the segments to be used during assignment in ascending order of replicas
+
+      // PriorityQueue throws IllegalArgumentException when given a size of zero
+      RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigList);
+
+      for (Map.Entry<String, SortedSet<SegmentName>> entry : sortedSegmentsByKafkaPartition.entrySet()) {
+        String kafkaPartition = entry.getKey();
+        SortedSet<SegmentName> segmentNames = entry.getValue();
+
+        // The only segment name which is allowed to be in CONSUMING state or null
+        SegmentName validConsumingSegment = allowedSegmentInConsumingStateByKafkaPartition.get(kafkaPartition);
+
+        for (SegmentName segmentName : segmentNames) {
+          Set<String> validReplicas = new HashSet<String>();
+          String segmentNameStr = segmentName.getSegmentName();
+          Map<String, String> externalViewState = externalView.getStateMap(segmentNameStr);
+
+          for (Map.Entry<String, String> instanceAndStateEntry : externalViewState.entrySet()) {
+            String instance = instanceAndStateEntry.getKey();
+            String state = instanceAndStateEntry.getValue();
+
+            // Skip pruned replicas (shutting down or otherwise disabled)
+            if (instancePruner.isInactive(instance)) {
+              continue;
+            }
+
+            // Replicas in ONLINE state are always allowed
+            if (state.equalsIgnoreCase(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+              validReplicas.add(instance);
+              continue;
+            }
+
+            // Replicas in CONSUMING state are only allowed on the last segment
+            if (state.equalsIgnoreCase(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)
+                && segmentName.equals(validConsumingSegment)) {
+              validReplicas.add(instance);
+            }
+          }
+
+          if (!validReplicas.isEmpty()) {
+            segmentSet.add(segmentNameStr);
+            instanceSet.addAll(validReplicas);
+            segmentToInstanceMap.put(segmentNameStr, validReplicas);
+            segmentToInstanceArrayMap.put(segmentNameStr, validReplicas.toArray(new String[validReplicas.size()]));
+
+            for (String validReplica : validReplicas) {
+              Set<String> segmentsForReplica = instanceToSegmentMap.get(validReplica);
+
+              if (segmentsForReplica == null) {
+                segmentsForReplica = new HashSet<>();
+                instanceToSegmentMap.put(validReplica, segmentsForReplica);
+              }
+
+              segmentsForReplica.add(segmentNameStr);
+            }
+          }
+
+          // If this segment is the segment allowed in CONSUMING state, don't process segments after it in that Kafka
+          // partition
+          if (segmentName.equals(validConsumingSegment)) {
+            break;
           }
         }
-
-        // If all replicas have this segment in consuming state (and not all of them are in ERROR state), then pick this
-        // segment to be the last allowed segment to be in CONSUMING state
-        if (allInConsumingState && 0 < replicasInConsumingState) {
-          lastAllowedSegmentInConsumingState = segmentName;
-          break;
-        }
       }
 
-      if (lastAllowedSegmentInConsumingState != null) {
-        allowedSegmentInConsumingStateByKafkaPartition.put(kafkaPartition, lastAllowedSegmentInConsumingState);
-      }
+      instanceArray = instanceSet.toArray(new String[instanceSet.size()]);
     }
 
-    // 3. Sort all the segments to be used during assignment in ascending order of replicas
-
-    // PriorityQueue throws IllegalArgumentException when given a size of zero
-    int segmentCount = Math.max(externalView.getPartitionSet().size(), 1);
-    PriorityQueue<Pair<String, Set<String>>> segmentToReplicaSetQueue = new PriorityQueue<Pair<String, Set<String>>>(
-        segmentCount,
-        new Comparator<Pair<String, Set<String>>>() {
-          @Override
-          public int compare(Pair<String, Set<String>> firstPair, Pair<String, Set<String>> secondPair) {
-            return Integer.compare(firstPair.getRight().size(), secondPair.getRight().size());
-          }
-        });
-    RoutingTableInstancePruner instancePruner = new RoutingTableInstancePruner(instanceConfigList);
-
-    for (Map.Entry<String, SortedSet<SegmentName>> entry : sortedSegmentsByKafkaPartition.entrySet()) {
-      String kafkaPartition = entry.getKey();
-      SortedSet<SegmentName> segmentNames = entry.getValue();
-
-      // The only segment name which is allowed to be in CONSUMING state or null
-      SegmentName validConsumingSegment = allowedSegmentInConsumingStateByKafkaPartition.get(kafkaPartition);
-
-      for (SegmentName segmentName : segmentNames) {
-        Set<String> validReplicas = new HashSet<String>();
-        Map<String, String> externalViewState = externalView.getStateMap(segmentName.getSegmentName());
-
-        for (Map.Entry<String, String> instanceAndStateEntry : externalViewState.entrySet()) {
-          String instance = instanceAndStateEntry.getKey();
-          String state = instanceAndStateEntry.getValue();
-
-          // Skip pruned replicas (shutting down or otherwise disabled)
-          if (instancePruner.isInactive(instance)) {
-            continue;
-          }
-
-          // Replicas in ONLINE state are always allowed
-          if (state.equalsIgnoreCase(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
-            validReplicas.add(instance);
-            continue;
-          }
-
-          // Replicas in CONSUMING state are only allowed on the last segment
-          if (state.equalsIgnoreCase(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)
-              && segmentName.equals(validConsumingSegment)) {
-            validReplicas.add(instance);
-          }
-        }
-
-        segmentToReplicaSetQueue.add(new ImmutablePair<String, Set<String>>(segmentName.getSegmentName(),
-            validReplicas));
-
-        // If this segment is the segment allowed in CONSUMING state, don't process segments after it in that Kafka
-        // partition
-        if (segmentName.equals(validConsumingSegment)) {
-          break;
-        }
-      }
+    @Override
+    protected Set<String> getSegmentSet() {
+      return segmentSet;
     }
 
-    // 4. For each segment to be used during assignment, pick a random replica, weighted by the number of segments
-    //    assigned to each replica.
-    List<ServerToSegmentSetMap> routingTables = new ArrayList<ServerToSegmentSetMap>(routingTableCount);
-    for(int i = 0; i < routingTableCount; ++i) {
-      Map<String, Set<String>> instanceToSegmentSetMap = new HashMap<String, Set<String>>();
-
-      PriorityQueue<Pair<String, Set<String>>> segmentToReplicaSetQueueCopy =
-          new PriorityQueue<Pair<String, Set<String>>>(segmentToReplicaSetQueue);
-
-      while (!segmentToReplicaSetQueueCopy.isEmpty()) {
-        Pair<String, Set<String>> segmentAndValidReplicaSet = segmentToReplicaSetQueueCopy.poll();
-        String segment = segmentAndValidReplicaSet.getKey();
-        Set<String> validReplicaSet = segmentAndValidReplicaSet.getValue();
-
-        String replica = pickWeightedRandomReplica(validReplicaSet, instanceToSegmentSetMap, _random);
-        if (replica != null) {
-          Set<String> segmentsForInstance = instanceToSegmentSetMap.get(replica);
-
-          if (segmentsForInstance == null) {
-            segmentsForInstance = new HashSet<String>();
-            instanceToSegmentSetMap.put(replica, segmentsForInstance);
-          }
-
-          segmentsForInstance.add(segment);
-        }
-      }
-
-      routingTables.add(new ServerToSegmentSetMap(instanceToSegmentSetMap));
+    @Override
+    protected String[] getInstanceArray() {
+      return instanceArray;
     }
 
-    return routingTables;
+    @Override
+    protected Set<String> getInstanceSet() {
+      return instanceSet;
+    }
+
+    @Override
+    protected Map<String, Set<String>> getInstanceToSegmentMap() {
+      return instanceToSegmentMap;
+    }
+
+    @Override
+    protected Map<String, String[]> getSegmentToInstanceArrayMap() {
+      return segmentToInstanceArrayMap;
+    }
+
+    @Override
+    protected Map<String, Set<String>> getSegmentToInstanceMap() {
+      return segmentToInstanceMap;
+    }
   }
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
@@ -39,17 +39,11 @@ import org.slf4j.LoggerFactory;
 /**
  * Routing table builder for large offline clusters (over 20-30 servers) that avoids having each request go to every server.
  */
-public class LargeClusterRoutingTableBuilder extends AbstractRoutingTableBuilder {
+public class LargeClusterRoutingTableBuilder extends GeneratorBasedRoutingTableBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(LargeClusterRoutingTableBuilder.class);
 
   /** Number of servers to hit for each query (this is a soft limit, not a hard limit) */
   private int TARGET_SERVER_COUNT_PER_QUERY = 20;
-
-  /** Number of routing tables to keep */
-  private static final int ROUTING_TABLE_COUNT = 500;
-
-  /** Number of routing tables to generate during the optimization phase */
-  private static final int ROUTING_TABLE_GENERATION_COUNT = 1000;
 
   private final Random random;
 
@@ -61,7 +55,12 @@ public class LargeClusterRoutingTableBuilder extends AbstractRoutingTableBuilder
     this.random = random;
   }
 
-  private class RoutingTableGenerator {
+  @Override
+  protected RoutingTableGenerator buildRoutingTableGenerator() {
+    return new LargeClusterOfflineRoutingTableGenerator();
+  }
+
+  private class LargeClusterOfflineRoutingTableGenerator extends BaseRoutingTableGenerator {
     private Map<String, Set<String>> segmentToInstanceMap = new HashMap<>();
     private Map<String, Set<String>> instanceToSegmentMap = new HashMap<>();
     private Set<String> segmentsWithAtLeastOneOnlineReplica = new HashSet<>();
@@ -69,7 +68,11 @@ public class LargeClusterRoutingTableBuilder extends AbstractRoutingTableBuilder
     private String[] instanceArray;
     private Map<String, String[]> segmentToInstanceArrayMap;
 
-    private void init(ExternalView externalView, List<InstanceConfig> instanceConfigList) {
+    private LargeClusterOfflineRoutingTableGenerator() {
+      super(TARGET_SERVER_COUNT_PER_QUERY, random);
+    }
+
+    public void init(ExternalView externalView, List<InstanceConfig> instanceConfigList) {
       RoutingTableInstancePruner pruner = new RoutingTableInstancePruner(instanceConfigList);
 
       // Compute the inverse of the external view
@@ -115,97 +118,42 @@ public class LargeClusterRoutingTableBuilder extends AbstractRoutingTableBuilder
       segmentToInstanceArrayMap = new HashMap<>();
     }
 
-    private Map<String, Set<String>> generateRoutingTable() {
-      // List of segments that have no instance serving them
-      Set<String> segmentsNotHandledByServers = new HashSet<>(segmentsWithAtLeastOneOnlineReplica);
+    @Override
+    protected Set<String> getSegmentSet() {
+      return segmentsWithAtLeastOneOnlineReplica;
+    }
 
-      // List of servers in this routing table
-      Set<String> instancesInRoutingTable = new HashSet<>(TARGET_SERVER_COUNT_PER_QUERY);
+    @Override
+    protected String[] getInstanceArray() {
+      return instanceArray;
+    }
 
-      // If there are not enough instances, add them all
-      if (instanceArray.length <= TARGET_SERVER_COUNT_PER_QUERY) {
-        instancesInRoutingTable.addAll(allValidInstancesSet);
-        segmentsNotHandledByServers.clear();
-      } else {
-        // Otherwise add TARGET_SERVER_COUNT_PER_QUERY instances
-        while (instancesInRoutingTable.size() < TARGET_SERVER_COUNT_PER_QUERY) {
-          String randomInstance = instanceArray[random.nextInt(instanceArray.length)];
-          instancesInRoutingTable.add(randomInstance);
-          segmentsNotHandledByServers.removeAll(instanceToSegmentMap.get(randomInstance));
-        }
-      }
+    @Override
+    protected Set<String> getInstanceSet() {
+      return allValidInstancesSet;
+    }
 
-      // If there are segments that have no instance that can serve them, add a server to serve them
-      while (!segmentsNotHandledByServers.isEmpty()) {
-        // Get the instances in array format
-        String segmentNotHandledByServers = segmentsNotHandledByServers.iterator().next();
+    @Override
+    protected Map<String, Set<String>> getInstanceToSegmentMap() {
+      return instanceToSegmentMap;
+    }
 
-        String[] instancesArrayForThisSegment = segmentToInstanceArrayMap.get(segmentNotHandledByServers);
+    @Override
+    protected Map<String, String[]> getSegmentToInstanceArrayMap() {
+      return segmentToInstanceArrayMap;
+    }
 
-        if (instancesArrayForThisSegment == null) {
-          Set<String> instanceSet = segmentToInstanceMap.get(segmentNotHandledByServers);
-          instancesArrayForThisSegment = instanceSet.toArray(new String[instanceSet.size()]);
-          segmentToInstanceArrayMap.put(segmentNotHandledByServers, instancesArrayForThisSegment);
-        }
-
-        // Pick a random instance that can serve this segment
-        String instance = instancesArrayForThisSegment[random.nextInt(instancesArrayForThisSegment.length)];
-        instancesInRoutingTable.add(instance);
-        segmentsNotHandledByServers.removeAll(instanceToSegmentMap.get(instance));
-      }
-
-      // Sort all the segments to be used during assignment in ascending order of replicas
-      int segmentCount = Math.max(segmentsWithAtLeastOneOnlineReplica.size(), 1);
-      PriorityQueue<Pair<String, Set<String>>> segmentToReplicaSetQueue = new PriorityQueue<>(segmentCount,
-          new Comparator<Pair<String, Set<String>>>() {
-            @Override
-            public int compare(Pair<String, Set<String>> firstPair, Pair<String, Set<String>> secondPair) {
-              return Integer.compare(firstPair.getRight().size(), secondPair.getRight().size());
-            }
-          });
-
-      for (String segment : segmentsWithAtLeastOneOnlineReplica) {
-        // Instances for this segment is the intersection of all instances for this segment and the instances that we
-        // have in this routing table
-        Set<String> instancesForThisSegment = new HashSet<>(segmentToInstanceMap.get(segment));
-        instancesForThisSegment.retainAll(instancesInRoutingTable);
-
-        segmentToReplicaSetQueue.add(new ImmutablePair<>(segment, instancesForThisSegment));
-      }
-
-      // Create the routing table from the segment -> instances priority queue
-      Map<String, Set<String>> instanceToSegmentSetMap = new HashMap<>();
-      int[] replicas = new int[10];
-      while(!segmentToReplicaSetQueue.isEmpty()) {
-        Pair<String, Set<String>> segmentAndReplicaSet = segmentToReplicaSetQueue.poll();
-        String segment = segmentAndReplicaSet.getKey();
-        Set<String> replicaSet = segmentAndReplicaSet.getValue();
-        replicas[replicaSet.size() - 1]++;
-
-        String instance = pickWeightedRandomReplica(replicaSet, instanceToSegmentSetMap, random);
-        if (instance != null) {
-          Set<String> segmentsAssignedToInstance = instanceToSegmentSetMap.get(instance);
-
-          if (segmentsAssignedToInstance == null) {
-            segmentsAssignedToInstance = new HashSet<>();
-            instanceToSegmentSetMap.put(instance, segmentsAssignedToInstance);
-          }
-
-          segmentsAssignedToInstance.add(segment);
-        } else {
-          LOGGER.error("null replica while trying to find replicas for segment {}, this shouldn't happen", segment);
-        }
-      }
-
-      return instanceToSegmentSetMap;
+    @Override
+    protected Map<String, Set<String>> getSegmentToInstanceMap() {
+      return segmentToInstanceMap;
     }
   }
 
   @Override
   public void init(Configuration configuration) {
     // TODO jfim This is a broker-level configuration for now, until we refactor the configuration of the routing table to allow per-table routing settings
-    if (configuration.containsKey("targetServerCountPerQuery")) {
-      final String targetServerCountPerQuery = configuration.getString("targetServerCountPerQuery");
+    if (configuration.containsKey("offlineTargetServerCountPerQuery")) {
+      final String targetServerCountPerQuery = configuration.getString("offlineTargetServerCountPerQuery");
       try {
         TARGET_SERVER_COUNT_PER_QUERY = Integer.parseInt(targetServerCountPerQuery);
       } catch (Exception e) {
@@ -213,109 +161,8 @@ public class LargeClusterRoutingTableBuilder extends AbstractRoutingTableBuilder
             "Could not get the target server count per query from configuration value {}, keeping default value {}",
             targetServerCountPerQuery, TARGET_SERVER_COUNT_PER_QUERY, e);
       }
+    } else {
+      LOGGER.info("Using default value for target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
     }
-  }
-
-  @Override
-  public List<ServerToSegmentSetMap> computeRoutingTableFromExternalView(String tableName, ExternalView externalView,
-      List<InstanceConfig> instanceConfigList) {
-    // The default routing table algorithm tries to balance all available segments across all servers, so that each
-    // server is hit on every query. This works fine with small clusters (say less than 20 servers) but for larger
-    // clusters, this adds up to significant overhead (one request must be enqueued for each server, processed,
-    // returned, deserialized, aggregated, etc.).
-    //
-    // For large clusters, we want to avoid hitting every server, as this also has an adverse effect on client tail
-    // latency. This is due to the fact that a query cannot return until it has received a response from each server,
-    // and the greater the number of servers that are hit, the more likely it is that one of the servers will be a
-    // straggler (eg. due to contention for query processing threads, GC, etc.). We also want to balance the segments
-    // within any given routing table so that each server in the routing table has approximately the same number of
-    // segments to process.
-    //
-    // To do so, we have a routing table generator that generates routing tables by picking a random subset of servers.
-    // With this set of servers, we check if the set of segments served by these servers is complete. If the set of
-    // segments served does not cover all of the segments, we compute the list of missing segments and pick a random
-    // server that serves these missing segments until we have complete coverage of all the segments.
-    //
-    // We then order the segments in ascending number of replicas within our server set, in order to allocate the
-    // segments with fewer replicas first. This ensures that segments that are 'easier' to allocate are more likely to
-    // end up on a replica with fewer segments.
-    //
-    // Then, we pick a random replica for each segment, iterating from fewest replicas to most replicas, inversely
-    // weighted by the number of segments already assigned to that replica. This ensures that we build a routing table
-    // that's as even as possible.
-    //
-    // The algorithm to generate a routing table is thus:
-    // 1. Compute the inverse external view, a mapping of servers to segments
-    // 2. For each routing table to generate:
-    //   a) Pick TARGET_SERVER_COUNT_PER_QUERY distinct servers
-    //   b) Check if the server set covers all the segments; if not, add additional servers until it does.
-    //   c) Order the segments in our server set in ascending order of number of replicas present in our server set
-    //   d) For each segment, pick a random replica with proper weighting
-    //   e) Return that routing table
-    //
-    // Given that we can generate routing tables at will, we then generate many routing tables and use them to optimize
-    // according to two criteria: the variance in workload per server for any individual table as well as the variance
-    // in workload per server across all the routing tables. To do so, we generate an initial set of routing tables
-    // according to a per-routing table metric and discard the worst routing tables.
-
-    RoutingTableGenerator routingTableGenerator = new RoutingTableGenerator();
-    routingTableGenerator.init(externalView, instanceConfigList);
-
-    PriorityQueue<Pair<Map<String, Set<String>>, Float>> topRoutingTables = new PriorityQueue<>(ROUTING_TABLE_COUNT, new Comparator<Pair<Map<String, Set<String>>, Float>>() {
-      @Override
-      public int compare(Pair<Map<String, Set<String>>, Float> left, Pair<Map<String, Set<String>>, Float> right) {
-        // Float.compare sorts in ascending order and we want a max heap, so we need to return the negative of the comparison
-        return -Float.compare(left.getValue(), right.getValue());
-      }
-    });
-
-    for (int i = 0; i < ROUTING_TABLE_COUNT; i++) {
-      topRoutingTables.add(generateRoutingTableWithMetric(routingTableGenerator));
-    }
-
-    // Generate routing more tables and keep the ROUTING_TABLE_COUNT top ones
-    for(int i = 0; i < (ROUTING_TABLE_GENERATION_COUNT - ROUTING_TABLE_COUNT); ++i) {
-      Pair<Map<String, Set<String>>, Float> newRoutingTable = generateRoutingTableWithMetric(routingTableGenerator);
-      Pair<Map<String, Set<String>>, Float> worstRoutingTable = topRoutingTables.peek();
-
-      // If the new routing table is better than the worst one, keep it
-      if (newRoutingTable.getRight() < worstRoutingTable.getRight()) {
-        topRoutingTables.poll();
-        topRoutingTables.add(newRoutingTable);
-      }
-    }
-
-    // Return the best routing tables
-    List<ServerToSegmentSetMap> routingTables = new ArrayList<>(topRoutingTables.size());
-    while(!topRoutingTables.isEmpty()) {
-      Pair<Map<String, Set<String>>, Float> routingTableWithMetric = topRoutingTables.poll();
-      routingTables.add(new ServerToSegmentSetMap(routingTableWithMetric.getKey()));
-    }
-
-    return routingTables;
-  }
-
-  private Pair<Map<String, Set<String>>, Float> generateRoutingTableWithMetric(RoutingTableGenerator routingTableGenerator) {
-    Map<String, Set<String>> routingTable = routingTableGenerator.generateRoutingTable();
-    int segmentCount = 0;
-    int serverCount = 0;
-
-    // Compute the number of segments and servers (for the average part of the variance)
-    for (Set<String> segmentsForServer : routingTable.values()) {
-      int segmentCountForServer = segmentsForServer.size();
-      segmentCount += segmentCountForServer;
-      serverCount++;
-    }
-
-    // Compute the variance of the number of segments allocated per server
-    float averageSegmentCount = ((float) segmentCount) / serverCount;
-    float variance = 0.0f;
-    for (Set<String> segmentsForServer : routingTable.values()) {
-      int segmentCountForServer = segmentsForServer.size();
-      float difference = segmentCountForServer - averageSegmentCount;
-      variance += difference * difference;
-    }
-
-    return new ImmutablePair<>(routingTable, variance);
   }
 }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import org.apache.commons.configuration.BaseConfiguration;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;
@@ -46,7 +47,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
     Random random = new Random();
 
     KafkaLowLevelConsumerRoutingTableBuilder routingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
-    routingTableBuilder.init(null);
+    routingTableBuilder.init(new BaseConfiguration());
 
     long totalNanos = 0L;
 
@@ -151,7 +152,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
     final int CONSUMING_SEGMENT_COUNT = SEGMENT_COUNT - ONLINE_SEGMENT_COUNT;
 
     KafkaLowLevelConsumerRoutingTableBuilder routingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
-    routingTableBuilder.init(null);
+    routingTableBuilder.init(new BaseConfiguration());
 
     List<SegmentName> segmentNames = new ArrayList<SegmentName>();
     for(int i = 0; i < SEGMENT_COUNT; ++i) {


### PR DESCRIPTION
Add code to limit the number of servers hit per query for LLC realtime tables,
similar to the one for large clusters. Refactor both the LLC routing table code
and the large cluster routing table code to share the routing table generation
code and only passing a different set of segments and replicas based on the
idiosyncracies of each table type (eg. for LLC, we don't want multiple
CONSUMING segments, for offline we only care about ONLINE, etc.).

Remove leftover debugging code that accumulated the number of replicas in a
fixed size array.