### PR TITLE
Implement total count threshold transformation function

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
@@ -100,7 +100,12 @@ public class AlertTaskRunnerV2 implements TaskRunner {
         if (resultsForFunction != null && resultsForFunction.size() > 0) {
           mergedAnomaliesAllResults.addAll(resultsForFunction);
         }
+        // TODO:
+        // fetch anomalies having id lesser than the watermark for the same function with notified = false & endTime > last one day
+        // these anomalies are the ones that did not qualify filtration rule and got modified.
       }
+
+
       // apply filtration rule
       List<MergedAnomalyResultDTO> results =
           AlertFilterHelper.applyFiltrationRule(mergedAnomaliesAllResults);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -285,7 +285,6 @@ public class AnomalyMergeExecutor implements Runnable {
         }
       }
 
-      // TODO: Re-enable scaling factor for holiday effect
       // Transform Time Series
       List<ScalingFactor> scalingFactors = OverrideConfigHelper
           .getTimeSeriesScalingFactors(overrideConfigDAO, anomalyFunctionSpec.getCollection(),

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyDetectionContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyDetectionContext.java
@@ -2,7 +2,9 @@ package com.linkedin.thirdeye.anomalydetection.context;
 
 import com.linkedin.thirdeye.anomalydetection.function.AnomalyDetectionFunction;
 import com.linkedin.thirdeye.anomalydetection.model.prediction.PredictionModel;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The context for performing an anomaly detection on the sets of time series from the same
@@ -16,14 +18,14 @@ public class AnomalyDetectionContext {
   private TimeSeriesKey timeSeriesKey;
   private long bucketSizeInMS; // the bucket size, gap between timestamps, in millisecond
 
-  private TimeSeries current;
-  private List<TimeSeries> baselines;
+  private Map<String, TimeSeries> current = new HashMap<>();
+  private Map<String, List<TimeSeries>> baselines = new HashMap<>();
 
   //TODO: Add DAO for accessing historical anomalies or scaling factor
 
   // The followings are intermediate results and are appended during anomaly detection
-  private TimeSeries transformedCurrent;
-  private List<TimeSeries> transformedBaselines;
+  private Map<String, TimeSeries> transformedCurrent = new HashMap<>();
+  private Map<String, List<TimeSeries>> transformedBaselines = new HashMap<>();
 
   private PredictionModel trainedPredictionModel;
 
@@ -44,29 +46,29 @@ public class AnomalyDetectionContext {
   /**
    * Returns the current (observed) time series, which is not transformed.
    */
-  public TimeSeries getCurrent() {
-    return current;
+  public TimeSeries getCurrent(String metricName) {
+    return current.get(metricName);
   }
 
   /**
    * Set the current (observed) time series.
    */
-  public void setCurrent(TimeSeries current) {
-    this.current = current;
+  public void setCurrent(String metricName, TimeSeries current) {
+    this.current.put(metricName, current);
   }
 
   /**
    * Returns the set of baseline time series for training the prediction model.
    */
-  public List<TimeSeries> getBaselines() {
-    return baselines;
+  public List<TimeSeries> getBaselines(String metricName) {
+    return baselines.get(metricName);
   }
 
   /**
    * Sets the set of baseline time series for training the prediction model.
    */
-  public void setBaselines(List<TimeSeries> baselines) {
-    this.baselines = baselines;
+  public void setBaselines(String metricName, List<TimeSeries> baselines) {
+    this.baselines.put(metricName, baselines);
   }
 
   /**
@@ -103,32 +105,32 @@ public class AnomalyDetectionContext {
    * Returns the transformed current (observed) time series. If no transformation function is setup
    * in the context, then the original current time series is returned.
    */
-  public TimeSeries getTransformedCurrent() {
-    return transformedCurrent;
+  public TimeSeries getTransformedCurrent(String metricName) {
+    return transformedCurrent.get(metricName);
   }
 
   /**
    * Sets the transformed current (observed) time series. This method is supposed to be used by
    * transformation functions.
    */
-  public void setTransformedCurrent(TimeSeries transformedCurrent) {
-    this.transformedCurrent = transformedCurrent;
+  public void setTransformedCurrent(String metricName, TimeSeries transformedCurrent) {
+    this.transformedCurrent.put(metricName, transformedCurrent);
   }
 
   /**
    * Returns the set of transformed baseline time series. If no transformation function is setup
    * in the context, then the original set of baseline time series is returned.
    */
-  public List<TimeSeries> getTransformedBaselines() {
-    return transformedBaselines;
+  public List<TimeSeries> getTransformedBaselines(String metricName) {
+    return transformedBaselines.get(metricName);
   }
 
   /**
    * Sets the set of transformed baseline time series. This method is supposed to be used by
    * transformation functions.
    */
-  public void setTransformedBaselines(List<TimeSeries> transformedBaselines) {
-    this.transformedBaselines = transformedBaselines;
+  public void setTransformedBaselines(String metricName, List<TimeSeries> transformedBaselines) {
+    this.transformedBaselines.put(metricName, transformedBaselines);
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
@@ -91,14 +91,17 @@ public class BackwardAnomalyFunctionUtils {
     timeSeriesKey.setMetricName(metric);
     anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
 
-    // Split metric time series to observed time series and baselines
-    List<Interval> intervals =
-        anomalyFunction.getTimeSeriesIntervals(windowStart.getMillis(), windowEnd.getMillis());
-    List<TimeSeries> timeSeriesList =
-        BackwardAnomalyFunctionUtils.splitSetsOfTimeSeries(timeSeries, metric, intervals);
-    anomalyDetectionContext.setCurrent(timeSeriesList.get(0));
-    timeSeriesList.remove(0);
-    anomalyDetectionContext.setBaselines(timeSeriesList);
+    // Split time series to observed time series and baselines for each metric
+    for (String metricName : anomalyFunction.getSpec().getMetrics()) {
+      List<Interval> intervals =
+          anomalyFunction.getTimeSeriesIntervals(windowStart.getMillis(), windowEnd.getMillis());
+      List<TimeSeries> timeSeriesList =
+          BackwardAnomalyFunctionUtils.splitSetsOfTimeSeries(timeSeries, metric, intervals);
+      anomalyDetectionContext.setCurrent(metricName, timeSeriesList.get(0));
+      timeSeriesList.remove(0);
+      anomalyDetectionContext.setBaselines(metricName, timeSeriesList);
+    }
+
 
     return anomalyDetectionContext;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/WeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/WeekOverWeekRuleFunction.java
@@ -14,6 +14,7 @@ import com.linkedin.thirdeye.anomalydetection.model.prediction.NoopPredictionMod
 import com.linkedin.thirdeye.anomalydetection.model.prediction.PredictionModel;
 import com.linkedin.thirdeye.anomalydetection.model.prediction.SeasonalAveragePredictionModel;
 import com.linkedin.thirdeye.anomalydetection.model.transform.MovingAverageSmoothingFunction;
+import com.linkedin.thirdeye.anomalydetection.model.transform.TotalCountThresholdRemovalFunction;
 import com.linkedin.thirdeye.anomalydetection.model.transform.TransformationFunction;
 import com.linkedin.thirdeye.anomalydetection.model.transform.ZeroRemovalFunction;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
@@ -64,6 +65,14 @@ public class WeekOverWeekRuleFunction extends AbstractModularizedAnomalyFunction
     currentTimeSeriesTransformationChain.add(zeroRemover);
     baselineTimeSeriesTransformationChain.add(zeroRemover);
 
+    // Add total count threshold transformation
+    if (this.properties.containsKey(TotalCountThresholdRemovalFunction.TOTAL_COUNT_METRIC_NAME)) {
+      TransformationFunction totalCountThresholdFunction = new TotalCountThresholdRemovalFunction();
+      totalCountThresholdFunction.init(this.properties);
+      currentTimeSeriesTransformationChain.add(totalCountThresholdFunction);
+    }
+
+    // Add moving average smoothing transformation
     if (this.properties.containsKey(ENABLE_SMOOTHING)) {
       TransformationFunction movingAverageSoothingFunction = new MovingAverageSmoothingFunction();
       movingAverageSoothingFunction.init(this.properties);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/detection/SimpleThresholdDetectionModel.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/detection/SimpleThresholdDetectionModel.java
@@ -34,8 +34,10 @@ public class SimpleThresholdDetectionModel extends AbstractDetectionModel {
 
     long bucketSizeInMillis = anomalyDetectionContext.getBucketSizeInMS();
 
+    String mainMetric =
+        anomalyDetectionContext.getAnomalyDetectionFunction().getSpec().getTopicMetric();
     // Compute the weight of this time series (average across whole)
-    TimeSeries currentTimeSeries = anomalyDetectionContext.getTransformedCurrent();
+    TimeSeries currentTimeSeries = anomalyDetectionContext.getTransformedCurrent(mainMetric);
     double averageValue = 0;
     for (long time : currentTimeSeries.timestampSet()) {
       averageValue += currentTimeSeries.get(time);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/merge/SimplePercentageMergeModel.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/merge/SimplePercentageMergeModel.java
@@ -49,7 +49,9 @@ public class SimplePercentageMergeModel extends AbstractMergeModel {
     TimeSeries expectedTimeSeries = expectedTimeSeriesPredictionModel.getExpectedTimeSeries();
     long expectedStartTime = expectedTimeSeries.getTimeSeriesInterval().getStartMillis();
 
-    TimeSeries observedTimeSeries = anomalyDetectionContext.getTransformedCurrent();
+    String mainMetric =
+        anomalyDetectionContext.getAnomalyDetectionFunction().getSpec().getTopicMetric();
+    TimeSeries observedTimeSeries = anomalyDetectionContext.getTransformedCurrent(mainMetric);
     long observedStartTime = observedTimeSeries.getTimeSeriesInterval().getStartMillis();
 
     double avgObserved = 0d;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/transform/MovingAverageSmoothingFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/transform/MovingAverageSmoothingFunction.java
@@ -44,7 +44,7 @@ public class MovingAverageSmoothingFunction extends AbstractTransformationFuncti
     // Check if the moving average window size is larger than the time series itself
     long transformedStartTime = startTime + bucketSizeInMillis * (movingAverageWindowSize - 1);
     if (transformedStartTime > endTime) {
-      String metricName = anomalyDetectionContext.getTimeSeriesKey().getMetricName();
+      String metricName = anomalyDetectionContext.getAnomalyDetectionFunction().getSpec().getTopicMetric();
       DimensionMap dimensionMap = anomalyDetectionContext.getTimeSeriesKey().getDimensionMap();
       LOGGER.warn(
           "Input time series (Metric:{}, Dimension:{}) is shorter than the moving average "

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/transform/TotalCountThresholdRemovalFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/transform/TotalCountThresholdRemovalFunction.java
@@ -1,0 +1,51 @@
+package com.linkedin.thirdeye.anomalydetection.model.transform;
+
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
+import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
+import org.apache.commons.lang3.StringUtils;
+
+public class TotalCountThresholdRemovalFunction extends AbstractTransformationFunction {
+  public static final String TOTAL_COUNT_METRIC_NAME = "totalCountName";
+  public static final String TOTAL_COUNT_THRESHOLD = "totalCountThreshold";
+
+  /**
+   * Returns an empty time series if the sum of the total count metric does not exceed the
+   * threshold.
+   *
+   * @param timeSeries              the time series that provides the data points to be
+   *                                transformed.
+   * @param anomalyDetectionContext the anomaly detection context that could provide additional
+   *                                information for the transformation. Specifically, the time
+   *                                series that provide the values to compute the total count. Note
+   *                                that this function simply sum up the values of the specified
+   *                                time series and hence the timestamp of that time series does not
+   *                                matter. Moreover, this metric has to be put in the set of
+   *                                current time series.
+   *
+   * @return the original time series the sum of the values in total count time series exceeds the
+   * threshold.
+   */
+  @Override public TimeSeries transform(TimeSeries timeSeries,
+      AnomalyDetectionContext anomalyDetectionContext) {
+    String totalCountMetricName = getProperties().getProperty(TOTAL_COUNT_METRIC_NAME);
+    if (StringUtils.isBlank(totalCountMetricName)) {
+      return timeSeries;
+    }
+
+    double totalCountThreshold =
+        Double.valueOf(getProperties().getProperty(TOTAL_COUNT_THRESHOLD, "0"));
+
+    TimeSeries totalCountTS = anomalyDetectionContext.getCurrent(totalCountMetricName);
+    double sum = 0d;
+    for (long timestamp : totalCountTS.timestampSet()) {
+      sum += totalCountTS.get(timestamp);
+    }
+    if (Double.compare(sum, totalCountThreshold) < 0) {
+      TimeSeries emptyTimeSeries = new TimeSeries();
+      emptyTimeSeries.setTimeSeriesInterval(timeSeries.getTimeSeriesInterval());
+      return emptyTimeSeries;
+    } else {
+      return timeSeries;
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestWeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestWeekOverWeekRuleFunction.java
@@ -5,12 +5,15 @@ import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
 import com.linkedin.thirdeye.anomalydetection.context.TimeSeriesKey;
 import com.linkedin.thirdeye.anomalydetection.model.detection.SimpleThresholdDetectionModel;
 import com.linkedin.thirdeye.anomalydetection.model.transform.MovingAverageSmoothingFunction;
+import com.linkedin.thirdeye.anomalydetection.model.transform.TotalCountThresholdRemovalFunction;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.joda.time.Interval;
 import org.testng.Assert;
@@ -26,6 +29,8 @@ public class TestWeekOverWeekRuleFunction {
   private final static long baseline1StartTime = 1000 + oneWeekInMillis;
   private final static long baseline2StartTime = 1000;
 
+  private final static String mainMetric = "testMetric";
+
   @DataProvider(name = "timeSeriesDataProvider")
   public Object[][] timeSeriesDataProvider() {
     // The properties for the testing time series
@@ -34,7 +39,7 @@ public class TestWeekOverWeekRuleFunction {
 
     // Set up time series key for the testing time series
     TimeSeriesKey timeSeriesKey = new TimeSeriesKey();
-    String metric = "testMetric";
+    String metric = mainMetric;
     timeSeriesKey.setMetricName(metric);
     DimensionMap dimensionMap = new DimensionMap();
     dimensionMap.put("dimensionName1", "dimensionValue1");
@@ -108,13 +113,18 @@ public class TestWeekOverWeekRuleFunction {
     properties.put(WeekOverWeekRuleFunction.BASELINE, "w/w");
     properties.put(SimpleThresholdDetectionModel.CHANGE_THRESHOLD, "-0.2");
 
+    // Create anomaly function spec
+    AnomalyFunctionDTO functionSpec = new AnomalyFunctionDTO();
+    functionSpec.setMetric(mainMetric);
+    functionSpec.setProperties(toString(properties));
+
     WeekOverWeekRuleFunction function = new WeekOverWeekRuleFunction();
-    function.init(properties);
+    function.init(functionSpec);
     anomalyDetectionContext.setAnomalyDetectionFunction(function);
-    anomalyDetectionContext.setCurrent(observedTimeSeries);
+    anomalyDetectionContext.setCurrent(mainMetric, observedTimeSeries);
     List<TimeSeries> singleBaseline = new ArrayList<>();
     singleBaseline.add(baselines.get(0));
-    anomalyDetectionContext.setBaselines(singleBaseline);
+    anomalyDetectionContext.setBaselines(mainMetric, singleBaseline);
     anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
 
     List<RawAnomalyResultDTO> rawAnomalyResults = function.analyze(anomalyDetectionContext);
@@ -163,21 +173,20 @@ public class TestWeekOverWeekRuleFunction {
     properties.put(WeekOverWeekRuleFunction.BASELINE, "w/2wAvg");
     properties.put(SimpleThresholdDetectionModel.CHANGE_THRESHOLD, "0.2");
 
+    // Create anomaly function spec
+    AnomalyFunctionDTO functionSpec = new AnomalyFunctionDTO();
+    functionSpec.setMetric(mainMetric);
+    functionSpec.setProperties(toString(properties));
+
     WeekOverWeekRuleFunction function = new WeekOverWeekRuleFunction();
-    function.init(properties);
+    function.init(functionSpec);
     anomalyDetectionContext.setAnomalyDetectionFunction(function);
-    anomalyDetectionContext.setCurrent(observedTimeSeries);
-    anomalyDetectionContext.setBaselines(baselines);
+    anomalyDetectionContext.setCurrent(mainMetric, observedTimeSeries);
+    anomalyDetectionContext.setBaselines(mainMetric, baselines);
     anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
 
     List<RawAnomalyResultDTO> rawAnomalyResults = function.analyze(anomalyDetectionContext);
-    Assert.assertEquals(rawAnomalyResults.size(), expectedRawAnomalies.size());
-    for (int i = 0; i < rawAnomalyResults.size(); ++i) {
-      RawAnomalyResultDTO actualAnomaly = rawAnomalyResults.get(i);
-      RawAnomalyResultDTO expectedAnomaly = rawAnomalyResults.get(i);
-      Assert.assertEquals(actualAnomaly.getWeight(), expectedAnomaly.getWeight(), EPSILON);
-      Assert.assertEquals(actualAnomaly.getScore(), expectedAnomaly.getScore(), EPSILON);
-    }
+    compareWo2WAvgRawAnomalies(rawAnomalyResults);
 
 
     // Test data model
@@ -205,16 +214,21 @@ public class TestWeekOverWeekRuleFunction {
     properties.put(WeekOverWeekRuleFunction.ENABLE_SMOOTHING, "true");
     properties.put(MovingAverageSmoothingFunction.MOVING_AVERAGE_SMOOTHING_WINDOW_SIZE, "3");
 
+    // Create anomaly function spec
+    AnomalyFunctionDTO functionSpec = new AnomalyFunctionDTO();
+    functionSpec.setMetric(mainMetric);
+    functionSpec.setProperties(toString(properties));
+
     WeekOverWeekRuleFunction function = new WeekOverWeekRuleFunction();
-    function.init(properties);
+    function.init(functionSpec);
     anomalyDetectionContext.setAnomalyDetectionFunction(function);
-    anomalyDetectionContext.setCurrent(observedTimeSeries);
-    anomalyDetectionContext.setBaselines(baselines);
+    anomalyDetectionContext.setCurrent(mainMetric, observedTimeSeries);
+    anomalyDetectionContext.setBaselines(mainMetric, baselines);
     anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
 
     List<RawAnomalyResultDTO> rawAnomalyResults = function.analyze(anomalyDetectionContext);
     // The transformed observed time series is resized from 5 to 3 due to moving average algorithm
-    Assert.assertEquals(anomalyDetectionContext.getTransformedCurrent().size(), 3);
+    Assert.assertEquals(anomalyDetectionContext.getTransformedCurrent(mainMetric).size(), 3);
     // No anomalies after smoothing the time series
     Assert.assertEquals(rawAnomalyResults.size(), 0);
   }
@@ -245,11 +259,16 @@ public class TestWeekOverWeekRuleFunction {
     properties.put(WeekOverWeekRuleFunction.BASELINE, "w/2wAvg");
     properties.put(SimpleThresholdDetectionModel.CHANGE_THRESHOLD, "0.2");
 
+    // Create anomaly function spec
+    AnomalyFunctionDTO functionSpec = new AnomalyFunctionDTO();
+    functionSpec.setMetric(mainMetric);
+    functionSpec.setProperties(toString(properties));
+
     WeekOverWeekRuleFunction function = new WeekOverWeekRuleFunction();
-    function.init(properties);
+    function.init(functionSpec);
     anomalyDetectionContext.setAnomalyDetectionFunction(function);
-    anomalyDetectionContext.setCurrent(observedTimeSeries);
-    anomalyDetectionContext.setBaselines(baselines);
+    anomalyDetectionContext.setCurrent(mainMetric, observedTimeSeries);
+    anomalyDetectionContext.setBaselines(mainMetric, baselines);
     anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
 
     MergedAnomalyResultDTO mergedAnomaly = new MergedAnomalyResultDTO();
@@ -266,8 +285,8 @@ public class TestWeekOverWeekRuleFunction {
     double observedTotal = 0d;
     double baselineTotal = 0d;
     Interval interval = new Interval(mergedAnomaly.getStartTime(), mergedAnomaly.getEndTime());
-    TimeSeries observedTS = anomalyDetectionContext.getTransformedCurrent();
-    List<TimeSeries> baselineTSs = anomalyDetectionContext.getTransformedBaselines();
+    TimeSeries observedTS = anomalyDetectionContext.getTransformedCurrent(mainMetric);
+    List<TimeSeries> baselineTSs = anomalyDetectionContext.getTransformedBaselines(mainMetric);
     for (long timestamp : observedTS.timestampSet()) {
       if (interval.contains(timestamp)) {
         observedTotal += observedTS.get(timestamp);
@@ -291,6 +310,73 @@ public class TestWeekOverWeekRuleFunction {
     Assert.assertEquals(mergedAnomaly.getScore(), expectedScore, EPSILON);
   }
 
+  @Test(dataProvider = "timeSeriesDataProvider") public void testTotalCountThresholdFunction(
+      Properties properties, TimeSeriesKey timeSeriesKey, long bucketSizeInMs,
+      TimeSeries observedTimeSeries, List<TimeSeries> baselines) throws Exception {
+    AnomalyDetectionContext anomalyDetectionContext = new AnomalyDetectionContext();
+    anomalyDetectionContext.setBucketSizeInMS(bucketSizeInMs);
+
+    // Append properties for anomaly function specific setting
+    String totalCountTimeSeriesName = "totalCount";
+    TimeSeries totalCountTimeSeries = new TimeSeries();
+    {
+      totalCountTimeSeries.set(observedStartTime, 10d);
+      totalCountTimeSeries.set(observedStartTime + bucketMillis, 10d);
+      totalCountTimeSeries.set(observedStartTime + bucketMillis * 2, 10d);
+      totalCountTimeSeries.set(observedStartTime + bucketMillis * 3, 10d);
+      totalCountTimeSeries.set(observedStartTime + bucketMillis * 4, 10d);
+      Interval totalCountTimeSeriesInterval =
+          new Interval(observedStartTime, observedStartTime + bucketMillis * 5);
+      totalCountTimeSeries.setTimeSeriesInterval(totalCountTimeSeriesInterval);
+    }
+    properties.put(TotalCountThresholdRemovalFunction.TOTAL_COUNT_METRIC_NAME, totalCountTimeSeriesName);
+    properties.put(TotalCountThresholdRemovalFunction.TOTAL_COUNT_THRESHOLD, "51");
+
+    properties.put(WeekOverWeekRuleFunction.BASELINE, "w/2wAvg");
+    properties.put(SimpleThresholdDetectionModel.CHANGE_THRESHOLD, "0.2");
+
+
+    // Create anomaly function spec
+    AnomalyFunctionDTO functionSpec = new AnomalyFunctionDTO();
+    functionSpec.setMetric(mainMetric);
+    functionSpec.setProperties(toString(properties));
+
+    // Create anomalyDetectionContext using anomaly function spec
+    WeekOverWeekRuleFunction function = new WeekOverWeekRuleFunction();
+    function.init(functionSpec);
+    anomalyDetectionContext.setAnomalyDetectionFunction(function);
+    anomalyDetectionContext.setCurrent(mainMetric, observedTimeSeries);
+    anomalyDetectionContext.setBaselines(mainMetric, baselines);
+    anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
+    anomalyDetectionContext.setCurrent(totalCountTimeSeriesName, totalCountTimeSeries);
+
+    List<RawAnomalyResultDTO> rawAnomalyResults = function.analyze(anomalyDetectionContext);
+    // No anomalies after smoothing the time series
+    Assert.assertEquals(rawAnomalyResults.size(), 0);
+
+
+    // Test disabled total count by lowering the threshold
+    anomalyDetectionContext = new AnomalyDetectionContext();
+    anomalyDetectionContext.setBucketSizeInMS(bucketSizeInMs);
+
+    properties.put(TotalCountThresholdRemovalFunction.TOTAL_COUNT_THRESHOLD, "0");
+    // Create anomaly function spec
+    functionSpec = new AnomalyFunctionDTO();
+    functionSpec.setMetric(mainMetric);
+    functionSpec.setProperties(toString(properties));
+    function = new WeekOverWeekRuleFunction();
+    function.init(functionSpec);
+
+    anomalyDetectionContext.setAnomalyDetectionFunction(function);
+    anomalyDetectionContext.setCurrent(mainMetric, observedTimeSeries);
+    anomalyDetectionContext.setBaselines(mainMetric, baselines);
+    anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
+    anomalyDetectionContext.setCurrent(totalCountTimeSeriesName, totalCountTimeSeries);
+
+    rawAnomalyResults = function.analyze(anomalyDetectionContext);
+    compareWo2WAvgRawAnomalies(rawAnomalyResults);
+  }
+
   @Test
   public void testParseWowString() {
     String testString = "w/w";
@@ -310,5 +396,46 @@ public class TestWeekOverWeekRuleFunction {
 
     testString = "A Random string 34 and it is 54 a long one";
     Assert.assertEquals(WeekOverWeekRuleFunction.parseWowString(testString), "34");
+  }
+
+  private String toString(Properties properties) {
+    if (properties != null && properties.size() != 0) {
+      List<String> propertyEntry = new ArrayList<>();
+      StringBuilder sb = new StringBuilder();
+      Set<Object> keys = properties.keySet();
+      for (Object key : keys) {
+        sb.append((String) key).append("=").append((String) properties.get(key));
+        propertyEntry.add(sb.toString());
+        sb.setLength(0);
+      }
+      return String.join(";", propertyEntry);
+    }
+    return "";
+  }
+
+  private void compareWo2WAvgRawAnomalies(List<RawAnomalyResultDTO> rawAnomalyResults) {
+    // Expecting the same anomaly result from analyzeWo2WAvg
+    List<RawAnomalyResultDTO> expectedRawAnomalies = new ArrayList<>();
+    RawAnomalyResultDTO rawAnomaly1 = new RawAnomalyResultDTO();
+    rawAnomaly1.setStartTime(observedStartTime + bucketMillis * 2);
+    rawAnomaly1.setEndTime(observedStartTime + bucketMillis * 3);
+    rawAnomaly1.setWeight(0.3d);
+    rawAnomaly1.setScore(15d);
+    expectedRawAnomalies.add(rawAnomaly1);
+
+    RawAnomalyResultDTO rawAnomaly2 = new RawAnomalyResultDTO();
+    rawAnomaly2.setStartTime(observedStartTime + bucketMillis * 3);
+    rawAnomaly2.setEndTime(observedStartTime + bucketMillis * 4);
+    rawAnomaly2.setWeight(0.22727272727272727);
+    rawAnomaly2.setScore(15d);
+    expectedRawAnomalies.add(rawAnomaly2);
+
+    Assert.assertEquals(rawAnomalyResults.size(), expectedRawAnomalies.size());
+    for (int i = 0; i < rawAnomalyResults.size(); ++i) {
+      RawAnomalyResultDTO actualAnomaly = rawAnomalyResults.get(i);
+      RawAnomalyResultDTO expectedAnomaly = rawAnomalyResults.get(i);
+      Assert.assertEquals(actualAnomaly.getWeight(), expectedAnomaly.getWeight(), EPSILON);
+      Assert.assertEquals(actualAnomaly.getScore(), expectedAnomaly.getScore(), EPSILON);
+    }
   }
 }


### PR DESCRIPTION
1. Introduce multi-metrics to AnomalyDetectionContext.
2. Create a new transformation function, which checks the total count of the specified metric and remove the values from the main metric if total count does not satisfy user-specified threshold.

Test: 
1. An unit test for the new transformation function and multi-metrics anomaly detection context. The backward compatibility is also tested in the new unit test.
2. Integration test on local. Specifically, backfilled 1 month of anomalies using the new transformation function.