### PR TITLE
Remove keyword 'LIKE' from PQL grammar.

### DIFF
--- a/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
+++ b/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
@@ -90,7 +90,7 @@ betweenClause:
 
 regexpLikeClause:
   REGEXP_LIKE '(' expression ',' literal ')';
-  
+
 booleanOperator: OR | AND;
 
 groupByClause: GROUP BY groupByList;
@@ -124,7 +124,6 @@ LIMIT: L I M I T;
 NOT : N O T;
 OR: O R;
 REGEXP_LIKE: R E G E X P '_' L I K E;
-LIKE: L I K E;
 ORDER: O R D E R;
 SELECT: S E L E C T;
 TOP: T O P;


### PR DESCRIPTION
Removing the keyword 'LIKE' from PQL grammar as it is not supported
currently.