### PR TITLE
Improve summary algorithm

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/CostFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/CostFunction.java
@@ -30,4 +30,14 @@ public class CostFunction {
       return 0.;
     }
   }
+
+  public static double errWithPercentageRemoval(double v1, double v2, double parentRatio,
+      double threshold, double currentBaselineSum) {
+    double percentageContribution = (((v1 + v2) / currentBaselineSum) * 100);
+    if (Double.compare(percentageContribution, threshold) < 0) {
+      return 0d;
+    } else {
+      return err4EmptyValues(v1, v2, parentRatio) * Math.log(percentageContribution);
+    }
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/Cube.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/Cube.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class Cube { // the cube (Ca|Cb)
   private static final Logger LOG = LoggerFactory.getLogger(Cube.class);
   private static final int DEFAULT_TOP_DIMENSION = 3;
+  public static final double PERCENTAGE_CONTRIBUTION_THRESHOLD = 3d;
 
   private double topBaselineValue;
   private double topCurrentValue;
@@ -307,12 +308,10 @@ public class Cube { // the cube (Ca|Cb)
         Row wowValues = wowValuesOfOneDimension.get(j);
         String dimValue = wowValues.getDimensionValues().get(0);
 
-        double dimValueCost = CostFunction.err4EmptyValues(wowValues.baselineValue, wowValues.currentValue, topRatio);
-        double percentage = (wowValues.baselineValue + wowValues.currentValue) * 100 / (currentTotal + baselineTotal);
-        if (Double.compare(percentage, Math.E) < 0) {
-          percentage = Math.E;
-        }
-        dimValueCost *= Math.log(percentage);
+        double dimValueCost = CostFunction
+            .errWithPercentageRemoval(wowValues.baselineValue, wowValues.currentValue, topRatio,
+                PERCENTAGE_CONTRIBUTION_THRESHOLD, currentTotal + baselineTotal);
+
         double contributionFactor = (wowValues.baselineValue + wowValues.currentValue)/(baselineTotal + currentTotal);
         costSet.add(new DimNameValueCostEntry(dimension, dimValue, dimValueCost , contributionFactor, wowValues.currentValue, wowValues.baselineValue));
         cost += dimValueCost;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/Cube.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/Cube.java
@@ -221,22 +221,28 @@ public class Cube { // the cube (Ca|Cb)
   }
   static class DimNameValueCostEntry implements Comparable<DimNameValueCostEntry>{
     double contributionFactor;
-    public DimNameValueCostEntry(String dimension, String dimValue, double dimValueCost, double contributionFactor) {
+    public DimNameValueCostEntry(String dimension, String dimValue, double dimValueCost, double contributionFactor, double curValue, double preValue) {
       this.dimName = dimension;
       this.dimValue = dimValue;
       this.cost = dimValueCost;
       this.contributionFactor = contributionFactor;
+      this.curValue = curValue;
+      this.preValue = preValue;
     }
     String dimName;
     String dimValue;
     double cost;
+    double curValue;
+    double preValue;
     @Override
     public int compareTo(DimNameValueCostEntry that) {
       return Double.compare(that.cost, this.cost);
     }
     @Override
     public String toString() {
-      return "DimNameValueCostEntry [contributionFactor=" + contributionFactor + ", dimName=" + dimName + ", dimValue=" + dimValue + ", cost=" + cost + "]";
+      return "[contributionFactor=" + contributionFactor + ", dimName=" + dimName + ", dimValue="
+          + dimValue + ", cost=" + cost + ", delta=" + (curValue - preValue) + ", ratio=" + (
+          curValue / preValue) + "]";
     }
 
 
@@ -306,9 +312,13 @@ public class Cube { // the cube (Ca|Cb)
         String dimValue = wowValues.getDimensionValues().get(0);
 
         double dimValueCost = CostFunction.err4EmptyValues(wowValues.baselineValue, wowValues.currentValue, topRatio);
-        dimValueCost *= Math.log((wowValues.baselineValue + wowValues.currentValue) * 100 / (currentTotal + baselineTotal));
+        double percentage = (wowValues.baselineValue + wowValues.currentValue) * 100 / (currentTotal + baselineTotal);
+        if (Double.compare(percentage, Math.E) < 0) {
+          percentage = Math.E;
+        }
+        dimValueCost *= Math.log(percentage);
         double contributionFactor = (wowValues.baselineValue + wowValues.currentValue)/(baselineTotal + currentTotal);
-        costSet.add(new DimNameValueCostEntry(dimension, dimValue, dimValueCost , contributionFactor));
+        costSet.add(new DimNameValueCostEntry(dimension, dimValue, dimValueCost , contributionFactor, wowValues.currentValue, wowValues.baselineValue));
         cost += dimValueCost;
       }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/DimNameValueCostEntry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/DimNameValueCostEntry.java
@@ -5,15 +5,15 @@ public class DimNameValueCostEntry implements Comparable<DimNameValueCostEntry>{
   private String dimName;
   private String dimValue;
   private double cost;
-  private double curValue;
+  private double currentValue;
   private double baselineValue;
 
-  public DimNameValueCostEntry(String dimension, String dimValue, double dimValueCost, double contributionFactor, double curValue, double baselineValue) {
+  public DimNameValueCostEntry(String dimension, String dimValue, double dimValueCost, double contributionFactor, double currentValue, double baselineValue) {
     this.dimName = dimension;
     this.dimValue = dimValue;
     this.cost = dimValueCost;
     this.contributionFactor = contributionFactor;
-    this.curValue = curValue;
+    this.currentValue = currentValue;
     this.baselineValue = baselineValue;
   }
 
@@ -49,12 +49,12 @@ public class DimNameValueCostEntry implements Comparable<DimNameValueCostEntry>{
     this.cost = cost;
   }
 
-  public double getCurValue() {
-    return curValue;
+  public double getCurrentValue() {
+    return currentValue;
   }
 
-  public void setCurValue(double curValue) {
-    this.curValue = curValue;
+  public void setCurrentValue(double currentValue) {
+    this.currentValue = currentValue;
   }
 
   public double getBaselineValue() {
@@ -73,8 +73,8 @@ public class DimNameValueCostEntry implements Comparable<DimNameValueCostEntry>{
   @Override
   public String toString() {
     return "[contributionFactor=" + contributionFactor + ", dimName=" + dimName + ", dimValue="
-        + dimValue + ", cost=" + cost + ", delta=" + (curValue - baselineValue) + ", ratio=" + (
-        curValue / baselineValue) + "]";
+        + dimValue + ", cost=" + cost + ", delta=" + (currentValue - baselineValue) + ", ratio=" + (
+        currentValue / baselineValue) + "]";
   }
 }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/DimNameValueCostEntry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/DimNameValueCostEntry.java
@@ -1,0 +1,80 @@
+package com.linkedin.thirdeye.client.diffsummary;
+
+public class DimNameValueCostEntry implements Comparable<DimNameValueCostEntry>{
+  private double contributionFactor;
+  private String dimName;
+  private String dimValue;
+  private double cost;
+  private double curValue;
+  private double baselineValue;
+
+  public DimNameValueCostEntry(String dimension, String dimValue, double dimValueCost, double contributionFactor, double curValue, double baselineValue) {
+    this.dimName = dimension;
+    this.dimValue = dimValue;
+    this.cost = dimValueCost;
+    this.contributionFactor = contributionFactor;
+    this.curValue = curValue;
+    this.baselineValue = baselineValue;
+  }
+
+  public double getContributionFactor() {
+    return contributionFactor;
+  }
+
+  public void setContributionFactor(double contributionFactor) {
+    this.contributionFactor = contributionFactor;
+  }
+
+  public String getDimName() {
+    return dimName;
+  }
+
+  public void setDimName(String dimName) {
+    this.dimName = dimName;
+  }
+
+  public String getDimValue() {
+    return dimValue;
+  }
+
+  public void setDimValue(String dimValue) {
+    this.dimValue = dimValue;
+  }
+
+  public double getCost() {
+    return cost;
+  }
+
+  public void setCost(double cost) {
+    this.cost = cost;
+  }
+
+  public double getCurValue() {
+    return curValue;
+  }
+
+  public void setCurValue(double curValue) {
+    this.curValue = curValue;
+  }
+
+  public double getBaselineValue() {
+    return baselineValue;
+  }
+
+  public void setBaselineValue(double baselineValue) {
+    this.baselineValue = baselineValue;
+  }
+
+  @Override
+  public int compareTo(DimNameValueCostEntry that) {
+    return Double.compare(this.cost, that.cost);
+  }
+
+  @Override
+  public String toString() {
+    return "[contributionFactor=" + contributionFactor + ", dimName=" + dimName + ", dimValue="
+        + dimValue + ", cost=" + cost + ", delta=" + (curValue - baselineValue) + ", ratio=" + (
+        curValue / baselineValue) + "]";
+  }
+}
+

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -204,7 +204,12 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
         if (hasGroupBy) {
           groupKeys = new String[resultSet.getGroupKeyLength()];
           for (int grpKeyIdx = 0; grpKeyIdx < resultSet.getGroupKeyLength(); grpKeyIdx++) {
-            String groupKeyVal = resultSet.getGroupKeyString(r, grpKeyIdx);
+            String groupKeyVal = "";
+            try {
+              groupKeyVal = resultSet.getGroupKeyString(r, grpKeyIdx);
+            } catch (Exception e) {
+              // IGNORE FOR NOW, workaround for Pinot Bug
+            }
             if (hasGroupByTime && grpKeyIdx == 0) {
               int timeBucket;
               long millis;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/BaseResponseRow.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/BaseResponseRow.java
@@ -1,0 +1,9 @@
+package com.linkedin.thirdeye.dashboard.views.diffsummary;
+
+public class BaseResponseRow {
+  public double baselineValue;
+  public double currentValue;
+  public String percentageChange;
+  public String contributionChange;
+  public String contributionToOverallChange;
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/Summary.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/Summary.java
@@ -311,10 +311,8 @@ public class Summary {
     public void insertRowToDPArray(DPArray dp, HierarchyNode node, double targetRatio) {
       double baselineValue = node.getBaselineValue();
       double currentValue = node.getCurrentValue();
-      double percentage = (((baselineValue + currentValue) / topValue) * 100);
-      if (Double.compare(percentage, Math.E) < 0) percentage = Math.E;
-      double cost = CostFunction.err4EmptyValues(baselineValue, currentValue, targetRatio) * Math.log(percentage);
-//      double cost = CostFunction.err4EmptyValues(baselineValue, currentValue, targetRatio);
+      double cost = CostFunction.errWithPercentageRemoval(baselineValue, currentValue, targetRatio,
+          Cube.PERCENTAGE_CONTRIBUTION_THRESHOLD, topValue);
 
       for (int n = dp.size() - 1; n > 0; --n) {
         double val1 = dp.slotAt(n - 1).cost;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/Summary.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/Summary.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.dashboard.views.diffsummary;
 
+import com.linkedin.thirdeye.client.diffsummary.DimNameValueCostEntry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -29,12 +30,14 @@ public class Summary {
   private final RowInserter basicRowInserter = new BasicRowInserter();
   private RowInserter oneSideErrorRowInserter = basicRowInserter;
   private RowInserter leafRowInserter = basicRowInserter;
+  private List<DimNameValueCostEntry> costSet;
 
   public Summary(Cube cube) {
     this.cube = cube;
     this.maxLevelCount = cube.getDimensions().size();
     this.topValue = cube.getTopBaselineValue() + cube.getTopCurrentValue();
     this.levelCount = this.maxLevelCount;
+    this.costSet = cube.getCostSet();
   }
 
   public SummaryResponse computeSummary(int answerSize) {
@@ -70,7 +73,8 @@ public class Summary {
     }
     computeChildDPArray(root);
     List<HierarchyNode> answer = new ArrayList<>(dpArrays.get(0).getAnswer());
-    SummaryResponse response = SummaryResponse.buildResponse(answer, this.levelCount);
+    SummaryResponse response = new SummaryResponse();
+    response.build(answer, this.levelCount, this.costSet);
 
     return response;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/SummaryGainerLoserResponseRow.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/SummaryGainerLoserResponseRow.java
@@ -1,0 +1,19 @@
+package com.linkedin.thirdeye.dashboard.views.diffsummary;
+
+
+public class SummaryGainerLoserResponseRow extends BaseResponseRow {
+  public String dimensionName;
+  public String dimensionValue;
+  public String cost;
+
+  public static SummaryGainerLoserResponseRow buildNotAvailableRow() {
+    SummaryGainerLoserResponseRow row = new SummaryGainerLoserResponseRow();
+    row.dimensionName = SummaryResponse.NOT_AVAILABLE;
+    row.dimensionValue = SummaryResponse.NOT_AVAILABLE;
+    row.cost = SummaryResponse.NOT_AVAILABLE;
+    row.percentageChange = SummaryResponse.NOT_AVAILABLE;
+    row.contributionChange = SummaryResponse.NOT_AVAILABLE;
+    row.contributionToOverallChange = SummaryResponse.NOT_AVAILABLE;
+    return row;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/SummaryResponseRow.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/views/diffsummary/SummaryResponseRow.java
@@ -9,13 +9,8 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 /**
  * A POJO for front-end representation.
  */
-public class SummaryResponseRow {
+public class SummaryResponseRow extends BaseResponseRow {
   public List<String> names;
-  public double baselineValue;
-  public double currentValue;
-  public String percentageChange;
-  public String contributionChange;
-  public String contributionToOverallChange;
   public String otherDimensionValues;
 
   public static SummaryResponseRow buildNotAvailableRow() {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
@@ -304,8 +304,12 @@ function renderHeatMapSummary(summaryData){
     $("#heat-map-" + summaryData.metricName +"-difference-summary-table").DataTable({
         "bSort" : false
     });
-    $("#heat-map-" + summaryData.metricName +"-gainer-summary-table").DataTable();
-    $("#heat-map-" + summaryData.metricName +"-loser-summary-table").DataTable();
+    $("#heat-map-" + summaryData.metricName +"-gainer-summary-table").DataTable({
+        "order": [[ 7, "desc" ]]
+    });
+    $("#heat-map-" + summaryData.metricName +"-loser-summary-table").DataTable({
+        "order": [[ 7, "desc" ]]
+    });
 }
 
 function heatMapEventListeners(tab) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
@@ -25,7 +25,7 @@ function getHeatmap(tab) {
             "&currentEnd=" + hash.currentEnd +
             "&dimensions=" + hash.dimensions +
             "&topDimensions=3" +
-            "&oneSideError=true" +
+            "&oneSideError=false" +
             "&summarySize=10" +
             "&hierarchies=[[\"browser_name\", \"browser_version\"],[\"continent\",\"countryCode\"]]"
         var metrics = hash.metrics.split(",")
@@ -283,9 +283,7 @@ function renderD3heatmap(data, tab, templatePlaceHolder) {
             drawTreemap(root_0, placeholder_0)
             drawTreemap(root_1, placeholder_1)
             drawTreemap(root_2, placeholder_2)
-
         }
-
     }
 }
 
@@ -306,6 +304,8 @@ function renderHeatMapSummary(summaryData){
     $("#heat-map-" + summaryData.metricName +"-difference-summary-table").DataTable({
         "bSort" : false
     });
+    $("#heat-map-" + summaryData.metricName +"-gainer-summary-table").DataTable();
+    $("#heat-map-" + summaryData.metricName +"-loser-summary-table").DataTable();
 }
 
 function heatMapEventListeners(tab) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map-summary.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map-summary.ftl
@@ -1,10 +1,7 @@
 <section id="dimension-heat-map-section">
     <script id="heatmap-summary-template" type="text/x-handlebars-template">
         {{#with @root/summaryData}}
-
             <table id="heat-map-{{metricName}}-difference-summary-table" style="width:100%;">
-
-
                 <thead>
                 <tr>
                     <th colspan="{{dimensions.length}}">Dimension</th>
@@ -43,6 +40,82 @@
                 {{/each}}
                 {{/with}}<!--end of summaryData -->
                 </tbody>
+            </table>
+            <table id="heat-map-{{metricName}}-gainer-summary-table" style="width:100%;">
+              <thead>
+              <tr>
+                <th colspan="{{dimensions.length}}">Top {{gainer.length}} Gainer</th>
+                <th></th>
+                <th></th>
+                <th></th>
+                <th></th>
+                <th></th>
+              </tr>
+              <tr>
+                <th class="summary-header">Dimension</th>
+                <th class="summary-header"> </th>
+                <th class="summary-header">Baseline</th>
+                <th class="summary-header">Current</th>
+                <th class="summary-header thin-column">Percentage Change</th>
+                <th class="summary-header thin-column">Contribution Change</th>
+                <th class="summary-header thin-column">Contribution To Overall Change</th>
+                <th class="summary-header thin-column">Score</th>
+              </tr>
+              </thead>
+              {{#with @root/summaryData/gainer}}
+              <tbody>
+              {{#each this as |row rowIndex|}}
+              <tr>
+                <td style="background-color: rgba(222, 222, 222, 0.5);">{{row.dimensionName}}</td>
+                <td style="background-color: rgba(222, 222, 222, 0.5);">{{row.dimensionValue}}</td>
+                <td align="right">{{row.baselineValue}}</td>
+                <td align="right">{{row.currentValue}}</td>
+                <td align="right">{{row.percentageChange}}</td>
+                <td align="right">{{row.contributionChange}}</td>
+                <td align="right">{{row.contributionToOverallChange}}</td>
+                <td align="right">{{row.cost}}</td>
+              </tr>
+              {{/each}}
+              {{/with}}<!--end of summaryData -->
+              </tbody>
+            </table>
+            <table id="heat-map-{{metricName}}-loser-summary-table" style="width:100%;">
+              <thead>
+              <tr>
+                <th colspan="{{dimensions.length}}">Top {{loser.length}} Loser</th>
+                <th></th>
+                <th></th>
+                <th></th>
+                <th></th>
+                <th></th>
+              </tr>
+              <tr>
+                <th class="summary-header">Dimension</th>
+                <th class="summary-header"> </th>
+                <th class="summary-header">Baseline</th>
+                <th class="summary-header">Current</th>
+                <th class="summary-header thin-column">Percentage Change</th>
+                <th class="summary-header thin-column">Contribution Change</th>
+                <th class="summary-header thin-column">Contribution To Overall Change</th>
+                <th class="summary-header thin-column">Score</th>
+              </tr>
+              </thead>
+              {{#with @root/summaryData/loser}}
+              <tbody>
+              {{#each this as |row rowIndex|}}
+              <tr>
+                <td style="background-color: rgba(222, 222, 222, 0.5);">{{row.dimensionName}}</td>
+                <td style="background-color: rgba(222, 222, 222, 0.5);">{{row.dimensionValue}}</td>
+                <td align="right">{{row.baselineValue}}</td>
+                <td align="right">{{row.currentValue}}</td>
+                <td align="right">{{row.percentageChange}}</td>
+                <td align="right">{{row.contributionChange}}</td>
+                <td align="right">{{row.contributionToOverallChange}}</td>
+                <td align="right">{{row.cost}}</td>
+              </tr>
+              {{/each}}
+              {{/with}}<!--end of summaryData -->
+              </tbody>
             </table>
         {{/with}}<!--end of summaryData scope-->
     </script>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map-summary.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map-summary.ftl
@@ -4,7 +4,7 @@
             <table id="heat-map-{{metricName}}-difference-summary-table" style="width:100%;">
                 <thead>
                 <tr>
-                    <th colspan="{{dimensions.length}}">Top 3 Multi-Dimensions Drill Down (Select "Dimensions" from the left panel to specify interested dimensions)</th>
+                    <th colspan="{{dimensions.length}}">Multi-Dimensional Outlier Summary</th>
                     <th></th>
                     <th></th>
                     <th></th>
@@ -41,10 +41,11 @@
                 {{/with}}<!--end of summaryData -->
                 </tbody>
             </table>
+            <hr>
             <table id="heat-map-{{metricName}}-gainer-summary-table" style="width:100%;">
               <thead>
               <tr>
-                <th colspan="{{dimensions.length}}">Top {{gainer.length}} Gainers of Single Dimension</th>
+                <th colspan="{{dimensions.length}}">Top {{gainer.length}} Gainers among all Single Dimensions</th>
                 <th></th>
                 <th></th>
                 <th></th>
@@ -79,10 +80,11 @@
               {{/with}}<!--end of summaryData -->
               </tbody>
             </table>
+            <hr>
             <table id="heat-map-{{metricName}}-loser-summary-table" style="width:100%;">
               <thead>
               <tr>
-                <th colspan="{{dimensions.length}}">Top {{loser.length}} Losers of Single Dimension</th>
+                <th colspan="{{dimensions.length}}">Top {{loser.length}} Losers among all Single Dimensions</th>
                 <th></th>
                 <th></th>
                 <th></th>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map-summary.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map-summary.ftl
@@ -4,7 +4,7 @@
             <table id="heat-map-{{metricName}}-difference-summary-table" style="width:100%;">
                 <thead>
                 <tr>
-                    <th colspan="{{dimensions.length}}">Dimension</th>
+                    <th colspan="{{dimensions.length}}">Top 3 Multi-Dimensions Drill Down (Select "Dimensions" from the left panel to specify interested dimensions)</th>
                     <th></th>
                     <th></th>
                     <th></th>
@@ -44,7 +44,7 @@
             <table id="heat-map-{{metricName}}-gainer-summary-table" style="width:100%;">
               <thead>
               <tr>
-                <th colspan="{{dimensions.length}}">Top {{gainer.length}} Gainer</th>
+                <th colspan="{{dimensions.length}}">Top {{gainer.length}} Gainers of Single Dimension</th>
                 <th></th>
                 <th></th>
                 <th></th>
@@ -52,8 +52,8 @@
                 <th></th>
               </tr>
               <tr>
-                <th class="summary-header">Dimension</th>
-                <th class="summary-header"> </th>
+                <th>Dimension Name</th>
+                <th>Dimension Value</th>
                 <th class="summary-header">Baseline</th>
                 <th class="summary-header">Current</th>
                 <th class="summary-header thin-column">Percentage Change</th>
@@ -82,7 +82,7 @@
             <table id="heat-map-{{metricName}}-loser-summary-table" style="width:100%;">
               <thead>
               <tr>
-                <th colspan="{{dimensions.length}}">Top {{loser.length}} Loser</th>
+                <th colspan="{{dimensions.length}}">Top {{loser.length}} Losers of Single Dimension</th>
                 <th></th>
                 <th></th>
                 <th></th>
@@ -90,8 +90,8 @@
                 <th></th>
               </tr>
               <tr>
-                <th class="summary-header">Dimension</th>
-                <th class="summary-header"> </th>
+                <th>Dimension Name</th>
+                <th>Dimension Value</th>
                 <th class="summary-header">Baseline</th>
                 <th class="summary-header">Current</th>
                 <th class="summary-header thin-column">Percentage Change</th>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map.ftl
@@ -91,9 +91,10 @@
         <div id="funnel-table-msg" class="tip-to-user uk-alert">
           <i class="close-parent uk-icon-close"></i>
           <span>This table shows interesting records that explains the difference between current and baseline total.
-              Dimensions of records are drilled down from left to right. The symbol (ALL) means the values on that
-              dimension are aggregated. The symbol "(ALL)-" means the current row excludes the values of rows below
-              it, e.g., the first row excludes rows 2-10.
+              Top 3 interesting dimensions are vertically drilled down from left to right. You may select "Dimensions"
+              from the left panel to narrow down the interesting dimensions and increase the accuracy of this summary.
+              The symbol "(ALL)" means the values on that dimension are aggregated; "(ALL)-" means the current row
+              excludes the rows below it, e.g., the first row excludes rows 2-10.
           </span>
         </div>
         <div id="difference-summary-{{metricName}}" class="difference-summary uk-margin-bottom">

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/compare-tab/heat-map.ftl
@@ -87,20 +87,20 @@
             </div>
 
         </div>
-            <h3>Beta Feature: Outlier Summary</h3>
-            <div id="funnel-table-msg" class="tip-to-user uk-alert">
-              <i class="close-parent uk-icon-close"></i>
-              <span>This table shows interesting records that explains the difference between current and baseline total.
-                  Dimensions of records are drilled down from left to right. The symbol (ALL) means the values on that
-                  dimension are aggregated. The symbol "(ALL)-" means the current row excludes the values of rows below
-                  it, e.g., the first row excludes rows 2-10.
-              </span>
+        <h3>Beta Feature: Outlier Summary</h3>
+        <div id="funnel-table-msg" class="tip-to-user uk-alert">
+          <i class="close-parent uk-icon-close"></i>
+          <span>This table shows interesting records that explains the difference between current and baseline total.
+              Dimensions of records are drilled down from left to right. The symbol (ALL) means the values on that
+              dimension are aggregated. The symbol "(ALL)-" means the current row excludes the values of rows below
+              it, e.g., the first row excludes rows 2-10.
+          </span>
+        </div>
+        <div id="difference-summary-{{metricName}}" class="difference-summary uk-margin-bottom">
+            <div class="loader">
+                <i class="uk-icon-spinner uk-icon-spin uk-icon-large"></i>
             </div>
-            <div id="difference-summary-{{metricName}}" class="difference-summary uk-margin-bottom">
-                <div class="loader">
-                    <i class="uk-icon-spinner uk-icon-spin uk-icon-large"></i>
-                </div>
-            </div>
+        </div>
         {{/each}}
         {{/with}}
         <div id="tooltip" class="hidden">


### PR DESCRIPTION
New improvements to outlier summary algorithm
1. Small nodes (contribution percentage < 3%) always merge with its parent in order to increase the readability of the summary.
2. Add gainer and loser summaries to show top 5 gainers and losers among all single dimensions.
3. Improve the construction logic of multi-dimensional tree: Sometimes Pinot returns a node that do not have parent; this kind of node will be discarded to remain the integrity of the structure of the tree.

Tested on local.

Thanks @kishoreg's initial contribution to this improvement. Specifically, the implementation of the logic to compute the costs for each nodes on each single dimension.