### PR TITLE
Refactor anomaly detection framework for adding grouping logic

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContext.java
@@ -1,0 +1,50 @@
+package com.linkedin.thirdeye.anomaly.detection;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
+import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
+import java.util.List;
+import java.util.Map;
+
+public class AnomalyDetectionInputContext {
+  Map<DimensionMap, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap;
+  ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> existingRawAnomalies;
+  ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> knownMergedAnomalies;
+  List<ScalingFactor> scalingFactors;
+
+  public Map<DimensionMap, MetricTimeSeries> getDimensionKeyMetricTimeSeriesMap() {
+    return dimensionKeyMetricTimeSeriesMap;
+  }
+
+  public void setDimensionKeyMetricTimeSeriesMap(
+      Map<DimensionMap, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap) {
+    this.dimensionKeyMetricTimeSeriesMap = dimensionKeyMetricTimeSeriesMap;
+  }
+
+  public ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> getExistingRawAnomalies() {
+    return existingRawAnomalies;
+  }
+
+  public void setExistingRawAnomalies(ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> existingRawAnomalies) {
+    this.existingRawAnomalies = existingRawAnomalies;
+  }
+
+  public ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> getKnownMergedAnomalies() {
+    return knownMergedAnomalies;
+  }
+
+  public void setKnownMergedAnomalies(ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> knownMergedAnomalies) {
+    this.knownMergedAnomalies = knownMergedAnomalies;
+  }
+
+  public List<ScalingFactor> getScalingFactors() {
+    return scalingFactors;
+  }
+
+  public void setScalingFactors(List<ScalingFactor> scalingFactors) {
+    this.scalingFactors = scalingFactors;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionOutputContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionOutputContext.java
@@ -1,28 +1,28 @@
 package com.linkedin.thirdeye.anomaly.detection;
 
-import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 
 public class AnomalyDetectionOutputContext {
-  ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> rawAnomalies;
-  ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies;
+  ListMultimap<DimensionMap, RawAnomalyResultDTO> rawAnomalies;
+  ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies;
 
-  public ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> getRawAnomalies() {
+  public ListMultimap<DimensionMap, RawAnomalyResultDTO> getRawAnomalies() {
     return rawAnomalies;
   }
 
-  public void setRawAnomalies(ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> rawAnomalies) {
+  public void setRawAnomalies(ListMultimap<DimensionMap, RawAnomalyResultDTO> rawAnomalies) {
     this.rawAnomalies = rawAnomalies;
   }
 
-  public ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> getMergedAnomalies() {
+  public ListMultimap<DimensionMap, MergedAnomalyResultDTO> getMergedAnomalies() {
     return mergedAnomalies;
   }
 
   public void setMergedAnomalies(
-      ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies) {
+      ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies) {
     this.mergedAnomalies = mergedAnomalies;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionOutputContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionOutputContext.java
@@ -1,0 +1,28 @@
+package com.linkedin.thirdeye.anomaly.detection;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
+
+public class AnomalyDetectionOutputContext {
+  ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> rawAnomalies;
+  ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies;
+
+  public ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> getRawAnomalies() {
+    return rawAnomalies;
+  }
+
+  public void setRawAnomalies(ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> rawAnomalies) {
+    this.rawAnomalies = rawAnomalies;
+  }
+
+  public ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> getMergedAnomalies() {
+    return mergedAnomalies;
+  }
+
+  public void setMergedAnomalies(
+      ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies) {
+    this.mergedAnomalies = mergedAnomalies;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -118,17 +118,14 @@ public class DetectionTaskRunner implements TaskRunner {
     if (jobName != null && jobName.toLowerCase().startsWith(BACKFILL_PREFIX)) {
       isBackfill = true;
     }
-    // TODO: Create AnomalyMergeExecutor in class level in order to reuse the resource
-    // syncAnomalyMergeExecutor is supposed to perform lightweight merges (i.e., anomalies that have the same function
-    // id and at the same dimensions) after each detection task. Consequently, a null thread pool is passed the merge
-    // executor on purpose in order to prevent an undesired asynchronous merge happens.
-//    AnomalyMergeExecutor syncAnomalyMergeExecutor = new AnomalyMergeExecutor(null, anomalyFunctionFactory);
-//    syncAnomalyMergeExecutor.synchronousMergeBasedOnFunctionIdAndDimension(anomalyFunctionSpec, isBackfill);
+
+    // Update merged anomalies
     TimeBasedAnomalyMerger timeBasedAnomalyMerger = new TimeBasedAnomalyMerger(anomalyFunctionFactory);
     ListMultimap<DimensionMap, MergedAnomalyResultDTO> resultMergedAnomalies =
       timeBasedAnomalyMerger.mergeAnomalies(anomalyFunctionSpec, resultRawAnomalies, isBackfill);
     detectionTaskSuccessCounter.inc();
 
+    // TODO: Change to DataSink
     AnomalyDetectionOutputContext adOutputContext = new AnomalyDetectionOutputContext();
     adOutputContext.setRawAnomalies(resultRawAnomalies);
     adOutputContext.setMergedAnomalies(resultMergedAnomalies);
@@ -452,7 +449,6 @@ public class DetectionTaskRunner implements TaskRunner {
         result.setScore(normalize(result.getScore()));
         result.setWeight(normalize(result.getWeight()));
         result.setFunction(spec);
-//        DAO_REGISTRY.getRawAnomalyResultDAO().save(result);
       } catch (Exception e) {
         LOG.error("Exception in saving anomaly result : " + result.toString(), e);
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -25,13 +25,16 @@ import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import java.util.concurrent.ExecutionException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.NullArgumentException;
 import org.joda.time.DateTime;
+import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static com.linkedin.thirdeye.anomaly.utils.ThirdeyeMetricUtil.*;
@@ -49,28 +52,31 @@ public class DetectionTaskRunner implements TaskRunner {
   private long jobExecutionId;
 
   private List<String> collectionDimensions;
-  private List<MergedAnomalyResultDTO> knownMergedAnomalies;
-  private List<ScalingFactor> scalingFactors;
-  private List<RawAnomalyResultDTO> existingRawAnomalies;
+  private AnomalyFunctionFactory anomalyFunctionFactory;
   private BaseAnomalyFunction anomalyFunction;
 
-  protected void setupTask(TaskInfo taskInfo) {
+  public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
+    detectionTaskCounter.inc();
+    List<TaskResult> taskResult = new ArrayList<>();
+
+    LOG.info("Setting up task {}", taskInfo);
+    setupTask(taskInfo, taskContext);
+
+    // Run for all pairs of window start and window end
+    for (int i = 0; i < windowStarts.size(); i ++) {
+      runTask(windowStarts.get(i), windowEnds.get(i));
+    }
+
+    return taskResult;
+  }
+
+  private void setupTask(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
     DetectionTaskInfo detectionTaskInfo = (DetectionTaskInfo) taskInfo;
     windowStarts = detectionTaskInfo.getWindowStartTime();
     windowEnds = detectionTaskInfo.getWindowEndTime();
     anomalyFunctionSpec = detectionTaskInfo.getAnomalyFunctionSpec();
     jobExecutionId = detectionTaskInfo.getJobExecutionId();
-  }
-
-  public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
-    detectionTaskCounter.inc();
-    LOG.info("Begin executing task {}", taskInfo);
-
-    setupTask(taskInfo);
-
-    List<TaskResult> taskResult = new ArrayList<>();
-
-    AnomalyFunctionFactory anomalyFunctionFactory = taskContext.getAnomalyFunctionFactory();
+    anomalyFunctionFactory = taskContext.getAnomalyFunctionFactory();
     anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
 
     String dataset = anomalyFunctionSpec.getCollection();
@@ -88,75 +94,45 @@ public class DetectionTaskRunner implements TaskRunner {
         "Running anomaly detection job with metricFunction: [{}], topic metric [{}], collection: [{}]",
         anomalyFunctionSpec.getFunctionName(), anomalyFunctionSpec.getTopicMetric(),
         anomalyFunctionSpec.getCollection());
-
-
-    // Run for all pairs of window start and window end
-    for (int i = 0; i < windowStarts.size(); i ++) {
-      DateTime windowStart = windowStarts.get(i);
-      DateTime windowEnd = windowEnds.get(i);
-      LOG.info("Running for time range {} to  {}", windowStart, windowEnd);
-
-      // Get Time Series
-      List<Pair<Long, Long>> startEndTimeRanges = anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis());
-      Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap = TimeSeriesUtil.getTimeSeriesForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
-
-      // Get existing anomalies for this time range and this function id for all combinations of dimensions
-      if (anomalyFunction.useHistoryAnomaly()) {
-        // if this anomaly function uses history data, then we get all time ranges
-        knownMergedAnomalies = getKnownMergedAnomalies(anomalyFunctionSpec.getId(),
-            anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
-      } else {
-        // otherwise, we only get the merge anomaly for current window in order to remove duplicate raw anomalies
-        List<Pair<Long, Long>> currentTimeRange = new ArrayList<>();
-        currentTimeRange.add(new Pair<>(windowStart.getMillis(), windowEnd.getMillis()));
-        knownMergedAnomalies = getKnownMergedAnomalies(anomalyFunctionSpec.getId(), currentTimeRange);
-      }
-      // We always find existing raw anomalies to prevent duplicate raw anomalies are generated
-      existingRawAnomalies = getExistingRawAnomalies(anomalyFunctionSpec.getId(), windowStart.getMillis(), windowEnd.getMillis());
-
-      scalingFactors = OverrideConfigHelper
-          .getTimeSeriesScalingFactors(DAO_REGISTRY.getOverrideConfigDAO(), anomalyFunctionSpec.getCollection(),
-              anomalyFunctionSpec.getMetric(), anomalyFunctionSpec.getId(),
-              anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
-
-      exploreDimensionsAndAnalyze(dimensionKeyMetricTimeSeriesMap, windowStart, windowEnd);
-
-      boolean isBackfill = false;
-      // If the current job is a backfill (adhoc) detection job, set notified flag to true so the merged anomalies do not
-      // induce alerts and emails.
-      String jobName = DAO_REGISTRY.getJobDAO().getJobNameByJobId(jobExecutionId);
-      if (jobName != null && jobName.toLowerCase().startsWith(BACKFILL_PREFIX)) {
-        isBackfill = true;
-      }
-      detectionTaskSuccessCounter.inc();
-
-      // TODO: Create AnomalyMergeExecutor in class level in order to reuse the resource
-      // syncAnomalyMergeExecutor is supposed to perform lightweight merges (i.e., anomalies that have the same function
-      // id and at the same dimensions) after each detection task. Consequently, a null thread pool is passed the merge
-      // executor on purpose in order to prevent an undesired asynchronous merge happens.
-      AnomalyMergeExecutor syncAnomalyMergeExecutor = new AnomalyMergeExecutor(null, anomalyFunctionFactory);
-      syncAnomalyMergeExecutor.synchronousMergeBasedOnFunctionIdAndDimension(anomalyFunctionSpec, isBackfill);
-      detectionTaskSuccessCounter.inc();
-    }
-    return taskResult;
   }
 
 
-  private void exploreDimensionsAndAnalyze(Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap,
-      DateTime windowStart, DateTime windowEnd) {
-    int anomalyCounter = 0;
+  private void runTask(DateTime windowStart, DateTime windowEnd)
+      throws JobExecutionException, ExecutionException {
 
-    // Sort the known merged and raw anomalies by their dimension names
-    ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> dimensionNamesToKnownMergedAnomalies = ArrayListMultimap.create();
-    for (MergedAnomalyResultDTO knownMergedAnomaly : knownMergedAnomalies) {
-      dimensionNamesToKnownMergedAnomalies.put(knownMergedAnomaly.getDimensions(), knownMergedAnomaly);
-    }
-    ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> dimensionNamesToKnownRawAnomalies = ArrayListMultimap.create();
-    for (RawAnomalyResultDTO existingRawAnomaly : existingRawAnomalies) {
-      dimensionNamesToKnownRawAnomalies.put(existingRawAnomaly.getDimensions(), existingRawAnomaly);
-    }
+    LOG.info("Running anomaly detection for time range {} to  {}", windowStart, windowEnd);
 
-    String metricName = anomalyFunction.getSpec().getTopicMetric();
+    // TODO: Change to DataFetchers/DataSources
+    AnomalyDetectionInputContext adContext = fetchData(windowStart, windowEnd);
+
+    Map<DimensionMap, List<RawAnomalyResultDTO>> resultRawAnomalies = dimensionalShuffleAndUnifyAnalyze(windowStart, windowEnd, adContext);
+    detectionTaskSuccessCounter.inc();
+
+    boolean isBackfill = false;
+    // If the current job is a backfill (adhoc) detection job, set notified flag to true so the merged anomalies do not
+    // induce alerts and emails.
+    String jobName = DAO_REGISTRY.getJobDAO().getJobNameByJobId(jobExecutionId);
+    if (jobName != null && jobName.toLowerCase().startsWith(BACKFILL_PREFIX)) {
+      isBackfill = true;
+    }
+    // TODO: Create AnomalyMergeExecutor in class level in order to reuse the resource
+    // syncAnomalyMergeExecutor is supposed to perform lightweight merges (i.e., anomalies that have the same function
+    // id and at the same dimensions) after each detection task. Consequently, a null thread pool is passed the merge
+    // executor on purpose in order to prevent an undesired asynchronous merge happens.
+    AnomalyMergeExecutor syncAnomalyMergeExecutor = new AnomalyMergeExecutor(null, anomalyFunctionFactory);
+    syncAnomalyMergeExecutor.synchronousMergeBasedOnFunctionIdAndDimension(anomalyFunctionSpec, isBackfill);
+    detectionTaskSuccessCounter.inc();
+  }
+
+
+  private AnomalyDetectionInputContext fetchData(DateTime windowStart, DateTime windowEnd)
+      throws JobExecutionException, ExecutionException {
+    AnomalyDetectionInputContext adContext = new AnomalyDetectionInputContext();
+
+    // Get Time Series
+    List<Pair<Long, Long>> startEndTimeRanges = anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis());
+    Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap = TimeSeriesUtil.getTimeSeriesForAnomalyDetection(anomalyFunctionSpec, startEndTimeRanges);
+    Map<DimensionMap, MetricTimeSeries> dimensionMapMetricTimeSeriesMap = new HashMap<>();
     for (Map.Entry<DimensionKey, MetricTimeSeries> entry : dimensionKeyMetricTimeSeriesMap.entrySet()) {
       DimensionKey dimensionKey = entry.getKey();
 
@@ -166,8 +142,7 @@ public class DetectionTaskRunner implements TaskRunner {
       String[] dimensionValues = dimensionKey.getDimensionValues();
       boolean isOTHERDimension = false;
       for (String dimensionValue : dimensionValues) {
-        if (dimensionValue.equalsIgnoreCase(ResponseParserUtils.OTHER) ||
-            dimensionValue.equalsIgnoreCase(ResponseParserUtils.UNKNOWN)) {
+        if (dimensionValue.equalsIgnoreCase(ResponseParserUtils.OTHER) || dimensionValue.equalsIgnoreCase(ResponseParserUtils.UNKNOWN)) {
           isOTHERDimension = true;
           break;
         }
@@ -176,65 +151,124 @@ public class DetectionTaskRunner implements TaskRunner {
         continue;
       }
 
-      DimensionMap exploredDimensions = DimensionMap.fromDimensionKey(dimensionKey, collectionDimensions);
+      DimensionMap dimensionMap = DimensionMap.fromDimensionKey(dimensionKey, collectionDimensions);
+      dimensionMapMetricTimeSeriesMap.put(dimensionMap, entry.getValue());
 
       if (entry.getValue().getTimeWindowSet().size() < 1) {
-        LOG.warn("Insufficient data for {} to run anomaly detection function", exploredDimensions);
+        LOG.warn("Insufficient data for {} to run anomaly detection function", dimensionMap);
         continue;
       }
-
-      // Get current entry's knownMergedAnomalies, which should have the same explored dimensions
-      List<MergedAnomalyResultDTO> knownMergedAnomaliesOfAnEntry = dimensionNamesToKnownMergedAnomalies.get(exploredDimensions);
-
-      try {
-        // Run algorithm
-        MetricTimeSeries metricTimeSeries = entry.getValue();
-        LOG.info("Analyzing anomaly function with explored dimensions: {}, windowStart: {}, windowEnd: {}",
-            exploredDimensions, windowStart, windowEnd);
-
-        List<MergedAnomalyResultDTO> historyMergedAnomalies;
-        if (anomalyFunction.useHistoryAnomaly()) {
-          historyMergedAnomalies = retainHistoryMergedAnomalies(windowStart.getMillis(), knownMergedAnomaliesOfAnEntry);
-        } else {
-          historyMergedAnomalies = Collections.emptyList();
-        }
-
-        LOG.info("Checking if any known anomalies overlap with the monitoring window of anomaly detection, which could result in unwanted holes in current values.");
-        AnomalyUtils.logAnomaliesOverlapWithWindow(windowStart, windowEnd, historyMergedAnomalies);
-
-        // Scaling time series according to the scaling factor
-        if (CollectionUtils.isNotEmpty(scalingFactors)) {
-          Properties properties = anomalyFunction.getProperties();
-          MetricTransfer.rescaleMetric(metricTimeSeries, windowStart.getMillis(), scalingFactors,
-              metricName, properties);
-        }
-
-        List<RawAnomalyResultDTO> resultsOfAnEntry = anomalyFunction
-            .analyze(exploredDimensions, metricTimeSeries, windowStart, windowEnd, historyMergedAnomalies);
-
-        // Remove detected anomalies that have existed in database
-        if (CollectionUtils.isNotEmpty(resultsOfAnEntry)) {
-          List<RawAnomalyResultDTO> existingRawAnomaliesOfAnEntry =
-              dimensionNamesToKnownRawAnomalies.get(exploredDimensions);
-          resultsOfAnEntry = removeFromExistingRawAnomalies(resultsOfAnEntry, existingRawAnomaliesOfAnEntry);
-        }
-        if (CollectionUtils.isNotEmpty(resultsOfAnEntry)) {
-          List<MergedAnomalyResultDTO> existingMergedAnomalies =
-              retainExistingMergedAnomalies(windowStart.getMillis(), windowEnd.getMillis(), knownMergedAnomaliesOfAnEntry);
-          resultsOfAnEntry = removeFromExistingMergedAnomalies(resultsOfAnEntry, existingMergedAnomalies);
-        }
-
-        // Handle results
-        handleResults(resultsOfAnEntry);
-
-        LOG.info("Dimension {} has {} anomalies in window {} to {}", exploredDimensions, resultsOfAnEntry.size(),
-            windowStart, windowEnd);
-        anomalyCounter += resultsOfAnEntry.size();
-      } catch (Exception e) {
-        LOG.error("Could not compute for {}", exploredDimensions, e);
-      }
     }
+    adContext.setDimensionKeyMetricTimeSeriesMap(dimensionMapMetricTimeSeriesMap);
+
+    // Get existing anomalies for this time range and this function id for all combinations of dimensions
+    List<MergedAnomalyResultDTO> knownMergedAnomalies;
+    if (anomalyFunction.useHistoryAnomaly()) {
+      // if this anomaly function uses history data, then we get all time ranges
+      knownMergedAnomalies = getKnownMergedAnomalies(anomalyFunctionSpec.getId(),
+          anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
+    } else {
+      // otherwise, we only get the merge anomaly for current window in order to remove duplicate raw anomalies
+      List<Pair<Long, Long>> currentTimeRange = new ArrayList<>();
+      currentTimeRange.add(new Pair<>(windowStart.getMillis(), windowEnd.getMillis()));
+      knownMergedAnomalies = getKnownMergedAnomalies(anomalyFunctionSpec.getId(), currentTimeRange);
+    }
+    // Sort the known merged and raw anomalies by their dimension names
+    ArrayListMultimap<DimensionMap, MergedAnomalyResultDTO> dimensionMapToKnownMergedAnomalies = ArrayListMultimap.create();
+    for (MergedAnomalyResultDTO knownMergedAnomaly : knownMergedAnomalies) {
+      dimensionMapToKnownMergedAnomalies.put(knownMergedAnomaly.getDimensions(), knownMergedAnomaly);
+    }
+    adContext.setKnownMergedAnomalies(dimensionMapToKnownMergedAnomalies);
+
+    // We always find existing raw anomalies to prevent duplicate raw anomalies are generated
+    List<RawAnomalyResultDTO> existingRawAnomalies = getExistingRawAnomalies(anomalyFunctionSpec.getId(), windowStart.getMillis(), windowEnd.getMillis());
+    ArrayListMultimap<DimensionMap, RawAnomalyResultDTO> dimensionNamesToKnownRawAnomalies = ArrayListMultimap.create();
+    for (RawAnomalyResultDTO existingRawAnomaly : existingRawAnomalies) {
+      dimensionNamesToKnownRawAnomalies.put(existingRawAnomaly.getDimensions(), existingRawAnomaly);
+    }
+    adContext.setExistingRawAnomalies(dimensionNamesToKnownRawAnomalies);
+
+    List<ScalingFactor> scalingFactors = OverrideConfigHelper
+        .getTimeSeriesScalingFactors(DAO_REGISTRY.getOverrideConfigDAO(), anomalyFunctionSpec.getCollection(),
+            anomalyFunctionSpec.getMetric(), anomalyFunctionSpec.getId(),
+            anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
+    adContext.setScalingFactors(scalingFactors);
+
+    return adContext;
+  }
+
+  private Map<DimensionMap, List<RawAnomalyResultDTO>> dimensionalShuffleAndUnifyAnalyze(DateTime windowStart, DateTime windowEnd,
+      AnomalyDetectionInputContext anomalyDetectionInputContext) {
+    int anomalyCounter = 0;
+    Map<DimensionMap, List<RawAnomalyResultDTO>> resultRawAnomalies = new HashMap<>();
+
+    for (DimensionMap dimensionMap : anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().keySet()) {
+      List<RawAnomalyResultDTO> resultsOfAnEntry = runAnalyze(windowStart, windowEnd, anomalyDetectionInputContext, dimensionMap);
+
+      // TODO: Move to outside of analyze method
+      // Set raw anomalies' properties and store them to DB
+      handleResults(resultsOfAnEntry);
+
+      LOG.info("Dimension {} has {} anomalies in window {} to {}", dimensionMap, resultsOfAnEntry.size(),
+          windowStart, windowEnd);
+      anomalyCounter += resultsOfAnEntry.size();
+      resultRawAnomalies.put(dimensionMap, resultsOfAnEntry);
+    }
+
     LOG.info("{} anomalies found in total", anomalyCounter);
+    return resultRawAnomalies;
+  }
+
+  private List<RawAnomalyResultDTO> runAnalyze(DateTime windowStart, DateTime windowEnd,
+      AnomalyDetectionInputContext anomalyDetectionInputContext, DimensionMap dimensionMap) {
+    String metricName = anomalyFunction.getSpec().getTopicMetric();
+    MetricTimeSeries metricTimeSeries = anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensionMap);
+
+    // Get current entry's knownMergedAnomalies, which should have the same explored dimensions
+    List<MergedAnomalyResultDTO> knownMergedAnomaliesOfAnEntry =
+        anomalyDetectionInputContext.getKnownMergedAnomalies().get(dimensionMap);
+    List<MergedAnomalyResultDTO> historyMergedAnomalies;
+    if (anomalyFunction.useHistoryAnomaly()) {
+      historyMergedAnomalies = retainHistoryMergedAnomalies(windowStart.getMillis(), knownMergedAnomaliesOfAnEntry);
+    } else {
+      historyMergedAnomalies = Collections.emptyList();
+    }
+
+    LOG.info("Analyzing anomaly function with explored dimensions: {}, windowStart: {}, windowEnd: {}",
+        dimensionMap, windowStart, windowEnd);
+
+    AnomalyUtils.logAnomaliesOverlapWithWindow(windowStart, windowEnd, historyMergedAnomalies);
+
+    List<RawAnomalyResultDTO> resultsOfAnEntry = Collections.emptyList();
+    try {
+      // Run algorithm
+      // Scaling time series according to the scaling factor
+      List<ScalingFactor> scalingFactors = anomalyDetectionInputContext.getScalingFactors();
+      if (CollectionUtils.isNotEmpty(scalingFactors)) {
+        Properties properties = anomalyFunction.getProperties();
+        MetricTransfer.rescaleMetric(metricTimeSeries, windowStart.getMillis(), scalingFactors,
+            metricName, properties);
+      }
+
+      resultsOfAnEntry = anomalyFunction
+          .analyze(dimensionMap, metricTimeSeries, windowStart, windowEnd, historyMergedAnomalies);
+    } catch (Exception e) {
+      LOG.error("Could not compute for {}", dimensionMap, e);
+    }
+
+    // Remove detected anomalies that have existed in database
+    if (CollectionUtils.isNotEmpty(resultsOfAnEntry)) {
+      List<RawAnomalyResultDTO> existingRawAnomaliesOfAnEntry =
+          anomalyDetectionInputContext.getExistingRawAnomalies().get(dimensionMap);
+      resultsOfAnEntry = removeFromExistingRawAnomalies(resultsOfAnEntry, existingRawAnomaliesOfAnEntry);
+    }
+    if (CollectionUtils.isNotEmpty(resultsOfAnEntry)) {
+      List<MergedAnomalyResultDTO> existingMergedAnomalies =
+          retainExistingMergedAnomalies(windowStart.getMillis(), windowEnd.getMillis(), knownMergedAnomaliesOfAnEntry);
+      resultsOfAnEntry = removeFromExistingMergedAnomalies(resultsOfAnEntry, existingMergedAnomalies);
+    }
+
+    return resultsOfAnEntry;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -25,125 +25,42 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.CollectionUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+public class TimeBasedAnomalyMerger {
+  private final static Logger LOG = LoggerFactory.getLogger(TimeBasedAnomalyMerger.class);
 
-/**
- * finds raw anomalies grouped by a strategy and merges them with an existing (in the same group) or
- * new {@link com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO}
- */
-public class AnomalyMergeExecutor implements Runnable {
   private final MergedAnomalyResultManager mergedResultDAO;
   private final RawAnomalyResultManager anomalyResultDAO;
-  private final AnomalyFunctionManager anomalyFunctionDAO;
   private final OverrideConfigManager overrideConfigDAO;
-  private final ScheduledExecutorService executorService;
   private final AnomalyFunctionFactory anomalyFunctionFactory;
 
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
-  private final static Logger LOG = LoggerFactory.getLogger(AnomalyMergeExecutor.class);
-
-  private final static AnomalyMergeConfig DEFAULT_MERGE_CONFIG;
+  private final static AnomalyMergeConfig DEFAULT_TIME_BASED_MERGE_CONFIG;
   static {
-    DEFAULT_MERGE_CONFIG = new AnomalyMergeConfig();
-    DEFAULT_MERGE_CONFIG.setSequentialAllowedGap(TimeUnit.HOURS.toMillis(2)); // merge anomalies apart 2 hours
-    DEFAULT_MERGE_CONFIG.setMaxMergeDurationLength(TimeUnit.DAYS.toMillis(7) - 3600_000); // break anomaly longer than 6 days 23 hours
-    DEFAULT_MERGE_CONFIG.setMergeStrategy(AnomalyMergeStrategy.FUNCTION_DIMENSIONS);
+    DEFAULT_TIME_BASED_MERGE_CONFIG = new AnomalyMergeConfig();
+    DEFAULT_TIME_BASED_MERGE_CONFIG.setSequentialAllowedGap(TimeUnit.HOURS.toMillis(2)); // merge anomalies apart 2 hours
+    DEFAULT_TIME_BASED_MERGE_CONFIG.setMaxMergeDurationLength(TimeUnit.DAYS.toMillis(7) - 3600_000); // break anomaly longer than 6 days 23 hours
+    DEFAULT_TIME_BASED_MERGE_CONFIG.setMergeStrategy(AnomalyMergeStrategy.FUNCTION_DIMENSIONS);
   }
 
-  private final static AnomalyMergeConfig DEFAULT_SYNCHRONIZED_MERGE_CONFIG;
-  static {
-    DEFAULT_SYNCHRONIZED_MERGE_CONFIG = new AnomalyMergeConfig();
-    DEFAULT_SYNCHRONIZED_MERGE_CONFIG.setSequentialAllowedGap(DEFAULT_MERGE_CONFIG.getSequentialAllowedGap());
-    DEFAULT_SYNCHRONIZED_MERGE_CONFIG.setMaxMergeDurationLength(DEFAULT_MERGE_CONFIG.getMaxMergeDurationLength());
-    // Synchronized merge always use FUNCTION_DIMENSIONS merge strategy
-    DEFAULT_SYNCHRONIZED_MERGE_CONFIG.setMergeStrategy(AnomalyMergeStrategy.FUNCTION_DIMENSIONS);
-  }
-
-  public AnomalyMergeExecutor(ScheduledExecutorService executorService, AnomalyFunctionFactory anomalyFunctionFactory) {
+  public TimeBasedAnomalyMerger(AnomalyFunctionFactory anomalyFunctionFactory) {
     this.mergedResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
     this.anomalyResultDAO = DAO_REGISTRY.getRawAnomalyResultDAO();
-    this.anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
     this.overrideConfigDAO = DAO_REGISTRY.getOverrideConfigDAO();
-    this.executorService = executorService;
     this.anomalyFunctionFactory = anomalyFunctionFactory;
   }
 
-  public void start() {
-    // running every 15 mins
-    executorService.scheduleWithFixedDelay(this, 0, 15, TimeUnit.MINUTES);
-  }
-
-  public void stop() {
-    executorService.shutdown();
-  }
-
   /**
-   * Performs asynchronous merge base on function id and dimensions.
-   */
-  public void run() {
-    ExecutorService taskExecutorService = Executors.newFixedThreadPool(5);
-    List<Future<Integer>> taskCallbacks = new ArrayList<>();
-    List<AnomalyFunctionDTO> activeFunctions = anomalyFunctionDAO.findAllActiveFunctions();
-
-    // for each anomaly function, find raw unmerged results and perform merge
-    for (AnomalyFunctionDTO function : activeFunctions) {
-      Callable<Integer> task = () -> {
-        final boolean isBackfill = false;
-        // TODO : move merge config within the AnomalyFunction; Every function should have its own merge config.
-        AnomalyMergeConfig anomalyMergeConfig = function.getAnomalyMergeConfig();
-        if (anomalyMergeConfig == null) {
-          anomalyMergeConfig = DEFAULT_MERGE_CONFIG;
-        }
-        return mergeAnomalies(function, anomalyMergeConfig, isBackfill);
-      };
-      Future<Integer> taskFuture = taskExecutorService.submit(task);
-      taskCallbacks.add(taskFuture);
-    }
-
-    // wait till all the tasks complete
-    try {
-      for (Future<Integer> future : taskCallbacks) {
-        future.get();
-      }
-    } catch (Exception e) {
-      LOG.error("Error in merge execution", e);
-    }
-  }
-
-  /**
-   * Performs a time based merge, which merged anomalies that have the same function id and dimensions.
+   * Performs a time based merge, which merged anomalies that have the same function id and dimensions, etc.
    * This method is supposed to be performed by anomaly detectors right after their anomaly detection.
    *
-   * @param functionSpec the spec of the function that detects anomalies
-   * @param isBackfill set to true to disable the alert of the merged anomalies
-   *
-   * @return the number of merged anomalies after merging
-   */
-  public int synchronousMergeBasedOnFunctionIdAndDimension(AnomalyFunctionDTO functionSpec, boolean isBackfill) {
-    if (functionSpec.getIsActive()) {
-      AnomalyMergeConfig anomalyMergeConfig = functionSpec.getAnomalyMergeConfig();
-      if (anomalyMergeConfig == null) {
-        anomalyMergeConfig = DEFAULT_SYNCHRONIZED_MERGE_CONFIG;
-      }
-      return mergeAnomalies(functionSpec, anomalyMergeConfig, isBackfill);
-    } else {
-      return 0;
-    }
-  }
-
-  /**
-   * Merges raw anomalies according to the given merge configuration. The merge logic works as following:
+   * Time based merge logic works as following:
    *
    * Step 1: for the given function, find all groups of raw (unprocessed) anomalies based on
    *         merge strategy (FunctionId and/or dimensions)
@@ -156,37 +73,80 @@ public class AnomalyMergeExecutor implements Runnable {
    *
    * Step 5: persist merged anomalies
    *
-   * @param functionSpc the spec of the function that has unmerged anomalies
-   * @param mergeConfig the merge strategy
+   * @param functionSpec the spec of the function that detects anomalies
+   * @param isBackfill set to true to disable the alert of the merged anomalies
    *
-   * @return the number of merged anomalies
+   * @return the number of merged anomalies after merging
    */
-  private int mergeAnomalies(AnomalyFunctionDTO functionSpc, AnomalyMergeConfig mergeConfig, boolean isBackfill) {
-    List<RawAnomalyResultDTO> unmergedResults = anomalyResultDAO.findUnmergedByFunctionId(functionSpc.getId());
-
-    LOG.info("Running merge for function id : [{}], found [{}] raw anomalies", functionSpc.getId(), unmergedResults.size());
-
-    if (unmergedResults.size() > 0) {
-      List<MergedAnomalyResultDTO> output = new ArrayList<>();
-      switch (mergeConfig.getMergeStrategy()) {
-        case FUNCTION:
-          performMergeBasedOnFunctionId(functionSpc, mergeConfig, unmergedResults, output);
-          break;
-        case FUNCTION_DIMENSIONS:
-          performMergeBasedOnFunctionIdAndDimensions(functionSpc, mergeConfig, unmergedResults, output);
-          break;
-        default:
-          throw new IllegalArgumentException("Merge strategy " + mergeConfig.getMergeStrategy() + " not supported");
+  public List<MergedAnomalyResultDTO> mergeAnomalies(AnomalyFunctionDTO functionSpec, boolean isBackfill) {
+      AnomalyMergeConfig mergeConfig = functionSpec.getAnomalyMergeConfig();
+      if (mergeConfig == null) {
+        mergeConfig = DEFAULT_TIME_BASED_MERGE_CONFIG;
       }
-      for (MergedAnomalyResultDTO mergedAnomalyResultDTO : output) {
+
+    List<RawAnomalyResultDTO> unmergedAnomalies = anomalyResultDAO.findUnmergedByFunctionId(functionSpec.getId());
+
+    LOG.info("Running merge for function id : [{}], found [{}] raw anomalies", functionSpec.getId(), unmergedAnomalies.size());
+
+    if (unmergedAnomalies.size() == 0) {
+      return Collections.emptyList();
+    } else {
+      List<MergedAnomalyResultDTO> mergedAnomalies = new ArrayList<>();
+
+      timeBasedMerge(functionSpec, mergeConfig, unmergedAnomalies, mergedAnomalies);
+
+      // Update information of merged anomalies
+      for (MergedAnomalyResultDTO mergedAnomalyResultDTO : mergedAnomalies) {
         if (isBackfill) {
           mergedAnomalyResultDTO.setNotified(isBackfill);
         } // else notified flag is left as is
         updateMergedScoreAndPersist(mergedAnomalyResultDTO, mergeConfig);
       }
-      return output.size();
-    } else {
-      return 0;
+
+      return mergedAnomalies;
+    }
+  }
+
+  private void timeBasedMerge(AnomalyFunctionDTO function,
+      AnomalyMergeConfig mergeConfig, List<RawAnomalyResultDTO> unmergedResults,
+      List<MergedAnomalyResultDTO> output) {
+    Map<DimensionMap, List<RawAnomalyResultDTO>> dimensionsResultMap = new HashMap<>();
+    for (RawAnomalyResultDTO anomalyResult : unmergedResults) {
+      DimensionMap exploredDimensions = anomalyResult.getDimensions();
+      if (!dimensionsResultMap.containsKey(exploredDimensions)) {
+        dimensionsResultMap.put(exploredDimensions, new ArrayList<>());
+      }
+      dimensionsResultMap.get(exploredDimensions).add(anomalyResult);
+    }
+    for (DimensionMap exploredDimensions : dimensionsResultMap.keySet()) {
+      List<RawAnomalyResultDTO> unmergedResultsByDimensions = dimensionsResultMap.get(exploredDimensions);
+      long anomalyWindowStart = Long.MAX_VALUE;
+      long anomalyWindowEnd = Long.MIN_VALUE;
+      for (RawAnomalyResultDTO unmergedResultsByDimension : unmergedResultsByDimensions) {
+        anomalyWindowStart = Math.min(anomalyWindowStart, unmergedResultsByDimension.getStartTime());
+        anomalyWindowEnd = Math.max(anomalyWindowEnd, unmergedResultsByDimension.getEndTime());
+      }
+
+      // NOTE: We get "latest overlapped (Conflict)" merged anomaly instead of "latest" merged anomaly in order to
+      // prevent the merge results of current (online) detection interfere the merge results of back-fill (offline)
+      // detection.
+      // Moreover, the window start is modified by mergeConfig.getSequentialAllowedGap() in order to allow a gap between
+      // anomalies to be merged.
+      MergedAnomalyResultDTO latestOverlappedMergedResult =
+          mergedResultDAO.findLatestConflictByFunctionIdDimensions(function.getId(), exploredDimensions.toString(),
+              anomalyWindowStart - mergeConfig.getSequentialAllowedGap(), anomalyWindowEnd);
+
+      List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
+          .mergeAnomalies(latestOverlappedMergedResult, unmergedResultsByDimensions,
+              mergeConfig.getMaxMergeDurationLength(), mergeConfig.getSequentialAllowedGap());
+      for (MergedAnomalyResultDTO mergedResult : mergedResults) {
+        mergedResult.setFunction(function);
+        mergedResult.setDimensions(exploredDimensions);
+      }
+      LOG.info(
+          "Merging [{}] raw anomalies into [{}] merged anomalies for function id : [{}] and dimensions : [{}]",
+          unmergedResultsByDimensions.size(), mergedResults.size(), function.getId(), exploredDimensions);
+      output.addAll(mergedResults);
     }
   }
 
@@ -266,15 +226,15 @@ public class AnomalyMergeExecutor implements Runnable {
       // Retrieve history merged anomalies
       if (anomalyFunction.useHistoryAnomaly()) {
         switch (mergeConfig.getMergeStrategy()) {
-          case FUNCTION:
-            knownAnomalies = getHistoryMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
-            break;
-          case FUNCTION_DIMENSIONS:
-            knownAnomalies = getHistoryMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis(),
-                anomalyMergedResult.getDimensions());
-            break;
-          default:
-            throw new IllegalArgumentException("Merge strategy " + mergeConfig.getMergeStrategy() + " not supported");
+        case FUNCTION:
+          knownAnomalies = getHistoryMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
+          break;
+        case FUNCTION_DIMENSIONS:
+          knownAnomalies = getHistoryMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis(),
+              anomalyMergedResult.getDimensions());
+          break;
+        default:
+          throw new IllegalArgumentException("Merge strategy " + mergeConfig.getMergeStrategy() + " not supported");
         }
 
         if (knownAnomalies.size() > 0) {
@@ -373,72 +333,5 @@ public class AnomalyMergeExecutor implements Runnable {
     }
 
     return results;
-  }
-
-  @Deprecated
-  private void performMergeBasedOnFunctionId(AnomalyFunctionDTO function,
-      AnomalyMergeConfig mergeConfig, List<RawAnomalyResultDTO> unmergedResults,
-      List<MergedAnomalyResultDTO> output) {
-    // Now find last MergedAnomalyResult in same category
-    MergedAnomalyResultDTO latestMergedResult =
-        mergedResultDAO.findLatestByFunctionIdOnly(function.getId());
-    // TODO : get mergeConfig from function
-    List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
-        .mergeAnomalies(latestMergedResult, unmergedResults, mergeConfig.getMaxMergeDurationLength(),
-            mergeConfig.getSequentialAllowedGap());
-    for (MergedAnomalyResultDTO mergedResult : mergedResults) {
-      mergedResult.setFunction(function);
-    }
-    LOG.info("Merging [{}] raw anomalies into [{}] merged anomalies for function id : [{}]",
-        unmergedResults.size(), mergedResults.size(), function.getId());
-    output.addAll(mergedResults);
-  }
-
-  private void performMergeBasedOnFunctionIdAndDimensions(AnomalyFunctionDTO function,
-      AnomalyMergeConfig mergeConfig, List<RawAnomalyResultDTO> unmergedResults,
-      List<MergedAnomalyResultDTO> output) {
-    Map<DimensionMap, List<RawAnomalyResultDTO>> dimensionsResultMap = new HashMap<>();
-    for (RawAnomalyResultDTO anomalyResult : unmergedResults) {
-      DimensionMap exploredDimensions = anomalyResult.getDimensions();
-      if (!dimensionsResultMap.containsKey(exploredDimensions)) {
-        dimensionsResultMap.put(exploredDimensions, new ArrayList<>());
-      }
-      dimensionsResultMap.get(exploredDimensions).add(anomalyResult);
-    }
-    for (DimensionMap exploredDimensions : dimensionsResultMap.keySet()) {
-      List<RawAnomalyResultDTO> unmergedResultsByDimensions = dimensionsResultMap.get(exploredDimensions);
-      long anomalyWindowStart = Long.MAX_VALUE;
-      long anomalyWindowEnd = Long.MIN_VALUE;
-      for (RawAnomalyResultDTO unmergedResultsByDimension : unmergedResultsByDimensions) {
-        anomalyWindowStart = Math.min(anomalyWindowStart, unmergedResultsByDimension.getStartTime());
-        anomalyWindowEnd = Math.max(anomalyWindowEnd, unmergedResultsByDimension.getEndTime());
-      }
-
-      // NOTE: We get "latest overlapped (Conflict)" merged anomaly instead of "latest" merged anomaly in order to
-      // prevent the merge results of current (online) detection interfere the merge results of back-fill (offline)
-      // detection.
-      // Moreover, the window start is modified by mergeConfig.getSequentialAllowedGap() in order to allow a gap between
-      // anomalies to be merged.
-      MergedAnomalyResultDTO latestOverlappedMergedResult =
-          mergedResultDAO.findLatestConflictByFunctionIdDimensions(function.getId(), exploredDimensions.toString(),
-              anomalyWindowStart - mergeConfig.getSequentialAllowedGap(), anomalyWindowEnd);
-
-      List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
-          .mergeAnomalies(latestOverlappedMergedResult, unmergedResultsByDimensions,
-              mergeConfig.getMaxMergeDurationLength(), mergeConfig.getSequentialAllowedGap());
-      for (MergedAnomalyResultDTO mergedResult : mergedResults) {
-        mergedResult.setFunction(function);
-        mergedResult.setDimensions(exploredDimensions);
-      }
-      LOG.info(
-          "Merging [{}] raw anomalies into [{}] merged anomalies for function id : [{}] and dimensions : [{}]",
-          unmergedResultsByDimensions.size(), mergedResults.size(), function.getId(), exploredDimensions);
-      output.addAll(mergedResults);
-    }
-  }
-
-  private String createMessage(double severity, Double currentVal, Double baseLineVal) {
-    return String.format("change : %.2f %%, currentVal : %.2f, baseLineVal : %.2f", severity * 100,
-        currentVal, baseLineVal);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -12,7 +12,6 @@ import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.client.DAORegistry;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
-import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
@@ -187,15 +186,6 @@ public class TimeBasedAnomalyMerger {
             function.getCollection(), function.getTopicMetric(), function.getFunctionName(), new DateTime(mergedResult.getStartTime()), new DateTime(mergedResult.getEndTime()), e);
       }
     }
-//    try {
-//      // persist the merged result
-//      mergedResultDAO.update(mergedResult);
-//      for (RawAnomalyResultDTO rawAnomalyResultDTO : mergedResult.getAnomalyResults()) {
-//        anomalyResultDAO.update(rawAnomalyResultDTO);
-//      }
-//    } catch (Exception e) {
-//      LOG.error("Could not persist merged result : [" + mergedResult.toString() + "]", e);
-//    }
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -2,9 +2,7 @@ package com.linkedin.thirdeye.anomaly.merge;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.MultimapBuilder;
 import com.linkedin.pinot.pql.parsers.utils.Pair;
-import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionOutputContext;
 import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
 import com.linkedin.thirdeye.anomaly.override.OverrideConfigHelper;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
@@ -24,9 +22,7 @@ import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
 import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.CollectionUtils;
@@ -38,7 +34,6 @@ public class TimeBasedAnomalyMerger {
   private final static Logger LOG = LoggerFactory.getLogger(TimeBasedAnomalyMerger.class);
 
   private final MergedAnomalyResultManager mergedResultDAO;
-  private final RawAnomalyResultManager anomalyResultDAO;
   private final OverrideConfigManager overrideConfigDAO;
   private final AnomalyFunctionFactory anomalyFunctionFactory;
 
@@ -54,7 +49,6 @@ public class TimeBasedAnomalyMerger {
 
   public TimeBasedAnomalyMerger(AnomalyFunctionFactory anomalyFunctionFactory) {
     this.mergedResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
-    this.anomalyResultDAO = DAO_REGISTRY.getRawAnomalyResultDAO();
     this.overrideConfigDAO = DAO_REGISTRY.getOverrideConfigDAO();
     this.anomalyFunctionFactory = anomalyFunctionFactory;
   }
@@ -98,27 +92,28 @@ public class TimeBasedAnomalyMerger {
     if (unmergedAnomalies.size() == 0) {
       return ArrayListMultimap.create();
     } else {
-      ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies = timeBasedMerge(functionSpec, mergeConfig, unmergedAnomalies);
+      ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies =
+          dimensionalShuffleAndUnifyMerge(functionSpec, mergeConfig, unmergedAnomalies);
 
       // Update information of merged anomalies
       for (MergedAnomalyResultDTO mergedAnomalyResultDTO : mergedAnomalies.values()) {
         if (isBackfill) {
           mergedAnomalyResultDTO.setNotified(isBackfill);
         } // else notified flag is left as is
-        updateMergedScoreAndPersist(mergedAnomalyResultDTO, mergeConfig);
+        updateMergedAnomalyInfo(mergedAnomalyResultDTO, mergeConfig);
       }
 
       return mergedAnomalies;
     }
   }
 
-  private ListMultimap<DimensionMap, MergedAnomalyResultDTO> timeBasedMerge(AnomalyFunctionDTO function,
+  private ListMultimap<DimensionMap, MergedAnomalyResultDTO> dimensionalShuffleAndUnifyMerge(AnomalyFunctionDTO function,
       AnomalyMergeConfig mergeConfig, ListMultimap<DimensionMap, RawAnomalyResultDTO> dimensionsResultMap) {
 
     ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies = ArrayListMultimap.create();
 
-    for (DimensionMap exploredDimensions : dimensionsResultMap.keySet()) {
-      List<RawAnomalyResultDTO> unmergedResultsByDimensions = dimensionsResultMap.get(exploredDimensions);
+    for (DimensionMap dimensionMap : dimensionsResultMap.keySet()) {
+      List<RawAnomalyResultDTO> unmergedResultsByDimensions = dimensionsResultMap.get(dimensionMap);
       long anomalyWindowStart = Long.MAX_VALUE;
       long anomalyWindowEnd = Long.MIN_VALUE;
       for (RawAnomalyResultDTO unmergedResultsByDimension : unmergedResultsByDimensions) {
@@ -132,7 +127,7 @@ public class TimeBasedAnomalyMerger {
       // Moreover, the window start is modified by mergeConfig.getSequentialAllowedGap() in order to allow a gap between
       // anomalies to be merged.
       MergedAnomalyResultDTO latestOverlappedMergedResult =
-          mergedResultDAO.findLatestConflictByFunctionIdDimensions(function.getId(), exploredDimensions.toString(),
+          mergedResultDAO.findLatestConflictByFunctionIdDimensions(function.getId(), dimensionMap.toString(),
               anomalyWindowStart - mergeConfig.getSequentialAllowedGap(), anomalyWindowEnd);
 
       List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
@@ -140,44 +135,51 @@ public class TimeBasedAnomalyMerger {
               mergeConfig.getMaxMergeDurationLength(), mergeConfig.getSequentialAllowedGap());
       for (MergedAnomalyResultDTO mergedResult : mergedResults) {
         mergedResult.setFunction(function);
-        mergedResult.setDimensions(exploredDimensions);
+        mergedResult.setDimensions(dimensionMap);
       }
       LOG.info(
           "Merging [{}] raw anomalies into [{}] merged anomalies for function id : [{}] and dimensions : [{}]",
-          unmergedResultsByDimensions.size(), mergedResults.size(), function.getId(), exploredDimensions);
-      mergedAnomalies.putAll(exploredDimensions, mergedResults);
+          unmergedResultsByDimensions.size(), mergedResults.size(), function.getId(), dimensionMap);
+      mergedAnomalies.putAll(dimensionMap, mergedResults);
     }
 
     return mergedAnomalies;
   }
 
-  private void updateMergedScoreAndPersist(MergedAnomalyResultDTO mergedResult, AnomalyMergeConfig mergeConfig) {
+  private void updateMergedAnomalyInfo(MergedAnomalyResultDTO mergedResult, AnomalyMergeConfig mergeConfig) {
     // Calculate default score and weight in case of the failure during updating score and weight through Pinot's value
     double weightedScoreSum = 0.0;
     double weightedWeightSum = 0.0;
     double totalBucketSize = 0.0;
+    double avgCurrent = 0.0;
+    double avgBaseline = 0.0;
 
     double normalizationFactor = 1000; // to prevent from double overflow
+    List<RawAnomalyResultDTO> rawAnomalies = mergedResult.getAnomalyResults();
     String anomalyMessage = "";
-    for (RawAnomalyResultDTO anomalyResult : mergedResult.getAnomalyResults()) {
+    for (RawAnomalyResultDTO anomalyResult : rawAnomalies) {
       anomalyResult.setMerged(true);
       double bucketSizeSeconds = (anomalyResult.getEndTime() - anomalyResult.getStartTime()) / 1000;
       weightedScoreSum += (anomalyResult.getScore() / normalizationFactor) * bucketSizeSeconds;
       weightedWeightSum += (anomalyResult.getWeight() / normalizationFactor) * bucketSizeSeconds;
       totalBucketSize += bucketSizeSeconds;
+      avgCurrent += anomalyResult.getAvgCurrentVal();
+      avgBaseline += anomalyResult.getAvgBaselineVal();
       anomalyMessage = anomalyResult.getMessage();
     }
     if (totalBucketSize != 0) {
       mergedResult.setScore((weightedScoreSum / totalBucketSize) * normalizationFactor);
       mergedResult.setWeight((weightedWeightSum / totalBucketSize) * normalizationFactor);
+      mergedResult.setAvgCurrentVal(avgCurrent / rawAnomalies.size());
+      mergedResult.setAvgBaselineVal(avgBaseline / rawAnomalies.size());
     }
 
     mergedResult.setMessage(anomalyMessage);
 
-    if (mergedResult.getAnomalyResults().size() > 1) {
+    if (rawAnomalies.size() > 1) {
       // recompute weight using anomaly function specific method
       try {
-        updateMergedAnomalyWeight(mergedResult, mergeConfig);
+        computeMergedAnomalyInfo(mergedResult, mergeConfig);
       } catch (Exception e) {
         AnomalyFunctionDTO function = mergedResult.getFunction();
         LOG.warn(
@@ -185,62 +187,52 @@ public class TimeBasedAnomalyMerger {
             function.getCollection(), function.getTopicMetric(), function.getFunctionName(), new DateTime(mergedResult.getStartTime()), new DateTime(mergedResult.getEndTime()), e);
       }
     }
-    try {
-      // persist the merged result
-      mergedResultDAO.update(mergedResult);
-      for (RawAnomalyResultDTO rawAnomalyResultDTO : mergedResult.getAnomalyResults()) {
-        anomalyResultDAO.update(rawAnomalyResultDTO);
-      }
-    } catch (Exception e) {
-      LOG.error("Could not persist merged result : [" + mergedResult.toString() + "]", e);
-    }
+//    try {
+//      // persist the merged result
+//      mergedResultDAO.update(mergedResult);
+//      for (RawAnomalyResultDTO rawAnomalyResultDTO : mergedResult.getAnomalyResults()) {
+//        anomalyResultDAO.update(rawAnomalyResultDTO);
+//      }
+//    } catch (Exception e) {
+//      LOG.error("Could not persist merged result : [" + mergedResult.toString() + "]", e);
+//    }
   }
 
   /**
    * Uses function-specific method to re-computes the weight of merged anomaly.
    *
-   * @param anomalyMergedResult the merged anomaly to be updated
+   * @param mergedAnomalies the merged anomaly to be updated
    * @param mergeConfig the merge configuration that was applied when merge the merged anomaly
    * @throws Exception if error occurs when retrieving the time series for calculating the weight
    */
-  private void updateMergedAnomalyWeight(MergedAnomalyResultDTO anomalyMergedResult, AnomalyMergeConfig mergeConfig)
+  private void computeMergedAnomalyInfo(MergedAnomalyResultDTO mergedAnomalies, AnomalyMergeConfig mergeConfig)
       throws Exception {
-    AnomalyFunctionDTO anomalyFunctionSpec = anomalyMergedResult.getFunction();
+    AnomalyFunctionDTO anomalyFunctionSpec = mergedAnomalies.getFunction();
     BaseAnomalyFunction anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
 
     List<Pair<Long, Long>> startEndTimeRanges =
-        anomalyFunction.getDataRangeIntervals(anomalyMergedResult.getStartTime(), anomalyMergedResult.getEndTime());
+        anomalyFunction.getDataRangeIntervals(mergedAnomalies.getStartTime(), mergedAnomalies.getEndTime());
 
     TimeGranularity timeGranularity = new TimeGranularity(anomalyFunctionSpec.getBucketSize(),
         anomalyFunctionSpec.getBucketUnit());
 
     MetricTimeSeries metricTimeSeries =
         TimeSeriesUtil.getTimeSeriesByDimension(anomalyFunctionSpec, startEndTimeRanges,
-            anomalyMergedResult.getDimensions(), timeGranularity);
+            mergedAnomalies.getDimensions(), timeGranularity);
 
     if (metricTimeSeries != null) {
-      DateTime windowStart = new DateTime(anomalyMergedResult.getStartTime());
-      DateTime windowEnd = new DateTime(anomalyMergedResult.getEndTime());
+      DateTime windowStart = new DateTime(mergedAnomalies.getStartTime());
+      DateTime windowEnd = new DateTime(mergedAnomalies.getEndTime());
 
       List<MergedAnomalyResultDTO> knownAnomalies = Collections.emptyList();
 
       // Retrieve history merged anomalies
       if (anomalyFunction.useHistoryAnomaly()) {
-        switch (mergeConfig.getMergeStrategy()) {
-        case FUNCTION:
-          knownAnomalies = getHistoryMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis());
-          break;
-        case FUNCTION_DIMENSIONS:
-          knownAnomalies = getHistoryMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis(),
-              anomalyMergedResult.getDimensions());
-          break;
-        default:
-          throw new IllegalArgumentException("Merge strategy " + mergeConfig.getMergeStrategy() + " not supported");
-        }
+        knownAnomalies = getHistoryMergedAnomalies(anomalyFunction, windowStart.getMillis(), windowEnd.getMillis(),
+            mergedAnomalies.getDimensions());
 
         if (knownAnomalies.size() > 0) {
           LOG.info("Found {} history anomalies for computing the weight of current merged anomaly.", knownAnomalies.size());
-          LOG.info("Checking if any known anomalies overlap with the monitoring window of anomaly detection, which could result in unwanted holes in current values.");
           AnomalyUtils.logAnomaliesOverlapWithWindow(windowStart, windowEnd, knownAnomalies);
         }
       }
@@ -248,54 +240,16 @@ public class TimeBasedAnomalyMerger {
       // Transform Time Series
       List<ScalingFactor> scalingFactors = OverrideConfigHelper
           .getTimeSeriesScalingFactors(overrideConfigDAO, anomalyFunctionSpec.getCollection(),
-              anomalyFunctionSpec.getTopicMetric(), anomalyFunctionSpec.getId(), anomalyFunction
-                  .getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
+              anomalyFunctionSpec.getTopicMetric(), anomalyFunctionSpec.getId(),
+              anomalyFunction.getDataRangeIntervals(windowStart.getMillis(), windowEnd.getMillis()));
       if (CollectionUtils.isNotEmpty(scalingFactors)) {
         Properties properties = anomalyFunction.getProperties();
         MetricTransfer.rescaleMetric(metricTimeSeries, windowStart.getMillis(), scalingFactors,
             anomalyFunctionSpec.getTopicMetric(), properties);
       }
 
-      anomalyFunction.updateMergedAnomalyInfo(anomalyMergedResult, metricTimeSeries, windowStart, windowEnd,
-          knownAnomalies);
+      anomalyFunction.updateMergedAnomalyInfo(mergedAnomalies, metricTimeSeries, windowStart, windowEnd, knownAnomalies);
     }
-  }
-
-  /**
-   * Returns history merged anomalies of the function id that are needed for computing the weight of the new merged
-   * anomalies; history anomalies are anomalies that occurs before the window of current merged anomaly.
-   *
-   * @param anomalyFunction the anomaly function that detects the merged anomaly
-   * @param anomalyWindowStart the start of the merged anomaly
-   * @param anomalyWindowEnd the end of the merged anomaly
-   *
-   * @return history merged anomalies of the function id that are needed for computing the weight of the new merged
-   * anomalies
-   */
-  private List<MergedAnomalyResultDTO> getHistoryMergedAnomalies(BaseAnomalyFunction anomalyFunction,
-      long anomalyWindowStart, long anomalyWindowEnd) {
-
-    List<Pair<Long, Long>> startEndTimeRanges =
-        anomalyFunction.getDataRangeIntervals(anomalyWindowStart, anomalyWindowEnd);
-
-    List<MergedAnomalyResultDTO> results = new ArrayList<>();
-    for (Pair<Long, Long> startEndTimeRange : startEndTimeRanges) {
-      // we don't need the known anomalies on current window; we only need those on history data
-      if (anomalyWindowStart <= startEndTimeRange.getFirst()
-          && startEndTimeRange.getSecond() <= anomalyWindowEnd) {
-        continue;
-      }
-      try {
-        results.addAll(
-            mergedResultDAO.findAllConflictByFunctionId(anomalyFunction.getSpec().getId(), startEndTimeRange.getFirst(),
-                startEndTimeRange.getSecond()));
-      } catch (Exception e) {
-        LOG.error("Unable to get history merged anomalies for function {} in the anomaly window {} -- {}: {}",
-            anomalyFunction.getSpec().getId(), anomalyWindowStart, anomalyWindowEnd, e);
-      }
-    }
-
-    return results;
   }
 
   /**
@@ -319,13 +273,12 @@ public class TimeBasedAnomalyMerger {
     List<MergedAnomalyResultDTO> results = new ArrayList<>();
     for (Pair<Long, Long> startEndTimeRange : startEndTimeRanges) {
       // we don't need the known anomalies on current window; we only need those on history data
-      if (anomalyWindowStart <= startEndTimeRange.getFirst()
-          && startEndTimeRange.getSecond() <= anomalyWindowEnd) {
+      if (anomalyWindowStart <= startEndTimeRange.getFirst() && startEndTimeRange.getSecond() <= anomalyWindowEnd) {
         continue;
       }
       try {
-        results.addAll(
-            mergedResultDAO.findAllConflictByFunctionIdDimensions(anomalyFunction.getSpec().getId(), startEndTimeRange.getFirst(),
+        results.addAll(mergedResultDAO
+            .findAllConflictByFunctionIdDimensions(anomalyFunction.getSpec().getId(), startEndTimeRange.getFirst(),
                 startEndTimeRange.getSecond(), dimensions.toString()));
       } catch (Exception e) {
         LOG.error("Unable to get history merged anomalies for function {} on dimensions {} in the anomaly window {} -- {}: {}",


### PR DESCRIPTION
1. Move the anomalies' time based merge logic to TimeBasedAnomalyMerger.java. The merger will be shut down and change to a grouper in the next PR.

2. Refactor anomaly detection flow: 
    2-a. Move all data fetching/persistence to the begin/end of anomaly detection task.
    2-b. Anomaly detection method, analyze, and update merged anomaly method now only return raw anomalies and updated merged anomalies without storing them to DB.

Tested by comparing the anomalies results from pre-refactored code and this refactored code: Two sets of anomalies are exactly matched.