### PR TITLE
Refactor segment creation stats gathering

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/RecordReaderSegmentCreationDataSource.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.creator;
+
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.extractors.FieldExtractor;
+import com.linkedin.pinot.core.data.readers.RecordReader;
+import com.linkedin.pinot.core.segment.creator.impl.stats.SegmentPreIndexStatsCollectorImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * {@link com.linkedin.pinot.core.segment.creator.SegmentCreationDataSource} that uses a
+ * {@link com.linkedin.pinot.core.data.readers.RecordReader} as the underlying data source.
+ */
+public class RecordReaderSegmentCreationDataSource implements SegmentCreationDataSource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RecordReaderSegmentCreationDataSource.class);
+
+  public RecordReaderSegmentCreationDataSource(RecordReader recordReader) {
+    _recordReader = recordReader;
+
+    try {
+      recordReader.init();
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while initializing record reader", e);
+      Utils.rethrowException(e);
+    }
+
+  }
+
+  private RecordReader _recordReader;
+
+  @Override
+  public SegmentPreIndexStatsCollector gatherStats(FieldExtractor fieldExtractor) {
+    try {
+      SegmentPreIndexStatsCollector collector = new SegmentPreIndexStatsCollectorImpl(_recordReader.getSchema());
+      collector.init();
+
+      // Gather the stats
+      GenericRow readRow = new GenericRow();
+      GenericRow transformedRow = new GenericRow();
+      while (_recordReader.hasNext()) {
+        transformedRow = readNextRowSanitized(readRow, transformedRow, fieldExtractor);
+        collector.collectRow(transformedRow);
+      }
+
+      collector.build();
+      return collector;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while gathering stats", e);
+      Utils.rethrowException(e);
+      return null;
+    }
+  }
+
+  private GenericRow readNextRowSanitized(GenericRow readRow, GenericRow transformedRow, FieldExtractor extractor) {
+    readRow = GenericRow.createOrReuseRow(readRow);
+    readRow = _recordReader.next(readRow);
+    transformedRow = GenericRow.createOrReuseRow(transformedRow);
+    return extractor.transform(readRow, transformedRow);
+  }
+
+  @Override
+  public RecordReader getRecordReader() {
+    try {
+      _recordReader.rewind();
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while rewinding record reader", e);
+      Utils.rethrowException(e);
+    }
+
+    return _recordReader;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentCreationDataSource.java
@@ -13,19 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.linkedin.pinot.core.segment.creator;
 
-import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.extractors.FieldExtractor;
+import com.linkedin.pinot.core.data.readers.RecordReader;
 
-public interface SegmentPreIndexStatsCollector extends SegmentPreIndexStatsContainer {
 
-  void init();
+/**
+ * Data source used to build segments
+ */
+public interface SegmentCreationDataSource {
+  SegmentPreIndexStatsCollector gatherStats(FieldExtractor fieldExtractor);
 
-  void build() throws Exception;
-
-  void collectRow(GenericRow row) throws Exception;
-
-  void collectRow(GenericRow row, boolean isAggregated) throws Exception;
-
-  void logStats();
+  RecordReader getRecordReader();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentPreIndexStatsContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentPreIndexStatsContainer.java
@@ -15,17 +15,15 @@
  */
 package com.linkedin.pinot.core.segment.creator;
 
-import com.linkedin.pinot.core.data.GenericRow;
+/**
+ * Container for per-column stats for a segment
+ */
+public interface SegmentPreIndexStatsContainer {
+  AbstractColumnStatisticsCollector getColumnProfileFor(String column) throws Exception;
 
-public interface SegmentPreIndexStatsCollector extends SegmentPreIndexStatsContainer {
+  int getRawDocCount();
 
-  void init();
+  int getAggregatedDocCount();
 
-  void build() throws Exception;
-
-  void collectRow(GenericRow row) throws Exception;
-
-  void collectRow(GenericRow row, boolean isAggregated) throws Exception;
-
-  void logStats();
+  int getTotalDocCount();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -28,15 +28,15 @@ import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector
 import com.linkedin.pinot.core.segment.creator.SegmentPreIndexStatsCollector;
 
 
-/**
- * Nov 7, 2014
- */
-
 public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCollector {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPreIndexStatsCollectorImpl.class);
 
   private final Schema dataSchema;
-  Map<String, AbstractColumnStatisticsCollector> columnStatsCollectorMap;
+  private Map<String, AbstractColumnStatisticsCollector> columnStatsCollectorMap;
+
+  private int rawDocCount;
+  private int aggregatedDocCount;
+  private int totalDocCount;
 
   public SegmentPreIndexStatsCollectorImpl(Schema dataSchema) {
     this.dataSchema = dataSchema;
@@ -102,6 +102,28 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
         }
       }
     }
+
+    ++totalDocCount;
+    if (!isAggregated) {
+      ++rawDocCount;
+    } else {
+      ++aggregatedDocCount;
+    }
+  }
+
+  @Override
+  public int getRawDocCount() {
+    return rawDocCount;
+  }
+
+  @Override
+  public int getAggregatedDocCount() {
+    return aggregatedDocCount;
+  }
+
+  @Override
+  public int getTotalDocCount() {
+    return totalDocCount;
   }
 
   public static <T> T convertInstanceOfObject(Object o, Class<T> clazz) {


### PR DESCRIPTION
Refactor the stats gathering part of segment creation by moving the
stats gathering logic into a SegmentCreationDataSource. This allows
data sources to provide stats from auxiliary information (eg. existing
dictionaries for realtime segments or other file metadata)

Other minor cleanups as well.