### PR TITLE
THIRDEYE-1242 : Increase frequency of schedulers

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
@@ -62,7 +62,7 @@ public class DetectionJobScheduler implements Runnable {
   private final long SYNC_SLEEP_SECONDS = 5;
 
   public void start() throws SchedulerException {
-    scheduledExecutorService.scheduleAtFixedRate(this, 0, 15, TimeUnit.MINUTES);
+    scheduledExecutorService.scheduleWithFixedDelay(this, 0, 5, TimeUnit.MINUTES);
   }
 
   public void shutdown() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorConstants.java
@@ -11,6 +11,6 @@ public class MonitorConstants {
   }
 
   public static int DEFAULT_EXPIRE_DAYS_AGO = 3;
-  public static TimeGranularity DEFAULT_MONITOR_FREQUENCY = new TimeGranularity(4, TimeUnit.HOURS);
+  public static TimeGranularity DEFAULT_MONITOR_FREQUENCY = new TimeGranularity(1, TimeUnit.HOURS);
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessScheduler.java
@@ -24,7 +24,7 @@ public class DataCompletenessScheduler {
     dataCompletenessJobContext = new DataCompletenessJobContext();
     dataCompletenessJobRunner = new DataCompletenessJobRunner(dataCompletenessJobContext);
 
-    scheduledExecutorService.scheduleWithFixedDelay(dataCompletenessJobRunner, 0, 15, TimeUnit.MINUTES);
+    scheduledExecutorService.scheduleWithFixedDelay(dataCompletenessJobRunner, 0, 5, TimeUnit.MINUTES);
   }
 
   public void shutdown() {


### PR DESCRIPTION
Data completeness will wait 5 minutes between runs (instead of 15 minutes between runs)
Detection Scheduler will wait 5 minutes between runs (instead of 15 minutes fixed interval)
Monitor will run after every hour instead of 4 hours