### PR TITLE
Add partition function to mimic Kafka's default partitioner.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/PartitionFunctionFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/PartitionFunctionFactory.java
@@ -16,6 +16,8 @@
 package com.linkedin.pinot.core.data.partition;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nonnull;
 
 
@@ -27,8 +29,26 @@ public class PartitionFunctionFactory {
 
   // Enum for various partition functions to be added.
   public enum PartitionFunctionType {
-    MODULO
+    Modulo,
+    DefaultKafkaPartitioner;
     // Add more functions here.
+
+    private static final Map<String, PartitionFunctionType> VALUE_MAP = new HashMap<>();
+
+    static {
+      for (PartitionFunctionType functionType : PartitionFunctionType.values()) {
+        VALUE_MAP.put(functionType.name().toLowerCase(), functionType);
+      }
+    }
+
+    public static PartitionFunctionType fromString(String name) {
+      PartitionFunctionType functionType = VALUE_MAP.get(name.toLowerCase());
+
+      if (functionType == null) {
+        throw new IllegalArgumentException("No enum constant for: " + name);
+      }
+      return functionType;
+    }
   }
 
   /**
@@ -48,10 +68,13 @@ public class PartitionFunctionFactory {
     String functionName = tokens[0];
     String[] args = Arrays.copyOfRange(tokens, 1, tokens.length);
 
-    PartitionFunctionType function = PartitionFunctionType.valueOf(functionName.toUpperCase());
+    PartitionFunctionType function = PartitionFunctionType.fromString(functionName);
     switch (function) {
-      case MODULO:
+      case Modulo:
         return new ModuloPartitionFunction(args);
+
+      case DefaultKafkaPartitioner:
+        return new DefaultKafkaPartitionFunction(args);
 
       default:
         throw new IllegalArgumentException("Illegal partition function name: " + functionName);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/partition/PartitionFunctionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/partition/PartitionFunctionTest.java
@@ -40,12 +40,52 @@ public class PartitionFunctionTest {
 
     for (int i = 0; i < 1000; i++) {
       int divisor = random.nextInt();
+
+      // Avoid divide-by-zero.
+      if (divisor == 0) {
+        divisor = 1;
+      }
+
       String partitionFunctionString = "MoDuLo" + PartitionFunctionFactory.PARTITION_FUNCTION_DELIMITER + divisor;
       PartitionFunction partitionFunction = PartitionFunctionFactory.getPartitionFunction(partitionFunctionString);
+      Assert.assertEquals(partitionFunction.toString().toLowerCase(), partitionFunctionString.toLowerCase());
 
       for (int j = 0; j < 1000; j++) {
         int value = random.nextInt();
         Assert.assertEquals(partitionFunction.getPartition(value), (value % divisor));
+      }
+    }
+  }
+
+  /**
+   * Unit test for {@link DefaultKafkaPartitionFunction}.
+   * <ul>
+   *   <li> Tests that partition values are in expected range. </li>
+   *   <li> Tests that toString returns expected string. </li>
+   * </ul>
+   */
+  @Test
+  public void testDefaultKafkaPartitioner() {
+    long seed = System.currentTimeMillis();
+    Random random = new Random(seed);
+
+    for (int i = 0; i < 1000; i++) {
+      int divisor = Math.abs(random.nextInt());
+
+      // Avoid divide-by-zero.
+      if (divisor == 0) {
+        divisor = 1;
+      }
+
+      String partitionFunctionString =
+          "deFaultkAfkapArtitioNER" + PartitionFunctionFactory.PARTITION_FUNCTION_DELIMITER + divisor;
+      PartitionFunction partitionFunction = PartitionFunctionFactory.getPartitionFunction(partitionFunctionString);
+      Assert.assertEquals(partitionFunction.toString().toLowerCase(), partitionFunctionString.toLowerCase());
+
+      for (int j = 0; j < 1000; j++) {
+        Integer value = random.nextInt();
+        Assert.assertTrue(partitionFunction.getPartition(value.toString()) < divisor,
+            "Illegal: " + partitionFunction.getPartition(value.toString()) + " " + divisor);
       }
     }
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentPartitionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentPartitionTest.java
@@ -104,7 +104,9 @@ public class SegmentPartitionTest {
     SegmentMetadataImpl metadata = (SegmentMetadataImpl) _segment.getSegmentMetadata();
     ColumnMetadata columnMetadata = metadata.getColumnMetadataFor(PARTITIONED_COLUMN_NAME);
 
-    Assert.assertEquals(columnMetadata.getPartitionFunction().toString(), expectedPartitionFunction.toLowerCase());
+    Assert.assertEquals(columnMetadata.getPartitionFunction().toString().toLowerCase(),
+        expectedPartitionFunction.toLowerCase());
+
     List<IntRange> partitionValues = columnMetadata.getPartitionRanges();
     Assert.assertEquals(partitionValues.size(), 1);
     List<IntRange> expectedPartitionValues = ColumnPartitionConfig.rangesFromString(


### PR DESCRIPTION
1. Added partition function that mimics Kafka's default partitioner.
This will be used to validate parittioning in LLC. For validated
segments, partitioning info will be written out in the metadata,
partition based pruner can pick it up during query execution.

2. Added unit test for the same.