### PR TITLE
[TE] Add data filter for removing noisy time series

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -230,6 +230,15 @@ public class DetectionTaskRunner implements TaskRunner {
     ListMultimap<DimensionMap, RawAnomalyResultDTO> resultRawAnomalies = ArrayListMultimap.create();
 
     for (DimensionMap dimensionMap : anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().keySet()) {
+      // Skip anomaly detection if the current time series does not pass data filter, which may check if the traffic
+      // or total count of the data has enough volume for produce sufficient confidence anomaly results
+      MetricTimeSeries metricTimeSeries =
+          anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensionMap);
+      DataFilter dataFilter = DataFilterFactory.fromSpec(anomalyFunctionSpec.getDataFilter());
+      if (!dataFilter.isQualified(metricTimeSeries, dimensionMap)) {
+        continue;
+      }
+
       List<RawAnomalyResultDTO> resultsOfAnEntry = runAnalyze(windowStart, windowEnd, anomalyDetectionInputContext, dimensionMap);
 
       // Set raw anomalies' properties

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -104,8 +104,7 @@ public class DetectionTaskRunner implements TaskRunner {
   }
 
 
-  private void runTask(DateTime windowStart, DateTime windowEnd)
-      throws JobExecutionException, ExecutionException {
+  private void runTask(DateTime windowStart, DateTime windowEnd) throws JobExecutionException, ExecutionException {
 
     LOG.info("Running anomaly detection for time range {} to  {}", windowStart, windowEnd);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -10,6 +10,8 @@ import com.linkedin.thirdeye.anomaly.task.TaskInfo;
 import com.linkedin.thirdeye.anomaly.task.TaskResult;
 import com.linkedin.thirdeye.anomaly.task.TaskRunner;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
+import com.linkedin.thirdeye.anomalydetection.datafilter.DataFilter;
+import com.linkedin.thirdeye.anomalydetection.datafilter.DataFilterFactory;
 import com.linkedin.thirdeye.api.DimensionKey;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
@@ -245,6 +247,9 @@ public class DetectionTaskRunner implements TaskRunner {
 
   private List<RawAnomalyResultDTO> runAnalyze(DateTime windowStart, DateTime windowEnd,
       AnomalyDetectionInputContext anomalyDetectionInputContext, DimensionMap dimensionMap) {
+
+    List<RawAnomalyResultDTO> resultsOfAnEntry = Collections.emptyList();
+
     String metricName = anomalyFunction.getSpec().getTopicMetric();
     MetricTimeSeries metricTimeSeries = anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensionMap);
 
@@ -272,7 +277,6 @@ public class DetectionTaskRunner implements TaskRunner {
 
     AnomalyUtils.logAnomaliesOverlapWithWindow(windowStart, windowEnd, historyMergedAnomalies);
 
-    List<RawAnomalyResultDTO> resultsOfAnEntry = Collections.emptyList();
     try {
       // Run algorithm
       // Scaling time series according to the scaling factor

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/TimeSeriesUtil.java
@@ -86,7 +86,7 @@ public abstract class TimeSeriesUtil {
 
     DatasetConfigDTO dataset = DAORegistry.getInstance().getDatasetConfigDAO().findByDataset(anomalyFunctionSpec.getCollection());
     boolean doRollUp = true;
-    if (!dataset.isActive()) {
+    if (!dataset.isAdditive()) {
       doRollUp = false;
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
@@ -1,0 +1,155 @@
+package com.linkedin.thirdeye.anomalydetection.datafilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
+import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
+import com.linkedin.thirdeye.api.DimensionMap;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.apache.commons.lang3.StringUtils;
+
+public class AverageThresholdDataFilter extends BaseDataFilter {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String METRIC_NAME_KEY = "metricName";
+  private static final String THRESHOLD_KEY = "threshold";
+  // If the value of a bucket is smaller than MIN_DEAD_ZONE_KEY, then that bucket is omitted
+  private static final String MIN_DEAD_ZONE_KEY = "minDeadZone";
+  // If the value of a bucket is larger than MIN_DEAD_ZONE_KEY, then that bucket is omitted
+  private static final String MAX_DEAD_ZONE_KEY = "maxDeadZone";
+
+  private static final double DEFAULT_THRESHOLD = Double.NEGATIVE_INFINITY;
+  private static final double DEFAULT_MIN_DEAD_ZONE = Double.NEGATIVE_INFINITY;
+  private static final double DEFAULT_MAX_DEAD_ZONE = Double.POSITIVE_INFINITY;
+
+  // Override threshold to different dimension map
+  private static final String OVERRIDE_THRESHOLD_KEY = "overrideThreshold";
+  // The override threshold for different dimension maps, which could form a hierarchy.
+  private NavigableMap<DimensionMap, Double> overrideThreshold = new TreeMap<>();
+
+
+  @Override
+  public void setParameters(Map<String, String> props) {
+    super.setParameters(props);
+    if (props.containsKey(OVERRIDE_THRESHOLD_KEY)) {
+      String overrideJsonPayLoad = props.get(OVERRIDE_THRESHOLD_KEY);
+      try {
+        overrideThreshold = OBJECT_MAPPER.readValue(overrideJsonPayLoad, NavigableMap.class);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Returns if the average value of a time series, which is specified by metricName and dimensionMap, passes the
+   * threshold.
+   *
+   * Advanced Usage: A bucket is taken into consider only if its value is located inside live zone, which is specified
+   * by minDeadZone and maxDeadZone. In other words, if a value is smaller than minDeadZone or is larger than
+   * maxDeadZone, then this value is ignored when calculating the average value.
+   *
+   * @param context the context for retrieving the time series.
+   * @param dimensionMap the dimension map of the time series.
+   * @return if the average value of the given time series passes the threshold.
+   */
+  @Override
+  public boolean isQualified(AnomalyDetectionContext context, DimensionMap dimensionMap) {
+    // Initialize threshold from users' setting
+    double threshold = DEFAULT_THRESHOLD;
+    if (props.containsKey(THRESHOLD_KEY)) {
+      threshold = Double.parseDouble(props.get(THRESHOLD_KEY));
+    }
+    if (Double.isNaN(threshold)) {
+      throw new IllegalStateException("Threshold cannot be NaN.");
+    }
+    // Read the override threshold for the dimension of this time series
+    threshold = overrideThresholdForDimensions(dimensionMap, threshold);
+    if (threshold == Double.NEGATIVE_INFINITY) {
+      return true;
+    } else if (threshold == Double.POSITIVE_INFINITY) {
+      return false;
+    }
+
+    // Initialize metricName from users' setting
+    String metricName = props.get(METRIC_NAME_KEY);
+    if (StringUtils.isBlank(metricName)) {
+      throw new IllegalArgumentException("metric name cannot be a blank String.");
+    }
+
+    // Initialize minDeadZone from users' setting
+    double minDeadZone = DEFAULT_MIN_DEAD_ZONE;
+    if (props.containsKey(MIN_DEAD_ZONE_KEY)) {
+      minDeadZone = Double.parseDouble(props.get(MIN_DEAD_ZONE_KEY));
+      if (Double.isNaN(minDeadZone)) {
+        minDeadZone = Double.NEGATIVE_INFINITY;
+      }
+    }
+    // Initialize maxDeadZone from users' setting
+    double maxDeadZone = DEFAULT_MAX_DEAD_ZONE;
+    if (props.containsKey(MAX_DEAD_ZONE_KEY)) {
+      maxDeadZone = Double.parseDouble(props.get(MAX_DEAD_ZONE_KEY));
+      if (Double.isNaN(maxDeadZone)) {
+        maxDeadZone = Double.POSITIVE_INFINITY;
+      }
+    }
+
+    // Compute average values among all buckets and check if it passes the threshold
+    List<TimeSeries> timeSeries = context.getBaselines(metricName);
+    double sum = 0d;
+    int count = 0;
+    for (TimeSeries series : timeSeries) {
+      for (long timestamp : series.timestampSet()) {
+        double value = series.get(timestamp);
+        if (isLiveBucket(value, minDeadZone, maxDeadZone)) {
+          sum += value;
+          ++count;
+        }
+      }
+    }
+    return count > 0 && (sum / count) > threshold;
+  }
+
+  /**
+   * The value of a bucket is considered during the calculation of average bucket value only if the value is not a NaN
+   * and it is not located in the dead zone, which is defined by minDeadZone and maxDeadZone.
+   *
+   * @param value the value to be tested
+   * @param minDeadZone if the given value is smaller than minDeadZone, then the value is located in the dead zone.
+   * @param maxDeadZone if the given value is larger than maxDeadZone, then the value is located in the dead zone.
+   * @return true is the value should be considered when calculating the average of bucket values.
+   */
+  private boolean isLiveBucket(double value, double minDeadZone, double maxDeadZone) {
+    if (!Double.isNaN(value)) {
+      return false;
+    } else if (Double.compare(minDeadZone, value) > 0) {
+      return false;
+    } else if (Double.compare(maxDeadZone, value) < 0) {
+      return false;
+    } else return true;
+  }
+
+  /**
+   * Find the override threshold based on the given dimension map. The override threshold could given in a hierarchical
+   * dimension structure. Assume that the dimension map contains two dimensions: country and pageName. We could override
+   * the threshold in country level by specifying: overrideDimensionMap {country=US}, overrideThreshold=100. In this
+   * case, any dimensions that contain {country=US}, e.g., {country=US, pageName=homePage}, would use the override
+   * threshold.
+   *
+   * @param dimensionMap the dimension map to be used to search the override threshold.
+   * @param defaultThreshold the default threshold if override threshold does not exist.
+   *
+   * @return the threshold for the given dimension map.
+   */
+  private double overrideThresholdForDimensions(DimensionMap dimensionMap, double defaultThreshold) {
+    for (DimensionMap overrideDimensionMap : overrideThreshold.descendingKeySet()) {
+      if (dimensionMap.isChild(overrideDimensionMap)) {
+        return overrideThreshold.get(overrideDimensionMap);
+      }
+    }
+    return defaultThreshold;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
@@ -17,8 +17,8 @@ import org.slf4j.LoggerFactory;
  * The data filter determines whether the average value of a time series passes the threshold.
  *
  * Advance Usage 1: A bucket of the time series is taken into consider only if its value is located inside the live
- * zone, which is specified by minLiveZone and maxLveZone. In other words, if a bucket's value is smaller than
- * minLiveZone or is larger than maxLveZone, then this bucket is ignored when calculating the average value.
+ * zone, which is specified by minLiveZone and maxLiveZone. In other words, if a bucket's value is smaller than
+ * minLiveZone or is larger than maxLiveZone, then this bucket is ignored when calculating the average value.
  *
  * Advance Usage 2: The threshold could be overridden for different dimensions. For instance, the default threshold
  * for any combination of dimensions could be 1000. However, we could override the threshold for any sub-dimensions that

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
@@ -51,6 +51,7 @@ public class AverageThresholdDataFilter extends BaseDataFilter {
   @Override
   public void setParameters(Map<String, String> props) {
     super.setParameters(props);
+    // Initialize the lookup table for overriding thresholds
     if (props.containsKey(OVERRIDE_THRESHOLD_KEY)) {
       String overrideJsonPayLoad = props.get(OVERRIDE_THRESHOLD_KEY);
       try {
@@ -123,7 +124,12 @@ public class AverageThresholdDataFilter extends BaseDataFilter {
         ++count;
       }
     }
-    return count > 0 && (sum / count) > threshold;
+    if (count > 0) {
+      double average = sum / count;
+      return average > threshold;
+    } else {
+      return false;
+    }
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/BaseDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/BaseDataFilter.java
@@ -1,0 +1,13 @@
+package com.linkedin.thirdeye.anomalydetection.datafilter;
+
+import java.util.Collections;
+import java.util.Map;
+
+abstract class BaseDataFilter implements DataFilter {
+  protected Map<String, String> props = Collections.emptyMap();
+
+  @Override
+  public void setParameters(Map<String, String> props) {
+    this.props = props;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilter.java
@@ -1,0 +1,22 @@
+package com.linkedin.thirdeye.anomalydetection.datafilter;
+
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
+import com.linkedin.thirdeye.api.DimensionMap;
+import java.util.Map;
+
+public interface DataFilter {
+
+  /**
+   * Sets parameters for this filter.
+   * @param props the properties for this filter.
+   */
+  void setParameters(Map<String, String> props);
+
+  /**
+   * Returns if the given data, which is a time series with the given metric name and dimension map, passes the filter.
+   * @param context the context for retrieving the time series.
+   * @param dimensionMap the dimension map to retrieve the time series.
+   * @return true if the time series passes this filter.
+   */
+  boolean isQualified(AnomalyDetectionContext context, DimensionMap dimensionMap);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilter.java
@@ -1,7 +1,7 @@
 package com.linkedin.thirdeye.anomalydetection.datafilter;
 
-import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
 import java.util.Map;
 
 public interface DataFilter {
@@ -14,9 +14,9 @@ public interface DataFilter {
 
   /**
    * Returns if the given data, which is a time series with the given metric name and dimension map, passes the filter.
-   * @param context the context for retrieving the time series.
+   * @param metricTimeSeries the context for retrieving the time series.
    * @param dimensionMap the dimension map to retrieve the time series.
    * @return true if the time series passes this filter.
    */
-  boolean isQualified(AnomalyDetectionContext context, DimensionMap dimensionMap);
+  boolean isQualified(MetricTimeSeries metricTimeSeries, DimensionMap dimensionMap);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactory.java
@@ -1,0 +1,35 @@
+package com.linkedin.thirdeye.anomalydetection.datafilter;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+public class DataFilterFactory {
+  private static final String FILTER_TYPE_KEY = "type";
+
+  public DataFilter fromSpec(Map<String, String> spec) {
+    if (MapUtils.isEmpty(spec)) {
+      spec = Collections.emptyMap();
+    }
+    DataFilter dataFilter = fromStringType(spec.get(FILTER_TYPE_KEY));
+    dataFilter.setParameters(spec);
+
+    return dataFilter;
+  }
+
+  private DataFilter fromStringType(String type) {
+    String upperCaseType = "";
+    if (StringUtils.isNotBlank(type)) {
+      upperCaseType = type.toUpperCase();
+    }
+    switch (upperCaseType) {
+    case "": // speed optimization for most use cases
+      return new DummyDataFilter();
+    case "AVERAGETHRESHOLDDATAFILTER":
+      return new AverageThresholdDataFilter();
+    default:
+      return new DummyDataFilter();
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactory.java
@@ -7,6 +7,11 @@ import org.apache.commons.lang3.StringUtils;
 
 public class DataFilterFactory {
   public static final String FILTER_TYPE_KEY = "type";
+  private static final DataFilter DUMMY_DATA_FILTER = new DummyDataFilter();
+
+  public enum FilterType {
+    DUMMY, AVERAGE_THRESHOLD
+  }
 
   public static DataFilter fromSpec(Map<String, String> spec) {
     if (MapUtils.isEmpty(spec)) {
@@ -19,17 +24,25 @@ public class DataFilterFactory {
   }
 
   private static DataFilter fromStringType(String type) {
-    String upperCaseType = "";
-    if (StringUtils.isNotBlank(type)) {
-      upperCaseType = type.toUpperCase();
+    if (StringUtils.isBlank(type)) { // backward compatibility
+      return DUMMY_DATA_FILTER;
     }
-    switch (upperCaseType) {
-    case "": // speed optimization for most use cases
-      return new DummyDataFilter();
-    case "AVERAGETHRESHOLDDATAFILTER":
-      return new AverageThresholdDataFilter();
-    default:
-      return new DummyDataFilter();
+
+    FilterType filterType = FilterType.DUMMY;
+    for (FilterType enumFilterType : FilterType.class.getEnumConstants()) {
+      if (enumFilterType.name().compareToIgnoreCase(type) == 0) {
+        filterType = enumFilterType;
+        break;
+      }
+    }
+
+    switch (filterType) {
+      case DUMMY: // speed optimization for most use cases
+        return DUMMY_DATA_FILTER;
+      case AVERAGE_THRESHOLD:
+        return new AverageThresholdDataFilter();
+      default:
+        return DUMMY_DATA_FILTER;
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactory.java
@@ -6,9 +6,9 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class DataFilterFactory {
-  private static final String FILTER_TYPE_KEY = "type";
+  public static final String FILTER_TYPE_KEY = "type";
 
-  public DataFilter fromSpec(Map<String, String> spec) {
+  public static DataFilter fromSpec(Map<String, String> spec) {
     if (MapUtils.isEmpty(spec)) {
       spec = Collections.emptyMap();
     }
@@ -18,7 +18,7 @@ public class DataFilterFactory {
     return dataFilter;
   }
 
-  private DataFilter fromStringType(String type) {
+  private static DataFilter fromStringType(String type) {
     String upperCaseType = "";
     if (StringUtils.isNotBlank(type)) {
       upperCaseType = type.toUpperCase();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
@@ -1,0 +1,11 @@
+package com.linkedin.thirdeye.anomalydetection.datafilter;
+
+import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
+import com.linkedin.thirdeye.api.DimensionMap;
+
+public class DummyDataFilter extends BaseDataFilter {
+  @Override
+  public boolean isQualified(AnomalyDetectionContext context, DimensionMap dimensionMap) {
+    return true;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
@@ -1,11 +1,11 @@
 package com.linkedin.thirdeye.anomalydetection.datafilter;
 
-import com.linkedin.thirdeye.anomalydetection.context.AnomalyDetectionContext;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
 
 public class DummyDataFilter extends BaseDataFilter {
   @Override
-  public boolean isQualified(AnomalyDetectionContext context, DimensionMap dimensionMap) {
+  public boolean isQualified(MetricTimeSeries metricTimeSeries, DimensionMap dimensionMap) {
     return true;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
@@ -2,8 +2,13 @@ package com.linkedin.thirdeye.anomalydetection.datafilter;
 
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
+import java.util.Map;
 
 public class DummyDataFilter extends BaseDataFilter {
+  @Override
+  public void setParameters(Map<String, String> props) {
+  }
+
   @Override
   public boolean isQualified(MetricTimeSeries metricTimeSeries, DimensionMap dimensionMap) {
     return true;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
@@ -72,6 +72,32 @@ public class DimensionMap implements SortedMap<String, String>, Comparable<Dimen
   }
 
   /**
+   * Returns if this dimension map is a child of the given dimension map, i.e., the given dimension map is a subset
+   * of this dimension map.
+   *
+   * @param that the given dimension map.
+   * @return true if this dimension map is a child of the given dimension map.
+   */
+  public boolean isChild(DimensionMap that) {
+    if (that == null) { // equals to an empty dimension map, which is the root level of all dimensions
+      return true;
+    } else if (that.size() < this.size()) {
+      // parent dimension map must be a subset of this dimension map
+      for (Entry<String, String> parentDimensionEntry : that.entrySet()) {
+        String thisDimensionValue = this.get(parentDimensionEntry.getKey());
+        if (!parentDimensionEntry.getValue().equals(thisDimensionValue)) {
+          return false;
+        }
+      }
+      return true;
+    } else if (that.size() == this.size()) {
+      return this.equals(that);
+    } else {
+      return false;
+    }
+  }
+
+  /**
    * Returns a JSON string representation of this dimension map for {@link com.linkedin.thirdeye.datalayer.dao.GenericPojoDao}
    * to persistent the map to backend database.
    *

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/DimensionMap.java
@@ -32,16 +32,6 @@ public class DimensionMap implements SortedMap<String, String>, Comparable<Dimen
   }
 
   /**
-   * (Backward compatibility) For cleaning old anomalies from database.
-   *
-   * TODO: Remove this constructor after old anomalies are deleted
-   *
-   * @param dimensionKeyString
-   */
-  public DimensionMap(String dimensionKeyString) {
-  }
-
-  /**
    * Returns a dimension map according to the given dimension key.
    *
    * Assume that the given dimension key is [US,front_page,*,*,...] and the schema dimension names are
@@ -66,20 +56,16 @@ public class DimensionMap implements SortedMap<String, String>, Comparable<Dimen
     return dimensionMap;
   }
 
-  public String toJson()
-      throws JsonProcessingException {
-    return OBJECT_MAPPER.writeValueAsString(this);
-  }
-
   /**
-   * Returns if this dimension map is a child of the given dimension map, i.e., the given dimension map is a subset
-   * of this dimension map.
+   * Returns if this dimension map equals or is a child of the given dimension map, i.e., the given dimension map is
+   * a subset of this dimension map.
    *
    * @param that the given dimension map.
    * @return true if this dimension map is a child of the given dimension map.
    */
-  public boolean isChild(DimensionMap that) {
-    if (that == null) { // equals to an empty dimension map, which is the root level of all dimensions
+  public boolean equalsOrChildOf(DimensionMap that) {
+    // A null dimension map equals to an empty dimension map, which is the root level of all dimensions
+    if (that == null) {
       return true;
     } else if (that.size() < this.size()) {
       // parent dimension map must be a subset of this dimension map
@@ -95,6 +81,11 @@ public class DimensionMap implements SortedMap<String, String>, Comparable<Dimen
     } else {
       return false;
     }
+  }
+
+  public String toJson()
+      throws JsonProcessingException {
+    return OBJECT_MAPPER.writeValueAsString(this);
   }
 
   /**
@@ -138,7 +129,7 @@ public class DimensionMap implements SortedMap<String, String>, Comparable<Dimen
    * Examples:
    * 1. a={}, b={"K"="V"} --> a="", b="KV" --> a < b
    * 2. a={"K"="V"}, b={"K"="V"} --> a="KV", b="KV" --> a = b
-   * 3. a={"K2"="V1"}, b={"K1"="V1","K2"="V2"} --> a="K2V1", b="K1V1K2V2" --> b < a
+   * 3. a={"K2"="V1"}, b={"K1"="V1","K2"="V2"} --> a="K2V1", b="K1V1K2V2" --> a > b
    *
    * @param o the dimension to compare to
    */

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
@@ -33,8 +33,9 @@ import org.slf4j.LoggerFactory;
 public class TimeSeriesHandler {
   private static final Logger LOG = LoggerFactory.getLogger(TimeSeriesHandler.class);
   private final QueryCache queryCache;
-  private ExecutorService executorService;
   private final boolean doRollUp; // roll up small metrics to OTHER dimension
+  private ExecutorService executorService;
+
 
   public TimeSeriesHandler(QueryCache queryCache) {
     this.queryCache = queryCache;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
@@ -34,9 +34,15 @@ public class TimeSeriesHandler {
   private static final Logger LOG = LoggerFactory.getLogger(TimeSeriesHandler.class);
   private final QueryCache queryCache;
   private ExecutorService executorService;
+  private boolean doRollUp = true; // roll up small metrics to OTHER dimension
 
   public TimeSeriesHandler(QueryCache queryCache) {
     this.queryCache = queryCache;
+  }
+
+  public TimeSeriesHandler(QueryCache queryCache, boolean doRollUp) {
+    this.queryCache = queryCache;
+    this.doRollUp = doRollUp;
   }
 
   public TimeSeriesResponse handle(TimeSeriesRequest timeSeriesRequest) throws Exception {
@@ -60,7 +66,7 @@ public class TimeSeriesHandler {
     TimeSeriesResponseParser timeSeriesResponseParser =
         new TimeSeriesResponseParser(response, timeranges,
             timeSeriesRequest.getAggregationTimeGranularity(),
-            timeSeriesRequest.getGroupByDimensions());
+            timeSeriesRequest.getGroupByDimensions(), doRollUp);
     List<TimeSeriesRow> rows = timeSeriesResponseParser.parseResponse();
     // compute the derived metrics
     computeDerivedMetrics(timeSeriesRequest, rows);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesHandler.java
@@ -34,10 +34,11 @@ public class TimeSeriesHandler {
   private static final Logger LOG = LoggerFactory.getLogger(TimeSeriesHandler.class);
   private final QueryCache queryCache;
   private ExecutorService executorService;
-  private boolean doRollUp = true; // roll up small metrics to OTHER dimension
+  private final boolean doRollUp; // roll up small metrics to OTHER dimension
 
   public TimeSeriesHandler(QueryCache queryCache) {
     this.queryCache = queryCache;
+    this.doRollUp = true;
   }
 
   public TimeSeriesHandler(QueryCache queryCache, boolean doRollUp) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
@@ -3,7 +3,6 @@ package com.linkedin.thirdeye.datalayer.pojo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeConfig;
 import com.linkedin.thirdeye.api.TimeGranularity;
@@ -58,6 +57,12 @@ public class AnomalyFunctionBean extends AbstractBean {
   private String filters;
 
   private long metricId;
+
+  // Used to remove time series with small traffic or total count if the information is available
+  // This filter is different from the calculation of OTHER dimensions because it removes the time series if the
+  // count is not satisfied. Moreover, we won't have top level traffic or total count information when this filter
+  // is invoked, i.e., this filter is a local filter to time series with a certain dimensions.
+  private Map<String, String> dataFilter;
 
   private Map<String, String> alertFilter;
 
@@ -253,6 +258,14 @@ public class AnomalyFunctionBean extends AbstractBean {
 
   public void setAlertFilter(Map<String, String> alertFilter) {
     this.alertFilter = alertFilter;
+  }
+
+  public Map<String, String> getDataFilter() {
+    return dataFilter;
+  }
+
+  public void setDataFilter(Map<String, String> dataFilter) {
+    this.dataFilter = dataFilter;
   }
 
   public AnomalyMergeConfig getAnomalyMergeConfig() {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilterTest.java
@@ -14,7 +14,7 @@ public class AverageThresholdDataFilterTest {
   @Test
   public void testCreate() {
     Map<String, String> dataFilter = new HashMap<>();
-    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "AVERAGETHRESHOLDDATAFILTER");
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
     dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, "metricName");
     dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "1000");
     dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "100");

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilterTest.java
@@ -1,0 +1,46 @@
+package com.linkedin.thirdeye.anomalydetection.datafilter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.thirdeye.api.DimensionMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AverageThresholdDataFilterTest {
+  @Test
+  public void testCreate() {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "AVERAGETHRESHOLDDATAFILTER");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, "metricName");
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "1000");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "100");
+
+    NavigableMap<DimensionMap, Double> overrideThreshold = new TreeMap<>();
+
+    DimensionMap dimensionMap = new DimensionMap();
+    dimensionMap.put("K1", "V1");
+    overrideThreshold.put(dimensionMap, 350d);
+    DimensionMap dimensionMap2 = new DimensionMap();
+    dimensionMap2.put("K1", "V2");
+    overrideThreshold.put(dimensionMap2, 350d);
+
+    try {
+      ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+      String writeValueAsString = OBJECT_MAPPER.writeValueAsString(overrideThreshold);
+      dataFilter.put(AverageThresholdDataFilter.OVERRIDE_THRESHOLD_KEY, writeValueAsString);
+
+      AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+      averageThresholdDataFilter.setParameters(dataFilter);
+
+      NavigableMap<DimensionMap, Double> overrideThresholdMap = averageThresholdDataFilter.getOverrideThreshold();
+      Assert.assertEquals(overrideThresholdMap.get(dimensionMap), overrideThreshold.get(dimensionMap));
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+    }
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactoryTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactoryTest.java
@@ -1,0 +1,23 @@
+package com.linkedin.thirdeye.anomalydetection.datafilter;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DataFilterFactoryTest {
+
+  @Test
+  public void testFromSpecNull() throws Exception {
+    DataFilter dataFilter = DataFilterFactory.fromSpec(null);
+    Assert.assertEquals(dataFilter.getClass(), DummyDataFilter.class);
+  }
+
+  @Test
+  public void testDataFilterCreation() {
+    Map<String, String> spec = new HashMap<>();
+    spec.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    DataFilter dataFilter = DataFilterFactory.fromSpec(spec);
+    Assert.assertEquals(dataFilter.getClass(), AverageThresholdDataFilter.class);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/DimensionMapTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/DimensionMapTest.java
@@ -1,0 +1,68 @@
+package com.linkedin.thirdeye.api;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DimensionMapTest {
+
+  @Test
+  public void testComparison() {
+    DimensionMap d1;
+    DimensionMap d2;
+
+    // Case 1: a={}, b={"K"="V"} --> a="", b="KV" --> a < b
+    d1 = new DimensionMap();
+    d2 = new DimensionMap();
+    d2.put("K", "V");
+    Assert.assertEquals(d1.compareTo(d2) < 0, "".compareTo("KV") < 0);
+
+    // Case 2: a={"K"="V"}, b={"K"="V"} --> a="KV", b="KV" --> a = b
+    d1 = new DimensionMap();
+    d2 = new DimensionMap();
+    d1.put("K", "V");
+    d2.put("K", "V");
+    Assert.assertEquals(d1.compareTo(d2) == 0, "KV".compareTo("KV") == 0);
+
+    // Case 3: a={"K2"="V1"}, b={"K1"="V1","K2"="V2"} --> a="K2V1", b="K1V1K2V2" --> a > b
+    d1 = new DimensionMap();
+    d2 = new DimensionMap();
+    d1.put("K2", "V1");
+    d2.put("K1", "V1");
+    d2.put("K2", "V2");
+    Assert.assertEquals(d1.compareTo(d2) > 0, "K2V1".compareTo("K1V1K2V2") > 0);
+  }
+
+  @Test
+  public void testEqualsOrIsChild() {
+    DimensionMap d1;
+    DimensionMap d2;
+
+    // Case 1: a={}, b={"K"="V"} --> a is parent of b
+    d1 = new DimensionMap();
+    d2 = new DimensionMap();
+    d2.put("K", "V");
+    Assert.assertFalse(d1.equalsOrChildOf(d2));
+    Assert.assertTrue(d2.equalsOrChildOf(d1));
+
+    // Case 2: a={"K"="V"}, b={"K"="V"} --> a and b are sibling or self
+    d1 = new DimensionMap();
+    d2 = new DimensionMap();
+    d1.put("K", "V1");
+    d2.put("K", "V2");
+    Assert.assertFalse(d1.equalsOrChildOf(d2));
+    Assert.assertFalse(d2.equalsOrChildOf(d1));
+
+    // Case 3: a={"K2"="V1"}, b={"K1"="V1","K2"="V2"} --> a and b does not have any relation
+    d1 = new DimensionMap();
+    d2 = new DimensionMap();
+    d1.put("K2", "V1");
+    d2.put("K1", "V1");
+    d2.put("K2", "V2");
+    Assert.assertFalse(d1.equalsOrChildOf(d2));
+    Assert.assertFalse(d2.equalsOrChildOf(d1));
+
+    // Case 4: a=null, b={"K"="V"} --> a is universal parent
+    d2 = new DimensionMap();
+    Assert.assertTrue(d2.equalsOrChildOf(null));
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/DimensionMapTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/DimensionMapTest.java
@@ -6,6 +6,21 @@ import org.testng.annotations.Test;
 public class DimensionMapTest {
 
   @Test
+  public void testCreate() {
+    DimensionMap dimensionOrg = new DimensionMap();
+    dimensionOrg.put("K1", "V1");
+    dimensionOrg.put("K2", "V2");
+
+    String jsonString = dimensionOrg.toString();
+
+    DimensionMap dimensionClone1 = new DimensionMap(jsonString);
+    Assert.assertEquals(dimensionClone1, dimensionOrg);
+
+    DimensionMap dimensionClone2 = new DimensionMap("{K1=V1,K2=V2}");
+    Assert.assertEquals(dimensionClone2, dimensionOrg);
+  }
+
+  @Test
   public void testComparison() {
     DimensionMap d1;
     DimensionMap d2;
@@ -15,6 +30,7 @@ public class DimensionMapTest {
     d2 = new DimensionMap();
     d2.put("K", "V");
     Assert.assertEquals(d1.compareTo(d2) < 0, "".compareTo("KV") < 0);
+    Assert.assertEquals(d2.compareTo(d1) > 0, "KV".compareTo("") > 0);
 
     // Case 2: a={"K"="V"}, b={"K"="V"} --> a="KV", b="KV" --> a = b
     d1 = new DimensionMap();
@@ -22,6 +38,7 @@ public class DimensionMapTest {
     d1.put("K", "V");
     d2.put("K", "V");
     Assert.assertEquals(d1.compareTo(d2) == 0, "KV".compareTo("KV") == 0);
+    Assert.assertEquals(d2.compareTo(d1) == 0, "KV".compareTo("KV") == 0);
 
     // Case 3: a={"K2"="V1"}, b={"K1"="V1","K2"="V2"} --> a="K2V1", b="K1V1K2V2" --> a > b
     d1 = new DimensionMap();
@@ -30,6 +47,7 @@ public class DimensionMapTest {
     d2.put("K1", "V1");
     d2.put("K2", "V2");
     Assert.assertEquals(d1.compareTo(d2) > 0, "K2V1".compareTo("K1V1K2V2") > 0);
+    Assert.assertEquals(d2.compareTo(d1) < 0, "K1V1K2V2".compareTo("K2V1") < 0);
   }
 
   @Test

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMergedAnomalyResultManager.java
@@ -71,6 +71,7 @@ public class TestMergedAnomalyResultManager extends AbstractManagerTestBase {
     MergedAnomalyResultDTO mergedResultById = mergedAnomalyResultDAO.findById(mergedResult.getId());
     Assert.assertEquals(mergedResultById.getAnomalyResults(), rawResults);
     Assert.assertEquals(mergedResultById.getAnomalyResults().get(0).getId(), anomalyResultId);
+    Assert.assertEquals(mergedResultById.getDimensions(), result.getDimensions());
 
     List<MergedAnomalyResultDTO> mergedResultsByMetricDimensionsTime = mergedAnomalyResultDAO
         .findByCollectionMetricDimensionsTime(mergedResult.getCollection(), mergedResult.getMetric(),


### PR DESCRIPTION
1. Introduce a data filter stage before anomaly detection in order to remove noisy time series, e.g., ratio time series that is generated when traffic or total count is low.

2. Implement an Average Threshold data filter which average the values of the given time series and test if it exceeds the threshold. The filter provides two advanced usages:
  I. A live zone could be set on the values of bucket. For instance, we could ignore all buckets with very small values, which could be noise of the time series. A live zone could be defined by a min and/or a max value.
  II. User could define the override threshold for certain dimensions. For example, we could override the threshold for all time series whose country=US.

3. Add roll up option to disable/enable rolling up low volume time series. The roll up functionality was designed for UI; however, this function could swallow time series for anomaly detection. Now we could disable this function through this flag.

Tested with new unit tests and local integration test, which backfills anomalies for one month.