### PR TITLE
[PINOT-4406] Optimize idealstate updates when deleting segments from same table

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -15,6 +15,42 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Predicate;
+import org.apache.commons.lang.StringUtils;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ClusterMessagingService;
+import org.apache.helix.Criteria;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
@@ -62,44 +98,8 @@ import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
 import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
 import com.linkedin.pinot.controller.helix.starter.HelixConfig;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.lang.StringUtils;
-import org.apache.helix.AccessOption;
-import org.apache.helix.ClusterMessagingService;
-import org.apache.helix.Criteria;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.HelixManager;
-import org.apache.helix.InstanceType;
-import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.model.CurrentState;
-import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.model.InstanceConfig;
-import org.apache.helix.model.LiveInstance;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.json.JSONException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class PinotHelixResourceManager {
@@ -375,9 +375,7 @@ public class PinotHelixResourceManager {
     final PinotResourceManagerResponse res = new PinotResourceManagerResponse();
     try {
       HelixHelper.removeSegmentsFromIdealState(_helixZkManager, tableName, segments);
-      for (String segment : segments) {
-        _segmentDeletionManager.deleteSegment(tableName, segment);
-      }
+      _segmentDeletionManager.deleteSegments(tableName, segments);
 
       res.message += "Segment " + StringUtils.join(segments, ',') + " successfully deleted.";
       res.status = ResponseStatus.success;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -117,7 +117,7 @@ public class SegmentDeletionManager {
     }
 
     int nSegmentsDeleted = 0;
-    if (segmentsToDelete.size() > 0) {
+    if (!segmentsToDelete.isEmpty()) {
       for (String segmentId : segmentsToDelete) {
         String segmentPropertyStorePath = ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segmentId);
         LOGGER.info("Trying to delete segment : {} from Property store.", segmentId);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -17,6 +17,8 @@ package com.linkedin.pinot.controller.helix.core;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -26,6 +28,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,14 +38,10 @@ import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.SegmentName;
 
-
-/**
- *
- */
 public class SegmentDeletionManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentDeletionManager.class);
-  private static final long MAX_DELETION_DELAY_SECONDS = 3600L;
+  private static final long MAX_DELETION_DELAY_SECONDS = 300L;  // Maximum of 5 minutes back-off to retry the deletion
   private static final long DEFAULT_DELETION_DELAY_SECONDS = 2L;
 
   private final ScheduledExecutorService _executorService;
@@ -51,7 +51,7 @@ public class SegmentDeletionManager {
   private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private final String DELETED_SEGMENTS = "Deleted_Segments";
 
-  SegmentDeletionManager(String localDiskDir, HelixAdmin helixAdmin, String helixClusterName, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  public SegmentDeletionManager(String localDiskDir, HelixAdmin helixAdmin, String helixClusterName, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _localDiskDir = localDiskDir;
     _helixAdmin = helixAdmin;
     _helixClusterName = helixClusterName;
@@ -71,108 +71,113 @@ public class SegmentDeletionManager {
     _executorService.shutdownNow();
   }
 
-  public void deleteSegment(final String tableName, final String segmentId) {
-    deleteSegmentWithDelay(tableName, segmentId, DEFAULT_DELETION_DELAY_SECONDS);
+  public void deleteSegments(final String tableName, final List<String> segmentIds) {
+    deleteSegmentsWithDelay(tableName, segmentIds, DEFAULT_DELETION_DELAY_SECONDS);
   }
 
-  private void deleteSegmentWithDelay(final String tableName, final String segmentId, final long deletionDelaySeconds) {
+  protected void deleteSegmentsWithDelay(final String tableName, final List<String> segmentIds,
+      final long deletionDelaySeconds) {
     _executorService.schedule(new Runnable() {
       @Override
       public void run() {
-        deleteSegmentFromPropertyStoreAndLocal(tableName, segmentId, deletionDelaySeconds);
+        deleteSegmentFromPropertyStoreAndLocal(tableName, segmentIds, deletionDelaySeconds);
       }
     }, deletionDelaySeconds, TimeUnit.SECONDS);
   }
 
-  /**
-   * Check if segment got deleted from IdealStates and ExternalView.
-   * If segment got removed, then delete this segment from PropertyStore and local disk.
-   *
-   * @param tableName
-   * @param segmentId
-   */
-  private synchronized void deleteSegmentFromPropertyStoreAndLocal(String tableName, String segmentId, long deletionDelay) {
+  protected synchronized void deleteSegmentFromPropertyStoreAndLocal(String tableName, List<String> segmentIds, long deletionDelay) {
     // Check if segment got removed from ExternalView and IdealStates
-    if (_helixAdmin.getResourceExternalView(_helixClusterName, tableName) == null ||
-        _helixAdmin.getResourceIdealState(_helixClusterName, tableName) == null) {
+    if (_helixAdmin.getResourceExternalView(_helixClusterName, tableName) == null
+        || _helixAdmin.getResourceIdealState(_helixClusterName, tableName) == null) {
       LOGGER.warn("Resource: {} is not set up in idealState or ExternalView, won't do anything", tableName);
       return;
     }
 
-    boolean isSegmentReadyToDelete = false;
+    List<String> segmentsToDelete = new ArrayList<>(segmentIds.size());
+    List<String> segmentsToRetryLater = new ArrayList<>(segmentIds.size());
+
     try {
-      Map<String, String> segmentToInstancesMapFromExternalView = _helixAdmin.getResourceExternalView(_helixClusterName, tableName).getStateMap(segmentId);
-      Map<String, String> segmentToInstancesMapFromIdealStates = _helixAdmin.getResourceIdealState(_helixClusterName, tableName).getInstanceStateMap(segmentId);
-      if ((segmentToInstancesMapFromExternalView == null || segmentToInstancesMapFromExternalView.isEmpty())
-          && (segmentToInstancesMapFromIdealStates == null || segmentToInstancesMapFromIdealStates.isEmpty())) {
-        isSegmentReadyToDelete = true;
-      } else {
-        long effectiveDeletionDelay = Math.min(deletionDelay * 2, MAX_DELETION_DELAY_SECONDS);
-        LOGGER.info("Segment: {} is still in IdealStates: {} or ExternalView: {}, will retry in {} seconds.", segmentId,
-            segmentToInstancesMapFromIdealStates, segmentToInstancesMapFromExternalView, effectiveDeletionDelay);
-        deleteSegmentWithDelay(tableName, segmentId, effectiveDeletionDelay);
-        return;
+      ExternalView externalView = _helixAdmin.getResourceExternalView(_helixClusterName, tableName);
+      IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableName);
+
+      for (String segmentId : segmentIds) {
+        Map<String, String> segmentToInstancesMapFromExternalView = externalView.getStateMap(segmentId);
+        Map<String, String> segmentToInstancesMapFromIdealStates = idealState.getInstanceStateMap(segmentId);
+        if ((segmentToInstancesMapFromExternalView == null || segmentToInstancesMapFromExternalView.isEmpty()) && (
+            segmentToInstancesMapFromIdealStates == null || segmentToInstancesMapFromIdealStates.isEmpty())) {
+          segmentsToDelete.add(segmentId);
+        } else {
+          segmentsToRetryLater.add(segmentId);
+        }
       }
     } catch (Exception e) {
-      LOGGER.warn("Caught exception while processing segment " + segmentId, e);
-      isSegmentReadyToDelete = true;
+      LOGGER.warn("Caught exception while checking helix states for table {} " + tableName, e);
+      segmentsToDelete = segmentIds;
+      segmentsToRetryLater.clear();
     }
 
-    if (isSegmentReadyToDelete) {
-      String segmentPropertyStorePath = ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segmentId);
-      LOGGER.info("Trying to delete segment : {} from Property store.", segmentId);
-      boolean deletionFromPropertyStoreSuccessful = true;
-      if (_propertyStore.exists(segmentPropertyStorePath, AccessOption.PERSISTENT)) {
-        deletionFromPropertyStoreSuccessful = _propertyStore.remove(segmentPropertyStorePath, AccessOption.PERSISTENT);
-      }
+    int nSegmentsDeleted = 0;
+    if (segmentsToDelete.size() > 0) {
+      for (String segmentId : segmentsToDelete) {
+        String segmentPropertyStorePath = ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segmentId);
+        LOGGER.info("Trying to delete segment : {} from Property store.", segmentId);
+        boolean deletionFromPropertyStoreSuccessful = true;
+        if (_propertyStore.exists(segmentPropertyStorePath, AccessOption.PERSISTENT)) {
+          deletionFromPropertyStoreSuccessful = _propertyStore.remove(segmentPropertyStorePath, AccessOption.PERSISTENT);
+        }
 
-      if (!deletionFromPropertyStoreSuccessful) {
-        long effectiveDeletionDelay = Math.min(deletionDelay * 2, MAX_DELETION_DELAY_SECONDS);
-        LOGGER.warn("Failed to delete segment {} from property store, will retry in {} seconds.", segmentId,
-            effectiveDeletionDelay);
-        deleteSegmentWithDelay(tableName, segmentId, effectiveDeletionDelay);
-        return;
-      }
-
-      final String rawTableName = TableNameBuilder.extractRawTableName(tableName);
-      if (_localDiskDir != null) {
-        File fileToMove = new File(new File(_localDiskDir, rawTableName), segmentId);
-        if (fileToMove.exists()) {
-          File targetDir = new File(new File(_localDiskDir, DELETED_SEGMENTS), rawTableName);
-          try {
-            // Overwrites the file if it already exists in the target directory.
-            FileUtils.copyFileToDirectory(fileToMove, targetDir, true);
-            LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(),
-                targetDir.getAbsolutePath());
-            if (!fileToMove.delete()) {
-              LOGGER.warn("Could not delete file", segmentId, fileToMove.getAbsolutePath());
-            }
-          } catch (IOException e) {
-            LOGGER.warn("Could not move segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(),
-                targetDir.getAbsolutePath(), e);
-          }
+        if (deletionFromPropertyStoreSuccessful) {
+          removeSegmentFromStore(tableName, segmentId);
+          nSegmentsDeleted++;
         } else {
-          CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
-          switch (tableType) {
-            case OFFLINE:
-              LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
-              break;
-            case REALTIME:
-              if (SegmentName.isLowLevelConsumerSegmentName(segmentId)) {
-                LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
-              }
-              break;
-            default:
-              LOGGER.warn("Unsupported table type {} when deleting segment {}", tableType, segmentId);
+          segmentsToRetryLater.add(segmentId);
+        }
+      }
+    }
+
+    LOGGER.info("Deleted {} segments from table {}", nSegmentsDeleted, tableName);
+
+    if (segmentsToRetryLater.size() > 0) {
+      long effectiveDeletionDelay = Math.min(deletionDelay * 2, MAX_DELETION_DELAY_SECONDS);
+      LOGGER.info("Postponing deletion of {} segments from table {}", nSegmentsDeleted, tableName);
+      deleteSegmentsWithDelay(tableName, segmentsToRetryLater, effectiveDeletionDelay);
+      return;
+    }
+  }
+
+  protected void removeSegmentFromStore(String tableName, String segmentId) {
+    final String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    if (_localDiskDir != null) {
+      File fileToMove = new File(new File(_localDiskDir, rawTableName), segmentId);
+      if (fileToMove.exists()) {
+        File targetDir = new File(new File(_localDiskDir, DELETED_SEGMENTS), rawTableName);
+        try {
+          // Overwrites the file if it already exists in the target directory.
+          FileUtils.copyFileToDirectory(fileToMove, targetDir, true);
+          LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(), targetDir.getAbsolutePath());
+          if (!fileToMove.delete()) {
+            LOGGER.warn("Could not delete file", segmentId, fileToMove.getAbsolutePath());
           }
+        } catch (IOException e) {
+          LOGGER.warn("Could not move segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(), targetDir.getAbsolutePath(), e);
         }
       } else {
-        LOGGER.info("localDiskDir is not configured, won't delete segment {} from disk", segmentId);
+        CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+        switch (tableType) {
+          case OFFLINE:
+            LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
+            break;
+          case REALTIME:
+            if (SegmentName.isLowLevelConsumerSegmentName(segmentId)) {
+              LOGGER.warn("Not found local segment file for segment {}" + fileToMove.getAbsolutePath());
+            }
+            break;
+          default:
+            LOGGER.warn("Unsupported table type {} when deleting segment {}", tableType, segmentId);
+        }
       }
     } else {
-      long effectiveDeletionDelay = Math.min(deletionDelay * 2, MAX_DELETION_DELAY_SECONDS);
-      LOGGER.info("Segment: {} is still in IdealStates or ExternalView, will retry in {} seconds.", segmentId, effectiveDeletionDelay);
-      deleteSegmentWithDelay(tableName, segmentId, effectiveDeletionDelay);
+      LOGGER.info("localDiskDir is not configured, won't delete segment {} from disk", segmentId);
     }
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/PinotResourceManagerTest.java
@@ -18,26 +18,21 @@ package com.linkedin.pinot.controller.helix;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
-import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
@@ -203,11 +198,9 @@ public class PinotResourceManagerTest {
           _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME,
               TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(TABLE_NAME));
 
-      for (final String segmentId : externalView.getPartitionSet()) {
-        deleteOneSegment(TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(TABLE_NAME), segmentId);
-        // Waiting for the external view to update
-        Thread.sleep(2000);
-      }
+      List<String> segmentsList = new ArrayList<>(externalView.getPartitionSet().size());
+      segmentsList.addAll(externalView.getPartitionSet());
+      _pinotHelixResourceManager.deleteSegments(TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(TABLE_NAME), segmentsList);
     }
     assert(!segmentFile.exists());
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.controller.helix.core.SegmentDeletionManager;
+import junit.framework.Assert;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class SegmentDeletionManagerTest {
+  final static String tableName = "table";
+  final static String clusterName = "mock";
+
+  HelixAdmin makeHelixAdmin() {
+    HelixAdmin admin = mock(HelixAdmin.class);
+    ExternalView ev = mock(ExternalView.class);
+    IdealState is = mock(IdealState.class);
+    when(admin.getResourceExternalView(clusterName, tableName)).thenReturn(ev);
+    when(admin.getResourceIdealState(clusterName, tableName)).thenReturn(is);
+
+    List<String> segmentsInIs = segmentsInIdealStateOrExtView();
+    Map<String, String> dummy = new HashMap<>(1);
+    dummy.put("someHost", "ONLINE");
+    for (String segment : segmentsInIs) {
+      when(is.getInstanceStateMap(segment)).thenReturn(dummy);
+    }
+    when(ev.getStateMap(anyString())).thenReturn(null);
+
+    return admin;
+  }
+
+  ZkHelixPropertyStore<ZNRecord> makePropertyStore() {
+    ZkHelixPropertyStore store = mock(ZkHelixPropertyStore.class);
+    List<String> failedSegs = segmentsFailingPropStore();
+    for (String segment : failedSegs) {
+      String propStorePath = ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segment);
+      when(store.remove(propStorePath, AccessOption.PERSISTENT)).thenReturn(false);
+    }
+    List<String> successfulSegs = segmentsThatShouldBeDeleted();
+    for (String segment : successfulSegs) {
+      String propStorePath = ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segment);
+      when(store.remove(propStorePath, AccessOption.PERSISTENT)).thenReturn(true);
+    }
+
+    when(store.exists(anyString(), anyInt())).thenReturn(true);
+    return store;
+  }
+
+  List<String> segmentsThatShouldBeDeleted() {
+    List<String> result = new ArrayList<>(3);
+    result.add("seg1");
+    result.add("seg2");
+    result.add("seg3");
+    return result;
+  }
+
+  List<String> segmentsInIdealStateOrExtView() {
+    List<String> result = new ArrayList<>(3);
+    result.add("seg11");
+    result.add("seg12");
+    result.add("seg13");
+    return result;
+  }
+
+  List<String> segmentsFailingPropStore() {
+    List<String> result = new ArrayList<>(3);
+    result.add("seg21");
+    result.add("seg22");
+    result.add("seg23");
+    return result;
+  }
+
+  @Test
+  public void testBulkDeleteWithFailures() throws Exception {
+    HelixAdmin helixAdmin =  makeHelixAdmin();
+    ZkHelixPropertyStore<ZNRecord> propertyStore = makePropertyStore();
+    FakeDeletionManager deletionManager = new FakeDeletionManager(helixAdmin, propertyStore);
+    List<String> segments = segmentsThatShouldBeDeleted();
+    segments.addAll(segmentsInIdealStateOrExtView());
+    segments.addAll(segmentsFailingPropStore());
+    deletionManager.deleteSegmenetsFromPropertyStoreAndLocal(tableName, segments);
+
+    for (String segment : segmentsFailingPropStore()) {
+      Assert.assertTrue(deletionManager.segmentsToRetry.contains(segment));
+    }
+
+    for (String segment : segmentsInIdealStateOrExtView()) {
+      Assert.assertTrue(deletionManager.segmentsToRetry.contains(segment));
+    }
+
+    for (String segment : segmentsThatShouldBeDeleted()) {
+      Assert.assertTrue(deletionManager.segmentsRemovedFromStore.contains(segment));
+    }
+  }
+
+  public static class FakeDeletionManager extends SegmentDeletionManager {
+
+    public Set<String> segmentsRemovedFromStore = new HashSet<>();
+    public Set<String> segmentsToRetry = new HashSet<>();
+
+    FakeDeletionManager(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+      super(null, helixAdmin, clusterName, propertyStore);
+    }
+
+    public void deleteSegmenetsFromPropertyStoreAndLocal(String tableName, List<String> segments) {
+      super.deleteSegmentFromPropertyStoreAndLocal(tableName, segments, 0L);
+    }
+
+    @Override
+    protected void removeSegmentFromStore(String tableName, String segmentId) {
+      segmentsRemovedFromStore.add(segmentId);
+    }
+    @Override
+    protected void deleteSegmentsWithDelay(final String tableName, final List<String> segmentIds,
+        final long deletionDelaySeconds) {
+      segmentsToRetry.addAll(segmentIds);
+    }
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -17,6 +17,7 @@
 package com.linkedin.pinot.controller.helix.core.util;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -188,7 +189,7 @@ public class SegmentDeletionManagerTest {
       segmentsRemovedFromStore.add(segmentId);
     }
     @Override
-    protected void deleteSegmentsWithDelay(final String tableName, final List<String> segmentIds,
+    protected void deleteSegmentsWithDelay(final String tableName, final Collection<String> segmentIds,
         final long deletionDelaySeconds) {
       segmentsToRetry.addAll(segmentIds);
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -125,10 +125,22 @@ public class SegmentDeletionManagerTest {
 
   @Test
   public void testBulkDeleteWithFailures() throws Exception {
+    testBulkDeleteWithFailures(true);
+    testBulkDeleteWithFailures(false);
+  }
+
+  public void testBulkDeleteWithFailures(boolean useSet) throws Exception {
     HelixAdmin helixAdmin =  makeHelixAdmin();
     ZkHelixPropertyStore<ZNRecord> propertyStore = makePropertyStore();
     FakeDeletionManager deletionManager = new FakeDeletionManager(helixAdmin, propertyStore);
-    List<String> segments = segmentsThatShouldBeDeleted();
+    Collection<String> segments;
+    if (useSet) {
+      segments = new HashSet<String>();
+    } else {
+      segments = new ArrayList<String>();
+    }
+
+    segments.addAll(segmentsThatShouldBeDeleted());
     segments.addAll(segmentsInIdealStateOrExtView());
     segments.addAll(segmentsFailingPropStore());
     deletionManager.deleteSegmenetsFromPropertyStoreAndLocal(tableName, segments);
@@ -152,7 +164,8 @@ public class SegmentDeletionManagerTest {
     HelixAdmin helixAdmin =  makeHelixAdmin();
     ZkHelixPropertyStore<ZNRecord> propertyStore = makePropertyStore();
     FakeDeletionManager deletionManager = new FakeDeletionManager(helixAdmin, propertyStore);
-    List<String> segments = segmentsThatShouldBeDeleted();
+    Set<String> segments = new HashSet<>();
+    segments.addAll(segmentsThatShouldBeDeleted());
     deletionManager.deleteSegmenetsFromPropertyStoreAndLocal(tableName, segments);
 
     Assert.assertEquals(deletionManager.segmentsToRetry.size(), 0);
@@ -180,7 +193,7 @@ public class SegmentDeletionManagerTest {
       super(null, helixAdmin, clusterName, propertyStore);
     }
 
-    public void deleteSegmenetsFromPropertyStoreAndLocal(String tableName, List<String> segments) {
+    public void deleteSegmenetsFromPropertyStoreAndLocal(String tableName, Collection<String> segments) {
       super.deleteSegmentFromPropertyStoreAndLocal(tableName, segments, 0L);
     }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.controller.helix.retention;
 
-import com.linkedin.pinot.common.data.MetricFieldSpec;
-import com.linkedin.pinot.core.startree.hll.HllConstants;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -40,6 +38,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
@@ -53,6 +52,7 @@ import com.linkedin.pinot.controller.helix.core.retention.RetentionManager;
 import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.startree.hll.HllConstants;
 import javax.annotation.Nullable;
 
 
@@ -113,9 +113,7 @@ public class RetentionManagerTest {
 
   public void cleanupSegments() throws InterruptedException {
     _retentionManager.stop();
-    for (String segmentId : _pinotHelixResourceManager.getAllSegmentsForResource(_offlineTableName)) {
-      _pinotHelixResourceManager.deleteSegment(_offlineTableName, segmentId);
-    }
+    _pinotHelixResourceManager.deleteSegments(_offlineTableName, _pinotHelixResourceManager.getAllSegmentsForResource(_offlineTableName));
     while (_helixZkManager.getHelixPropertyStore()
         .getChildNames(ZKMetadataProvider.constructPropertyStorePathForResource(_offlineTableName),
             AccessOption.PERSISTENT)


### PR DESCRIPTION
It is likely that segments from the same table expire at the same time. Instead
of handling each segment independently, group the deletes of multiple
segments within the same table.