### PR TITLE
[PINOT-4637] Configure the average number of multi-values per row.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/FileBasedInstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/FileBasedInstanceDataManagerConfig.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.data.manager.config;
 
-import com.linkedin.pinot.common.segment.ReadMode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.segment.ReadMode;
 
 
 /**
@@ -135,6 +135,11 @@ public class FileBasedInstanceDataManagerConfig implements InstanceDataManagerCo
   @Override
   public String getSegmentFormatVersion() {
     return _instanceDataManagerConfiguration.getString(SEGMENT_FORMAT_VERSION);
+  }
+
+  @Override
+  public String getAvgMultiValueCount() {
+    throw new RuntimeException("Unsupported");
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -15,8 +15,8 @@
  */
 package com.linkedin.pinot.core.data.manager.config;
 
-import com.linkedin.pinot.common.segment.ReadMode;
 import org.apache.commons.configuration.Configuration;
+import com.linkedin.pinot.common.segment.ReadMode;
 
 
 public interface InstanceDataManagerConfig {
@@ -35,6 +35,8 @@ public interface InstanceDataManagerConfig {
   ReadMode getReadMode();
 
   String getSegmentFormatVersion();
+
+  String getAvgMultiValueCount();
 
   boolean isEnableDefaultColumns();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
@@ -15,6 +15,12 @@
  */
 package com.linkedin.pinot.core.data.manager.config;
 
+import java.util.List;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
@@ -23,12 +29,6 @@ import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.index.loader.columnminmaxvalue.ColumnMinMaxValueGeneratorMode;
-import java.util.List;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -41,6 +41,8 @@ public class TableDataManagerConfig {
   private static final String READ_MODE = "readMode";
   private static final String TABLE_DATA_MANAGER_DATA_DIRECTORY = "directory";
   private static final String TABLE_DATA_MANAGER_NAME = "name";
+  private static final String REALTIME_AVG_MULTI_VALUE_COUNT = "avgMvCount";
+  private static final int DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT = 2;
 
   private final Configuration _tableDataManagerConfig;
 
@@ -69,6 +71,10 @@ public class TableDataManagerConfig {
     return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_NAME);
   }
 
+  public int getRealtimeAvgMvCount() {
+    return _tableDataManagerConfig.getInt(REALTIME_AVG_MULTI_VALUE_COUNT);
+  }
+
   public static TableDataManagerConfig getDefaultHelixTableDataManagerConfig(
       InstanceDataManagerConfig instanceDataManagerConfig, String tableName)
       throws ConfigurationException {
@@ -86,6 +92,16 @@ public class TableDataManagerConfig {
     } else {
       defaultConfig.addProperty(READ_MODE, ReadMode.heap);
     }
+    int avgMultiValueCount = DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT;
+    if (instanceDataManagerConfig.getAvgMultiValueCount() != null) {
+      try {
+        avgMultiValueCount = Integer.valueOf(instanceDataManagerConfig.getAvgMultiValueCount());
+      } catch (NumberFormatException e) {
+        // Ignore
+      }
+    }
+    defaultConfig.addProperty(REALTIME_AVG_MULTI_VALUE_COUNT, new Integer(avgMultiValueCount));
+
     if (instanceDataManagerConfig.getSegmentFormatVersion() != null) {
       defaultConfig.addProperty(IndexLoadingConfigMetadata.KEY_OF_SEGMENT_FORMAT_VERSION,
           instanceDataManagerConfig.getSegmentFormatVersion());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -15,6 +15,15 @@
  */
 package com.linkedin.pinot.core.data.manager.realtime;
 
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.IndexingConfig;
@@ -40,16 +49,6 @@ import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
 import com.linkedin.pinot.core.segment.index.loader.Loaders;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TimerTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class HLRealtimeSegmentDataManager extends SegmentDataManager {
@@ -160,7 +159,8 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
     // lets create a new realtime segment
     segmentLogger.info("Started kafka stream provider");
     realtimeSegment = new RealtimeSegmentImpl(schema, kafkaStreamProviderConfig.getSizeThresholdToFlushSegment(), tableName,
-        segmentMetadata.getSegmentName(), kafkaStreamProviderConfig.getStreamName(), serverMetrics, invertedIndexColumns);
+        segmentMetadata.getSegmentName(), kafkaStreamProviderConfig.getStreamName(), serverMetrics, invertedIndexColumns,
+        _realtimeTableDataManager.getAvgMultiValueCount());
     realtimeSegment.setSegmentMetadata(segmentMetadata, this.schema);
     notifier = realtimeTableDataManager;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -800,7 +800,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
 
     // Start new realtime segment
     _realtimeSegment = new RealtimeSegmentImpl(schema, _segmentMaxRowCount, tableConfig.getTableName(),
-        segmentZKMetadata.getSegmentName(), _kafkaTopic, _serverMetrics, invertedIndexColumns);
+        segmentZKMetadata.getSegmentName(), _kafkaTopic, _serverMetrics, invertedIndexColumns, _realtimeTableDataManager.getAvgMultiValueCount());
     _realtimeSegment.setSegmentMetadata(segmentZKMetadata, schema);
 
     // Create message decoder

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -57,6 +57,10 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
     super();
   }
 
+  public int getAvgMultiValueCount() {
+    return _tableDataManagerConfig.getRealtimeAvgMvCount();
+  }
+
   @Override
   protected void doShutdown() {
     _segmentAsyncExecutorService.shutdown();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
@@ -15,13 +15,13 @@
  */
 package com.linkedin.pinot.core.io.readerwriter.impl;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import com.linkedin.pinot.core.io.reader.impl.FixedByteSingleValueMultiColReader;
 import com.linkedin.pinot.core.io.readerwriter.BaseSingleColumnMultiValueReaderWriter;
 import com.linkedin.pinot.core.io.writer.impl.FixedByteSingleValueMultiColWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**
@@ -80,18 +80,13 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
   private int columnSizeInBytes;
   private int maxNumberOfMultiValuesPerRow;
 
-  public FixedByteSingleColumnMultiValueReaderWriter(int rows, int columnSizeInBytes, int maxNumberOfMultiValuesPerRow)
+  public FixedByteSingleColumnMultiValueReaderWriter(int rows, int columnSizeInBytes, int maxNumberOfMultiValuesPerRow,
+      int avgMultiValueCount)
       throws IOException {
-    int initialCapacity = Math.max(maxNumberOfMultiValuesPerRow, rows * AVERAGE_NUM_VALUES_PER_ROW);
+    int initialCapacity = Math.max(maxNumberOfMultiValuesPerRow, rows * avgMultiValueCount);
     int incrementalCapacity =
         Math.max(maxNumberOfMultiValuesPerRow, (int) (initialCapacity * 1.0f * INCREMENT_PERCENTAGE / 100));
     init(rows, columnSizeInBytes, maxNumberOfMultiValuesPerRow, initialCapacity, incrementalCapacity);
-  }
-
-  public FixedByteSingleColumnMultiValueReaderWriter(int rows, int columnSizeInBytes, int maxNumberOfMultiValuesPerRow,
-      int initialCapacity, int incrementalCapacity) throws IOException {
-    init(rows, columnSizeInBytes, maxNumberOfMultiValuesPerRow, initialCapacity, incrementalCapacity);
-
   }
 
   private void init(int rows, int columnSizeInBytes, int maxNumberOfMultiValuesPerRow, int initialCapacity,

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeFileBasedReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeFileBasedReaderTest.java
@@ -42,6 +42,7 @@ import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderImpl;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.realtime.impl.kafka.RealtimeSegmentImplTest;
 import com.linkedin.pinot.core.segment.index.loader.Loaders;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
 import com.yammer.metrics.core.MetricsRegistry;
@@ -82,7 +83,7 @@ public class RealtimeFileBasedReaderTest {
     final String tableName = RealtimeFileBasedReaderTest.class.getSimpleName()+".noTable";
     provider.init(config, tableName, new ServerMetrics(new MetricsRegistry()));
 
-    realtimeSegment = new RealtimeSegmentImpl(schema, 100000, tableName, segmentName, AVRO_DATA, new
+    realtimeSegment = RealtimeSegmentImplTest.createRealtimeSegmentImpl(schema, 100000, tableName, segmentName, AVRO_DATA, new
         ServerMetrics(new MetricsRegistry()));
     GenericRow row = provider.next(new GenericRow());
     while (row != null) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -15,6 +15,15 @@
  */
 package com.linkedin.pinot.core.realtime;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.data.Schema;
@@ -37,17 +46,9 @@ import com.linkedin.pinot.core.operator.filter.ScanBasedFilterOperator;
 import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.FileBasedStreamProviderImpl;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.realtime.impl.kafka.RealtimeSegmentImplTest;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
 import com.yammer.metrics.core.MetricsRegistry;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 public class RealtimeSegmentTest {
   private static final String AVRO_DATA = "data/test_data-mv.avro";
@@ -86,9 +87,9 @@ public class RealtimeSegmentTest {
     List<String> invertedIdxCols = new ArrayList<>();
     invertedIdxCols.add("count");
     segmentWithInvIdx = new RealtimeSegmentImpl(schema, 100000, tableName, "noSegment", AVRO_DATA, new ServerMetrics(new MetricsRegistry()),
-        invertedIdxCols);
-    segmentWithoutInvIdx =
-        new RealtimeSegmentImpl(schema, 100000, tableName, "noSegment", AVRO_DATA, new ServerMetrics(new MetricsRegistry()));
+        invertedIdxCols, 2);
+    segmentWithoutInvIdx = RealtimeSegmentImplTest.createRealtimeSegmentImpl(schema, 100000, tableName, "noSegment",
+        AVRO_DATA, new ServerMetrics(new MetricsRegistry()));
     GenericRow row = provider.next(new GenericRow());
     while (row != null) {
       segmentWithInvIdx.index(row);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
@@ -27,18 +27,26 @@ public class MultiValueDictionaryTest {
   private static final String COL_NAME = "greek";
   private static final int NROWS = 1000;
   private static final int MAX_N_VALUES = FixedByteSingleColumnMultiValueReaderWriter.DEFAULT_MAX_NUMBER_OF_MULTIVALUES;
-  private static final long RANDOM_SEED = System.nanoTime();
 
   @Test
-  public void testMultiValueIndexing()
+  public void testMultiValueIndexing() {
+    final long seed = System.nanoTime();
+    try {
+      testMultiValueIndexing(seed);
+    } catch (Exception e) {
+      Assert.fail("Failed with seed=" + seed);
+    }
+  }
+
+  public void testMultiValueIndexing(final long seed)
       throws Exception {
     final FieldSpec mvIntFs = new DimensionFieldSpec(COL_NAME, FieldSpec.DataType.LONG, false);
     final LongMutableDictionary dict = new LongMutableDictionary(COL_NAME);
     final FixedByteSingleColumnMultiValueReaderWriter indexer =
-        new FixedByteSingleColumnMultiValueReaderWriter(NROWS, Integer.SIZE / 8, MAX_N_VALUES);
+        new FixedByteSingleColumnMultiValueReaderWriter(NROWS, Integer.SIZE / 8, MAX_N_VALUES, 2);
 
     // Insert rows into the indexer and dictionary
-    Random random = new Random(RANDOM_SEED);
+    Random random = new Random(seed);
     for (int row = 0; row < NROWS; row++) {
       int nValues = Math.abs(random.nextInt()) % MAX_N_VALUES;
       Long[] val = new Long[nValues];
@@ -54,17 +62,17 @@ public class MultiValueDictionaryTest {
     }
 
     // Read back rows and make sure that the values are good.
-    random = new Random(RANDOM_SEED);
+    random = new Random(seed);
     final int[] dictIds = new int[MAX_N_VALUES];
     for (int row = 0; row < NROWS; row++) {
       int nValues = indexer.getIntArray(row, dictIds);
       Assert.assertEquals(nValues, Math.abs(random.nextInt()) % MAX_N_VALUES,
-          "Mismatching number of values, random seed is: " + RANDOM_SEED);
+          "Mismatching number of values, random seed is: " + seed);
 
       for (int i = 0; i < nValues; i++) {
         Long val = dict.getLongValue(dictIds[i]);
         Assert.assertEquals(val.longValue(), random.nextLong(),
-            "Value mismatch at row " + row + ", random seed is: " + RANDOM_SEED);
+            "Value mismatch at row " + row + ", random seed is: " + seed);
       }
     }
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
@@ -15,8 +15,8 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
-import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.yammer.metrics.core.MetricsRegistry;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -24,14 +24,21 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.yammer.metrics.core.MetricsRegistry;
 
 
 /**
  * Test for RealtimeSegmentImpl
  */
 public class RealtimeSegmentImplTest {
+  public static RealtimeSegmentImpl createRealtimeSegmentImpl(Schema schema, int sizeThresholdToFlushSegment, String tableName, String segmentName, String streamName,
+      ServerMetrics serverMetrics) throws IOException {
+    return new RealtimeSegmentImpl(schema, sizeThresholdToFlushSegment, tableName, segmentName, streamName, serverMetrics, new ArrayList<String>(),
+        2);
+  }
   @Test
   public void testDropInvalidRows() throws Exception {
     Schema schema = new Schema.SchemaBuilder()
@@ -41,8 +48,8 @@ public class RealtimeSegmentImplTest {
         .addTime("time", TimeUnit.SECONDS, FieldSpec.DataType.LONG)
         .build();
 
-    RealtimeSegmentImpl realtimeSegment = new RealtimeSegmentImpl(schema, 100, "noTable", "noSegment", schema.getSchemaName(),
-        new ServerMetrics(new MetricsRegistry()));
+    RealtimeSegmentImpl realtimeSegment = createRealtimeSegmentImpl(schema, 100, "noTable", "noSegment",
+        schema.getSchemaName(), new ServerMetrics(new MetricsRegistry()));
 
     // Segment should be empty
     Assert.assertEquals(realtimeSegment.getRawDocumentCount(), 0);

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
@@ -15,27 +15,37 @@
  */
 package com.linkedin.pinot.index.readerwriter;
 
-import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 
 
 public class FixedByteSingleColumnMultiValueReaderWriterTest {
 
   @Test
-  public void testIntArray()
+  public void testIntArray() {
+    Random r = new Random();
+    final long seed = r.nextLong();
+    try {
+      testIntArray(seed);
+    } catch (Exception e) {
+      Assert.fail("Failed with seed " + seed);
+    }
+  }
+
+  public void testIntArray(final long seed)
       throws IOException {
     FixedByteSingleColumnMultiValueReaderWriter readerWriter;
     int rows = 1000;
     int columnSizeInBytes = Integer.SIZE / 8;
     int maxNumberOfMultiValuesPerRow = 2000;
     readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(rows, columnSizeInBytes, maxNumberOfMultiValuesPerRow);
+        new FixedByteSingleColumnMultiValueReaderWriter(rows, columnSizeInBytes, maxNumberOfMultiValuesPerRow, 2);
 
-    Random r = new Random();
+    Random r = new Random(seed);
     int[][] data = new int[rows][];
     for (int i = 0; i < rows; i++) {
       data[i] = new int[r.nextInt(maxNumberOfMultiValuesPerRow)];
@@ -46,10 +56,9 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     }
     int[] ret = new int[maxNumberOfMultiValuesPerRow];
     for (int i = 0; i < rows; i++) {
-
       int length = readerWriter.getIntArray(i, ret);
-      Assert.assertEquals(data[i].length, length);
-      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)));
+      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed="+seed);
     }
     readerWriter.close();
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
@@ -15,10 +15,6 @@
  */
 package com.linkedin.pinot.queries;
 
-import com.linkedin.pinot.common.query.QueryRequest;
-import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
-import com.linkedin.pinot.core.data.manager.offline.TableDataManagerProvider;
-import com.linkedin.pinot.core.query.reduce.BrokerReduceService;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -29,7 +25,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -40,12 +35,12 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.common.query.QueryRequest;
 import com.linkedin.pinot.common.query.ReduceService;
 import com.linkedin.pinot.common.query.gen.AvroQueryGenerator;
 import com.linkedin.pinot.common.query.gen.AvroQueryGenerator.TestGroupByAggreationQuery;
@@ -53,15 +48,19 @@ import com.linkedin.pinot.common.query.gen.AvroQueryGenerator.TestSimpleAggreati
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
 import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.manager.config.FileBasedInstanceDataManagerConfig;
 import com.linkedin.pinot.core.data.manager.offline.FileBasedInstanceDataManager;
+import com.linkedin.pinot.core.data.manager.offline.TableDataManagerProvider;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.utils.AvroUtils;
 import com.linkedin.pinot.core.query.executor.ServerQueryExecutorV1Impl;
+import com.linkedin.pinot.core.query.reduce.BrokerReduceService;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.AvroRecordToPinotRowGenerator;
+import com.linkedin.pinot.core.realtime.impl.kafka.RealtimeSegmentImplTest;
 import com.linkedin.pinot.pql.parsers.Pql2Compiler;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
 import com.linkedin.pinot.util.TestUtils;
@@ -275,7 +274,7 @@ public class RealtimeQueriesSentinelTest {
   }
 
   private IndexSegment getRealtimeSegment() throws IOException {
-    RealtimeSegmentImpl realtimeSegmentImpl = new RealtimeSegmentImpl(PINOT_SCHEMA, 100000, "testTable", "testTable_testTable", AVRO_DATA,
+    RealtimeSegmentImpl realtimeSegmentImpl = RealtimeSegmentImplTest.createRealtimeSegmentImpl(PINOT_SCHEMA, 100000, "testTable", "testTable_testTable", AVRO_DATA,
         new ServerMetrics(new MetricsRegistry()));
     realtimeSegmentImpl.setSegmentMetadata(getRealtimeSegmentZKMetadata());
     try {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -34,7 +34,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   // Average number of values in multi-valued columns in any table in this instance.
   // This value is used to allocate initial memory for multi-valued columns in realtime segments in consuming state.
-  private static final String AVERAGE_MV_COUNT = "realtime.avgMultiValueCount";
+  private static final String AVERAGE_MV_COUNT = "realtime.averageMultiValueEntriesPerRow";
   private static final String INSTANCE_SEGMENT_METADATA_LOADER_CLASS = "segment.metadata.loader.class";
   // Key of instance id
   public static final String INSTANCE_ID = "id";

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -18,11 +18,10 @@ package com.linkedin.pinot.server.starter.helix;
 import java.util.Iterator;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
-
-import com.linkedin.pinot.common.segment.ReadMode;
-import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
 
 
 /**
@@ -33,6 +32,9 @@ import org.slf4j.LoggerFactory;
 public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixInstanceDataManagerConfig.class);
 
+  // Average number of values in multi-valued columns in any table in this instance.
+  // This value is used to allocate initial memory for multi-valued columns in realtime segments in consuming state.
+  private static final String AVERAGE_MV_COUNT = "realtime.avgMultiValueCount";
   private static final String INSTANCE_SEGMENT_METADATA_LOADER_CLASS = "segment.metadata.loader.class";
   // Key of instance id
   public static final String INSTANCE_ID = "id";
@@ -119,6 +121,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public boolean isEnableDefaultColumns() {
     return _instanceDataManagerConfiguration.getBoolean(ENABLE_DEFAULT_COLUMNS, false);
+  }
+
+  @Override
+  public String getAvgMultiValueCount() {
+    return _instanceDataManagerConfiguration.getString(AVERAGE_MV_COUNT, null);
   }
 
   @Override


### PR DESCRIPTION
For multi-valued columns in realtime segments, we allocate memory initial memory assuming that the average
number of values in any row for that column is 10. Changed the default to 2, and made it configurable
for individual server instances if needed.

Modifed the tests to print the seed value in case of exceptions