### PR TITLE
Implement a RELOAD message to trigger segments reload

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.common.data;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadataLoader;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
@@ -37,7 +38,9 @@ public interface DataManager {
 
   void removeSegment(String segmentName);
 
-  void refreshSegment(String oldSegmentName, SegmentMetadata newSegmentMetadata);
+  void reloadSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull CommonConstants.Helix.TableType tableType,
+      @Nullable AbstractTableConfig tableConfig, @Nullable Schema schema)
+      throws Exception;
 
   void shutDown();
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/messages/SegmentRefreshMessage.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/messages/SegmentRefreshMessage.java
@@ -29,8 +29,8 @@ import org.apache.helix.model.Message;
  * Changing this class to include new fields is a change in the protocol, so the new fields must be made optional,
  * and coded in such a way that either controller or server may be upgraded first.
  */
-public class SegmentRefreshMessage  extends Message {
-  private static final String REFRESH_SEGMENT_MSG = "REFRESH_SEGMENT";
+public class SegmentRefreshMessage extends Message {
+  public static final String REFRESH_SEGMENT_MSG_SUB_TYPE = "REFRESH_SEGMENT";
 
   private static final String SIMPLE_FIELD_CRC = "PINOT_SEGMENT_CRC";
 
@@ -44,7 +44,7 @@ public class SegmentRefreshMessage  extends Message {
     super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
     setResourceName(tableName);
     setPartitionName(segmentName);
-    setMsgSubType(REFRESH_SEGMENT_MSG);
+    setMsgSubType(REFRESH_SEGMENT_MSG_SUB_TYPE);
     // Give it infinite time to process the message, as long as session is alive
     setExecutionTimeout(-1);
     getRecord().setSimpleField(SIMPLE_FIELD_CRC, Long.toString(crc));
@@ -56,7 +56,7 @@ public class SegmentRefreshMessage  extends Message {
    */
   public SegmentRefreshMessage(final Message message) {
     super(message.getRecord());
-    if (!message.getMsgSubType().equals(REFRESH_SEGMENT_MSG)) {
+    if (!message.getMsgSubType().equals(REFRESH_SEGMENT_MSG_SUB_TYPE)) {
       throw new IllegalArgumentException("Invalid message subtype:" + message.getMsgSubType());
     }
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/messages/SegmentReloadMessage.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/messages/SegmentReloadMessage.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.messages;
+
+import com.google.common.base.Preconditions;
+import java.util.UUID;
+import org.apache.helix.model.Message;
+
+
+/**
+ * This Helix message is sent from the controller to the servers when a request is received to reload an existing
+ * segment.
+ */
+public class SegmentReloadMessage extends Message {
+  public static final String RELOAD_SEGMENT_MSG_SUB_TYPE = "RELOAD_SEGMENT";
+
+  public SegmentReloadMessage(String tableName, String segmentName) {
+    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    setResourceName(tableName);
+    setPartitionName(segmentName);
+    setMsgSubType(RELOAD_SEGMENT_MSG_SUB_TYPE);
+    // Give it infinite time to process the message, as long as session is alive
+    setExecutionTimeout(-1);
+  }
+
+  public SegmentReloadMessage(Message message) {
+    super(message.getRecord());
+    String msgSubType = message.getMsgSubType();
+    Preconditions.checkArgument(msgSubType.equals(RELOAD_SEGMENT_MSG_SUB_TYPE),
+        "Invalid message sub type: " + msgSubType + " for SegmentReloadMessage");
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
@@ -23,6 +23,7 @@ import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadataLoader;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.core.data.manager.config.FileBasedInstanceDataManagerConfig;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
@@ -200,8 +201,10 @@ public class FileBasedInstanceDataManager implements InstanceDataManager {
   }
 
   @Override
-  public void refreshSegment(String oldSegmentName, SegmentMetadata newSegmentMetadata) {
-    throw new UnsupportedOperationException();
+  public void reloadSegment(@Nonnull SegmentMetadata segmentMetadata,
+      @Nonnull CommonConstants.Helix.TableType tableType, @Nullable AbstractTableConfig tableConfig,
+      @Nullable Schema schema) {
+    throw new UnsupportedOperationException("Unsupported reloading segment in FileBasedInstanceDataManager");
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -63,8 +63,9 @@ import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataK
 
 
 public class SegmentMetadataImpl implements SegmentMetadata {
-
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentMetadataImpl.class);
+
+  private static final String RELOAD_TEMP_DIR_SUFFIX = ".reload.tmp";
 
   private final PropertiesConfiguration _segmentMetadataPropertiesConfiguration;
   private final File _metadataFile;
@@ -106,7 +107,16 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     _columnMetadataMap = new HashMap<String, ColumnMetadata>();
     _allColumns = new HashSet<String>();
     _schema = new Schema();
-    _indexDir = new File(indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME).getAbsoluteFile().getParent();
+
+    // For segment reload, we will load segment from the temporary index directory, but we need to set indexDir to the
+    // original index directory
+    String indexDirToLoad = indexDir.getPath();
+    if (indexDirToLoad.endsWith(RELOAD_TEMP_DIR_SUFFIX)) {
+      _indexDir = indexDirToLoad.substring(0, indexDirToLoad.length() - RELOAD_TEMP_DIR_SUFFIX.length());
+    } else {
+      _indexDir = indexDirToLoad;
+    }
+
     init();
     File creationMetaFile = SegmentDirectoryPaths.findCreationMetaFile(indexDir);
     if (creationMetaFile != null) {


### PR DESCRIPTION
Allow reload a single segment, and all segments from a table. Provide
    restlet API to reload the segments. The reload is atomic, which means no
    downtime, no doubled-result. Added tests to use reload message.