### PR TITLE
Add configurable thresholds for routing tables

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
@@ -74,8 +74,8 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
   private final RoutingTableBuilder _realtimeHLCRoutingTableBuilder;
   private final RoutingTableBuilder _realtimeLLCRoutingTableBuilder;
 
-  private static final int MIN_SERVER_COUNT_FOR_LARGE_CLUSTER = 30;
-  private static final int MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER = 4;
+  private static int MIN_SERVER_COUNT_FOR_LARGE_CLUSTER = 30;
+  private static int MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER = 4;
 
   /*
    * _brokerRoutingTable has entries for offline as well as realtime tables. For the
@@ -116,6 +116,34 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
     _smallClusterRoutingTableBuilder = new BalancedRandomRoutingTableBuilder();
     _realtimeHLCRoutingTableBuilder = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
     _realtimeLLCRoutingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
+
+    if (configuration.containsKey("minServerCountForLargeCluster")) {
+      final String minServerCountForLargeCluster = configuration.getString("minServerCountForLargeCluster");
+      try {
+        MIN_SERVER_COUNT_FOR_LARGE_CLUSTER = Integer.parseInt(minServerCountForLargeCluster);
+        LOGGER.info("Using large cluster min server count of {}", MIN_SERVER_COUNT_FOR_LARGE_CLUSTER);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Could not get the large cluster min server count from configuration value {}, keeping default value {}",
+            minServerCountForLargeCluster, MIN_SERVER_COUNT_FOR_LARGE_CLUSTER, e);
+      }
+    } else {
+      LOGGER.info("Using default value for large cluster min server count of {}", MIN_SERVER_COUNT_FOR_LARGE_CLUSTER);
+    }
+
+    if (configuration.containsKey("minReplicaCountForLargeCluster")) {
+      final String minReplicaCountForLargeCluster = configuration.getString("minReplicaCountForLargeCluster");
+      try {
+        MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER = Integer.parseInt(minReplicaCountForLargeCluster);
+        LOGGER.info("Using large cluster min replica count of {}", MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER);
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Could not get the large cluster min replica count from configuration value {}, keeping default value {}",
+            minReplicaCountForLargeCluster, MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER, e);
+      }
+    } else {
+      LOGGER.info("Using default value for large cluster min replica count of {}", MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER);
+    }
 
     _largeClusterRoutingTableBuilder.init(configuration);
     _smallClusterRoutingTableBuilder.init(configuration);

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
@@ -55,13 +55,14 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRout
       final String targetServerCountPerQuery = configuration.getString("realtimeTargetServerCountPerQuery");
       try {
         TARGET_SERVER_COUNT_PER_QUERY = Integer.parseInt(targetServerCountPerQuery);
+        LOGGER.info("Using realtime target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
       } catch (Exception e) {
         LOGGER.warn(
-            "Could not get the target server count per query from configuration value {}, keeping default value {}",
+            "Could not get the realtime target server count per query from configuration value {}, keeping default value {}",
             targetServerCountPerQuery, TARGET_SERVER_COUNT_PER_QUERY, e);
       }
     } else {
-      LOGGER.info("Using default value for target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
+      LOGGER.info("Using default value for realtime target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
     }
   }
 

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
@@ -156,13 +156,14 @@ public class LargeClusterRoutingTableBuilder extends GeneratorBasedRoutingTableB
       final String targetServerCountPerQuery = configuration.getString("offlineTargetServerCountPerQuery");
       try {
         TARGET_SERVER_COUNT_PER_QUERY = Integer.parseInt(targetServerCountPerQuery);
+        LOGGER.info("Using offline target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
       } catch (Exception e) {
         LOGGER.warn(
-            "Could not get the target server count per query from configuration value {}, keeping default value {}",
+            "Could not get the offline target server count per query from configuration value {}, keeping default value {}",
             targetServerCountPerQuery, TARGET_SERVER_COUNT_PER_QUERY, e);
       }
     } else {
-      LOGGER.info("Using default value for target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
+      LOGGER.info("Using default value for offline target server count of {}", TARGET_SERVER_COUNT_PER_QUERY);
     }
   }
 }


### PR DESCRIPTION
Add configurable thresholds for routing tables

Add configurable thresholds for determining whether or not to use the
large cluster routing table strategy. Added logging for the
configuration of all the routing table builders.