### PR TITLE
Disable anomaly detection on OTHER dimension

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -156,7 +156,8 @@ public class DetectionTaskRunner implements TaskRunner {
       String[] dimensionValues = dimensionKey.getDimensionValues();
       boolean isOTHERDimension = false;
       for (String dimensionValue : dimensionValues) {
-        if (dimensionValue.equals(ResponseParserUtils.OTHER)) {
+        if (dimensionValue.equalsIgnoreCase(ResponseParserUtils.OTHER) ||
+            dimensionValue.equalsIgnoreCase(ResponseParserUtils.UNKNOWN)) {
           isOTHERDimension = true;
           break;
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
@@ -8,6 +8,7 @@ import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.client.MetricExpression;
+import com.linkedin.thirdeye.client.ResponseParserUtils;
 import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesHandler;
 import com.linkedin.thirdeye.client.timeseries.TimeSeriesRequest;
@@ -126,7 +127,7 @@ public abstract class TimeSeriesUtil {
 
     boolean hasOTHERDimensionName = false;
     for (String dimensionValue : dimensionMap.values()) {
-      if (dimensionValue.equalsIgnoreCase("other")) {
+      if (dimensionValue.equals(ResponseParserUtils.OTHER)) {
         hasOTHERDimensionName = true;
         break;
       }
@@ -185,7 +186,7 @@ public abstract class TimeSeriesUtil {
           boolean foundOTHER = false;
           for (String dimensionValue : dimensionKey.getDimensionValues()) {
 
-            if (dimensionValue.equalsIgnoreCase("OTHER")) {
+            if (dimensionValue.equals(ResponseParserUtils.OTHER)) {
               metricTimeSeries = entry.getValue();
               foundOTHER = true;
               break;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
@@ -127,7 +127,7 @@ public abstract class TimeSeriesUtil {
 
     boolean hasOTHERDimensionName = false;
     for (String dimensionValue : dimensionMap.values()) {
-      if (dimensionValue.equals(ResponseParserUtils.OTHER)) {
+      if (dimensionValue.equalsIgnoreCase(ResponseParserUtils.OTHER)) {
         hasOTHERDimensionName = true;
         break;
       }
@@ -186,7 +186,7 @@ public abstract class TimeSeriesUtil {
           boolean foundOTHER = false;
           for (String dimensionValue : dimensionKey.getDimensionValues()) {
 
-            if (dimensionValue.equals(ResponseParserUtils.OTHER)) {
+            if (dimensionValue.equalsIgnoreCase(ResponseParserUtils.OTHER)) {
               metricTimeSeries = entry.getValue();
               foundOTHER = true;
               break;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ResponseParserUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ResponseParserUtils.java
@@ -18,6 +18,7 @@ public class ResponseParserUtils {
   public static String TIME_DIMENSION_JOINER_ESCAPED = "\\|";
   public static String TIME_DIMENSION_JOINER = "|";
   public static String OTHER = "OTHER";
+  public static String UNKNOWN = "UNKNOWN";
 
   public static Map<String, ThirdEyeResponseRow> createResponseMapByTimeAndDimension(
       ThirdEyeResponse thirdEyeResponse) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
@@ -79,10 +79,6 @@ public abstract class ThirdEyeConfiguration extends Configuration {
     return getRootDir() + "/detector-config/anomaly-functions/functions.properties";
   }
 
-  public String getAnomaliesViewConfigPath() {
-    return getRootDir() + "/webapp-config/anomaly-views/views.properties";
-  }
-
   public String getSmtpHost() {
     return smtpHost;
   }


### PR DESCRIPTION
If the current time series belongs to OTHER dimension, which consists of time series whose sum of all its values belows 1% of sum of all time series values, then its anomaly is meaningless. 

Thus, we don't want to detection anomalies on time series of OTHER dimension.