### PR TITLE
Add additional metrics around server query performance

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -30,7 +30,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   LAST_REALTIME_SEGMENT_INITIAL_CONSUMPTION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_CATCHUP_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_COMPLETION_DURATION_SECONDS("seconds", false),
-  KAFKA_PARTITION_OFFSET_LAG("messages", false);
+  KAFKA_PARTITION_OFFSET_LAG("messages", false),
+  RUNNING_QUERIES("runningQueries", false);
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/QueryRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/QueryRequest.java
@@ -47,6 +47,7 @@ public class QueryRequest {
   private ListeningExecutorService queryWorkers;
 
   private final ServerMetrics serverMetrics;
+  private int segmentCountAfterPruning;
 
   public QueryRequest(InstanceRequest request, ServerMetrics serverMetrics) {
     this.instanceRequest = request;
@@ -120,5 +121,13 @@ public class QueryRequest {
 
   public void setQueryWorkers(ListeningExecutorService queryWorkers) {
     this.queryWorkers = queryWorkers;
+  }
+
+  public void setSegmentCountAfterPruning(int segmentCountAfterPruning) {
+    this.segmentCountAfterPruning = segmentCountAfterPruning;
+  }
+
+  public int getSegmentCountAfterPruning() {
+    return segmentCountAfterPruning;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/context/TimerContext.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/context/TimerContext.java
@@ -124,7 +124,6 @@ public class TimerContext {
 
   void recordPhaseTime(Timer phaseTimer) {
     serverMetrics.addPhaseTiming(brokerRequest, phaseTimer.queryPhase, phaseTimer.getDurationNs());
-    phaseTimers.remove(phaseTimer.queryPhase);
   }
 
   // for logging


### PR DESCRIPTION
Track the number of running queries in the server as a gauge.
This will track all the queries received by netty workers which
is bound by the number of netty threads in simple request handler
but that can change with scheduled request handler. Moved logging
query timing numbers to request handler to have more timers and
better information on total query time.