### PR TITLE
In Pinot Broker, use a separate SPECTATOR to process non-instance messages.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/BrokerResourceOnlineOfflineStateModelFactory.java
@@ -15,8 +15,10 @@
  */
 package com.linkedin.pinot.broker.broker.helix;
 
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.common.utils.helix.HelixHelper;
+import com.linkedin.pinot.routing.HelixExternalViewBasedRouting;
 import java.util.List;
-
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -31,10 +33,6 @@ import org.apache.helix.participant.statemachine.Transition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.pinot.common.Utils;
-import com.linkedin.pinot.common.utils.helix.HelixHelper;
-import com.linkedin.pinot.routing.HelixExternalViewBasedRouting;
-
 
 /**
  * Broker Resource layer state model to take over how to operate on:
@@ -43,14 +41,16 @@ import com.linkedin.pinot.routing.HelixExternalViewBasedRouting;
  *
  */
 public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFactory<StateModel> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerResourceOnlineOfflineStateModelFactory.class);
 
-  private HelixManager _helixManager;
-  private HelixAdmin _helixAdmin;
-  private HelixExternalViewBasedRouting _helixExternalViewBasedRouting;
+  private final HelixManager _helixManager;
+  private final HelixAdmin _helixAdmin;
+  private final HelixExternalViewBasedRouting _helixExternalViewBasedRouting;
 
   public BrokerResourceOnlineOfflineStateModelFactory(HelixManager helixManager,
       HelixExternalViewBasedRouting helixExternalViewBasedRouting) {
     _helixManager = helixManager;
+    _helixAdmin = helixManager.getClusterManagmentTool();
     _helixExternalViewBasedRouting = helixExternalViewBasedRouting;
   }
 
@@ -65,12 +65,9 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
   @StateModelInfo(states = "{'OFFLINE','ONLINE', 'DROPPED'}", initialState = "OFFLINE")
   public class BrokerResourceOnlineOfflineStateModel extends StateModel {
-    private final Logger LOGGER = LoggerFactory.getLogger(BrokerResourceOnlineOfflineStateModelFactory.class);
 
     @Transition(from = "OFFLINE", to = "ONLINE")
     public void onBecomeOnlineFromOffline(Message message, NotificationContext context) {
-      ensureHelixAdminIsInitialized();
-
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeOnlineFromOffline() : " + message);
         Builder keyBuilder = _helixManager.getHelixDataAccessor().keyBuilder();
@@ -91,8 +88,6 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
     @Transition(from = "ONLINE", to = "OFFLINE")
     public void onBecomeOfflineFromOnline(Message message, NotificationContext context) {
-      ensureHelixAdminIsInitialized();
-
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeOfflineFromOnline() : " + message);
         String tableName = message.getPartitionName();
@@ -106,8 +101,6 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
     @Transition(from = "OFFLINE", to = "DROPPED")
     public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
-      ensureHelixAdminIsInitialized();
-
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeDroppedFromOffline() : " + message);
         String tableName = message.getPartitionName();
@@ -121,8 +114,6 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
     @Transition(from = "ONLINE", to = "DROPPED")
     public void onBecomeDroppedFromOnline(Message message, NotificationContext context) {
-      ensureHelixAdminIsInitialized();
-
       try {
         LOGGER.info("BrokerResourceOnlineOfflineStateModel.onBecomeDroppedFromOnline() : " + message);
         String tableName = message.getPartitionName();
@@ -136,16 +127,7 @@ public class BrokerResourceOnlineOfflineStateModelFactory extends StateModelFact
 
     @Transition(from = "ERROR", to = "OFFLINE")
     public void onBecomeOfflineFromError(Message message, NotificationContext context) {
-      ensureHelixAdminIsInitialized();
-
       LOGGER.info("Resetting the state for broker resource:{} from ERROR to OFFLINE", message.getPartitionName());
-    }
-
-  }
-
-  private void ensureHelixAdminIsInitialized() {
-    if (_helixAdmin == null) {
-      _helixAdmin = _helixManager.getClusterManagmentTool();
     }
   }
 }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.common.metrics.BrokerMeter;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.NetUtil;
+import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.routing.HelixExternalViewBasedRouting;
 import com.linkedin.pinot.routing.RoutingTableSelector;
@@ -38,16 +39,12 @@ import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.PreConnectCallback;
 import org.apache.helix.ZNRecord;
-import org.apache.helix.manager.zk.ZNRecordSerializer;
-import org.apache.helix.manager.zk.ZkBaseDataAccessor;
-import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.participant.StateMachineEngine;
 import org.apache.helix.participant.statemachine.StateModelFactory;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.linkedin.pinot.common.utils.ServiceStatus;
 
 
 /**
@@ -59,9 +56,9 @@ public class HelixBrokerStarter {
 
   private static final String PROPERTY_STORE = "PROPERTYSTORE";
 
+  private final HelixManager _spectatorHelixManager;
   private final HelixManager _helixManager;
   private final HelixAdmin _helixAdmin;
-  private final ZkClient _zkClient;
   private final Configuration _pinotHelixProperties;
   private final HelixExternalViewBasedRouting _helixExternalViewBasedRouting;
   private final BrokerServerBuilder _brokerServerBuilder;
@@ -98,41 +95,38 @@ public class HelixBrokerStarter {
     // Remove all white-spaces from the list of zkServers (if any).
     String zkServers = zkServer.replaceAll("\\s+", "");
 
-    LOGGER.info("Starting Zookeeper client");
-    _zkClient =
-        new ZkClient(getZkAddressForBroker(zkServers, helixClusterName),
-            ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, new ZNRecordSerializer());
-    _propertyStore = new ZkHelixPropertyStore<ZNRecord>(new ZkBaseDataAccessor<ZNRecord>(_zkClient), "/", null);
+    LOGGER.info("Connecting Helix components");
+    // Connect spectator Helix manager.
+    _spectatorHelixManager =
+        HelixManagerFactory.getZKHelixManager(helixClusterName, brokerId, InstanceType.SPECTATOR, zkServers);
+    _spectatorHelixManager.connect();
+    _helixAdmin = _spectatorHelixManager.getClusterManagmentTool();
+    _propertyStore = _spectatorHelixManager.getHelixPropertyStore();
     RoutingTableSelector selector = RoutingTableSelectorFactory.getRoutingTableSelector(
         pinotHelixProperties.subset(ROUTING_TABLE_SELECTOR_SUBSET_KEY), _propertyStore);
-
-    LOGGER.info("Connecting Helix components");
-    // _brokerServerBuilder = startBroker();
-    _helixManager =
-        HelixManagerFactory.getZKHelixManager(helixClusterName, brokerId, InstanceType.PARTICIPANT, zkServers);
-    _helixExternalViewBasedRouting = new HelixExternalViewBasedRouting(_propertyStore, selector, _helixManager,
+    _helixExternalViewBasedRouting = new HelixExternalViewBasedRouting(_propertyStore, selector, _spectatorHelixManager,
         pinotHelixProperties.subset(ROUTING_TABLE_PARAMS_SUBSET_KEY));
     _brokerServerBuilder = startBroker(_pinotHelixProperties);
-    final StateMachineEngine stateMachineEngine = _helixManager.getStateMachineEngine();
-    final StateModelFactory<?> stateModelFactory =
-        new BrokerResourceOnlineOfflineStateModelFactory(_helixManager, _helixExternalViewBasedRouting);
+    ClusterChangeMediator clusterChangeMediator =
+        new ClusterChangeMediator(_helixExternalViewBasedRouting, _brokerServerBuilder.getBrokerMetrics());
+    _spectatorHelixManager.addExternalViewChangeListener(clusterChangeMediator);
+    _spectatorHelixManager.addInstanceConfigChangeListener(clusterChangeMediator);
+    _spectatorHelixManager.addLiveInstanceChangeListener(_liveInstancesListener);
+
+    // Connect participant Helix manager.
+    _helixManager =
+        HelixManagerFactory.getZKHelixManager(helixClusterName, brokerId, InstanceType.PARTICIPANT, zkServers);
+    StateMachineEngine stateMachineEngine = _helixManager.getStateMachineEngine();
+    StateModelFactory<?> stateModelFactory =
+        new BrokerResourceOnlineOfflineStateModelFactory(_spectatorHelixManager, _helixExternalViewBasedRouting);
     stateMachineEngine.registerStateModelFactory(BrokerResourceOnlineOfflineStateModelFactory.getStateModelDef(),
         stateModelFactory);
     _helixManager.connect();
-    _helixAdmin = _helixManager.getClusterManagmentTool();
     addInstanceTagIfNeeded(helixClusterName, brokerId);
-
 
     // Register the service status handler
     ServiceStatus.setServiceStatusCallback(
         new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixAdmin, helixClusterName, brokerId));
-
-    ClusterChangeMediator clusterChangeMediator = new ClusterChangeMediator(_helixExternalViewBasedRouting,
-        _brokerServerBuilder.getBrokerMetrics());
-    _helixManager.addExternalViewChangeListener(clusterChangeMediator);
-    _helixManager.addInstanceConfigChangeListener(clusterChangeMediator);
-
-    _helixManager.addLiveInstanceChangeListener(_liveInstancesListener);
 
     _brokerServerBuilder.getBrokerMetrics().addCallbackGauge(
         "helix.connected", new Callable<Long>() {
@@ -163,7 +157,7 @@ public class HelixBrokerStarter {
     InstanceConfig instanceConfig = _helixAdmin.getInstanceConfig(clusterName, instanceName);
     List<String> instanceTags = instanceConfig.getTags();
     if (instanceTags == null || instanceTags.isEmpty()) {
-      if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_helixManager.getHelixPropertyStore())) {
+      if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_propertyStore)) {
         _helixAdmin.addInstanceTag(clusterName, instanceName,
             ControllerTenantNameBuilder.getBrokerTenantNameForTenant(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
       } else {
@@ -226,6 +220,10 @@ public class HelixBrokerStarter {
     return StringUtils.join(tokens, ",");
   }
 
+  public HelixManager getSpectatorHelixManager() {
+    return _spectatorHelixManager;
+  }
+
   public HelixExternalViewBasedRouting getHelixExternalViewBasedRouting() {
     return _helixExternalViewBasedRouting;
   }
@@ -253,9 +251,9 @@ public class HelixBrokerStarter {
       _helixManager.disconnect();
     }
 
-    if (_zkClient != null) {
-      LOGGER.info("Closing Zookeeper client");
-      _zkClient.close();
+    if (_spectatorHelixManager != null) {
+      LOGGER.info("Disconnecting spectator Helix manager");
+      _spectatorHelixManager.disconnect();
     }
   }
 


### PR DESCRIPTION
Fix the issue that broker keep processing external view changes and block other listeners.
Use spectator Helix manager to manage non-instance messages.
    
Tested in a cluster with about 1,000 tables. With the change, messages got processed immediately, compare to other brokers that take several minutes to get the message.