### PR TITLE
Add view of baseline of min-max function if it is available

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/AnomalyDetectionFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/AnomalyDetectionFunction.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.anomalydetection.function;
 
+import com.linkedin.thirdeye.anomaly.views.AnomalyTimelinesView;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
 import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
 import com.linkedin.thirdeye.anomalydetection.model.detection.DetectionModel;
@@ -57,12 +58,24 @@ public interface AnomalyDetectionFunction {
   /**
    * Updates the information of the given merged anomaly.
    *
-   * @param anomalyDetectionContext
-   * @param anomalyToUpdated
+   * @param anomalyDetectionContext context that provide time series data
+   * @param anomalyToUpdated the anomaly to be updated
    *
    * @throws Exception
    */
   void updateMergedAnomalyInfo(AnomalyDetectionContext anomalyDetectionContext,
       MergedAnomalyResultDTO anomalyToUpdated) throws Exception;
 
+  /**
+   * Returns the time series that are located in the given time window.
+   * @param anomalyDetectionContext context that provide time series data
+   * @param bucketMillis bucket size in millis
+   * @param metric the target metric name
+   * @param viewWindowStartTime window start, inclusive
+   * @param viewWindowEndTime window end, exclusive
+   * @param knownAnomalies known anomalies
+   * @return the time series that are located in the given time window.
+   */
+  AnomalyTimelinesView getTimeSeriesView(AnomalyDetectionContext anomalyDetectionContext, long bucketMillis,
+      String metric, long viewWindowStartTime, long viewWindowEndTime, List<MergedAnomalyResultDTO> knownAnomalies);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/merge/MinMaxThresholdMergeModel.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/model/merge/MinMaxThresholdMergeModel.java
@@ -52,13 +52,20 @@ public class MinMaxThresholdMergeModel extends AbstractMergeModel {
       }
     }
 
-    if (currentBucketCount != 0d) {
+    if (currentBucketCount > 0) {
       currentAverageValue /= currentBucketCount;
       deviationFromThreshold /= currentBucketCount;
     }
     anomalyToUpdated.setScore(currentAverageValue);
     anomalyToUpdated.setWeight(deviationFromThreshold);
     anomalyToUpdated.setAvgCurrentVal(currentAverageValue);
+    double value = 0d;
+    if (min != null) {
+      value = min;
+    } else if (max != null) {
+      value = max;
+    }
+    anomalyToUpdated.setAvgBaselineVal(value);
 
     String message =
         String.format(DEFAULT_MESSAGE_TEMPLATE, deviationFromThreshold, currentAverageValue, min, max);


### PR DESCRIPTION
1. For min max function, the baseline time series is a straight line of min or max threshold. Since current UI allows only one baseline, current implementation use min before max as the baseline if its value is available. If both values are not available, then 0 is shown as the baseline.

2. For BaseModularizedAnomalyFunciton, if the returned predication model does not provide any predicted time series, then 0s are used as the default baseline time series.

Tested on local dashboard.