### PR TITLE
Refine TimeGranularity handling for non-additive dataset

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobRunner.java
@@ -31,7 +31,7 @@ import com.linkedin.thirdeye.util.ThirdEyeUtils;
 public class DetectionJobRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(DetectionJobRunner.class);
-  private final static DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
+  private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private TaskGenerator taskGenerator;
@@ -86,7 +86,7 @@ public class DetectionJobRunner {
     try {
       DatasetConfigDTO datasetConfig = DAO_REGISTRY.getDatasetConfigDAO().findByDataset(collection);
       TimeSpec timespec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
-      TimeGranularity dataGranularity = timespec.getDataGranularity();
+      TimeGranularity dataGranularity = datasetConfig.bucketTimeGranularity();
       String timeFormat = timespec.getFormat();
       if (dataGranularity.getUnit().equals(TimeUnit.DAYS)) {
         DateTimeZone dataTimeZone = Utils.getDataTimeZone(collection);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/TimeGranularity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/TimeGranularity.java
@@ -8,15 +8,24 @@ import org.joda.time.Period;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TimeGranularity {
-  private int size;
-  private TimeUnit unit;
+  private final int size;
+  private final TimeUnit unit;
 
   public TimeGranularity() {
+    this(1, TimeUnit.HOURS);
   }
 
   public TimeGranularity(int size, TimeUnit unit) {
     this.size = size;
     this.unit = unit;
+  }
+
+  /**
+   * Copy constructor
+   * @param that to be copied
+   */
+  public TimeGranularity(TimeGranularity that) {
+    this(that.getSize(), that.getUnit());
   }
 
   @JsonProperty
@@ -29,42 +38,59 @@ public class TimeGranularity {
     return unit;
   }
 
+  /**
+   * Returns the equivalent milliseconds of this time granularity.
+   *
+   * @return the equivalent milliseconds of this time granularity.
+   */
   public long toMillis() {
     return toMillis(1);
   }
 
-  public Period toPeriod() {
-    Period period = null;
-    switch (unit) {
-    case DAYS:
-      period = new Period(0, 0, 0, size, 0, 0, 0, 0);
-      break;
-    case HOURS:
-      period = new Period(0, 0, 0, 0, size, 0, 0, 0);
-      break;
-    case MINUTES:
-      period = new Period(0, 0, 0, 0, 0, size, 0, 0);
-      break;
-    case SECONDS:
-      period = new Period(0, 0, 0, 0, 0, 0, size, 0);
-      break;
-    case MILLISECONDS:
-      period = new Period(0, 0, 0, 0, 0, 0, 0, size);
-      break;
-    default:
-      period = new Period(0, 0, 0, 0, size, 0, 0, 0);
-      break;
-    }
-    return period;
+  /**
+   * Returns the equivalent milliseconds of the specified number of this time granularity. Highly suggested to use
+   * toPeriod instead of this method for handling daylight saving time issue.
+   *
+   * @param number the specified number of this time granularity.
+   *
+   * @return the equivalent milliseconds of the specified number of this time granularity.
+   */
+  public long toMillis(long number) {
+    return unit.toMillis(number * size);
   }
 
   /**
-   * Converts time in bucketed unit to millis
-   * @param time
-   * @return
+   * Returns an equivalent Period object of this time granularity.
+   *
+   * @return an equivalent Period object of this time granularity.
    */
-  public long toMillis(long time) {
-    return unit.toMillis(time * size);
+  public Period toPeriod() {
+    return toPeriod(1);
+  }
+
+  /**
+   * Returns an equivalent Period object of the specified number of this time granularity.
+   *
+   * @param number the specified number of this time granularity.
+   *
+   * @return an equivalent Period object of the specified number of this time granularity.
+   */
+  public Period toPeriod(int number) {
+    int size = this.size * number;
+    switch (unit) {
+    case DAYS:
+      return new Period(0, 0, 0, size, 0, 0, 0, 0);
+    case HOURS:
+      return new Period(0, 0, 0, 0, size, 0, 0, 0);
+    case MINUTES:
+      return new Period(0, 0, 0, 0, 0, size, 0, 0);
+    case SECONDS:
+      return new Period(0, 0, 0, 0, 0, 0, size, 0);
+    case MILLISECONDS:
+      return new Period(0, 0, 0, 0, 0, 0, 0, size);
+    default:
+      return new Period(0, 0, 0, 0, size, 0, 0, 0);
+    }
   }
 
   /**
@@ -83,6 +109,37 @@ public class TimeGranularity {
     return unit.convert(millis, TimeUnit.MILLISECONDS) / size;
   }
 
+  /**
+   * Initialize time granularity from its aggregation string representation, in which duration and unit are separated
+   * by "_". For instance, "5_MINUTES" initialize a time granularity with size = 5 and TimeUnit = "MINUTES".
+   *
+   * @param timeGranularityString the aggregation string representation of the time granularity.
+   *
+   * @return time granularity that is initialized from the given aggregation string representation.
+   */
+  public static TimeGranularity fromString(String timeGranularityString) {
+    if (timeGranularityString.contains("_")) {
+      String[] split = timeGranularityString.split("_");
+      return new TimeGranularity(Integer.parseInt(split[0]), TimeUnit.valueOf(split[1]));
+    } else {
+      return new TimeGranularity(1, TimeUnit.valueOf(timeGranularityString));
+    }
+  }
+
+  /**
+   * Return the string representation of this time granularity, in which duration and unit are separated by "_".
+   *
+   * @return the string representation of this time granularity, in which duration and unit are separated by "_".
+   */
+  public String toAggregationGranularityString() {
+    return size + "_" + unit;
+  }
+
+  /**
+   * Return the string representation of this time granularity, in which duration and unit are separated by "-".
+   *
+   * @return the string representation of this time granularity, in which duration and unit are separated by "-".
+   */
   @Override
   public String toString() {
     return size + "-" + unit;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/autoload/pinot/metrics/ConfigGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/autoload/pinot/metrics/ConfigGenerator.java
@@ -33,7 +33,7 @@ public class ConfigGenerator {
     datasetConfigDTO.setTimeDuration(timeSpec.getTimeUnitSize());
     datasetConfigDTO.setTimeUnit(timeSpec.getTimeType());
     datasetConfigDTO.setTimeFormat(timeSpec.getTimeFormat());
-    datasetConfigDTO.setExpectedDelay(getExpectedDelayFromTimeunit(datasetConfigDTO.getTimeUnit()));
+    datasetConfigDTO.setExpectedDelay(getExpectedDelayFromTimeunit(timeSpec.getTimeType()));
     if (timeSpec.getTimeFormat().startsWith(TimeFormat.SIMPLE_DATE_FORMAT.toString())) {
       datasetConfigDTO.setTimezone(PDT_TIMEZONE);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -117,7 +117,7 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
     for (MetricFunction metricFunction : request.getMetricFunctions()) {
       String dataset = metricFunction.getDataset();
       DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(dataset);
-      TimeSpec dataTimeSpec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
+      TimeSpec dataTimeSpec = ThirdEyeUtils.getTimestampTimeSpecFromDatasetConfig(datasetConfig);
       if (timeSpec == null) {
         timeSpec = dataTimeSpec;
       }
@@ -178,7 +178,7 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
 
       String dataset = metricFunction.getDataset();
       DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(dataset);
-      TimeSpec dataTimeSpec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
+      TimeSpec dataTimeSpec = ThirdEyeUtils.getTimestampTimeSpecFromDatasetConfig(datasetConfig);
 
       TimeGranularity dataGranularity = null;
       long startTime = request.getStartTimeInclusive().getMillis();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessAlgorithm.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessAlgorithm.java
@@ -55,8 +55,9 @@ public interface DataCompletenessAlgorithm {
    * and if not available, computes and stores them, for the rest of the computation to use
    * @param dataset
    * @param bucketNameToBucketValueMS
-   * @param bucketNameToTimeValues
+   * @param dateTimeFormatter
    * @param timeSpec
+   * @param zone
    */
   public void computeBaselineCountsIfNotPresent(String dataset, Map<String, Long> bucketNameToBucketValueMS,
       DateTimeFormatter dateTimeFormatter, TimeSpec timeSpec, DateTimeZone zone);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DatasetConfigResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DatasetConfigResource.java
@@ -61,7 +61,7 @@ public class DatasetConfigResource {
       datasetConfigDTO.setMetricNamesColumn(metricNamesColumn);
       datasetConfigDTO.setMetricValuesColumn(metricValuesColumn);
       datasetConfigDTO.setNonAdditiveBucketSize(nonAdditiveBucketSize);
-      datasetConfigDTO.setNonAdditiveBucketUnit(nonAdditiveBucketUnit);
+      datasetConfigDTO.setNonAdditiveBucketUnit(TimeUnit.valueOf(nonAdditiveBucketUnit));
       datasetConfigDTO.setPreAggregatedKeyword(preAggregatedKeyword);
       datasetConfigDTO.setTimeColumn(timeColumn);
       datasetConfigDTO.setTimeDuration(timeDuration);
@@ -105,7 +105,7 @@ public class DatasetConfigResource {
       datasetConfigDTO.setMetricAsDimension(metricAsDimension);
       datasetConfigDTO.setMetricValuesColumn(metricValuesColumn);
       datasetConfigDTO.setNonAdditiveBucketSize(nonAdditiveBucketSize);
-      datasetConfigDTO.setNonAdditiveBucketUnit(nonAdditiveBucketUnit);
+      datasetConfigDTO.setNonAdditiveBucketUnit(TimeUnit.valueOf(nonAdditiveBucketUnit));
       datasetConfigDTO.setPreAggregatedKeyword(preAggregatedKeyword);
       datasetConfigDTO.setTimeColumn(timeColumn);
       datasetConfigDTO.setTimeDuration(timeDuration);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -239,8 +239,8 @@ public class DataResource {
 
     MetricConfigDTO metricConfig = metricConfigDAO.findById(metricId);
     DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(metricConfig.getDataset());
-    int dataTimeSize = datasetConfig.getTimeDuration();
-    TimeUnit dataTimeUnit = datasetConfig.getTimeUnit();
+    int dataTimeSize = datasetConfig.bucketTimeGranularity().getSize();
+    TimeUnit dataTimeUnit = datasetConfig.bucketTimeGranularity().getUnit();
 
     List<String> dataGranularities = new ArrayList<>();
     switch (dataTimeUnit) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/DatasetConfigDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/DatasetConfigDTO.java
@@ -1,7 +1,32 @@
 package com.linkedin.thirdeye.datalayer.dto;
 
+import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
+import java.util.concurrent.TimeUnit;
 
 public class DatasetConfigDTO extends DatasetConfigBean {
 
+  private TimeGranularity bucketTimeGranularity;
+
+  /**
+   * Returns the granularity of a bucket (a data point) of this dataset. The granularity of a bucket, which may be
+   * different from the granularity that is defined in dataset configuration, which actually defines the granularity of
+   * the timestamp of each data point. This variable provides the actual granularity when the granularity defined in
+   * the dataset config is different from the granularity of data point. This information is crucial for non-additive
+   * dataset.
+   *
+   * @return the granularity of a bucket (a data point) of this dataset
+   */
+  public TimeGranularity bucketTimeGranularity() {
+    if (bucketTimeGranularity == null) {
+      if (this.isAdditive()) {
+        bucketTimeGranularity = new TimeGranularity(getTimeDuration(), getTimeUnit());
+      } else {
+        int size = getNonAdditiveBucketSize() != null ? getNonAdditiveBucketSize() : getTimeDuration();
+        TimeUnit timeUnit = getNonAdditiveBucketUnit() != null ? getNonAdditiveBucketUnit() : getTimeUnit();
+        bucketTimeGranularity = new TimeGranularity(size, timeUnit);
+      }
+    }
+    return bucketTimeGranularity;
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -42,17 +42,36 @@ public class DatasetConfigBean extends AbstractBean {
 
   private boolean active = true;
 
+  /** Configuration for non-additive dataset **/
+  // By default, every dataset is additive and this section of configurations should be ignored.
   private boolean additive = true;
+
+  // We assume that non-additive dataset has a default TOP dimension value, which is specified via preAggregatedKeyword,
+  // for each dimension. When ThirdEye constructs query string to backend database, it automatically appends the keyword
+  // for ALL dimensions except the dimension that has been specified by filter the one specified in
+  // dimensionsHaveNoPreAggregation (because some dimension may not have such pre-aggregated dimension value).
+  // For example, assume that we have three dimensions: D1, D2, D3. The preAggregatedKeyword is "all" and D2 does not
+  // has any pre-aggregated dimension value, i.e., dimensionsHaveNoPreAggregation=[D2]. The filter given by user is
+  // {D3=V3}. Then the query should append the WHERE condition {D1=all, D2=V3} in order to get the correct results from
+  // this non-additive dataset.
   private List<String> dimensionsHaveNoPreAggregation = Collections.emptyList();
+
+  // The pre-aggregated keyword
   private String preAggregatedKeyword = DEFAULT_PREAGGREGATED_DIMENSION_VALUE;
+
+  // the actual time duration for non-additive dataset
   private Integer nonAdditiveBucketSize;
-  private String nonAdditiveBucketUnit;
+
+  // the actual time unit for non-additive dataset
+  private TimeUnit nonAdditiveBucketUnit;
+  /** End of Configuration for non-additive dataset **/
 
   private boolean realtime = false;
 
   private boolean requiresCompletenessCheck = false;
 
   private TimeGranularity expectedDelay = DEFAULT_DAILY_EXPECTED_DELAY;
+
 
   public String getDataset() {
     return dataset;
@@ -78,6 +97,14 @@ public class DatasetConfigBean extends AbstractBean {
     this.timeColumn = timeColumn;
   }
 
+  /**
+   * Use DatasetConfigDTO.bucketTimeGranularity instead of this method for considering the additives of the dataset.
+   *
+   * This method is preserved for reading object from database via object mapping (i.e., Java reflection)
+   *
+   * @return the time unit of the granularity of the timestamp of each data point.
+   */
+  @Deprecated
   public TimeUnit getTimeUnit() {
     return timeUnit;
   }
@@ -86,6 +113,14 @@ public class DatasetConfigBean extends AbstractBean {
     this.timeUnit = timeUnit;
   }
 
+  /**
+   * Use DatasetConfigDTO.bucketTimeGranularity instead of this method for considering the additives of the dataset.
+   *
+   * This method is preserved for reading object from database via object mapping (i.e., Java reflection)
+   *
+   * @return the duration of the granularity of the timestamp of each data point.
+   */
+  @Deprecated
   public Integer getTimeDuration() {
     return timeDuration;
   }
@@ -183,11 +218,11 @@ public class DatasetConfigBean extends AbstractBean {
     this.nonAdditiveBucketSize = nonAdditiveBucketSize;
   }
 
-  public String getNonAdditiveBucketUnit() {
+  public TimeUnit getNonAdditiveBucketUnit() {
     return nonAdditiveBucketUnit;
   }
 
-  public void setNonAdditiveBucketUnit(String nonAdditiveBucketUnit) {
+  public void setNonAdditiveBucketUnit(TimeUnit nonAdditiveBucketUnit) {
     this.nonAdditiveBucketUnit = nonAdditiveBucketUnit;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
@@ -140,7 +140,7 @@ public abstract class BaseAnomalyFunction implements AnomalyFunction {
   }
 
   private AnomalyOffset getDefaultOffsets(DatasetConfigDTO datasetConfig) {
-    TimeUnit dataTimeUnit = datasetConfig.getTimeUnit();
+    TimeUnit dataTimeUnit = datasetConfig.bucketTimeGranularity().getUnit();
     Period preOffsetPeriod = null;
     Period postOffsetPeriod = null;
     switch (dataTimeUnit) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -183,23 +183,23 @@ public abstract class ThirdEyeUtils {
     return sortedFilters;
   }
 
-  public static TimeSpec getTimeSpecFromDataset(String dataset) {
-
-    TimeSpec timespec = null;
-    try {
-      DatasetConfigDTO datasetConfig = CACHE_REGISTRY.getDatasetConfigCache().get(dataset);
-      timespec = getTimeSpecFromDatasetConfig(datasetConfig);
-    } catch (ExecutionException e) {
-      LOG.error("Exception when fetching datasetconfig from cache", e);
-    }
-    return timespec;
-  }
-
-  public static TimeSpec getTimeSpecFromDatasetConfig(DatasetConfigDTO datasetConfig) {
+  private static String getTimeFormatString(DatasetConfigDTO datasetConfig) {
     String timeFormat = datasetConfig.getTimeFormat();
     if (timeFormat.startsWith(TimeFormat.SIMPLE_DATE_FORMAT.toString())) {
       timeFormat = getSDFPatternFromTimeFormat(timeFormat);
     }
+    return timeFormat;
+  }
+
+  public static TimeSpec getTimeSpecFromDatasetConfig(DatasetConfigDTO datasetConfig) {
+    String timeFormat = getTimeFormatString(datasetConfig);
+    TimeSpec timespec = new TimeSpec(datasetConfig.getTimeColumn(),
+        new TimeGranularity(datasetConfig.bucketTimeGranularity()), timeFormat);
+    return timespec;
+  }
+
+  public static TimeSpec getTimestampTimeSpecFromDatasetConfig(DatasetConfigDTO datasetConfig) {
+    String timeFormat = getTimeFormatString(datasetConfig);
     TimeSpec timespec = new TimeSpec(datasetConfig.getTimeColumn(),
         new TimeGranularity(datasetConfig.getTimeDuration(), datasetConfig.getTimeUnit()), timeFormat);
     return timespec;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/autoload/pinot/metrics/AutoloadPinotMetricsServiceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/autoload/pinot/metrics/AutoloadPinotMetricsServiceTest.java
@@ -6,7 +6,6 @@ import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
-import com.linkedin.thirdeye.client.DAORegistry;
 import com.linkedin.thirdeye.datalayer.bao.AbstractManagerTestBase;
 import com.linkedin.thirdeye.datalayer.dto.DashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
@@ -18,9 +17,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -51,8 +48,8 @@ public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
     Assert.assertEquals(datasetConfig.getDimensions(), schema.getDimensionNames());
     Assert.assertEquals(datasetConfig.getTimeColumn(), schema.getTimeColumnName());
     TimeGranularitySpec timeGranularitySpec = schema.getTimeFieldSpec().getOutgoingGranularitySpec();
-    Assert.assertEquals(datasetConfig.getTimeUnit(), timeGranularitySpec.getTimeType());
-    Assert.assertEquals(datasetConfig.getTimeDuration(), new Integer(timeGranularitySpec.getTimeUnitSize()));
+    Assert.assertEquals(datasetConfig.bucketTimeGranularity().getUnit(), timeGranularitySpec.getTimeType());
+    Assert.assertEquals(datasetConfig.bucketTimeGranularity().getSize(), timeGranularitySpec.getTimeUnitSize());
     Assert.assertEquals(datasetConfig.getTimeFormat(), timeGranularitySpec.getTimeFormat());
     Assert.assertEquals(datasetConfig.getTimezone(), "UTC");
     Assert.assertEquals(datasetConfig.getExpectedDelay().getUnit(), TimeUnit.HOURS);


### PR DESCRIPTION
1. Refine TimeGranularity class.

2. Fix time granularity handling for non-additive dataset in datacompleteness checker, new UI, and new endpoints.

Tested with local dashboard and controllers.