### PR TITLE
[TE] Extend merged anomaly for unifying anomaly result class

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
@@ -8,6 +8,7 @@ import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.alert.AlertTaskRunner;
 import com.linkedin.thirdeye.anomaly.alert.v2.AlertTaskRunnerV2;
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.client.DAORegistry;
 import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
@@ -15,6 +16,7 @@ import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 
@@ -126,11 +128,12 @@ public class AnomalyReportGenerator {
       for (MergedAnomalyResultDTO anomaly : anomalies) {
         metrics.add(anomaly.getMetric());
 
-        if (anomaly.getFeedback() != null) {
+        AnomalyFeedback feedback = anomaly.getFeedback();
+        if (feedback != null) {
           feedbackCollected++;
-          if (anomaly.getFeedback().getFeedbackType().equals(AnomalyFeedbackType.ANOMALY)) {
+          if (feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY)) {
             trueAlert++;
-          } else if (anomaly.getFeedback().getFeedbackType()
+          } else if (feedback.getFeedbackType()
               .equals(AnomalyFeedbackType.NOT_ANOMALY)) {
             falseAlert++;
           } else {
@@ -139,7 +142,7 @@ public class AnomalyReportGenerator {
         }
 
         String feedbackVal = getFeedback(
-            anomaly.getFeedback() == null ? "Not Resolved" : "Resolved(" + anomaly.getFeedback().getFeedbackType().name() + ")");
+            feedback == null ? "Not Resolved" : "Resolved(" + feedback.getFeedbackType().name() + ")");
 
         DateTimeZone dateTimeZone = Utils.getDataTimeZone(anomaly.getCollection());
         AnomalyReportDTO anomalyReportDTO = new AnomalyReportDTO(String.valueOf(anomaly.getId()),

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -397,7 +397,7 @@ public class DetectionTaskRunner implements TaskRunner {
     for (RawAnomalyResultDTO rawAnomaly : rawAnomalies) {
       boolean isContained = false;
       for (MergedAnomalyResultDTO existingAnomaly : existingAnomalies) {
-        if (existingAnomaly.getStartTime().compareTo(rawAnomaly.getStartTime()) <= 0
+        if (Double.compare(existingAnomaly.getStartTime(), rawAnomaly.getStartTime()) <= 0
             && rawAnomaly.getEndTime().compareTo(existingAnomaly.getEndTime()) <= 0) {
           isContained = true;
           break;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -397,7 +397,7 @@ public class DetectionTaskRunner implements TaskRunner {
     for (RawAnomalyResultDTO rawAnomaly : rawAnomalies) {
       boolean isContained = false;
       for (MergedAnomalyResultDTO existingAnomaly : existingAnomalies) {
-        if (Double.compare(existingAnomaly.getStartTime(), rawAnomaly.getStartTime()) <= 0
+        if (Long.compare(existingAnomaly.getStartTime(), rawAnomaly.getStartTime()) <= 0
             && rawAnomaly.getEndTime().compareTo(existingAnomaly.getEndTime()) <= 0) {
           isContained = true;
           break;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyTimeBasedSummarizer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyTimeBasedSummarizer.java
@@ -44,12 +44,12 @@ public abstract class AnomalyTimeBasedSummarizer {
       List<RawAnomalyResultDTO> anomalies, long maxMergedDurationMillis, long sequentialAllowedGap) {
 
     // sort anomalies in natural order of start time
-    Collections
-        .sort(anomalies, new Comparator<RawAnomalyResultDTO>() {
-          @Override public int compare(RawAnomalyResultDTO o1, RawAnomalyResultDTO o2) {
-            return (int) ((o1.getStartTime() - o2.getStartTime()) / 1000);
-          }
-        });
+    Collections.sort(anomalies, new Comparator<RawAnomalyResultDTO>() {
+      @Override
+      public int compare(RawAnomalyResultDTO o1, RawAnomalyResultDTO o2) {
+        return (int) ((o1.getStartTime() - o2.getStartTime()) / 1000);
+      }
+    });
 
     boolean applySequentialGapBasedSplit = false;
     boolean applyMaxDurationBasedSplit = false;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyFeedback.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyFeedback.java
@@ -1,0 +1,42 @@
+package com.linkedin.thirdeye.anomalydetection.context;
+
+import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
+import com.linkedin.thirdeye.constant.FeedbackStatus;
+
+public interface AnomalyFeedback {
+  /**
+   * Set feedback type (e.g., anomaly, anomaly no action, etc.)
+   * @param feedbackType feedback type
+   */
+  void setFeedbackType(AnomalyFeedbackType feedbackType);
+
+  /**
+   * Get feedback type (e.g., anomaly, anomaly no action, etc.)
+   * @return feedback type
+   */
+  AnomalyFeedbackType getFeedbackType();
+
+  /**
+   * Set status (e.g., in progress, resolve, etc.) of this feedback.
+   * @param status status of this feedback
+   */
+  void setStatus(FeedbackStatus status);
+
+  /**
+   * Get status (e.g., in progress, resolve, etc.) of this feedback.
+   * @return status of this feedback
+   */
+  FeedbackStatus getStatus();
+
+  /**
+   * Set comment for this feedback.
+   * @param comment comment for this feedback.
+   */
+  void setComment(String comment);
+
+  /**
+   * Get comment of this feedback.
+   * @return comment of this feedback.
+   */
+  String getComment();
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyResult.java
@@ -79,13 +79,13 @@ public interface AnomalyResult {
    * Set anomaly feedback (i.e., user label) of this anomaly.
    * @param anomalyFeedback anomaly feedback of this anomaly.
    */
-  void setAnomalyFeedback(AnomalyFeedback anomalyFeedback);
+  void setFeedback(AnomalyFeedback anomalyFeedback);
 
   /**
    * Return anomaly feedback (i.e., user label) of this anomaly.
    * @return anomaly feedback of this anomaly.
    */
-  AnomalyFeedback getAnomalyFeedback();
+  AnomalyFeedback getFeedback();
 
   /**
    * Set the properties (e.g., pattern=UP, baselineLift=1.7, etc.) of this anomaly.

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyResult.java
@@ -1,0 +1,87 @@
+package com.linkedin.thirdeye.anomalydetection.context;
+
+public interface AnomalyResult {
+  /**
+   * Set start time in millis, inclusive.
+   * @param startTime start time in millis, inclusive.
+   */
+  void setStartTime(long startTime);
+
+  /**
+   * Get start time in millis, inclusive.
+   * @return start time in millis, inclusive.
+   */
+  long getStartTime();
+
+  /**
+   * Set end time in millis, exclusive.
+   * @param endTime end time in millis, exclusive.
+   */
+  void setEndTime(long endTime);
+
+  /**
+   * Get end time in millis, exclusive.
+   * @return end time in millis, exclusive.
+   */
+  long getEndTime();
+
+  /**
+   * Set score (e.g., confidence level) of this anomaly.
+   * @param score score of this anomaly.
+   */
+  void setScore(double score);
+
+  /**
+   * Get score (e.g., confidence level) of this anomaly.
+   * @return score of this anomaly.
+   */
+  double getScore();
+
+  /**
+   * Set weight (e.g., change percentage) of this anomaly.
+   * @param weight weight of this anomaly.
+   */
+  void setWeight(double weight);
+
+  /**
+   * Get weight (e.g., change percentage) of this anomaly.
+   * @return weight of this anomaly.
+   */
+  double getWeight();
+
+  /**
+   * Set average current value of this anomaly.
+   * @param avgCurrentVal average current value of this anomaly.
+   */
+  void setAvgCurrentVal(double avgCurrentVal);
+
+  /**
+   * Get average current value of this anomaly.
+   * @return average current value of this anomaly.
+   */
+  double getAvgCurrentVal();
+
+  /**
+   * Set average baseline value of this anomaly.
+   * @param avgBaselineVal average baseline value of this anomaly.
+   */
+  void setAvgBaselineVal(double avgBaselineVal);
+
+  /**
+   * Get average baseline value of this anomaly.
+   * @return average baseline value of this anomaly.
+   */
+  double getAvgBaselineVal();
+
+  /**
+   * Set anomaly feedback (i.e., user label) of this anomaly.
+   * @param anomalyFeedback anomaly feedback of this anomaly.
+   */
+  void setAnomalyFeedback(AnomalyFeedback anomalyFeedback);
+
+  /**
+   * Return anomaly feedback (i.e., user label) of this anomaly.
+   * @return anomaly feedback of this anomaly.
+   */
+  AnomalyFeedback getAnomalyFeedback();
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/AnomalyResult.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.anomalydetection.context;
 
+import java.util.Map;
+
 public interface AnomalyResult {
   /**
    * Set start time in millis, inclusive.
@@ -84,4 +86,16 @@ public interface AnomalyResult {
    * @return anomaly feedback of this anomaly.
    */
   AnomalyFeedback getAnomalyFeedback();
+
+  /**
+   * Set the properties (e.g., pattern=UP, baselineLift=1.7, etc.) of this anomaly.
+   * @param properties the properties of this anomaly.
+   */
+  void setProperties(Map<String, String> properties);
+
+  /**
+   * Return the properties (e.g., pattern=UP, baselineLift=1.7, etc.) of this anomaly.
+   * @return the properties of this anomaly.
+   */
+  Map<String, String> getProperties();
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyFeedbackType.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyFeedbackType.java
@@ -1,5 +1,5 @@
 package com.linkedin.thirdeye.constant;
 
 public enum AnomalyFeedbackType {
-  ANOMALY, NOT_ANOMALY, ANOMALY_NO_ACTION
+  ANOMALY, NOT_ANOMALY, ANOMALY_NO_ACTION, NO_FEEDBACK
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -5,6 +5,7 @@ import com.linkedin.thirdeye.anomaly.alert.util.AlertFilterHelper;
 import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionInputContext;
 import com.linkedin.thirdeye.anomaly.merge.TimeBasedAnomalyMerger;
 import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.dashboard.Utils;
@@ -511,7 +512,7 @@ public class AnomalyResource {
         throw new IllegalArgumentException("AnomalyResult not found with id " + anomalyResultId);
       }
       AnomalyFeedbackDTO feedbackRequest = OBJECT_MAPPER.readValue(payload, AnomalyFeedbackDTO.class);
-      AnomalyFeedbackDTO feedback = result.getFeedback();
+      AnomalyFeedback feedback = result.getFeedback();
       if (feedback == null) {
         feedback = new AnomalyFeedbackDTO();
         result.setFeedback(feedback);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -7,6 +7,7 @@ import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionInputContext;
 import com.linkedin.thirdeye.anomaly.detection.TimeSeriesUtil;
 import com.linkedin.thirdeye.anomaly.merge.TimeBasedAnomalyMerger;
 import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
 import com.linkedin.thirdeye.api.TimeGranularity;
@@ -224,7 +225,7 @@ public class AnomaliesResource {
     int resolvedAnomalies = 0;
     int unresolvedAnomalies = 0;
     for (MergedAnomalyResultDTO mergedAnomaly : mergedAnomalies) {
-      AnomalyFeedbackDTO anomalyFeedback = mergedAnomaly.getFeedback();
+      AnomalyFeedback anomalyFeedback = mergedAnomaly.getFeedback();
       if (anomalyFeedback == null || anomalyFeedback.getFeedbackType() == null) {
         unresolvedAnomalies ++;
       } else if (anomalyFeedback != null && anomalyFeedback.getFeedbackType() != null
@@ -368,7 +369,7 @@ public class AnomaliesResource {
       if (result == null) {
         throw new IllegalArgumentException("AnomalyResult not found with id " + mergedAnomalyId);
       }
-      AnomalyFeedbackDTO feedback = result.getFeedback();
+      AnomalyFeedback feedback = result.getFeedback();
       if (feedback == null) {
         feedback = new AnomalyFeedbackDTO();
         result.setFeedback(feedback);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -280,28 +280,29 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
   public void updateAnomalyFeedback(MergedAnomalyResultDTO entity) {
     MergedAnomalyResultBean bean = convertDTO2Bean(entity, MergedAnomalyResultBean.class);
-    if (entity.getFeedback() != null) {
-      if (entity.getFeedback().getId() == null) {
-        AnomalyFeedbackBean feedbackBean =
-            (AnomalyFeedbackBean) convertDTO2Bean(entity.getFeedback(), AnomalyFeedbackBean.class);
+    AnomalyFeedbackDTO feedbackDTO = (AnomalyFeedbackDTO) entity.getFeedback();
+    if (feedbackDTO != null) {
+      if (feedbackDTO.getId() == null) {
+        AnomalyFeedbackBean feedbackBean = convertDTO2Bean(feedbackDTO, AnomalyFeedbackBean.class);
         Long feedbackId = genericPojoDao.put(feedbackBean);
-        entity.getFeedback().setId(feedbackId);
+        feedbackDTO.setId(feedbackId);
       } else {
-        AnomalyFeedbackBean feedbackBean = genericPojoDao.get(entity.getFeedback().getId(), AnomalyFeedbackBean.class);
-        feedbackBean.setStatus(entity.getFeedback().getStatus());
-        feedbackBean.setFeedbackType(entity.getFeedback().getFeedbackType());
-        feedbackBean.setComment(entity.getFeedback().getComment());
+        AnomalyFeedbackBean feedbackBean = genericPojoDao.get(feedbackDTO.getId(), AnomalyFeedbackBean.class);
+        feedbackBean.setStatus(feedbackDTO.getStatus());
+        feedbackBean.setFeedbackType(feedbackDTO.getFeedbackType());
+        feedbackBean.setComment(feedbackDTO.getComment());
         genericPojoDao.update(feedbackBean);
       }
-      bean.setAnomalyFeedbackId(entity.getFeedback().getId());
+      bean.setAnomalyFeedbackId(feedbackDTO.getId());
     }
     genericPojoDao.update(bean);
   }
 
   protected MergedAnomalyResultBean convertMergeAnomalyDTO2Bean(MergedAnomalyResultDTO entity) {
     MergedAnomalyResultBean bean = convertDTO2Bean(entity, MergedAnomalyResultBean.class);
-    if (entity.getFeedback() != null && entity.getFeedback().getId() != null) {
-        bean.setAnomalyFeedbackId(entity.getFeedback().getId());
+    AnomalyFeedbackDTO feedbackDTO = (AnomalyFeedbackDTO) entity.getFeedback();
+    if (feedbackDTO != null && feedbackDTO.getId() != null) {
+        bean.setAnomalyFeedbackId(feedbackDTO.getId());
     }
 
     if (entity.getFunction() != null) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFeedbackDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFeedbackDTO.java
@@ -1,8 +1,17 @@
 package com.linkedin.thirdeye.datalayer.dto;
 
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import java.io.Serializable;
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFeedbackBean;
 
-public class AnomalyFeedbackDTO extends AnomalyFeedbackBean implements Serializable {
+public class AnomalyFeedbackDTO extends AnomalyFeedbackBean implements AnomalyFeedback, Serializable {
   private static final long serialVersionUID = 1L;
+
+  public AnomalyFeedbackDTO() { }
+
+  public AnomalyFeedbackDTO(AnomalyFeedback anomalyFeedback) {
+    this.setFeedbackType(anomalyFeedback.getFeedbackType());
+    this.setStatus(anomalyFeedback.getStatus());
+    this.setComment(anomalyFeedback.getComment());
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFeedbackDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFeedbackDTO.java
@@ -1,17 +1,32 @@
 package com.linkedin.thirdeye.datalayer.dto;
 
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
+import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
+import com.linkedin.thirdeye.constant.FeedbackStatus;
 import java.io.Serializable;
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFeedbackBean;
 
 public class AnomalyFeedbackDTO extends AnomalyFeedbackBean implements AnomalyFeedback, Serializable {
   private static final long serialVersionUID = 1L;
 
-  public AnomalyFeedbackDTO() { }
+  public AnomalyFeedbackDTO() {
+    this.setFeedbackType(AnomalyFeedbackType.NO_FEEDBACK);
+    this.setStatus(FeedbackStatus.NEW);
+    this.setComment("");
+  }
 
   public AnomalyFeedbackDTO(AnomalyFeedback anomalyFeedback) {
-    this.setFeedbackType(anomalyFeedback.getFeedbackType());
-    this.setStatus(anomalyFeedback.getStatus());
-    this.setComment(anomalyFeedback.getComment());
+    this();
+    if (anomalyFeedback != null) {
+      if (anomalyFeedback.getFeedbackType() != null) {
+        this.setFeedbackType(anomalyFeedback.getFeedbackType());
+      }
+      if (anomalyFeedback.getStatus() != null) {
+        this.setStatus(anomalyFeedback.getStatus());
+      }
+      if (anomalyFeedback.getFeedbackType() != null) {
+        this.setComment(anomalyFeedback.getComment());
+      }
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
@@ -17,12 +17,20 @@ public class MergedAnomalyResultDTO extends MergedAnomalyResultBean implements A
 
   private AnomalyFunctionDTO function;
 
-  public AnomalyFeedbackDTO getFeedback() {
-    return feedback;
+  @Override
+  public void setFeedback(AnomalyFeedback anomalyFeedback) {
+    if (anomalyFeedback == null) {
+      this.feedback = null;
+    } else if (anomalyFeedback instanceof AnomalyFeedbackDTO) {
+      this.feedback = (AnomalyFeedbackDTO) anomalyFeedback;
+    } else {
+      this.feedback = new AnomalyFeedbackDTO(anomalyFeedback);
+    }
   }
 
-  public void setFeedback(AnomalyFeedbackDTO feedback) {
-    this.feedback = feedback;
+  @Override
+  public AnomalyFeedback getFeedback() {
+    return this.feedback;
   }
 
   public List<RawAnomalyResultDTO> getAnomalyResults() {
@@ -39,21 +47,5 @@ public class MergedAnomalyResultDTO extends MergedAnomalyResultBean implements A
 
   public void setFunction(AnomalyFunctionDTO function) {
     this.function = function;
-  }
-
-  @Override
-  public void setAnomalyFeedback(AnomalyFeedback anomalyFeedback) {
-    if (anomalyFeedback == null) {
-      this.feedback = null;
-    } else if (anomalyFeedback instanceof AnomalyFeedbackDTO) {
-      this.feedback = (AnomalyFeedbackDTO) anomalyFeedback;
-    } else {
-      this.feedback = new AnomalyFeedbackDTO(anomalyFeedback);
-    }
-  }
-
-  @Override
-  public AnomalyFeedback getAnomalyFeedback() {
-    return this.feedback;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.datalayer.dto;
 
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.thirdeye.datalayer.pojo.MergedAnomalyResultBean;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class MergedAnomalyResultDTO extends MergedAnomalyResultBean {
+public class MergedAnomalyResultDTO extends MergedAnomalyResultBean implements AnomalyResult {
 
   private AnomalyFeedbackDTO feedback;
 
@@ -37,5 +39,15 @@ public class MergedAnomalyResultDTO extends MergedAnomalyResultBean {
 
   public void setFunction(AnomalyFunctionDTO function) {
     this.function = function;
+  }
+
+  @Override
+  public void setAnomalyFeedback(AnomalyFeedback anomalyFeedback) {
+    this.feedback = new AnomalyFeedbackDTO(anomalyFeedback);
+  }
+
+  @Override
+  public AnomalyFeedback getAnomalyFeedback() {
+    return this.feedback;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/MergedAnomalyResultDTO.java
@@ -43,7 +43,13 @@ public class MergedAnomalyResultDTO extends MergedAnomalyResultBean implements A
 
   @Override
   public void setAnomalyFeedback(AnomalyFeedback anomalyFeedback) {
-    this.feedback = new AnomalyFeedbackDTO(anomalyFeedback);
+    if (anomalyFeedback == null) {
+      this.feedback = null;
+    } else if (anomalyFeedback instanceof AnomalyFeedbackDTO) {
+      this.feedback = (AnomalyFeedbackDTO) anomalyFeedback;
+    } else {
+      this.feedback = new AnomalyFeedbackDTO(anomalyFeedback);
+    }
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/RawAnomalyResultDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/RawAnomalyResultDTO.java
@@ -3,6 +3,8 @@ package com.linkedin.thirdeye.datalayer.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.linkedin.thirdeye.datalayer.pojo.RawAnomalyResultBean;
+
+@Deprecated
 public class RawAnomalyResultDTO extends RawAnomalyResultBean {
 
   private AnomalyFeedbackDTO feedback;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -21,7 +21,7 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
   private double score; // confidence level
   private double weight; // change percentage, whose absolute value is severity
 
-  private Map<String, String> context; // additional anomaly detection result
+  private Map<String, String> properties; // additional anomaly detection properties (e.g., patter=UP, etc.)
 
   private Long createdTime;
   private boolean notified;
@@ -29,22 +29,6 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
   //TODO: deprecate raw anomaly list and message
   private String message;
   private List<Long> rawAnomalyIdList;
-
-  public double getAvgCurrentVal(){
-    return this.avgCurrentVal;
-  }
-
-  public double getAvgBaselineVal(){
-    return this.avgBaselineVal;
-  }
-
-  public void setAvgCurrentVal(double val){
-    this.avgCurrentVal = val;
-  }
-
-  public void setAvgBaselineVal(double val){
-    this.avgBaselineVal = val;
-  }
 
 
   public Long getFunctionId() {
@@ -63,12 +47,12 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
     this.anomalyFeedbackId = anomalyFeedbackId;
   }
 
-  public List<Long> getRawAnomalyIdList() {
-    return rawAnomalyIdList;
+  public String getCollection() {
+    return collection;
   }
 
-  public void setRawAnomalyIdList(List<Long> rawAnomalyIdList) {
-    this.rawAnomalyIdList = rawAnomalyIdList;
+  public void setCollection(String collection) {
+    this.collection = collection;
   }
 
   public String getMetric() {
@@ -103,12 +87,44 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
     this.dimensions = dimensions;
   }
 
+  public double getAvgCurrentVal(){
+    return this.avgCurrentVal;
+  }
+
+  public double getAvgBaselineVal(){
+    return this.avgBaselineVal;
+  }
+
+  public void setAvgCurrentVal(double val){
+    this.avgCurrentVal = val;
+  }
+
+  public void setAvgBaselineVal(double val){
+    this.avgBaselineVal = val;
+  }
+
   public double getScore() {
     return score;
   }
 
   public void setScore(double score) {
     this.score = score;
+  }
+
+  public double getWeight() {
+    return weight;
+  }
+
+  public void setWeight(double weight) {
+    this.weight = weight;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, String> properties) {
+    this.properties = properties;
   }
 
   public Long getCreatedTime() {
@@ -127,25 +143,6 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
     this.notified = notified;
   }
 
-  public String getCollection() {
-    return collection;
-  }
-
-  public void setCollection(String collection) {
-    this.collection = collection;
-  }
-
-  /**
-   * Weight is change ratio. The absolute value of weight is severity.
-   */
-  public double getWeight() {
-    return weight;
-  }
-
-  public void setWeight(double weight) {
-    this.weight = weight;
-  }
-
   public String getMessage() {
     return message;
   }
@@ -154,12 +151,12 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
     this.message = message;
   }
 
-  public Map<String, String> getContext() {
-    return context;
+  public List<Long> getRawAnomalyIdList() {
+    return rawAnomalyIdList;
   }
 
-  public void setContext(Map<String, String> context) {
-    this.context = context;
+  public void setRawAnomalyIdList(List<Long> rawAnomalyIdList) {
+    this.rawAnomalyIdList = rawAnomalyIdList;
   }
 
   @Override
@@ -200,7 +197,7 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
     return "MergedAnomalyResultBean{" + "functionId=" + functionId + ", anomalyFeedbackId=" + anomalyFeedbackId
         + ", collection='" + collection + '\'' + ", metric='" + metric + '\'' + ", dimensions=" + dimensions.toString()
         + ", startTime=" + startTime + ", endTime=" + endTime + ", avgCurrentVal=" + avgCurrentVal + ", avgBaselineVal="
-        + avgBaselineVal + ", score=" + score + ", weight=" + weight + ", context=" + context.toString() + ", notified="
-        + notified + ", rawAnomalyIdList=" + rawAnomalyIdList + ", createdTime=" + createdTime + '}';
+        + avgBaselineVal + ", score=" + score + ", weight=" + weight + ", properties=" + properties.toString()
+        + ", notified=" + notified + ", rawAnomalyIdList=" + rawAnomalyIdList + ", createdTime=" + createdTime + '}';
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -13,8 +13,8 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
   private String collection;
   private String metric;
   private DimensionMap dimensions;
-  private Long startTime;
-  private Long endTime;
+  private long startTime;
+  private long endTime;
 
   private double avgCurrentVal; // actual value
   private double avgBaselineVal; // expected value
@@ -79,19 +79,19 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
     this.metric = metric;
   }
 
-  public Long getStartTime() {
+  public long getStartTime() {
     return startTime;
   }
 
-  public void setStartTime(Long startTime) {
+  public void setStartTime(long startTime) {
     this.startTime = startTime;
   }
 
-  public Long getEndTime() {
+  public long getEndTime() {
     return endTime;
   }
 
-  public void setEndTime(Long endTime) {
+  public void setEndTime(long endTime) {
     this.endTime = endTime;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -2,29 +2,33 @@ package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.linkedin.thirdeye.api.DimensionMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.apache.commons.lang.ObjectUtils;
 
 
-public class MergedAnomalyResultBean extends AbstractBean
-    implements Comparable<MergedAnomalyResultBean> {
+public class MergedAnomalyResultBean extends AbstractBean implements Comparable<MergedAnomalyResultBean> {
   private Long functionId;
   private Long anomalyFeedbackId;
-  private List<Long> rawAnomalyIdList;
   private String collection;
   private String metric;
   private DimensionMap dimensions;
   private Long startTime;
   private Long endTime;
-  // significance level
-  private double score;
-  // severity
-  private double weight;
+
+  private double avgCurrentVal; // actual value
+  private double avgBaselineVal; // expected value
+  private double score; // confidence level
+  private double weight; // change percentage, whose absolute value is severity
+
+  private Map<String, String> context; // additional anomaly detection result
+
   private Long createdTime;
-  private String message;
   private boolean notified;
-  private double avgCurrentVal;
-  private double avgBaselineVal;
+
+  //TODO: deprecate raw anomaly list and message
+  private String message;
+  private List<Long> rawAnomalyIdList;
 
   public double getAvgCurrentVal(){
     return this.avgCurrentVal;
@@ -150,6 +154,14 @@ public class MergedAnomalyResultBean extends AbstractBean
     this.message = message;
   }
 
+  public Map<String, String> getContext() {
+    return context;
+  }
+
+  public void setContext(Map<String, String> context) {
+    this.context = context;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(getId(), startTime, endTime, collection, metric, dimensions, score, avgBaselineVal, avgCurrentVal);
@@ -161,11 +173,11 @@ public class MergedAnomalyResultBean extends AbstractBean
       return false;
     }
     MergedAnomalyResultBean m = (MergedAnomalyResultBean) o;
-    return Objects.equals(getId(), m.getId()) && Objects.equals(startTime, m.getStartTime())
-        && Objects.equals(endTime, m.getEndTime()) && Objects.equals(collection, m.getCollection())
-        && Objects.equals(metric, m.getMetric()) && Objects.equals(dimensions, m.getDimensions())
-        && Objects.equals(avgBaselineVal, m.getAvgBaselineVal())
-        && Objects.equals(avgCurrentVal, m.getAvgCurrentVal());
+    return Objects.equals(getId(), m.getId()) && Objects.equals(startTime, m.getStartTime()) && Objects
+        .equals(endTime, m.getEndTime()) && Objects.equals(collection, m.getCollection()) && Objects
+        .equals(metric, m.getMetric()) && Objects.equals(dimensions, m.getDimensions()) && Objects
+        .equals(score, m.getScore()) && Objects.equals(avgBaselineVal, m.getAvgBaselineVal()) && Objects
+        .equals(avgCurrentVal, m.getAvgCurrentVal());
   }
 
   @Override
@@ -185,12 +197,10 @@ public class MergedAnomalyResultBean extends AbstractBean
 
   @Override
   public String toString() {
-    return "MergedAnomalyResultBean{" + "anomalyFeedbackId=" + anomalyFeedbackId + ", functionId="
-        + functionId + ", rawAnomalyIdList=" + rawAnomalyIdList + ", collection='" + collection
-        + '\'' + ", metric='" + metric + '\'' + ", dimensions='" + dimensions + '\''
-        + ", startTime=" + startTime + ", endTime=" + endTime + ", score=" + score + ", weight="
-        + weight + ", createdTime=" + createdTime + ", message='" + message + '\''
-        + ", currentVal=" + avgCurrentVal + ", baseLineVal=" + avgBaselineVal
-        + ", notified=" + notified + '}';
+    return "MergedAnomalyResultBean{" + "functionId=" + functionId + ", anomalyFeedbackId=" + anomalyFeedbackId
+        + ", collection='" + collection + '\'' + ", metric='" + metric + '\'' + ", dimensions=" + dimensions.toString()
+        + ", startTime=" + startTime + ", endTime=" + endTime + ", avgCurrentVal=" + avgCurrentVal + ", avgBaselineVal="
+        + avgBaselineVal + ", score=" + score + ", weight=" + weight + ", context=" + context.toString() + ", notified="
+        + notified + ", rawAnomalyIdList=" + rawAnomalyIdList + ", createdTime=" + createdTime + '}';
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
@@ -8,7 +8,7 @@ import org.joda.time.DateTime;
 
 import com.google.common.base.MoreObjects;
 
-
+@Deprecated
 public class RawAnomalyResultBean extends AbstractBean implements Comparable<RawAnomalyResultBean> {
 
   private Long functionId;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlertFilterEvaluationUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlertFilterEvaluationUtil.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.detector.email.filter;
 
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
@@ -59,7 +60,7 @@ public class AlertFilterEvaluationUtil {
     int FN = 0;
     for (MergedAnomalyResultDTO anomaly: mergedAnomalyResultDTOS) {
       boolean predLabel = alertFilter.isQualified(anomaly);
-      AnomalyFeedbackDTO feedback = anomaly.getFeedback();
+      AnomalyFeedback feedback = anomaly.getFeedback();
       boolean label = !(feedback == null || feedback.getFeedbackType() == AnomalyFeedbackType.NOT_ANOMALY);
       //predicted true
       if (predLabel) {
@@ -98,7 +99,7 @@ public class AlertFilterEvaluationUtil {
     for(MergedAnomalyResultDTO anomaly: anomalies) {
       totalAnomalies++;
       // evaluate feedbacks
-      AnomalyFeedbackDTO feedback = anomaly.getFeedback();
+      AnomalyFeedback feedback = anomaly.getFeedback();
       if (feedback != null) {
         totalResponses++;
         AnomalyFeedbackType feedbackType = feedback.getFeedbackType();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlphaBetaAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlphaBetaAlertFilter.java
@@ -70,7 +70,7 @@ public class AlphaBetaAlertFilter extends BaseAlertFilter {
   @Override
   public boolean isQualified(MergedAnomalyResultDTO anomaly) {
     double lengthInHour =
-        (anomaly.getEndTime().doubleValue() - anomaly.getStartTime().doubleValue()) / 36_00_000;
+        (double) (anomaly.getEndTime() - anomaly.getStartTime()) / 36_00_000d;
     // In ThirdEye, the absolute value of weight is the severity
     double qualificationScore =
         Math.pow(lengthInHour, alpha) * Math.pow(Math.abs(anomaly.getWeight()), beta);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
@@ -56,8 +56,8 @@ public class TestMergedAnomalyResultManager extends AbstractManagerTestBase {
     List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
         .mergeAnomalies(rawResults, mergeConfig.getMaxMergeDurationLength(),
             mergeConfig.getSequentialAllowedGap());
-    Assert.assertEquals(mergedResults.get(0).getStartTime(),result.getStartTime());
-    Assert.assertEquals(mergedResults.get(0).getEndTime(),result.getEndTime());
+    Assert.assertEquals(mergedResults.get(0).getStartTime(), (long) result.getStartTime());
+    Assert.assertEquals(mergedResults.get(0).getEndTime(), (long) result.getEndTime());
     Assert.assertEquals(mergedResults.get(0).getAnomalyResults().get(0), result);
 
     // Let's persist the merged result

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/FetchMetricDataAndExistingAnomaliesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/FetchMetricDataAndExistingAnomaliesTool.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.tools;
 
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import java.util.Iterator;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -138,7 +139,7 @@ public class FetchMetricDataAndExistingAnomaliesTool {
       res.dimensions = mergedResult.getDimensions();
       res.setFilters(anomalyFunction.getFilters());
       res.severity = mergedResult.getWeight();
-      AnomalyFeedbackDTO feedback = mergedResult.getFeedback();
+      AnomalyFeedback feedback = mergedResult.getFeedback();
       res.feedbackType = (feedback == null)? null : feedback.getFeedbackType();
       resultNodes.add(res);
     }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/anomaly/report/GenerateAnomalyReport.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/anomaly/report/GenerateAnomalyReport.java
@@ -7,6 +7,7 @@ import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.alert.AlertTaskRunner;
 import com.linkedin.thirdeye.anomaly.alert.util.EmailHelper;
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
 import com.linkedin.thirdeye.datalayer.bao.EmailConfigurationManager;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
@@ -14,6 +15,7 @@ import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.EmailConfigurationManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.MergedAnomalyResultManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.MetricConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
 import com.linkedin.thirdeye.datalayer.dto.EmailConfigurationDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
@@ -121,18 +123,19 @@ public class GenerateAnomalyReport {
 
       for (MergedAnomalyResultDTO anomaly : anomalies) {
         metrics.add(anomaly.getMetric());
-        if (anomaly.getFeedback() != null) {
+        AnomalyFeedback feedback = anomaly.getFeedback();
+        if (feedback != null) {
           feedbackCollected++;
-          if (anomaly.getFeedback().getFeedbackType().equals(AnomalyFeedbackType.ANOMALY)) {
+          if (feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY)) {
             trueAlert++;
-          } else if (anomaly.getFeedback().getFeedbackType().equals(AnomalyFeedbackType.NOT_ANOMALY)) {
+          } else if (feedback.getFeedbackType().equals(AnomalyFeedbackType.NOT_ANOMALY)) {
             falseAlert++;
           } else {
             nonActionable++;
           }
         }
         String feedbackVal = getFeedback(
-            anomaly.getFeedback() == null ? "NA" : anomaly.getFeedback().getFeedbackType().name());
+            feedback == null ? "NA" : feedback.getFeedbackType().name());
 
         AnomalyReportDTO anomalyReportDTO =
             new AnomalyReportDTO(String.valueOf(anomaly.getId()), feedbackVal,


### PR DESCRIPTION
This PR is the first step of unifying the anomaly class in ThirdEye open source project and internal anomaly library.

In this PR, we create interfaces -- AnomalyResult and AnomalyFeedback -- for passing anomaly result and feedback between TE and anomaly library. The goal of this design is isolating users' library from DTO and Bean class.

Tested locally