### PR TITLE
Eliminate getSimpleName() call for each operator during query execution.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BReusableFilteredDocIdSetOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BReusableFilteredDocIdSetOperator.java
@@ -32,6 +32,8 @@ import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
  * for many ColumnarReaderDataSource.
  */
 public class BReusableFilteredDocIdSetOperator extends BaseOperator {
+  private static final String OPERATOR_NAME = "BReusableFilteredDocIdSetOperator";
+
   private static final ThreadLocal<int[]> DOC_ID_ARRAY = new ThreadLocal<int[]>() {
     @Override
     protected int[] initialValue() {
@@ -95,6 +97,11 @@ public class BReusableFilteredDocIdSetOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BaseOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BaseOperator.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseOperator implements Operator {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseOperator.class);
 
-  private final String _operatorName = getClass().getSimpleName();
+  private final String _operatorName = getOperatorName();
 
   @Override
   public final Block nextBlock() {
@@ -55,9 +55,9 @@ public abstract class BaseOperator implements Operator {
 
   public abstract Block getNextBlock(BlockId blockId);
 
-  public String getOperatorName() {
-    return _operatorName;
-  }
+  // Enforcing sub-class to implement the getOperatorName(), as they can just return a static final,
+  // as opposed to this super class calling getClass().getSimpleName().
+  public abstract String getOperatorName();
 
   @Override
   public ExecutionStatistics getExecutionStatistics() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineGroupByOperator.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MCombineGroupByOperator extends BaseOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MCombineGroupByOperator.class);
+  private static final String OPERATOR_NAME = "MCombineGroupByOperator";
 
   // TODO: check whether it is better to use thread local.
   // Choose a proper prime number for the number of locks.
@@ -248,6 +249,11 @@ public class MCombineGroupByOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineOperator.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MCombineOperator extends BaseOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MCombineOperator.class);
+  private static final String OPERATOR_NAME = "MCombineOperator";
 
   private final List<Operator> _operators;
   private final BrokerRequest _brokerRequest;
@@ -198,6 +199,11 @@ public class MCombineOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MProjectionOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MProjectionOperator.java
@@ -31,6 +31,7 @@ import java.util.Map;
  *
  */
 public class MProjectionOperator extends BaseOperator {
+  private static final String OPERATOR_NAME = "MProjectionOperator";
 
   private final BReusableFilteredDocIdSetOperator _docIdSetOperator;
   private final Map<String, BaseOperator> _columnToDataSourceMap;
@@ -83,6 +84,11 @@ public class MProjectionOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException("Not supported in MProjectionOperator!");
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   // TODO: remove this method.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/UResultOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/UResultOperator.java
@@ -28,7 +28,7 @@ import com.linkedin.pinot.core.operator.blocks.InstanceResponseBlock;
  *
  */
 public class UResultOperator extends BaseOperator {
-
+  private static final String OPERATOR_NAME = "UResultOperator";
   private final Operator _operator;
 
   public UResultOperator(Operator combinedOperator) {
@@ -49,6 +49,11 @@ public class UResultOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/AndOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/AndOperator.java
@@ -31,6 +31,7 @@ import com.linkedin.pinot.core.operator.docidsets.FilterBlockDocIdSet;
 
 public class AndOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(AndOperator.class);
+  private static final String OPERATOR_NAME = "AndOperator";
 
   private List<Operator> operators;
   private AndBlock andBlock;
@@ -65,5 +66,10 @@ public class AndOperator extends BaseFilterOperator {
       operator.close();
     }
     return true;
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BitmapBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BitmapBasedFilterOperator.java
@@ -33,6 +33,7 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 public class BitmapBasedFilterOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(BitmapBasedFilterOperator.class);
+  private static final String OPERATOR_NAME = "BitmapBasedFilterOperator";
 
   private DataSource dataSource;
   private BitmapBlock bitmapBlock;
@@ -42,7 +43,7 @@ public class BitmapBasedFilterOperator extends BaseFilterOperator {
   private int endDocId;
 
   /**
-   * 
+   *
    * @param dataSource
    * @param startDocId inclusive
    * @param endDocId inclusive
@@ -96,4 +97,8 @@ public class BitmapBasedFilterOperator extends BaseFilterOperator {
     return true;
   }
 
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/CompositeOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/CompositeOperator.java
@@ -24,7 +24,7 @@ import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
 import com.linkedin.pinot.core.operator.blocks.CompositeBaseFilterBlock;
 
 public class CompositeOperator extends BaseFilterOperator{
-
+  private static final String OPERATOR_NAME = "CompositeOperator";
   private List<Operator> operators;
 
   public CompositeOperator(List<Operator> operators) {
@@ -50,4 +50,8 @@ public class CompositeOperator extends BaseFilterOperator{
     return new CompositeBaseFilterBlock(blocks);
   }
 
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/MatchEntireSegmentOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/MatchEntireSegmentOperator.java
@@ -21,7 +21,7 @@ import com.linkedin.pinot.core.operator.blocks.MatchEntireSegmentDocIdSetBlock;
 
 
 public class MatchEntireSegmentOperator extends BaseFilterOperator {
-
+  private static final String OPERATOR_NAME = "MatchEntireSegmentOperator";
   private int _totalDocs;
 
   public MatchEntireSegmentOperator(int totalDocs) {
@@ -41,5 +41,10 @@ public class MatchEntireSegmentOperator extends BaseFilterOperator {
   @Override
   public BaseFilterBlock nextFilterBlock(BlockId blockId) {
     return new MatchEntireSegmentDocIdSetBlock(_totalDocs);
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/OrOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/OrOperator.java
@@ -31,6 +31,7 @@ import com.linkedin.pinot.core.operator.docidsets.FilterBlockDocIdSet;
 
 public class OrOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(OrOperator.class);
+  private static final String OPERATOR_NAME = "OrOperator";
 
   private List<Operator> operators;
   private OrBlock orBlock;
@@ -65,5 +66,10 @@ public class OrOperator extends BaseFilterOperator {
       operator.close();
     }
     return true;
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -37,6 +37,7 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 public class ScanBasedFilterOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ScanBasedFilterOperator.class);
+  private static final String OPERATOR_NAME = "ScanBasedFilterOperator";
 
   private DataSource dataSource;
   private Integer startDocId;
@@ -92,6 +93,11 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
   public boolean close() {
     dataSource.close();
     return true;
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   public static class ScanBlock extends BaseFilterBlock {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
@@ -41,6 +41,7 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SortedInvertedIndexBasedFilterOperator.class);
+  private static final String OPERATOR_NAME = "SortedInvertedIndexBasedFilterOperator";
 
   private DataSource dataSource;
 
@@ -195,6 +196,11 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
   @Override
   public boolean close() {
     return true;
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   public static class SortedBlock extends BaseFilterBlock {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/StarTreeIndexOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/StarTreeIndexOperator.java
@@ -52,6 +52,8 @@ import com.linkedin.pinot.core.operator.docidsets.FilterBlockDocIdSet;
 
 public class StarTreeIndexOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(StarTreeIndexOperator.class);
+  private static final String OPERATOR_NAME = "StarTreeIndexOperator";
+
   private final int numRawDocs;
   private IndexSegment segment;
 
@@ -237,6 +239,12 @@ public class StarTreeIndexOperator extends BaseFilterOperator {
 
   private BaseFilterOperator createFilterOperator(final MutableRoaringBitmap answer) {
     return new BaseFilterOperator() {
+      private static final String OPERATOR_NAME = "Anonymous";
+
+      @Override
+      public String getOperatorName() {
+        return OPERATOR_NAME;
+      }
 
       @Override
       public boolean open() {
@@ -475,6 +483,11 @@ public class StarTreeIndexOperator extends BaseFilterOperator {
     newEntry.remainingPredicateColumns = predicateColumns;
     newEntry.remainingGroupByColumns = groupByColumns;
     searchQueue.add(newEntry);
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   class SearchEntry {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -33,6 +33,8 @@ import javax.annotation.Nonnull;
  * The <code>AggregationOperator</code> class provides the operator for aggregation group-by query on a single segment.
  */
 public class AggregationGroupByOperator extends BaseOperator {
+  private static final String OPERATOR_NAME = "AggregationGroupByOperator";
+
   private final AggregationFunctionContext[] _aggregationFunctionContexts;
   private final GroupBy _groupBy;
   private final int _numGroupsLimit;
@@ -85,6 +87,11 @@ public class AggregationGroupByOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
@@ -32,6 +32,7 @@ import javax.annotation.Nonnull;
  * The <code>AggregationOperator</code> class provides the operator for aggregation only query on a single segment.
  */
 public class AggregationOperator extends BaseOperator {
+  private static final String OPERATOR_NAME = "AggregationOperator";
   private final AggregationFunctionContext[] _aggregationFunctionContexts;
   private final TransformExpressionOperator _transformOperator;
   private final long _numTotalRawDocs;
@@ -78,6 +79,11 @@ public class AggregationOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MSelectionOnlyOperator extends BaseOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MSelectionOnlyOperator.class);
+  private static final String OPERATOR_NAME = "MSelectionOnlyOperator";
 
   private final IndexSegment _indexSegment;
   private final MProjectionOperator _projectionOperator;
@@ -107,6 +108,11 @@ public class MSelectionOnlyOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOrderByOperator.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MSelectionOrderByOperator extends BaseOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MSelectionOrderByOperator.class);
+  private static final String OPERATOR_NAME = "MSelectionOrderByOperator";
 
   private final IndexSegment _indexSegment;
   private final MProjectionOperator _projectionOperator;
@@ -112,6 +113,11 @@ public class MSelectionOrderByOperator extends BaseOperator {
   @Override
   public Block getNextBlock(BlockId blockId) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
@@ -39,6 +39,7 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 
 public class RealtimeColumnDataSource extends DataSource {
+  private static final String OPERATOR_NAME = "RealtimeColumnDataSource";
 
   private static final int REALTIME_DICTIONARY_INIT_ID = 1;
   private Predicate predicate;
@@ -100,6 +101,11 @@ public class RealtimeColumnDataSource extends DataSource {
       blockReturned = false;
     }
     return getBlock();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/AndOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/AndOperatorTest.java
@@ -144,6 +144,13 @@ public class AndOperatorTest {
   public BaseFilterOperator makeFilterOperator(final int[] list) {
 
     return new BaseFilterOperator() {
+      private static final String OPERATOR_NAME = "Anonymous";
+
+      @Override
+      public String getOperatorName() {
+        return OPERATOR_NAME;
+      }
+
       boolean alreadyInvoked = false;
 
       @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/OrOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/OrOperatorTest.java
@@ -133,6 +133,13 @@ public class OrOperatorTest {
 
   public BaseFilterOperator makeFilterOperator(final int[] list) {
     return new BaseFilterOperator() {
+      public static final String OPERATOR_NAME = "Anonymous";
+
+      @Override
+      public String getOperatorName() {
+        return OPERATOR_NAME;
+      }
+
       boolean alreadyInvoked = false;
 
       @Override

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/RawIndexBenchmark.java
@@ -291,6 +291,7 @@ public class RawIndexBenchmark {
    * Helper class to generate doc id's for lookup
    */
   class TestFilterOperator extends BaseFilterOperator {
+    private static final String OPERATOR_NAME = "TestFilterOperator";
     private int[] _filteredDocIds;
 
     public TestFilterOperator(int[] filteredDocIds) {
@@ -310,6 +311,11 @@ public class RawIndexBenchmark {
     @Override
     public boolean close() {
       return true;
+    }
+
+    @Override
+    public String getOperatorName() {
+      return OPERATOR_NAME;
     }
   }
 


### PR DESCRIPTION
The current code calls getSimpleName() for each operator, for each
segment, for each query, and thus starts showing up in CPU profiles.
This change fixes the issue as follows:

1. In BaseOperator class, remove the call to getSimpleName(), and make
getOperatorName() abstract, thus enforcing sub classes to implement it.

2. All sub classes have a static final string as their name, that is
returned by their implementation of getOperatorName().