### PR TITLE
Prefetch mmap data during segment load time

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
@@ -27,9 +27,7 @@ import com.linkedin.pinot.core.io.reader.impl.FixedByteSingleValueMultiColReader
 import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitMultiValueReader;
 import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitSingleValueReader;
 import com.linkedin.pinot.core.io.reader.impl.v1.FixedByteChunkSingleValueReader;
-import com.linkedin.pinot.core.io.reader.impl.v1.FixedByteSingleValueReader;
 import com.linkedin.pinot.core.io.reader.impl.v1.VarByteChunkSingleValueReader;
-import com.linkedin.pinot.core.segment.creator.impl.fwd.SingleValueFixedByteRawIndexCreator;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.readers.BitmapInvertedIndexReader;
 import com.linkedin.pinot.core.segment.index.readers.DoubleDictionary;
@@ -68,14 +66,11 @@ public abstract class ColumnIndexContainer {
 
     if (metadata.isSorted() && metadata.isSingleValue()) {
       return loadSorted(column, segmentReader, metadata, dictionary);
-      //return loadSorted(column, indexDir, metadata, dictionary, mode);
     }
 
     if (metadata.isSingleValue()) {
       return loadUnsorted(column, segmentReader, metadata, dictionary, loadInverted);
-      //return loadUnsorted(column, indexDir, metadata, dictionary, mode, loadInverted);
     }
-    //return loadMultiValue(column, indexDir, metadata, dictionary, mode, loadInverted);
     return loadMultiValue(column, segmentReader, metadata, dictionary, loadInverted);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -37,6 +38,13 @@ import org.slf4j.LoggerFactory;
 
 class SegmentLocalFSDirectory extends SegmentDirectory {
   private static Logger LOGGER = LoggerFactory.getLogger(SegmentLocalFSDirectory.class);
+
+  // matches most systems
+  private static final int PAGE_SIZE_BYTES = 4096;
+  // Prefetch limit...arbitrary but related to common server memory and data size profiles
+  private static final long MAX_MMAP_PREFETCH_PAGES = 100 * 1024 * 1024 * 1024L / PAGE_SIZE_BYTES;
+  private static final double PREFETCH_SLOWDOWN_PCT = 0.67;
+  private static AtomicLong prefetchedPages = new AtomicLong(0);
 
   private final File segmentDirectory;
   SegmentLock segmentLock;
@@ -215,15 +223,61 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
 
   private PinotDataBuffer getIndexForColumn(String column, ColumnIndexType type)
       throws IOException {
+    PinotDataBuffer buffer;
     switch (type) {
       case DICTIONARY:
-        return columnIndexDirectory.getDictionaryBufferFor(column);
+        buffer = columnIndexDirectory.getDictionaryBufferFor(column);
+        break;
       case FORWARD_INDEX:
-        return columnIndexDirectory.getForwardIndexBufferFor(column);
+        buffer = columnIndexDirectory.getForwardIndexBufferFor(column);
+        break;
       case INVERTED_INDEX:
-        return columnIndexDirectory.getInvertedIndexBufferFor(column);
+        buffer = columnIndexDirectory.getInvertedIndexBufferFor(column);
+        break;
       default:
         throw new RuntimeException("Unknown index type: " + type.name());
+    }
+    if (readMode == ReadMode.mmap) {
+      prefetchMmapData(buffer);
+    }
+    return buffer;
+  }
+
+  private void prefetchMmapData(PinotDataBuffer buffer) {
+    // mmap mode causes high number of major page faults after server restart.
+    // This impacts latency especially for prod "online" use cases that require low latency.
+    // This function proactively loads pages in memory to lower the variance in
+    // latencies after server startup.
+
+    // This has to handle two different data size profiles
+    // 1. Servers with data size close to main memory size
+    // 2. Servers with very large data sizes (terabytes)
+    // To prevent it from loading terabytes of data on startup, we put a limit
+    // on the number of pages this will prefetch (OS will do something more on top of this)
+    // The logic here is as follows:
+    // Server doesn't know total data size it is expected to serve. So this will
+    // load all data till 2/3rd (PREFETCH_SLOWDOWN_PCT) of the configured limit. After that it will only
+    // read the header page. We read headers because that has more frequently accessed
+    // information which will have bigger impact on the latency. This can go over the limit
+    // because it doesn't stop at any point. But that's not an issue considering this is
+    // an optimization.
+
+    // Prefetch limit and slowdown percentage are arbitrary
+    if (prefetchedPages.get() >= MAX_MMAP_PREFETCH_PAGES) {
+      return;
+    }
+
+    final long prefetchSlowdownPageLimit = (long) (PREFETCH_SLOWDOWN_PCT * MAX_MMAP_PREFETCH_PAGES);
+    if (prefetchedPages.get() >= prefetchSlowdownPageLimit) {
+      buffer.getByte(0);
+      prefetchedPages.incrementAndGet();
+    } else {
+      // pos needs to be long because buffer.size() is 32 bit but
+      // adding 4k can make it go over int size
+      for (long pos = 0; pos < buffer.size() && prefetchedPages.get() < prefetchSlowdownPageLimit; pos += PAGE_SIZE_BYTES) {
+        buffer.getByte((int)pos);
+        prefetchedPages.incrementAndGet();
+      }
     }
   }
 


### PR DESCRIPTION
Server restarts impact latencies for mmap data especially
for online, low latency use cases. This commit will proactively
fetch mmap pages to memory during segment load time, slowing down
to prefetch only header pages after a point and stopping at configured
limit. Limits are imposed to handle large data sizes to avoid prefetching
terabytes of data.