### PR TITLE
Remove redundant data member from BaseOperator class.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BaseOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BaseOperator.java
@@ -29,15 +29,13 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseOperator implements Operator {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseOperator.class);
 
-  private final String _operatorName = getOperatorName();
-
   @Override
   public final Block nextBlock() {
     long start = System.currentTimeMillis();
     Block ret = getNextBlock();
     long end = System.currentTimeMillis();
-    LOGGER.trace("Time spent in {}: {}", _operatorName, (end - start));
-    TraceContext.logLatency(_operatorName, (end - start));
+    LOGGER.trace("Time spent in {}: {}", getOperatorName(), (end - start));
+    TraceContext.logLatency(getOperatorName(), (end - start));
     return ret;
   }
 
@@ -46,8 +44,8 @@ public abstract class BaseOperator implements Operator {
     long start = System.currentTimeMillis();
     Block ret = getNextBlock(blockId);
     long end = System.currentTimeMillis();
-    LOGGER.trace("Time spent in {}: {}", _operatorName, (end - start));
-    TraceContext.logLatency(_operatorName, (end - start));
+    LOGGER.trace("Time spent in {}: {}", getOperatorName(), (end - start));
+    TraceContext.logLatency(getOperatorName(), (end - start));
     return ret;
   }
 


### PR DESCRIPTION
Remove the _operatorName data member from this class, and replace it
with getOperatorName() method call. This avoids storing the information
in multiple places.