### PR TITLE
Disable prefetch for zero-length pages

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/store/SegmentLocalFSDirectory.java
@@ -269,8 +269,10 @@ class SegmentLocalFSDirectory extends SegmentDirectory {
 
     final long prefetchSlowdownPageLimit = (long) (PREFETCH_SLOWDOWN_PCT * MAX_MMAP_PREFETCH_PAGES);
     if (prefetchedPages.get() >= prefetchSlowdownPageLimit) {
-      buffer.getByte(0);
-      prefetchedPages.incrementAndGet();
+      if (0 < buffer.size()) {
+        buffer.getByte(0);
+        prefetchedPages.incrementAndGet();
+      }
     } else {
       // pos needs to be long because buffer.size() is 32 bit but
       // adding 4k can make it go over int size


### PR DESCRIPTION
Disable prefetch for zero-length pages, as there is no data to
actually prefetch.