### PR TITLE
Use the smallest value between current and baseline bucket number

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
@@ -73,6 +73,9 @@ public class TimeOnTimeResponseParser {
     metricFunctions = baselineResponse.getMetricFunctions();
     numMetrics = metricFunctions.size();
     numTimeBuckets = Math.min(currentRanges.size(), baselineRanges.size());
+    if (currentRanges.size() != baselineRanges.size()) {
+      LOGGER.info("Current and baseline time series have different length, which could be induced by DST.");
+    }
     rows = new ArrayList<>();
 
     if (hasGroupByTime) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeResponseParser.java
@@ -72,7 +72,7 @@ public class TimeOnTimeResponseParser {
 
     metricFunctions = baselineResponse.getMetricFunctions();
     numMetrics = metricFunctions.size();
-    numTimeBuckets = baselineRanges.size();
+    numTimeBuckets = Math.min(currentRanges.size(), baselineRanges.size());
     rows = new ArrayList<>();
 
     if (hasGroupByTime) {


### PR DESCRIPTION
Problem: Exception when showing time over time comparison between two weeks and one of the week contains DST changes.

Fix: Ensure the dashboard does not go out of boundary of both current and baseline time series

Tested on local.