### PR TITLE
Add support for Server side Time segment pruning.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.common.segment;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
@@ -31,6 +32,14 @@ public interface SegmentMetadata {
   String getTableName();
 
   String getIndexType();
+
+  String getTimeColumn();
+
+  long getStartTime();
+
+  long getEndTime();
+
+  TimeUnit getTimeUnit();
 
   Duration getTimeGranularity();
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
@@ -531,6 +531,26 @@ public class RetentionManagerTest {
       }
 
       @Override
+      public String getTimeColumn() {
+        return null;
+      }
+
+      @Override
+      public long getStartTime() {
+        return Long.valueOf(startTime);
+      }
+
+      @Override
+      public long getEndTime() {
+        return Long.valueOf(endTime);
+      }
+
+      @Override
+      public TimeUnit getTimeUnit() {
+        return segmentTimeUnit;
+      }
+
+      @Override
       public String getIndexDir() {
         return null;
       }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -563,6 +563,26 @@ public class ValidationManagerTest {
     }
 
     @Override
+    public String getTimeColumn() {
+      return null;
+    }
+
+    @Override
+    public long getStartTime() {
+      return Long.MAX_VALUE;
+    }
+
+    @Override
+    public long getEndTime() {
+      return Long.MIN_VALUE;
+    }
+
+    @Override
+    public TimeUnit getTimeUnit() {
+      return null;
+    }
+
+    @Override
     public Duration getTimeGranularity() {
       return _timeGranularity;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/TimeSegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/TimeSegmentPruner.java
@@ -15,11 +15,16 @@
  */
 package com.linkedin.pinot.core.query.pruner;
 
-import org.apache.commons.configuration.Configuration;
-import org.joda.time.Interval;
-
 import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.request.FilterOperator;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.core.common.predicate.RangePredicate;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.commons.configuration.Configuration;
 
 
 /**
@@ -33,11 +38,80 @@ public class TimeSegmentPruner implements SegmentPruner {
 
   @Override
   public boolean prune(IndexSegment segment, BrokerRequest brokerRequest) {
-    Interval interval = segment.getSegmentMetadata().getTimeInterval();
-    if (interval != null && brokerRequest.getTimeInterval() != null && !new Interval(brokerRequest.getTimeInterval()).contains(interval)) {
-      return true;
+    SegmentMetadata metadata = segment.getSegmentMetadata();
+    String timeColumn = metadata.getTimeColumn();
+
+    if (timeColumn == null) {
+      return false;
     }
-    return false;
+
+    TimeInterval segmentInterval = new TimeInterval(metadata.getStartTime(), metadata.getEndTime());
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    return (filterQueryTree != null && pruneSegment(filterQueryTree, segmentInterval, timeColumn));
+  }
+
+  /**
+   * Helper method to determine if a segment can be pruned based on segment's time metadata and
+   * the predicates on time column. It's algorithm is as follows:
+   *
+   * <ul>
+   *   <li> For leaf node: Returns true if there is a predicate on time and apply the predicate would result
+   *   in filtering out all docs of the segment, false otherwise. </li>
+   *   <li> For non-leaf AND node: True if any of its children returned true, false otherwise. </li>
+   *   <li> For non-leaf OR node: True if all its children returned true, false otherwise. </li>
+   * </ul>
+   *
+   * @param filterQueryTree Filter tree for the query.
+   * @param segmentInterval Time interval of the segment to be pruned.
+   * @return True if segment can be pruned out, false otherwise.
+   */
+  public static boolean pruneSegment(@Nonnull FilterQueryTree filterQueryTree, @Nonnull TimeInterval segmentInterval,
+      @Nonnull String timeColumn) {
+    List<FilterQueryTree> children = filterQueryTree.getChildren();
+
+    // Leaf Node
+    FilterOperator operator = filterQueryTree.getOperator();
+    if (children == null || children.isEmpty()) {
+      if (filterQueryTree.getColumn().equals(timeColumn)) {
+        List<String> predicateValue = filterQueryTree.getValue();
+
+        switch (operator) {
+          case EQUALITY:
+            return !segmentInterval.contains(Long.parseLong(predicateValue.get(0)));
+
+          case RANGE:
+            return !segmentInterval.overlaps(getIntervalFromString(timeColumn, predicateValue));
+
+          default:
+            return false; // Only prune for equality and range, for now.
+        }
+      } else {
+        return false;
+      }
+    } else {
+
+      switch (operator) {
+        case AND:
+          for (FilterQueryTree child : children) {
+            if (pruneSegment(child, segmentInterval, timeColumn)) {
+              return true;
+            }
+          }
+          return false;
+
+        case OR:
+          for (FilterQueryTree child : children) {
+            if (!pruneSegment(child, segmentInterval, timeColumn)) {
+              return false;
+            }
+          }
+          return true;
+
+        default:
+          throw new IllegalArgumentException(
+              "Illegal operator type in filter query tree: " + operator.getClass().getName());
+      }
+    }
   }
 
   @Override
@@ -48,5 +122,61 @@ public class TimeSegmentPruner implements SegmentPruner {
   @Override
   public String toString() {
     return "TimeSegmentPruner";
+  }
+
+  /**
+   * Helper method that generates TimeInterval from a RangePredicate string.
+   *
+   * @param rangeString Range String
+   * @return TimeInterval for the rangeString
+   */
+  private static TimeInterval getIntervalFromString(String timeColumn, List<String> rangeString) {
+    RangePredicate range = new RangePredicate(timeColumn, rangeString);
+    String lowerString = range.getLowerBoundary();
+
+    // Given that segment's time range is guaranteed to be between
+    // TimeUtils.VALID_MIN_TIME_MILLIS and TimeUtils.VALID_MAX_TIME_MILLIS (very small portion of long range),
+    // it is OK to be avoid long overflow when converting exclusive to inclusive.
+    long lower = lowerString.equals(RangePredicate.UNBOUNDED) ? 0 : Long.parseLong(lowerString);
+    lower = (range.includeLowerBoundary() || lower == Long.MAX_VALUE) ? lower : lower + 1;
+
+    String upperString = range.getUpperBoundary();
+    long upper = upperString.equals(RangePredicate.UNBOUNDED) ? Long.MAX_VALUE : Long.parseLong(upperString);
+    upper = (range.includeUpperBoundary() || upper == Long.MIN_VALUE) ? upper : upper - 1;
+
+    return new TimeInterval(lower, upper);
+  }
+
+  /**
+   * Utility class to represent time interval, with start and end both inclusive.
+   */
+  public static class TimeInterval {
+    private final long _start;
+    private final long _end;
+
+    public TimeInterval(long start, long end) {
+      _start = start;
+      _end = end;
+    }
+
+    public long getStart() {
+      return _start;
+    }
+
+    public long getEnd() {
+      return _end;
+    }
+
+    public boolean contains(long value) {
+      return (value >= _start && value <= _end);
+    }
+
+    public boolean overlaps(TimeInterval that) {
+      // Degenerate case: any one of the intervals is inverted, so it cannot overlap with the other.
+      if (this._start > this._end || that._start > that._end) {
+        return false;
+      }
+      return !((this._start > that._end) || (this._end < that._start));
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.core.startree.hll.HllConstants;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.joda.time.Duration;
@@ -76,6 +77,26 @@ public class SimpleSegmentMetadata implements SegmentMetadata {
   @Override
   public String getIndexType() {
     return _indexType;
+  }
+
+  @Override
+  public String getTimeColumn() {
+    return null;
+  }
+
+  @Override
+  public long getStartTime() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public long getEndTime() {
+    return Long.MIN_VALUE;
+  }
+
+  @Override
+  public TimeUnit getTimeUnit() {
+    return null;
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/pruner/TimeSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/pruner/TimeSegmentPrunerTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.query.pruner;
+
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.core.query.pruner.TimeSegmentPruner;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import junit.framework.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link com.linkedin.pinot.core.query.pruner.TimeSegmentPruner} class.
+ */
+public class TimeSegmentPrunerTest {
+  private static final String TIME_COLUMN_NAME = "time";
+  Pql2Compiler _compiler;
+
+  @BeforeClass
+  public void setup() {
+    _compiler = new Pql2Compiler();
+  }
+
+  @Test
+  public void test() {
+    // Query without time predicate
+    String query = "select count(*) from table where foo = 'bar'";
+    Assert.assertFalse(
+        runPruner(query, new TimeSegmentPruner.TimeInterval(Long.MIN_VALUE, Long.MAX_VALUE), TIME_COLUMN_NAME));
+
+    // Equality predicate
+    query = "select count(*) from table where time = 10";
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 10), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 20), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 25), TIME_COLUMN_NAME));
+
+    // Equality predicate with OR
+    query = "select count(*) from table where time = 10 or time = 20";
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 9), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(11, 19), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(25, 35), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 25), TIME_COLUMN_NAME));
+
+    // Equality predicate OR'd with range
+    query = "select count(*) from table where time = 10 or time between 20 and 30";
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 9), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(11, 19), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(31, 40), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 25), TIME_COLUMN_NAME));
+
+    query = "select count(*) from table where time > 10 and time < 20";
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 10), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 30), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(11, 15), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 25), TIME_COLUMN_NAME));
+
+    query = "select count(*) from table where time between 10 and 20";
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 9), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(21, 30), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 15), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 25), TIME_COLUMN_NAME));
+
+    query = "select count(*) from table where time between 10 and 20 or time between 15 and 25";
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 9), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(26, 30), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 15), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 25), TIME_COLUMN_NAME));
+
+    // Disjoint time intervals
+    query = "select count(*) from table where time < 10 or time > 20";
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 30), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 20), TIME_COLUMN_NAME));
+
+    // Time < 0 is not allowed, so it should always prune.
+    query = "select count(*) from table where time < 0";
+    Assert.assertTrue(
+        runPruner(query, new TimeSegmentPruner.TimeInterval(Long.MIN_VALUE, Long.MAX_VALUE), TIME_COLUMN_NAME));
+
+    // Time = 0 is not allowed, so it should always prune.
+    query = "select count(*) from table where time between 0 and 0";
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(-10, -1), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(1, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 10), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 0), TIME_COLUMN_NAME));
+
+    // Degenerate case of invalid range where start > end
+    query = "select count(*) from table where time between 20 and 10";
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 9), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 30), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 15), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 20), TIME_COLUMN_NAME));
+    Assert.assertTrue(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 25), TIME_COLUMN_NAME));
+
+    // OR with non time column, should never prune.
+    query = "select count(*) from table where time between 10 and 20 or foo = 'bar'";
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(0, 9), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(21, 30), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(10, 15), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(15, 20), TIME_COLUMN_NAME));
+    Assert.assertFalse(runPruner(query, new TimeSegmentPruner.TimeInterval(20, 25), TIME_COLUMN_NAME));
+  }
+
+  /**
+   * Helper method to invoke the pruner for a given query and time interval.
+   *
+   * @param query Query for pruning
+   * @param segmentTimeInterval Time interval of segment to be pruned.
+   * @param timeColumn Time column name of segment to be pruned.
+   * @return
+   */
+  private boolean runPruner(String query, TimeSegmentPruner.TimeInterval segmentTimeInterval, String timeColumn) {
+    BrokerRequest brokerRequest = _compiler.compileToBrokerRequest(query);
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    return TimeSegmentPruner.pruneSegment(filterQueryTree, segmentTimeInterval, timeColumn);
+  }
+}


### PR DESCRIPTION
1. Server will now prune segments based on start/end time in the segment
metadata and time filter predicate(s) on the query. Observed QPS
improvement from 700 to 1400 on one server with 40GB of data.

2. Pruning out segments results in their docs not being counted towards
totalRawDocs in the query response. Fixed it by couting the totalRawDocs
before pruning.

3. Added api's on SegmentMetadata to get TimeColumn, TimeUnit &
Start/EndTime.

4. Added unit test for the same.