### PR TITLE
Return valid empty response if all segments got pruned

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -30,7 +30,6 @@ import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.common.datatable.DataTableBuilder;
 import com.linkedin.pinot.core.common.datatable.DataTableImplV2;
 import com.linkedin.pinot.core.query.aggregation.AggregationFunctionContext;
-import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
 import com.linkedin.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import com.linkedin.pinot.core.query.selection.SelectionOperatorUtils;
 import java.io.Serializable;
@@ -218,9 +217,8 @@ public class IntermediateResultsBlock implements Block {
     FieldSpec.DataType[] columnTypes = new FieldSpec.DataType[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {
       AggregationFunctionContext aggregationFunctionContext = _aggregationFunctionContexts[i];
-      AggregationFunction aggregationFunction = aggregationFunctionContext.getAggregationFunction();
-      columnNames[i] = aggregationFunction.getColumnName(aggregationFunctionContext.getAggregationColumns());
-      columnTypes[i] = aggregationFunction.getIntermediateResultDataType();
+      columnNames[i] = aggregationFunctionContext.getAggregationColumnName();
+      columnTypes[i] = aggregationFunctionContext.getAggregationFunction().getIntermediateResultDataType();
     }
 
     // Build the data table.
@@ -260,8 +258,7 @@ public class IntermediateResultsBlock implements Block {
     for (int i = 0; i < numAggregationFunctions; i++) {
       dataTableBuilder.startRow();
       AggregationFunctionContext aggregationFunctionContext = _aggregationFunctionContexts[i];
-      dataTableBuilder.setColumn(0, aggregationFunctionContext.getAggregationFunction()
-          .getColumnName(aggregationFunctionContext.getAggregationColumns()));
+      dataTableBuilder.setColumn(0, aggregationFunctionContext.getAggregationColumnName());
       dataTableBuilder.setColumn(1, _combinedAggregationGroupByResult.get(i));
       dataTableBuilder.finishRow();
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/AggregationFunctionContext.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/AggregationFunctionContext.java
@@ -35,8 +35,8 @@ public class AggregationFunctionContext {
   }
 
   public AggregationFunctionContext(String[] aggrColumns, AggregationFunction aggregationFunction) {
-    this._aggrColumns = aggrColumns;
-    this._aggregationFunction = aggregationFunction;
+    _aggrColumns = aggrColumns;
+    _aggregationFunction = aggregationFunction;
   }
 
   /**
@@ -53,5 +53,12 @@ public class AggregationFunctionContext {
    */
   public String[] getAggregationColumns() {
     return _aggrColumns;
+  }
+
+  /**
+   * Returns the aggregation column name for the results.
+   */
+  public String getAggregationColumnName() {
+    return _aggregationFunction.getColumnName(_aggrColumns);
   }
 }


### PR DESCRIPTION
When all segments a are pruned, use the broker request to build a valid empty response.
For SELECT * query, do not expand the columns.