### PR TITLE
Filter optimization to avoid unnecessary predicate evaluation.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/AndOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/AndOperator.java
@@ -33,10 +33,10 @@ public class AndOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(AndOperator.class);
   private static final String OPERATOR_NAME = "AndOperator";
 
-  private List<Operator> operators;
+  private List<BaseFilterOperator> operators;
   private AndBlock andBlock;
 
-  public AndOperator(List<Operator> operators) {
+  public AndOperator(List<BaseFilterOperator> operators) {
     this.operators = operators;
   }
 
@@ -58,6 +58,16 @@ public class AndOperator extends BaseFilterOperator {
     }
     andBlock = new AndBlock(blockDocIdSets);
     return andBlock;
+  }
+
+  @Override
+  public boolean isResultEmpty() {
+    for (BaseFilterOperator operator : operators) {
+      if (operator.isResultEmpty()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BaseFilterOperator.java
@@ -17,8 +17,6 @@ package com.linkedin.pinot.core.operator.filter;
 
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockId;
-import com.linkedin.pinot.core.common.Operator;
-import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
 
@@ -29,16 +27,7 @@ import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
  */
 public abstract class BaseFilterOperator extends BaseOperator {
 
-  private Predicate predicate;
   private int nextBlockCallCounter = 0;
-
-  public void setPredicate(Predicate predicate) {
-    this.predicate = predicate;
-  }
-
-  public Predicate getPredicate() {
-    return predicate;
-  }
 
   @Override
   public final BaseFilterBlock getNextBlock() {
@@ -56,4 +45,6 @@ public abstract class BaseFilterOperator extends BaseOperator {
   }
 
   public abstract BaseFilterBlock nextFilterBlock(BlockId blockId);
+
+  public abstract boolean isResultEmpty();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/CompositeOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/CompositeOperator.java
@@ -25,9 +25,9 @@ import com.linkedin.pinot.core.operator.blocks.CompositeBaseFilterBlock;
 
 public class CompositeOperator extends BaseFilterOperator{
   private static final String OPERATOR_NAME = "CompositeOperator";
-  private List<Operator> operators;
+  private List<BaseFilterOperator> operators;
 
-  public CompositeOperator(List<Operator> operators) {
+  public CompositeOperator(List<BaseFilterOperator> operators) {
     this.operators = operators;
   }
 
@@ -48,6 +48,16 @@ public class CompositeOperator extends BaseFilterOperator{
       blocks.add((BaseFilterBlock) operator.nextBlock());
     }
     return new CompositeBaseFilterBlock(blocks);
+  }
+
+  @Override
+  public boolean isResultEmpty() {
+    for (BaseFilterOperator operator : operators) {
+      if (!operator.isResultEmpty()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/EmptyFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/EmptyFilterOperator.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.operator.filter;
+
+import com.linkedin.pinot.core.common.BlockDocIdIterator;
+import com.linkedin.pinot.core.common.BlockId;
+import com.linkedin.pinot.core.common.Constants;
+import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
+import com.linkedin.pinot.core.operator.docidsets.FilterBlockDocIdSet;
+
+
+/**
+ * Extension of {@link BaseFilterOperator} that is empty, i.e. does not match any doc ids.
+ */
+public final class EmptyFilterOperator extends BaseFilterOperator {
+  private static final String OPERATOR_NAME = "EmptyFilterOperator";
+
+  @Override
+  public BaseFilterBlock nextFilterBlock(BlockId blockId) {
+    return new ExcludeEntireSegmentDocIdSetBlock();
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
+  }
+
+  @Override
+  public boolean open() {
+    return true;
+  }
+
+  @Override
+  public boolean close() {
+    return true;
+  }
+
+  @Override
+  public boolean isResultEmpty() {
+    return true;
+  }
+
+  public static class ExcludeEntireSegmentDocIdSetBlock extends BaseFilterBlock {
+    @Override
+    public FilterBlockDocIdSet getFilteredBlockDocIdSet() {
+      return new EmptyDocIdSet();
+    }
+
+    @Override
+    public BlockId getId() {
+      return null;
+    }
+  }
+
+  /**
+   * Implementation of {@link FilterBlockDocIdSet} that is empty.
+   */
+  public static final class EmptyDocIdSet implements FilterBlockDocIdSet {
+
+    @Override
+    public int getMinDocId() {
+      return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public int getMaxDocId() {
+      return Integer.MIN_VALUE;
+    }
+
+    @Override
+    public void setStartDocId(int startDocId) {
+      // Nothing to set.
+    }
+
+    @Override
+    public void setEndDocId(int endDocId) {
+      // Nothing to set.
+    }
+
+    @Override
+    public long getNumEntriesScannedInFilter() {
+      return 0L;
+    }
+
+    @Override
+    public BlockDocIdIterator iterator() {
+      return new EmptyDocIdSetIterator();
+    }
+
+    @Override
+    public <T> T getRaw() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Implementation of {@link BlockDocIdIterator} that is empty.
+   */
+  public static final class EmptyDocIdSetIterator implements BlockDocIdIterator {
+
+    @Override
+    public int advance(int targetDocId) {
+      return Constants.EOF;
+    }
+
+    @Override
+    public int next() {
+      return Constants.EOF;
+    }
+
+    @Override
+    public int currentDocId() {
+      return Constants.EOF;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/MatchEntireSegmentOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/MatchEntireSegmentOperator.java
@@ -44,6 +44,11 @@ public class MatchEntireSegmentOperator extends BaseFilterOperator {
   }
 
   @Override
+  public boolean isResultEmpty() {
+    return false;
+  }
+
+  @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/OrOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/OrOperator.java
@@ -33,10 +33,10 @@ public class OrOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(OrOperator.class);
   private static final String OPERATOR_NAME = "OrOperator";
 
-  private List<Operator> operators;
+  private List<BaseFilterOperator> operators;
   private OrBlock orBlock;
 
-  public OrOperator(List<Operator> operators) {
+  public OrOperator(List<BaseFilterOperator> operators) {
     this.operators = operators;
   }
 
@@ -58,6 +58,16 @@ public class OrOperator extends BaseFilterOperator {
     }
     orBlock = new OrBlock(blockDocIdSets);
     return orBlock;
+  }
+
+  @Override
+  public boolean isResultEmpty() {
+    for (BaseFilterOperator operator : operators) {
+      if (!operator.isResultEmpty()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -15,9 +15,6 @@
  */
 package com.linkedin.pinot.core.operator.filter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockDocIdValueSet;
 import com.linkedin.pinot.core.common.BlockId;
@@ -32,24 +29,28 @@ import com.linkedin.pinot.core.operator.docidsets.ScanBasedMultiValueDocIdSet;
 import com.linkedin.pinot.core.operator.docidsets.ScanBasedSingleValueDocIdSet;
 import com.linkedin.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import com.linkedin.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
-import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ScanBasedFilterOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ScanBasedFilterOperator.class);
   private static final String OPERATOR_NAME = "ScanBasedFilterOperator";
 
+  private final PredicateEvaluator predicateEvaluator;
   private DataSource dataSource;
   private Integer startDocId;
   private Integer endDocId;
   private String name;
 
   /**
+   * @param predicate
    * @param dataSource
    * @param startDocId inclusive
    * @param endDocId inclusive
    */
-  public ScanBasedFilterOperator(DataSource dataSource, Integer startDocId, Integer endDocId) {
+  public ScanBasedFilterOperator(Predicate predicate, DataSource dataSource, Integer startDocId, Integer endDocId) {
+    this.predicateEvaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dataSource.getDictionary());
     this.dataSource = dataSource;
     this.startDocId = startDocId;
     this.endDocId = endDocId;
@@ -64,19 +65,17 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
 
   @Override
   public BaseFilterBlock nextFilterBlock(BlockId BlockId) {
-    Predicate predicate = getPredicate();
-    Dictionary dictionary = dataSource.getDictionary();
     DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
     FilterBlockDocIdSet docIdSet;
     Block nextBlock = dataSource.nextBlock();
     BlockValSet blockValueSet = nextBlock.getBlockValueSet();
     BlockMetadata blockMetadata = nextBlock.getMetadata();
-    PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dictionary);
     if (dataSourceMetadata.isSingleValue()) {
-      docIdSet =
-          new ScanBasedSingleValueDocIdSet(dataSource.getOperatorName(), blockValueSet, blockMetadata, evaluator);
+      docIdSet = new ScanBasedSingleValueDocIdSet(dataSource.getOperatorName(), blockValueSet, blockMetadata,
+          predicateEvaluator);
     } else {
-      docIdSet = new ScanBasedMultiValueDocIdSet(dataSource.getOperatorName(), blockValueSet, blockMetadata, evaluator);
+      docIdSet = new ScanBasedMultiValueDocIdSet(dataSource.getOperatorName(), blockValueSet, blockMetadata,
+          predicateEvaluator);
     }
 
     if (startDocId != null) {
@@ -87,6 +86,11 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
       docIdSet.setEndDocId(endDocId);
     }
     return new ScanBlock(docIdSet);
+  }
+
+  @Override
+  public boolean isResultEmpty() {
+    return predicateEvaluator.alwaysFalse();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.filter;
 
+import com.linkedin.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,9 +34,7 @@ import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
 import com.linkedin.pinot.core.operator.docidsets.FilterBlockDocIdSet;
 import com.linkedin.pinot.core.operator.docidsets.SortedDocIdSet;
 import com.linkedin.pinot.core.operator.filter.predicate.PredicateEvaluator;
-import com.linkedin.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import com.linkedin.pinot.core.segment.index.readers.SortedInvertedIndexReader;
-import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 
 public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
@@ -43,6 +42,8 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(SortedInvertedIndexBasedFilterOperator.class);
   private static final String OPERATOR_NAME = "SortedInvertedIndexBasedFilterOperator";
 
+  private final Predicate predicate;
+  private PredicateEvaluator predicateEvaluator;
   private DataSource dataSource;
 
   private SortedBlock sortedBlock;
@@ -57,7 +58,9 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
    * @param startDocId inclusive
    * @param endDocId inclusive
    */
-  public SortedInvertedIndexBasedFilterOperator(DataSource dataSource, int startDocId, int endDocId) {
+  public SortedInvertedIndexBasedFilterOperator(Predicate predicate, DataSource dataSource, int startDocId, int endDocId) {
+    this.predicate = predicate;
+    this.predicateEvaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dataSource.getDictionary());
     this.dataSource = dataSource;
     this.startDocId = startDocId;
     this.endDocId = endDocId;
@@ -70,11 +73,8 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
 
   @Override
   public BaseFilterBlock nextFilterBlock(BlockId BlockId) {
-    Predicate predicate = getPredicate();
     final SortedInvertedIndexReader invertedIndex = (SortedInvertedIndexReader) dataSource.getInvertedIndex();
-    Dictionary dictionary = dataSource.getDictionary();
     List<IntPair> pairs = new ArrayList<IntPair>();
-    PredicateEvaluator evaluator = PredicateEvaluatorProvider.getPredicateFunctionFor(predicate, dictionary);
 
     // At this point, we need to create a list of matching docId ranges. There are two kinds of operators:
     //
@@ -97,12 +97,12 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
       case EQ:
       case IN:
       case RANGE:
-        dictionaryIds = evaluator.getMatchingDictionaryIds();
+        dictionaryIds = predicateEvaluator.getMatchingDictionaryIds();
         break;
       case NEQ:
       case NOT_IN:
         additiveRanges = false;
-        dictionaryIds = evaluator.getNonMatchingDictionaryIds();
+        dictionaryIds = predicateEvaluator.getNonMatchingDictionaryIds();
         break;
       case REGEX:
         throw new RuntimeException("Regex is not supported");
@@ -191,6 +191,11 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
     LOGGER.debug("Creating a Sorted Block with pairs: {}", pairs);
     sortedBlock = new SortedBlock(dataSource.getOperatorName(), pairs);
     return sortedBlock;
+  }
+
+  @Override
+  public boolean isResultEmpty() {
+    return predicateEvaluator.alwaysFalse();
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -15,22 +15,10 @@
  */
 package com.linkedin.pinot.core.realtime;
 
-import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.yammer.metrics.core.MetricsRegistry;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockDocIdIterator;
 import com.linkedin.pinot.core.common.BlockMetadata;
@@ -50,6 +38,16 @@ import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderImpl;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
+import com.yammer.metrics.core.MetricsRegistry;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class RealtimeSegmentTest {
   private static final String AVRO_DATA = "data/test_data-mv.avro";
@@ -129,11 +127,11 @@ public class RealtimeSegmentTest {
   public void testMetricPredicateWithInvIdx() throws Exception {
     DataSource ds1 = segmentWithInvIdx.getDataSource("count");
 
-    BitmapBasedFilterOperator op = new BitmapBasedFilterOperator(ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("890662862");
     Predicate predicate = new EqPredicate("count", rhs);
-    op.setPredicate(predicate);
+    BitmapBasedFilterOperator op =
+        new BitmapBasedFilterOperator(predicate, ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
 
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
@@ -156,11 +154,11 @@ public class RealtimeSegmentTest {
   public void testMetricPredicateWithoutInvIdx() throws Exception {
     DataSource ds1 = segmentWithoutInvIdx.getDataSource("count");
 
-    ScanBasedFilterOperator op = new ScanBasedFilterOperator(ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("890662862");
     Predicate predicate = new EqPredicate("count", rhs);
-    op.setPredicate(predicate);
+    ScanBasedFilterOperator op =
+        new ScanBasedFilterOperator(predicate, ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
 
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
@@ -183,12 +181,12 @@ public class RealtimeSegmentTest {
   public void testNoMatchFilteringMetricPredicateWithInvIdx() throws Exception {
     DataSource ds1 = segmentWithInvIdx.getDataSource("count");
 
-    BitmapBasedFilterOperator op = new BitmapBasedFilterOperator(ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("890662862");
     Predicate predicate = new NEqPredicate("count", rhs);
+    BitmapBasedFilterOperator op =
+        new BitmapBasedFilterOperator(predicate, ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
 
-    op.setPredicate(predicate);
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
 
@@ -207,12 +205,12 @@ public class RealtimeSegmentTest {
   public void testNoMatchFilteringMetricPredicateWithoutInvIdx() throws Exception {
     DataSource ds1 = segmentWithoutInvIdx.getDataSource("count");
 
-    ScanBasedFilterOperator op = new ScanBasedFilterOperator(ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("890662862");
     Predicate predicate = new NEqPredicate("count", rhs);
+    ScanBasedFilterOperator op =
+        new ScanBasedFilterOperator(predicate, ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
 
-    op.setPredicate(predicate);
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
 
@@ -231,11 +229,11 @@ public class RealtimeSegmentTest {
   public void testRangeMatchFilteringMetricPredicateWithInvIdx() throws Exception {
     DataSource ds1 = segmentWithInvIdx.getDataSource("count");
 
-    BitmapBasedFilterOperator op = new BitmapBasedFilterOperator(ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("[0\t\t*)");
     Predicate predicate = new RangePredicate("count", rhs);
-    op.setPredicate(predicate);
+    BitmapBasedFilterOperator op =
+        new BitmapBasedFilterOperator(predicate, ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
 
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
@@ -258,11 +256,11 @@ public class RealtimeSegmentTest {
   public void testRangeMatchFilteringMetricPredicateWithoutInvIdx() throws Exception {
     DataSource ds1 = segmentWithoutInvIdx.getDataSource("count");
 
-    ScanBasedFilterOperator op = new ScanBasedFilterOperator(ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("[0\t\t*)");
     Predicate predicate = new RangePredicate("count", rhs);
-    op.setPredicate(predicate);
+    ScanBasedFilterOperator op =
+        new ScanBasedFilterOperator(predicate, ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
 
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
@@ -285,13 +283,12 @@ public class RealtimeSegmentTest {
   public void testNoRangeMatchFilteringMetricPredicateWithInvIdx() throws Exception {
     DataSource ds1 = segmentWithInvIdx.getDataSource("count");
 
-    BitmapBasedFilterOperator op = new BitmapBasedFilterOperator(ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("[0\t\t100)");
     Predicate predicate = new RangePredicate("count", rhs);
-    op.setPredicate(predicate);
+    BitmapBasedFilterOperator op =
+        new BitmapBasedFilterOperator(predicate, ds1, 0, segmentWithInvIdx.getRawDocumentCount() - 1);
 
-    op.setPredicate(predicate);
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
 
@@ -310,13 +307,12 @@ public class RealtimeSegmentTest {
   public void testNoRangeMatchFilteringMetricPredicateWithoutInvIdx() throws Exception {
     DataSource ds1 = segmentWithoutInvIdx.getDataSource("count");
 
-    ScanBasedFilterOperator op = new ScanBasedFilterOperator(ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
     List<String> rhs = new ArrayList<String>();
     rhs.add("[0\t\t100)");
     Predicate predicate = new RangePredicate("count", rhs);
-    op.setPredicate(predicate);
+    ScanBasedFilterOperator op =
+        new ScanBasedFilterOperator(predicate, ds1, 0, segmentWithoutInvIdx.getRawDocumentCount() - 1);
 
-    op.setPredicate(predicate);
     Block b = op.nextBlock();
     BlockDocIdIterator iterator = b.getBlockDocIdSet().iterator();
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/AndOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/AndOperatorTest.java
@@ -15,20 +15,17 @@
  */
 package com.linkedin.pinot.operator;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.testng.annotations.Test;
-
 import com.linkedin.pinot.core.common.BlockDocIdIterator;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockId;
 import com.linkedin.pinot.core.common.Constants;
-import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
 import com.linkedin.pinot.core.operator.filter.AndOperator;
 import com.linkedin.pinot.core.operator.filter.BaseFilterOperator;
 import com.linkedin.pinot.core.operator.filter.OrOperator;
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.annotations.Test;
 
 
 public class AndOperatorTest {
@@ -37,7 +34,7 @@ public class AndOperatorTest {
   public void testIntersectionForTwoLists() {
     int[] list1 = new int[] { 2, 3, 10, 15, 16, 28 };
     int[] list2 = new int[] { 3, 6, 8, 20, 28 };
-    List<Operator> operators = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(makeFilterOperator(list1));
     operators.add(makeFilterOperator(list2));
     final AndOperator andOperator = new AndOperator(operators);
@@ -61,7 +58,7 @@ public class AndOperatorTest {
     int[] list2 = new int[] { 3, 6, 8, 20, 28 };
     int[] list3 = new int[] { 1, 2, 3, 6, 30 };
 
-    List<Operator> operators = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators = new ArrayList<BaseFilterOperator>();
     operators.add(makeFilterOperator(list1));
     operators.add(makeFilterOperator(list2));
     operators.add(makeFilterOperator(list3));
@@ -87,12 +84,12 @@ public class AndOperatorTest {
     int[] list2 = new int[] { 3, 6, 8, 20, 28 };
     int[] list3 = new int[] { 1, 2, 3, 6, 30 };
 
-    List<Operator> operators = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(makeFilterOperator(list1));
     operators.add(makeFilterOperator(list2));
 
     final AndOperator andOperator1 = new AndOperator(operators);
-    List<Operator> operators1 = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators1 = new ArrayList<>();
     operators1.add(andOperator1);
     operators1.add(makeFilterOperator(list3));
 
@@ -117,12 +114,12 @@ public class AndOperatorTest {
     int[] list2 = new int[] { 3, 6, 8, 20, 28 };
     int[] list3 = new int[] { 1, 2, 3, 6, 30 };
 
-    List<Operator> operators = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(makeFilterOperator(list3));
     operators.add(makeFilterOperator(list2));
 
     final OrOperator orOperator = new OrOperator(operators);
-    List<Operator> operators1 = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators1 = new ArrayList<>();
     operators1.add(orOperator);
     operators1.add(makeFilterOperator(list1));
 
@@ -174,6 +171,11 @@ public class AndOperatorTest {
         alreadyInvoked = true;
 
         return new ArrayBasedFilterBlock(list);
+      }
+
+      @Override
+      public boolean isResultEmpty() {
+        return false;
       }
     };
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/OrOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/OrOperatorTest.java
@@ -21,7 +21,6 @@ import com.linkedin.pinot.core.common.BlockDocIdIterator;
 import com.linkedin.pinot.core.common.BlockDocIdSet;
 import com.linkedin.pinot.core.common.BlockId;
 import com.linkedin.pinot.core.common.Constants;
-import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
 import com.linkedin.pinot.core.operator.filter.BaseFilterOperator;
 import com.linkedin.pinot.core.operator.filter.OrOperator;
@@ -40,8 +39,8 @@ public class OrOperatorTest {
   public void testIntersectionForTwoLists() {
     int[] list1 = new int[] { 2, 3, 10, 15, 16, 28 };
     int[] list2 = new int[] { 3, 6, 8, 20, 28 };
-    ;
-    List<Operator> operators = new ArrayList<Operator>();
+
+    List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(makeFilterOperator(list1));
     operators.add(makeFilterOperator(list2));
     final OrOperator orOperator = new OrOperator(operators);
@@ -69,7 +68,7 @@ public class OrOperatorTest {
     int[] list2 = new int[] { 3, 6, 8, 20, 28 };
     int[] list3 = new int[] { 1, 2, 3, 6, 30 };
 
-    List<Operator> operators = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(makeFilterOperator(list1));
     operators.add(makeFilterOperator(list2));
     operators.add(makeFilterOperator(list3));
@@ -106,12 +105,12 @@ public class OrOperatorTest {
     set.addAll(Lists.newArrayList(ArrayUtils.toObject(list3)));
     Iterator<Integer> expectedIterator = set.iterator();
 
-    List<Operator> operators = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(makeFilterOperator(list1));
     operators.add(makeFilterOperator(list2));
 
     final OrOperator orOperator1 = new OrOperator(operators);
-    List<Operator> operators1 = new ArrayList<Operator>();
+    List<BaseFilterOperator> operators1 = new ArrayList<>();
     operators1.add(orOperator1);
     operators1.add(makeFilterOperator(list3));
 
@@ -162,6 +161,11 @@ public class OrOperatorTest {
         }
         alreadyInvoked = true;
         return new ArrayBasedFilterBlock(list);
+      }
+
+      @Override
+      public boolean isResultEmpty() {
+        return false;
       }
     };
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/FilterTreeOptimizationTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/FilterTreeOptimizationTest.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.operator.filter;
+
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.core.common.BlockDocIdIterator;
+import com.linkedin.pinot.core.common.BlockDocIdSet;
+import com.linkedin.pinot.core.common.Constants;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.readers.FileFormat;
+import com.linkedin.pinot.core.data.readers.RecordReader;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.operator.blocks.BaseFilterBlock;
+import com.linkedin.pinot.core.operator.filter.BaseFilterOperator;
+import com.linkedin.pinot.core.plan.FilterPlanNode;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.linkedin.pinot.core.segment.index.loader.Loaders;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import com.linkedin.pinot.query.transform.TransformExpressionOperatorTest;
+import com.linkedin.pinot.util.TestUtils;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for optimization of predicates that evaluate to always false, during filter tree creation.
+ */
+public class FilterTreeOptimizationTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TransformExpressionOperatorTest.class);
+
+  private static final String SEGMENT_DIR_NAME =
+      System.getProperty("java.io.tmpdir") + File.separator + "filterOptimization";
+  private static final String SEGMENT_NAME = "filterOptSeg";
+  private static final String TABLE_NAME = "filterOptTable";
+
+  private static final int NUM_ROWS = 1000;
+  private static final String[] DIMENSIONS = new String[]{"dim_0", "dim_1", "dim_2", "dim_3"};
+  private static final int MAX_DIMENSION_VALUES = 100;
+
+  private IndexSegment _indexSegment;
+  private Pql2Compiler _compiler;
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    Schema schema = buildSchema(DIMENSIONS);
+    buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, schema);
+    _indexSegment = Loaders.IndexSegment.load(new File(SEGMENT_DIR_NAME, SEGMENT_NAME), ReadMode.heap);
+    _compiler = new Pql2Compiler();
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(new File(SEGMENT_DIR_NAME));
+  }
+
+  @Test
+  public void test() {
+    // No alwaysFalse predicates
+    testQuery(
+        String.format("select count(*) from %s where (%s = 'dim_0_1' AND %s <> 'dim_1_2')", TABLE_NAME, DIMENSIONS[0],
+            DIMENSIONS[1]));
+
+    // (nonAlwaysFalse AND (nonAlwaysFalse AND alwaysFalse)
+    testQuery(
+        String.format("select count(*) from %s where (%s = 'dim_0_1' AND (%s <> 'dim_1_2' AND %s = 'x'))", TABLE_NAME,
+            DIMENSIONS[0], DIMENSIONS[1], DIMENSIONS[2]));
+
+    // (alwaysFalse OR (alwaysFalse OR alwaysFalse))
+    testQuery(
+        String.format("select count(*) from %s where (%s = 'x' OR (%s ='y' OR %s = 'z'))", TABLE_NAME,
+            DIMENSIONS[0], DIMENSIONS[1], DIMENSIONS[2]));
+
+    // ((alwaysFalse AND nonAlwaysFalse) OR AlwaysFalse)
+    testQuery(
+        String.format("select count(*) from %s where ((%s = 'x' AND %s ='dim_1_5') OR %s = 'z')", TABLE_NAME,
+            DIMENSIONS[0], DIMENSIONS[1], DIMENSIONS[2]));
+  }
+
+  /**
+   * Helper method to perform the actual testing for the given query.
+   * <ul>
+   *   <li> Constructs the operator tree with and without alwaysFalse optimizations. </li>
+   *   <li> Compares that all docIds filtered by the two operators are identical. </li>
+   * </ul>
+   * @param query Query to run.
+   */
+  private void testQuery(String query) {
+    BrokerRequest brokerRequest = _compiler.compileToBrokerRequest(query);
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+
+    BaseFilterOperator expectedOperator =
+        FilterPlanNode.constructPhysicalOperator(filterQueryTree, _indexSegment, false);
+
+    BaseFilterOperator actualOperator = FilterPlanNode.constructPhysicalOperator(filterQueryTree, _indexSegment, true);
+
+    BaseFilterBlock expectedBlock;
+    while ((expectedBlock = expectedOperator.getNextBlock()) != null) {
+      BaseFilterBlock actualBlock = actualOperator.getNextBlock();
+      Assert.assertNotNull(actualBlock);
+
+      final BlockDocIdSet expectedDocIdSet = expectedBlock.getBlockDocIdSet();
+      final BlockDocIdIterator expectedIterator = expectedDocIdSet.iterator();
+      final BlockDocIdSet actualDocIdSet = actualBlock.getBlockDocIdSet();
+      final BlockDocIdIterator actualIterator = actualDocIdSet.iterator();
+
+      int expectedDocId;
+      int actualDocId;
+      while (((expectedDocId = expectedIterator.next()) != Constants.EOF) && ((actualDocId = actualIterator.next())
+          != Constants.EOF)) {
+        Assert.assertEquals(actualDocId, expectedDocId);
+      }
+
+      Assert.assertTrue(expectedIterator.next() == Constants.EOF);
+      Assert.assertTrue(actualIterator.next() == Constants.EOF);
+    }
+  }
+
+  /**
+   * Helper method to build a segment.
+   *
+   * @param segmentDirName Name of segment directory
+   * @param segmentName Name of segment
+   * @param schema Schema for segment
+   * @return Schema built for the segment
+   * @throws Exception
+   */
+  private RecordReader buildSegment(String segmentDirName, String segmentName, Schema schema)
+      throws Exception {
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setOutDir(segmentDirName);
+    config.setFormat(FileFormat.AVRO);
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(segmentName);
+
+    final List<GenericRow> data = new ArrayList<>();
+    for (int row = 0; row < NUM_ROWS; row++) {
+      HashMap<String, Object> map = new HashMap<>();
+      for (String dimensionName : DIMENSIONS) {
+        map.put(dimensionName, dimensionName + '_' + (row % MAX_DIMENSION_VALUES));
+      }
+
+      GenericRow genericRow = new GenericRow();
+      genericRow.init(map);
+      data.add(genericRow);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    RecordReader reader = new TestUtils.GenericRowRecordReader(schema, data);
+    driver.init(config, reader);
+    driver.build();
+
+    LOGGER.info("Built segment {} at {}", segmentName, segmentDirName);
+    return reader;
+  }
+
+  /**
+   * Helper method to build a schema containing dimensions with names passed in.
+   *
+   * @param dimensions Dimension names
+   *
+   */
+  private static Schema buildSchema(String[] dimensions) {
+    Schema schema = new Schema();
+    for (String dimension : dimensions) {
+      DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec(dimension, FieldSpec.DataType.STRING, true);
+      schema.addField(dimensionFieldSpec);
+    }
+    return schema;
+  }
+}

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/RawIndexBenchmark.java
@@ -304,6 +304,11 @@ public class RawIndexBenchmark {
     }
 
     @Override
+    public boolean isResultEmpty() {
+      return false;
+    }
+
+    @Override
     public boolean open() {
       return true;
     }


### PR DESCRIPTION
Filter optimization to avoid unnecessary predicate evaluation.

Replace AND/OR operators with EmptyFilterOperator if one child (all
children for OR) of AND Operator always evaluates to false. Doing so in
planning phase completely eliminates thread overheads during execution
phase. In an example use-case with 180 segments, where most segments are
eliminated due to time filters in query, this change provided > 25%
improvement in QPS, while improving latency by 10%.

1. All filter operators now implement alwaysFalse(). Leaf level filter
operators use predicate evaluator for the same. While non leaf filters
(AND/OR) decide that based on their children (one child is alwaysFalse
for AND, all children alwaysFalse for OR).

2. While creating FilterPlan, return an emtpy filter operator for all
AND's that have at least one child that always evaluates to false. This
helps optimize the filter tree by collapsing parts of the tree that are
alwaysFalse.

3. Removed set/getPredicate() from BaseFilterOperator, leaf level filter
operators take predicate in constructor now.

4. Added unit test to test the always false optimizations.