### PR TITLE
[PINOT-4748] Retry on temporary kafka failures in the controller

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -15,10 +15,10 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.ZNRecord;
@@ -35,6 +35,8 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import com.linkedin.pinot.common.utils.retry.RetryPolicy;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactoryImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
@@ -212,23 +214,21 @@ public class PinotTableIdealStateBuilder {
     LOGGER.info("Assigning {} partitions to instances for simple consumer for table {}", nPartitions, realtimeTableName);
 
     segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas,
-        kafkaMetadata.getKafkaConsumerProperties().get(Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET), kafkaMetadata.getBootstrapHosts(),
-        idealState, create, PinotLLCRealtimeSegmentManager.getRealtimeTableFlushSize(realtimeTableConfig));
+        kafkaMetadata.getKafkaConsumerProperties().get(Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET),
+        kafkaMetadata.getBootstrapHosts(), idealState, create,
+        PinotLLCRealtimeSegmentManager.getRealtimeTableFlushSize(realtimeTableConfig));
   }
 
   public static int getPartitionCount(KafkaStreamMetadata kafkaMetadata) {
-    String bootstrapHosts = kafkaMetadata.getBootstrapHosts();
-    if (bootstrapHosts == null || bootstrapHosts.isEmpty()) {
-      throw new RuntimeException("Invalid value for " + Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST);
-    }
-    SimpleConsumerWrapper consumerWrapper = SimpleConsumerWrapper.forMetadataConsumption(
-        new KafkaSimpleConsumerFactoryImpl(), kafkaMetadata.getBootstrapHosts(),
-        PinotTableIdealStateBuilder.class.getSimpleName() + "-" + kafkaMetadata.getKafkaTopicName(), KAFKA_CONNECTION_TIMEOUT_MILLIS);
-
-    try {
-      return consumerWrapper.getPartitionCount(kafkaMetadata.getKafkaTopicName(), /*maxWaitTimeMs=*/5000L);
-    } finally {
-      IOUtils.closeQuietly(consumerWrapper);
+    KafkaPartitionsCountFetcher fetcher = new KafkaPartitionsCountFetcher(kafkaMetadata);
+    RetryPolicy policy = RetryPolicies.noDelayRetryPolicy(3);
+    boolean successful = policy.attempt(fetcher);
+    if (successful) {
+      return fetcher.getPartitionCount();
+    } else {
+      Exception e = fetcher.getException();
+      LOGGER.error("Could not get partition count for {}", kafkaMetadata.getKafkaTopicName(), e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -282,5 +282,53 @@ public class PinotTableIdealStateBuilder {
       groupId = streamProviderConfig.get(keyOfGroupId);
     }
     return groupId;
+  }
+
+  private static class KafkaPartitionsCountFetcher implements Callable<Boolean> {
+    private int _partitionCount = -1;
+    private final KafkaStreamMetadata _kafkaStreamMetadata;
+    private Exception _exception;
+
+    private KafkaPartitionsCountFetcher(KafkaStreamMetadata kafkaStreamMetadata) {
+      _kafkaStreamMetadata = kafkaStreamMetadata;
+    }
+
+    private int getPartitionCount() {
+      return _partitionCount;
+    }
+
+    private Exception getException() {
+      return _exception;
+    }
+
+    @Override
+    public Boolean call() throws Exception {
+      final String bootstrapHosts = _kafkaStreamMetadata.getBootstrapHosts();
+      final String kafkaTopicName = _kafkaStreamMetadata.getKafkaTopicName();
+      if (bootstrapHosts == null || bootstrapHosts.isEmpty()) {
+        throw new RuntimeException("Invalid value for " + Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST);
+      }
+      SimpleConsumerWrapper consumerWrapper = SimpleConsumerWrapper.forMetadataConsumption(
+          new KafkaSimpleConsumerFactoryImpl(), bootstrapHosts,
+          PinotTableIdealStateBuilder.class.getSimpleName() + "-" + kafkaTopicName, KAFKA_CONNECTION_TIMEOUT_MILLIS);
+
+      try {
+        _partitionCount = consumerWrapper.getPartitionCount(kafkaTopicName, /*maxWaitTimeMs=*/5000L);
+        if (_exception != null) {
+          // We had at least one failure, but succeeded now. Log an info
+          LOGGER.info("Successfully retrieved partition count as {} for {}", _partitionCount, kafkaTopicName);
+        }
+        return Boolean.TRUE;
+      } catch (SimpleConsumerWrapper.TransientConsumerException e) {
+        LOGGER.warn("Could not get Kafka partition count for {}:{}", kafkaTopicName, e.getMessage());
+        _exception = e;
+        return Boolean.FALSE;
+      } catch (Exception e) {
+        _exception = e;
+        throw e;
+      } finally {
+        IOUtils.closeQuietly(consumerWrapper);
+      }
+    }
   }
 }


### PR DESCRIPTION
Kafka failures when we try to get number of partitions, or the current offset from Kafka
are usually temporary, and a single retry should fix things. Added retry logic for these
cases, logging error only when all retries fail.