### PR TITLE
Cleanup: Remove fieldspec dependency from mutable dictionaries.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleMutableDictionary.java
@@ -15,16 +15,13 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.common.data.FieldSpec;
-
-
 public class DoubleMutableDictionary extends MutableDictionaryReader {
 
   private Double min = Double.MAX_VALUE;
   private Double max = Double.MIN_VALUE;
 
-  public DoubleMutableDictionary(FieldSpec spec) {
-    super(spec);
+  public DoubleMutableDictionary(String column) {
+    super(column);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatMutableDictionary.java
@@ -15,16 +15,13 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.common.data.FieldSpec;
-
-
 public class FloatMutableDictionary extends MutableDictionaryReader {
 
   private Float min = Float.MAX_VALUE;
   private Float max = Float.MIN_VALUE;
 
-  public FloatMutableDictionary(FieldSpec spec) {
-    super(spec);
+  public FloatMutableDictionary(String column) {
+    super(column);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntMutableDictionary.java
@@ -15,16 +15,13 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.common.data.FieldSpec;
-
-
 public class IntMutableDictionary extends MutableDictionaryReader {
 
   private Integer min = Integer.MAX_VALUE;
   private Integer max = Integer.MIN_VALUE;
 
-  public IntMutableDictionary(FieldSpec spec) {
-    super(spec);
+  public IntMutableDictionary(String column) {
+    super(column);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
@@ -15,16 +15,13 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.common.data.FieldSpec;
-
-
 public class LongMutableDictionary extends MutableDictionaryReader {
 
   private Long min = Long.MAX_VALUE;
   private Long max = Long.MIN_VALUE;
 
-  public LongMutableDictionary(FieldSpec spec) {
-    super(spec);
+  public LongMutableDictionary(String column) {
+    super(column);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
@@ -23,13 +23,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 
 public abstract class MutableDictionaryReader implements Dictionary {
+  private final String column;
   protected BiMap<Integer, Object> dictionaryIdBiMap;
-  protected FieldSpec spec;
   protected boolean hasNull = false;
   private final AtomicInteger dictionaryIdGenerator;
 
-  public MutableDictionaryReader(FieldSpec spec) {
-    this.spec = spec;
+  public MutableDictionaryReader(String column) {
+    this.column = column;
     this.dictionaryIdBiMap = HashBiMap.<Integer, Object> create();
     dictionaryIdGenerator = new AtomicInteger(-1);
   }
@@ -174,7 +174,7 @@ public abstract class MutableDictionaryReader implements Dictionary {
   public abstract String toString(int dictionaryId);
 
   public void print() {
-    System.out.println("************* printing dictionary for column : " + spec.getName() + " ***************");
+    System.out.println("************* printing dictionary for column : " + column + " ***************");
     for (Integer key : dictionaryIdBiMap.keySet()) {
       System.out.println(key + "," + dictionaryIdBiMap.get(key));
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/RealtimeDictionaryProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/RealtimeDictionaryProvider.java
@@ -21,18 +21,19 @@ import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 public class RealtimeDictionaryProvider {
 
   public static MutableDictionaryReader getDictionaryFor(FieldSpec spec) {
+    String column = spec.getName();
     switch (spec.getDataType()) {
       case INT:
-        return new IntMutableDictionary(spec);
+        return new IntMutableDictionary(column);
       case LONG:
-        return new LongMutableDictionary(spec);
+        return new LongMutableDictionary(column);
       case FLOAT:
-        return new FloatMutableDictionary(spec);
+        return new FloatMutableDictionary(column);
       case DOUBLE:
-        return new DoubleMutableDictionary(spec);
+        return new DoubleMutableDictionary(column);
       case BOOLEAN:
       case STRING:
-        return new StringMutableDictionary(spec);
+        return new StringMutableDictionary(column);
     }
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
@@ -15,16 +15,13 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.common.data.FieldSpec;
-
-
 public class StringMutableDictionary extends MutableDictionaryReader {
 
   private String min = null;
   private String max = null;
 
-  public StringMutableDictionary(FieldSpec spec) {
-    super(spec);
+  public StringMutableDictionary(String column) {
+    super(column);
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
@@ -33,7 +33,7 @@ public class MultiValueDictionaryTest {
   public void testMultiValueIndexing()
       throws Exception {
     final FieldSpec mvIntFs = new DimensionFieldSpec(COL_NAME, FieldSpec.DataType.LONG, false);
-    final LongMutableDictionary dict = new LongMutableDictionary(mvIntFs);
+    final LongMutableDictionary dict = new LongMutableDictionary(COL_NAME);
     final FixedByteSingleColumnMultiValueReaderWriter indexer =
         new FixedByteSingleColumnMultiValueReaderWriter(NROWS, Integer.SIZE / 8, MAX_N_VALUES);
 


### PR DESCRIPTION
MutableDictionary can be reused for creating on-the-fly dictionary for
TransformBlock, where the data has been transformed, thus does not have
a dictionary of its own.

In the current code, MutableDictionary requires FieldSpec in the
constructor, but does not really use it, other than getting the column
name for the FieldSpec. Removing the FieldSpec dependency would allow it
to be reused for TransformBlock (which does not have a FieldSpec).