### PR TITLE
[TE] Fix frontend max data time issue for non-additive dataset

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/cache/CollectionMaxDataTimeCacheLoader.java
@@ -54,7 +54,7 @@ public class CollectionMaxDataTimeCacheLoader extends CacheLoader<String, Long> 
       DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(collection);
       // By default, query only offline, unless dataset has been marked as realtime
       String tableName = ThirdEyeUtils.computeTableName(collection);
-      TimeSpec timeSpec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
+      TimeSpec timeSpec = ThirdEyeUtils.getTimestampTimeSpecFromDatasetConfig(datasetConfig);
       long prevMaxDataTime = getPrevMaxDataTime(collection, timeSpec);
       String maxTimePql = String.format(COLLECTION_MAX_TIME_QUERY_TEMPLATE, timeSpec.getColumnName(), tableName,
           timeSpec.getColumnName(), prevMaxDataTime);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -172,7 +172,7 @@ public class DashboardResource {
       HashMap<String, String> map = new HashMap<>();
       long maxDataTime = collectionMaxDataTimeCache.get(collection);
       DatasetConfigDTO datasetConfig = CACHE_REGISTRY_INSTANCE.getDatasetConfigCache().get(collection);
-      TimeSpec timespec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
+      TimeSpec timespec = ThirdEyeUtils.getTimestampTimeSpecFromDatasetConfig(datasetConfig);
       TimeGranularity dataGranularity = timespec.getDataGranularity();
       map.put("maxTime", "" + maxDataTime);
       map.put("dataGranularity", dataGranularity.getUnit().toString());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -197,6 +197,18 @@ public abstract class ThirdEyeUtils {
     return timeFormat;
   }
 
+  /**
+   * Returns the time spec of the buckets (data points) in the specified dataset config. For additive dataset, this
+   * method returns the same time spec as getTimestampTimeSpecFromDatasetConfig; however, for non-additive dataset,
+   * this method return the time spec for buckets (data points) instead of the one for the timestamp in the backend
+   * database. For example, the data points of a non-additive dataset could be 5-MINUTES granularity, but timestamp's
+   * granularity could be 1-Milliseconds. For additive dataset, the discrepancy is not an issue, but it could be
+   * a problem for non-additive dataset.
+   *
+   * @param datasetConfig the given dataset config
+   *
+   * @return the time spec of the buckets (data points) in the specified dataset config.
+   */
   public static TimeSpec getTimeSpecFromDatasetConfig(DatasetConfigDTO datasetConfig) {
     String timeFormat = getTimeFormatString(datasetConfig);
     TimeSpec timespec = new TimeSpec(datasetConfig.getTimeColumn(),
@@ -204,6 +216,16 @@ public abstract class ThirdEyeUtils {
     return timespec;
   }
 
+  /**
+   * Returns the time spec of the timestamp in the specified dataset config. The timestamp time spec is mainly used
+   * for constructing the queries to backend database. For most use case, this method returns the same time spec as
+   * getTimeSpecFromDatasetConfig(); however, if the dataset is non-additive, then getTimeSpecFromDatasetConfig
+   * should be used unless the application is related to database queries.
+   *
+   * @param datasetConfig the given dataset config
+   *
+   * @return the time spec of the timestamp in the specified dataset config.
+   */
   public static TimeSpec getTimestampTimeSpecFromDatasetConfig(DatasetConfigDTO datasetConfig) {
     String timeFormat = getTimeFormatString(datasetConfig);
     TimeSpec timespec = new TimeSpec(datasetConfig.getTimeColumn(),


### PR DESCRIPTION
Fix max data time in dashboard is shown incorrectly for non-additive dataset whose timestamp granularity is different from bucket granularity.

Tested on local dashboard.