### PR TITLE
[PINOT-4432] Upgrade helix to 0.6.7

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
@@ -22,7 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.helix.ZNRecord;
-import org.apache.helix.controller.strategy.AutoRebalanceStrategy;
+import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
+import org.apache.helix.controller.stages.ClusterDataCache;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.zookeeper.data.Stat;
@@ -166,7 +167,8 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
     LOGGER.info("New Nodes:" + instancesInClusterWithTag);
     Map<String, Map<String, String>> currentMapping = currentIdealState.getRecord().getMapFields();
     ZNRecord newZnRecord = rebalanceStrategy
-        .computePartitionAssignment(instancesInClusterWithTag, currentMapping, instancesInClusterWithTag);
+        .computePartitionAssignment(instancesInClusterWithTag, instancesInClusterWithTag, currentMapping, new ClusterDataCache());
+
     final Map<String, Map<String, String>> newMapping = newZnRecord.getMapFields();
     LOGGER.info("Current segment Assignment:");
     printSegmentAssignment(currentMapping);

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.7.6</avro.version>
-    <helix.version>0.6.5</helix.version>
+    <helix.version>0.6.7</helix.version>
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
     <kafka.version>0.9.0.1</kafka.version>
     <zkclient.version>0.7</zkclient.version>


### PR DESCRIPTION
We need this to use helix-0.6.7 to get the task scheduling functionality.