### PR TITLE
Add support for metrics from multiple datasets in a derived metric

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
@@ -130,7 +130,7 @@ public abstract class EmailHelper {
       comparisonRequest.setEndDateInclusive(true);
 
       List<MetricExpression> metricExpressions = new ArrayList<>();
-      MetricExpression expression = new MetricExpression(config.getMetric());
+      MetricExpression expression = new MetricExpression(config.getMetric(), config.getCollection());
       metricExpressions.add(expression);
       comparisonRequest.setMetricExpressions(metricExpressions);
       comparisonRequest.setAggregationTimeGranularity(bucketGranularity);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricExpression.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricExpression.java
@@ -8,6 +8,9 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import com.linkedin.thirdeye.constant.MetricAggFunction;
+import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 import parsii.eval.Expression;
 import parsii.eval.Parser;
@@ -23,44 +26,37 @@ public class MetricExpression {
   private String expressionName;
   private String expression;
   private MetricAggFunction aggFunction = MetricAggFunction.SUM;
+  private String dataset;
 
-  public MetricExpression() {
-
+  public MetricExpression(String expression, String dataset) {
+    this(expression.replaceAll("[\\s]+", ""), expression, dataset);
   }
 
-  public MetricExpression(String expression) {
-    this(expression.replaceAll("[\\s]+", ""), expression);
+  public MetricExpression(String expressionName, String expression, String dataset) {
+    this(expressionName, expression, MetricAggFunction.SUM, dataset);
   }
 
-  public MetricExpression(String expressionName, String expression) {
-    this(expressionName, expression, MetricAggFunction.SUM);
-  }
-
-  public MetricExpression(String expressionName, String expression, MetricAggFunction aggFunction) {
+  public MetricExpression(String expressionName, String expression, MetricAggFunction aggFunction, String dataset) {
     this.expressionName = expressionName;
     this.expression = expression;
     this.aggFunction = aggFunction;
-  }
-
-  public void setAggFunction(MetricAggFunction aggFunction) {
-    this.aggFunction = aggFunction;
+    this.dataset = dataset;
   }
 
   public String getExpressionName() {
     return expressionName;
   }
 
-  public void setExpressionName(String expressionName) {
-    this.expressionName = expressionName;
-  }
 
   public String getExpression() {
     return expression;
   }
 
-  public void setExpression(String expression) {
-    this.expression = expression;
+
+  public String getDataset() {
+    return dataset;
   }
+
 
   @Override
   public String toString() {
@@ -70,7 +66,7 @@ public class MetricExpression {
   public List<MetricFunction> computeMetricFunctions() {
     try {
       Scope scope = Scope.create();
-      Set<String> metricNames = new TreeSet<>();
+      Set<String> metricTokens = new TreeSet<>(); // can be either metric names or ids ! :-/
 
       // expression parser errors out on variables starting with _
       // we're replacing the __COUNT default metric, with an escaped string
@@ -78,14 +74,22 @@ public class MetricExpression {
       String modifiedExpressions = expression.replace(COUNT_METRIC, COUNT_METRIC_ESCAPED);
 
       Parser.parse(modifiedExpressions, scope);
-      metricNames = scope.getLocalNames();
+      metricTokens = scope.getLocalNames();
 
       ArrayList<MetricFunction> metricFunctions = new ArrayList<>();
-      for (String metricName : metricNames) {
-        if (metricName.equals(COUNT_METRIC_ESCAPED)) {
-          metricName = COUNT_METRIC;
+      for (String metricToken : metricTokens) {
+        Long metricId = null;
+        String metricDataset = dataset;
+        if (metricToken.equals(COUNT_METRIC_ESCAPED)) {
+          metricToken = COUNT_METRIC;
+        } else {
+          metricId = Long.valueOf(metricToken.replace(MetricConfigBean.DERIVED_METRIC_ID_PREFIX, ""));
+          MetricConfigDTO metricConfig = ThirdEyeUtils.getMetricConfigFromId(metricId);
+          if (metricConfig != null) {
+            metricDataset = metricConfig.getDataset();
+          }
         }
-        metricFunctions.add(new MetricFunction(aggFunction, metricName));
+        metricFunctions.add(new MetricFunction(aggFunction, metricToken, metricId, metricDataset));
       }
       return metricFunctions;
     } catch (ParseException e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricExpression.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricExpression.java
@@ -18,6 +18,11 @@ import parsii.eval.Scope;
 import parsii.eval.Variable;
 import parsii.tokenizer.ParseException;
 
+/**
+ * This class maintains the metric name, the metric expression composed of metric ids, and the aggregation function
+ * The dataset is required here, because we need to know which dataset to query in cases of count(*)  and select max(time)
+ * For other cases, it can be derived from the metric id in the expression
+ */
 public class MetricExpression {
 
   private static String COUNT_METRIC = "__COUNT";

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricFunction.java
@@ -8,15 +8,20 @@ public class MetricFunction implements Comparable<MetricFunction> {
 
   private MetricAggFunction functionName;
   private String metricName;
+  private Long metricId;
+  private String dataset;
 
   public MetricFunction() {
 
   }
 
   public MetricFunction(@JsonProperty("functionName") MetricAggFunction functionName,
-      @JsonProperty("metricName") String metricName) {
+      @JsonProperty("metricName") String metricName, @JsonProperty("metricId") Long metricId,
+      @JsonProperty("dataset") String dataset) {
     this.functionName = functionName;
     this.metricName = metricName;
+    this.metricId = metricId;
+    this.dataset = dataset;
   }
 
   private String format(String functionName, String metricName) {
@@ -32,7 +37,7 @@ public class MetricFunction implements Comparable<MetricFunction> {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(functionName, metricName);
+    return Objects.hashCode(functionName, metricName, metricId, dataset);
   }
 
   @Override
@@ -40,9 +45,11 @@ public class MetricFunction implements Comparable<MetricFunction> {
     if (!(obj instanceof MetricFunction)) {
       return false;
     }
-    MetricFunction that = (MetricFunction) obj;
-    return Objects.equal(this.functionName, that.functionName)
-        && Objects.equal(this.metricName, that.metricName);
+    MetricFunction mf = (MetricFunction) obj;
+    return Objects.equal(functionName, mf.functionName)
+        && Objects.equal(metricName, mf.metricName)
+        && Objects.equal(metricId, mf.metricId)
+        && Objects.equal(dataset, mf.dataset);
   }
 
   @Override
@@ -65,4 +72,22 @@ public class MetricFunction implements Comparable<MetricFunction> {
   public void setFunctionName(MetricAggFunction functionName) {
     this.functionName = functionName;
   }
+
+  public Long getMetricId() {
+    return metricId;
+  }
+
+  public void setMetricId(Long metricId) {
+    this.metricId = metricId;
+  }
+
+  public String getDataset() {
+    return dataset;
+  }
+
+  public void setDataset(String dataset) {
+    this.dataset = dataset;
+  }
+
+
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ResponseParserUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ResponseParserUtils.java
@@ -62,7 +62,6 @@ public class ResponseParserUtils {
 
     ThirdEyeRequest request = response.getRequest();
     ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
-    requestBuilder.setCollection(request.getCollection());
     requestBuilder.setStartTimeInclusive(request.getStartTimeInclusive());
     requestBuilder.setEndTimeExclusive(request.getEndTimeExclusive());
     requestBuilder.setFilterSet(request.getFilterSet());
@@ -84,7 +83,6 @@ public class ResponseParserUtils {
     ThirdEyeRequest request = response.getRequest();
     Map<Integer, List<Double>> metricSums = new HashMap<>();
     ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
-    requestBuilder.setCollection(request.getCollection());
     requestBuilder.setStartTimeInclusive(request.getStartTimeInclusive());
     requestBuilder.setEndTimeExclusive(request.getEndTimeExclusive());
     requestBuilder.setFilterSet(request.getFilterSet());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
@@ -251,6 +251,8 @@ public class ThirdEyeRequest {
 
     public ThirdEyeRequest build(String requestReference) {
       String dataset = null;
+      // Since we don't have dataset anymore, we are using the first metric function, to derive the dataset name
+      // and then using that dataset to figure out if non additive
       try {
         if (CollectionUtils.isNotEmpty(metricFunctions)) {
           dataset = ThirdEyeUtils.getDatasetFromMetricFunction(metricFunctions.get(0));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.client;
 
 import com.linkedin.thirdeye.dashboard.configs.CollectionConfig;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -29,7 +31,6 @@ import org.slf4j.LoggerFactory;
  * objects can be constructed via {@link ThirdEyeRequestBuilder}.
  */
 public class ThirdEyeRequest {
-  private final String collection;
   private final List<MetricFunction> metricFunctions;
   private final DateTime startTime;
   private final DateTime endTime;
@@ -44,7 +45,6 @@ public class ThirdEyeRequest {
 
   private ThirdEyeRequest(String requestReference, ThirdEyeRequestBuilder builder) {
     this.requestReference = requestReference;
-    this.collection = builder.collection;
     this.metricFunctions = builder.metricFunctions;
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
@@ -64,10 +64,6 @@ public class ThirdEyeRequest {
 
   public String getRequestReference() {
     return requestReference;
-  }
-
-  public String getCollection() {
-    return collection;
   }
 
   public List<MetricFunction> getMetricFunctions() {
@@ -107,7 +103,7 @@ public class ThirdEyeRequest {
   @Override
   public int hashCode() {
     // TODO do we intentionally omit request reference here?
-    return Objects.hash(collection, metricFunctions, startTime, endTime, filterSet, filterClause,
+    return Objects.hash(metricFunctions, startTime, endTime, filterSet, filterClause,
         groupByDimensions, groupByTimeGranularity);
   };
 
@@ -118,8 +114,7 @@ public class ThirdEyeRequest {
     }
     ThirdEyeRequest other = (ThirdEyeRequest) o;
     // TODO do we intentionally omit request reference here?
-    return Objects.equals(getCollection(), other.getCollection())
-        && Objects.equals(getMetricFunctions(), other.getMetricFunctions())
+    return Objects.equals(getMetricFunctions(), other.getMetricFunctions())
         && Objects.equals(getStartTimeInclusive(), other.getStartTimeInclusive())
         && Objects.equals(getEndTimeExclusive(), other.getEndTimeExclusive())
         && Objects.equals(getFilterSet(), other.getFilterSet())
@@ -132,7 +127,7 @@ public class ThirdEyeRequest {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("requestReference", requestReference)
-        .add("collection", collection).add("metricFunctions", metricFunctions)
+        .add("metricFunctions", metricFunctions)
         .add("startTime", startTime).add("endTime", endTime).add("filterSet", filterSet)
         .add("filterClause", filterClause).add("groupBy", groupByDimensions)
         .add("groupByTimeGranularity", groupByTimeGranularity).toString();
@@ -142,7 +137,6 @@ public class ThirdEyeRequest {
     private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeRequestBuilder.class);
     private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
 
-    private String collection;
     private List<MetricFunction> metricFunctions;
     private DateTime startTime;
     private DateTime endTime;
@@ -158,7 +152,6 @@ public class ThirdEyeRequest {
     }
 
     public ThirdEyeRequestBuilder(ThirdEyeRequest request) {
-      this.collection = request.getCollection();
       this.metricFunctions = request.getMetricFunctions();
       this.startTime = request.getStartTimeInclusive();
       this.endTime = request.getEndTimeExclusive();
@@ -168,8 +161,7 @@ public class ThirdEyeRequest {
       this.groupByTimeGranularity = request.getGroupByTimeGranularity();
     }
 
-    public ThirdEyeRequestBuilder setCollection(String collection) {
-      this.collection = collection;
+    public ThirdEyeRequestBuilder setDatasets(List<String> datasets) {
       return this;
     }
 
@@ -258,15 +250,20 @@ public class ThirdEyeRequest {
     }
 
     public ThirdEyeRequest build(String requestReference) {
+      String dataset = null;
       try {
-        DatasetConfigDTO datasetConfig = CACHE_REGISTRY_INSTANCE.getDatasetConfigCache().get(collection);
-        if (!datasetConfig.isAdditive()) {
-          List<String> collectionDimensionNames = datasetConfig.getDimensions();
-          decorateFilterSetForPrecomputedDataset(filterSet, groupBy, collectionDimensionNames,
-              datasetConfig.getDimensionsHaveNoPreAggregation(), datasetConfig.getPreAggregatedKeyword());
+        if (CollectionUtils.isNotEmpty(metricFunctions)) {
+          dataset = ThirdEyeUtils.getDatasetFromMetricFunction(metricFunctions.get(0));
+          DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(dataset);
+
+          if (!datasetConfig.isAdditive()) {
+            List<String> collectionDimensionNames = datasetConfig.getDimensions();
+            decorateFilterSetForPrecomputedDataset(filterSet, groupBy, collectionDimensionNames,
+                datasetConfig.getDimensionsHaveNoPreAggregation(), datasetConfig.getPreAggregatedKeyword());
+          }
         }
       } catch (Exception e) {
-        LOG.debug("Collection config for collection {} does not exist", collection);
+        LOG.debug("Collection config for collection {} does not exist", dataset);
       }
       return new ThirdEyeRequest(requestReference, this);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/DimensionFiltersCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/DimensionFiltersCacheLoader.java
@@ -23,21 +23,21 @@ public class DimensionFiltersCacheLoader extends CacheLoader<String, String> {
   }
 
   @Override
-  public String load(String collection) throws Exception {
+  public String load(String dataset) throws Exception {
     DateTime startDateTime = new DateTime(System.currentTimeMillis()).minusDays(7);
     DateTime endDateTime = new DateTime(System.currentTimeMillis());
 
     String jsonFilters = null;
     try {
-      LOGGER.info("Loading dimension filters cache {}", collection);
-      List<String> dimensions = Utils.getSortedDimensionNames(collection);
+      LOGGER.info("Loading dimension filters cache {}", dataset);
+      List<String> dimensions = Utils.getSortedDimensionNames(dataset);
       Map<String, List<String>> filters =
-          Utils.getFilters(queryCache, collection, "filters", dimensions, startDateTime, endDateTime);
+          Utils.getFilters(queryCache, dataset, "filters", dimensions, startDateTime, endDateTime);
       jsonFilters = OBJECT_MAPPER.writeValueAsString(filters);
 
     } catch (Exception e) {
       LOGGER.error("Error while fetching dimension values in filter drop down for collection: {}",
-          collection, e);
+          dataset, e);
     }
 
     return jsonFilters;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/ThirdEyeRequestGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/ThirdEyeRequestGenerator.java
@@ -60,7 +60,6 @@ public class ThirdEyeRequestGenerator {
       String groupByDimension, TimeGranularity aggTimeGranularity) {
     ThirdEyeRequestBuilder requestBuilder = new ThirdEyeRequestBuilder();
     // COMMON to ALL REQUESTS
-    requestBuilder.setCollection(comparisonRequest.getCollectionName());
     requestBuilder.setFilterSet(comparisonRequest.getFilterSet());
     requestBuilder.setFilterClause(comparisonRequest.getFilterClause());
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeComparisonHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeComparisonHandler.java
@@ -36,8 +36,6 @@ public class TimeOnTimeComparisonHandler {
 
   public TimeOnTimeComparisonResponse handle(TimeOnTimeComparisonRequest comparisonRequest)
       throws Exception {
-    ThirdEyeRequestBuilder builder = new ThirdEyeRequestBuilder();
-    builder.setCollection(comparisonRequest.getCollectionName());
     List<Range<DateTime>> baselineTimeranges = new ArrayList<>();
     List<Range<DateTime>> currentTimeranges = new ArrayList<>();
     TimeGranularity aggregationTimeGranularity = comparisonRequest.getAggregationTimeGranularity();
@@ -147,7 +145,6 @@ public class TimeOnTimeComparisonHandler {
   private static ThirdEyeRequest createThirdEyeRequest(String requestReference,
       TimeOnTimeComparisonRequest comparisonRequest, DateTime start, DateTime end) {
     ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
-    requestBuilder.setCollection(comparisonRequest.getCollectionName());
     requestBuilder.setStartTimeInclusive(start);
     requestBuilder.setEndTimeExclusive(end);
     requestBuilder.setFilterSet(comparisonRequest.getFilterSet());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/PinotThirdEyeSummaryClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/PinotThirdEyeSummaryClient.java
@@ -144,7 +144,6 @@ public class PinotThirdEyeSummaryClient implements OLAPDataBaseClient {
 
     // baseline requests
     ThirdEyeRequestBuilder builder = ThirdEyeRequest.newBuilder();
-    builder.setCollection(collection);
     builder.setMetricFunctions(metricFunctions);
     builder.setGroupBy(groupBy);
     builder.setStartTimeInclusive(baselineStartInclusive);
@@ -154,7 +153,6 @@ public class PinotThirdEyeSummaryClient implements OLAPDataBaseClient {
 
     // current requests
     builder = ThirdEyeRequest.newBuilder();
-    builder.setCollection(collection);
     builder.setMetricFunctions(metricFunctions);
     builder.setGroupBy(groupBy);
     builder.setStartTimeInclusive(currentStartInclusive);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeResponse.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeResponse.java
@@ -17,8 +17,7 @@ public class PinotThirdEyeResponse extends BaseThirdEyeResponse {
   private List<ThirdEyeResponseRow> responseRows;
   private List<String[]> rows;
 
-  public PinotThirdEyeResponse(ThirdEyeRequest request, List<String[]> rows,
-      TimeSpec dataTimeSpec) {
+  public PinotThirdEyeResponse(ThirdEyeRequest request, List<String[]> rows, TimeSpec dataTimeSpec) {
     super(request, dataTimeSpec);
     this.rows = rows;
     this.responseRows = new ArrayList<>(rows.size());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
@@ -103,7 +103,6 @@ public class TimeSeriesHandler {
   private static ThirdEyeRequest createThirdEyeRequest(String requestReference,
       TimeSeriesRequest timeSeriesRequest, DateTime start, DateTime end) {
     ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
-    requestBuilder.setCollection(timeSeriesRequest.getCollectionName());
     requestBuilder.setStartTimeInclusive(start);
     requestBuilder.setEndTimeExclusive(end);
     requestBuilder.setFilterSet(timeSeriesRequest.getFilterSet());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -45,14 +45,13 @@ public class Utils {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static ThirdEyeCacheRegistry CACHE_REGISTRY = ThirdEyeCacheRegistry.getInstance();
 
-  public static List<ThirdEyeRequest> generateRequests(String collection, String requestReference,
+  public static List<ThirdEyeRequest> generateRequests(String dataset, String requestReference,
       MetricFunction metricFunction, List<String> dimensions, DateTime start, DateTime end) {
 
     List<ThirdEyeRequest> requests = new ArrayList<>();
 
     for (String dimension : dimensions) {
       ThirdEyeRequestBuilder requestBuilder = new ThirdEyeRequestBuilder();
-      requestBuilder.setCollection(collection);
       List<MetricFunction> metricFunctions = Arrays.asList(metricFunction);
       requestBuilder.setMetricFunctions(metricFunctions);
 
@@ -67,14 +66,14 @@ public class Utils {
     return requests;
   }
 
-  public static Map<String, List<String>> getFilters(QueryCache queryCache, String collection,
+  public static Map<String, List<String>> getFilters(QueryCache queryCache, String dataset,
       String requestReference, List<String> dimensions, DateTime start,
       DateTime end) throws Exception {
 
-    MetricFunction metricFunction = new MetricFunction(MetricAggFunction.COUNT, "*");
+    MetricFunction metricFunction = new MetricFunction(MetricAggFunction.COUNT, "*", null, dataset);
 
     List<ThirdEyeRequest> requests =
-        generateRequests(collection, requestReference, metricFunction, dimensions, start, end);
+        generateRequests(dataset, requestReference, metricFunction, dimensions, start, end);
 
     Map<ThirdEyeRequest, Future<ThirdEyeResponse>> queryResultMap =
         queryCache.getQueryResultsAsync(requests);
@@ -139,7 +138,7 @@ public class Utils {
   }
 
   public static List<MetricExpression> convertToMetricExpressions(String metricsJson,
-      MetricAggFunction aggFunction, String collection) throws ExecutionException {
+      MetricAggFunction aggFunction, String dataset) throws ExecutionException {
 
     List<MetricExpression> metricExpressions = new ArrayList<>();
     if (metricsJson == null) {
@@ -160,9 +159,9 @@ public class Utils {
       }
     }
     for (String metricExpressionName : metricExpressionNames) {
-      String derivedMetricExpression = ThirdEyeUtils.getDerivedMetricExpression(metricExpressionName, collection);
+      String derivedMetricExpression = ThirdEyeUtils.getDerivedMetricExpression(metricExpressionName, dataset);
       MetricExpression metricExpression = new MetricExpression(metricExpressionName, derivedMetricExpression,
-           aggFunction);
+           aggFunction, dataset);
       metricExpressions.add(metricExpression);
     }
     return metricExpressions;
@@ -255,7 +254,7 @@ public class Utils {
       List<MetricFunction> metricFunctions) {
     List<MetricExpression> metricExpressions = new ArrayList<>();
     for (MetricFunction function : metricFunctions) {
-      metricExpressions.add(new MetricExpression(function.getMetricName()));
+      metricExpressions.add(new MetricExpression(function.getMetricName(), function.getDataset()));
     }
     return metricExpressions;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/SeverityComputationUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/SeverityComputationUtil.java
@@ -73,7 +73,6 @@ public class SeverityComputationUtil {
   private ThirdEyeRequest createThirdEyeRequest(long currentWindowStart, long currentWindowEnd)
       throws ExecutionException {
     ThirdEyeRequestBuilder requestBuilder = ThirdEyeRequest.newBuilder();
-    requestBuilder.setCollection(collectionName);
     requestBuilder.setStartTimeInclusive(new DateTime(currentWindowStart));
     requestBuilder.setEndTimeExclusive(new DateTime(currentWindowEnd));
     // requestBuilder.setFilterSet(comparisonRequest.getFilterSet());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -215,13 +215,13 @@ public abstract class ThirdEyeUtils {
   }
 
   public static MetricExpression getMetricExpressionFromMetricConfig(MetricConfigDTO metricConfig) {
-    MetricExpression metricExpression = new MetricExpression();
-    metricExpression.setExpressionName(metricConfig.getName());
+    String expression = null;
     if (metricConfig.isDerived()) {
-      metricExpression.setExpression(metricConfig.getDerivedMetricExpression());
+      expression = metricConfig.getDerivedMetricExpression();
     } else {
-      metricExpression.setExpression(MetricConfigBean.DERIVED_METRIC_ID_PREFIX + metricConfig.getId());
+      expression = MetricConfigBean.DERIVED_METRIC_ID_PREFIX + metricConfig.getId();
     }
+    MetricExpression metricExpression = new MetricExpression(metricConfig.getName(), expression, metricConfig.getDataset());
     return metricExpression;
   }
 
@@ -354,6 +354,40 @@ public abstract class ThirdEyeUtils {
       break;
     }
     return new Period(0, 0, 0, 7 * numWeeksAgo, 0, 0, 0, 0);
+  }
+
+  public static DatasetConfigDTO getDatasetConfigFromName(String dataset) {
+    DatasetConfigDTO datasetConfig = null;
+    try {
+      datasetConfig = CACHE_REGISTRY.getDatasetConfigCache().get(dataset);
+    } catch (ExecutionException e) {
+      LOG.error("Exception in getting dataset config {} from cache", dataset, e);
+    }
+    return datasetConfig;
+  }
+
+  public static String getDatasetFromMetricFunction(MetricFunction metricFunction) {
+    MetricConfigDTO metricConfig = getMetricConfigFromId(metricFunction.getMetricId());
+    return metricConfig.getDataset();
+  }
+
+  public static MetricConfigDTO getMetricConfigFromId(Long metricId) {
+    MetricConfigDTO metricConfig = null;
+    if (metricId != null) {
+      metricConfig = DAO_REGISTRY.getMetricConfigDAO().findById(metricId);
+    }
+    return metricConfig;
+  }
+
+
+  public static MetricConfigDTO getMetricConfigFromNameAndDataset(String metricName, String dataset) {
+    MetricConfigDTO metricConfig = null;
+    try {
+      metricConfig = CACHE_REGISTRY.getMetricConfigCache().get(new MetricDataset(metricName, dataset));
+    } catch (ExecutionException e) {
+      LOG.error("Exception while fetching metric by name {} and dataset {}", metricName, dataset, e);
+    }
+    return metricConfig;
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeTest.java
@@ -72,7 +72,7 @@ public class TimeOnTimeTest {
     comparisonRequest.setCurrentStart(new DateTime(2016, 4, 8, 00, 00));
     comparisonRequest.setCurrentEnd(new DateTime(2016, 4, 9, 00, 00));
     List<MetricFunction> metricFunctions = new ArrayList<>();
-    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT"));
+    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection));
     List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metricFunctions);
     metricExpressions.add(new MetricExpression("submit_rate", "submits/impressions"));
     comparisonRequest.setMetricExpressions(metricExpressions);
@@ -94,7 +94,7 @@ public class TimeOnTimeTest {
         Lists.newArrayList("browserName", "contactsOrigin", "deviceName", "continent",
             "countryCode", "environment", "locale", "osName", "pageKey", "source", "sourceApp"));
     List<MetricFunction> metricFunctions = new ArrayList<>();
-    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT"));
+    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection));
     comparisonRequest.setMetricExpressions(Utils.convertToMetricExpressions(metricFunctions));
     comparisonRequest.setAggregationTimeGranularity(null);
     return comparisonRequest;
@@ -116,7 +116,7 @@ public class TimeOnTimeTest {
     comparisonRequest.setGroupByDimensions(Lists.newArrayList("environment"));
 
     List<MetricFunction> metricFunctions = new ArrayList<>();
-    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT"));
+    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection));
     comparisonRequest.setMetricExpressions(Utils.convertToMetricExpressions(metricFunctions));
     comparisonRequest.setAggregationTimeGranularity(new TimeGranularity(1, TimeUnit.HOURS));
     return comparisonRequest;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TestTimeSeriesResponseUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TestTimeSeriesResponseUtils.java
@@ -132,7 +132,7 @@ public class TestTimeSeriesResponseUtils {
   private List<MetricFunction> createSumFunctions(String... metricNames) {
     List<MetricFunction> result = new ArrayList<>();
     for (String metricName : metricNames) {
-      result.add(new MetricFunction(MetricAggFunction.SUM, metricName));
+      result.add(new MetricFunction(MetricAggFunction.SUM, metricName, 0L, "dataset"));
     }
     return result;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesTest.java
@@ -26,7 +26,7 @@ public class TimeSeriesTest {
   private static final String THIRDEYE_ABOOK = "thirdeyeAbook";
   private static final String COUNT = "__COUNT";
   private static final MetricFunction DEFAULT_METRIC_FUNCTION =
-      new MetricFunction(MetricAggFunction.SUM, COUNT);
+      new MetricFunction(MetricAggFunction.SUM, COUNT, 0L, THIRDEYE_ABOOK);
   private static final MetricExpression SUBMIT_RATE_EXPRESSION =
       new MetricExpression("submit_rate", "submits/impressions");
   private static final DateTime START = new DateTime(2016, 4, 1, 00, 00);


### PR DESCRIPTION
A derived metric expression can now be composed of metrics from different datasets. When creating the metric config, put only one of the dataset's name in the dataset field.
The datasets should have the same time granularity and time column name. Heatmaps will only work if dimensions are identical.