### PR TITLE
Implement total count threshold transformation function

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/WeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/WeekOverWeekRuleFunction.java
@@ -13,6 +13,7 @@ import com.linkedin.thirdeye.anomalydetection.model.prediction.NoopPredictionMod
 import com.linkedin.thirdeye.anomalydetection.model.prediction.PredictionModel;
 import com.linkedin.thirdeye.anomalydetection.model.prediction.SeasonalAveragePredictionModel;
 import com.linkedin.thirdeye.anomalydetection.model.transform.MovingAverageSmoothingFunction;
+import com.linkedin.thirdeye.anomalydetection.model.transform.TotalCountThresholdRemovalFunction;
 import com.linkedin.thirdeye.anomalydetection.model.transform.TransformationFunction;
 import com.linkedin.thirdeye.anomalydetection.model.transform.ZeroRemovalFunction;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
@@ -60,6 +61,13 @@ public class WeekOverWeekRuleFunction extends AbstractModularizedAnomalyFunction
     TransformationFunction zeroRemover = new ZeroRemovalFunction();
     currentTimeSeriesTransformationChain.add(zeroRemover);
     baselineTimeSeriesTransformationChain.add(zeroRemover);
+
+    // Add total count threshold transformation
+    if (this.properties.containsKey(TotalCountThresholdRemovalFunction.TOTAL_COUNT_METRIC_NAME)) {
+      TransformationFunction totalCountThresholdFunction = new TotalCountThresholdRemovalFunction();
+      totalCountThresholdFunction.init(this.properties);
+      currentTimeSeriesTransformationChain.add(totalCountThresholdFunction);
+    }
 
     // Add moving average smoothing transformation
     if (this.properties.containsKey(ENABLE_SMOOTHING)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/transform/TotalCountThresholdRemovalFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/transform/TotalCountThresholdRemovalFunction.java
@@ -1,0 +1,51 @@
+package com.linkedin.thirdeye.anomalydetection.model.transform;
+
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
+import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
+import org.apache.commons.lang3.StringUtils;
+
+public class TotalCountThresholdRemovalFunction extends AbstractTransformationFunction {
+  public static final String TOTAL_COUNT_METRIC_NAME = "totalCountName";
+  public static final String TOTAL_COUNT_THRESHOLD = "totalCountThreshold";
+
+  /**
+   * Returns an empty time series if the sum of the total count metric does not exceed the
+   * threshold.
+   *
+   * @param timeSeries              the time series that provides the data points to be
+   *                                transformed.
+   * @param anomalyDetectionContext the anomaly detection context that could provide additional
+   *                                information for the transformation. Specifically, the time
+   *                                series that provide the values to compute the total count. Note
+   *                                that this function simply sum up the values of the specified
+   *                                time series and hence the timestamp of that time series does not
+   *                                matter. Moreover, this metric has to be put in the set of
+   *                                current time series.
+   *
+   * @return the original time series the sum of the values in total count time series exceeds the
+   * threshold.
+   */
+  @Override public TimeSeries transform(TimeSeries timeSeries,
+      AnomalyDetectionContext anomalyDetectionContext) {
+    String totalCountMetricName = getProperties().getProperty(TOTAL_COUNT_METRIC_NAME);
+    if (StringUtils.isBlank(totalCountMetricName)) {
+      return timeSeries;
+    }
+
+    double totalCountThreshold =
+        Double.valueOf(getProperties().getProperty(TOTAL_COUNT_THRESHOLD, "0"));
+
+    TimeSeries totalCountTS = anomalyDetectionContext.getCurrent(totalCountMetricName);
+    double sum = 0d;
+    for (long timestamp : totalCountTS.timestampSet()) {
+      sum += totalCountTS.get(timestamp);
+    }
+    if (Double.compare(sum, totalCountThreshold) < 0) {
+      TimeSeries emptyTimeSeries = new TimeSeries();
+      emptyTimeSeries.setTimeSeriesInterval(timeSeries.getTimeSeriesInterval());
+      return emptyTimeSeries;
+    } else {
+      return timeSeries;
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestWeekOverWeekRuleFunction.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestWeekOverWeekRuleFunction.java
@@ -89,21 +89,7 @@ public class TestWeekOverWeekRuleFunction {
   @Test(dataProvider = "timeSeriesDataProvider") public void analyzeWoW(
       Properties properties, TimeSeriesKey timeSeriesKey, long bucketSizeInMs,
       TimeSeries observedTimeSeries, List<TimeSeries> baselines) throws Exception {
-    // Expected RawAnomalies without smoothing
-    List<RawAnomalyResultDTO> expectedRawAnomalies = new ArrayList<>();
-    RawAnomalyResultDTO rawAnomaly1 = new RawAnomalyResultDTO();
-    rawAnomaly1.setStartTime(observedStartTime + bucketMillis);
-    rawAnomaly1.setEndTime(observedStartTime + bucketMillis * 2);
-    rawAnomaly1.setWeight(-0.25d);
-    rawAnomaly1.setScore(15d);
-    expectedRawAnomalies.add(rawAnomaly1);
 
-    RawAnomalyResultDTO rawAnomaly2 = new RawAnomalyResultDTO();
-    rawAnomaly2.setStartTime(observedStartTime + bucketMillis * 4);
-    rawAnomaly2.setEndTime(observedStartTime + bucketMillis * 5);
-    rawAnomaly2.setWeight(-0.2857142857d);
-    rawAnomaly2.setScore(15d);
-    expectedRawAnomalies.add(rawAnomaly2);
 
     AnomalyDetectionContext anomalyDetectionContext = new AnomalyDetectionContext();
     anomalyDetectionContext.setBucketSizeInMS(bucketSizeInMs);
@@ -127,13 +113,7 @@ public class TestWeekOverWeekRuleFunction {
     anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
 
     List<RawAnomalyResultDTO> rawAnomalyResults = function.analyze(anomalyDetectionContext);
-    Assert.assertEquals(rawAnomalyResults.size(), expectedRawAnomalies.size());
-    for (int i = 0; i < rawAnomalyResults.size(); ++i) {
-      RawAnomalyResultDTO actualAnomaly = rawAnomalyResults.get(i);
-      RawAnomalyResultDTO expectedAnomaly = rawAnomalyResults.get(i);
-      Assert.assertEquals(actualAnomaly.getWeight(), expectedAnomaly.getWeight(), EPSILON);
-      Assert.assertEquals(actualAnomaly.getScore(), expectedAnomaly.getScore(), EPSILON);
-    }
+    compareWoWRawAnomalies(rawAnomalyResults);
 
     // Test data model
     List<Interval> expectedDataRanges = new ArrayList<>();
@@ -345,7 +325,7 @@ public class TestWeekOverWeekRuleFunction {
     return "";
   }
 
-  private void compareWo2WAvgRawAnomalies(List<RawAnomalyResultDTO> rawAnomalyResults) {
+  private void compareWo2WAvgRawAnomalies(List<RawAnomalyResultDTO> actualAnomalyResults) {
     // Expecting the same anomaly result from analyzeWo2WAvg
     List<RawAnomalyResultDTO> expectedRawAnomalies = new ArrayList<>();
     RawAnomalyResultDTO rawAnomaly1 = new RawAnomalyResultDTO();
@@ -362,10 +342,35 @@ public class TestWeekOverWeekRuleFunction {
     rawAnomaly2.setScore(15d);
     expectedRawAnomalies.add(rawAnomaly2);
 
-    Assert.assertEquals(rawAnomalyResults.size(), expectedRawAnomalies.size());
-    for (int i = 0; i < rawAnomalyResults.size(); ++i) {
-      RawAnomalyResultDTO actualAnomaly = rawAnomalyResults.get(i);
-      RawAnomalyResultDTO expectedAnomaly = rawAnomalyResults.get(i);
+    compareActualAndExpectedRawAnomalies(actualAnomalyResults, expectedRawAnomalies);
+  }
+
+  private void compareWoWRawAnomalies(List<RawAnomalyResultDTO> actualAnomalyResults) {
+    // Expected RawAnomalies of WoW without smoothing
+    List<RawAnomalyResultDTO> expectedRawAnomalies = new ArrayList<>();
+    RawAnomalyResultDTO rawAnomaly1 = new RawAnomalyResultDTO();
+    rawAnomaly1.setStartTime(observedStartTime + bucketMillis);
+    rawAnomaly1.setEndTime(observedStartTime + bucketMillis * 2);
+    rawAnomaly1.setWeight(-0.25d);
+    rawAnomaly1.setScore(15d);
+    expectedRawAnomalies.add(rawAnomaly1);
+
+    RawAnomalyResultDTO rawAnomaly2 = new RawAnomalyResultDTO();
+    rawAnomaly2.setStartTime(observedStartTime + bucketMillis * 4);
+    rawAnomaly2.setEndTime(observedStartTime + bucketMillis * 5);
+    rawAnomaly2.setWeight(-0.2857142857d);
+    rawAnomaly2.setScore(15d);
+    expectedRawAnomalies.add(rawAnomaly2);
+
+    compareActualAndExpectedRawAnomalies(actualAnomalyResults, expectedRawAnomalies);
+  }
+
+  private void compareActualAndExpectedRawAnomalies(List<RawAnomalyResultDTO> actualAnomalyResults,
+      List<RawAnomalyResultDTO> expectedRawAnomalies) {
+    Assert.assertEquals(actualAnomalyResults.size(), expectedRawAnomalies.size());
+    for (int i = 0; i < actualAnomalyResults.size(); ++i) {
+      RawAnomalyResultDTO actualAnomaly = actualAnomalyResults.get(i);
+      RawAnomalyResultDTO expectedAnomaly = actualAnomalyResults.get(i);
       Assert.assertEquals(actualAnomaly.getWeight(), expectedAnomaly.getWeight(), EPSILON);
       Assert.assertEquals(actualAnomaly.getScore(), expectedAnomaly.getScore(), EPSILON);
     }


### PR DESCRIPTION
Create a new transformation function, which checks the total count of the specified metric and removes the values from the main metric if total count does not satisfy user-specified threshold.

This transformation function is designed to use with WoW on a ratio such as R=A/B. If R fluctuates a lot when the value of A or B is low, then many false anomalies are generated. By chaining TotalCountThresholdFunction with WoW function, we ensure that the detection happens only when A or B's total value exceeds a certain threshold in that detection window.

Test:
1. An unit test for the new transformation function and multi-metrics anomaly detection context. The backward compatibility is also tested in the new unit test.
2. Integration test on local; backfilled 1 month of anomalies with the new transformation function.