### PR TITLE
Update merge anomaly info even it has only one raw anomaly

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/detection/SimpleThresholdDetectionModel.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/detection/SimpleThresholdDetectionModel.java
@@ -71,20 +71,22 @@ public class SimpleThresholdDetectionModel extends AbstractDetectionModel {
       if (!expectedTimeSeries.hasTimestamp(expectedTimestamp)) {
         continue;
       }
-      double expectedValue = expectedTimeSeries.get(expectedTimestamp);
+      double baselineValue = expectedTimeSeries.get(expectedTimestamp);
       double currentValue = currentTimeSeries.get(currentTimestamp);
-      if (isAnomaly(currentValue, expectedValue, changeThreshold)) {
+      if (isAnomaly(currentValue, baselineValue, changeThreshold)) {
         RawAnomalyResultDTO anomalyResult = new RawAnomalyResultDTO();
         anomalyResult.setDimensions(dimensionMap);
         anomalyResult.setProperties(getProperties().toString());
         anomalyResult.setStartTime(currentTimestamp);
         anomalyResult.setEndTime(currentTimestamp + bucketSizeInMillis); // point-in-time
         anomalyResult.setScore(averageValue);
-        anomalyResult.setWeight(calculateChange(currentValue, expectedValue));
-        String message = getAnomalyResultMessage(changeThreshold, currentValue, expectedValue);
+        anomalyResult.setWeight(calculateChange(currentValue, baselineValue));
+        anomalyResult.setAvgCurrentVal(currentValue);
+        anomalyResult.setAvgBaselineVal(baselineValue);
+        String message = getAnomalyResultMessage(changeThreshold, currentValue, baselineValue);
         anomalyResult.setMessage(message);
         anomalyResults.add(anomalyResult);
-        if (currentValue == 0.0 || expectedValue == 0.0) {
+        if (currentValue == 0.0 || baselineValue == 0.0) {
           anomalyResult.setDataMissing(true);
         }
       }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -323,11 +323,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
     List<RawAnomalyResultDTO> rawAnomalies = rawAnomalyResultDAO.findUnmergedByFunctionId(functionId);
     Assert.assertTrue(rawAnomalies.size() == 0);
 
-    // start merge
-    // startMerger();
-
     // check merged anomalies
-    // Thread.sleep(4000);
     List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByFunctionId(functionId);
     Assert.assertTrue(mergedAnomalies.size() > 0);
 
@@ -355,6 +351,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
     dataCompletenessScheduler.start();
   }
 
+  // TODO: Change to startGrouper
   private void startMerger() throws Exception {
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     anomalyMergeExecutor = new AnomalyMergeExecutor(executorService, anomalyFunctionFactory);


### PR DESCRIPTION
The avgBaselineVal and avgCurrentVal are not updated when the merged anomaly has only one raw anomaly. In the original code, the information is updated through default calculation, which is not working for unknown reasons.

This PR adds another default calculator which copies the information from the raw anomaly to the merged anomaly if there is only one raw anomaly exists.

Tested on local