### PR TITLE
Fix DST issue in query result parser

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/TimeRangeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/TimeRangeUtils.java
@@ -63,21 +63,23 @@ public class TimeRangeUtils {
   }
 
   /**
-   * Given time granularity and start time (with correct time zone information), returns the bucket
-   * index of the current time (with correct time zone information).
+   * Given time granularity and start time (with local time zone information), returns the bucket
+   * index of the current time (with local time zone information).
    *
    * The reason to use this method to calculate the bucket index is to align the shifted data point
-   * due to daylight saving time to the correct bucket. Note that this method have no effect if
-   * the input time use UTC timezone.
+   * due to daylight saving time to the correct bucket index. Note that this method have no effect
+   * if the input time use UTC timezone.
    *
-   * For instance, considering March 13th 2016, when DST takes effect. When we processing daily
-   * data, whose timestamp is aligned at 0 am at each day. The data point on March 14th would be
-   * actually aligned to 13th's bucket because the two data point only has 23 hours difference.
-   * Therefore, we cannot calculate the bucket index simply divide the timestamp by millis of 24
-   * hours.
+   * For instance, considering March 13th 2016, the day DST takes effect. Assume that our daily
+   * data whose timestamp is aligned at 0 am at each day, then the data point on March 14th would
+   * be actually aligned to 13th's bucket. Because the two data point only has 23 hours difference.
+   * Therefore, we cannot calculate the bucket index simply divide the difference between timestamps
+   * by millis of 24 hours.
    *
-   * We don't check for granularity finer than DAYS because those granularity has lose precision on
-   * timestamp and the alignment doesn't help much in comparison with the default case.
+   * We don't need to consider the case of HOURS because the size of a bucket does not change when
+   * the time granularity is smaller than DAYS. In DAYS, the bucket size could be 23, 24, or 25
+   * hours due to DST. In HOURS or anything smaller, the bucket size does not change. Hence, we
+   * simply compute the bucket index using one fixed bucket size (i.e., interval).
    *
    * @param granularity the time granularity of the bucket
    * @param start the start time of the first bucket

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/TimeRangeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/TimeRangeUtils.java
@@ -88,7 +88,7 @@ public class TimeRangeUtils {
     int index = -1;
     switch (granularity.getUnit()) {
     case DAYS:
-      Days d = Days.daysBetween(start, current);
+      Days d = Days.daysBetween(start.toLocalDate(), current.toLocalDate());
       index = d.getDays() / granularity.getSize();
       break;
     default:

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.client.pinot;
 
+import com.linkedin.thirdeye.client.TimeRangeUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -14,6 +15,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
@@ -178,7 +180,8 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
     String collection = datasetConfig.getDataset();
     TimeGranularity dataGranularity = null;
     long startTime = request.getStartTimeInclusive().getMillis();
-    long interval = -1;
+    DateTimeZone dateTimeZone = Utils.getDataTimeZone(collection);
+    DateTime startDateTime = new DateTime(startTime, dateTimeZone);
     TimeSpec timespec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
     dataGranularity = timespec.getDataGranularity();
     boolean isISOFormat = false;
@@ -186,11 +189,10 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
     String timeFormat = timespec.getFormat();
     if (timeFormat != null && !timeFormat.equals(TimeSpec.SINCE_EPOCH_FORMAT)) {
       isISOFormat = true;
-      inputDataDateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZone(Utils.getDataTimeZone(collection));
+      inputDataDateTimeFormatter = DateTimeFormat.forPattern(timeFormat).withZone(dateTimeZone);
     }
     if (request.getGroupByTimeGranularity() != null) {
       hasGroupByTime = true;
-      interval = request.getGroupByTimeGranularity().toMillis();
     }
     LinkedHashMap<String, String[]> dataMap = new LinkedHashMap<>();
     for (int i = 0; i < resultSets.size(); i++) {
@@ -216,7 +218,9 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
                 skipRowDueToError = true;
                 break;
               }
-              timeBucket = (int) ((millis - startTime) / interval);
+              timeBucket = TimeRangeUtils
+                  .computeBucketIndex(request.getGroupByTimeGranularity(), startDateTime,
+                      new DateTime(millis, dateTimeZone));
               groupKeyVal = String.valueOf(timeBucket);
             }
             groupKeys[grpKeyIdx] = groupKeyVal;


### PR DESCRIPTION
The reason to use create this method is to calculate the bucket index is to align the shifted data point due to daylight saving time to the correct bucket. Note that this method have no effect if the input time use UTC timezone.

An example issue: Considering March 13th 2016, when DST takes effect. When we processing daily data, whose timestamp is aligned at 0 am at each day. The data point on March 14th would be actually aligned to 13th's bucket because the two data point only has 23 hours difference. Therefore, we cannot calculate the bucket index simply divide the timestamp by milliseconds of 24 hours.

We don't check for granularity finer than DAYS because those granularity has lose precision during the transition of DST and this method doesn't help much in comparison with the default case.

Tested on local.