### PR TITLE
[PINOT-4603] Extended the protocol with the lease message

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -93,6 +93,7 @@ public class SegmentCompletionProtocol {
 
   public static final String STATUS_KEY = "status";
   public static final String OFFSET_KEY = "offset";
+  public static final String BUILD_TIME_KEY = "buildTimeSec";  // Sent by controller in COMMIT message
 
   public static final String MSG_TYPE_CONSUMED = "segmentConsumed";
   public static final String MSG_TYPE_COMMMIT = "segmentCommit";
@@ -102,21 +103,28 @@ public class SegmentCompletionProtocol {
   public static final String PARAM_OFFSET = "offset";
   public static final String PARAM_INSTANCE_ID = "instance";
   public static final String PARAM_REASON = "reason";
+  public static final String PARAM_EXT_TIME_SEC = "extTimeSec"; // Sent by servers to request additional time to build
+  public static final String PARAM_NUM_ROWS = "nRows"; // Sent by servers to indicate the number of rows read so far
+  public static final String PARAM_BUILD_TIME_MS = "buildTimeMs"; // Time taken to build segment
+  public static final String PARAM_WAIT_TIME_MS = "waitTimeMs";   // Time taken to wait for build to start.
+
+  public static final String REASON_REACHED_MAX_ROWS = "maxRows";  // Stop reason sent by server as max num rows reached
+  public static final String REASON_REACHED_MAX_TIME = "maxTime";  // Stop reason sent by server as max time reached
 
   // Canned responses
-  public static final Response RESP_NOT_LEADER = new Response(new Response.Params().setStatus(
+  public static final Response RESP_NOT_LEADER = new Response(new Response.Params().withStatus(
       ControllerResponseStatus.NOT_LEADER));
-  public static final Response RESP_FAILED = new Response(new Response.Params().setStatus(
+  public static final Response RESP_FAILED = new Response(new Response.Params().withStatus(
       ControllerResponseStatus.FAILED));
-  public static final Response RESP_DISCARD = new Response(new Response.Params().setStatus(
+  public static final Response RESP_DISCARD = new Response(new Response.Params().withStatus(
       ControllerResponseStatus.DISCARD));
-  public static final Response RESP_COMMIT_SUCCESS = new Response(new Response.Params().setStatus(
+  public static final Response RESP_COMMIT_SUCCESS = new Response(new Response.Params().withStatus(
       ControllerResponseStatus.COMMIT_SUCCESS));
-  public static final Response RESP_COMMIT_CONTINUE = new Response(new Response.Params().setStatus(
+  public static final Response RESP_COMMIT_CONTINUE = new Response(new Response.Params().withStatus(
       ControllerResponseStatus.COMMIT_CONTINUE));
-  public static final Response RESP_PROCESSED = new Response(new Response.Params().setStatus(
+  public static final Response RESP_PROCESSED = new Response(new Response.Params().withStatus(
       ControllerResponseStatus.PROCESSED));
-  public static final Response RESP_NOT_SENT = new Response(new Response.Params().setStatus(
+  public static final Response RESP_NOT_SENT = new Response(new Response.Params().withStatus(
       ControllerResponseStatus.NOT_SENT));
 
   public static long getMaxSegmentCommitTimeMs() {
@@ -132,42 +140,44 @@ public class SegmentCompletionProtocol {
   }
 
   public static abstract class Request {
-    final String _segmentName;
-    final long _offset;
-    final String _instanceId;
-    final String _reason;
+    final Params _params;
 
     private Request(Params params) {
-      _segmentName = params.getSegmentName();
-      _instanceId = params.getInstanceId();
-      _offset = params.getOffset();
-      _reason = params.getReason();
+      _params = params;
     }
 
     public abstract String getUrl(String hostPort);
 
     protected String getUri(String msgType) {
       return "/" + msgType + "?" +
-        PARAM_SEGMENT_NAME + "=" + _segmentName + "&" +
-        PARAM_OFFSET + "=" + _offset + "&" +
-        PARAM_INSTANCE_ID + "=" + _instanceId +
-          (_reason == null ? "" : ("&" + PARAM_REASON + "=" + _reason));
+        PARAM_SEGMENT_NAME + "=" + _params.getSegmentName() + "&" +
+        PARAM_OFFSET + "=" + _params.getOffset() + "&" +
+        PARAM_INSTANCE_ID + "=" + _params.getInstanceId() +
+          (_params.getReason() == null ? "" : ("&" + PARAM_REASON + "=" + _params.getReason())) +
+          (_params.getBuildTimeMs() <= 0 ? "" :("&" + PARAM_BUILD_TIME_MS + "=" + _params.getBuildTimeMs())) +
+          (_params.getWaitTimeMs() <= 0 ? "" : ("&" + PARAM_WAIT_TIME_MS + "=" + _params.getWaitTimeMs())) +
+          (_params.getExtTimeSec() <= 0 ? "" : ("&" + PARAM_EXT_TIME_SEC + "=" + _params.getExtTimeSec())) +
+          (_params.getNumRows() <= 0 ? "" : ("&" + PARAM_NUM_ROWS + "=" + _params.getNumRows()));
     }
 
     public static class Params {
-      private static final String UNKNOWN_SEGMENT = "UNKNOWN_SEGMENT";
-      private static final long UNKNOWN_OFFSET = -1L;
-      private static final String UNKNOWN_INSTANCE = "UNKNOWN_INSTANCE";
-
       private long _offset;
       private String _segmentName;
       private String _instanceId;
       private String _reason;
+      private int _numRows;
+      private long _buildTimeMs;
+      private long _waitTimeMs;
+      private int _extTimeSec;
 
       public Params() {
-        _offset = UNKNOWN_OFFSET;
-        _segmentName = UNKNOWN_SEGMENT;
-        _instanceId = UNKNOWN_INSTANCE;
+        _offset = -1L;
+        _segmentName = "UNKNOWN_SEGMENT";
+        _instanceId = "UNKNOWN_INSTANCE";
+        _numRows = -1;
+        _buildTimeMs = -1;
+        _waitTimeMs = -1;
+        _extTimeSec = -1;
       }
       public Params withOffset(long offset) {
         _offset = offset;
@@ -185,6 +195,22 @@ public class SegmentCompletionProtocol {
         _reason = reason;
         return this;
       }
+      public Params withNumRows(int numRows) {
+        _numRows = numRows;
+        return this;
+      }
+      public Params withBuildTimeMs(long buildTimeMs) {
+        _buildTimeMs = buildTimeMs;
+        return this;
+      }
+      public Params withWaitTimeMs(long waitTimeMs) {
+        _waitTimeMs = waitTimeMs;
+        return this;
+      }
+      public Params withExtTimeSec(int extTimeSec) {
+        _extTimeSec = extTimeSec;
+        return this;
+      }
 
       public String getSegmentName() {
         return _segmentName;
@@ -197,6 +223,18 @@ public class SegmentCompletionProtocol {
       }
       public String getInstanceId() {
         return _instanceId;
+      }
+      public int getNumRows() {
+        return _numRows;
+      }
+      public long getBuildTimeMs() {
+        return _buildTimeMs;
+      }
+      public long getWaitTimeMs() {
+        return _waitTimeMs;
+      }
+      public int getExtTimeSec() {
+        return _extTimeSec;
       }
     }
   }
@@ -238,6 +276,7 @@ public class SegmentCompletionProtocol {
   public static class Response {
     final ControllerResponseStatus _status;
     final long _offset;
+    final long _buildTimeSec;
 
     public Response(String jsonRespStr) {
       JSONObject jsonObject = JSONObject.parseObject(jsonRespStr);
@@ -255,11 +294,19 @@ public class SegmentCompletionProtocol {
         status = ControllerResponseStatus.FAILED;
       }
       _status = status;
+
+      Long buildTimeObj = jsonObject.getLong(BUILD_TIME_KEY);
+      if (buildTimeObj == null) {
+        _buildTimeSec = -1;
+      } else {
+        _buildTimeSec = buildTimeObj;
+      }
     }
 
     public Response(Params params) {
       _status = params.getStatus();
       _offset = params.getOffset();
+      _buildTimeSec = params.getBuildTimeSec();
     }
 
     public ControllerResponseStatus getStatus() {
@@ -270,6 +317,10 @@ public class SegmentCompletionProtocol {
       return _offset;
     }
 
+    public long getBuildTimeSec() {
+      return _buildTimeSec;
+    }
+
     public String toJsonString() {
       StringBuilder builder = new StringBuilder();
       builder.append("{\"" + STATUS_KEY + "\":" + "\"" + _status.name() + "\"," + "\"" + OFFSET_KEY + "\":" + _offset);
@@ -278,23 +329,26 @@ public class SegmentCompletionProtocol {
     }
 
     public static class Params {
-      private static ControllerResponseStatus DEFAULT_RESPONSE_STATUS = ControllerResponseStatus.FAILED;
-      private static long DEFAULT_RESP_OFFSET = -1L;
-
       private ControllerResponseStatus _status;
       private long _offset;
+      private long _buildTimeSec;
 
       public Params() {
-        _offset = DEFAULT_RESP_OFFSET;
-        _status = DEFAULT_RESPONSE_STATUS;
+        _offset = -1L;
+        _status = ControllerResponseStatus.FAILED;
+        _buildTimeSec = -1;
       }
 
-      public Params setOffset(long offset) {
+      public Params withOffset(long offset) {
         _offset = offset;
         return this;
       }
-      public Params setStatus(ControllerResponseStatus status) {
+      public Params withStatus(ControllerResponseStatus status) {
         _status = status;
+        return this;
+      }
+      public Params withBuildTimeSec(long buildTimeSec) {
+        _buildTimeSec = buildTimeSec;
         return this;
       }
 
@@ -303,6 +357,9 @@ public class SegmentCompletionProtocol {
       }
       public long getOffset() {
         return _offset;
+      }
+      public long getBuildTimeSec() {
+        return _buildTimeSec;
       }
     }
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -103,13 +103,13 @@ public class SegmentCompletionProtocol {
   public static final String PARAM_OFFSET = "offset";
   public static final String PARAM_INSTANCE_ID = "instance";
   public static final String PARAM_REASON = "reason";
-  public static final String PARAM_EXT_TIME_SEC = "extTimeSec"; // Sent by servers to request additional time to build
-  public static final String PARAM_NUM_ROWS = "nRows"; // Sent by servers to indicate the number of rows read so far
-  public static final String PARAM_BUILD_TIME_MS = "buildTimeMs"; // Time taken to build segment
-  public static final String PARAM_WAIT_TIME_MS = "waitTimeMs";   // Time taken to wait for build to start.
+  public static final String PARAM_EXTRA_TIME_SEC = "extraTimeSec"; // Sent by servers to request additional time to build
+  public static final String PARAM_ROW_COUNT = "rowCount"; // Sent by servers to indicate the number of rows read so far
+  public static final String PARAM_BUILD_TIME_MILLIS = "buildTimeMillis"; // Time taken to build segment
+  public static final String PARAM_WAIT_TIME_MILLIS = "waitTimeMillis";   // Time taken to wait for build to start.
 
-  public static final String REASON_REACHED_MAX_ROWS = "maxRows";  // Stop reason sent by server as max num rows reached
-  public static final String REASON_REACHED_MAX_TIME = "maxTime";  // Stop reason sent by server as max time reached
+  public static final String REASON_ROW_LIMIT = "rowLimit";  // Stop reason sent by server as max num rows reached
+  public static final String REASON_TIME_LIMIT = "timeLimit";  // Stop reason sent by server as max time reached
 
   // Canned responses
   public static final Response RESP_NOT_LEADER = new Response(new Response.Params().withStatus(
@@ -135,7 +135,7 @@ public class SegmentCompletionProtocol {
     MAX_SEGMENT_COMMIT_TIME_MS = commitTimeMs;
   }
 
-  public static int getDefaultMaxSegmentCommitTimeSec() {
+  public static int getDefaultMaxSegmentCommitTimeSeconds() {
     return DEFAULT_MAX_SEGMENT_COMMIT_TIME_SEC;
   }
 
@@ -154,10 +154,10 @@ public class SegmentCompletionProtocol {
         PARAM_OFFSET + "=" + _params.getOffset() + "&" +
         PARAM_INSTANCE_ID + "=" + _params.getInstanceId() +
           (_params.getReason() == null ? "" : ("&" + PARAM_REASON + "=" + _params.getReason())) +
-          (_params.getBuildTimeMs() <= 0 ? "" :("&" + PARAM_BUILD_TIME_MS + "=" + _params.getBuildTimeMs())) +
-          (_params.getWaitTimeMs() <= 0 ? "" : ("&" + PARAM_WAIT_TIME_MS + "=" + _params.getWaitTimeMs())) +
-          (_params.getExtTimeSec() <= 0 ? "" : ("&" + PARAM_EXT_TIME_SEC + "=" + _params.getExtTimeSec())) +
-          (_params.getNumRows() <= 0 ? "" : ("&" + PARAM_NUM_ROWS + "=" + _params.getNumRows()));
+          (_params.getBuildTimeMillis() <= 0 ? "" :("&" + PARAM_BUILD_TIME_MILLIS + "=" + _params.getBuildTimeMillis())) +
+          (_params.getWaitTimeMillis() <= 0 ? "" : ("&" + PARAM_WAIT_TIME_MILLIS + "=" + _params.getWaitTimeMillis())) +
+          (_params.getExtTimeSec() <= 0 ? "" : ("&" + PARAM_EXTRA_TIME_SEC + "=" + _params.getExtTimeSec())) +
+          (_params.getNumRows() <= 0 ? "" : ("&" + PARAM_ROW_COUNT + "=" + _params.getNumRows()));
     }
 
     public static class Params {
@@ -166,8 +166,8 @@ public class SegmentCompletionProtocol {
       private String _instanceId;
       private String _reason;
       private int _numRows;
-      private long _buildTimeMs;
-      private long _waitTimeMs;
+      private long _buildTimeMillis;
+      private long _waitTimeMillis;
       private int _extTimeSec;
 
       public Params() {
@@ -175,8 +175,8 @@ public class SegmentCompletionProtocol {
         _segmentName = "UNKNOWN_SEGMENT";
         _instanceId = "UNKNOWN_INSTANCE";
         _numRows = -1;
-        _buildTimeMs = -1;
-        _waitTimeMs = -1;
+        _buildTimeMillis = -1;
+        _waitTimeMillis = -1;
         _extTimeSec = -1;
       }
       public Params withOffset(long offset) {
@@ -199,12 +199,12 @@ public class SegmentCompletionProtocol {
         _numRows = numRows;
         return this;
       }
-      public Params withBuildTimeMs(long buildTimeMs) {
-        _buildTimeMs = buildTimeMs;
+      public Params withBuildTimeMillis(long buildTimeMillis) {
+        _buildTimeMillis = buildTimeMillis;
         return this;
       }
-      public Params withWaitTimeMs(long waitTimeMs) {
-        _waitTimeMs = waitTimeMs;
+      public Params withWaitTimeMillis(long waitTimeMillis) {
+        _waitTimeMillis = waitTimeMillis;
         return this;
       }
       public Params withExtTimeSec(int extTimeSec) {
@@ -227,11 +227,11 @@ public class SegmentCompletionProtocol {
       public int getNumRows() {
         return _numRows;
       }
-      public long getBuildTimeMs() {
-        return _buildTimeMs;
+      public long getBuildTimeMillis() {
+        return _buildTimeMillis;
       }
-      public long getWaitTimeMs() {
-        return _waitTimeMs;
+      public long getWaitTimeMillis() {
+        return _waitTimeMillis;
       }
       public int getExtTimeSec() {
         return _extTimeSec;
@@ -276,7 +276,7 @@ public class SegmentCompletionProtocol {
   public static class Response {
     final ControllerResponseStatus _status;
     final long _offset;
-    final long _buildTimeSec;
+    final long _buildTimeSeconds;
 
     public Response(String jsonRespStr) {
       JSONObject jsonObject = JSONObject.parseObject(jsonRespStr);
@@ -297,16 +297,16 @@ public class SegmentCompletionProtocol {
 
       Long buildTimeObj = jsonObject.getLong(BUILD_TIME_KEY);
       if (buildTimeObj == null) {
-        _buildTimeSec = -1;
+        _buildTimeSeconds = -1;
       } else {
-        _buildTimeSec = buildTimeObj;
+        _buildTimeSeconds = buildTimeObj;
       }
     }
 
     public Response(Params params) {
       _status = params.getStatus();
       _offset = params.getOffset();
-      _buildTimeSec = params.getBuildTimeSec();
+      _buildTimeSeconds = params.getBuildTimeSeconds();
     }
 
     public ControllerResponseStatus getStatus() {
@@ -317,8 +317,8 @@ public class SegmentCompletionProtocol {
       return _offset;
     }
 
-    public long getBuildTimeSec() {
-      return _buildTimeSec;
+    public long getBuildTimeSeconds() {
+      return _buildTimeSeconds;
     }
 
     public String toJsonString() {
@@ -347,8 +347,8 @@ public class SegmentCompletionProtocol {
         _status = status;
         return this;
       }
-      public Params withBuildTimeSec(long buildTimeSec) {
-        _buildTimeSec = buildTimeSec;
+      public Params withBuildTimeSeconds(long buildTimeSeconds) {
+        _buildTimeSec = buildTimeSeconds;
         return this;
       }
 
@@ -358,7 +358,7 @@ public class SegmentCompletionProtocol {
       public long getOffset() {
         return _offset;
       }
-      public long getBuildTimeSec() {
+      public long getBuildTimeSeconds() {
         return _buildTimeSec;
       }
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerConf.java
@@ -142,7 +142,7 @@ public class ControllerConf extends PropertiesConfiguration {
     if (containsKey(SEGMENT_COMMIT_TIMEOUT_SECONDS)) {
       return Integer.parseInt((String)getProperty(SEGMENT_COMMIT_TIMEOUT_SECONDS));
     }
-    return SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSec();
+    return SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds();
   }
 
   public boolean isUpdateSegmentStateModel() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -351,6 +351,11 @@ public class SegmentCompletionManager {
       if (savedCommitTime != null && savedCommitTime > initialCommitTimeMs) {
         initialCommitTimeMs = savedCommitTime;
       }
+      if (initialCommitTimeMs > MAX_COMMIT_TIME_FOR_ALL_SEGMENTS_SEC * 1000) {
+        // The table has a really high value configured for max commit time. Set it to a higher value than default
+        // and go from there.
+        initialCommitTimeMs = MAX_COMMIT_TIME_FOR_ALL_SEGMENTS_SEC * 1000;
+      }
       _initialCommitTimeMs = initialCommitTimeMs;
       _maxTimeAllowedToCommitMs = _startTimeMs + _initialCommitTimeMs;
       LOGGER = LoggerFactory.getLogger("SegmentFinalizerFSM_"  + segmentName.getSegmentName());

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -461,7 +461,7 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(s2).withOffset(s2Offset).withSegmentName(segmentNameStr);
     response = segmentCompletionMgr.segmentConsumed(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
-    long commitTimeSec = response.getBuildTimeSec();
+    long commitTimeSec = response.getBuildTimeSeconds();
     Assert.assertTrue(commitTimeSec > 0);
 
     // Fast forward to one second before commit time, and send a lease renewal request for 20s
@@ -527,7 +527,7 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(s2).withOffset(s2Offset).withSegmentName(segmentNameStr);
     response = segmentCompletionMgr.segmentConsumed(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
-    long commitTimeSec = response.getBuildTimeSec();
+    long commitTimeSec = response.getBuildTimeSeconds();
     Assert.assertTrue(commitTimeSec > 0);
 
     // Fast forward to one second before commit time, and send a lease renewal request for 20s
@@ -580,7 +580,7 @@ public class SegmentCompletionTest {
     params = new Request.Params().withInstanceId(s2).withOffset(s2Offset).withSegmentName(segmentNameStr);
     response = segmentCompletionMgr.segmentConsumed(params);
     Assert.assertEquals(response.getStatus(), SegmentCompletionProtocol.ControllerResponseStatus.COMMIT);
-    long commitTimeSec = response.getBuildTimeSec();
+    long commitTimeSec = response.getBuildTimeSeconds();
     Assert.assertTrue(commitTimeSec > 0);
 
     // Fast forward to one second before commit time, and send a lease renewal request for 20s
@@ -593,7 +593,7 @@ public class SegmentCompletionTest {
 
     final int leaseTimeSec = 20;
     // Lease will not be granted if the time taken so far plus lease time exceeds the max allowabale.
-    while (segmentCompletionMgr._secconds + leaseTimeSec <= startTime + SegmentCompletionManager.getMaxCommitTimeForAllSegmentsSec()) {
+    while (segmentCompletionMgr._secconds + leaseTimeSec <= startTime + SegmentCompletionManager.getMaxCommitTimeForAllSegmentsSeconds()) {
       params = new Request.Params().withInstanceId(s2).withOffset(s2Offset).withSegmentName(segmentNameStr).withExtTimeSec(
           leaseTimeSec);
       response = segmentCompletionMgr.extendBuildTime(params);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -594,7 +594,6 @@ public class SegmentCompletionTest {
     final int leaseTimeSec = 20;
     // Lease will not be granted if the time taken so far plus lease time exceeds the max allowabale.
     while (segmentCompletionMgr._secconds + leaseTimeSec <= startTime + SegmentCompletionManager.getMaxCommitTimeForAllSegmentsSec()) {
-      System.out.println("time=" + segmentCompletionMgr._secconds);
       params = new Request.Params().withInstanceId(s2).withOffset(s2Offset).withSegmentName(segmentNameStr).withExtTimeSec(
           leaseTimeSec);
       response = segmentCompletionMgr.extendBuildTime(params);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -183,7 +183,9 @@ public class LLRealtimeSegmentDataManagerTest {
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).setOffset(endOffset));
+        new SegmentCompletionProtocol.Response.Params().withStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.HOLD).withOffset(
+            endOffset));
     // And then never consume as long as we get a hold response, 100 times.
     for (int i = 0; i < 100; i++) {
       segmentDataManager._responses.add(response);
@@ -209,10 +211,10 @@ public class LLRealtimeSegmentDataManagerTest {
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response holdResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset).withStatus(
             SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset).withStatus(
             SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse);
@@ -240,15 +242,18 @@ public class LLRealtimeSegmentDataManagerTest {
     segmentDataManager._consumeOffsets.add(firstOffset);
     segmentDataManager._consumeOffsets.add(catchupOffset); // Offset after catchup
     final SegmentCompletionProtocol.Response holdResponse1 = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setStatus(SegmentCompletionProtocol.ControllerResponseStatus.HOLD).
-            setOffset(firstOffset));
+        new SegmentCompletionProtocol.Response.Params().withStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.HOLD).
+            withOffset(firstOffset));
     final SegmentCompletionProtocol.Response catchupResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setStatus(SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP).setOffset(catchupOffset));
+        new SegmentCompletionProtocol.Response.Params().withStatus(
+            SegmentCompletionProtocol.ControllerResponseStatus.CATCH_UP).withOffset(
+            catchupOffset));
     final SegmentCompletionProtocol.Response holdResponse2 = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setOffset(catchupOffset).setStatus(
+        new SegmentCompletionProtocol.Response.Params().withOffset(catchupOffset).withStatus(
             SegmentCompletionProtocol.ControllerResponseStatus.HOLD));
     final SegmentCompletionProtocol.Response commitResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setOffset(catchupOffset).setStatus(
+        new SegmentCompletionProtocol.Response.Params().withOffset(catchupOffset).withStatus(
             SegmentCompletionProtocol.ControllerResponseStatus.COMMIT));
     // And then never consume as long as we get a hold response, 100 times.
     segmentDataManager._responses.add(holdResponse1);
@@ -274,7 +279,7 @@ public class LLRealtimeSegmentDataManagerTest {
     final long endOffset = _startOffset + 500;
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response discardResponse = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset).withStatus(
             SegmentCompletionProtocol.ControllerResponseStatus.DISCARD));
     segmentDataManager._responses.add(discardResponse);
 
@@ -296,7 +301,7 @@ public class LLRealtimeSegmentDataManagerTest {
     final long endOffset = _startOffset + 500;
     segmentDataManager._consumeOffsets.add(endOffset);
     SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
-    params.setOffset(endOffset).setStatus(SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
+    params.withOffset(endOffset).withStatus(SegmentCompletionProtocol.ControllerResponseStatus.KEEP);
     final SegmentCompletionProtocol.Response keepResponse = new SegmentCompletionProtocol.Response(params);
     segmentDataManager._responses.add(keepResponse);
 
@@ -319,7 +324,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // We should consume initially...
     segmentDataManager._consumeOffsets.add(endOffset);
     final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
-        new SegmentCompletionProtocol.Response.Params().setOffset(endOffset).setStatus(
+        new SegmentCompletionProtocol.Response.Params().withOffset(endOffset).withStatus(
             SegmentCompletionProtocol.ControllerResponseStatus.NOT_LEADER));
     // And then never consume as long as we get a Not leader response, 100 times.
     for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Added protocol extension on the controller side to field the build-extension time
to be sent by the server.

The SegmentCompletionManager indicates to the server in the COMMIT response the max
time that the server can take before the SCM declares it dead. The SCM expects the
server to send a (newly introduced) extendBuildTime() message that extends the time
as often as needed.

Added test cases