### PR TITLE
Log exception message instead of exception stacktrace when ideal state is not updated.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -111,8 +111,11 @@ public class HelixHelper {
           } catch (Exception e) {
             boolean idealStateIsCompressed = updatedIdealState.getRecord().getBooleanField("enableCompression", false);
 
+            // Failure to update due to valid reasons such as node already updated by another thread is also thrown
+            // as exception (KeeperException). Unfortunately, DataAccessor.set() does not have declaration that it
+            // throws KeeperException, and hence we cannot explicitly catch it.
             LOGGER.warn("Caught exception while updating ideal state for resource {} (compressed={}), retrying.",
-                resourceName, idealStateIsCompressed, e);
+                resourceName, idealStateIsCompressed, e.getMessage());
             return false;
           }
 


### PR DESCRIPTION
Failure to update ideal state because node's version number changed
throws an exception. Since this is expected when multiple threads are
trying to update the node concurrently, this is not really an error.
Logging exception message instead of the entire exception stack trace.