### PR TITLE
Calculate offset for baselines using Period instead of millis, so that DST is handled correctly

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.commons.lang.StringUtils;
+import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,7 @@ import com.linkedin.thirdeye.client.cache.MetricDataset;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean.COMPARE_MODE;
 import com.linkedin.thirdeye.datalayer.pojo.DashboardConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
@@ -332,6 +334,26 @@ public abstract class ThirdEyeUtils {
       LOG.error("Exception in getting dataset name {}", collection, e);
     }
     return dataset;
+  }
+
+  public static Period getbaselineOffsetPeriodByMode(COMPARE_MODE compareMode) {
+    int numWeeksAgo = 1;
+    switch (compareMode) {
+    case Wo2W:
+      numWeeksAgo = 2;
+      break;
+    case Wo3W:
+      numWeeksAgo = 3;
+      break;
+    case Wo4W:
+      numWeeksAgo = 4;
+      break;
+    case WoW:
+    default:
+      numWeeksAgo = 1;
+      break;
+    }
+    return new Period(0, 0, 0, 7 * numWeeksAgo, 0, 0, 0, 0);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/detection/TestDetectionJobSchedulerUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/detection/TestDetectionJobSchedulerUtils.java
@@ -95,8 +95,6 @@ public class TestDetectionJobSchedulerUtils {
     AnomalyFunctionDTO anomalyFunction = new AnomalyFunctionDTO();
     anomalyFunction.setFrequency(new TimeGranularity(15, TimeUnit.MINUTES));
 
-
-
     DateTimeFormatter dateTimeFormatter = DetectionJobSchedulerUtils.
         getDateTimeFormatterForDataset(datasetConfig, dateTimeZone);
 
@@ -211,7 +209,133 @@ public class TestDetectionJobSchedulerUtils {
     Assert.assertNotNull(newEntries.get("20170213"));
     Assert.assertNotNull(newEntries.get("20170214"));
     Assert.assertEquals(newEntries.get(currentDateTimeStringRounded), new Long(currentDateTimeRounded.getMillis()));
-
   }
+
+  @Test
+  public void testGetNewEntriesForDSTBegins() throws Exception {
+
+    DatasetConfigDTO datasetConfig = new DatasetConfigDTO();
+    datasetConfig.setTimeColumn("Date");
+    datasetConfig.setTimeUnit(TimeUnit.DAYS);
+    datasetConfig.setTimeDuration(1);
+    DateTimeZone dateTimeZone = DateTimeZone.UTC;
+
+    AnomalyFunctionDTO anomalyFunction = new AnomalyFunctionDTO();
+
+    // DST started on 2017031203
+    DateTimeFormatter dateTimeFormatter = DetectionJobSchedulerUtils.
+        getDateTimeFormatterForDataset(datasetConfig, dateTimeZone);
+    String currentDateTimeString = "201703120437";
+    String currentDateTimeStringRounded = "20170312";
+    DateTime currentDateTime = minuteDateTimeFormatter.parseDateTime(currentDateTimeString);
+    DateTime currentDateTimeRounded = dateTimeFormatter.parseDateTime(currentDateTimeStringRounded);
+    DetectionStatusDTO lastEntryForFunction = null;
+
+    // null last entry
+    Map<String, Long> newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 1);
+    Assert.assertEquals(newEntries.get(currentDateTimeStringRounded), new Long(currentDateTimeRounded.getMillis()));
+
+    // last entry same as current time
+    lastEntryForFunction = new DetectionStatusDTO();
+    lastEntryForFunction.setDateToCheckInSDF(currentDateTimeStringRounded);
+    lastEntryForFunction.setDateToCheckInMS(currentDateTimeRounded.getMillis());
+
+    newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 0);
+
+    // last entry 1 day before current time, before DST
+    String lastEntryDateTimeString = "20170311";
+    DateTime lastEntryDateTime = dateTimeFormatter.parseDateTime(lastEntryDateTimeString);
+    lastEntryForFunction = new DetectionStatusDTO();
+    lastEntryForFunction.setDateToCheckInSDF(lastEntryDateTimeString);
+    lastEntryForFunction.setDateToCheckInMS(lastEntryDateTime.getMillis());
+
+    newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 1);
+    Assert.assertEquals(newEntries.get(currentDateTimeStringRounded), new Long(currentDateTimeRounded.getMillis()));
+
+    // last entry 3 days before current time
+    lastEntryDateTimeString = "20170309";
+    lastEntryDateTime = dateTimeFormatter.parseDateTime(lastEntryDateTimeString);
+    lastEntryForFunction = new DetectionStatusDTO();
+    lastEntryForFunction.setDateToCheckInSDF(lastEntryDateTimeString);
+    lastEntryForFunction.setDateToCheckInMS(lastEntryDateTime.getMillis());
+
+    newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 3);
+    Assert.assertNotNull(newEntries.get("20170310"));
+    Assert.assertNotNull(newEntries.get("20170311"));
+    Assert.assertNotNull(newEntries.get("20170312"));
+    Assert.assertEquals(newEntries.get(currentDateTimeStringRounded), new Long(currentDateTimeRounded.getMillis()));
+  }
+
+  @Test
+  public void testGetNewEntriesForDSTEnds() throws Exception {
+
+    DatasetConfigDTO datasetConfig = new DatasetConfigDTO();
+    datasetConfig.setTimeColumn("Date");
+    datasetConfig.setTimeUnit(TimeUnit.DAYS);
+    datasetConfig.setTimeDuration(1);
+    DateTimeZone dateTimeZone = DateTimeZone.UTC;
+
+    AnomalyFunctionDTO anomalyFunction = new AnomalyFunctionDTO();
+
+    // DST ended on 2016110602
+    DateTimeFormatter dateTimeFormatter = DetectionJobSchedulerUtils.
+        getDateTimeFormatterForDataset(datasetConfig, dateTimeZone);
+    String currentDateTimeString = "201611060437";
+    String currentDateTimeStringRounded = "20161106";
+    DateTime currentDateTime = minuteDateTimeFormatter.parseDateTime(currentDateTimeString);
+    DateTime currentDateTimeRounded = dateTimeFormatter.parseDateTime(currentDateTimeStringRounded);
+    DetectionStatusDTO lastEntryForFunction = null;
+
+    // null last entry
+    Map<String, Long> newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 1);
+    Assert.assertEquals(newEntries.get(currentDateTimeStringRounded), new Long(currentDateTimeRounded.getMillis()));
+
+    // last entry same as current time
+    lastEntryForFunction = new DetectionStatusDTO();
+    lastEntryForFunction.setDateToCheckInSDF(currentDateTimeStringRounded);
+    lastEntryForFunction.setDateToCheckInMS(currentDateTimeRounded.getMillis());
+
+    newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 0);
+
+    // last entry 1 day before current time, before DST ended
+    String lastEntryDateTimeString = "20161105";
+    DateTime lastEntryDateTime = dateTimeFormatter.parseDateTime(lastEntryDateTimeString);
+    lastEntryForFunction = new DetectionStatusDTO();
+    lastEntryForFunction.setDateToCheckInSDF(lastEntryDateTimeString);
+    lastEntryForFunction.setDateToCheckInMS(lastEntryDateTime.getMillis());
+
+    newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 1);
+    Assert.assertEquals(newEntries.get(currentDateTimeStringRounded), new Long(currentDateTimeRounded.getMillis()));
+
+    // last entry 3 days before current time
+    lastEntryDateTimeString = "20161103";
+    lastEntryDateTime = dateTimeFormatter.parseDateTime(lastEntryDateTimeString);
+    lastEntryForFunction = new DetectionStatusDTO();
+    lastEntryForFunction.setDateToCheckInSDF(lastEntryDateTimeString);
+    lastEntryForFunction.setDateToCheckInMS(lastEntryDateTime.getMillis());
+
+    newEntries = DetectionJobSchedulerUtils.
+        getNewEntries(currentDateTime, lastEntryForFunction, anomalyFunction, datasetConfig, dateTimeZone);
+    Assert.assertEquals(newEntries.size(), 3);
+    Assert.assertNotNull(newEntries.get("20161104"));
+    Assert.assertNotNull(newEntries.get("20161105"));
+    Assert.assertNotNull(newEntries.get("20161106"));
+    Assert.assertEquals(newEntries.get(currentDateTimeStringRounded), new Long(currentDateTimeRounded.getMillis()));
+  }
+
 
 }


### PR DESCRIPTION
This fixes the wow, wo2w, wo3w chart on Investigate page of anomalies, which was showing 0s for daily anomalies due to this issue
This also fixes how scheduler calculates its new buckets