### PR TITLE
Updating table configuration should ensure that realtime cluster is setup

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1102,10 +1102,12 @@ public class PinotHelixResourceManager {
     if (type == TableType.REALTIME) {
       ZKMetadataProvider.setRealtimeTableConfig(_propertyStore, tableNameWithSuffix,
           AbstractTableConfig.toZnRecord(config));
+      ensureRealtimeClusterIsSetUp(config, tableNameWithSuffix, config.getIndexingConfig());
     } else {
       ZKMetadataProvider.setOfflineTableConfig(_propertyStore, tableNameWithSuffix,
           AbstractTableConfig.toZnRecord(config));
     }
+
   }
 
   public void updateMetadataConfigFor(String tableName, TableType type, TableCustomConfig newConfigs) throws Exception {


### PR DESCRIPTION
PUT call to update table configuration should ensure that realtime cluster
is setup to maintain backwards compatibility.