### PR TITLE
Temporarily disabling TimeSegmentPruner.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/TimeSegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/TimeSegmentPruner.java
@@ -36,8 +36,17 @@ import org.apache.commons.configuration.Configuration;
  */
 public class TimeSegmentPruner implements SegmentPruner {
 
+  private static final boolean DISABLED = true;
+
   @Override
   public boolean prune(IndexSegment segment, BrokerRequest brokerRequest) {
+    // TODO: It turns out that segment metadata is always in millisSinceEpoch, where as data in the
+    // time column can be in any format (daysSinceEpoch or millis, or yyyymmdd, yyyy-mm-dd, etc). Temporarily disabling
+    // this feature until we can handle this.
+    if (DISABLED) {
+      return false;
+    }
+
     SegmentMetadata metadata = segment.getSegmentMetadata();
     String timeColumn = metadata.getTimeColumn();
 


### PR DESCRIPTION
While time column is expected to be long, it may not necessarily be, due
to user error or other reasons.  Also the start/end time in metadata may
not match actual time column data. Disabling TimeSegmentPruner until
we can handle these.