### PR TITLE
Reuse in-memory dictionary during stats gathering

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
@@ -74,6 +74,10 @@ public class RealtimeSingleValueBlock implements Block {
     return new RealtimeSingleValueSet(reader, docIdSearchableOffset + 1, spec.getDataType());
   }
 
+  public FixedByteSingleColumnSingleValueReaderWriter getReader() {
+    return reader;
+  }
+
   @Override
   public BlockDocIdValueSet getBlockDocIdValueSet() {
     return null;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -22,9 +22,9 @@ import java.util.List;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
-import com.linkedin.pinot.core.data.readers.RecordReader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.realtime.converter.stats.RealtimeSegmentSegmentCreationDataSource;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 
@@ -82,7 +82,7 @@ public class RealtimeSegmentConverter {
 
   public void build(SegmentVersion segmentVersion) throws Exception {
     // lets create a record reader
-    RecordReader reader;
+    RealtimeSegmentRecordReader reader;
     if (sortedColumn == null) {
       reader = new RealtimeSegmentRecordReader(realtimeSegmentImpl, dataSchema);
     } else {
@@ -104,7 +104,7 @@ public class RealtimeSegmentConverter {
     genConfig.setOutDir(outputPath);
     genConfig.setSegmentName(segmentName);
     final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(genConfig, reader);
+    driver.init(genConfig, new RealtimeSegmentSegmentCreationDataSource(realtimeSegmentImpl, reader, dataSchema));
     driver.build();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.converter.stats;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockMultiValIterator;
+import com.linkedin.pinot.core.data.partition.PartitionFunction;
+import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
+import com.linkedin.pinot.core.operator.blocks.RealtimeSingleValueBlock;
+import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
+import java.util.List;
+import org.apache.commons.lang.math.IntRange;
+
+
+/**
+ * Column statistics for a column coming from an in-memory realtime segment.
+ */
+public class RealtimeColumnStatistics implements ColumnStatistics {
+  private final RealtimeColumnDataSource _dataSource;
+  private final int[] _sortedDocIdIterationOrder;
+  private final MutableDictionaryReader _dictionaryReader;
+  private final Block _block;
+
+  public RealtimeColumnStatistics(RealtimeColumnDataSource dataSource, int[] sortedDocIdIterationOrder) {
+    _dataSource = dataSource;
+    _sortedDocIdIterationOrder = sortedDocIdIterationOrder;
+    _dictionaryReader = dataSource.getDictionary();
+    _block = dataSource.getNextBlock();
+  }
+
+  @Override
+  public Object getMinValue() {
+    return _dictionaryReader.getMinVal();
+  }
+
+  @Override
+  public Object getMaxValue() {
+    return _dictionaryReader.getMaxVal();
+  }
+
+  @Override
+  public Object getUniqueValuesSet() {
+    return _dictionaryReader.getSortedValues();
+  }
+
+  @Override
+  public int getCardinality() {
+    return _dictionaryReader.length();
+  }
+
+  @Override
+  public int getLengthOfLargestElement() {
+    // Length of longest string
+    int maximumStringLength = 0;
+
+    // If this column is a string column, iterate over the dictionary to find the maximum length
+    if (_dataSource.getDataSourceMetadata().getDataType() == FieldSpec.DataType.STRING) {
+      final int length = _dictionaryReader.length();
+      for (int i = 0; i < length; i++) {
+        maximumStringLength = Math.max(_dictionaryReader.getStringValue(i).length(), maximumStringLength);
+      }
+    }
+
+    return maximumStringLength;
+  }
+
+  @Override
+  public boolean isSorted() {
+    // Multivalue columns can't be in sorted order
+    if (!_block.getMetadata().isSingleValue()) {
+      return false;
+    }
+
+    // If this is a single value, then by definition the data is sorted
+    final int blockLength = _block.getMetadata().getLength();
+    if (blockLength <= 1 || getCardinality() <= 1) {
+      return true;
+    }
+
+    // Iterate over all data to figure out whether or not it's in sorted order
+    SingleColumnSingleValueReader singleValueReader = ((RealtimeSingleValueBlock) _block).getReader();
+
+    int docIdIndex = _sortedDocIdIterationOrder != null ? _sortedDocIdIterationOrder[0] : 0;
+    int dictionaryId = singleValueReader.getInt(docIdIndex);
+    Comparable previousValue = (Comparable) _dictionaryReader.get(dictionaryId);
+    for (int i = 1; i < blockLength; i++) {
+      docIdIndex = _sortedDocIdIterationOrder != null ? _sortedDocIdIterationOrder[i] : i;
+      dictionaryId = singleValueReader.getInt(docIdIndex);
+      Comparable currentValue = (Comparable) _dictionaryReader.get(dictionaryId);
+      // If previousValue is greater than currentValue
+      if (0 < previousValue.compareTo(currentValue)) {
+        return false;
+      } else {
+        previousValue = currentValue;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int getTotalNumberOfEntries() {
+    // Number of multivalue entries
+    int multivalueEntryCount = 0;
+
+    // If this column is a multivalue column, iterate over all data to find the total number of multivalue entries (this
+    // information doesn't seem to be exposed via an API)
+    if (!_block.getMetadata().isSingleValue()) {
+      int[] dictionaryIds = new int[getMaxNumberOfMultiValues()];
+
+      BlockMultiValIterator valIterator = (BlockMultiValIterator) _block.getBlockValueSet().iterator();
+      while(valIterator.hasNext()) {
+        multivalueEntryCount += valIterator.nextIntVal(dictionaryIds);
+      }
+    }
+
+    return multivalueEntryCount;
+  }
+
+  @Override
+  public int getMaxNumberOfMultiValues() {
+    return _block.getMetadata().getMaxNumberOfMultiValues();
+  }
+
+  @Override
+  public boolean hasNull() {
+    return false;
+  }
+
+  @Override
+  public PartitionFunction getPartitionFunction() {
+    return null;
+  }
+
+  @Override
+  public List<IntRange> getPartitionRanges() {
+    return null;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeSegmentSegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeSegmentSegmentCreationDataSource.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.converter.stats;
+
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.core.data.readers.RecordReader;
+import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentRecordReader;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.segment.creator.SegmentCreationDataSource;
+import com.linkedin.pinot.core.segment.creator.SegmentPreIndexStatsContainer;
+import com.linkedin.pinot.core.segment.creator.StatsCollectorConfig;
+
+
+/**
+ * Segment creation data source that is based on an in-memory realtime segment.
+ */
+public class RealtimeSegmentSegmentCreationDataSource implements SegmentCreationDataSource {
+  private final RealtimeSegmentImpl _realtimeSegment;
+  private final RealtimeSegmentRecordReader _realtimeSegmentRecordReader;
+  private final Schema _schema;
+
+  public RealtimeSegmentSegmentCreationDataSource(RealtimeSegmentImpl realtimeSegment, RealtimeSegmentRecordReader realtimeSegmentRecordReader, Schema schema) {
+    _realtimeSegment = realtimeSegment;
+    _realtimeSegmentRecordReader = realtimeSegmentRecordReader;
+    _schema = schema;
+  }
+
+  @Override
+  public SegmentPreIndexStatsContainer gatherStats(StatsCollectorConfig statsCollectorConfig) {
+    if (!statsCollectorConfig.getSchema().equals(_schema)) {
+      throw new RuntimeException("Incompatible schemas used for conversion and extraction");
+    }
+
+    return new RealtimeSegmentStatsContainer(_realtimeSegment, _realtimeSegmentRecordReader);
+  }
+
+  @Override
+  public RecordReader getRecordReader() {
+    return _realtimeSegmentRecordReader;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeSegmentStatsContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeSegmentStatsContainer.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.converter.stats;
+
+import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentRecordReader;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
+import com.linkedin.pinot.core.segment.creator.SegmentPreIndexStatsContainer;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Stats container for an in-memory realtime segment.
+ */
+public class RealtimeSegmentStatsContainer implements SegmentPreIndexStatsContainer {
+  private final RealtimeSegmentImpl _realtimeSegment;
+  private final RealtimeSegmentRecordReader _realtimeSegmentRecordReader;
+  private final Map<String, ColumnStatistics> _columnStatisticsMap = new HashMap<>();
+
+  public RealtimeSegmentStatsContainer(RealtimeSegmentImpl realtimeSegment, RealtimeSegmentRecordReader realtimeSegmentRecordReader) {
+    _realtimeSegment = realtimeSegment;
+    _realtimeSegmentRecordReader = realtimeSegmentRecordReader;
+
+    // Create all column statistics
+    for (String columnName : realtimeSegment.getColumnNames()) {
+      _columnStatisticsMap.put(columnName, new RealtimeColumnStatistics(realtimeSegment.getDataSource(columnName),
+          _realtimeSegmentRecordReader.getSortedDocIdIterationOrder()));
+    }
+  }
+
+  @Override
+  public ColumnStatistics getColumnProfileFor(String column) throws Exception {
+    return _columnStatisticsMap.get(column);
+  }
+
+  @Override
+  public int getRawDocCount() {
+    return _realtimeSegment.getRawDocumentCount();
+  }
+
+  @Override
+  public int getAggregatedDocCount() {
+    return 0;
+  }
+
+  @Override
+  public int getTotalDocCount() {
+    return getRawDocCount();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -349,7 +349,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   }
 
   @Override
-  public DataSource getDataSource(String columnName) {
+  public RealtimeColumnDataSource getDataSource(String columnName) {
     FieldSpec fieldSpec = dataSchema.getFieldSpecFor(columnName);
 
     if (fieldSpec.getFieldType() == FieldType.METRIC) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
@@ -192,7 +192,7 @@ public class RealtimeColumnDataSource extends DataSource {
   }
 
   @Override
-  public Dictionary getDictionary() {
+  public MutableDictionaryReader getDictionary() {
     return dictionary;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleMutableDictionary.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import java.util.Arrays;
+
+
 public class DoubleMutableDictionary extends MutableDictionaryReader {
 
   private Double min = Double.MAX_VALUE;
@@ -151,6 +154,20 @@ public class DoubleMutableDictionary extends MutableDictionaryReader {
     }
 
     return ret;
+  }
+
+  @Override
+  public Object getSortedValues() {
+    int valueCount = length();
+    double[] values = new double[valueCount];
+
+    for (int i = 0; i < valueCount; i++) {
+      values[i] = getDoubleValue(i);
+    }
+
+    Arrays.sort(values);
+
+    return values;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatMutableDictionary.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import java.util.Arrays;
+
+
 public class FloatMutableDictionary extends MutableDictionaryReader {
 
   private Float min = Float.MAX_VALUE;
@@ -151,6 +154,20 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
     }
 
     return ret;
+  }
+
+  @Override
+  public Object getSortedValues() {
+    int valueCount = length();
+    float[] values = new float[valueCount];
+
+    for (int i = 0; i < valueCount; i++) {
+      values[i] = getFloatValue(i);
+    }
+
+    Arrays.sort(values);
+
+    return values;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntMutableDictionary.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import java.util.Arrays;
+
+
 public class IntMutableDictionary extends MutableDictionaryReader {
 
   private Integer min = Integer.MAX_VALUE;
@@ -129,6 +132,20 @@ public class IntMutableDictionary extends MutableDictionaryReader {
       int dictId = dictionaryIds[iter];
       outValues[outStartPos++] = getInt(dictId);
     }
+  }
+
+  @Override
+  public Object getSortedValues() {
+    int valueCount = length();
+    int[] values = new int[valueCount];
+
+    for (int i = 0; i < valueCount; i++) {
+      values[i] = getIntValue(i);
+    }
+
+    Arrays.sort(values);
+
+    return values;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongMutableDictionary.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import java.util.Arrays;
+
+
 public class LongMutableDictionary extends MutableDictionaryReader {
 
   private Long min = Long.MAX_VALUE;
@@ -152,6 +155,20 @@ public class LongMutableDictionary extends MutableDictionaryReader {
     }
 
     return ret;
+  }
+
+  @Override
+  public Object getSortedValues() {
+    int valueCount = length();
+    long[] values = new long[valueCount];
+
+    for (int i = 0; i < valueCount; i++) {
+      values[i] = getLongValue(i);
+    }
+
+    Arrays.sort(values);
+
+    return values;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
@@ -121,6 +121,8 @@ public abstract class MutableDictionaryReader implements Dictionary {
 
   }
 
+  public abstract Object getSortedValues();
+
   protected Integer getIndexOfFromBiMap(Object val) {
     Integer ret = dictionaryIdBiMap.inverse().get(val);
     if (ret == null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringMutableDictionary.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import java.util.Arrays;
+
+
 public class StringMutableDictionary extends MutableDictionaryReader {
 
   private String min = null;
@@ -130,6 +133,20 @@ public class StringMutableDictionary extends MutableDictionaryReader {
     }
 
     return ret;
+  }
+
+  @Override
+  public Object getSortedValues() {
+    int valueCount = length();
+    Object[] values = new Object[valueCount];
+
+    for (int i = 0; i < valueCount; i++) {
+      values[i] = getStringValue(i);
+    }
+
+    Arrays.sort(values);
+
+    return values;
   }
 
   private String getString(int dictionaryId) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentCreationDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/SegmentCreationDataSource.java
@@ -20,10 +20,10 @@ import com.linkedin.pinot.core.data.readers.RecordReader;
 
 
 /**
- * Data source used to build segments
+ * Data source used to build segments.
  */
 public interface SegmentCreationDataSource {
-  SegmentPreIndexStatsCollector gatherStats(StatsCollectorConfig statsCollectorConfig);
+  SegmentPreIndexStatsContainer gatherStats(StatsCollectorConfig statsCollectorConfig);
 
   RecordReader getRecordReader();
 }


### PR DESCRIPTION
Reuse the in-memory data structures when writing realtime segment to
disk instead of iterating over the in-memory segment row-by-row to
build the column dictionaries and determine the per-column statistics.
Almost doubles the performance of realtime segment write.