### PR TITLE
[PINOT-4603] Re-factor parameter passing in Segment Completion Protocol

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -43,6 +43,7 @@ import com.alibaba.fastjson.JSONObject;
  * https://github.com/linkedin/pinot/wiki/Low-level-kafka-consumers
  */
 public class SegmentCompletionProtocol {
+
   /**
    * MAX_HOLD_TIME_MS is the maximum time (msecs) for which a server will be in HOLDING state, after which it will
    * send in a SegmentConsumedRequest with its current offset in kafka.
@@ -103,12 +104,13 @@ public class SegmentCompletionProtocol {
   public static final String PARAM_REASON = "reason";
 
   // Canned responses
-  public static final Response RESP_NOT_LEADER = new Response(ControllerResponseStatus.NOT_LEADER, -1L);
-  public static final Response RESP_FAILED = new Response(ControllerResponseStatus.FAILED, -1L);
-  public static final Response RESP_DISCARD = new Response(ControllerResponseStatus.DISCARD, -1L);
-  public static final Response RESP_COMMIT_SUCCESS = new Response(ControllerResponseStatus.COMMIT_SUCCESS, -1L);
-  public static final Response RESP_COMMIT_CONTINUE = new Response(ControllerResponseStatus.COMMIT_CONTINUE, -1L);
-  public static final Response RESP_PROCESSED = new Response(ControllerResponseStatus.PROCESSED, -1L);
+  public static final Response RESP_NOT_LEADER = new Response(new Response.Params().setStatus(ControllerResponseStatus.NOT_LEADER));
+  public static final Response RESP_FAILED = new Response(new Response.Params().setStatus(ControllerResponseStatus.FAILED));
+  public static final Response RESP_DISCARD = new Response(new Response.Params().setStatus(ControllerResponseStatus.DISCARD));
+  public static final Response RESP_COMMIT_SUCCESS = new Response(new Response.Params().setStatus(ControllerResponseStatus.COMMIT_SUCCESS));
+  public static final Response RESP_COMMIT_CONTINUE = new Response(new Response.Params().setStatus(ControllerResponseStatus.COMMIT_CONTINUE));
+  public static final Response RESP_PROCESSED = new Response(new Response.Params().setStatus(ControllerResponseStatus.PROCESSED));
+  public static final Response RESP_NOT_SENT = new Response(new Response.Params().setStatus(ControllerResponseStatus.NOT_SENT));
 
   public static long getMaxSegmentCommitTimeMs() {
     return MAX_SEGMENT_COMMIT_TIME_MS;
@@ -128,11 +130,11 @@ public class SegmentCompletionProtocol {
     final String _instanceId;
     final String _reason;
 
-    public Request(String segmentName, long offset, String instanceId, String reason) {
-      _segmentName = segmentName;
-      _instanceId = instanceId;
-      _offset = offset;
-      _reason = reason;
+    private Request(Params params) {
+      _segmentName = params.getSegmentName();
+      _instanceId = params.getInstanceId();
+      _offset = params.getOffset();
+      _reason = params.getReason();
     }
 
     public abstract String getUrl(String hostPort);
@@ -144,17 +146,65 @@ public class SegmentCompletionProtocol {
         PARAM_INSTANCE_ID + "=" + _instanceId +
           (_reason == null ? "" : ("&" + PARAM_REASON + "=" + _reason));
     }
+
+    public static class Params {
+      private static final String UNKNOWN_SEGMENT = "UNKNOWN_SEGMENT";
+      private static final long UNKNOWN_OFFSET = -1L;
+      private static final String UNKNOWN_INSTANCE = "UNKNOWN_INSTANCE";
+
+      long _offset;
+      String _segmentName;
+      String _instanceId;
+      String _reason;
+
+      public Params() {
+        resetInternal();
+      }
+      public Params reset() {
+        resetInternal();
+        return this;
+      }
+      private void resetInternal() {
+        _offset = UNKNOWN_OFFSET;
+        _segmentName = UNKNOWN_SEGMENT;
+        _instanceId = UNKNOWN_INSTANCE;
+      }
+      public Params setOffset(long offset) {
+        _offset = offset;
+        return this;
+      }
+      public Params setSegmentName(String segmentName) {
+        _segmentName = segmentName;
+        return this;
+      }
+      public Params setInstanceId(String instanceId) {
+        _instanceId = instanceId;
+        return this;
+      }
+      public Params setReason(String reason) {
+        _reason = reason;
+        return this;
+      }
+
+      public String getSegmentName() {
+        return _segmentName;
+      }
+      public long getOffset() {
+        return _offset;
+      }
+      public String getReason() {
+        return _reason;
+      }
+      public String getInstanceId() {
+        return _instanceId;
+      }
+    }
   }
 
+
   public static class SegmentConsumedRequest extends Request {
-    /**
-     *
-     * @param segmentName Name of the LLC segment
-     * @param offset Next offset from which the kafka client will consume, if it does.
-     * @param instanceId Name of the instance reporting this event.
-     */
-    public SegmentConsumedRequest(String segmentName, long offset, String instanceId) {
-      super(segmentName, offset, instanceId, null);
+    public SegmentConsumedRequest(Params params) {
+      super(params);
     }
     @Override
       public String getUrl(final String hostPort) {
@@ -163,14 +213,9 @@ public class SegmentCompletionProtocol {
   }
 
   public static class SegmentCommitRequest extends Request {
-    /**
-     *
-     * @param segmentName Name of the LLC segment
-     * @param offset Next offset from which the kafka client will consume, if it does.
-     * @param instanceId Name of the instance reporting this event.
-     */
-    public SegmentCommitRequest(String segmentName, long offset, String instanceId) {
-      super(segmentName, offset, instanceId, null);
+
+    public SegmentCommitRequest(Params params) {
+      super(params);
     }
     @Override
       public String getUrl(final String hostPort) {
@@ -180,9 +225,10 @@ public class SegmentCompletionProtocol {
 
   public static class SegmentStoppedConsuming extends Request {
 
-    public SegmentStoppedConsuming(String segmentName, long offset, String instanceId, String reason) {
-      super(segmentName, offset, instanceId, reason);
+    public SegmentStoppedConsuming(Params params) {
+      super(params);
     }
+
     @Override
     public String getUrl(final String hostPort) {
       return "http://" + hostPort + getUri(MSG_TYPE_STOPPED_CONSUMING);
@@ -211,9 +257,9 @@ public class SegmentCompletionProtocol {
       _status = status;
     }
 
-    public Response(ControllerResponseStatus status, long offset) {
-      _status = status;
-      _offset = offset;
+    public Response(Params params) {
+      _status = params.getStatus();
+      _offset = params.getOffset();
     }
 
     public ControllerResponseStatus getStatus() {
@@ -225,8 +271,46 @@ public class SegmentCompletionProtocol {
     }
 
     public String toJsonString() {
-      return "{\"" + STATUS_KEY + "\":" + "\"" + _status.name() + "\"," +
-        "\"" + OFFSET_KEY + "\":" + _offset + "}";
+      StringBuilder builder = new StringBuilder();
+      builder.append("{\"" + STATUS_KEY + "\":" + "\"" + _status.name() + "\"," + "\"" + OFFSET_KEY + "\":" + _offset);
+      builder.append("}");
+      return builder.toString();
+    }
+
+    public static class Params {
+      private static ControllerResponseStatus DEFAULT_RESPONSE_STATUS = ControllerResponseStatus.FAILED;
+      private static long DEFAULT_RESP_OFFSET = -1L;
+
+      ControllerResponseStatus _status;
+      long _offset;
+
+      public Params() {
+        resetInternal();
+      }
+      public Params reset() {
+        resetInternal();
+        return this;
+      }
+      private void resetInternal() {
+        _offset = DEFAULT_RESP_OFFSET;
+        _status = DEFAULT_RESPONSE_STATUS;
+      }
+
+      public Params setOffset(long offset) {
+        _offset = offset;
+        return this;
+      }
+      public Params setStatus(ControllerResponseStatus status) {
+        _status = status;
+        return this;
+      }
+
+      public ControllerResponseStatus getStatus() {
+        return _status;
+      }
+      public long getOffset() {
+        return _offset;
+      }
     }
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -104,13 +104,20 @@ public class SegmentCompletionProtocol {
   public static final String PARAM_REASON = "reason";
 
   // Canned responses
-  public static final Response RESP_NOT_LEADER = new Response(new Response.Params().setStatus(ControllerResponseStatus.NOT_LEADER));
-  public static final Response RESP_FAILED = new Response(new Response.Params().setStatus(ControllerResponseStatus.FAILED));
-  public static final Response RESP_DISCARD = new Response(new Response.Params().setStatus(ControllerResponseStatus.DISCARD));
-  public static final Response RESP_COMMIT_SUCCESS = new Response(new Response.Params().setStatus(ControllerResponseStatus.COMMIT_SUCCESS));
-  public static final Response RESP_COMMIT_CONTINUE = new Response(new Response.Params().setStatus(ControllerResponseStatus.COMMIT_CONTINUE));
-  public static final Response RESP_PROCESSED = new Response(new Response.Params().setStatus(ControllerResponseStatus.PROCESSED));
-  public static final Response RESP_NOT_SENT = new Response(new Response.Params().setStatus(ControllerResponseStatus.NOT_SENT));
+  public static final Response RESP_NOT_LEADER = new Response(new Response.Params().setStatus(
+      ControllerResponseStatus.NOT_LEADER));
+  public static final Response RESP_FAILED = new Response(new Response.Params().setStatus(
+      ControllerResponseStatus.FAILED));
+  public static final Response RESP_DISCARD = new Response(new Response.Params().setStatus(
+      ControllerResponseStatus.DISCARD));
+  public static final Response RESP_COMMIT_SUCCESS = new Response(new Response.Params().setStatus(
+      ControllerResponseStatus.COMMIT_SUCCESS));
+  public static final Response RESP_COMMIT_CONTINUE = new Response(new Response.Params().setStatus(
+      ControllerResponseStatus.COMMIT_CONTINUE));
+  public static final Response RESP_PROCESSED = new Response(new Response.Params().setStatus(
+      ControllerResponseStatus.PROCESSED));
+  public static final Response RESP_NOT_SENT = new Response(new Response.Params().setStatus(
+      ControllerResponseStatus.NOT_SENT));
 
   public static long getMaxSegmentCommitTimeMs() {
     return MAX_SEGMENT_COMMIT_TIME_MS;
@@ -152,36 +159,29 @@ public class SegmentCompletionProtocol {
       private static final long UNKNOWN_OFFSET = -1L;
       private static final String UNKNOWN_INSTANCE = "UNKNOWN_INSTANCE";
 
-      long _offset;
-      String _segmentName;
-      String _instanceId;
-      String _reason;
+      private long _offset;
+      private String _segmentName;
+      private String _instanceId;
+      private String _reason;
 
       public Params() {
-        resetInternal();
-      }
-      public Params reset() {
-        resetInternal();
-        return this;
-      }
-      private void resetInternal() {
         _offset = UNKNOWN_OFFSET;
         _segmentName = UNKNOWN_SEGMENT;
         _instanceId = UNKNOWN_INSTANCE;
       }
-      public Params setOffset(long offset) {
+      public Params withOffset(long offset) {
         _offset = offset;
         return this;
       }
-      public Params setSegmentName(String segmentName) {
+      public Params withSegmentName(String segmentName) {
         _segmentName = segmentName;
         return this;
       }
-      public Params setInstanceId(String instanceId) {
+      public Params withInstanceId(String instanceId) {
         _instanceId = instanceId;
         return this;
       }
-      public Params setReason(String reason) {
+      public Params withReason(String reason) {
         _reason = reason;
         return this;
       }
@@ -281,17 +281,10 @@ public class SegmentCompletionProtocol {
       private static ControllerResponseStatus DEFAULT_RESPONSE_STATUS = ControllerResponseStatus.FAILED;
       private static long DEFAULT_RESP_OFFSET = -1L;
 
-      ControllerResponseStatus _status;
-      long _offset;
+      private ControllerResponseStatus _status;
+      private long _offset;
 
       public Params() {
-        resetInternal();
-      }
-      public Params reset() {
-        resetInternal();
-        return this;
-      }
-      private void resetInternal() {
         _offset = DEFAULT_RESP_OFFSET;
         _status = DEFAULT_RESPONSE_STATUS;
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommit.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommit.java
@@ -63,14 +63,15 @@ public class LLCSegmentCommit extends PinotSegmentUploadRestletResource {
     LOGGER.info("segment={} offset={} instance={} ", _segmentNameStr, _offset, _instanceId);
     final SegmentCompletionManager segmentCompletionManager = getSegmentCompletionManager();
 
-    SegmentCompletionProtocol.Response response = segmentCompletionManager.segmentCommitStart(_segmentNameStr,
-        _instanceId, _offset);
+    final SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
+    reqParams.setInstanceId(_instanceId).setSegmentName(_segmentNameStr).setOffset(_offset);
+    SegmentCompletionProtocol.Response response = segmentCompletionManager.segmentCommitStart(reqParams);
     if (response.equals(SegmentCompletionProtocol.RESP_COMMIT_CONTINUE)) {
 
       // Get the segment and put it in the right place.
       boolean success = uploadSegment(_instanceId, _segmentNameStr);
 
-      response = segmentCompletionManager.segmentCommitEnd(_segmentNameStr, _instanceId, _offset, success);
+      response = segmentCompletionManager.segmentCommitEnd(reqParams, success);
     }
 
     LOGGER.info("Response: instance={}  segment={} status={} offset={}", _instanceId, _segmentNameStr, response.getStatus(), response.getOffset());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommit.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommit.java
@@ -64,7 +64,7 @@ public class LLCSegmentCommit extends PinotSegmentUploadRestletResource {
     final SegmentCompletionManager segmentCompletionManager = getSegmentCompletionManager();
 
     final SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
-    reqParams.setInstanceId(_instanceId).setSegmentName(_segmentNameStr).setOffset(_offset);
+    reqParams.withInstanceId(_instanceId).withSegmentName(_segmentNameStr).withOffset(_offset);
     SegmentCompletionProtocol.Response response = segmentCompletionManager.segmentCommitStart(reqParams);
     if (response.equals(SegmentCompletionProtocol.RESP_COMMIT_CONTINUE)) {
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentConsumed.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentConsumed.java
@@ -51,7 +51,7 @@ public class LLCSegmentConsumed extends ServerResource {
       return new StringRepresentation(SegmentCompletionProtocol.RESP_FAILED.toJsonString());
     }
     SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
-    reqParams.setSegmentName(segmentName).setInstanceId(instanceId).setOffset(Long.valueOf(offset));
+    reqParams.withSegmentName(segmentName).withInstanceId(instanceId).withOffset(Long.valueOf(offset));
     LOGGER.info("Request: segment={} offset={} instance={} ", segmentName, offset, instanceId);
     SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().segmentConsumed(reqParams);
     LOGGER.info("Response: instance={} segment={} status={} offset={}", instanceId, segmentName, response.getStatus(), response.getOffset());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentConsumed.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentConsumed.java
@@ -50,8 +50,10 @@ public class LLCSegmentConsumed extends ServerResource {
     if (offset == null || segmentName == null || instanceId == null) {
       return new StringRepresentation(SegmentCompletionProtocol.RESP_FAILED.toJsonString());
     }
+    SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
+    reqParams.setSegmentName(segmentName).setInstanceId(instanceId).setOffset(Long.valueOf(offset));
     LOGGER.info("Request: segment={} offset={} instance={} ", segmentName, offset, instanceId);
-    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().segmentConsumed(segmentName, instanceId, Long.valueOf(offset));
+    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().segmentConsumed(reqParams);
     LOGGER.info("Response: instance={} segment={} status={} offset={}", instanceId, segmentName, response.getStatus(), response.getOffset());
     return new StringRepresentation(response.toJsonString());
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentStoppedConsuming.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentStoppedConsuming.java
@@ -52,7 +52,8 @@ public class LLCSegmentStoppedConsuming extends PinotSegmentUploadRestletResourc
       return new StringRepresentation(SegmentCompletionProtocol.RESP_FAILED.toJsonString());
     }
     SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
-    reqParams.setSegmentName(segmentName).setOffset(Long.valueOf(offset)).setInstanceId(instanceId).setReason(reason);
+    reqParams.withSegmentName(segmentName).withOffset(Long.valueOf(offset)).withInstanceId(instanceId).withReason(
+        reason);
     LOGGER.info("Request: segment={} offset={} instance={} ", segmentName, offset, instanceId);
     SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().segmentStoppedConsuming(reqParams);
     LOGGER.info("Response: instance={} segment={} status={} offset={}", instanceId, segmentName, response.getStatus(), response.getOffset());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentStoppedConsuming.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentStoppedConsuming.java
@@ -51,8 +51,10 @@ public class LLCSegmentStoppedConsuming extends PinotSegmentUploadRestletResourc
     if (offset == null || segmentName == null || instanceId == null) {
       return new StringRepresentation(SegmentCompletionProtocol.RESP_FAILED.toJsonString());
     }
+    SegmentCompletionProtocol.Request.Params reqParams = new SegmentCompletionProtocol.Request.Params();
+    reqParams.setSegmentName(segmentName).setOffset(Long.valueOf(offset)).setInstanceId(instanceId).setReason(reason);
     LOGGER.info("Request: segment={} offset={} instance={} ", segmentName, offset, instanceId);
-    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().segmentStoppedConsuming(segmentName, instanceId, Long.valueOf(offset), reason);
+    SegmentCompletionProtocol.Response response = SegmentCompletionManager.getInstance().segmentStoppedConsuming(reqParams);
     LOGGER.info("Response: instance={} segment={} status={} offset={}", instanceId, segmentName, response.getStatus(), response.getOffset());
     return new StringRepresentation(response.toJsonString());
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -16,8 +16,6 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime;
 
-import com.linkedin.pinot.common.config.IndexingConfig;
-import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -57,6 +55,7 @@ import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.stream.KafkaStreamMetadata;
 import com.linkedin.pinot.common.metrics.ControllerMeter;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
@@ -982,7 +981,7 @@ public class PinotLLCRealtimeSegmentManager {
     }
 
     if (!updateKafkaAssignment) {
-      LOGGER.info("Not updating Kafka partition assignment for table {}");
+      LOGGER.info("Not updating Kafka partition assignment for table {}", realtimeTableName);
       return;
     }
 
@@ -993,7 +992,7 @@ public class PinotLLCRealtimeSegmentManager {
     }
     ZNRecord newPartitionAssignment = generatePartitionAssignment(kafkaStreamMetadata.getKafkaTopicName(), currentPartitionCount, currentInstances, currentReplicaCount);
     writeKafkaPartitionAssignemnt(realtimeTableName, newPartitionAssignment);
-    LOGGER.info("Successfully updated Kafka partition assignment for table {}");
+    LOGGER.info("Successfully updated Kafka partition assignment for table {}", realtimeTableName);
   }
 
   /*

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommitTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/LLCSegmentCommitTest.java
@@ -16,8 +16,6 @@
 
 package com.linkedin.pinot.controller.api.restlet.resources;
 
-import com.linkedin.pinot.common.metrics.ControllerMetrics;
-import com.yammer.metrics.core.MetricsRegistry;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.helix.HelixManager;
@@ -27,11 +25,13 @@ import org.restlet.representation.Representation;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.alibaba.fastjson.JSONObject;
+import com.linkedin.pinot.common.metrics.ControllerMetrics;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.ControllerTestUtils;
 import com.linkedin.pinot.controller.helix.core.realtime.SegmentCompletionManager;
+import com.yammer.metrics.core.MetricsRegistry;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -152,18 +152,18 @@ public class LLCSegmentCommitTest {
     }
 
     @Override
-    public SegmentCompletionProtocol.Response segmentConsumed(final String segmentNameStr, final String instanceId, final long offset) {
+    public SegmentCompletionProtocol.Response segmentConsumed(SegmentCompletionProtocol.Request.Params reqParams) {
       return null;
     }
 
     @Override
-    public SegmentCompletionProtocol.Response segmentCommitStart(final String segmentNameStr, final String instanceId, final long offset) {
+    public SegmentCompletionProtocol.Response segmentCommitStart(SegmentCompletionProtocol.Request.Params reqParams) {
       commitStartCalled = true;
       return commitStartResponse;
     }
 
     @Override
-    public SegmentCompletionProtocol.Response segmentCommitEnd(final String segmentNameStr, final String instanceId, final long offset, boolean success) {
+    public SegmentCompletionProtocol.Response segmentCommitEnd(SegmentCompletionProtocol.Request.Params reqParams, boolean success) {
       commitEndCalled = true;
       uploadSuccess = success;
       return commitEndResponse;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -584,7 +584,10 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   // Inform the controller that the server had to stop consuming due to an error.
   protected void postStopConsumedMsg(String reason) {
     do {
-      SegmentCompletionProtocol.Response response = _protocolHandler.segmentStoppedConsuming(_segmentNameStr, _currentOffset, reason);
+      SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
+      params.setOffset(_currentOffset).setReason(reason).setSegmentName(_segmentNameStr);
+
+      SegmentCompletionProtocol.Response response = _protocolHandler.segmentStoppedConsuming(params);
       if (response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED) {
         LOGGER.info("Got response {}", response.toJsonString());
         break;
@@ -597,7 +600,9 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   protected SegmentCompletionProtocol.Response postSegmentConsumedMsg() {
     // Post segmentConsumed to current leader.
     // Retry maybe once if leader is not found.
-    return _protocolHandler.segmentConsumed(_segmentNameStr, _currentOffset);
+    SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
+    params.setOffset(_currentOffset).setSegmentName(_segmentNameStr);
+    return _protocolHandler.segmentConsumed(params);
   }
 
   public void goOnlineFromConsuming(RealtimeSegmentZKMetadata metadata) throws InterruptedException {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -585,7 +585,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   protected void postStopConsumedMsg(String reason) {
     do {
       SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-      params.setOffset(_currentOffset).setReason(reason).setSegmentName(_segmentNameStr);
+      params.withOffset(_currentOffset).withReason(reason).withSegmentName(_segmentNameStr);
 
       SegmentCompletionProtocol.Response response = _protocolHandler.segmentStoppedConsuming(params);
       if (response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED) {
@@ -601,7 +601,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
     // Post segmentConsumed to current leader.
     // Retry maybe once if leader is not found.
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-    params.setOffset(_currentOffset).setSegmentName(_segmentNameStr);
+    params.withOffset(_currentOffset).withSegmentName(_segmentNameStr);
     return _protocolHandler.segmentConsumed(params);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -52,7 +52,7 @@ public class ServerSegmentCompletionProtocolHandler {
 
   public SegmentCompletionProtocol.Response segmentCommit(long offset, final String segmentName, final File segmentTarFile) throws FileNotFoundException {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-    params.setInstanceId(_instance).setOffset(offset).setSegmentName(segmentName);
+    params.withInstanceId(_instance).withOffset(offset).withSegmentName(segmentName);
     SegmentCompletionProtocol.SegmentCommitRequest request = new SegmentCompletionProtocol.SegmentCommitRequest(params);
 
     final InputStream inputStream = new FileInputStream(segmentTarFile);
@@ -78,13 +78,13 @@ public class ServerSegmentCompletionProtocolHandler {
   }
 
   public SegmentCompletionProtocol.Response segmentConsumed(SegmentCompletionProtocol.Request.Params params) {
-    params.setInstanceId(_instance);
+    params.withInstanceId(_instance);
     SegmentCompletionProtocol.SegmentConsumedRequest request = new SegmentCompletionProtocol.SegmentConsumedRequest(params);
     return doHttp(request, null);
   }
 
   public SegmentCompletionProtocol.Response segmentStoppedConsuming(SegmentCompletionProtocol.Request.Params params) {
-    params.setInstanceId(_instance);
+    params.withInstanceId(_instance);
     SegmentCompletionProtocol.SegmentStoppedConsuming request = new SegmentCompletionProtocol.SegmentStoppedConsuming(params);
     return doHttp(request, null);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -51,7 +51,10 @@ public class ServerSegmentCompletionProtocolHandler {
   }
 
   public SegmentCompletionProtocol.Response segmentCommit(long offset, final String segmentName, final File segmentTarFile) throws FileNotFoundException {
-    SegmentCompletionProtocol.SegmentCommitRequest request = new SegmentCompletionProtocol.SegmentCommitRequest(segmentName, offset, _instance);
+    SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
+    params.setInstanceId(_instance).setOffset(offset).setSegmentName(segmentName);
+    SegmentCompletionProtocol.SegmentCommitRequest request = new SegmentCompletionProtocol.SegmentCommitRequest(params);
+
     final InputStream inputStream = new FileInputStream(segmentTarFile);
     Part[] parts = {
         new FilePart(segmentName, new PartSource() {
@@ -74,25 +77,26 @@ public class ServerSegmentCompletionProtocolHandler {
     return doHttp(request, parts);
   }
 
-  public SegmentCompletionProtocol.Response segmentConsumed(String segmentName, long offset) {
-    SegmentCompletionProtocol.SegmentConsumedRequest request = new SegmentCompletionProtocol.SegmentConsumedRequest(segmentName, offset, _instance);
+  public SegmentCompletionProtocol.Response segmentConsumed(SegmentCompletionProtocol.Request.Params params) {
+    params.setInstanceId(_instance);
+    SegmentCompletionProtocol.SegmentConsumedRequest request = new SegmentCompletionProtocol.SegmentConsumedRequest(params);
     return doHttp(request, null);
   }
 
-  public SegmentCompletionProtocol.Response segmentStoppedConsuming(String segmentName, long offset, String reason) {
-    SegmentCompletionProtocol.SegmentStoppedConsuming request = new SegmentCompletionProtocol.SegmentStoppedConsuming(segmentName, offset, _instance, reason);
+  public SegmentCompletionProtocol.Response segmentStoppedConsuming(SegmentCompletionProtocol.Request.Params params) {
+    params.setInstanceId(_instance);
+    SegmentCompletionProtocol.SegmentStoppedConsuming request = new SegmentCompletionProtocol.SegmentStoppedConsuming(params);
     return doHttp(request, null);
   }
 
   private SegmentCompletionProtocol.Response doHttp(SegmentCompletionProtocol.Request request, Part[] parts) {
-    SegmentCompletionProtocol.Response response =
-        new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.NOT_SENT, -1L);
+    SegmentCompletionProtocol.Response response = SegmentCompletionProtocol.RESP_NOT_SENT;
     HttpClient httpClient = new HttpClient();
     ControllerLeaderLocator leaderLocator = ControllerLeaderLocator.getInstance();
     final String leaderAddress = leaderLocator.getControllerLeader();
     if (leaderAddress == null) {
       LOGGER.error("No leader found {}", this.toString());
-      return new SegmentCompletionProtocol.Response(SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER, -1L);
+      return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String url = request.getUrl(leaderAddress);
     HttpMethodBase method;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -183,7 +183,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.HOLD, endOffset);
+        new SegmentCompletionProtocol.Response.Params().setStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).setOffset(endOffset));
     // And then never consume as long as we get a hold response, 100 times.
     for (int i = 0; i < 100; i++) {
       segmentDataManager._responses.add(response);
@@ -209,9 +209,11 @@ public class LLRealtimeSegmentDataManagerTest {
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response holdResponse = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.HOLD, endOffset);
+        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.COMMIT, endOffset);
+        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse);
     segmentDataManager._responses.add(commitResponse);
@@ -238,13 +240,16 @@ public class LLRealtimeSegmentDataManagerTest {
     segmentDataManager._consumeOffsets.add(firstOffset);
     segmentDataManager._consumeOffsets.add(catchupOffset); // Offset after catchup
     final SegmentCompletionProtocol.Response holdResponse1 = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.HOLD, firstOffset);
+        new SegmentCompletionProtocol.Response.Params().setStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).
+            setOffset(firstOffset));
     final SegmentCompletionProtocol.Response catchupResponse = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP, catchupOffset);
+        new SegmentCompletionProtocol.Response.Params().setStatus(SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP).setOffset(catchupOffset));
     final SegmentCompletionProtocol.Response holdResponse2 = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.HOLD, catchupOffset);
+        new SegmentCompletionProtocol.Response.Params().setOffset(catchupOffset).setStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.COMMIT, catchupOffset);
+        new SegmentCompletionProtocol.Response.Params().setOffset(catchupOffset).setStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse1);
     segmentDataManager._responses.add(catchupResponse);
@@ -269,7 +274,8 @@ public class LLRealtimeSegmentDataManagerTest {
     final long endOffset = _startOffset + 500;
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response discardResponse = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.DISCARD, endOffset);
+        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.DISCARD));
     segmentDataManager._responses.add(discardResponse);
 
     consumer.run();
@@ -289,8 +295,9 @@ public class LLRealtimeSegmentDataManagerTest {
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
     final long endOffset = _startOffset + 500;
     segmentDataManager._consumeOffsets.add(endOffset);
-    final SegmentCompletionProtocol.Response keepResponse = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.KEEP, endOffset);
+    SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
+    params.setOffset(endOffset).setStatus(SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
+    final SegmentCompletionProtocol.Response keepResponse = new SegmentCompletionProtocol.Response(params);
     segmentDataManager._responses.add(keepResponse);
 
     consumer.run();
@@ -312,7 +319,8 @@ public class LLRealtimeSegmentDataManagerTest {
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
-        SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER, endOffset);
+        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER));
     // And then never consume as long as we get a Not leader response, 100 times.
     for (int i = 0; i < 100; i++) {
       segmentDataManager._responses.add(response);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
@@ -155,8 +155,9 @@ public class SegmentCompletionIntegrationTests extends RealtimeClusterIntegratio
 
     // Now report to the controller that we had to stop consumption
     ServerSegmentCompletionProtocolHandler protocolHandler = new ServerSegmentCompletionProtocolHandler(_serverInstance);
-    SegmentCompletionProtocol.Response response = protocolHandler.segmentStoppedConsuming(_segmentName, 45688L,
-        "RandomReason");
+    SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
+    params.setOffset(45688L).setSegmentName(_segmentName).setReason("RandomReason");
+    SegmentCompletionProtocol.Response response = protocolHandler.segmentStoppedConsuming(params);
     Assert.assertTrue(response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED);
 
     while (now() < endTime) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
@@ -156,7 +156,7 @@ public class SegmentCompletionIntegrationTests extends RealtimeClusterIntegratio
     // Now report to the controller that we had to stop consumption
     ServerSegmentCompletionProtocolHandler protocolHandler = new ServerSegmentCompletionProtocolHandler(_serverInstance);
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
-    params.setOffset(45688L).setSegmentName(_segmentName).setReason("RandomReason");
+    params.withOffset(45688L).withSegmentName(_segmentName).withReason("RandomReason");
     SegmentCompletionProtocol.Response response = protocolHandler.segmentStoppedConsuming(params);
     Assert.assertTrue(response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED);
 


### PR DESCRIPTION
This is the first check-in towards adding a lease-based segment build time.
Changing the parmeters to be a class makes it easier to add additional parameters
and features around it