### PR TITLE
Stats gathering spring cleaning

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/DefaultSegmentNameGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/DefaultSegmentNameGenerator.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.core.segment;
 
 import com.linkedin.pinot.common.utils.StringUtil;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
+import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
 
 
 public class DefaultSegmentNameGenerator implements SegmentNameGenerator {
@@ -77,7 +77,7 @@ public class DefaultSegmentNameGenerator implements SegmentNameGenerator {
    * @throws Exception
    */
   @Override
-  public String getSegmentName(AbstractColumnStatisticsCollector statsCollector) throws Exception {
+  public String getSegmentName(ColumnStatistics statsCollector) throws Exception {
     if (_segmentName != null) {
       return _segmentName;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/SegmentNameGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/SegmentNameGenerator.java
@@ -15,12 +15,12 @@
  */
 package com.linkedin.pinot.core.segment;
 
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
+import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
 
 
 /**
  * An interface that allows generates names for segments depending on the naming scheme.
  */
 public interface SegmentNameGenerator {
-  public String getSegmentName(AbstractColumnStatisticsCollector timeColStatsCollector) throws Exception;
+  String getSegmentName(ColumnStatistics timeColStatsCollector) throws Exception;
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/ColumnStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/ColumnStatistics.java
@@ -17,50 +17,43 @@ package com.linkedin.pinot.core.segment.creator;
 
 /**
  * An interface to read the column statistics from statistics collectors.
- *
  */
 public interface ColumnStatistics {
     /**
      * @return Minimum value of the column
-     * @throws Exception
      */
-    Object getMinValue() throws Exception;
+    Object getMinValue();
 
     /**
      * @return Maximum value of the column
-     * @throws Exception
      */
-    Object getMaxValue() throws Exception;
+    Object getMaxValue();
 
     /**
      *
      * @return An array of elements that has the unique values for this column, sorted order.
-     * @throws Exception
      */
-    Object getUniqueValuesSet() throws Exception;
+    Object getUniqueValuesSet();
 
     /**
      *
      * @return The number of unique values of this column.
-     * @throws Exception
      */
-    int getCardinality() throws Exception;
+    int getCardinality();
 
     /**
      *
      * @return For string objects, returns the length of the longest string value. For others, returns -1.
-     * @throws Exception
      */
-    int getLengthOfLargestElement() throws Exception;
+    int getLengthOfLargestElement();
 
     /**
-     *
-     * @return The number of null values in the input for this column.
+     * Whether or not the data in this column is in ascending order.
+     * @return true if the data is in ascending order.
      */
-    int getNumInputNullValues();
+    boolean isSorted();
 
     /**
-     *
      * @return total number of entries
      */
     int getTotalNumberOfEntries();
@@ -71,7 +64,6 @@ public interface ColumnStatistics {
     int getMaxNumberOfMultiValues();
 
     /**
-     * @note
      * @return Returns if any of the values have nulls in the segments.
      */
     boolean hasNull();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentPreIndexStatsContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentPreIndexStatsContainer.java
@@ -19,7 +19,7 @@ package com.linkedin.pinot.core.segment.creator;
  * Container for per-column stats for a segment
  */
 public interface SegmentPreIndexStatsContainer {
-  AbstractColumnStatisticsCollector getColumnProfileFor(String column) throws Exception;
+  ColumnStatistics getColumnProfileFor(String column) throws Exception;
 
   int getRawDocCount();
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.mutable.MutableLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.collect.HashBiMap;
@@ -43,7 +42,6 @@ import com.linkedin.pinot.core.data.readers.RecordReader;
 import com.linkedin.pinot.core.data.readers.RecordReaderFactory;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
 import com.linkedin.pinot.core.segment.creator.ColumnIndexCreationInfo;
 import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
 import com.linkedin.pinot.core.segment.creator.ForwardIndexType;
@@ -442,14 +440,6 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
     // Persist creation metadata to disk
     persistCreationMeta(segmentOutputDir, crc);
-    Map<String, MutableLong> nullCountMap = recordReader.getNullCountMap();
-    if (nullCountMap != null) {
-      for (Map.Entry<String, MutableLong> entry : nullCountMap.entrySet()) {
-        AbstractColumnStatisticsCollector columnStatisticsCollector =
-            segmentStats.getColumnProfileFor(entry.getKey());
-        columnStatisticsCollector.setNumInputNullValues(entry.getValue().intValue());
-      }
-    }
 
     convertFormatIfNeeded(segmentOutputDir);
     LOGGER.info("Driver, record read time : {}", totalRecordReadTime);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
@@ -20,21 +20,14 @@ import it.unimi.dsi.fastutil.doubles.DoubleSet;
 import java.util.Arrays;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
 
-
-/**
- * Nov 7, 2014
- */
 
 public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
-
   private Double min = null;
   private Double max = null;
   private final DoubleSet rawDoubleSet;
   private final DoubleSet aggregatedDoubleSet;
   private double[] sortedDoubleList;
-  private boolean hasNull = false;
   private boolean sealed = false;
 
   public DoubleColumnPreIndexStatsCollector(FieldSpec spec) {
@@ -93,35 +86,35 @@ public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatistics
   }
 
   @Override
-  public Double getMinValue() throws Exception {
+  public Double getMinValue() {
     if (sealed) {
       return min;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public Double getMaxValue() throws Exception {
+  public Double getMaxValue() {
     if (sealed) {
       return max;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public Object getUniqueValuesSet() throws Exception {
+  public Object getUniqueValuesSet() {
     if (sealed) {
       return sortedDoubleList;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public int getCardinality() throws Exception {
+  public int getCardinality() {
     if (sealed) {
       return sortedDoubleList.length;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
@@ -20,21 +20,14 @@ import it.unimi.dsi.fastutil.floats.FloatSet;
 import java.util.Arrays;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
 
-
-/**
- * Nov 7, 2014
- */
 
 public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
-
   private Float min = Float.MAX_VALUE;
   private Float max = Float.MIN_VALUE;
   private final FloatSet rawFloatSet;
   private final FloatSet aggregatedFloatSet;
   private float[] sortedFloatList;
-  private boolean hasNull = false;
   private boolean sealed = false;
 
   public FloatColumnPreIndexStatsCollector(FieldSpec spec) {
@@ -93,35 +86,35 @@ public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
   }
 
   @Override
-  public Float getMinValue() throws Exception {
+  public Float getMinValue() {
     if (sealed) {
       return min;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public Float getMaxValue() throws Exception {
+  public Float getMaxValue() {
     if (sealed) {
       return max;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public Object getUniqueValuesSet() throws Exception {
+  public Object getUniqueValuesSet() {
     if (sealed) {
       return sortedFloatList;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public int getCardinality() throws Exception {
+  public int getCardinality() {
     if (sealed) {
       return sortedFloatList.length;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
@@ -20,20 +20,13 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Arrays;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
 
-
-/**
- * Nov 7, 2014
- */
 
 public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
-
   private Integer min = null;
   private Integer max = null;
   private final IntSet rawIntSet;
   private final IntSet aggregatedIntSet;
-  private boolean hasNull = false;
   private int[] sortedIntList;
   private boolean sealed = false;
 
@@ -95,35 +88,35 @@ public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
 
 
   @Override
-  public Integer getMinValue() throws Exception {
+  public Integer getMinValue() {
     if (sealed) {
       return min;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public Integer getMaxValue() throws Exception {
+  public Integer getMaxValue() {
     if (sealed) {
       return max;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for max value");
+    throw new IllegalStateException("you must seal the collector first before asking for max value");
   }
 
   @Override
-  public Object getUniqueValuesSet() throws Exception {
+  public Object getUniqueValuesSet() {
     if (sealed) {
       return sortedIntList;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for unique value set");
+    throw new IllegalStateException("you must seal the collector first before asking for unique value set");
   }
 
   @Override
-  public int getCardinality() throws Exception {
+  public int getCardinality() {
     if (sealed) {
       return sortedIntList.length;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for cardinality");
+    throw new IllegalStateException("you must seal the collector first before asking for cardinality");
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
@@ -20,21 +20,14 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import java.util.Arrays;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
 
-
-/**
- * Nov 7, 2014
- */
 
 public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
-
   private Long min = null;
   private Long max = null;
   private final LongSet rawLongSet;
   private final LongSet aggregatedLongSet;
   private long[] sortedLongList;
-  private boolean hasNull = false;
   private boolean sealed = false;
 
   public LongColumnPreIndexStatsCollector(FieldSpec spec) {
@@ -53,7 +46,6 @@ public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCo
    * @param set
    */
   private void collectEntry(Object entry, LongSet set) {
-
     if (entry instanceof Object[]) {
       for (final Object e : (Object[]) entry) {
         set.add(((Number) e).longValue());
@@ -94,35 +86,35 @@ public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCo
   }
 
   @Override
-  public Long getMinValue() throws Exception {
+  public Long getMinValue() {
     if (sealed) {
       return min;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public Long getMaxValue() throws Exception {
+  public Long getMaxValue() {
     if (sealed) {
       return max;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public Object getUniqueValuesSet() throws Exception {
+  public Object getUniqueValuesSet() {
     if (sealed) {
       return sortedLongList;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public int getCardinality() throws Exception {
+  public int getCardinality() {
     if (sealed) {
       return sortedLongList.length;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.core.data.GenericRow;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
+import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
 import com.linkedin.pinot.core.segment.creator.SegmentPreIndexStatsCollector;
 
 
@@ -44,7 +44,7 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
 
   @Override
   public void init() {
-    columnStatsCollectorMap = new HashMap<String, AbstractColumnStatisticsCollector>();
+    columnStatsCollectorMap = new HashMap<>();
 
     for (final FieldSpec spec : dataSchema.getAllFieldSpecs()) {
       switch (spec.getDataType()) {
@@ -71,14 +71,14 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
   }
 
   @Override
-  public void build() throws Exception {
+  public void build() {
     for (final String column : columnStatsCollectorMap.keySet()) {
       columnStatsCollectorMap.get(column).seal();
     }
   }
 
   @Override
-  public AbstractColumnStatisticsCollector getColumnProfileFor(String column) throws Exception {
+  public ColumnStatistics getColumnProfileFor(String column) {
     return columnStatsCollectorMap.get(column);
   }
 
@@ -124,15 +124,6 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
   @Override
   public int getTotalDocCount() {
     return totalDocCount;
-  }
-
-  public static <T> T convertInstanceOfObject(Object o, Class<T> clazz) {
-    try {
-      return clazz.cast(o);
-    } catch (final ClassCastException e) {
-      LOGGER.warn("Caught exception while converting instance", e);
-      return null;
-    }
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
@@ -21,13 +21,8 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 
-
-/**
- * Nov 7, 2014
- */
 
 public class StringColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
   private static final Charset UTF_8 = Charset.forName("UTF-8");
@@ -38,7 +33,6 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
   private final ObjectSet<String> rawStringSet;
   private final ObjectSet<String> aggregatedStringSet;
   private String[] sortedStringList;
-  private boolean hasNull = false;
   private boolean sealed = false;
 
   public StringColumnPreIndexStatsCollector(FieldSpec spec) {
@@ -108,43 +102,43 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
 
 
   @Override
-  public String getMinValue() throws Exception {
+  public String getMinValue() {
     if (sealed) {
       return min;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for min value");
+    throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
   @Override
-  public String getMaxValue() throws Exception {
+  public String getMaxValue() {
     if (sealed) {
       return max;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for max value");
+    throw new IllegalStateException("you must seal the collector first before asking for max value");
   }
 
   @Override
-  public Object[] getUniqueValuesSet() throws Exception {
+  public Object[] getUniqueValuesSet() {
     if (sealed) {
       return sortedStringList;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for unique values set");
+    throw new IllegalStateException("you must seal the collector first before asking for unique values set");
   }
 
   @Override
-  public int getLengthOfLargestElement() throws Exception {
+  public int getLengthOfLargestElement() {
     if (sealed) {
       return longestStringLength;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for longest value");
+    throw new IllegalStateException("you must seal the collector first before asking for longest value");
   }
 
   @Override
-  public int getCardinality() throws Exception {
+  public int getCardinality() {
     if (sealed) {
       return sortedStringList.length;
     }
-    throw new IllegalAccessException("you must seal the collector first before asking for cardinality");
+    throw new IllegalStateException("you must seal the collector first before asking for cardinality");
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
@@ -23,7 +23,7 @@ import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.utils.AvroUtils;
-import com.linkedin.pinot.core.segment.creator.AbstractColumnStatisticsCollector;
+import com.linkedin.pinot.core.segment.creator.impl.stats.AbstractColumnStatisticsCollector;
 import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentCreationDriverFactory;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentDictionaryCreator;


### PR DESCRIPTION
Refactor the per-column statistics collector to return ColumnStatistics
instead of returning AbstractColumnStatisticsCollector. Remove API to
get the number of nulls in the input data.

Other cleanups:
- Move the column statistics collector base class in the stats package
  instead of having it part of the segment creator package
- Remove all of the "throws Exception" from the ColumnStatistics API
- Replace all instances of IllegalAccessException (which is used for
  reflection) by the correct IllegalStateException (method invoked when
  the state of the object does not allow for this method invokation)
- Add @Override annotations as needed
- Remove unneeded empty abstract methods implied by the interface
  implementation
- Removed Javadoc blocks that contained no documentation