### PR TITLE
Fix routing table unload from broker

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
@@ -74,13 +74,13 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeOnlineFromOffline() : " + message);
         Builder keyBuilder = _helixManager.getHelixDataAccessor().keyBuilder();
-        String resourceName = message.getPartitionName();
+        String tableName = message.getPartitionName();
         HelixDataAccessor helixDataAccessor = _helixManager.getHelixDataAccessor();
         List<InstanceConfig> instanceConfigList = helixDataAccessor.getChildValues(keyBuilder.instanceConfigs());
 
         _helixExternalViewBasedRouting.markDataResourceOnline(
-            resourceName,
-            HelixHelper.getExternalViewForResource(_helixAdmin, _helixManager.getClusterName(), resourceName),
+            tableName,
+            HelixHelper.getExternalViewForResource(_helixAdmin, _helixManager.getClusterName(), tableName),
             instanceConfigList);
       } catch (Exception e) {
         LOGGER.error("Caught exception during OFFLINE -> ONLINE transition", e);
@@ -95,8 +95,8 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeOfflineFromOnline() : " + message);
-        String resourceName = message.getResourceName();
-        _helixExternalViewBasedRouting.markDataResourceOffline(resourceName);
+        String tableName = message.getPartitionName();
+        _helixExternalViewBasedRouting.markDataResourceOffline(tableName);
       } catch (Exception e) {
         LOGGER.error("Caught exception during ONLINE -> OFFLINE transition", e);
         Utils.rethrowException(e);
@@ -110,8 +110,8 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeDroppedFromOffline() : " + message);
-        String resourceName = message.getResourceName();
-        _helixExternalViewBasedRouting.markDataResourceOffline(resourceName);
+        String tableName = message.getPartitionName();
+        _helixExternalViewBasedRouting.markDataResourceOffline(tableName);
       } catch (Exception e) {
         LOGGER.error("Caught exception during OFFLINE -> DROPPED transition", e);
         Utils.rethrowException(e);
@@ -125,8 +125,8 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeDroppedFromOnline() : " + message);
-        String resourceName = message.getResourceName();
-        _helixExternalViewBasedRouting.markDataResourceOffline(resourceName);
+        String tableName = message.getPartitionName();
+        _helixExternalViewBasedRouting.markDataResourceOffline(tableName);
       } catch (Exception e) {
         LOGGER.error("Caught exception during ONLINE -> DROPPED transition", e);
         Utils.rethrowException(e);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.File;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -34,8 +35,10 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.ExternalView;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,7 +50,6 @@ import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.util.TestUtils;
-import junit.framework.Assert;
 import kafka.server.KafkaServerStartable;
 
 
@@ -328,6 +330,31 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
 
   @AfterClass
   public void tearDown() throws Exception {
+    // Try deleting the tables and check that they have no routing table
+    dropOfflineTable(getTableName());
+    dropRealtimeTable(getTableName());
+
+    long endTime = System.currentTimeMillis() + 15000;
+    boolean isRoutingTableEmpty = false;
+    JSONObject routingTableSnapshot = null;
+    while (System.currentTimeMillis() < endTime) {
+      try {
+        routingTableSnapshot = getDebugInfo("debug/routingTable/" + getTableName());
+
+        if (routingTableSnapshot.getJSONArray("routingTableSnapshot").length() == 0) {
+          isRoutingTableEmpty = true;
+          break;
+        }
+      } catch (Exception e) {
+        // Will retry in a bit
+      }
+
+      Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
+    }
+
+    Assert.assertTrue(isRoutingTableEmpty,
+        "Routing table is not empty, last snapshot is " + routingTableSnapshot.toString());
+
     stopBroker();
     stopController();
     stopServer();


### PR DESCRIPTION
Fix the routing table unload from brokers by passing in the correct
table name instead of "brokerResource."