### PR TITLE
upgrading front-end-maven-plugin

### DIFF
--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -179,15 +179,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <!-- Latest version for Maven 2 -->
-        <version>0.0.22</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>2.1</version>
-          </dependency>
-        </dependencies>
+        <version>1.3</version>
 
         <executions>
 


### PR DESCRIPTION
Neha's built was failing with the following error : 
`[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:0.0.22:install-node-and-npm (install node and npm) on project thirdeye-pinot: Execution install node and npm of goal com.github.eirslett:frontend-maven-plugin:0.0.22:install-node-and-npm failed: A required class was missing while executing com.github.eirslett:frontend-maven-plugin:0.0.22:install-node-and-npm: org/slf4j/helpers/MarkerIgnoringBase`

Upgrading the plugin to latest version to fix this issue. 

Both @npawar and I successfully tested this changes locally. 