### PR TITLE
[PINOT-4475] Handle SimpleDateFormat correctly when creating segments

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -52,6 +52,10 @@ import com.linkedin.pinot.core.startree.hll.HllConfig;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SegmentGeneratorConfig {
+  public enum TimeColumnType {
+    EPOCH,
+    SIMPLE_DATE
+  }
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentGeneratorConfig.class);
 
   private Map<String, String> _customProperties = new HashMap<>();
@@ -84,6 +88,8 @@ public class SegmentGeneratorConfig {
   private SegmentNameGenerator _segmentNameGenerator = null;
   private SegmentPartitionConfig _segmentPartitionConfig = null;
   private int _sequenceId = -1;
+  private TimeColumnType _timeColumnType = TimeColumnType.EPOCH;
+  private String _simpleDateFormat = null;
 
   public SegmentGeneratorConfig() {
   }
@@ -140,6 +146,19 @@ public class SegmentGeneratorConfig {
   public void setCustomProperties(Map<String, String> properties) {
     Preconditions.checkNotNull(properties);
     _customProperties.putAll(properties);
+  }
+
+  public void setSimpleDateFormat(String simpleDateFormat) {
+    _timeColumnType = TimeColumnType.SIMPLE_DATE;
+    _simpleDateFormat = simpleDateFormat;
+  }
+
+  public String getSimpleDateFormat() {
+    return _simpleDateFormat;
+  }
+
+  public TimeColumnType getTimeColumnType() {
+    return _timeColumnType;
   }
 
   public boolean containsCustomProperty(String key) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.joda.time.format.DateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
@@ -46,6 +47,8 @@ import com.linkedin.pinot.core.segment.DefaultSegmentNameGenerator;
 import com.linkedin.pinot.core.segment.SegmentNameGenerator;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.startree.hll.HllConfig;
+import javax.annotation.Nonnull;
+
 
 /**
  * Configuration properties used in the creation of index segments.
@@ -148,8 +151,13 @@ public class SegmentGeneratorConfig {
     _customProperties.putAll(properties);
   }
 
-  public void setSimpleDateFormat(String simpleDateFormat) {
+  public void setSimpleDateFormat(@Nonnull String simpleDateFormat) {
     _timeColumnType = TimeColumnType.SIMPLE_DATE;
+    try {
+      DateTimeFormat.forPattern(simpleDateFormat);
+    } catch (Exception e) {
+      throw new RuntimeException("Illegal simple date format specification", e);
+    }
     _simpleDateFormat = simpleDateFormat;
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/RawIndexCreatorTest.java
@@ -15,6 +15,18 @@
  */
 package com.linkedin.pinot.core.segment.index.creator;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
@@ -33,18 +45,6 @@ import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverIm
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import com.linkedin.pinot.core.segment.store.ColumnIndexType;
 import com.linkedin.pinot.core.segment.store.SegmentDirectory;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Random;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 
 /**
@@ -221,9 +221,8 @@ public class RawIndexCreatorTest {
 
       for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
         Object value;
-        FieldSpec.DataType dataType = fieldSpec.getDataType();
 
-        value = getRandomValue(dataType);
+        value = getRandomValue(_random, fieldSpec.getDataType());
         map.put(fieldSpec.getName(), value);
       }
 
@@ -248,27 +247,27 @@ public class RawIndexCreatorTest {
    * @param dataType Data type for which to generate the random value
    * @return Random value for the data type.
    */
-  private Object getRandomValue(FieldSpec.DataType dataType) {
+  public static Object getRandomValue(Random random, FieldSpec.DataType dataType) {
     Object value;
     switch (dataType) {
       case INT:
-        value = _random.nextInt();
+        value = random.nextInt();
         break;
 
       case LONG:
-        value = _random.nextLong();
+        value = random.nextLong();
         break;
 
       case FLOAT:
-        value = _random.nextFloat();
+        value = random.nextFloat();
         break;
 
       case DOUBLE:
-        value = _random.nextDouble();
+        value = random.nextDouble();
         break;
 
       case STRING:
-        value = StringUtil.trimTrailingNulls(RandomStringUtils.random(_random.nextInt(MAX_STRING_LENGTH_IN_BYTES)));
+        value = StringUtil.trimTrailingNulls(RandomStringUtils.random(random.nextInt(MAX_STRING_LENGTH_IN_BYTES)));
         break;
 
       default:

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.index.creator;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.data.TimeFieldSpec;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.readers.RecordReader;
+import com.linkedin.pinot.core.data.readers.TestRecordReader;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.store.SegmentDirectory;
+
+
+public class SegmentGenerationWithTimeColumnTest {
+  private static final String STRING_COL_NAME = "someString";
+  private static final String TIME_COL_NAME = "date";
+  private static final String TIME_COL_FORMAT = "yyyyMMdd";
+  private static final String SEGMENT_DIR_NAME = System.getProperty("java.io.tmpdir") + File.separator + "segmentGenTest";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final int NUM_ROWS = 10000;
+
+  private Random _random = new Random(System.nanoTime());
+
+  private long minTime;
+  private long maxTime;
+  private long startTime = System.currentTimeMillis();
+
+  @BeforeMethod
+  public void reset() {
+    minTime = Long.MAX_VALUE;
+    maxTime = Long.MIN_VALUE;
+    FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
+  }
+
+  @Test
+  public void testSimpleDateSegmentGeneration() throws Exception {
+    Schema schema = createSchema(true);
+    File segmentDir = buildSegment(schema, true);
+    SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
+    Assert.assertEquals(metadata.getStartTime(), sdfToMillis(minTime));
+    Assert.assertEquals(metadata.getEndTime(), sdfToMillis(maxTime));
+  }
+
+  @Test
+  public void testEpochDateSegmentGeneration() throws Exception {
+    Schema schema = createSchema(false);
+    File segmentDir = buildSegment(schema, false);
+    SegmentMetadataImpl metadata = SegmentDirectory.loadSegmentMetadata(segmentDir);
+    Assert.assertEquals(metadata.getStartTime(), minTime);
+    Assert.assertEquals(metadata.getEndTime(), maxTime);
+  }
+
+  private Schema createSchema(boolean isSimpleDate) {
+    Schema schema = new Schema();
+    schema.addField(new DimensionFieldSpec(STRING_COL_NAME, FieldSpec.DataType.STRING, true));
+    if (isSimpleDate) {
+      schema.addField(new TimeFieldSpec(TIME_COL_NAME, FieldSpec.DataType.INT, TimeUnit.DAYS));
+    } else {
+      schema.addField(new TimeFieldSpec(TIME_COL_NAME, FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS));
+    }
+    return schema;
+  }
+
+  private File buildSegment(Schema schema, boolean isSimpleDate)
+      throws Exception {
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setRawIndexCreationColumns(schema.getDimensionNames());
+
+    config.setOutDir(SEGMENT_DIR_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+    config.setTimeColumnName(TIME_COL_NAME);
+    if (isSimpleDate) {
+      config.setSimpleDateFormat(TIME_COL_FORMAT);
+    }
+
+    final List<GenericRow> rows = new ArrayList<>();
+    for (int row = 0; row < NUM_ROWS; row++) {
+      HashMap<String, Object> map = new HashMap<>();
+
+      for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+        Object value;
+
+        value = getRandomValueForColumn(fieldSpec, isSimpleDate);
+        map.put(fieldSpec.getName(), value);
+      }
+
+      GenericRow genericRow = new GenericRow();
+      genericRow.init(map);
+      rows.add(genericRow);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    RecordReader reader = new TestRecordReader(rows, schema);
+    driver.init(config, reader);
+    driver.build();
+    driver.getOutputDirectory().deleteOnExit();
+    return driver.getOutputDirectory();
+  }
+
+  private Object getRandomValueForColumn(FieldSpec fieldSpec, boolean isSimpleDate) {
+    if (fieldSpec.getName().equals(TIME_COL_NAME)) {
+      return getRandomValueForTimeColumn(isSimpleDate);
+    }
+    return RawIndexCreatorTest.getRandomValue(_random, fieldSpec.getDataType());
+  }
+
+  private Object getRandomValueForTimeColumn(boolean isSimpleDate) {
+    long randomMs = ThreadLocalRandom.current().nextLong(startTime);
+    long dateColVal = randomMs;
+    Object result;
+    if (isSimpleDate) {
+      DateTime dateTime = new DateTime(randomMs);
+      LocalDateTime localDateTime = dateTime.toLocalDateTime();
+      int year = localDateTime.getYear();
+      int month = localDateTime.getMonthOfYear();
+      int day = localDateTime.getDayOfMonth();
+      String dateColStr = String.format("%04d%02d%02d", year, month, day);
+      dateColVal = Integer.valueOf(dateColStr);
+      result = new Integer(Integer.valueOf(dateColStr));
+    } else {
+      result = new Long(dateColVal);
+    }
+
+    if (dateColVal < minTime) {
+      minTime = dateColVal;
+    }
+    if (dateColVal > maxTime) {
+      maxTime = dateColVal;
+    }
+    return result;
+  }
+
+  private long sdfToMillis(long value) {
+    DateTimeFormatter sdfFormatter = DateTimeFormat.forPattern(TIME_COL_FORMAT);
+    DateTime dateTime = DateTime.parse(Long.toString(value), sdfFormatter);
+    return dateTime.getMillis();
+  }
+}


### PR DESCRIPTION
If time column is of SimpleDateFormat type, the we need to set the start and end time
correctly in the segment.

Input files to pinot segment creator (for pure offline use cases) may contain time column values
like 20170324 to indicate Mar 24 2017. If we take this value to be from epoch, we will get year 57194.

Modified SegmentGeneratorConfig to take additional configuration for time type. The default
is epoch, so that the default behavior remains unchanged. Setting the time format correctly
will now re-adjust the start/end time of the segment if needed, so that the start and end time
in the segment metadata is reflected correctly.