### PR TITLE
Gracefully handle create requests for existing offline tables.

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResource.java
@@ -64,6 +64,9 @@ public class PinotTableRestletResource extends BasePinotControllerRestletResourc
         if (e instanceof PinotHelixResourceManager.InvalidTableConfigException) {
           LOGGER.info("Invalid table config for table: {}, {}", config.getTableName(), e.getMessage());
           setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
+        } else if (e instanceof PinotHelixResourceManager.TableAlreadyExistsException) {
+          LOGGER.info("Table: {} already exists", config.getTableName());
+          setStatus(Status.CLIENT_ERROR_CONFLICT);
         } else {
           LOGGER.error("Caught exception while adding table: {}", config.getTableName(), e);
           setStatus(Status.SERVER_ERROR_INTERNAL);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -15,43 +15,6 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
-import com.linkedin.pinot.common.messages.SegmentReloadMessage;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.Predicate;
-import org.apache.commons.lang.StringUtils;
-import org.apache.helix.AccessOption;
-import org.apache.helix.ClusterMessagingService;
-import org.apache.helix.Criteria;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixDataAccessor;
-import org.apache.helix.HelixManager;
-import org.apache.helix.InstanceType;
-import org.apache.helix.PropertyKey;
-import org.apache.helix.PropertyKey.Builder;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.model.CurrentState;
-import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.model.InstanceConfig;
-import org.apache.helix.model.LiveInstance;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.codehaus.jackson.JsonGenerationException;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.json.JSONException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
@@ -69,6 +32,7 @@ import com.linkedin.pinot.common.config.Tenant;
 import com.linkedin.pinot.common.config.TenantConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.messages.SegmentRefreshMessage;
+import com.linkedin.pinot.common.messages.SegmentReloadMessage;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
@@ -99,8 +63,43 @@ import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
 import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
 import com.linkedin.pinot.controller.helix.starter.HelixConfig;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Predicate;
+import org.apache.commons.lang.StringUtils;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ClusterMessagingService;
+import org.apache.helix.Criteria;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.InstanceType;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.PropertyKey.Builder;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.CurrentState;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.model.LiveInstance;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class PinotHelixResourceManager {
@@ -962,6 +961,8 @@ public class PinotHelixResourceManager {
 
   /**
    * Table APIs
+   * @throws InvalidTableConfigException
+   * @throws TableAlreadyExistsException for offline tables only if the table already exists
    */
   public void addTable(AbstractTableConfig config)
       throws IOException {
@@ -1000,7 +1001,11 @@ public class PinotHelixResourceManager {
     switch (type) {
       case OFFLINE:
         final String offlineTableName = config.getTableName();
-
+        // existing tooling relies on this check not existing for realtime table (to migrate to LLC)
+        // So, we avoid adding that for REALTIME just yet
+        if (getAllPinotTableNames().contains(offlineTableName)) {
+          throw new TableAlreadyExistsException("Table " + offlineTableName + " already exists");
+        }
         // now lets build an ideal state
         LOGGER.info("building empty ideal state for table : " + offlineTableName);
         final IdealState offlineIdealState =
@@ -1056,6 +1061,15 @@ public class PinotHelixResourceManager {
 
     public InvalidTableConfigException(Throwable cause) {
       super(cause);
+    }
+  }
+
+  public static class TableAlreadyExistsException extends RuntimeException {
+    public TableAlreadyExistsException(String message) {
+      super(message);
+    }
+    public TableAlreadyExistsException(String message, Throwable cause) {
+      super(message, cause);
     }
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotTableRestletResourceTest.java
@@ -71,6 +71,14 @@ public class PinotTableRestletResourceTest extends ControllerTest {
         "MMAP", "v1");
 
     sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(), request.toString());
+    boolean tableExistsError = false;
+    try {
+      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(), request.toString());
+    } catch (IOException e) {
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 409"), e.getMessage());
+      tableExistsError = true;
+    }
+    Assert.assertTrue(tableExistsError);
 
     // Create a table with an invalid name
     JSONObject metadata = new JSONObject();
@@ -103,6 +111,8 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(), request.toString());
 
+    // try again...should work because POST on existing RT table is allowed
+    sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(), request.toString());
   }
 
   @Test


### PR DESCRIPTION
Return 409 Conflict for requests to create existing offline tables.
POST for existing realtime tables is allowed and handled gracefully because
our tooling relies on that right now for migration to LLC.