### PR TITLE
[TE] Add time range when applying data filter

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -229,13 +229,13 @@ public class DetectionTaskRunner implements TaskRunner {
     int anomalyCounter = 0;
     ListMultimap<DimensionMap, RawAnomalyResultDTO> resultRawAnomalies = ArrayListMultimap.create();
 
+    DataFilter dataFilter = DataFilterFactory.fromSpec(anomalyFunctionSpec.getDataFilter());
     for (DimensionMap dimensionMap : anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().keySet()) {
       // Skip anomaly detection if the current time series does not pass data filter, which may check if the traffic
       // or total count of the data has enough volume for produce sufficient confidence anomaly results
       MetricTimeSeries metricTimeSeries =
           anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensionMap);
-      DataFilter dataFilter = DataFilterFactory.fromSpec(anomalyFunctionSpec.getDataFilter());
-      if (!dataFilter.isQualified(metricTimeSeries, dimensionMap)) {
+      if (!dataFilter.isQualified(metricTimeSeries, dimensionMap, windowStart.getMillis(), windowEnd.getMillis())) {
         continue;
       }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilter.java
@@ -8,15 +8,31 @@ public interface DataFilter {
 
   /**
    * Sets parameters for this filter.
+   *
    * @param props the properties for this filter.
    */
   void setParameters(Map<String, String> props);
 
   /**
    * Returns if the given data, which is a time series with the given metric name and dimension map, passes the filter.
+   *
    * @param metricTimeSeries the context for retrieving the time series.
-   * @param dimensionMap the dimension map to retrieve the time series.
+   * @param dimensionMap     the dimension map to retrieve the time series.
+   *
    * @return true if the time series passes this filter.
    */
   boolean isQualified(MetricTimeSeries metricTimeSeries, DimensionMap dimensionMap);
+
+  /**
+   * Returns if the given time series, which is specified by a metric name, a dimension map, and a pair of
+   * start and end timestamps, passes the filter.
+   *
+   * @param metricTimeSeries the context for retrieving the time series.
+   * @param dimensionMap     the dimension map of time series.
+   * @param windowStart      the start timestamp of the target data points, inclusive.
+   * @param windowEnd        the end timestamp of the target data points, exclusive.
+   *
+   * @return true if the time series passes this filter.
+   */
+  boolean isQualified(MetricTimeSeries metricTimeSeries, DimensionMap dimensionMap, long windowStart, long windowEnd);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/DummyDataFilter.java
@@ -13,4 +13,10 @@ public class DummyDataFilter extends BaseDataFilter {
   public boolean isQualified(MetricTimeSeries metricTimeSeries, DimensionMap dimensionMap) {
     return true;
   }
+
+  @Override
+  public boolean isQualified(MetricTimeSeries metricTimeSeries, DimensionMap dimensionMap, long windowStart,
+      long windowEnd) {
+    return true;
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactoryTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/DataFilterFactoryTest.java
@@ -16,6 +16,7 @@ public class DataFilterFactoryTest {
   @Test
   public void testDataFilterCreation() {
     Map<String, String> spec = new HashMap<>();
+    spec.put(AverageThresholdDataFilter.METRIC_NAME_KEY, "metricName");
     spec.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
     DataFilter dataFilter = DataFilterFactory.fromSpec(spec);
     Assert.assertEquals(dataFilter.getClass(), AverageThresholdDataFilter.class);


### PR DESCRIPTION
1. Add time range for data filter: we could specify a certain range of the time series for isQualify() method.

2. Performance improvement.

Tested with local anomaly detection: Backfilled 1~2 months of anomalies.