### PR TITLE
[PINOT-4462] Step 1 to add auto-cleanup of deleted segments

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -166,7 +166,7 @@ public class SegmentDeletionManager {
         File targetDir = new File(new File(_localDiskDir, DELETED_SEGMENTS), rawTableName);
         try {
           // Overwrites the file if it already exists in the target directory.
-          FileUtils.copyFileToDirectory(fileToMove, targetDir, true);
+          FileUtils.copyFileToDirectory(fileToMove, targetDir, false);
           LOGGER.info("Moved segment {} from {} to {}", segmentId, fileToMove.getAbsolutePath(), targetDir.getAbsolutePath());
           if (!fileToMove.delete()) {
             LOGGER.warn("Could not delete file", segmentId, fileToMove.getAbsolutePath());


### PR DESCRIPTION
We copy the deleted segments without preserving timestamp. This will allow us to
write a backkground thread that removes files from the DELETED directory that are
older by N or more days.

We need to let this code be in there for N days (if we want N day retention of
deleted segments)