### PR TITLE
Ensure time column can be parsed as an INT/LONG before running time based pruning.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.common.segment;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import java.util.Map;
@@ -32,6 +33,8 @@ public interface SegmentMetadata {
   String getTableName();
 
   String getIndexType();
+
+  FieldSpec.DataType getColumnDataType(String column);
 
   String getTimeColumn();
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.helix.retention;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -528,6 +529,11 @@ public class RetentionManagerTest {
       @Override
       public String getIndexType() {
         return "offline";
+      }
+
+      @Override
+      public FieldSpec.DataType getColumnDataType(String column) {
+        return null;
       }
 
       @Override

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.validation;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
@@ -560,6 +561,11 @@ public class ValidationManagerTest {
     @Override
     public String getIndexType() {
       return _indexType;
+    }
+
+    @Override
+    public FieldSpec.DataType getColumnDataType(String column) {
+      return null;
     }
 
     @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.query.utils;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.segment.StarTreeMetadata;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -77,6 +78,11 @@ public class SimpleSegmentMetadata implements SegmentMetadata {
   @Override
   public String getIndexType() {
     return _indexType;
+  }
+
+  @Override
+  public FieldSpec.DataType getColumnDataType(String column) {
+    return null;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.index;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
@@ -410,6 +411,12 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   @Override
   public String getIndexType() {
     return IndexType.COLUMNAR.toString();
+  }
+
+  @Override
+  public FieldSpec.DataType getColumnDataType(String column) {
+    ColumnMetadata metadata = _columnMetadataMap.get(column);
+    return (metadata != null) ? metadata.getDataType() : null;
   }
 
   @Override


### PR DESCRIPTION
In case of bad input where time column is not really a number (ie cannot
be parsed as an INT/LONG), skip running the time based pruner.