### PR TITLE
ThirdEye: make completeness check fully depend on dataset config

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -1,16 +1,8 @@
 package com.linkedin.thirdeye.anomaly;
 
-import com.linkedin.thirdeye.anomaly.alert.v2.AlertJobSchedulerV2;
-import com.linkedin.thirdeye.dashboard.resources.AnomalyFunctionResource;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
 import com.linkedin.thirdeye.anomaly.alert.AlertJobResource;
 import com.linkedin.thirdeye.anomaly.alert.AlertJobScheduler;
+import com.linkedin.thirdeye.anomaly.alert.v2.AlertJobSchedulerV2;
 import com.linkedin.thirdeye.anomaly.detection.DetectionJobResource;
 import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
 import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeExecutor;
@@ -20,12 +12,17 @@ import com.linkedin.thirdeye.autoload.pinot.metrics.AutoLoadPinotMetricsService;
 import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.common.BaseThirdEyeApplication;
 import com.linkedin.thirdeye.completeness.checker.DataCompletenessScheduler;
+import com.linkedin.thirdeye.dashboard.resources.AnomalyFunctionResource;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
-
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class ThirdEyeAnomalyApplication
     extends BaseThirdEyeApplication<ThirdEyeAnomalyConfiguration> {
@@ -115,7 +112,7 @@ public class ThirdEyeAnomalyApplication
           autoLoadPinotMetricsService.start();
         }
         if (config.isDataCompleteness()) {
-          dataCompletenessScheduler = new DataCompletenessScheduler(config.getDatasetsToCheck());
+          dataCompletenessScheduler = new DataCompletenessScheduler();
           dataCompletenessScheduler.start();
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
@@ -11,7 +11,6 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
   private boolean merger = false;
   private boolean autoload = false;
   private boolean dataCompleteness = false;
-  private String datasetsToCheck = "";
 
   private long id;
   private String dashboardHost;
@@ -102,14 +101,6 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
 
   public void setDataCompleteness(boolean dataCompleteness) {
     this.dataCompleteness = dataCompleteness;
-  }
-
-  public String getDatasetsToCheck() {
-    return datasetsToCheck;
-  }
-
-  public void setDatasetsToCheck(String datasetsToCheck) {
-    this.datasetsToCheck = datasetsToCheck;
   }
 
   public void setSmtpConfiguration(SmtpConfiguration smtpConfiguration) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessJobRunner.java
@@ -1,28 +1,23 @@
 package com.linkedin.thirdeye.completeness.checker;
 
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.anomaly.job.JobRunner;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants.TaskStatus;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants.TaskType;
-import com.linkedin.thirdeye.anomaly.task.TaskGenerator;
 import com.linkedin.thirdeye.client.DAORegistry;
-import com.linkedin.thirdeye.datalayer.bao.JobManager;
-import com.linkedin.thirdeye.datalayer.bao.TaskManager;
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
 import com.linkedin.thirdeye.datalayer.dto.TaskDTO;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** job runner for data completeness job
  *
@@ -55,6 +50,16 @@ public class DataCompletenessJobRunner implements JobRunner {
     dataCompletenessJobContext.setCheckDurationStartTime(checkDurationStartTime);
     dataCompletenessJobContext.setCheckDurationEndTime(checkDurationEndTime);
     dataCompletenessJobContext.setJobName(jobName);
+
+    List<DatasetConfigDTO> datasets = DAO_REGISTRY.getDatasetConfigDAO()
+        .findActiveRequiresCompletenessCheck();
+
+    List<String> datasetsToCheck = new ArrayList<String>();
+    for(DatasetConfigDTO d: datasets) {
+      datasetsToCheck.add(d.getDataset());
+    }
+
+    dataCompletenessJobContext.setDatasetsToCheck(datasetsToCheck);
 
     // create data completeness job
     long jobExecutionId = createJob();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessScheduler.java
@@ -23,7 +23,7 @@ public class DataCompletenessScheduler {
     dataCompletenessJobContext = new DataCompletenessJobContext();
     dataCompletenessJobRunner = new DataCompletenessJobRunner(dataCompletenessJobContext);
 
-    scheduledExecutorService.scheduleWithFixedDelay(dataCompletenessJobRunner, 0, 5, TimeUnit.MINUTES);
+    scheduledExecutorService.scheduleWithFixedDelay(dataCompletenessJobRunner, 0, 15, TimeUnit.MINUTES);
   }
 
   public void shutdown() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessScheduler.java
@@ -1,17 +1,10 @@
 package com.linkedin.thirdeye.completeness.checker;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
-import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
 
 /**
  * The scheduler which will run periodically and schedule jobs and tasks for data completeness
@@ -20,27 +13,17 @@ public class DataCompletenessScheduler {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataCompletenessScheduler.class);
 
-  private ScheduledExecutorService scheduledExecutorService;
+  private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();;
   private DataCompletenessJobRunner dataCompletenessJobRunner;
   private DataCompletenessJobContext dataCompletenessJobContext;
-  private List<String> datasetsToCheck = new ArrayList<>();
-
-  public DataCompletenessScheduler(String datasetsToCheck) {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-    if (StringUtils.isNotBlank(datasetsToCheck)) {
-      this.datasetsToCheck = Lists.newArrayList(datasetsToCheck.split(","));
-    }
-  }
 
   public void start() {
-
     LOG.info("Starting data completeness checker service");
 
     dataCompletenessJobContext = new DataCompletenessJobContext();
-    dataCompletenessJobContext.setDatasetsToCheck(datasetsToCheck);
     dataCompletenessJobRunner = new DataCompletenessJobRunner(dataCompletenessJobContext);
 
-    scheduledExecutorService.scheduleWithFixedDelay(dataCompletenessJobRunner, 0, 15, TimeUnit.MINUTES);
+    scheduledExecutorService.scheduleWithFixedDelay(dataCompletenessJobRunner, 0, 5, TimeUnit.MINUTES);
   }
 
   public void shutdown() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/DatasetConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/DatasetConfigManager.java
@@ -1,13 +1,13 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
-import java.util.List;
-
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import java.util.List;
 
 
 public interface DatasetConfigManager extends AbstractManager<DatasetConfigDTO> {
 
   DatasetConfigDTO findByDataset(String dataset);
   List<DatasetConfigDTO> findActive();
+  List<DatasetConfigDTO> findActiveRequiresCompletenessCheck();
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/DatasetConfigManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/DatasetConfigManagerImpl.java
@@ -1,14 +1,12 @@
 package com.linkedin.thirdeye.datalayer.bao.jdbc;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.commons.collections.CollectionUtils;
-
 import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
 import com.linkedin.thirdeye.datalayer.util.Predicate;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
 
 public class DatasetConfigManagerImpl extends AbstractManagerImpl<DatasetConfigDTO>
     implements DatasetConfigManager {
@@ -41,4 +39,16 @@ public class DatasetConfigManagerImpl extends AbstractManagerImpl<DatasetConfigD
     return results;
   }
 
+  @Override
+  public List<DatasetConfigDTO> findActiveRequiresCompletenessCheck() {
+    Predicate activePredicate = Predicate.EQ("active", true);
+    Predicate completenessPredicate = Predicate.EQ("requiresCompletenessCheck", true);
+    List<DatasetConfigBean> list = genericPojoDao.get(Predicate.AND(activePredicate, completenessPredicate), DatasetConfigBean.class);
+    List<DatasetConfigDTO> results = new ArrayList<>();
+    for (DatasetConfigBean abstractBean : list) {
+      DatasetConfigDTO result = MODEL_MAPPER.map(abstractBean, DatasetConfigDTO.class);
+      results.add(result);
+    }
+    return results;
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/DatasetConfigIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/DatasetConfigIndex.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.datalayer.entity;
 public class DatasetConfigIndex extends AbstractIndexEntity {
   String dataset;
   boolean active;
+  boolean requiresCompletenessCheck;
 
   public String getDataset() {
     return dataset;
@@ -15,6 +16,12 @@ public class DatasetConfigIndex extends AbstractIndexEntity {
   }
   public void setActive(boolean active) {
     this.active = active;
+  }
+  public boolean isRequiresCompletenessCheck() {
+    return requiresCompletenessCheck;
+  }
+  public void setRequiresCompletenessCheck(boolean requiresCompletenessCheck) {
+    this.requiresCompletenessCheck = requiresCompletenessCheck;
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -1,13 +1,12 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.base.MoreObjects;
+import com.linkedin.thirdeye.api.TimeSpec;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.google.common.base.MoreObjects;
-import com.linkedin.thirdeye.api.TimeSpec;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class DatasetConfigBean extends AbstractBean {
@@ -227,14 +226,15 @@ public class DatasetConfigBean extends AbstractBean {
         && Objects.equals(preAggregatedKeyword, dc.getPreAggregatedKeyword())
         && Objects.equals(nonAdditiveBucketUnit, dc.getNonAdditiveBucketUnit())
         && Objects.equals(nonAdditiveBucketSize, dc.getNonAdditiveBucketSize())
-        && Objects.equals(realtime, dc.isRealtime());
+        && Objects.equals(realtime, dc.isRealtime())
+        && Objects.equals(requiresCompletenessCheck, dc.isRequiresCompletenessCheck());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), dataset, dimensions, timeColumn, timeUnit, timeDuration, timeFormat, timezone,
         metricAsDimension, metricNamesColumn, metricValuesColumn, autoDiscoverMetrics, active, additive,
-        dimensionsHaveNoPreAggregation, preAggregatedKeyword, nonAdditiveBucketSize, nonAdditiveBucketUnit, realtime);
+        dimensionsHaveNoPreAggregation, preAggregatedKeyword, nonAdditiveBucketSize, nonAdditiveBucketUnit, realtime, requiresCompletenessCheck);
   }
 
   @Override
@@ -246,6 +246,7 @@ public class DatasetConfigBean extends AbstractBean {
         .add("autoDiscoverMetrics", autoDiscoverMetrics).add("active", active).add("additive", additive)
         .add("dimensionsHaveNoPreAggregation", dimensionsHaveNoPreAggregation)
         .add("preAggregatedKeyword", preAggregatedKeyword).add("nonAdditiveBucketSize", nonAdditiveBucketSize)
-        .add("nonAdditiveBucketUnit", nonAdditiveBucketUnit).add("offlineOnly", realtime).toString();
+        .add("nonAdditiveBucketUnit", nonAdditiveBucketUnit).add("offlineOnly", realtime)
+        .add("requiresCompletenessCheck", requiresCompletenessCheck).toString();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.joda.time.DateTime;
 
-
 public abstract class AbstractManagerTestBase {
   protected static DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
@@ -155,6 +154,8 @@ public abstract class AbstractManagerTestBase {
     datasetConfigDTO.setTimeColumn("time");
     datasetConfigDTO.setTimeDuration(1);
     datasetConfigDTO.setTimeUnit(TimeUnit.HOURS);
+    datasetConfigDTO.setActive(true);
+    datasetConfigDTO.setRequiresCompletenessCheck(false);
     return datasetConfigDTO;
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestDatasetConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestDatasetConfigManager.java
@@ -1,13 +1,11 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import java.util.List;
-
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 
 public class TestDatasetConfigManager extends AbstractManagerTestBase {
 
@@ -29,11 +27,14 @@ public class TestDatasetConfigManager extends AbstractManagerTestBase {
   @Test
   public void testCreate() {
 
-    datasetConfigId1 = datasetConfigDAO.save(getTestDatasetConfig(collection1));
+    DatasetConfigDTO datasetConfig1 = getTestDatasetConfig(collection1);
+    datasetConfig1.setRequiresCompletenessCheck(true);
+    datasetConfigId1 = datasetConfigDAO.save(datasetConfig1);
     Assert.assertNotNull(datasetConfigId1);
 
     DatasetConfigDTO datasetConfig2 = getTestDatasetConfig(collection2);
     datasetConfig2.setActive(false);
+    datasetConfig2.setRequiresCompletenessCheck(true);
     datasetConfigId2 = datasetConfigDAO.save(datasetConfig2);
     Assert.assertNotNull(datasetConfigId2);
 
@@ -67,5 +68,10 @@ public class TestDatasetConfigManager extends AbstractManagerTestBase {
     datasetConfigDAO.deleteById(datasetConfigId2);
     DatasetConfigDTO datasetConfig = datasetConfigDAO.findById(datasetConfigId2);
     Assert.assertNull(datasetConfig);
+  }
+
+  @Test(dependsOnMethods = {"testCreate"})
+  public void testActiveRequiresCompletenessCheck() {
+    Assert.assertEquals(datasetConfigDAO.findActiveRequiresCompletenessCheck().size(), 1);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -323,7 +323,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
   }
 
   private void startDataCompletenessScheduler() throws Exception {
-    dataCompletenessScheduler = new DataCompletenessScheduler(collection);
+    dataCompletenessScheduler = new DataCompletenessScheduler();
     dataCompletenessScheduler.start();
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -123,6 +123,7 @@ create index merged_anomaly_result_start_time_idx on merged_anomaly_result_index
 create table if not exists dataset_config_index (
     dataset varchar(200) not null,
     active boolean,
+    requires_completeness_check boolean,
     base_id bigint(20) not null,
     create_time timestamp,
     update_time timestamp default current_timestamp,
@@ -131,6 +132,10 @@ create table if not exists dataset_config_index (
 ) ENGINE=InnoDB;
 create index dataset_config_dataset_idx on dataset_config_index(dataset);
 create index dataset_config_active_idx on dataset_config_index(active);
+create index dataset_config_requires_completeness_check_idx on dataset_config_index(requires_completeness_check);
+
+-- ALTER TABLE dataset_config_index ADD COLUMN requires_completeness_check boolean;
+-- UPDATE dataset_config_index SET requires_completeness_check = 0;
 
 create table if not exists metric_config_index (
     name varchar(200) not null,


### PR DESCRIPTION
CAUTION: contains database schema change, see create-schema.sql @ dataset_config_index

* select datasets for completeness check from dataset config index

* run completeness check on active datasets only

* remove datasetsToCheck configuration option