### PR TITLE
[TE] Temporary fix for duplicated alerts

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.HtmlEmail;
@@ -101,8 +102,8 @@ public class AlertTaskRunnerV2 implements TaskRunner {
       long lastNotifiedAnomaly = emailConfig.getAnomalyWatermark();
       for (Long functionId : functionIds) {
         List<MergedAnomalyResultDTO> resultsForFunction = anomalyMergedResultDAO
-            .findByFunctionIdAndIdGreaterThan(functionId, lastNotifiedAnomaly);
-        if (resultsForFunction != null && resultsForFunction.size() > 0) {
+            .findUnNotifiedByFunctionIdAndIdGreaterThan(functionId, lastNotifiedAnomaly);
+        if (CollectionUtils.isNotEmpty(resultsForFunction)) {
           mergedAnomaliesAllResults.addAll(resultsForFunction);
         }
         // fetch anomalies having id lesser than the watermark for the same function with notified = false & endTime > last one day
@@ -111,7 +112,7 @@ public class AlertTaskRunnerV2 implements TaskRunner {
         List<MergedAnomalyResultDTO> filteredAnomalies = anomalyMergedResultDAO
             .findUnNotifiedByFunctionIdAndIdLesserThanAndEndTimeGreaterThanLastOneDay(functionId,
                 lastNotifiedAnomaly);
-        if (filteredAnomalies != null && filteredAnomalies.size() > 0) {
+        if (CollectionUtils.isNotEmpty(filteredAnomalies)) {
           mergedAnomaliesAllResults.addAll(filteredAnomalies);
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -35,7 +35,7 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   List<MergedAnomalyResultDTO> findByFunctionId(Long functionId);
 
-  List<MergedAnomalyResultDTO> findByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId);
+  List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId);
 
   List<MergedAnomalyResultDTO> findByStartTimeInRangeAndFunctionId(long startTime, long endTime,
       long functionId);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -157,8 +157,9 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId) {
-    Predicate predicate = Predicate.AND(Predicate.EQ("functionId", functionId), Predicate.GT("baseId", anomalyId));
+  public List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId) {
+    Predicate predicate = Predicate.AND(Predicate.EQ("functionId", functionId), Predicate.GT("baseId", anomalyId),
+        Predicate.EQ("notified", false));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
     return batchConvertMergedAnomalyBean2DTO(list, true);
   }


### PR DESCRIPTION
This case happens when scheduler produces alert jobs faster than workers could consume. The main cause of this issue is that scheduler stores watermark in job contexts and every worker ignores the updated watermark in database. Therefore, the over-scheduled alert jobs would produce the same set of alerts even though some alerts have been sent when workers are catching up.

Now workers check both watermark and notified flag to reduce the number of duplicated alerts. Note that this fix is temporary and cannot handle data races, i.e., two workers picks up two separate alerts jobs with the same job context and send alerts before the other could set notified flag to true. 

The permanent fix should make scheduler stops scheduling new alert jobs when there are jobs in the queue.