### PR TITLE
TE: Fix null exception issue when updating merged anomalies

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContext.java
@@ -1,19 +1,21 @@
 package com.linkedin.thirdeye.anomaly.detection;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 public class AnomalyDetectionInputContext {
-  Map<DimensionMap, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap;
-  ListMultimap<DimensionMap, RawAnomalyResultDTO> existingRawAnomalies;
-  ListMultimap<DimensionMap, MergedAnomalyResultDTO> knownMergedAnomalies;
-  List<ScalingFactor> scalingFactors;
+  Map<DimensionMap, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap = Collections.emptyMap();
+  ListMultimap<DimensionMap, RawAnomalyResultDTO> existingRawAnomalies = ArrayListMultimap.create();;
+  ListMultimap<DimensionMap, MergedAnomalyResultDTO> knownMergedAnomalies = ArrayListMultimap.create();;
+  List<ScalingFactor> scalingFactors = Collections.emptyList();
 
   public Map<DimensionMap, MetricTimeSeries> getDimensionKeyMetricTimeSeriesMap() {
     return dimensionKeyMetricTimeSeriesMap;


### PR DESCRIPTION
The exception is thrown when there exists no known anomalies and hence the ListMultimap for knownMergedAnomalies is not initialized.

Tested on local and passed integration test.