### PR TITLE
Add AnomalyMergeConfig to AnomalyFunctionBean

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
+import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeConfig;
+import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeExecutor;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +54,8 @@ public class AnomalyFunctionBean extends AbstractBean {
   private long metricId;
 
   private Map<String, String> alertFilter;
+
+  private AnomalyMergeConfig anomalyMergeConfig;
 
 
   public long getMetricId() {
@@ -209,6 +213,14 @@ public class AnomalyFunctionBean extends AbstractBean {
 
   public void setAlertFilter(Map<String, String> alertFilter) {
     this.alertFilter = alertFilter;
+  }
+
+  public AnomalyMergeConfig getAnomalyMergeConfig() {
+    return anomalyMergeConfig;
+  }
+
+  public void setAnomalyMergeConfig(AnomalyMergeConfig anomalyMergeConfig) {
+    this.anomalyMergeConfig = anomalyMergeConfig;
   }
 
   @Override


### PR DESCRIPTION
Currently, every anomaly function uses the same merge config, i.e., anomalies that apart with each other within 2 hours are merged. This PR allows each anomaly function specify its own merge config.

Integration tested on local.