### PR TITLE
Fix test failure due to arbitrary test order of TestNG

### DIFF
--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -266,6 +266,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <threadCount>1</threadCount>
           <properties>
             <property>
               <name>listener</name>

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
@@ -82,6 +82,7 @@ public class DAORegistry {
    * @param DaoRegistry the DAO registry of new content.
    */
   public static void overrideSingletonDAORegistryForTesting(DAORegistry DaoRegistry) {
+    singleton.reset_internal();
     singleton.setAnomalyFunctionDAO(DaoRegistry.getAnomalyFunctionDAO());
     singleton.setEmailConfigurationDAO(DaoRegistry.getEmailConfigurationDAO());
     singleton.setRawAnomalyResultDAO(DaoRegistry.getRawAnomalyResultDAO());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
@@ -15,21 +15,6 @@ import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.AnomalyFunctionManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.DashboardConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.DataCompletenessConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.DatasetConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.EmailConfigurationManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.EventManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.IngraphDashboardConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.IngraphMetricConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.JobManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.MergedAnomalyResultManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.MetricConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.OverrideConfigManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.RawAnomalyResultManagerImpl;
-import com.linkedin.thirdeye.datalayer.bao.jdbc.TaskManagerImpl;
 
 /**
  * Singleton service registry for Data Access Objects (DAOs)

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
@@ -15,6 +15,21 @@ import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.AnomalyFunctionManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.DashboardConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.DataCompletenessConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.DatasetConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.EmailConfigurationManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.EventManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.IngraphDashboardConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.IngraphMetricConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.JobManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.MergedAnomalyResultManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.MetricConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.OverrideConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.RawAnomalyResultManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.TaskManagerImpl;
 
 /**
  * Singleton service registry for Data Access Objects (DAOs)
@@ -48,9 +63,47 @@ public class DAORegistry {
 
   /**
    * **USE FOR TESTING ONLY**
+   * Return a DAO registry for testing purpose, which may be performed in arbitrary order and
+   * hence need independent registry for each test.
+   *
+   * @return an independent DAO registry to the global singleton registry.
+   */
+  public static DAORegistry getTestInstance() {
+    return new DAORegistry();
+  }
+
+  /**
+   * **USE FOR TESTING ONLY**
+   * Override the singleton DAO registry's content with the given DAO registry.
+   * This method is used by testing methods only and should not be used in any production code.
+   * The reason we need this method is for solving TestNG's interleaved testing order among different
+   * test class.
+   *
+   * @param DaoRegistry the DAO registry of new content.
+   */
+  public static void overrideSingletonDAORegistryForTesting(DAORegistry DaoRegistry) {
+    singleton.setAnomalyFunctionDAO(DaoRegistry.getAnomalyFunctionDAO());
+    singleton.setEmailConfigurationDAO(DaoRegistry.getEmailConfigurationDAO());
+    singleton.setRawAnomalyResultDAO(DaoRegistry.getRawAnomalyResultDAO());
+    singleton.setMergedAnomalyResultDAO(DaoRegistry.getMergedAnomalyResultDAO());
+    singleton.setJobDAO(DaoRegistry.getJobDAO());
+    singleton.setTaskDAO(DaoRegistry.getTaskDAO());
+    singleton.setDatasetConfigDAO(DaoRegistry.getDatasetConfigDAO());
+    singleton.setMetricConfigDAO(DaoRegistry.getMetricConfigDAO());
+    singleton.setDashboardConfigDAO(DaoRegistry.getDashboardConfigDAO());
+    singleton.setIngraphMetricConfigDAO(DaoRegistry.getIngraphMetricConfigDAO());
+    singleton.setIngraphDashboardConfigDAO(DaoRegistry.getIngraphDashboardConfigDAO());
+    singleton.setOverrideConfigDAO(DaoRegistry.getOverrideConfigDAO());
+    singleton.setAlertConfigDAO(DaoRegistry.getAlertConfigDAO());
+    singleton.setDataCompletenessConfigDAO(DaoRegistry.getDataCompletenessConfigDAO());
+    singleton.setEventDAO(DaoRegistry.getEventDAO());
+  }
+
+  /**
+   * **USE FOR TESTING ONLY**
    * Reset registry to empty initial state.
    */
-  public static void reset() {
+  public static void resetForTesting() {
     singleton.reset_internal();
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/TestDBResources.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/TestDBResources.java
@@ -28,12 +28,12 @@ import java.sql.Connection;
 import org.apache.tomcat.jdbc.pool.DataSource;
 
 
-public class TestUtils {
+public class TestDBResources {
   private DataSource ds;
   private DAORegistry daoRegistry;
 
-  public static TestUtils setupDAO() {
-    TestUtils instance = new TestUtils();
+  public static TestDBResources setupDAO() {
+    TestDBResources instance = new TestDBResources();
     instance.setTestDaoRegistry(DAORegistry.getTestInstance());
     try {
       DAORegistry.resetForTesting();
@@ -45,7 +45,7 @@ public class TestUtils {
     }
   }
 
-  public static void teardownDAO(TestUtils instance) {
+  public static void teardownDAO(TestDBResources instance) {
     try {
       System.out.println("DAOs cleaned up");
       instance.cleanUp();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/TestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/TestUtils.java
@@ -30,7 +30,7 @@ import org.apache.tomcat.jdbc.pool.DataSource;
 
 public class TestUtils {
   private DataSource ds;
-  private DAORegistry DAO_REGISTRY;
+  private DAORegistry daoRegistry;
 
   public static TestUtils setupDAO() {
     TestUtils instance = new TestUtils();
@@ -54,12 +54,12 @@ public class TestUtils {
     }
   }
 
-  public void setTestDaoRegistry(DAORegistry DaoRegistry) {
-    DAO_REGISTRY = DaoRegistry;
+  public void setTestDaoRegistry(DAORegistry daoRegistry) {
+    this.daoRegistry = daoRegistry;
   }
 
   public DAORegistry getTestDaoRegistry() {
-    return DAO_REGISTRY;
+    return daoRegistry;
   }
 
   private void init() throws Exception {
@@ -131,21 +131,21 @@ public class TestUtils {
     Class<AnomalyFunctionManagerImpl> c = AnomalyFunctionManagerImpl.class;
     System.out.println(c);
 
-    DAO_REGISTRY.setAnomalyFunctionDAO(managerProvider.getInstance(AnomalyFunctionManagerImpl.class));
-    DAO_REGISTRY.setEmailConfigurationDAO(managerProvider.getInstance(EmailConfigurationManagerImpl.class));
-    DAO_REGISTRY.setRawAnomalyResultDAO(managerProvider.getInstance(RawAnomalyResultManagerImpl.class));
-    DAO_REGISTRY.setMergedAnomalyResultDAO(managerProvider.getInstance(MergedAnomalyResultManagerImpl.class));
-    DAO_REGISTRY.setJobDAO(managerProvider.getInstance(JobManagerImpl.class));
-    DAO_REGISTRY.setTaskDAO(managerProvider.getInstance(TaskManagerImpl.class));
-    DAO_REGISTRY.setDatasetConfigDAO(managerProvider.getInstance(DatasetConfigManagerImpl.class));
-    DAO_REGISTRY.setMetricConfigDAO(managerProvider.getInstance(MetricConfigManagerImpl.class));
-    DAO_REGISTRY.setDashboardConfigDAO(managerProvider.getInstance(DashboardConfigManagerImpl.class));
-    DAO_REGISTRY.setIngraphMetricConfigDAO(managerProvider.getInstance(IngraphMetricConfigManagerImpl.class));
-    DAO_REGISTRY.setIngraphDashboardConfigDAO(managerProvider.getInstance(IngraphDashboardConfigManagerImpl.class));
-    DAO_REGISTRY.setOverrideConfigDAO(managerProvider.getInstance(OverrideConfigManagerImpl.class));
-    DAO_REGISTRY.setAlertConfigDAO(managerProvider.getInstance(AlertConfigManagerImpl.class));
-    DAO_REGISTRY.setDataCompletenessConfigDAO(managerProvider.getInstance(DataCompletenessConfigManagerImpl.class));
-    DAO_REGISTRY.setEventDAO(managerProvider.getInstance(EventManagerImpl.class));
+    daoRegistry.setAnomalyFunctionDAO(managerProvider.getInstance(AnomalyFunctionManagerImpl.class));
+    daoRegistry.setEmailConfigurationDAO(managerProvider.getInstance(EmailConfigurationManagerImpl.class));
+    daoRegistry.setRawAnomalyResultDAO(managerProvider.getInstance(RawAnomalyResultManagerImpl.class));
+    daoRegistry.setMergedAnomalyResultDAO(managerProvider.getInstance(MergedAnomalyResultManagerImpl.class));
+    daoRegistry.setJobDAO(managerProvider.getInstance(JobManagerImpl.class));
+    daoRegistry.setTaskDAO(managerProvider.getInstance(TaskManagerImpl.class));
+    daoRegistry.setDatasetConfigDAO(managerProvider.getInstance(DatasetConfigManagerImpl.class));
+    daoRegistry.setMetricConfigDAO(managerProvider.getInstance(MetricConfigManagerImpl.class));
+    daoRegistry.setDashboardConfigDAO(managerProvider.getInstance(DashboardConfigManagerImpl.class));
+    daoRegistry.setIngraphMetricConfigDAO(managerProvider.getInstance(IngraphMetricConfigManagerImpl.class));
+    daoRegistry.setIngraphDashboardConfigDAO(managerProvider.getInstance(IngraphDashboardConfigManagerImpl.class));
+    daoRegistry.setOverrideConfigDAO(managerProvider.getInstance(OverrideConfigManagerImpl.class));
+    daoRegistry.setAlertConfigDAO(managerProvider.getInstance(AlertConfigManagerImpl.class));
+    daoRegistry.setDataCompletenessConfigDAO(managerProvider.getInstance(DataCompletenessConfigManagerImpl.class));
+    daoRegistry.setEventDAO(managerProvider.getInstance(EventManagerImpl.class));
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/autoload/pinot/metrics/AutoloadPinotMetricsServiceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/autoload/pinot/metrics/AutoloadPinotMetricsServiceTest.java
@@ -45,7 +45,7 @@ public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
    */
   @BeforeMethod
   void beforeMethod(){
-    DAORegistry.overrideSingletonDAORegistryForTesting(testUtils.getTestDaoRegistry());
+    DAORegistry.overrideSingletonDAORegistryForTesting(testDBResources.getTestDaoRegistry());
   }
 
   @Test

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/autoload/pinot/metrics/AutoloadPinotMetricsServiceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/autoload/pinot/metrics/AutoloadPinotMetricsServiceTest.java
@@ -6,6 +6,7 @@ import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
+import com.linkedin.thirdeye.client.DAORegistry;
 import com.linkedin.thirdeye.datalayer.bao.AbstractManagerTestBase;
 import com.linkedin.thirdeye.datalayer.dto.DashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
@@ -16,6 +17,7 @@ import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
@@ -24,7 +26,6 @@ public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
   private String dataset = "test-collection";
   private Schema schema;
   DatasetConfigDTO datasetConfig = null;
-  DatasetConfigDTO ingraphDatasetConfig = null;
 
   @BeforeClass
   void beforeClass() {
@@ -34,6 +35,17 @@ public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
   @AfterClass(alwaysRun = true)
   void afterClass() {
     super.cleanup();
+  }
+
+  /**
+   * This test class needs to use a class that accesses the global singleton DAO registry. Therefore,
+   * we need to copy the local DAO registry, which is created for this test, to the global one.
+   * Otherwise, the global singleton one may reference to an arbitrary DB that is created for this
+   * test.
+   */
+  @BeforeMethod
+  void beforeMethod(){
+    DAORegistry.overrideSingletonDAORegistryForTesting(testUtils.getTestDaoRegistry());
   }
 
   @Test
@@ -66,7 +78,6 @@ public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
     DashboardConfigDTO dashboardConfig = dashboardConfigDAO.
         findByName(DashboardConfigBean.DEFAULT_DASHBOARD_PREFIX + dataset);
     Assert.assertEquals(dashboardConfig.getMetricIds(), metricIds);
-
   }
 
   @Test(dependsOnMethods = {"testAddNewDataset"})
@@ -96,7 +107,6 @@ public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
     DashboardConfigDTO dashboardConfig = dashboardConfigDAO.
         findByName(DashboardConfigBean.DEFAULT_DASHBOARD_PREFIX + dataset);
     Assert.assertEquals(dashboardConfig.getMetricIds(), metricIds);
-
   }
 
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/TestDaoRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/TestDaoRegistry.java
@@ -1,8 +1,6 @@
 package com.linkedin.thirdeye.client;
 
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertConfigManagerImpl;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 public class TestDaoRegistry {
@@ -30,7 +28,7 @@ public class TestDaoRegistry {
   void testSingletonReset() {
     registry.setAlertConfigDAO(new AlertConfigManagerImpl());
     registry.getAlertConfigDAO();
-    DAORegistry.reset();
+    DAORegistry.resetForTesting();
 
     registry.setAlertConfigDAO(new AlertConfigManagerImpl());
     registry.getAlertConfigDAO();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -1,7 +1,7 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
 import com.google.common.collect.Lists;
-import com.linkedin.thirdeye.TestUtils;
+import com.linkedin.thirdeye.TestDBResources;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.override.OverrideConfigHelper;
 import com.linkedin.thirdeye.api.DimensionMap;
@@ -46,12 +46,12 @@ public abstract class AbstractManagerTestBase {
   protected DataCompletenessConfigManager dataCompletenessConfigDAO;
   protected EventManager eventManager;
 
-  protected TestUtils testUtils;
+  protected TestDBResources testDBResources;
   protected DAORegistry daoRegistry;
 
   protected void init() {
-    testUtils = TestUtils.setupDAO();
-    daoRegistry = testUtils.getTestDaoRegistry();
+    testDBResources = TestDBResources.setupDAO();
+    daoRegistry = testDBResources.getTestDaoRegistry();
     anomalyFunctionDAO = daoRegistry.getAnomalyFunctionDAO();
     rawAnomalyResultDAO = daoRegistry.getRawAnomalyResultDAO();
     jobDAO = daoRegistry.getJobDAO();
@@ -71,7 +71,7 @@ public abstract class AbstractManagerTestBase {
   }
 
   protected void cleanup() {
-    TestUtils.teardownDAO(testUtils);
+    TestDBResources.teardownDAO(testDBResources);
   }
 
   protected AnomalyFunctionDTO getTestFunctionSpec(String metricName, String collection) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -30,8 +30,6 @@ import java.util.concurrent.TimeUnit;
 import org.joda.time.DateTime;
 
 public abstract class AbstractManagerTestBase {
-  protected static DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
-
   protected AnomalyFunctionManager anomalyFunctionDAO;
   protected RawAnomalyResultManager rawAnomalyResultDAO;
   protected JobManager jobDAO;
@@ -48,28 +46,32 @@ public abstract class AbstractManagerTestBase {
   protected DataCompletenessConfigManager dataCompletenessConfigDAO;
   protected EventManager eventManager;
 
+  protected TestUtils testUtils;
+  protected DAORegistry daoRegistry;
+
   protected void init() {
-    TestUtils.setupDAO();
-    anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
-    rawAnomalyResultDAO = DAO_REGISTRY.getRawAnomalyResultDAO();
-    jobDAO = DAO_REGISTRY.getJobDAO();
-    taskDAO = DAO_REGISTRY.getTaskDAO();
-    emailConfigurationDAO = DAO_REGISTRY.getEmailConfigurationDAO();
-    mergedAnomalyResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
-    datasetConfigDAO = DAO_REGISTRY.getDatasetConfigDAO();
-    metricConfigDAO = DAO_REGISTRY.getMetricConfigDAO();
-    dashboardConfigDAO = DAO_REGISTRY.getDashboardConfigDAO();
-    ingraphDashboardConfigDAO = DAO_REGISTRY.getIngraphDashboardConfigDAO();
-    ingraphMetricConfigDAO = DAO_REGISTRY.getIngraphMetricConfigDAO();
-    overrideConfigDAO = DAO_REGISTRY.getOverrideConfigDAO();
-    alertConfigDAO = DAO_REGISTRY.getAlertConfigDAO();
-    dataCompletenessConfigDAO = DAO_REGISTRY.getDataCompletenessConfigDAO();
-    eventManager = DAO_REGISTRY.getEventDAO();
-    anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
+    testUtils = TestUtils.setupDAO();
+    daoRegistry = testUtils.getTestDaoRegistry();
+    anomalyFunctionDAO = daoRegistry.getAnomalyFunctionDAO();
+    rawAnomalyResultDAO = daoRegistry.getRawAnomalyResultDAO();
+    jobDAO = daoRegistry.getJobDAO();
+    taskDAO = daoRegistry.getTaskDAO();
+    emailConfigurationDAO = daoRegistry.getEmailConfigurationDAO();
+    mergedAnomalyResultDAO = daoRegistry.getMergedAnomalyResultDAO();
+    datasetConfigDAO = daoRegistry.getDatasetConfigDAO();
+    metricConfigDAO = daoRegistry.getMetricConfigDAO();
+    dashboardConfigDAO = daoRegistry.getDashboardConfigDAO();
+    ingraphDashboardConfigDAO = daoRegistry.getIngraphDashboardConfigDAO();
+    ingraphMetricConfigDAO = daoRegistry.getIngraphMetricConfigDAO();
+    overrideConfigDAO = daoRegistry.getOverrideConfigDAO();
+    alertConfigDAO = daoRegistry.getAlertConfigDAO();
+    dataCompletenessConfigDAO = daoRegistry.getDataCompletenessConfigDAO();
+    eventManager = daoRegistry.getEventDAO();
+    anomalyFunctionDAO = daoRegistry.getAnomalyFunctionDAO();
   }
 
   protected void cleanup() {
-    TestUtils.teardownDAO();
+    TestUtils.teardownDAO(testUtils);
   }
 
   protected AnomalyFunctionDTO getTestFunctionSpec(String metricName, String collection) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
@@ -21,17 +21,16 @@ public class TestAlertConfigManager extends AbstractManagerTestBase {
   }
 
   @Test
-  public void testCreateAlertConfig() {
+  public void testCreateAlertConfig() throws InterruptedException {
     AlertConfigDTO request = new AlertConfigDTO();
     request.setActive(true);
     request.setName("my alert config");
     alertConfigid = alertConfigDAO.save(request);
     Assert.assertTrue(alertConfigid > 0);
-
   }
 
   @Test (dependsOnMethods = {"testCreateAlertConfig"})
-  public void testFetchAlertConfig() {
+  public void testFetchAlertConfig() throws InterruptedException {
     // find by id
     AlertConfigDTO response = alertConfigDAO.findById(alertConfigid);
     Assert.assertNotNull(response);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
@@ -21,7 +21,7 @@ public class TestAlertConfigManager extends AbstractManagerTestBase {
   }
 
   @Test
-  public void testCreateAlertConfig() throws InterruptedException {
+  public void testCreateAlertConfig() {
     AlertConfigDTO request = new AlertConfigDTO();
     request.setActive(true);
     request.setName("my alert config");
@@ -30,7 +30,7 @@ public class TestAlertConfigManager extends AbstractManagerTestBase {
   }
 
   @Test (dependsOnMethods = {"testCreateAlertConfig"})
-  public void testFetchAlertConfig() throws InterruptedException {
+  public void testFetchAlertConfig() {
     // find by id
     AlertConfigDTO response = alertConfigDAO.findById(alertConfigid);
     Assert.assertNotNull(response);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -101,7 +101,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
    */
   @BeforeMethod
   void beforeMethod(){
-    DAORegistry.overrideSingletonDAORegistryForTesting(testUtils.getTestDaoRegistry());
+    DAORegistry.overrideSingletonDAORegistryForTesting(testDBResources.getTestDaoRegistry());
   }
 
   void cleanup_schedulers() throws SchedulerException {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -14,6 +14,7 @@ import com.linkedin.thirdeye.anomaly.task.TaskDriver;
 import com.linkedin.thirdeye.anomaly.task.TaskInfoFactory;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
+import com.linkedin.thirdeye.client.DAORegistry;
 import com.linkedin.thirdeye.client.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.client.ThirdEyeClient;
 import com.linkedin.thirdeye.client.ThirdEyeRequest;
@@ -52,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -81,7 +83,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
   @BeforeClass
   void beforeClass() {
     super.init();
-    Assert.assertNotNull(DAO_REGISTRY.getJobDAO());
+    Assert.assertNotNull(daoRegistry.getJobDAO());
 
   }
 
@@ -89,6 +91,17 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
   void afterClass() throws Exception {
     cleanup_schedulers();
     super.cleanup();
+  }
+
+  /**
+   * This test class needs to use a class that accesses the global singleton DAO registry. Therefore,
+   * we need to copy the local DAO registry, which is created for this test, to the global one.
+   * Otherwise, the global singleton one may reference to an arbitrary DB that is created for this
+   * test.
+   */
+  @BeforeMethod
+  void beforeMethod(){
+    DAORegistry.overrideSingletonDAORegistryForTesting(testUtils.getTestDaoRegistry());
   }
 
   void cleanup_schedulers() throws SchedulerException {
@@ -200,12 +213,12 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
   @Test(enabled=true)
   public void testThirdeyeAnomalyApplication() throws Exception {
 
-    Assert.assertNotNull(DAO_REGISTRY.getJobDAO());
+    Assert.assertNotNull(daoRegistry.getJobDAO());
 
     // setup caches and config
     setup();
 
-    Assert.assertNotNull(DAO_REGISTRY.getJobDAO());
+    Assert.assertNotNull(daoRegistry.getJobDAO());
 
     // startDataCompletenessChecker
     startDataCompletenessScheduler();

--- a/thirdeye/thirdeye-pinot/src/test/resources/persistence-local.yml
+++ b/thirdeye/thirdeye-pinot/src/test/resources/persistence-local.yml
@@ -3,7 +3,7 @@ databaseConfiguration:
  # user: root
  # password: root
  # driver: org.mysql.jdbc.Driver
-  url: jdbc:h2:~/te_test
+  url: jdbc:h2:~/te_test/h2db
   user: sa
   password: sa
   driver: org.h2.Driver


### PR DESCRIPTION
Observed issue: The database for testing would randomly disappear or be wiped out during the execution of test classes.

Issues that induce this problem:
1. We only have one global reference to test classes' DB.

2. We only have one global DAO registry for storing the references to different tables in the DB.

3. TestNG could interleave two different classes' @BeforeClass, @AfterClass methods. Assume that we have two class A and B. The following test order could happen: A.BeforeClass, A.tests, B.BeforeClass, A.AfterClass, B.tests, B.AfterClass. Furthermore, the database is wiped and created in @BeforeClass and database is wiped out again in @AfterClass. Due to this behavior, one test's DB could be wiped out by its subsequent or preceding test. Consequently, both tests fail at the end.

Solution:
1. Each test class has its own DB and its own reference to its DB.
2. Each test class has its own DAO Registry during its execution.

Test has done:
Local mvn test is passed.