### PR TITLE
Revert "Bump up jackson version number to fix method not found during runtime"

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.version>1.8</jdk.version>
     <dropwizard.version>0.8.4</dropwizard.version>
-    <jackson.version>2.8.3</jackson.version>
+    <jackson.version>2.5.1</jackson.version>
     <mysql.connector.version>5.1.39</mysql.connector.version>
     <quartz.version>2.2.1</quartz.version>
     <httpclient.version>4.5.2</httpclient.version>
@@ -156,13 +156,6 @@
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda</artifactId>
         <version>${jackson.version}</version>
-      </dependency>
-
-      <!-- yaml parser -->
-      <dependency>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-          <version>1.17</version>
       </dependency>
 
       <!-- utils -->

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClientConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClientConfig.java
@@ -1,13 +1,13 @@
 package com.linkedin.thirdeye.client.pinot;
 
-import io.dropwizard.configuration.ConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
 import java.io.File;
+import java.io.FileInputStream;
 
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.constructor.Constructor;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
-import javax.validation.Validation;
 
 public class PinotThirdEyeClientConfig {
 
@@ -72,17 +72,8 @@ public class PinotThirdEyeClientConfig {
   }
 
   public static PinotThirdEyeClientConfig fromFile(File dataSourceFile) throws Exception {
-    ConfigurationFactory<PinotThirdEyeClientConfig> factory =
-        new ConfigurationFactory<>(PinotThirdEyeClientConfig.class,
-            Validation.buildDefaultValidatorFactory().getValidator(), Jackson.newObjectMapper(),
-            "");
-    PinotThirdEyeClientConfig configuration;
-    try {
-      configuration = factory.build(dataSourceFile);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-    return configuration;
+    return (PinotThirdEyeClientConfig) new Yaml(new Constructor(PinotThirdEyeClientConfig.class))
+        .load(new FileInputStream(dataSourceFile));
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.dashboard;
 
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;
 import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
 
 public class ThirdEyeDashboardConfiguration extends ThirdEyeConfiguration {
@@ -7,4 +8,9 @@ public class ThirdEyeDashboardConfiguration extends ThirdEyeConfiguration {
   public ThirdEyeDashboardConfiguration() {
     super();
   }
+
+  public static void main(String[] args) {
+    System.out.println(new Yaml().dump(new ThirdEyeDashboardConfiguration()));
+  }
+
 }


### PR DESCRIPTION
linkedin/pinot#1074 builds on local but not on Hudson. Therefore, we need to reverts it and try to find another way to fix internal runtime/build issue.