### PR TITLE
Fix service status NPE

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
@@ -122,6 +122,11 @@ public class ServiceStatus {
         }
 
         for (String partition : idealState.getPartitionSet()) {
+          // If this partition is not in the external view, then it hasn't finished starting up
+          if (!externalView.getPartitionSet().contains(partition)) {
+            return Status.STARTING;
+          }
+
           String idealStateStatus = idealState.getInstanceStateMap(partition).get(_instanceName);
           String externalViewStatus = externalView.getStateMap(partition).get(_instanceName);
 


### PR DESCRIPTION
Fix the service status API throwing NPE if there are zero replicas for
a segment.