### PR TITLE
Filter optimization to merge range predicates on time columns.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/FilterQueryOptimizerRequest.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/FilterQueryOptimizerRequest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.requesthandler;
+
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+
+
+public class FilterQueryOptimizerRequest {
+
+  private FilterQueryTree _filterQueryTree = null;
+  private String _timeColumn = null;
+
+  public FilterQueryOptimizerRequest(FilterQueryOptimizerRequestBuilder builder) {
+    _filterQueryTree = builder._filterQueryTree;
+    _timeColumn = builder._timeColumn;
+  }
+
+  public FilterQueryTree getFilterQueryTree() {
+    return _filterQueryTree;
+  }
+
+  public String getTimeColumn() {
+    return _timeColumn;
+  }
+
+  public void setFilterQueryTree(FilterQueryTree filterQueryTree) {
+    _filterQueryTree = filterQueryTree;
+  }
+
+  public static class FilterQueryOptimizerRequestBuilder {
+    private FilterQueryTree _filterQueryTree;
+    private String _timeColumn;
+
+    public FilterQueryOptimizerRequestBuilder setFilterQueryTree(FilterQueryTree filterQueryTree) {
+      _filterQueryTree = filterQueryTree;
+      return this;
+    }
+
+    public FilterQueryOptimizerRequestBuilder setTimeColumn(String timeColumn) {
+      _timeColumn = timeColumn;
+      return this;
+    }
+
+    public FilterQueryOptimizerRequest build() {
+      return new FilterQueryOptimizerRequest(this);
+    }
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/FilterQueryTreeOptimizer.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/FilterQueryTreeOptimizer.java
@@ -24,7 +24,7 @@ import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 public abstract class FilterQueryTreeOptimizer {
   private final String _optimizationName = OptimizationFlags.optimizationName(this.getClass());
 
-  public abstract FilterQueryTree optimize(FilterQueryTree filterQueryTree);
+  public abstract FilterQueryTree optimize(FilterQueryOptimizerRequest request);
 
   public String getOptimizationName() {
     return _optimizationName;

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/FlattenNestedPredicatesFilterQueryTreeOptimizer.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/FlattenNestedPredicatesFilterQueryTreeOptimizer.java
@@ -30,7 +30,8 @@ public class FlattenNestedPredicatesFilterQueryTreeOptimizer extends FilterQuery
   public static int MAX_OPTIMIZING_DEPTH = 5;
 
   @Override
-  public FilterQueryTree optimize(FilterQueryTree filterQueryTree) {
+  public FilterQueryTree optimize(FilterQueryOptimizerRequest request) {
+    FilterQueryTree filterQueryTree = request.getFilterQueryTree();
     flatten(filterQueryTree, null, MAX_OPTIMIZING_DEPTH);
 
     return filterQueryTree;

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
@@ -36,8 +36,8 @@ import java.util.TreeSet;
  */
 public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer extends FilterQueryTreeOptimizer {
   @Override
-  public FilterQueryTree optimize(FilterQueryTree filterQueryTree) {
-    return optimize(filterQueryTree, null);
+  public FilterQueryTree optimize(FilterQueryOptimizerRequest request) {
+    return optimize(request.getFilterQueryTree(), null);
   }
 
   private FilterQueryTree optimize(FilterQueryTree filterQueryTree, FilterQueryTree parent) {

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizer.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizer.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.requesthandler;
+
+import com.linkedin.pinot.common.request.FilterOperator;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.core.common.predicate.RangePredicate;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+
+
+/**
+ * FilterOptimizer to merge intersecting range predicates:
+ * <ul>
+ *   <li> Given a filter query tree with range predicates on the same column, this optimizer merges the
+ *   predicates joined by AND by taking their intersection. </li>
+ *   <li> Pulls up merged predicates in the absence of other predicates on other columns. </li>
+ *   <li> Currently implemented to work for time column only. This is because the broker currently
+ *   does not know the data type for any columns, except for time column. </li>
+ * </ul>
+ */
+public class RangeMergeOptimizer extends FilterQueryTreeOptimizer {
+  private static final String DUMMY_STRING = "__dummy_string__";
+
+  @Override
+  public FilterQueryTree optimize(FilterQueryOptimizerRequest request) {
+    FilterQueryTree filterQueryTree = request.getFilterQueryTree();
+    optimizeRanges(filterQueryTree, request.getTimeColumn());
+
+    List<FilterQueryTree> children = filterQueryTree.getChildren();
+    if (children != null && children.size() == 1) {
+      return children.get(0);
+    }
+    return filterQueryTree;
+  }
+
+  /**
+   * Recursive method that performs the actual optimization of merging range predicates.
+   *
+   * @param current Current node being visited in the DFS of the filter query tree.
+   * @param timeColumn Name of time column
+   * @return Returns the optimized filter query tree
+   */
+  private static FilterQueryTree optimizeRanges(FilterQueryTree current, String timeColumn) {
+    if (current == null || timeColumn == null) {
+      return current;
+    }
+
+    List<FilterQueryTree> children = current.getChildren();
+    if (children == null || children.isEmpty()) {
+      return current;
+    }
+
+    ListIterator<FilterQueryTree> iterator = children.listIterator();
+    while (iterator.hasNext()) {
+      FilterQueryTree child = iterator.next();
+      optimizeRanges(child, timeColumn);
+
+      List<FilterQueryTree> grandChildren = child.getChildren();
+      if (grandChildren != null && grandChildren.size() == 1) {
+        iterator.remove();
+        iterator.add(grandChildren.get(0));
+      }
+    }
+
+    List<String> intersect = null;
+    iterator = children.listIterator();
+
+    while (iterator.hasNext()) {
+      FilterQueryTree child = iterator.next();
+      FilterOperator filterOperator = child.getOperator();
+      String column = child.getColumn();
+
+      if (filterOperator != null && column != null) {
+        if (column.equals(timeColumn) && filterOperator.equals(FilterOperator.RANGE)) {
+          intersect = (intersect == null) ? child.getValue() : intersectRanges(intersect, child.getValue());
+          iterator.remove();
+        }
+      }
+    }
+
+    if (intersect != null) {
+      children.add(new FilterQueryTree(timeColumn, intersect, FilterOperator.RANGE, null));
+    }
+    return current;
+  }
+
+  /**
+   * Helper method to compute intersection of two ranges.
+   * Assumes that values are 'long'. This is OK as this feature is used only for time-column.
+   *
+   * @param range1 First range
+   * @param range2 Second range
+   * @return Intersection of the given ranges.
+   */
+  private static List<String> intersectRanges(List<String> range1, List<String> range2) {
+
+    // Build temporary range predicates to parse the string range values.
+    RangePredicate predicate1 = new RangePredicate(DUMMY_STRING, range1);
+    RangePredicate predicate2 = new RangePredicate(DUMMY_STRING, range2);
+
+    String lowerString1 = predicate1.getLowerBoundary();
+    String upperString1 = predicate1.getUpperBoundary();
+
+    long lower1 = (lowerString1.equals("*")) ? Long.MIN_VALUE : Long.valueOf(lowerString1);
+    long upper1 = (upperString1.equals("*")) ? Long.MAX_VALUE : Long.valueOf(upperString1);
+
+    String lowerString2 = predicate2.getLowerBoundary();
+    String upperString2 = predicate2.getUpperBoundary();
+
+    long lower2 = (lowerString2.equals("*")) ? Long.MIN_VALUE : Long.valueOf(lowerString2);
+    long upper2 = (upperString2.equals("*")) ? Long.MAX_VALUE : Long.valueOf(upperString2);
+
+    final StringBuilder stringBuilder = new StringBuilder();
+    if (lower1 > lower2) {
+      stringBuilder.append(
+          (predicate1.includeLowerBoundary() ? RangePredicate.LOWER_INCLUSIVE : RangePredicate.LOWER_EXCLUSIVE));
+      stringBuilder.append(lower1);
+    } else if (lower1 < lower2) {
+      stringBuilder.append(
+          (predicate2.includeLowerBoundary() ? RangePredicate.LOWER_INCLUSIVE : RangePredicate.LOWER_EXCLUSIVE));
+      stringBuilder.append(lower2);
+    } else {
+      if (lower1 == Long.MIN_VALUE) { // lower1 == lower2
+        stringBuilder.append(RangePredicate.LOWER_EXCLUSIVE + RangePredicate.UNBOUNDED); // * always has '('
+      } else {
+        stringBuilder.append(
+            (predicate1.includeLowerBoundary() && predicate2.includeLowerBoundary()) ? RangePredicate.LOWER_INCLUSIVE
+                : RangePredicate.LOWER_EXCLUSIVE);
+        stringBuilder.append(lower1);
+      }
+    }
+
+    stringBuilder.append(RangePredicate.DELIMITER);
+    if (upper1 < upper2) {
+      stringBuilder.append(upper1);
+      stringBuilder.append(
+          (predicate1.includeUpperBoundary() ? RangePredicate.UPPER_INCLUSIVE : RangePredicate.UPPER_EXCLUSIVE));
+    } else if (upper2 < upper1) {
+      stringBuilder.append(upper2);
+      stringBuilder.append(
+          (predicate2.includeUpperBoundary() ? RangePredicate.UPPER_INCLUSIVE : RangePredicate.UPPER_EXCLUSIVE));
+    } else {
+      if (upper1 == Long.MAX_VALUE) { // lower1 == lower2
+        stringBuilder.append(RangePredicate.UNBOUNDED + RangePredicate.UPPER_EXCLUSIVE); // * always has ')'
+      } else {
+        stringBuilder.append(lower1);
+        stringBuilder.append(
+            (predicate1.includeUpperBoundary() && predicate2.includeUpperBoundary()) ? RangePredicate.UPPER_INCLUSIVE
+                : RangePredicate.UPPER_EXCLUSIVE);
+      }
+    }
+    return Collections.singletonList(stringBuilder.toString());
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizer.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizer.java
@@ -21,8 +21,6 @@ import com.linkedin.pinot.core.common.predicate.RangePredicate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.jar.Pack200;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -64,7 +62,8 @@ public class RangeMergeOptimizer extends FilterQueryTreeOptimizer {
     }
 
     // For OR, we optimize all its children, but do not propagate up.
-    if (current.getOperator() == FilterOperator.OR) {
+    FilterOperator operator = current.getOperator();
+    if (operator == FilterOperator.OR) {
       int length = children.size();
       for (int i = 0; i < length; i++) {
         children.set(i, optimizeRanges(children.get(i), timeColumn));
@@ -72,6 +71,8 @@ public class RangeMergeOptimizer extends FilterQueryTreeOptimizer {
       return current;
     }
 
+    // After this point, since the node has children, it can only be an 'AND' node (only OR/AND supported).
+    assert operator == FilterOperator.AND;
     List<FilterQueryTree> newChildren = new ArrayList<>();
     List<String> intersect = null;
 

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/FilterOptimizerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/FilterOptimizerTest.java
@@ -33,12 +33,13 @@ public class FilterOptimizerTest {
 
     Pql2Compiler pql2Compiler = new Pql2Compiler();
     BrokerRequest req;
+    String timeColumn = null;
     FilterQueryTree tree;
     int numLeaves;
     int numOps;
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE (A = 4 AND B = 5) AND (C=7)");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
     Assert.assertEquals(tree.getChildren().size(), 3);
     Assert.assertEquals(tree.getOperator(), FilterOperator.AND);
     for (FilterQueryTree node: tree.getChildren()) {
@@ -47,7 +48,7 @@ public class FilterOptimizerTest {
     }
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 AND B = 5) AND (C=7)) AND D=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
     Assert.assertEquals(tree.getChildren().size(), 4);
     Assert.assertEquals(tree.getOperator(), FilterOperator.AND);
     for (FilterQueryTree node: tree.getChildren()) {
@@ -56,7 +57,7 @@ public class FilterOptimizerTest {
     }
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE (A = 4 OR B = 5) OR (C=7)");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
     Assert.assertEquals(tree.getChildren().size(), 3);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     for (FilterQueryTree node: tree.getChildren()) {
@@ -65,7 +66,7 @@ public class FilterOptimizerTest {
     }
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR B = 5) OR (C=7)) OR D=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
     Assert.assertEquals(tree.getChildren().size(), 4);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     for (FilterQueryTree node: tree.getChildren()) {
@@ -75,7 +76,7 @@ public class FilterOptimizerTest {
 
     // 3-level test case
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 OR D = 9)) OR (C=7)) OR E=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
     Assert.assertEquals(tree.getChildren().size(), 5);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     for (FilterQueryTree node: tree.getChildren()) {
@@ -85,7 +86,7 @@ public class FilterOptimizerTest {
 
     // Mixed case.
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE ((A = 4 OR (B = 5 AND D = 9)) OR (C=7)) OR E=8");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
     Assert.assertEquals(tree.getChildren().size(), 4);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     numLeaves = 0;
@@ -106,7 +107,7 @@ public class FilterOptimizerTest {
     final int maxNodesAtTopLevel = FlattenNestedPredicatesFilterQueryTreeOptimizer.MAX_OPTIMIZING_DEPTH;
     String whereClause = constructWhereClause(FilterOperator.OR, maxNodesAtTopLevel + 50);
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE " + whereClause);
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, timeColumn));
     Assert.assertEquals(tree.getChildren().size(), maxNodesAtTopLevel+1);
     Assert.assertEquals(tree.getOperator(), FilterOperator.OR);
     numLeaves = 0;
@@ -134,7 +135,7 @@ public class FilterOptimizerTest {
     int numOps;
 
     req = pql2Compiler.compileToBrokerRequest("SELECT * FROM T WHERE (A = 4 AND (B = 5 OR D = 9))");
-    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req));
+    tree = RequestUtils.generateFilterQueryTree(_optimizer.optimize(req, null /* timeColumn */));
     Assert.assertEquals(tree.getChildren().size(), 2);
     Assert.assertEquals(tree.getOperator(), FilterOperator.AND);
     numOps = 0;

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
@@ -115,7 +115,7 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
   }
 
   private String filterQueryTreeForQuery(String query) {
-    BrokerRequest brokerRequest = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(query));
+    BrokerRequest brokerRequest = OPTIMIZER.optimize(COMPILER.compileToBrokerRequest(query), null /* timeColumn */);
     return RequestUtils.generateFilterQueryTree(brokerRequest).toString();
   }
 

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizerTest.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.requesthandler;
+
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link RangeMergeOptimizerTest}
+ */
+public class RangeMergeOptimizerTest {
+
+  private static final String TIME_COLUMN = "time";
+  private RangeMergeOptimizer _optimizer;
+  private FilterQueryOptimizerRequest.FilterQueryOptimizerRequestBuilder _builder;
+  private Pql2Compiler _compiler;
+
+  @BeforeClass
+  public void setup() {
+    _compiler = new Pql2Compiler();
+    _optimizer = new RangeMergeOptimizer();
+    _builder = new FilterQueryOptimizerRequest.FilterQueryOptimizerRequestBuilder();
+  }
+
+  @Test
+  public void test() {
+
+    // Query with single >
+    FilterQueryTree actualTree = buildFilterQueryTree("select * from table where time > 10", true);
+    FilterQueryTree expectedTree = buildFilterQueryTree("select * from table where time > 10", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with single >=
+    actualTree = buildFilterQueryTree("select * from table where time >= 10", true);
+    expectedTree = buildFilterQueryTree("select * from table where time >= 10", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with single <
+    actualTree = buildFilterQueryTree("select * from table where time < 10", true);
+    expectedTree = buildFilterQueryTree("select * from table where time < 10", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with single <=
+    actualTree = buildFilterQueryTree("select * from table where time <= 10", true);
+    expectedTree = buildFilterQueryTree("select * from table where time <= 10", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with >= and <=
+    actualTree = buildFilterQueryTree("select * from table where time >= 10 and time <= 20 and foo = 'bar'", true);
+    expectedTree = buildFilterQueryTree("select * from table where time between 10 and 20 and foo = 'bar'", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with no intersection
+    actualTree = buildFilterQueryTree("select * from table where time >= 10 and time <= 5", true);
+    expectedTree = buildFilterQueryTree("select * from table where time between 10 and 5", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with multiple ranges on time column
+    actualTree = buildFilterQueryTree("select * from table where time >= 10 and time <= 20 and time <= 15", true);
+    expectedTree = buildFilterQueryTree("select * from table where time between 10 and 15", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with multiple predicates
+    actualTree =
+        buildFilterQueryTree("select * from table where time >= 10 and time <= 20 and time <= 15 and foo = 'bar'",
+            true);
+    expectedTree = buildFilterQueryTree("select * from table where time between 10 and 15 and foo = 'bar'", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with nested predicates
+    actualTree =
+        buildFilterQueryTree("select * from table where (time >= 10 and time <= 20) and ((time >= 5 and time <= 15))",
+            true);
+    expectedTree = buildFilterQueryTree("select * from table where time between 10 and 15", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with nested predicates where not all ranges can be merged
+    actualTree = buildFilterQueryTree(
+        "select * from table where (time >= 10 and time <= 20) and (foo1 = 'bar1' and (foo2 = 'bar2' and (time >= 5 and time <= 15)))",
+        true);
+    expectedTree = buildFilterQueryTree(
+        "select * from table where time between 10 and 20 and (foo1 = 'bar1' and (foo2 = 'bar2' and (time between 5 and 15)))",
+        false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with time range in different levels of tree and all ranges can be merged
+    actualTree =
+        buildFilterQueryTree("select * from table where (((time >= 10 and time <= 20) and time >= 5) and time <= 15)",
+            true);
+    expectedTree = buildFilterQueryTree("select * from table where time between 10 and 15", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with time range of one value.
+    actualTree =
+        buildFilterQueryTree("select * from table where (time > 10 and time <= 20) and (time >= 20 and time <= 30)",
+            true);
+    expectedTree = buildFilterQueryTree("select * from table where time between 20 and 20", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query with OR predicates
+    actualTree = buildFilterQueryTree("select * from table where (foo = 'bar' or time < 10)", true);
+    expectedTree = buildFilterQueryTree("select * from table where (foo = 'bar' or time < 10)", false);
+    compareTrees(actualTree, expectedTree);
+
+    // Query without time column
+    actualTree = buildFilterQueryTree("select * from table where foo = 'bar'", true);
+    expectedTree = buildFilterQueryTree("select * from table where foo = 'bar'", false);
+    compareTrees(actualTree, expectedTree);
+  }
+
+  /**
+   * Helper method to compare two filter query trees
+   * @param actualTree Actual tree
+   * @param expectedTree Expected tree
+   */
+  private void compareTrees(FilterQueryTree actualTree, FilterQueryTree expectedTree) {
+    Assert.assertNotNull(actualTree);
+    Assert.assertNotNull(expectedTree);
+
+    Assert.assertEquals(actualTree.getOperator(), expectedTree.getOperator());
+    Assert.assertEquals(actualTree.getColumn(), expectedTree.getColumn());
+    Assert.assertEquals(actualTree.getValue(), expectedTree.getValue());
+
+    List<FilterQueryTree> actualChildren = actualTree.getChildren();
+    List<FilterQueryTree> expectedChildren = expectedTree.getChildren();
+
+    if (expectedChildren != null) {
+      Assert.assertNotNull(actualChildren);
+      Assert.assertEquals(actualChildren.size(), expectedChildren.size());
+
+      Map<String, FilterQueryTree> expectedSet = new HashMap<>(expectedChildren.size());
+      for (FilterQueryTree expectedChild : expectedChildren) {
+        expectedSet.put(expectedChild.getColumn(), expectedChild);
+      }
+
+      for (FilterQueryTree actualChild : actualChildren) {
+        FilterQueryTree expectedChild = expectedSet.get(actualChild.getColumn());
+        compareTrees(actualChild, expectedChild);
+      }
+    }
+  }
+
+  /**
+   * Helper method to build the filter query tree for the given query
+   * @param query Query for which to build the filter query tree
+   * @param optimize If true, then range optimization is performed
+   * @return Filter query tree for the query
+   */
+  private FilterQueryTree buildFilterQueryTree(String query, boolean optimize) {
+    BrokerRequest brokerRequest = _compiler.compileToBrokerRequest(query);
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+
+    if (optimize) {
+      FilterQueryOptimizerRequest request =
+          _builder.setFilterQueryTree(filterQueryTree).setTimeColumn(TIME_COLUMN).build();
+      return _optimizer.optimize(request);
+    } else {
+      return filterQueryTree;
+    }
+  }
+}

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/RangeMergeOptimizerTest.java
@@ -19,9 +19,7 @@ import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.common.utils.request.RequestUtils;
 import com.linkedin.pinot.pql.parsers.Pql2Compiler;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,6 +84,11 @@ public class RangeMergeOptimizerTest {
     range1.set(0, "(1\t\t10]");
     range2.set(0, "[10\t\t30)");
     testRangeOptimizer(range1, range2, "[10\t\t10]");
+
+    // Redundant case
+    range1.set(0, "(*\t\t10]");
+    range2.set(0, "(*\t\t30)");
+    testRangeOptimizer(range1, range2, "(*\t\t10]");
   }
 
   @Test
@@ -164,8 +167,11 @@ public class RangeMergeOptimizerTest {
     compareTrees(actualTree, expectedTree);
 
     // Query with OR predicates
-    actualTree = buildFilterQueryTree("select * from table where (foo1 = 'bar1' or (foo2 = 'bar2' and (time >= 10 and time <= 20)))", true);
-    expectedTree = buildFilterQueryTree("select * from table where (foo1 = 'bar1' or (foo2 = 'bar2' and time between 10 and 20))", false);
+    actualTree = buildFilterQueryTree(
+        "select * from table where (foo1 = 'bar1' or (foo2 = 'bar2' and (time >= 10 and time <= 20)))", true);
+    expectedTree =
+        buildFilterQueryTree("select * from table where (foo1 = 'bar1' or (foo2 = 'bar2' and time between 10 and 20))",
+            false);
     compareTrees(actualTree, expectedTree);
 
     // Query without time column

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/FilterQueryTree.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/FilterQueryTree.java
@@ -15,10 +15,8 @@
  */
 package com.linkedin.pinot.common.utils.request;
 
-import com.google.common.base.Objects;
-import java.util.List;
-
 import com.linkedin.pinot.common.request.FilterOperator;
+import java.util.List;
 
 
 public class FilterQueryTree {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/RangePredicate.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/RangePredicate.java
@@ -16,12 +16,21 @@
 package com.linkedin.pinot.core.common.predicate;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.linkedin.pinot.core.common.Predicate;
 
 
 public class RangePredicate extends Predicate {
+
+  public static final String DELIMITER = "\t\t";
+  public static final String LOWER_INCLUSIVE = "[";
+  public static final String LOWER_EXCLUSIVE = "(";
+
+  public static final String UPPER_INCLUSIVE = "]";
+  public static final String UPPER_EXCLUSIVE = ")";
+  public static final String UNBOUNDED = "*";
 
   private final boolean incLower;
   private final boolean incUpper;
@@ -32,11 +41,11 @@ public class RangePredicate extends Predicate {
     super(lhs, Type.RANGE, rhs);
 
     final String rangeString = rhs.get(0).trim();
-    lowerBoundary = rangeString.split("\t\t")[0].substring(1, rangeString.split("\t\t")[0].length());
-    upperBoundary = rangeString.split("\t\t")[1].substring(0, rangeString.split("\t\t")[1].length() - 1);
+    lowerBoundary = rangeString.split(DELIMITER)[0].substring(1, rangeString.split(DELIMITER)[0].length());
+    upperBoundary = rangeString.split(DELIMITER)[1].substring(0, rangeString.split(DELIMITER)[1].length() - 1);
 
-    if (rangeString.trim().startsWith("(")) {
-      if (lowerBoundary.equals("*")) {
+    if (rangeString.trim().startsWith(LOWER_EXCLUSIVE)) {
+      if (lowerBoundary.equals(UNBOUNDED)) {
         incLower = true;
       } else {
         incLower = false;
@@ -45,8 +54,8 @@ public class RangePredicate extends Predicate {
       incLower = true;
     }
 
-    if (rangeString.trim().endsWith(")")) {
-      if (upperBoundary.equals("*")) {
+    if (rangeString.trim().endsWith(UPPER_EXCLUSIVE)) {
+      if (upperBoundary.equals(UNBOUNDED)) {
         incUpper = true;
       } else {
         incUpper = false;


### PR DESCRIPTION
Predicates on time column of type (time > t1 and time <= t2)
can be optimized into a single range predicate with range (t1, t2].
This avoids potential scanning/searching of same data multiple times.

1. While this optimization can be done generically for all predicates,
   this PR does it for 'time' column only as broker does not have
   data type information for other columns.

2. Range intersection is performed for 'AND'. No merging is performed
   for 'OR' (union) in this PR (may be addressed in future PR's
   if need be).

3. If after merging a node is left with just one child with
   range predicate, the node is replaced by its child. But time
   range predicates are not pulled up in presence of other
   predicates, in this PR.

4. Added unit test for the same.