### PR TITLE
Avoid logging exception for bad table configuration

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
@@ -36,6 +36,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   CONTROLLER_TABLE_INSTANCES_GET_ERROR("TableInstancesGetError", true),
   CONTROLLER_TABLE_ADD_ERROR("TableAddError", true),
   CONTROLLER_TABLE_GET_ERROR("TableGetError", true),
+  CONTROLLER_TABLE_UPDATE_ERROR("TableUpdateError", true),
   CONTROLLER_TABLE_SCHEMA_GET_ERROR("TableSchemaGetError", true),
   CONTROLLER_TABLE_SCHEMA_UPDATE_ERROR("TableSchemaUpdateError", true),
   CONTROLLER_TABLE_TENANT_UPDATE_ERROR("TableTenantUpdateError", true),

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableIndexingConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableIndexingConfigs.java
@@ -1,10 +1,17 @@
 package com.linkedin.pinot.controller.api.restlet.resources;
 
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.metrics.ControllerMeter;
+import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
+import com.linkedin.pinot.common.restlet.swagger.Parameter;
+import com.linkedin.pinot.common.restlet.swagger.Paths;
+import com.linkedin.pinot.common.restlet.swagger.Summary;
+import com.linkedin.pinot.common.restlet.swagger.Tags;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.controller.api.ControllerRestApplication;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import java.io.File;
 import java.io.IOException;
-
-import com.linkedin.pinot.common.metrics.ControllerMeter;
-import com.linkedin.pinot.controller.api.ControllerRestApplication;
 import org.apache.commons.io.FileUtils;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
@@ -12,14 +19,6 @@ import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.Put;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.common.config.AbstractTableConfig;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
-import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
-import com.linkedin.pinot.common.restlet.swagger.Parameter;
-import com.linkedin.pinot.common.restlet.swagger.Paths;
-import com.linkedin.pinot.common.restlet.swagger.Summary;
-import com.linkedin.pinot.common.restlet.swagger.Tags;
 
 
 public class PinotTableIndexingConfigs extends BasePinotControllerRestletResource {
@@ -55,9 +54,14 @@ public class PinotTableIndexingConfigs extends BasePinotControllerRestletResourc
     }
     try {
       return updateIndexingConfig(tableName, entity);
+    } catch (PinotHelixResourceManager.InvalidTableConfigException e) {
+      LOGGER.info("Failed to update metadata configuration for table {}, error: {}", tableName, e.getMessage());
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(
+          ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      return errorResponseRepresentation(Status.CLIENT_ERROR_BAD_REQUEST, e.getMessage());
     } catch (final Exception e) {
       LOGGER.error("Caught exception while updating indexing configs for table {}", tableName, e);
-      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_INDEXING_GET_ERROR, 1L);
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       setStatus(Status.SERVER_ERROR_INTERNAL);
       return PinotSegmentUploadRestletResource.exceptionToStringRepresentation(e);
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableMetadataConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableMetadataConfigs.java
@@ -1,22 +1,24 @@
 package com.linkedin.pinot.controller.api.restlet.resources;
 
-import java.io.File;
-import java.io.IOException;
-
-import org.apache.commons.io.FileUtils;
-import org.restlet.representation.Representation;
-import org.restlet.representation.StringRepresentation;
-import org.restlet.resource.Put;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.common.config.AbstractTableConfig;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.common.metrics.ControllerMeter;
 import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
 import com.linkedin.pinot.common.restlet.swagger.Parameter;
 import com.linkedin.pinot.common.restlet.swagger.Paths;
 import com.linkedin.pinot.common.restlet.swagger.Summary;
 import com.linkedin.pinot.common.restlet.swagger.Tags;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.controller.api.ControllerRestApplication;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.restlet.data.Status;
+import org.restlet.representation.Representation;
+import org.restlet.representation.StringRepresentation;
+import org.restlet.resource.Put;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class PinotTableMetadataConfigs extends BasePinotControllerRestletResource {
@@ -46,8 +48,15 @@ public class PinotTableMetadataConfigs extends BasePinotControllerRestletResourc
 
     try {
       return updateTableMetadata(tableName, entity);
+    } catch (PinotHelixResourceManager.InvalidTableConfigException e) {
+      LOGGER.info("Failed to update metadata configuration for table {}, error: {}", tableName, e.getMessage());
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(
+          ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      return errorResponseRepresentation(Status.CLIENT_ERROR_BAD_REQUEST, e.getMessage());
     } catch (final Exception e) {
       LOGGER.error("Caught exception while updating metadata for table {}", tableName, e);
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(
+          ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       return PinotSegmentUploadRestletResource.exceptionToStringRepresentation(e);
     }
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResource.java
@@ -391,10 +391,18 @@ public class PinotTableRestletResource extends BasePinotControllerRestletResourc
 
       _pinotHelixResourceManager.setExistingTableConfig(config, tableNameWithType, tableType);
       return responseRepresentation(Status.SUCCESS_OK, "{\"status\" : \"Success\"}");
-    } catch (IOException e) {
+    } catch(PinotHelixResourceManager.InvalidTableConfigException e) {
+      LOGGER.info("Failed to update configuration for table {}, message: {}", tableName, e.getMessage());
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(
+          ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      return errorResponseRepresentation(Status.CLIENT_ERROR_BAD_REQUEST, e.getMessage());
+    } catch (Exception e) {
       LOGGER.error("Failed to update table configuration for table: {}", tableName, e);
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(
+          ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       return errorResponseRepresentation(Status.SERVER_ERROR_INTERNAL,
           "Internal error while updating table configuration");
+
     }
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableSegmentConfigs.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableSegmentConfigs.java
@@ -1,10 +1,17 @@
 package com.linkedin.pinot.controller.api.restlet.resources;
 
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.metrics.ControllerMeter;
+import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
+import com.linkedin.pinot.common.restlet.swagger.Parameter;
+import com.linkedin.pinot.common.restlet.swagger.Paths;
+import com.linkedin.pinot.common.restlet.swagger.Summary;
+import com.linkedin.pinot.common.restlet.swagger.Tags;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.controller.api.ControllerRestApplication;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import java.io.File;
 import java.io.IOException;
-
-import com.linkedin.pinot.common.metrics.ControllerMeter;
-import com.linkedin.pinot.controller.api.ControllerRestApplication;
 import org.apache.commons.io.FileUtils;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
@@ -12,14 +19,6 @@ import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.Put;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.common.config.AbstractTableConfig;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
-import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
-import com.linkedin.pinot.common.restlet.swagger.Parameter;
-import com.linkedin.pinot.common.restlet.swagger.Paths;
-import com.linkedin.pinot.common.restlet.swagger.Summary;
-import com.linkedin.pinot.common.restlet.swagger.Tags;
 
 
 public class PinotTableSegmentConfigs extends BasePinotControllerRestletResource {
@@ -51,9 +50,14 @@ public class PinotTableSegmentConfigs extends BasePinotControllerRestletResource
 
     try {
       return updateSegmentConfig(tableName, entity);
+    } catch (PinotHelixResourceManager.InvalidTableConfigException e) {
+      LOGGER.info("Failed to update metadata configuration for table {}, error: {}", tableName, e.getMessage());
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(
+          ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      return errorResponseRepresentation(Status.CLIENT_ERROR_BAD_REQUEST, e.getMessage());
     } catch (final Exception e) {
       LOGGER.error("Caught exception while updating segment config ", e);
-      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_SCHEMA_UPDATE_ERROR, 1L);
+      ControllerRestApplication.getControllerMetrics().addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       setStatus(Status.SERVER_ERROR_INTERNAL);
       return PinotSegmentUploadRestletResource.exceptionToStringRepresentation(e);
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -15,18 +15,6 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import org.apache.commons.compress.utils.IOUtils;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.model.builder.CustomModeISBuilder;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
@@ -40,6 +28,18 @@ import com.linkedin.pinot.common.utils.retry.RetryPolicy;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactoryImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.apache.commons.compress.utils.IOUtils;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.builder.CustomModeISBuilder;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -200,7 +200,8 @@ public class PinotTableIdealStateBuilder {
     try {
       nReplicas = Integer.valueOf(replicasPerPartitionStr);
     } catch (NumberFormatException e) {
-      throw new RuntimeException("Invalid value for replicasPerPartition, expected a number: " + replicasPerPartitionStr, e);
+      throw new PinotHelixResourceManager.InvalidTableConfigException(
+          "Invalid value for replicasPerPartition, expected a number: " + replicasPerPartitionStr, e);
     }
     if (idealState == null) {
       idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, nReplicas);
@@ -212,7 +213,6 @@ public class PinotTableIdealStateBuilder {
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();
     final int nPartitions = getPartitionCount(kafkaMetadata);
     LOGGER.info("Assigning {} partitions to instances for simple consumer for table {}", nPartitions, realtimeTableName);
-
     segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas,
         kafkaMetadata.getKafkaConsumerProperties().get(Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET),
         kafkaMetadata.getBootstrapHosts(), idealState, create,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -16,37 +16,8 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime;
 
-import com.google.common.base.Preconditions;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.helix.AccessOption;
-import org.apache.helix.ControllerChangeListener;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
-import org.apache.helix.NotificationContext;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.MinMaxPriorityQueue;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
@@ -77,6 +48,35 @@ import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ControllerChangeListener;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class PinotLLCRealtimeSegmentManager {
@@ -185,7 +185,7 @@ public class PinotLLCRealtimeSegmentManager {
       final List<String> instanceNames, int nReplicas, String initialOffset, String bootstrapHosts, IdealState
       idealState, boolean create, int flushSize) {
     if (nReplicas > instanceNames.size()) {
-      throw new RuntimeException("Replicas requested(" + nReplicas + ") cannot fit within number of instances(" +
+      throw new PinotHelixResourceManager.InvalidTableConfigException("Replicas requested(" + nReplicas + ") cannot fit within number of instances(" +
           instanceNames.size() + ") for table " + realtimeTableName + " topic " + topicName);
     }
     /*


### PR DESCRIPTION
For bad table configuration where number of replicas is greater than
number of instances or for invalid replicasPerPartition, log info and
return 400. Do not log exception.