### PR TITLE
Hookup FixedByteChunkSingleValue indexing.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/DataFetcher.java
@@ -177,8 +177,13 @@ public class DataFetcher {
    */
   public void fetchIntValues(String column, int[] inDocIds, int inStartPos, int length, int[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
-    dictionary.readIntValues(_reusableDictIds, 0, length, outValues, outStartPos);
+    if (dictionary != null) {
+      fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+      dictionary.readIntValues(_reusableDictIds, 0, length, outValues, outStartPos);
+    } else {
+      BlockValSet blockValSet = _columnToBlockValSetMap.get(column);
+      blockValSet.getIntValues(inDocIds, inStartPos, length, outValues, outStartPos);
+    }
   }
 
   /**
@@ -216,8 +221,13 @@ public class DataFetcher {
    */
   public void fetchLongValues(String column, int[] inDocIds, int inStartPos, int length, long[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
-    dictionary.readLongValues(_reusableDictIds, 0, length, outValues, outStartPos);
+    if (dictionary != null) {
+      fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+      dictionary.readLongValues(_reusableDictIds, 0, length, outValues, outStartPos);
+    } else {
+      BlockValSet blockValSet = _columnToBlockValSetMap.get(column);
+      blockValSet.getLongValues(inDocIds, inStartPos, length, outValues, outStartPos);
+    }
   }
 
   /**
@@ -255,8 +265,13 @@ public class DataFetcher {
    */
   public void fetchFloatValues(String column, int[] inDocIds, int inStartPos, int length, float[] outValues, int outStartPos) {
     Dictionary dictionary = getDictionaryForColumn(column);
-    fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
-    dictionary.readFloatValues(_reusableDictIds, 0, length, outValues, outStartPos);
+    if (dictionary != null) {
+      fetchSingleDictIds(column, inDocIds, inStartPos, length, _reusableDictIds, 0);
+      dictionary.readFloatValues(_reusableDictIds, 0, length, outValues, outStartPos);
+    } else {
+      BlockValSet blockValSet = _columnToBlockValSetMap.get(column);
+      blockValSet.getFloatValues(inDocIds, inStartPos, length, outValues, outStartPos);
+    }
   }
 
   /**
@@ -299,7 +314,7 @@ public class DataFetcher {
       dictionary.readDoubleValues(_reusableDictIds, 0, length, outValues, outStartPos);
     } else {
       BlockValSet blockValSet = _columnToBlockValSetMap.get(column);
-      blockValSet.getDoubleValues(inDocIds, 0, length, outValues, 0);
+      blockValSet.getDoubleValues(inDocIds, inStartPos, length, outValues, outStartPos);
     }
   }
 
@@ -340,7 +355,7 @@ public class DataFetcher {
       dictionary.readStringValues(_reusableDictIds, 0, length, outValues, outStartPos);
     } else {
       BlockValSet blockValSet = _columnToBlockValSetMap.get(column);
-      blockValSet.getStringValues(inDocIds, 0, length, outValues, 0);
+      blockValSet.getStringValues(inDocIds, inStartPos, length, outValues, outStartPos);
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
@@ -126,7 +126,7 @@ public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleVa
       throws IOException {
 
     // Write the chunk if it is non-empty.
-    if (_chunkBuffer.limit() > 0) {
+    if (_chunkBuffer.position() > 0) {
       writeChunk();
     }
 
@@ -147,6 +147,7 @@ public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleVa
    *
    */
   protected void writeChunk() {
+    _chunkBuffer.flip();
     _compressedBuffer.flip();
 
     int compressedSize;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
@@ -41,6 +41,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  * <ul>
  *   <li> Data bytes. </li>
  * </ul>
+ *
+ * Only sequential writes are supported.
  */
 @NotThreadSafe
 public class FixedByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
@@ -68,37 +70,42 @@ public class FixedByteChunkSingleValueWriter extends BaseChunkSingleValueWriter 
 
   @Override
   public void setInt(int row, int value) {
-    _chunkBuffer.putInt(_chunkDataOffset, value);
+    _chunkBuffer.putInt(value);
     _chunkDataOffset += INT_SIZE;
     flushChunkIfNeeded();
   }
 
   @Override
   public void setFloat(int row, float value) {
-    _chunkBuffer.putFloat(_chunkDataOffset, value);
+    _chunkBuffer.putFloat(value);
     _chunkDataOffset += FLOAT_SIZE;
     flushChunkIfNeeded();
   }
 
   @Override
   public void setLong(int row, long value) {
-    _chunkBuffer.putLong(_chunkDataOffset, value);
+    _chunkBuffer.putLong(value);
     _chunkDataOffset += LONG_SIZE;
     flushChunkIfNeeded();
   }
 
   @Override
   public void setDouble(int row, double value) {
-    _chunkBuffer.putDouble(_chunkDataOffset, value);
+    _chunkBuffer.putDouble(value);
     _chunkDataOffset += DOUBLE_SIZE;
     flushChunkIfNeeded();
+  }
+
+  @Override
+  protected void writeChunk() {
+    super.writeChunk();
+    _chunkDataOffset = 0;
   }
 
   private void flushChunkIfNeeded() {
     // If buffer filled, then compress and write to file.
     if (_chunkDataOffset == _chunkSize) {
       writeChunk();
-      _chunkDataOffset = 0;
     }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
@@ -40,6 +40,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  *   <li> Integer offsets to start position of rows: For partial chunks, offset values are 0 for missing rows. </li>
  *   <li> Data bytes. </li>
  * </ul>
+ *
+ * Only sequential writes are supported.
  */
 @NotThreadSafe
 public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
@@ -130,7 +132,6 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
       _chunkBuffer.putInt(i, 0);
     }
 
-    _chunkBuffer.flip(); // This is because setString changes 'position' of ByteBuffer.
     super.writeChunk();
 
     // Reset the chunk offsets.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/UnSortedSingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/UnSortedSingleValueSet.java
@@ -46,6 +46,105 @@ public final class UnSortedSingleValueSet extends BaseBlockValSet {
   }
 
   /**
+   * Reads int values for the given docIds and returns in the passed in double[].
+   * Only 'int' data type allowed to be read in as 'int'.
+   *
+   * @param inDocIds DocIds for which to get the values
+   * @param inStartPos start index in the inDocIds array
+   * @param inDocIdsSize size of docIds to read
+   * @param outValues Array where output is written
+   * @param outStartPos start index into output array
+   */
+  @Override
+  public void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
+    int inEndPos = inStartPos + inDocIdsSize;
+    ReaderContext context = sVReader.createContext();
+
+    if (columnMetadata.getDataType() == DataType.INT) {
+      for (int i = inStartPos; i < inEndPos; i++) {
+        outValues[outStartPos++] = sVReader.getInt(inDocIds[i], context);
+      }
+    } else {
+      throw new UnsupportedOperationException(
+          "Cannot fetch int values for column: " + columnMetadata.getColumnName());
+    }
+  }
+
+  /**
+   * Reads int values for the given docIds and returns in the passed in double[].
+   * Compatible data types ('int' and 'long') can be read in as long.
+   *
+   * @param inDocIds DocIds for which to get the values
+   * @param inStartPos start index in the inDocIds array
+   * @param inDocIdsSize size of docIds to read
+   * @param outValues Array where output is written
+   * @param outStartPos start index into output array
+   */
+  @Override
+  public void getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos) {
+    int inEndPos = inStartPos + inDocIdsSize;
+    ReaderContext context = sVReader.createContext();
+
+    switch (columnMetadata.getDataType()) {
+      case INT:
+        for (int i = inStartPos; i < inEndPos; i++) {
+          outValues[outStartPos++] = sVReader.getInt(inDocIds[i], context);
+        }
+        break;
+
+      case LONG:
+        for (int i = inStartPos; i < inEndPos; i++) {
+          outValues[outStartPos++] = sVReader.getLong(inDocIds[i], context);
+        }
+        break;
+
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot fetch long values for column: " + columnMetadata.getColumnName());
+    }
+  }
+
+  /**
+   * Reads int values for the given docIds and returns in the passed in double[].
+   * Compatible data types ('int', 'long' and 'float') can be read in as float.
+   *
+   * @param inDocIds DocIds for which to get the values
+   * @param inStartPos start index in the inDocIds array
+   * @param inDocIdsSize size of docIds to read
+   * @param outValues Array where output is written
+   * @param outStartPos start index into output array
+   */
+  @Override
+  public void getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos) {
+    int inEndPos = inStartPos + inDocIdsSize;
+    ReaderContext context = sVReader.createContext();
+
+    switch (columnMetadata.getDataType()) {
+      case INT:
+        for (int i = inStartPos; i < inEndPos; i++) {
+          outValues[outStartPos++] = sVReader.getInt(inDocIds[i], context);
+        }
+        break;
+
+      case LONG:
+        for (int i = inStartPos; i < inEndPos; i++) {
+          outValues[outStartPos++] = sVReader.getLong(inDocIds[i], context);
+        }
+        break;
+
+      case FLOAT:
+        for (int i = inStartPos; i < inEndPos; i++) {
+          outValues[outStartPos++] = sVReader.getFloat(inDocIds[i], context);
+        }
+        break;
+
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot fetch float values for column: " + columnMetadata.getColumnName());
+    }
+  }
+
+  /**
    * Reads double values for the given docIds and returns in the passed in double[].
    * Compatible types (int, float, long) can also be read in as double.
    *

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
@@ -64,7 +64,8 @@ public abstract class ColumnIndexContainer {
       dictionary = load(metadata, dictionaryBuffer);
     }
 
-    if (metadata.isSorted() && metadata.isSingleValue()) {
+    // TODO: Support sorted index without dictionary.
+    if (dictionary != null && metadata.isSorted() && metadata.isSingleValue()) {
       return loadSorted(column, segmentReader, metadata, dictionary);
     }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSourceImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSourceImpl.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.index.data.source;
 
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,20 +74,22 @@ public class ColumnDataSourceImpl extends DataSource {
   public Block getNextBlock(BlockId blockId) {
     Block b = null;
 
-    if (indexContainer.getColumnMetadata().isSingleValue()) {
-      if (indexContainer.getColumnMetadata().isSorted()) {
+    ColumnMetadata columnMetadata = indexContainer.getColumnMetadata();
+    if (columnMetadata.isSingleValue()) {
+      // TODO: Support sorted index without dictionary.
+      if (columnMetadata.hasDictionary() && columnMetadata.isSorted()) {
         b = new SortedSingleValueBlock(blockId,
             (SortedForwardIndexReader) indexContainer.getForwardIndex(),
-            indexContainer.getDictionary(), indexContainer.getColumnMetadata());
+            indexContainer.getDictionary(), columnMetadata);
       } else {
         b = new UnSortedSingleValueBlock(blockId,
             (SingleColumnSingleValueReader) indexContainer.getForwardIndex(),
-            indexContainer.getDictionary(), indexContainer.getColumnMetadata());
+            indexContainer.getDictionary(), columnMetadata);
       }
     } else {
       b = new MultiValueBlock(blockId,
           (SingleColumnMultiValueReader) indexContainer.getForwardIndex(),
-          indexContainer.getDictionary(), indexContainer.getColumnMetadata());
+          indexContainer.getDictionary(), columnMetadata);
     }
 
     return b;

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteChunkSingleValueReaderWriteTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteChunkSingleValueReaderWriteTest.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.index.readerwriter;
+
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.io.compression.ChunkCompressor;
+import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
+import com.linkedin.pinot.core.io.compression.ChunkDecompressor;
+import com.linkedin.pinot.core.io.reader.impl.ChunkReaderContext;
+import com.linkedin.pinot.core.io.reader.impl.v1.FixedByteChunkSingleValueReader;
+import com.linkedin.pinot.core.io.writer.impl.v1.FixedByteChunkSingleValueWriter;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import java.io.File;
+import java.nio.channels.FileChannel;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link FixedByteChunkSingleValueReader} and {@link FixedByteChunkSingleValueWriter} classes.
+ *
+ * This test writes {@link #NUM_VALUES} using {@link FixedByteChunkSingleValueWriter}. It then reads
+ * the values using {@link FixedByteChunkSingleValueReader}, and asserts that what was written is the same as
+ * what was read in.
+ *
+ * Number of docs and docs per chunk are chosen to generate complete as well partial chunks.
+ *
+ */
+public class FixedByteChunkSingleValueReaderWriteTest {
+
+  private static final int NUM_VALUES = 10009;
+  private static final int NUM_DOCS_PER_CHUNK = 5003;
+  private static final String TEST_FILE = System.getProperty("java.io.tmpdir") + File.separator + "FixedByteSVRTest";
+  private static final Random _random = new Random();
+
+  @Test
+  public void testInt()
+      throws Exception {
+    int[] expected = new int[NUM_VALUES];
+    for (int i = 0; i < NUM_VALUES; i++) {
+      expected[i] = _random.nextInt();
+    }
+
+    File outFile = new File(TEST_FILE);
+    FileUtils.deleteQuietly(outFile);
+
+    ChunkCompressor compressor = ChunkCompressorFactory.getCompressor("snappy");
+    FixedByteChunkSingleValueWriter writer =
+        new FixedByteChunkSingleValueWriter(outFile, compressor, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            V1Constants.Numbers.INTEGER_SIZE);
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      writer.setInt(i, expected[i]);
+    }
+    writer.close();
+
+    PinotDataBuffer pinotDataBuffer =
+        PinotDataBuffer.fromFile(outFile, ReadMode.mmap, FileChannel.MapMode.READ_ONLY, getClass().getName());
+
+    ChunkDecompressor uncompressor = ChunkCompressorFactory.getDecompressor("snappy");
+    FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(pinotDataBuffer, uncompressor);
+    ChunkReaderContext context = reader.createContext();
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      int actual = reader.getInt(i, context);
+      Assert.assertEquals(actual, expected[i]);
+    }
+    reader.close();
+    FileUtils.deleteQuietly(outFile);
+  }
+
+  @Test
+  public void testLong()
+      throws Exception {
+    long[] expected = new long[NUM_VALUES];
+    for (int i = 0; i < NUM_VALUES; i++) {
+      expected[i] = _random.nextLong();
+    }
+
+    File outFile = new File(TEST_FILE);
+    FileUtils.deleteQuietly(outFile);
+
+    ChunkCompressor compressor = ChunkCompressorFactory.getCompressor("snappy");
+    FixedByteChunkSingleValueWriter writer =
+        new FixedByteChunkSingleValueWriter(outFile, compressor, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            V1Constants.Numbers.LONG_SIZE);
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      writer.setLong(i, expected[i]);
+    }
+    writer.close();
+
+    PinotDataBuffer pinotDataBuffer =
+        PinotDataBuffer.fromFile(outFile, ReadMode.mmap, FileChannel.MapMode.READ_ONLY, getClass().getName());
+
+    ChunkDecompressor uncompressor = ChunkCompressorFactory.getDecompressor("snappy");
+    FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(pinotDataBuffer, uncompressor);
+    ChunkReaderContext context = reader.createContext();
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      long actual = reader.getLong(i, context);
+      Assert.assertEquals(actual, expected[i]);
+    }
+    reader.close();
+    FileUtils.deleteQuietly(outFile);
+  }
+
+  @Test
+  public void testFloat()
+      throws Exception {
+    float[] expected = new float[NUM_VALUES];
+    for (int i = 0; i < NUM_VALUES; i++) {
+      expected[i] = _random.nextFloat();
+    }
+
+    File outFile = new File(TEST_FILE);
+    FileUtils.deleteQuietly(outFile);
+
+    ChunkCompressor compressor = ChunkCompressorFactory.getCompressor("snappy");
+    FixedByteChunkSingleValueWriter writer =
+        new FixedByteChunkSingleValueWriter(outFile, compressor, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            V1Constants.Numbers.FLOAT_SIZE);
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      writer.setFloat(i, expected[i]);
+    }
+    writer.close();
+
+    PinotDataBuffer pinotDataBuffer =
+        PinotDataBuffer.fromFile(outFile, ReadMode.mmap, FileChannel.MapMode.READ_ONLY, getClass().getName());
+
+    ChunkDecompressor uncompressor = ChunkCompressorFactory.getDecompressor("snappy");
+    FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(pinotDataBuffer, uncompressor);
+    ChunkReaderContext context = reader.createContext();
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      float actual = reader.getFloat(i, context);
+      Assert.assertEquals(actual, expected[i]);
+    }
+    reader.close();
+    FileUtils.deleteQuietly(outFile);
+  }
+
+  @Test
+  public void testDouble()
+      throws Exception {
+    double[] expected = new double[NUM_VALUES];
+    for (int i = 0; i < NUM_VALUES; i++) {
+      expected[i] = _random.nextDouble();
+    }
+
+    File outFile = new File(TEST_FILE);
+    FileUtils.deleteQuietly(outFile);
+
+    ChunkCompressor compressor = ChunkCompressorFactory.getCompressor("snappy");
+    FixedByteChunkSingleValueWriter writer =
+        new FixedByteChunkSingleValueWriter(outFile, compressor, NUM_VALUES, NUM_DOCS_PER_CHUNK,
+            V1Constants.Numbers.DOUBLE_SIZE);
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      writer.setDouble(i, expected[i]);
+    }
+    writer.close();
+
+    PinotDataBuffer pinotDataBuffer =
+        PinotDataBuffer.fromFile(outFile, ReadMode.mmap, FileChannel.MapMode.READ_ONLY, getClass().getName());
+
+    ChunkDecompressor uncompressor = ChunkCompressorFactory.getDecompressor("snappy");
+    FixedByteChunkSingleValueReader reader = new FixedByteChunkSingleValueReader(pinotDataBuffer, uncompressor);
+    ChunkReaderContext context = reader.createContext();
+
+    for (int i = 0; i < NUM_VALUES; i++) {
+      double actual = reader.getDouble(i, context);
+      Assert.assertEquals(actual, expected[i]);
+    }
+    reader.close();
+    FileUtils.deleteQuietly(outFile);
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -139,7 +139,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
     }
 
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
-    config.setRawIndexCreationColumns(Collections.singletonList("column_1"));
+    config.setRawIndexCreationColumns(new ArrayList<String>(schema.getColumnNames()));
 
     config.setOutDir(SEGMENT_DIR_NAME);
     config.setSegmentName(SEGMENT_NAME);


### PR DESCRIPTION
1. Hooked up FixedButeChunkSingleValue indices into data
   fetching during query processing. Added reading of
   int, long and float data types from this index.

2. Fixed bug in FixedByteChunkSingleValueWriter.

3. Added unit test for FixedByteChunkSingleValueReader/Writer.
   Also, enhanced DataFetcherTest to support no-dictionary index.