### PR TITLE
Auto-fix segment consumption if idealstate update fails during LLC segment completion

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -669,8 +669,6 @@ public class PinotLLCRealtimeSegmentManager {
   }
 
   public void completeCommittingSegments(String realtimeTableName, List<String> segmentIds) {
-    IdealState idealState = getTableIdealState(realtimeTableName);
-
     Comparator<LLCSegmentName> comparator = new Comparator<LLCSegmentName>() {
       @Override
       public int compare(LLCSegmentName o1, LLCSegmentName o2) {
@@ -678,7 +676,7 @@ public class PinotLLCRealtimeSegmentManager {
       }
     };
 
-    Map<Integer, MinMaxPriorityQueue<LLCSegmentName>> partitionToLatestSegments = new HashMap<>(16);
+    Map<Integer, MinMaxPriorityQueue<LLCSegmentName>> partitionToLatestSegments = new HashMap<>();
 
     for (String segmentId : segmentIds) {
       LLCSegmentName segmentName = new LLCSegmentName(segmentId);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -27,9 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
-import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.joda.time.Duration;
@@ -248,6 +246,7 @@ public class ValidationManager {
       if (_autoCreateOnError) {
         _llcRealtimeSegmentManager.createConsumingSegment(realtimeTableName, nonConsumingKafkaPartitions, llcSegments,
             tableConfig);
+        _llcRealtimeSegmentManager.completeCommittingSegments(realtimeTableName, llcSegments);
       }
     }
     // Make this call after other validations (so that we verify that we are consistent against the existing partition

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -748,8 +748,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    protected void updateHelixIdealState(IdealState idealState, String realtimeTableName, Map<String, List<String>> idealStateEntries,
-        boolean create, int nReplicas) {
+    protected void updateIdealState(IdealState idealState, String realtimeTableName,
+        Map<String, List<String>> idealStateEntries, boolean create, int nReplicas) {
       _realtimeTableName = realtimeTableName;
       _idealStateEntries = idealStateEntries;
       _nReplicas = nReplicas;
@@ -759,7 +759,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       }
     }
 
-    protected void updateHelixIdealState(final String realtimeTableName, final List<String> newInstances,
+    protected void updateIdealState(final String realtimeTableName, final List<String> newInstances,
         final String oldSegmentNameStr, final String newSegmentNameStr) {
       _realtimeTableName = realtimeTableName;
       _newInstances = newInstances;


### PR DESCRIPTION
When a segment completes, we update zk with two changes:
1. Update proprtystore with a new LLC segment
2. Update idealstate to mark old segment in ONLINE and add a new segment in CONSUMING
These two updates cannot be done in a transaction. It is possible that the controller
fails after step 1 but before step 2. In that case, we had called the code to fix
things on a controller getting leadership.

It is also possible that the idealstate update fails due to concurrent updates to
the idealstate znode (e.g. retention manager, deletes by operator, etc.). In these
cases, we have a retry, but no guarantees.

With this change, we call the same logic that we call on leadership change.

Also changed the logic that detects and fixes the condition to use priority
queues to make the code more readable.

Existing unit tests cover this case already