### PR TITLE
[PINOT-4358] Added code to remove old LLC segments that are marked IN_PROGRESS but in OFFLINE state

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/EmptySegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/EmptySegmentOnlineOfflineStateModelFactory.java
@@ -49,6 +49,11 @@ public class EmptySegmentOnlineOfflineStateModelFactory extends StateModelFactor
       LOGGER.info("EmptySegmentOnlineOfflineStateModel.onBecomeOnlineFromOffline() : " + message);
     }
 
+    @Transition(from = "OFFLINE", to = "CONSUMING")
+    public void onBecomeConsumingFromOffline(Message message, NotificationContext context) {
+      LOGGER.info("EmptySegmentOnlineOfflineStateModel.onBecomeConsumingFromOffline() : " + message);
+    }
+
     @Transition(from = "ONLINE", to = "OFFLINE")
     public void onBecomeOfflineFromOnline(Message message, NotificationContext context) {
       LOGGER.info("EmptySegmentOnlineOfflineStateModel.onBecomeOfflineFromOnline() : " + message);
@@ -62,6 +67,11 @@ public class EmptySegmentOnlineOfflineStateModelFactory extends StateModelFactor
     @Transition(from = "ONLINE", to = "DROPPED")
     public void onBecomeDroppedFromOnline(Message message, NotificationContext context) {
       LOGGER.info("EmptySegmentOnlineOfflineStateModel.onBecomeDroppedFromOnline() : " + message);
+    }
+
+    @Transition(from = "CONSUMING", to = "DROPPED")
+    public void onBecomeDroppedFromConsuming(Message message, NotificationContext context) {
+      LOGGER.info("EmptySegmentOnlineOfflineStateModel.onBecomeDroppedFromConsuming() : " + message);
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -134,7 +134,7 @@ public class RetentionManager {
           idealState = HelixHelper.getTableIdealState(_pinotHelixResourceManager.getHelixZkManager(), tableName);
         }
       } catch (Exception e) {
-        LOGGER.warn("Could not get idealstate for {}", tableName);
+        LOGGER.warn("Could not get idealstate for {}", tableName, e);
         // Ignore, worst case we have some old inactive segments in place.
       }
       for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {


### PR DESCRIPTION
If LLC consumption fails with a permanent failure (or after a certain number of retries), we mark the
segment to be in OFFLINE state (and let the auto-creation mechanism come by and create new segments).
However, we leave these OFFLINE segments as cruft, never to be removed.

Changed RetentionManager to delete these segments.

Added a test.