### PR TITLE
[PINOT-4425] Controller should not assign segments to disabled server instances

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -15,6 +15,12 @@
  */
 package com.linkedin.pinot.common.utils.helix;
 
+import com.google.common.base.Function;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource.SegmentAssignmentStrategyType;
+import com.linkedin.pinot.common.utils.EqualityUtils;
+import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import com.linkedin.pinot.common.utils.retry.RetryPolicy;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-
 import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
@@ -37,16 +42,10 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Function;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.DataSource.SegmentAssignmentStrategyType;
-import com.linkedin.pinot.common.utils.EqualityUtils;
-import com.linkedin.pinot.common.utils.retry.RetryPolicies;
-import com.linkedin.pinot.common.utils.retry.RetryPolicy;
 
 
 public class HelixHelper {
@@ -392,5 +391,21 @@ public class HelixHelper {
     };
 
     updateIdealState(helixManager, tableName, updater, DEFAULT_RETRY_POLICY);
+  }
+
+  public static List<String> getEnabledInstancesWithTag(HelixAdmin helixAdmin, String helixClusterName, String instanceTag) {
+    List<String> instances = helixAdmin.getInstancesInCluster(helixClusterName);
+    List<String> enabledInstances = new ArrayList<>();
+    for (String instance : instances) {
+      InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(helixClusterName, instance);
+      if (instanceConfig == null) {
+        LOGGER.warn("InstanceConfig not found for instance: {}", instance);
+        continue;
+      }
+      if (instanceConfig.containsTag(instanceTag) && instanceConfig.getInstanceEnabled()) {
+        enabledInstances.add(instance);
+      }
+    }
+    return enabledInstances;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.Pairs;
 import com.linkedin.pinot.common.utils.Pairs.Number2ObjectPair;
+import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
 
     List<String> selectedInstances = new ArrayList<String>();
     Map<String, Integer> currentNumSegmentsPerInstanceMap = new HashMap<String, Integer>();
-    List<String> allTaggedInstances = helixAdmin.getInstancesInClusterWithTag(helixClusterName, serverTenantName);
+    List<String> allTaggedInstances = HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, serverTenantName);
 
     for (String instance : allTaggedInstances) {
       currentNumSegmentsPerInstanceMap.put(instance, 0);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
@@ -46,8 +46,7 @@ public class BucketizedSegmentStrategy implements SegmentAssignmentStrategy {
       serverTenantName = ControllerTenantNameBuilder.getOfflineTenantNameForTenant(tenantName);
     }
 
-    List<String> allInstances =
-        helixAdmin.getInstancesInClusterWithTag(helixClusterName, serverTenantName);
+    List<String> allInstances = HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, serverTenantName);
     List<String> selectedInstanceList = new ArrayList<String>();
     if (segmentMetadata.getShardingKey() != null) {
       for (String instance : allInstances) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.helix.core.sharding;
 
+import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -48,7 +49,7 @@ public class RandomAssignmentStrategy implements SegmentAssignmentStrategy {
     }
     final Random random = new Random(System.currentTimeMillis());
 
-    List<String> allInstanceList = helixAdmin.getInstancesInClusterWithTag(helixClusterName, serverTenantName);
+    List<String> allInstanceList = HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, serverTenantName);
     List<String> selectedInstanceList = new ArrayList<String>();
     for (int i = 0; i < numReplicas; ++i) {
       final int idx = random.nextInt(allInstanceList.size());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
@@ -15,11 +15,9 @@
  */
 package com.linkedin.pinot.controller.helix.core.sharding;
 
-import java.util.List;
-
-import org.apache.helix.HelixAdmin;
-
 import com.linkedin.pinot.common.segment.SegmentMetadata;
+import java.util.List;
+import org.apache.helix.HelixAdmin;
 
 
 /**
@@ -28,6 +26,9 @@ import com.linkedin.pinot.common.segment.SegmentMetadata;
  *
  */
 public interface SegmentAssignmentStrategy {
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, String helixClusterName,
+
+  List<String> getAssignedInstances(HelixAdmin helixAdmin, String helixClusterName,
       SegmentMetadata segmentMetadata, int numReplicas, String tenantName);
+
+
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -21,7 +21,6 @@ import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
-import java.io.FileInputStream;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -69,15 +68,16 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
   @BeforeMethod
   public void setupMethod(Object[] args)
       throws Exception {
+    ensureDirectoryExistsAndIsEmpty(_tmpDir);
+    ensureDirectoryExistsAndIsEmpty(_segmentsDir);
+    ensureDirectoryExistsAndIsEmpty(_tarsDir);
     if (args == null || args.length == 0) {
       return;
     }
     this.tableName = (String) args[0];
     SegmentVersion version = (SegmentVersion) args[1];
     addOfflineTable("DaysSinceEpoch", "daysSinceEpoch", -1, "", null, null, this.tableName, version);
-    ensureDirectoryExistsAndIsEmpty(_tmpDir);
-    ensureDirectoryExistsAndIsEmpty(_segmentsDir);
-    ensureDirectoryExistsAndIsEmpty(_tarsDir);
+
   }
 
   @AfterMethod

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
@@ -161,12 +161,16 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
     AutoRebalanceStrategy rebalanceStrategy = new AutoRebalanceStrategy(tableName, partitions, states);
 
     TableNameBuilder builder = new TableNameBuilder(tableType);
-    List<String> instancesInClusterWithTag = helixAdmin.getInstancesInClusterWithTag(clusterName, builder.forTable(tenantName));
-    LOGGER.info("Current: Nodes:" + currentHosts);
-    LOGGER.info("New Nodes:" + instancesInClusterWithTag);
+    String serverTenant = builder.forTable(tenantName);
+    List<String> instancesInClusterWithTag = helixAdmin.getInstancesInClusterWithTag(clusterName, serverTenant);
+    List<String> enabledInstancesWithTag =
+        HelixHelper.getEnabledInstancesWithTag(helixAdmin, clusterName, serverTenant);
+    LOGGER.info("Current nodes: {}", currentHosts);
+    LOGGER.info("New nodes: {}", instancesInClusterWithTag);
+    LOGGER.info("Enabled nodes: {}", enabledInstancesWithTag);
     Map<String, Map<String, String>> currentMapping = currentIdealState.getRecord().getMapFields();
     ZNRecord newZnRecord = rebalanceStrategy
-        .computePartitionAssignment(instancesInClusterWithTag, currentMapping, instancesInClusterWithTag);
+        .computePartitionAssignment(enabledInstancesWithTag, currentMapping, instancesInClusterWithTag);
     final Map<String, Map<String, String>> newMapping = newZnRecord.getMapFields();
     LOGGER.info("Current segment Assignment:");
     printSegmentAssignment(currentMapping);


### PR DESCRIPTION
Updated all segment assignment strategies to skip disabled server instances.
Also updated rebalancer and move replica group commands to skip disabled instances
in the destination list.

Testing: Integration test