### PR TITLE
Improve anomalies timeseries view

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
@@ -81,7 +81,8 @@ public abstract class TimeSeriesUtil {
         anomalyFunctionSpec.getBucketUnit());
 
     TimeSeriesResponse timeSeriesResponse =
-      getTimeSeriesResponseImpl(anomalyFunctionSpec, startEndTimeRanges, timeGranularity, filters, groupByDimensions);
+      getTimeSeriesResponseImpl(anomalyFunctionSpec, startEndTimeRanges, timeGranularity, filters, groupByDimensions,
+          false);
 
     try {
       Map<DimensionKey, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap =
@@ -103,14 +104,15 @@ public abstract class TimeSeriesUtil {
    * @param dimensionMap a dimension map that is used to construct the filter for retrieving the corresponding data
    *                     that was used to detected the anomaly
    * @param timeGranularity time granularity of the time series
-   *
+   * @param endTimeInclusive set to true if the end time should be inclusive; mainly used by the query for UI
    * @return the time series in the same format as those used by the given anomaly function for anomaly detection
    *
    * @throws JobExecutionException
    * @throws ExecutionException
    */
   public static MetricTimeSeries getTimeSeriesByDimension(AnomalyFunctionDTO anomalyFunctionSpec,
-      List<Pair<Long, Long>> startEndTimeRanges, DimensionMap dimensionMap, TimeGranularity timeGranularity)
+      List<Pair<Long, Long>> startEndTimeRanges, DimensionMap dimensionMap, TimeGranularity timeGranularity,
+      boolean endTimeInclusive)
       throws JobExecutionException, ExecutionException {
 
     // Get the original filter
@@ -143,7 +145,8 @@ public abstract class TimeSeriesUtil {
     }
 
     TimeSeriesResponse response =
-        getTimeSeriesResponseImpl(anomalyFunctionSpec, startEndTimeRanges, timeGranularity, filters, groupByDimensions);
+        getTimeSeriesResponseImpl(anomalyFunctionSpec, startEndTimeRanges, timeGranularity, filters, groupByDimensions,
+            endTimeInclusive);
     try {
       Map<DimensionKey, MetricTimeSeries> metricTimeSeriesMap = TimeSeriesResponseConverter.toMap(response,
           Utils.getSchemaDimensionNames(anomalyFunctionSpec.getCollection()));
@@ -203,7 +206,7 @@ public abstract class TimeSeriesUtil {
 
   private static TimeSeriesResponse getTimeSeriesResponseImpl(AnomalyFunctionDTO anomalyFunctionSpec,
       List<Pair<Long, Long>> startEndTimeRanges, TimeGranularity timeGranularity, Multimap<String, String> filters,
-      List<String> groupByDimensions)
+      List<String> groupByDimensions, boolean endTimeInclusive)
       throws JobExecutionException, ExecutionException {
 
     TimeSeriesHandler timeSeriesHandler =
@@ -222,6 +225,7 @@ public abstract class TimeSeriesUtil {
     request.setEndDateInclusive(false);
     request.setFilterSet(filters);
     request.setGroupByDimensions(groupByDimensions);
+    request.setEndDateInclusive(endTimeInclusive);
 
     LOG.info("Found [{}] time ranges to fetch data", startEndTimeRanges.size());
     for (Pair<Long, Long> timeRange : startEndTimeRanges) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -256,7 +256,7 @@ public class AnomalyMergeExecutor implements Runnable {
 
     MetricTimeSeries metricTimeSeries =
         TimeSeriesUtil.getTimeSeriesByDimension(anomalyFunctionSpec, startEndTimeRanges,
-            anomalyMergedResult.getDimensions(), timeGranularity);
+            anomalyMergedResult.getDimensions(), timeGranularity, false);
 
     if (metricTimeSeries != null) {
       DateTime windowStart = new DateTime(anomalyMergedResult.getStartTime());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -224,7 +224,7 @@ public class TimeBasedAnomalyMerger {
 
     AnomalyDetectionInputContext adInputContext =
         fetchDataByDimension(windowStartMillis, windowEndMillis, dimensions, anomalyFunction, mergedResultDAO,
-            overrideConfigDAO);
+            overrideConfigDAO, false);
 
     MetricTimeSeries metricTimeSeries = adInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
 
@@ -255,12 +255,13 @@ public class TimeBasedAnomalyMerger {
    * @param anomalyFunction the anomaly function that produces the anomaly
    * @param mergedResultDAO DAO for merged anomalies
    * @param overrideConfigDAO DAO for override configuration
+   * @param endTimeInclusive set to true if the end time should be inclusive; mainly used by the queries from UI
    * @return an anomaly detection input context that contains all the retrieved data
    * @throws Exception if it fails to retrieve time series from DB.
    */
   public static AnomalyDetectionInputContext fetchDataByDimension(long windowStartTime, long windowEndTime,
       DimensionMap dimensions, BaseAnomalyFunction anomalyFunction, MergedAnomalyResultManager mergedResultDAO,
-      OverrideConfigManager overrideConfigDAO)
+      OverrideConfigManager overrideConfigDAO, boolean endTimeInclusive)
       throws Exception {
     AnomalyFunctionDTO functionSpec = anomalyFunction.getSpec();
     List<Pair<Long, Long>> startEndTimeRanges = anomalyFunction.getDataRangeIntervals(windowStartTime, windowEndTime);
@@ -270,7 +271,7 @@ public class TimeBasedAnomalyMerger {
 
     // Retrieve Time Series
     MetricTimeSeries metricTimeSeries =
-        TimeSeriesUtil.getTimeSeriesByDimension(functionSpec, startEndTimeRanges, dimensions, timeGranularity);
+        TimeSeriesUtil.getTimeSeriesByDimension(functionSpec, startEndTimeRanges, dimensions, timeGranularity, endTimeInclusive);
     Map<DimensionMap, MetricTimeSeries> metricTimeSeriesMap = new HashMap<>();
     metricTimeSeriesMap.put(dimensions, metricTimeSeries);
     adInputContext.setDimensionKeyMetricTimeSeriesMap(metricTimeSeriesMap);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -1,7 +1,6 @@
 package com.linkedin.thirdeye.dashboard.resources;
 
 import com.google.common.cache.LoadingCache;
-import com.linkedin.pinot.pql.parsers.utils.Pair;
 import com.linkedin.thirdeye.anomaly.alert.util.AlertFilterHelper;
 import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionInputContext;
 import com.linkedin.thirdeye.anomaly.merge.TimeBasedAnomalyMerger;
@@ -21,7 +20,6 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -620,7 +618,7 @@ public class AnomalyResource {
 
     AnomalyDetectionInputContext adInputContext = TimeBasedAnomalyMerger
         .fetchDataByDimension(viewWindowStartTime, viewWindowEndTime, dimensions, anomalyFunction,
-            anomalyMergedResultDAO, overrideConfigDAO);
+            anomalyMergedResultDAO, overrideConfigDAO, false);
 
     MetricTimeSeries metricTimeSeries = adInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -609,6 +609,9 @@ public class AnomaliesResource {
       toIndex = mergedAnomalies.size();
     }
 
+    // Show most recent anomalies first, i.e., the anomaly whose end time is most recent then largest id shown at top
+    Collections.sort(mergedAnomalies, new MergedAnomalyEndTimeComparator().reversed());
+
     List<MergedAnomalyResultDTO> displayedAnomalies = mergedAnomalies.subList(fromIndex, toIndex);
     anomaliesWrapper.setNumAnomaliesOnPage(displayedAnomalies.size());
     LOG.info("Page number: {} Page size: {} Num anomalies on page: {}", pageNumber, pageSize, displayedAnomalies.size());
@@ -644,24 +647,22 @@ public class AnomaliesResource {
         LOG.error("Exception in getting AnomalyDetails", e);
       }
     }
-    // Show most recent anomalies first, i.e., the anomaly whose end time is most recent then largest id shown at top
-    Collections.sort(anomalyDetailsList, new AnomalyDetailsAnomalyEndTimeComparator().reversed());
     anomaliesWrapper.setAnomalyDetailsList(anomalyDetailsList);
 
     return anomaliesWrapper;
   }
 
   /**
-   * Return the natural order of AnomalyDetails by comparing their anomaly's end time.
+   * Return the natural order of MergedAnomaly by comparing their anomaly's end time.
    * The tie breaker is their anomaly ID.
    */
-  private static class AnomalyDetailsAnomalyEndTimeComparator implements Comparator<AnomalyDetails> {
+  private static class MergedAnomalyEndTimeComparator implements Comparator<MergedAnomalyResultDTO> {
     @Override
-    public int compare(AnomalyDetails anomaly1, AnomalyDetails anomaly2) {
-      if (anomaly1.getAnomalyRegionEndMillis() != anomaly2.getAnomalyRegionEndMillis()) {
-        return (int) (anomaly1.getAnomalyRegionEndMillis() - anomaly2.getAnomalyRegionEndMillis());
+    public int compare(MergedAnomalyResultDTO anomaly1, MergedAnomalyResultDTO anomaly2) {
+      if (anomaly1.getEndTime() != anomaly2.getEndTime()) {
+        return (int) (anomaly1.getEndTime() - anomaly2.getEndTime());
       } else {
-        return (int) (anomaly1.getAnomalyId() - anomaly2.getAnomalyId());
+        return (int) (anomaly1.getId() - anomaly2.getId());
       }
     }
   }
@@ -821,7 +822,6 @@ public class AnomaliesResource {
     anomalyDetails.setAnomalyId(mergedAnomaly.getId());
     anomalyDetails.setAnomalyRegionStart(timeSeriesDateFormatter.print(mergedAnomaly.getStartTime()));
     anomalyDetails.setAnomalyRegionEnd(timeSeriesDateFormatter.print(mergedAnomaly.getEndTime()));
-    anomalyDetails.setAnomalyRegionEndMillis(mergedAnomaly.getEndTime());
     Map<String, String> messageDataMap = getAnomalyMessageDataMap(mergedAnomaly.getMessage());
     anomalyDetails.setCurrent(messageDataMap.get(ANOMALY_CURRENT_VAL_KEY));
     anomalyDetails.setBaseline(messageDataMap.get(ANOMALY_BASELINE_VAL_KEY));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -18,7 +18,6 @@ import com.linkedin.thirdeye.dashboard.resources.v2.pojo.AnomalyDetails;
 import com.linkedin.thirdeye.dashboard.views.TimeBucket;
 import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
-import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
@@ -29,6 +28,8 @@ import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,7 +155,7 @@ public class AnomaliesResource {
       Pair<Long, Long> currentTmeRange = new Pair<>(anomaly.getStartTime(), anomaly.getEndTime());
       MetricTimeSeries ts = TimeSeriesUtil
           .getTimeSeriesByDimension(anomaly.getFunction(), Arrays.asList(currentTmeRange),
-              anomaly.getDimensions(), granularity);
+              anomaly.getDimensions(), granularity, false);
       double currentVal = getTotalFromTimeSeries(ts, dataset.isAdditive());
       response.setCurrentVal(currentVal);
 
@@ -164,7 +165,7 @@ public class AnomaliesResource {
             anomaly.getEndTime() - baselineOffset);
         MetricTimeSeries baselineTs = TimeSeriesUtil
             .getTimeSeriesByDimension(anomaly.getFunction(), Arrays.asList(baselineTmeRange),
-                anomaly.getDimensions(), granularity);
+                anomaly.getDimensions(), granularity, false);
         AnomalyDataCompare.CompareResult cr = new AnomalyDataCompare.CompareResult();
         double baseLineval = getTotalFromTimeSeries(baselineTs, dataset.isAdditive());
         cr.setBaselineValue(baseLineval);
@@ -643,9 +644,26 @@ public class AnomaliesResource {
         LOG.error("Exception in getting AnomalyDetails", e);
       }
     }
+    // Show most recent anomalies first, i.e., the anomaly whose end time is most recent then largest id shown at top
+    Collections.sort(anomalyDetailsList, new AnomalyDetailsAnomalyEndTimeComparator().reversed());
     anomaliesWrapper.setAnomalyDetailsList(anomalyDetailsList);
 
     return anomaliesWrapper;
+  }
+
+  /**
+   * Return the natural order of AnomalyDetails by comparing their anomaly's end time.
+   * The tie breaker is their anomaly ID.
+   */
+  private static class AnomalyDetailsAnomalyEndTimeComparator implements Comparator<AnomalyDetails> {
+    @Override
+    public int compare(AnomalyDetails anomaly1, AnomalyDetails anomaly2) {
+      if (anomaly1.getAnomalyRegionEndMillis() != anomaly2.getAnomalyRegionEndMillis()) {
+        return (int) (anomaly1.getAnomalyRegionEndMillis() - anomaly2.getAnomalyRegionEndMillis());
+      } else {
+        return (int) (anomaly1.getAnomalyId() - anomaly2.getAnomalyId());
+      }
+    }
   }
 
   private String getExternalURL(MergedAnomalyResultDTO mergedAnomaly) {
@@ -699,8 +717,6 @@ public class AnomaliesResource {
     TimeRange range = getTimeseriesOffsetedTimes(anomalyStartTime, anomalyEndTime, datasetConfig);
     long currentStartTime = range.getStart();
     long currentEndTime = range.getEnd();
-    long baselineStartTime = new DateTime(currentStartTime).minusDays(7).getMillis();
-    long baselineEndTime = new DateTime(currentEndTime).minusDays(7).getMillis();
 
     DimensionMap dimensions = mergedAnomaly.getDimensions();
     TimeGranularity timeGranularity =
@@ -710,7 +726,7 @@ public class AnomaliesResource {
     try {
       AnomalyDetectionInputContext adInputContext = TimeBasedAnomalyMerger
           .fetchDataByDimension(currentStartTime, currentEndTime, dimensions, anomalyFunction,
-              mergedAnomalyResultDAO, overrideConfigDAO);
+              mergedAnomalyResultDAO, overrideConfigDAO, true);
 
       MetricTimeSeries metricTimeSeries = adInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
 
@@ -730,8 +746,8 @@ public class AnomaliesResource {
               currentStartTime, currentEndTime, knownAnomalies);
 
       anomalyDetails = constructAnomalyDetails(metricName, dataset, datasetConfig, mergedAnomaly, anomalyFunctionSpec,
-          currentStartTime, currentEndTime, baselineStartTime, baselineEndTime, anomalyTimelinesView,
-          timeSeriesDateFormatter, startEndDateFormatterHours, startEndDateFormatterDays, externalUrl);
+          currentStartTime, currentEndTime, anomalyTimelinesView, timeSeriesDateFormatter, startEndDateFormatterHours,
+          startEndDateFormatterDays, externalUrl);
     } catch (Exception e) {
       LOG.error("Exception in constructing anomaly wrapper for anomaly {}", mergedAnomaly.getId(), e);
     }
@@ -745,10 +761,8 @@ public class AnomaliesResource {
    * @param datasetConfig
    * @param mergedAnomaly
    * @param anomalyFunction
-   * @param currentStartTime
-   * @param currentEndTime
-   * @param baselineStartTime
-   * @param baselineEndTime
+   * @param currentStartTime inclusive
+   * @param currentEndTime inclusive
    * @param anomalyTimelinesView
    * @param timeSeriesDateFormatter
    * @param startEndDateFormatterHours
@@ -758,9 +772,9 @@ public class AnomaliesResource {
    */
   private AnomalyDetails constructAnomalyDetails(String metricName, String dataset, DatasetConfigDTO datasetConfig,
       MergedAnomalyResultDTO mergedAnomaly, AnomalyFunctionDTO anomalyFunction, long currentStartTime,
-      long currentEndTime, long baselineStartTime, long baselineEndTime, AnomalyTimelinesView anomalyTimelinesView,
-      DateTimeFormatter timeSeriesDateFormatter, DateTimeFormatter startEndDateFormatterHours,
-      DateTimeFormatter startEndDateFormatterDays, String externalUrl) throws JSONException {
+      long currentEndTime, AnomalyTimelinesView anomalyTimelinesView, DateTimeFormatter timeSeriesDateFormatter,
+      DateTimeFormatter startEndDateFormatterHours, DateTimeFormatter startEndDateFormatterDays, String externalUrl)
+      throws JSONException {
 
     MetricConfigDTO metricConfigDTO = metricConfigDAO.findByMetricAndDataset(metricName, dataset);
 
@@ -772,22 +786,42 @@ public class AnomaliesResource {
       anomalyDetails.setMetricId(metricConfigDTO.getId());
     }
 
+    // The filter ensures that the returned time series from anomalies function only includes the values that are
+    // located inside the request windows (i.e., between currentStartTime and currentEndTime, inclusive).
+    List<TimeBucket> timeBuckets = anomalyTimelinesView.getTimeBuckets();
+    int timeStartIndex = -1;
+    int timeEndIndex = -1;
+    for (int i = 0; i < timeBuckets.size(); ++i) {
+      long currentTimeStamp = timeBuckets.get(i).getCurrentStart();
+      if (timeStartIndex < 0 &&  currentTimeStamp >= currentStartTime) {
+        timeStartIndex = i;
+        timeEndIndex = i + 1;
+      } else if (currentTimeStamp <= currentEndTime) {
+        timeEndIndex = i + 1;
+      } else if (currentTimeStamp > currentEndTime) {
+        break;
+      }
+    }
+    if (timeStartIndex < 0 || timeEndIndex < 0) {
+      timeStartIndex = 0;
+      timeEndIndex = 0;
+    }
+
     // get this from timeseries calls
-    List<String> dateValues = getDateFromTimeSeriesObject(anomalyTimelinesView.getTimeBuckets(), timeSeriesDateFormatter);
+    List<String> dateValues = getDateFromTimeSeriesObject(timeBuckets.subList(timeStartIndex, timeEndIndex), timeSeriesDateFormatter);
     anomalyDetails.setDates(dateValues);
     anomalyDetails.setCurrentEnd(getFormattedDateTime(currentEndTime, datasetConfig, startEndDateFormatterHours, startEndDateFormatterDays));
     anomalyDetails.setCurrentStart(getFormattedDateTime(currentStartTime, datasetConfig, startEndDateFormatterHours, startEndDateFormatterDays));
-    anomalyDetails.setBaselineEnd(getFormattedDateTime(baselineEndTime, datasetConfig, startEndDateFormatterHours, startEndDateFormatterDays));
-    anomalyDetails.setBaselineStart(getFormattedDateTime(baselineStartTime, datasetConfig, startEndDateFormatterHours, startEndDateFormatterDays));
-    List<String> baselineValues = getDataFromTimeSeriesObject(anomalyTimelinesView.getBaselineValues());
+    List<String> baselineValues = getDataFromTimeSeriesObject(anomalyTimelinesView.getBaselineValues().subList(timeStartIndex, timeEndIndex));
     anomalyDetails.setBaselineValues(baselineValues);
-    List<String> currentValues = getDataFromTimeSeriesObject(anomalyTimelinesView.getCurrentValues());
+    List<String> currentValues = getDataFromTimeSeriesObject(anomalyTimelinesView.getCurrentValues().subList(timeStartIndex, timeEndIndex));
     anomalyDetails.setCurrentValues(currentValues);
 
     // from function and anomaly
     anomalyDetails.setAnomalyId(mergedAnomaly.getId());
-    anomalyDetails.setAnomalyRegionStart(timeSeriesDateFormatter.print(Long.valueOf(mergedAnomaly.getStartTime())));
-    anomalyDetails.setAnomalyRegionEnd(timeSeriesDateFormatter.print(Long.valueOf(mergedAnomaly.getEndTime())));
+    anomalyDetails.setAnomalyRegionStart(timeSeriesDateFormatter.print(mergedAnomaly.getStartTime()));
+    anomalyDetails.setAnomalyRegionEnd(timeSeriesDateFormatter.print(mergedAnomaly.getEndTime()));
+    anomalyDetails.setAnomalyRegionEndMillis(mergedAnomaly.getEndTime());
     Map<String, String> messageDataMap = getAnomalyMessageDataMap(mergedAnomaly.getMessage());
     anomalyDetails.setCurrent(messageDataMap.get(ANOMALY_CURRENT_VAL_KEY));
     anomalyDetails.setBaseline(messageDataMap.get(ANOMALY_BASELINE_VAL_KEY));
@@ -808,8 +842,8 @@ public class AnomaliesResource {
     TimeUnit dataTimeunit = datasetConfig.getTimeUnit();
     Period offsetPeriod;
     switch (dataTimeunit) {
-      case DAYS: // 2 days
-        offsetPeriod = new Period(0, 0, 0, 2, 0, 0, 0, 0);
+      case DAYS: // 3 days
+        offsetPeriod = new Period(0, 0, 0, 3, 0, 0, 0, 0);
         break;
       case HOURS: // 10 hours
         offsetPeriod = new Period(0, 0, 0, 0, 10, 0, 0, 0);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/AnomalyDetails.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/AnomalyDetails.java
@@ -16,8 +16,6 @@ public class AnomalyDetails {
   List<String> dates;
   private String currentEnd;
   private String currentStart;
-  private String baselineEnd;
-  private String baselineStart;
   private List<String> baselineValues;
   private List<String> currentValues;
   private String current = "1000";
@@ -26,6 +24,7 @@ public class AnomalyDetails {
   //function details
   private String anomalyRegionStart;
   private String anomalyRegionEnd;
+  private long anomalyRegionEndMillis; // for sorting anomalies
   private Long anomalyFunctionId = 5L;
   private String anomalyFunctionName;
   private String anomalyFunctionType;
@@ -97,22 +96,6 @@ public class AnomalyDetails {
     this.currentStart = currentStart;
   }
 
-  public String getBaselineEnd() {
-    return baselineEnd;
-  }
-
-  public void setBaselineEnd(String baselineEnd) {
-    this.baselineEnd = baselineEnd;
-  }
-
-  public String getBaselineStart() {
-    return baselineStart;
-  }
-
-  public void setBaselineStart(String baselineStart) {
-    this.baselineStart = baselineStart;
-  }
-
   public List<String> getBaselineValues() {
     return baselineValues;
   }
@@ -163,6 +146,14 @@ public class AnomalyDetails {
 
   public Long getAnomalyFunctionId() {
     return anomalyFunctionId;
+  }
+
+  public void setAnomalyRegionEndMillis(long anomalyRegionEndMillis) {
+    this.anomalyRegionEndMillis = anomalyRegionEndMillis;
+  }
+
+  public long getAnomalyRegionEndMillis() {
+    return anomalyRegionEndMillis;
   }
 
   public void setAnomalyFunctionId(Long anomalyFunctionId) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/AnomalyDetails.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/AnomalyDetails.java
@@ -24,7 +24,6 @@ public class AnomalyDetails {
   //function details
   private String anomalyRegionStart;
   private String anomalyRegionEnd;
-  private long anomalyRegionEndMillis; // for sorting anomalies
   private Long anomalyFunctionId = 5L;
   private String anomalyFunctionName;
   private String anomalyFunctionType;
@@ -146,14 +145,6 @@ public class AnomalyDetails {
 
   public Long getAnomalyFunctionId() {
     return anomalyFunctionId;
-  }
-
-  public void setAnomalyRegionEndMillis(long anomalyRegionEndMillis) {
-    this.anomalyRegionEndMillis = anomalyRegionEndMillis;
-  }
-
-  public long getAnomalyRegionEndMillis() {
-    return anomalyRegionEndMillis;
   }
 
   public void setAnomalyFunctionId(Long anomalyFunctionId) {


### PR DESCRIPTION
1. Sort anomaly by their end time and id; the anomaly who has the most recent end time is shown at the top of the page. The sorting works for multiple pages.

2. Add filter to remove time series values that are not located in the view window.

3. Fix the issue that the last data point is not shown on UI.

Tested on local dashboard.