### PR TITLE
Yyuen/root cause analysis link

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -97,6 +97,14 @@ public class DataResource {
     this.anomaliesResoure = new AnomaliesResource();
   }
 
+//------------- endpoints to metric config -------------
+  @GET
+  @Path("data/metricId")
+  public List<MetricConfigDTO> getMetricsByName(@QueryParam("name") String name) {
+    List<MetricConfigDTO> metricConfigDTOs = metricConfigDAO.findByMetricName(name);
+    return metricConfigDTOs;
+  }
+
   //------------- endpoints to fetch summary -------------
   @GET
   @Path("summary/metrics")

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/Constants.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/Constants.js
@@ -36,6 +36,9 @@ function Constants() {
   this.TAB_ANOMALIES = 'anomalies';
   this.TAB_ANALYSIS = 'analysis';
 
+  this.DEFAULT_ANALYSIS_GRANULARITY = 'DAYS';
+  this.DEFAULT_ANALYSIS_DIMENSION = 'ALL';
+
   this.FEEDBACK_STRING_CONFIRMED_ANOMALY = 'Confirmed Anomaly';
   this.FEEDBACK_STRING_FALSE_ALARM = 'False Alarm';
   this.FEEDBACK_STRING_CONFIRMED_NOT_ACTIONABLE = 'Confirmed - Not Actionable';

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
@@ -157,9 +157,7 @@ DataService.prototype = {
         name,
       };
 
-      return this.getDataAsynchronous(url, data).then(([data]) => {
-        return data.id;
-      });
+      return this.getDataAsynchronous(url, data).then(([data]) => data.id);
     },
 
     fetchTimeseriesCompare: function (metricId, currentStart, currentEnd, baselineStart, baselineEnd,

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
@@ -154,7 +154,7 @@ DataService.prototype = {
     fetchMetricId(name) {
       const url = "/data/data/metricId";
       const data = {
-        name,
+        name
       };
 
       return this.getDataAsynchronous(url, data).then(([data]) => data.id);

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
@@ -148,7 +148,7 @@ DataService.prototype = {
     },
 
     fetchTimeseriesCompare: function (metricId, currentStart, currentEnd, baselineStart, baselineEnd,
-        dimension, filters, granularity) {
+        dimension = "ALL", filters = {}, granularity = "DAYS") {
       var url = "/timeseries/compare/" + metricId + "/" + currentStart + "/" + currentEnd + "/"
           + baselineStart + "/" + baselineEnd + "?dimension=" + dimension + "&filters="
           + JSON.stringify(filters) + "&granularity=" + granularity;
@@ -158,7 +158,7 @@ DataService.prototype = {
     },
 
   fetchHeatmapData: function (metricId, currentStart, currentEnd, baselineStart, baselineEnd,
-      filters) {
+      filters = {}) {
     var url = "/data/heatmap/" + metricId + "/" + currentStart + "/" + currentEnd + "/"
         + baselineStart + "/" + baselineEnd + "?filters=" + JSON.stringify(filters);
     console.log("heatmap data fetch URL ----> ");

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
@@ -30,7 +30,7 @@ DataService.prototype = {
       spinner.spin(target);
 
       console.log("request url:", url)
-      $.ajax({
+      return $.ajax({
         url: url,
         data: data,
         type: 'get',
@@ -43,7 +43,11 @@ DataService.prototype = {
         }
       }).done(function(data) {
         spinner.stop();
-        callback(data);
+        if (callback) {
+          callback(data);
+        } else {
+          return data;
+        }
       });
     },
 
@@ -145,6 +149,17 @@ DataService.prototype = {
     fetchFiltersForMetric : function(metricId) {
       var url = "/data/autocomplete/filters/metric/" + metricId;
       return this.getDataSynchronous(url);
+    },
+
+    fetchMetricId(name) {
+      const url = "/data/data/metricId";
+      const data = {
+        name,
+      };
+
+      return this.getDataAsynchronous(url, data).then(([data]) => {
+        return data.id;
+      });
     },
 
     fetchTimeseriesCompare: function (metricId, currentStart, currentEnd, baselineStart, baselineEnd,

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
@@ -34,6 +34,7 @@ function HashParams() {
   this.DASHBOARD_ANOMALY_SUMMARY_CONTROLLER = "anomalySummary";
   this.DASHBOARD_METRIC_SUMMARY_CONTROLLER = "metricSummary";
   this.DASHBOARD_WOW_SUMMARY_CONTROLLER = "wowSummary";
+
 }
 
 
@@ -104,5 +105,24 @@ HashParams.prototype = {
 
       console.log('hash Params init');
       console.log(this.controllerNameToParamNamesMap);
-    }
+    },
+
+    isSame(key, currentValue, newValue) {
+      switch(key){
+        case this.ANALYSIS_CURRENT_START:
+        case this.ANALYSIS_CURRENT_END :
+        case this.ANALYSIS_BASELINE_START :
+        case this.ANALYSIS_BASELINE_END :
+        case this.ANOMALIES_START_DATE :
+        case this.ANOMALIES_END_DATE:
+          return currentValue.isSame(newValue, 'day');
+          break;
+        case this.ANALYSIS_FILTERS:
+          return JSON.stringify(currentValue) == newValue;
+          break;
+        default:
+          return currentValue == newValue;
+      }
+    },
+
 };

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
@@ -14,6 +14,15 @@ function HashParams() {
   this.ANOMALIES_DASHBOARD_ID = 'dashboardId';
   this.ANOMALIES_ANOMALY_IDS = 'anomalyIds';
 
+  this.ANALYSIS_METRIC_ID = 'metricId';
+  this.ANALYSIS_CURRENT_START= 'currentStart';
+  this.ANALYSIS_CURRENT_END = 'currentEnd';
+  this.ANALYSIS_BASELINE_START = 'baselineStart';
+  this.ANALYSIS_BASELINE_END = 'baselineEnd';
+  this.ANALYSIS_FILTERS = 'filters';
+  this.ANALYSIS_GRANULARITY = 'granularity';
+  this.ANALYSIS_DIMENSION = 'dimension';
+
   this.RAND = 'rand';
 
   // this map has key = <controller name> and value = <map of param names and its default value>
@@ -81,9 +90,19 @@ HashParams.prototype = {
       this.controllerNameToParamNamesMap[this.ANOMALIES_CONTROLLER] = paramNamesToDefaultValuesMap;
 
       // analysis
-
+      paramNamesToDefaultValuesMap = {};
+      paramNamesToDefaultValuesMap[this.TAB] = constants.TAB_ANALYSIS;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_CURRENT_START] = null;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_CURRENT_END]= null;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_METRIC_ID]= null;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_BASELINE_START] = null;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_BASELINE_END] = null;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_FILTERS] = null;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_GRANULARITY] = constants.DEFAULT_ANALYSIS_GRANULARITY;
+      paramNamesToDefaultValuesMap[this.ANALYSIS_DIMENSION] = constants.DEFAULT_ANALYSIS_DIMENSION;
+      this.controllerNameToParamNamesMap[this.ANALYSIS_CONTROLLER] = paramNamesToDefaultValuesMap;
 
       console.log('hash Params init');
       console.log(this.controllerNameToParamNamesMap);
     }
-}
+};

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
@@ -116,10 +116,10 @@ HashParams.prototype = {
         case this.ANOMALIES_START_DATE :
         case this.ANOMALIES_END_DATE:
           return currentValue.isSame(newValue, 'day');
-          break;
+
         case this.ANALYSIS_FILTERS:
-          return JSON.stringify(currentValue) == newValue;
-          break;
+          return JSON.stringify(currentValue) === newValue;
+
         default:
           return currentValue == newValue;
       }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
@@ -52,11 +52,15 @@ HashService.prototype = {
         value = Number(value);
         break;
       case HASH_PARAMS.ANALYSIS_FILTERS:
-        if (typeof value === "string") {
+        try {
           value = JSON.parse(value);
+        } catch (e) {
+          // if not parsable, then use original value
         }
+        break;
     }
     this.params[key] = value;
+    return value;
   },
   get : function(key) {
     return this.params[key];
@@ -64,9 +68,7 @@ HashService.prototype = {
   update : function(paramsToUpdate) {
     console.log('hash service.update');
     console.log(paramsToUpdate)
-    for (var key in paramsToUpdate) {
-      this.set(key, paramsToUpdate[key]);
-    }
+    Object.keys(paramsToUpdate).forEach(key => this.set(key, paramsToUpdate[key]));
   },
   getParams : function() {
     console.log('getParams');
@@ -86,11 +88,9 @@ HashService.prototype = {
         continue;
       }
       var defaultValue = paramNamesToDefaultValuesMap[paramName];
-      var value = this.get(paramName);
-      if (!value && defaultValue) { //if default value is present, use that
-        value = defaultValue;
-        this.set(paramName, defaultValue);
-      }
+      //if default value is present, use that
+      var value = this.get(paramName) || this.set(paramName,  paramNamesToDefaultValuesMap[paramName]);
+
       if (value) {
         value = JSON.stringify(value);
         if (value.startsWith("\"")) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
@@ -51,6 +51,10 @@ HashService.prototype = {
       case HASH_PARAMS.ANOMALIES_PAGE_NUMBER:
         value = Number(value);
         break;
+      case HASH_PARAMS.ANALYSIS_FILTERS:
+        if (typeof value === "string") {
+          value = JSON.parse(value);
+        }
     }
     this.params[key] = value;
   },
@@ -151,7 +155,9 @@ HashService.prototype = {
       const [key, value] = param.split('=');
       const currentValue = params[key];
 
-      if (JSON.stringify(currentValue) !== value) {
+      const isSame = HASH_PARAMS.isSame(key, currentValue, value);
+
+      if (!isSame) {
         return true;
       }
     }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
@@ -61,7 +61,7 @@ HashService.prototype = {
     console.log('hash service.update');
     console.log(paramsToUpdate)
     for (var key in paramsToUpdate) {
-      this.params[key] = paramsToUpdate[key];
+      this.set(key, paramsToUpdate[key]);
     }
   },
   getParams : function() {
@@ -150,13 +150,8 @@ HashService.prototype = {
     for (let param of paramsToCheck.split('&')){
       const [key, value] = param.split('=');
       const currentValue = params[key];
-      const isMoment = moment.isMoment(currentValue);
 
-      if (isMoment) {
-        if(!currentValue.isSame(value, 'day')) {
-          return true;
-        }
-      } else if (currentValue != value) {
+      if (JSON.stringify(currentValue) !== value) {
         return true;
       }
     }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashService.js
@@ -42,6 +42,10 @@ HashService.prototype = {
     switch (key) {
       case HASH_PARAMS.ANOMALIES_START_DATE:
       case HASH_PARAMS.ANOMALIES_END_DATE:
+      case HASH_PARAMS.ANALYSIS_CURRENT_START:
+      case HASH_PARAMS.ANALYSIS_CURRENT_END:
+      case HASH_PARAMS.ANALYSIS_BASELINE_START:
+      case HASH_PARAMS.ANALYSIS_BASELINE_END:
         value = moment(value);
         break;
       case HASH_PARAMS.ANOMALIES_PAGE_NUMBER:
@@ -79,11 +83,11 @@ HashService.prototype = {
       }
       var defaultValue = paramNamesToDefaultValuesMap[paramName];
       var value = this.get(paramName);
-      if (value == undefined && defaultValue != undefined) { //if default value is present, use that
+      if (!value && defaultValue) { //if default value is present, use that
         value = defaultValue;
         this.set(paramName, defaultValue);
       }
-      if (value != undefined) {
+      if (value) {
         value = JSON.stringify(value);
         if (value.startsWith("\"")) {
           value = value.slice(1, -1);

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnalysisController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnalysisController.js
@@ -10,7 +10,7 @@ function AnalysisController(parentController) {
 
 AnalysisController.prototype = {
   handleAppEvent: function (hashParams) {
-    this.analysisModel.init(hashParams);
+    this.analysisModel.init(HASH_SERVICE.getParams());
     this.analysisModel.update(HASH_SERVICE.getParams());
     this.analysisView.init();
     this.analysisView.render();

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnalysisController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnalysisController.js
@@ -9,10 +9,11 @@ function AnalysisController(parentController) {
 }
 
 AnalysisController.prototype = {
-  handleAppEvent: function (hashParams) {
-    this.analysisModel.init(HASH_SERVICE.getParams());
-    this.analysisModel.update(HASH_SERVICE.getParams());
-    this.analysisView.init();
+  handleAppEvent: function () {
+    const hashParams = HASH_SERVICE.getParams();
+    this.analysisModel.init(hashParams);
+    this.analysisModel.update(hashParams);
+    this.analysisView.init(hashParams);
     this.analysisView.render();
     this.timeSeriesCompareController.handleAppEvent(hashParams);
   },

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
@@ -32,6 +32,13 @@ AnomalyResultController.prototype = {
   rootCauseAnalysisButtonClickEventHandler: function (sender, args) {
     console.log("received root cause analysis button click event at AnomalyResultController");
     console.log(args);
+    this.anomalyResultModel.getMetricIdFromName(args.metric).then((id) => {
+      args.metricId = id;
+      HASH_SERVICE.set("tab", 'analysis');
+      HASH_SERVICE.update(args);
+      HASH_SERVICE.refreshWindowHashForRouting('analysis');
+      HASH_SERVICE.routeTo('app');
+    });
 
     // Send this event and the args to parent controller, to route to AnalysisController
   },

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
@@ -34,6 +34,8 @@ AnomalyResultController.prototype = {
     console.log(args);
     this.anomalyResultModel.getMetricIdFromName(args.metric).then((id) => {
       args.metricId = id;
+
+      HASH_SERVICE.clear();
       HASH_SERVICE.set("tab", 'analysis');
       HASH_SERVICE.update(args);
       HASH_SERVICE.refreshWindowHashForRouting('analysis');

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
@@ -36,7 +36,7 @@ AnomalyResultController.prototype = {
       args.metricId = id;
 
       HASH_SERVICE.clear();
-      HASH_SERVICE.set("tab", 'analysis');
+      HASH_SERVICE.set('tab', 'analysis');
       HASH_SERVICE.update(args);
       HASH_SERVICE.refreshWindowHashForRouting('analysis');
       HASH_SERVICE.routeTo('app');

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/DimensionTreeMapController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/DimensionTreeMapController.js
@@ -5,10 +5,10 @@ function DimensionTreeMapController() {
 
 DimensionTreeMapController.prototype = {
 
-  handleAppEvent : function(hashParams) {
+  handleAppEvent : function() {
     console.log("----------------- rendering heatmap with hashParams ---------");
-    console.log(hashParams);
-    this.dimensionTreeMapModel.init(hashParams);
+    console.log(HASH_SERVICE.getParams());
+    this.dimensionTreeMapModel.init(HASH_SERVICE.getParams());
     this.dimensionTreeMapModel.update();
     this.dimensionTreeMapView.render();
   },

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/TimeSeriesCompareController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/TimeSeriesCompareController.js
@@ -10,13 +10,13 @@ function TimeSeriesCompareController(parentController) {
 }
 
 TimeSeriesCompareController.prototype = {
-  handleAppEvent: function (hashParams) {
-    this.timeSeriesCompareModel.init(hashParams);
+  handleAppEvent: function () {
+    this.timeSeriesCompareModel.init(HASH_SERVICE.getParams());
     this.timeSeriesCompareModel.update();
     this.timeSeriesCompareView.render();
 
     // render heatmap if view params are set in hashParams
-    this.dimensionTreeMapController.handleAppEvent(hashParams);
+    this.dimensionTreeMapController.handleAppEvent();
   },
 
   handleHeatMapRenderEvent: function (viewObject) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
@@ -149,5 +149,11 @@ AnomalyResultModel.prototype = {
     default:
       return feedbackType;
     }
-  }
+  },
+  getMetricIdFromName(name) {
+    if (!name) {
+      return;
+    }
+    return dataService.fetchMetricId(name);
+  },
 }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
@@ -151,9 +151,6 @@ AnomalyResultModel.prototype = {
     }
   },
   getMetricIdFromName(name) {
-    if (!name) {
-      return;
-    }
-    return dataService.fetchMetricId(name);
+    return name && dataService.fetchMetricId(name);
   },
 }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/DimensionTreeMapModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/DimensionTreeMapModel.js
@@ -26,6 +26,11 @@ DimensionTreeMapModel.prototype = {
         this.metricId = params.metric.id;
         this.metricName = params.metric.name;
       }
+
+      if (params.metricId) {
+        this.metricId = params.metricId;
+      }
+
       if (params.currentStart) {
         this.currentStart = params.currentStart;
       }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/TimeSeriesCompareModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/TimeSeriesCompareModel.js
@@ -25,10 +25,11 @@ TimeSeriesCompareModel.prototype = {
 
   init: function (params) {
     if (params) {
-      if (params.metric) {
+      if (params.metricId) {
         // metric is collection of id / name / alias
-        this.metricId = params.metric.id;
-        this.metricName = params.metric.name;
+        this.metricId = params.metricId;
+        // this.metricId = params.metric.id;
+        // this.metricName = params.metric.name;
       }
       if (params.currentStart) {
         this.currentStart = params.currentStart;

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/TimeSeriesCompareModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/TimeSeriesCompareModel.js
@@ -26,10 +26,10 @@ TimeSeriesCompareModel.prototype = {
   init: function (params) {
     if (params) {
       if (params.metricId) {
-        // metric is collection of id / name / alias
         this.metricId = params.metricId;
-        // this.metricId = params.metric.id;
-        // this.metricName = params.metric.name;
+      }
+      if (params.metricName) {
+        this.metricName = params.metricName;
       }
       if (params.currentStart) {
         this.currentStart = params.currentStart;

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
@@ -46,6 +46,7 @@ AnalysisView.prototype = {
       var metricAlias = selectedData.map(function (e) {return e.text})[0];
       var metricName = selectedData.map(function (e) {return e.name})[0];
       self.viewParams['metric'] = {id: metricId, alias: metricAlias, allowClear:true, name:metricName};
+      self.viewParams['metricId'] = metricId;
 
       // Now render the dimensions and filters for selected metric
       self.renderGranularity(self.viewParams.metric.id);

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
@@ -9,7 +9,7 @@ function AnalysisView(analysisModel) {
 
 AnalysisView.prototype = {
   init({metricId=""}) {
-    this.viewParams[metricId] = metricId;
+    this.viewParams.metricId = metricId;
   },
 
   render: function () {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
@@ -8,8 +8,9 @@ function AnalysisView(analysisModel) {
 }
 
 AnalysisView.prototype = {
-  init({metricId=""}) {
-    this.viewParams.metricId = metricId;
+  init(params = {}) {
+    const { metricId } = params;
+    this.viewParams.metricId = metricId || '';
   },
 
   render: function () {
@@ -40,17 +41,18 @@ AnalysisView.prototype = {
       }
     });
 
-    analysisMetricSelect.on("change", (e) => {
+    analysisMetricSelect.on('change', (e) => {
       const selectedElement = $(e.currentTarget);
-      const selectedData = selectedElement.select2("data");
+      const selectedData = selectedElement.select2('data');
       let metricId;
       let metricAlias;
       let metricName;
 
       if (selectedData.length) {
-        metricId = selectedData.map(function (e) {return e.id})[0];
-        metricAlias = selectedData.map(function (e) {return e.text})[0];
-        metricName = selectedData.map(function (e) {return e.name})[0];
+        const {id, text, name} = selectedData[0];
+        metricId = id;
+        metricAlias = text;
+        metricName = name;
       }
 
       this.viewParams['metric'] = {id: metricId, alias: metricAlias, allowClear:true, name:metricName};

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
@@ -42,8 +42,8 @@ AnalysisView.prototype = {
     });
 
     analysisMetricSelect.on('change', (e) => {
-      const selectedElement = $(e.currentTarget);
-      const selectedData = selectedElement.select2('data');
+      const $selectedElement = $(e.currentTarget);
+      const selectedData = $selectedElement.select2('data');
       let metricId;
       let metricAlias;
       let metricName;

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
@@ -8,7 +8,8 @@ function AnalysisView(analysisModel) {
 }
 
 AnalysisView.prototype = {
-  init: function () {
+  init({metricId=""}) {
+    this.viewParams[metricId] = metricId;
   },
 
   render: function () {
@@ -39,19 +40,26 @@ AnalysisView.prototype = {
       }
     });
 
-    analysisMetricSelect.on("change", function(e) {
-      var selectedElement = $(e.currentTarget);
-      var selectedData = selectedElement.select2("data");
-      var metricId = selectedData.map(function (e) {return e.id})[0];
-      var metricAlias = selectedData.map(function (e) {return e.text})[0];
-      var metricName = selectedData.map(function (e) {return e.name})[0];
-      self.viewParams['metric'] = {id: metricId, alias: metricAlias, allowClear:true, name:metricName};
-      self.viewParams['metricId'] = metricId;
+    analysisMetricSelect.on("change", (e) => {
+      const selectedElement = $(e.currentTarget);
+      const selectedData = selectedElement.select2("data");
+      let metricId;
+      let metricAlias;
+      let metricName;
+
+      if (selectedData.length) {
+        metricId = selectedData.map(function (e) {return e.id})[0];
+        metricAlias = selectedData.map(function (e) {return e.text})[0];
+        metricName = selectedData.map(function (e) {return e.name})[0];
+      }
+
+      this.viewParams['metric'] = {id: metricId, alias: metricAlias, allowClear:true, name:metricName};
+      this.viewParams['metricId'] = metricId;
 
       // Now render the dimensions and filters for selected metric
-      self.renderGranularity(self.viewParams.metric.id);
-      self.renderDimensions(self.viewParams.metric.id);
-      self.renderFilters(self.viewParams.metric.id);
+      this.renderGranularity(self.viewParams.metric.id);
+      this.renderDimensions(self.viewParams.metric.id);
+      this.renderFilters(self.viewParams.metric.id);
     }).trigger('change');
 
     // TIME RANGE SELECTION

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
@@ -344,8 +344,10 @@ AnomalyResultView.prototype = {
   setupListenersOnAnomaly : function(idx, anomaly) {
     var rootCauseAnalysisParams = {
       metric : anomaly.metric,
-      rangeStart : anomaly.currentStart,
-      rangeEnd : anomaly.currentEnd,
+      currentStart : anomaly.currentStart,
+      currentEnd : anomaly.currentEnd,
+      baselineStart: anomaly.baselineStart,
+      baselineEnd: anomaly.baselineEnd,
       dimension : anomaly.anomalyFunctionDimension
     }
     $('#root-cause-analysis-button-' + idx).click(rootCauseAnalysisParams, this.dataEventHandler.bind(this));

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
@@ -348,7 +348,8 @@ AnomalyResultView.prototype = {
       currentEnd : anomaly.currentEnd,
       baselineStart: anomaly.baselineStart,
       baselineEnd: anomaly.baselineEnd,
-      dimension : anomaly.anomalyFunctionDimension
+      // not needed at the moment since it returns {}
+      // dimension : anomaly.anomalyFunctionDimension
     }
     $('#root-cause-analysis-button-' + idx).click(rootCauseAnalysisParams, this.dataEventHandler.bind(this));
     var showDetailsParams = {


### PR DESCRIPTION
### What's new: 
- Hooked up the Anomalies result `root cause analysis` button
- Configure the Root Cause Analysis page to use the Hash Params and Hash Services 
- Root Cause Analysis now parses the hash correctly 
- Added custom end point (temporary) @cyenjung 

### Gif:
![mr3wd55ikd](https://cloud.githubusercontent.com/assets/8664954/22795826/eabba576-eeac-11e6-99b4-a7aa08e8b23a.gif)


### How this was tested: 
- Manually tested locally with prod data

### To do (in follow up PR): 
- metric name, granularity, dimension and filters are not prepopulated after a redirect. (no regression for default behavior/clicks)
- d3/c3 details panel not render correctly after a redirect
- Unify Hash Params for Root Cause Anomalies page so that it doesn't use both `params.metric` and `params.metricId`