### PR TITLE
Provide config to disable table level metrics for server and broker.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/BrokerServerBuilder.java
@@ -64,6 +64,8 @@ public class BrokerServerBuilder {
   private static final String METRICS_CONFIG_PREFIX = "pinot.broker.metrics";
   private static final long DEFAULT_BROKER_DELAY_SHUTDOWN_TIME_MS = 10 * 1000L;
   private static final String BROKER_DELAY_SHUTDOWN_TIME_CONFIG = "pinot.broker.delayShutdownTimeMs";
+  private static final String PINOT_BROKER_TABLE_LEVEL_METRICS = "pinot.broker.enableTableLevelMetrics";
+  private static final String PINOT_BROKER_TABLE_LEVEL_METRICS_LIST = "pinot.broker.tablelevel.metrics.whitelist";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServerBuilder.class);
   // Connection Pool Related
@@ -124,7 +126,7 @@ public class BrokerServerBuilder {
     _registry = new MetricsRegistry();
     MetricsHelper.initializeMetrics(_config.subset(METRICS_CONFIG_PREFIX));
     MetricsHelper.registerMetricsRegistry(_registry);
-    _brokerMetrics = new BrokerMetrics(_registry);
+    _brokerMetrics = new BrokerMetrics(_registry, !emitTableLevelMetrics());
     _brokerMetrics.initializeGlobalMeters();
     _state.set(State.INIT);
     _eventLoopGroup = new NioEventLoopGroup();
@@ -266,5 +268,9 @@ public class BrokerServerBuilder {
 
   public BrokerRequestHandler getBrokerRequestHandler() {
     return _requestHandler;
+  }
+
+  private boolean emitTableLevelMetrics() {
+    return _config.getBoolean(PINOT_BROKER_TABLE_LEVEL_METRICS, true);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMetrics.java
@@ -32,6 +32,10 @@ public class BrokerMetrics extends AbstractMetrics<BrokerQueryPhase, BrokerMeter
     super("pinot.broker.", metricsRegistry, BrokerMetrics.class);
   }
 
+  public BrokerMetrics(MetricsRegistry metricsRegistry, boolean global) {
+    super("pinot.broker.", metricsRegistry, BrokerMetrics.class, global);
+  }
+
   @Override
   protected BrokerQueryPhase[] getQueryPhases() {
     return BrokerQueryPhase.values();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMetrics.java
@@ -41,4 +41,8 @@ public class ServerMetrics extends AbstractMetrics<ServerQueryPhase, ServerMeter
   public ServerMetrics(MetricsRegistry metricsRegistry) {
     super("pinot.server.", metricsRegistry, ServerMetrics.class);
   }
+
+  public ServerMetrics(MetricsRegistry metricsRegistry, boolean global) {
+    super("pinot.server.", metricsRegistry, ServerMetrics.class, global);
+  }
 }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/conf/ServerConf.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/conf/ServerConf.java
@@ -27,6 +27,9 @@ public class ServerConf {
   private static final String PINOT_ = "pinot.";
   private static final String PINOT_SERVER_INSTANCE = "pinot.server.instance";
   private static final String PINOT_SERVER_METRICS = "pinot.server.metrics";
+  private static final String PINOT_SERVER_TABLE_LEVEL_METRICS = "pinot.server.enableTableLevelMetrics";
+  // List of metrics to always send table level metrics even if table level metrics is disabled
+  private static final String PINOT_SERVER_TABLE_LEVEL_METRICS_LIST = "pinot.server.tablelevel.metrics.whitelist";
   private static final String PINOT_SERVER_QUERY = "pinot.server.query.executor";
   private static final String PINOT_SERVER_REQUEST = "pinot.server.request";
   private static final String PINOT_SERVER_NETTY = "pinot.server.netty";
@@ -88,5 +91,9 @@ public class ServerConf {
    */
   public String[] getTransformFunctions() {
     return _serverConf.getStringArray(PINOT_SERVER_TRANSFORM_FUNCTIONS);
+  }
+
+  public boolean emitTableLevelMetrics() {
+    return _serverConf.getBoolean(PINOT_SERVER_TABLE_LEVEL_METRICS, true);
   }
 }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
@@ -181,7 +181,7 @@ public class ServerBuilder {
   private void initMetrics() {
     MetricsHelper.initializeMetrics(_serverConf.getMetricsConfig());
     MetricsHelper.registerMetricsRegistry(metricsRegistry);
-    _serverMetrics = new ServerMetrics(metricsRegistry);
+    _serverMetrics = new ServerMetrics(metricsRegistry, !_serverConf.emitTableLevelMetrics());
     _serverMetrics.initializeGlobalMeters();
 
     TableDataManagerProvider.setServerMetrics(_serverMetrics);


### PR DESCRIPTION
For clusters with a large number of tables, the number of server/broker metrics 
is too large. We now emit these metrics as a single global metric.