### PR TITLE
[TE] Yyuen/view contribution links to old ui

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/css/thirdeye.css
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/css/thirdeye.css
@@ -695,6 +695,8 @@ text {
   text-align: center;
   border: 1px solid #CCC;
   background-color: white;
+  list-style: none;
+  padding: 0;
 }
 
 .wow-card {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -42,7 +42,8 @@ InvestigateView.prototype = {
     };
   },
 
-  formatWowResults( wowResults, { anomalyRegionStart, anomalyRegionEnd, dataset, metric }){
+  formatWowResults( wowResults, args = {}){
+    const { anomalyRegionStart, anomalyRegionEnd, dataset, metric } = args;
     const start = moment(anomalyRegionStart);
     const end = moment(anomalyRegionEnd);
     const wowMapping = {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -33,22 +33,18 @@ InvestigateView.prototype = {
     const anomaly = this.investigateModel.getAnomaly();
     const wowData = this.investigateModel.getWowData();
     const currentValue = wowData.currentVal;
-
-    this.formatWowData(wowData.compareResults, anomaly);
-    const [ wow, wow2, wow3 ] = wowData.compareResults;
+    const wowResults = this.formatWowResults(wowData.compareResults, anomaly);
 
     this.investigateData = {
       anomaly,
       currentValue,
-      wow,
-      wow2,
-      wow3
+      wowResults,
     };
   },
 
-  formatWowData(wowData, { currentStart, currentEnd, dataset, metric }){
-    const start = moment(currentStart);
-    const end = moment(currentEnd);
+  formatWowResults( wowResults, { anomalyRegionStart, anomalyRegionEnd, dataset, metric }){
+    const start = moment(anomalyRegionStart);
+    const end = moment(anomalyRegionEnd);
     const wowMapping = {
       WoW: 7,
       Wo2W: 14,
@@ -56,13 +52,16 @@ InvestigateView.prototype = {
       Wo4W: 28
     };
 
-    wowData.forEach((wow) => {
-      const offset = wowMapping[wow.compareMode];
-      const baselineStart = start.clone().subtract(offset, 'days');
-      const baselineEnd = end.clone().subtract(offset, 'days');
-      wow.change *= 100;
-      wow.url = `dashboard#view=compare&dataset=${dataset}&compareMode=WoW&aggTimeGranularity=aggregateAll&currentStart=${start}&currentEnd=${end}&baselineStart=${baselineStart}&baselineEnd=${baselineEnd}&metrics=${metric}`;
-    });
+    return wowResults
+      .filter(wow => wow.compareMode !== 'Wo4W')
+      .map((wow) => {
+        const offset = wowMapping[wow.compareMode];
+        const baselineStart = start.clone().subtract(offset, 'days');
+        const baselineEnd = end.clone().subtract(offset, 'days');
+        wow.change *= 100;
+        wow.url = `dashboard#view=compare&dataset=${dataset.valueOf()}&compareMode=WoW&aggTimeGranularity=aggregateAll&currentStart=${start.valueOf()}&currentEnd=${end.valueOf()}&baselineStart=${baselineStart.valueOf()}&baselineEnd=${baselineEnd.valueOf()}&metrics=${metric}`;
+        return wow;
+      });
   },
 
   render () {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -39,7 +39,6 @@ InvestigateView.prototype = {
 
     this.investigateData = {
       anomaly,
-      externalUrls,
       currentValue,
       wow,
       wow2,
@@ -47,7 +46,7 @@ InvestigateView.prototype = {
     };
   },
 
-  formatWowData(wowData, {currentStart, currentEnd, dataset, metric}){
+  formatWowData(wowData, { currentStart, currentEnd, dataset, metric }){
     const start = moment(currentStart);
     const end = moment(currentEnd);
     const wowMapping = {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -59,12 +59,12 @@ InvestigateView.prototype = {
         const baselineStart = start.clone().subtract(offset, 'days');
         const baselineEnd = end.clone().subtract(offset, 'days');
         wow.change *= 100;
-        wow.url = `dashboard#view=compare&dataset=${dataset.valueOf()}&compareMode=WoW&aggTimeGranularity=aggregateAll&currentStart=${start.valueOf()}&currentEnd=${end.valueOf()}&baselineStart=${baselineStart.valueOf()}&baselineEnd=${baselineEnd.valueOf()}&metrics=${metric}`;
+        wow.url = `dashboard#view=compare&dataset=${dataset}&compareMode=WoW&aggTimeGranularity=aggregateAll&currentStart=${start.valueOf()}&currentEnd=${end.valueOf()}&baselineStart=${baselineStart.valueOf()}&baselineEnd=${baselineEnd.valueOf()}&metrics=${metric}`;
         return wow;
       });
   },
 
-  render () {
+  render() {
     const template_with_anomaly = this.investigate_template_compiled(this.investigateData);
     $("#investigate-place-holder").html(template_with_anomaly);
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -33,10 +33,8 @@ InvestigateView.prototype = {
     const anomaly = this.investigateModel.getAnomaly();
     const wowData = this.investigateModel.getWowData();
     const currentValue = wowData.currentVal;
-    const externalUrls = anomaly.externalUrl ? JSON.parse(anomaly.externalUrl) : null;
-    wowData.compareResults.forEach((result) => {
-      result.change *= 100;
-    });
+
+    this.formatWowData(wowData.compareResults, anomaly);
     const [ wow, wow2, wow3 ] = wowData.compareResults;
 
     this.investigateData = {
@@ -49,7 +47,26 @@ InvestigateView.prototype = {
     };
   },
 
-  render() {
+  formatWowData(wowData, {start, end, dataset, metric}){
+    const wowMapping = {
+      WoW: 7,
+      Wo2W: 14,
+      Wo3W: 21,
+      Wo4W: 28
+    };
+
+    wowData.forEach((wow) => {
+      let currentStart = moment(start);
+      let currentEnd = moment(end);
+      let offset = wowMapping[wow.compareMode];
+      let baselineStart = currentStart.clone().subtract(offset, 'days');
+      let baselineEnd = currentEnd.clone().subtract(offset, 'days');
+      wow.change *= 100;
+      wow.url = `dashboard#view=compare&dataset=${dataset}&compareMode=WoW&aggTimeGranularity=aggregateAll&currentStart=${currentStart}&currentEnd=${currentEnd}&baselineStart=${baselineStart}&baselineEnd=${baselineEnd}&metrics=${metric}`;
+    });
+  },
+
+  render () {
     const template_with_anomaly = this.investigate_template_compiled(this.investigateData);
     $("#investigate-place-holder").html(template_with_anomaly);
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -47,7 +47,9 @@ InvestigateView.prototype = {
     };
   },
 
-  formatWowData(wowData, {start, end, dataset, metric}){
+  formatWowData(wowData, {currentStart, currentEnd, dataset, metric}){
+    const start = moment(currentStart);
+    const end = moment(currentEnd);
     const wowMapping = {
       WoW: 7,
       Wo2W: 14,
@@ -56,13 +58,11 @@ InvestigateView.prototype = {
     };
 
     wowData.forEach((wow) => {
-      let currentStart = moment(start);
-      let currentEnd = moment(end);
-      let offset = wowMapping[wow.compareMode];
-      let baselineStart = currentStart.clone().subtract(offset, 'days');
-      let baselineEnd = currentEnd.clone().subtract(offset, 'days');
+      const offset = wowMapping[wow.compareMode];
+      const baselineStart = start.clone().subtract(offset, 'days');
+      const baselineEnd = end.clone().subtract(offset, 'days');
       wow.change *= 100;
-      wow.url = `dashboard#view=compare&dataset=${dataset}&compareMode=WoW&aggTimeGranularity=aggregateAll&currentStart=${currentStart}&currentEnd=${currentEnd}&baselineStart=${baselineStart}&baselineEnd=${baselineEnd}&metrics=${metric}`;
+      wow.url = `dashboard#view=compare&dataset=${dataset}&compareMode=WoW&aggTimeGranularity=aggregateAll&currentStart=${start}&currentEnd=${end}&baselineStart=${baselineStart}&baselineEnd=${baselineEnd}&metrics=${metric}`;
     });
   },
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
@@ -97,8 +97,8 @@
       <span class="investigate-title">Change Over Time</span>
     </div>
 
-    <div class="investigate-wow">
-      <div class="wow-card">
+    <ul class="investigate-wow">
+      <li class="wow-card">
         <div class="wow-card-header">
           <label class="label-medium-semibold">Current Total</label>
         </div>
@@ -107,10 +107,10 @@
         </div>
         <div class="wow-card-footer">
         </div>
-      </div>
+      </li>
 
       {{#each wowResults as |wow|}}
-        <div class="wow-card">
+        <li class="wow-card">
           <div class="wow-card-header">
             <label class="label-medium-semibold">{{wow.compareMode}}</label>
           </div>
@@ -119,11 +119,11 @@
             <span class="anomaly-change-delta {{colorDelta wow.change}}">({{formatPercent wow.change}})</span>
           </div>
           <div class="wow-card-footer">
-            <a id="wow1" href="{{wow.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
+            <a href="{{wow.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
           </div>
-        </div>
+        </li>
       {{/each}}
-    </div>
+    </ul>
 
   <!-- <div class="investigate-tips padding-all">
     <div class="investigate-icon">

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
@@ -105,8 +105,8 @@
         <div class="wow-card-body">
           {{formatDouble currentValue}}
         </div>
-<!--         <div class="wow-card-footer">
-        </div> -->
+        <div class="wow-card-footer">
+        </div>
       </div>
 
       <div class="wow-card">
@@ -117,9 +117,9 @@
           {{formatDouble wow.baselineValue}}
           <span class="anomaly-change-delta {{colorDelta wow.change}}">({{formatPercent wow.change}})</span>
         </div>
-<!--         <div class="wow-card-footer">
-          <a id="wow1" class="thirdeye-link">View Contribution Analysis</a>
-        </div> -->
+        <div class="wow-card-footer">
+          <a id="wow1" href="{{wow.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
+        </div>
       </div>
 
       <div class="wow-card">
@@ -130,9 +130,9 @@
           {{formatDouble wow2.baselineValue}}
           <span class="anomaly-change-delta {{colorDelta wow2.change}}">({{formatPercent wow2.change}})</span>
         </div>
-<!--         <div class="wow-card-footer">
-          <a id ="wow2" class="thirdeye-link">View Contribution Analysis</a>
-        </div> -->
+        <div class="wow-card-footer">
+          <a id ="wow2" href="{{wow2.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
+        </div>
       </div>
 
       <div class="wow-card">
@@ -143,9 +143,9 @@
           {{formatDouble wow3.baselineValue}}
           <span class="anomaly-change-delta {{colorDelta wow3.change}}">({{formatPercent wow3.change}})<span>
         </div>
-<!--         <div class="wow-card-footer">
-          <a id="wow3" class="thirdeye-link">View Contribution Analysis</a>
-        </div> -->
+        <div class="wow-card-footer">
+          <a id="wow3" href="{{wow3.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
+        </div>
       </div>
     </div>
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
@@ -109,46 +109,21 @@
         </div>
       </div>
 
-      <div class="wow-card">
-        <div class="wow-card-header">
-          <label class="label-medium-semibold">WoW</label>
+      {{#each wowResults as |wow|}}
+        <div class="wow-card">
+          <div class="wow-card-header">
+            <label class="label-medium-semibold">{{wow.compareMode}}</label>
+          </div>
+          <div class="wow-card-body">
+            {{formatDouble wow.baselineValue}}
+            <span class="anomaly-change-delta {{colorDelta wow.change}}">({{formatPercent wow.change}})</span>
+          </div>
+          <div class="wow-card-footer">
+            <a id="wow1" href="{{wow.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
+          </div>
         </div>
-        <div class="wow-card-body">
-          {{formatDouble wow.baselineValue}}
-          <span class="anomaly-change-delta {{colorDelta wow.change}}">({{formatPercent wow.change}})</span>
-        </div>
-        <div class="wow-card-footer">
-          <a id="wow1" href="{{wow.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
-        </div>
-      </div>
-
-      <div class="wow-card">
-        <div class="wow-card-header">
-          <label class="label-medium-semibold">Wo2W</label>
-        </div>
-        <div class="wow-card-body">
-          {{formatDouble wow2.baselineValue}}
-          <span class="anomaly-change-delta {{colorDelta wow2.change}}">({{formatPercent wow2.change}})</span>
-        </div>
-        <div class="wow-card-footer">
-          <a id ="wow2" href="{{wow2.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
-        </div>
-      </div>
-
-      <div class="wow-card">
-        <div class="wow-card-header">
-          <label class="label-medium-semibold">Wo3W</label>
-        </div>
-        <div class="wow-card-body">
-          {{formatDouble wow3.baselineValue}}
-          <span class="anomaly-change-delta {{colorDelta wow3.change}}">({{formatPercent wow3.change}})<span>
-        </div>
-        <div class="wow-card-footer">
-          <a id="wow3" href="{{wow3.url}}" target="_blank" class="thirdeye-link">View Contribution Analysis</a>
-        </div>
-      </div>
+      {{/each}}
     </div>
-
 
   <!-- <div class="investigate-tips padding-all">
     <div class="investigate-icon">


### PR DESCRIPTION
### What's new: 
- Hook up the `view contribution link` to the old UI. This is a temporary solution until we style the root cause analysis page. (target completion: 3/31)

### Jira: 
https://jira01.corp.linkedin.com:8443/browse/THIRDEYE-1158

### Screenshot: 
<img width="1104" alt="screen shot 2017-03-16 at 10 55 53 am" src="https://cloud.githubusercontent.com/assets/8664954/24018411/f765c1f2-0a50-11e7-8348-34220354e1ae.png">
