### PR TITLE
Bugfix for server instance shutdown state

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import com.linkedin.pinot.common.utils.NetUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
@@ -108,6 +109,7 @@ public abstract class ClusterTest extends ControllerTest {
             Integer.toString(Integer.valueOf(Server.DEFAULT_ADMIN_API_PORT) - i));
         configuration.setProperty(Server.CONFIG_OF_NETTY_PORT,
             Integer.toString(Integer.valueOf(Helix.DEFAULT_SERVER_NETTY_PORT) + i));
+        configuration.setProperty(Helix.KEY_OF_SERVER_NETTY_HOST, NetUtil.getHostnameOrAddress());
         configuration.setProperty(Server.CONFIG_OF_SEGMENT_FORMAT_VERSION, "v3");
         overrideOfflineServerConf(configuration);
         _serverStarters.add(new HelixServerStarter(getHelixClusterName(), ZkStarter.DEFAULT_ZK_STR, configuration));

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
@@ -163,6 +163,11 @@ public class DefaultColumnsClusterIntegrationTest extends BaseClusterIntegration
     }
   }
 
+  @Override
+  protected String getTableName() {
+    return "mytable";
+  }
+
   @Test
   public void testNewAddedColumns()
       throws Exception {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -83,7 +83,6 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
   private String tableName;
 
   private KafkaServerStartable kafkaStarter;
-  private HelixManager _zkHelixManager;
 
   protected void setSegmentCount(int segmentCount) {
     this.segmentCount = segmentCount;
@@ -102,6 +101,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   // In case inherited tests set up a different table name they can override this method.
+  @Override
   protected String getTableName() {
     return tableName;
   }
@@ -338,123 +338,10 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
     }
   }
 
-  protected void ensureZkHelixManagerIsInitialized() {
-    if (_zkHelixManager == null) {
-      _zkHelixManager = HelixManagerFactory.getZKHelixManager(getHelixClusterName(), "test_instance", InstanceType.SPECTATOR,
-          ZkStarter.DEFAULT_ZK_STR);
-      try {
-        _zkHelixManager.connect();
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-  }
-
+  @Override
   @Test
   public void testInstanceShutdown() {
-    ensureZkHelixManagerIsInitialized();
-
-    HelixAdmin clusterManagmentTool = _zkHelixManager.getClusterManagmentTool();
-    String clusterName = _zkHelixManager.getClusterName();
-    List<String> instances = clusterManagmentTool.getInstancesInCluster(clusterName);
-    Assert.assertFalse(instances.isEmpty(), "List of instances should not be empty");
-
-    // Mark all instances in the cluster as shutting down
-    for (String instance : instances) {
-      InstanceConfig instanceConfig = clusterManagmentTool.getInstanceConfig(clusterName, instance);
-      instanceConfig.getRecord().setBooleanField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, true);
-      clusterManagmentTool.setInstanceConfig(clusterName, instance, instanceConfig);
-    }
-
-    // Check that the routing table is empty
-    checkForEmptyRoutingTable(true, "Routing table is not empty after marking all instances as shutting down");
-
-    // Mark all instances as not shutting down
-    for (String instance : instances) {
-      InstanceConfig instanceConfig = clusterManagmentTool.getInstanceConfig(clusterName, instance);
-      instanceConfig.getRecord().setBooleanField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, false);
-      clusterManagmentTool.setInstanceConfig(clusterName, instance, instanceConfig);
-    }
-
-    // Check that the routing table is not empty
-    checkForEmptyRoutingTable(false, "Routing table is empty after marking all instances as not shutting down");
-  }
-
-  protected void checkForEmptyRoutingTable(final boolean checkForEmpty, String message) {
-    waitForRoutingTablePredicate(new Function<JSONArray, Boolean>() {
-      @Override
-      public Boolean apply(JSONArray input) {
-        try {
-          int tableCount = input.length();
-
-          // Routing table should have an entry for this table
-          if (tableCount == 0) {
-            return false;
-          }
-
-          // Each routing table entry for this table should have not have any server to segment mapping
-          for (int i = 0; i < tableCount; i++) {
-            JSONObject tableRouting = input.getJSONObject(i);
-            String tableName = tableRouting.getString("tableName");
-            if (tableName.startsWith(getTableName())) {
-              JSONArray routingTableEntries = tableRouting.getJSONArray("routingTableEntries");
-              int routingTableEntryCount = routingTableEntries.length();
-              for (int j = 0; j < routingTableEntryCount; j++) {
-                JSONObject routingTableEntry = routingTableEntries.getJSONObject(j);
-
-                boolean hasServerToSegmentMappings = routingTableEntry.keys().hasNext();
-
-                if (hasServerToSegmentMappings && checkForEmpty) {
-                  return false;
-                }
-
-                if (!hasServerToSegmentMappings && !checkForEmpty) {
-                  return false;
-                }
-              }
-            }
-          }
-
-          return true;
-        } catch (JSONException e) {
-          LOGGER.warn("Caught exception while reading the routing table, will retry", e);
-          return false;
-        }
-      }
-    }, 15000, message);
-
-  }
-
-  /**
-   * Wait for a predicate on the routing table to become true.
-   * @param predicate true when the routing table condition is met
-   * @param timeout Timeout for the predicate to become true
-   * @param message Message to display if the predicate does not become true after the timeout expires
-   */
-  protected void waitForRoutingTablePredicate(Function<JSONArray, Boolean> predicate, long timeout, String message) {
-    long endTime = System.currentTimeMillis() + timeout;
-    boolean isPredicateMet = false;
-    JSONObject routingTableSnapshot = null;
-    while (System.currentTimeMillis() < endTime && !isPredicateMet) {
-      try {
-        routingTableSnapshot = getDebugInfo("debug/routingTable/" + getTableName());
-
-        if (routingTableSnapshot != null) {
-          JSONArray routingTableSnapshotJson = routingTableSnapshot.getJSONArray("routingTableSnapshot");
-          if (routingTableSnapshotJson != null) {
-            isPredicateMet = predicate.apply(routingTableSnapshotJson);
-          }
-        } else {
-          LOGGER.warn("Got null routing table snapshot, retrying");
-        }
-      } catch (Exception e) {
-        // Will retry in a bit
-      }
-
-      Uninterruptibles.sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
-    }
-
-    Assert.assertTrue(isPredicateMet, message + ", last routing table snapshot is " + routingTableSnapshot.toString());
+    super.testInstanceShutdown();
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/MultipleNodeOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/MultipleNodeOfflineClusterIntegrationTest.java
@@ -15,6 +15,9 @@
  */
 package com.linkedin.pinot.integration.tests;
 
+import org.testng.annotations.Test;
+
+
 public class MultipleNodeOfflineClusterIntegrationTest extends OfflineClusterIntegrationTest {
   private static final int BROKER_COUNT = 3;
   private static final int SERVER_COUNT = 5;
@@ -25,5 +28,11 @@ public class MultipleNodeOfflineClusterIntegrationTest extends OfflineClusterInt
     startController();
     startServers(SERVER_COUNT);
     startBrokers(BROKER_COUNT);
+  }
+
+  @Override
+  @Test
+  public void testInstanceShutdown() {
+    super.testInstanceShutdown();
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -319,4 +319,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
     }
     FileUtils.deleteDirectory(_tmpDir);
   }
+
+  @Override
+  protected String getTableName() {
+    return "mytable";
+  }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -131,4 +131,9 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
     }
     FileUtils.deleteDirectory(_tmpDir);
   }
+
+  @Override
+  protected String getTableName() {
+    return "mytable";
+  }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -372,6 +372,11 @@ public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTe
     // Ignored.
   }
 
+  @Override
+  protected String getTableName() {
+    return tableName;
+  }
+
   @AfterClass
   public void tearDown() {
     stopServer();

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
@@ -377,7 +377,7 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
           routingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
 
       // Keep track of the instance configs that are used in that routing table
-      updateInstanceConfigsMapFromRoutingTables(relevantInstanceConfigs, instanceConfigs, serverToSegmentSetMap);
+      updateInstanceConfigsMapFromExternalView(relevantInstanceConfigs, instanceConfigs, externalView);
 
       _brokerRoutingTable.put(tableName, serverToSegmentSetMap);
 
@@ -391,7 +391,7 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
               .computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
 
           // Keep track of the instance configs that are used in that routing table
-          updateInstanceConfigsMapFromRoutingTables(relevantInstanceConfigs, instanceConfigs, llcserverToSegmentSetMap);
+          updateInstanceConfigsMapFromExternalView(relevantInstanceConfigs, instanceConfigs, externalView);
 
           _llcBrokerRoutingTable.put(tableName, llcserverToSegmentSetMap);
         } catch (Exception e) {
@@ -522,13 +522,13 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
         _helixManager.getClusterName(), table);
   }
 
-  private void updateInstanceConfigsMapFromRoutingTables(Map<String, InstanceConfig> relevantInstanceConfigs,
-      List<InstanceConfig> instanceConfigs, List<ServerToSegmentSetMap> serverToSegmentSetMaps) {
+  private void updateInstanceConfigsMapFromExternalView(Map<String, InstanceConfig> relevantInstanceConfigs,
+      List<InstanceConfig> instanceConfigs, ExternalView externalView) {
     Set<String> relevantInstanceNames = new HashSet<>();
 
-    // Gather all the instance names contained in the routing table
-    for (ServerToSegmentSetMap serverToSegmentSetMap : serverToSegmentSetMaps) {
-      relevantInstanceNames.addAll(serverToSegmentSetMap.getServerSet());
+    // Gather all the instance names contained in the external view
+    for (String partitionName : externalView.getPartitionSet()) {
+      relevantInstanceNames.addAll(externalView.getStateMap(partitionName).keySet());
     }
 
     // Update the relevant instance config map with the instance configs given

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilder.java
@@ -66,7 +66,7 @@ public class BalancedRandomRoutingTableBuilder implements RoutingTableBuilder {
 
     String[] segmentSet = externalView.getPartitionSet().toArray(new String[0]);
     for (String segment : segmentSet) {
-      Map<String, String> instanceToStateMap = externalView.getStateMap(segment);
+      Map<String, String> instanceToStateMap = new HashMap<>(externalView.getStateMap(segment));
       for (String instance : instanceToStateMap.keySet().toArray(new String[0])) {
         if (!instanceToStateMap.get(instance).equals("ONLINE") || pruner.isInactive(instance)) {
           LOGGER.info("Removing offline/inactive instance '{}' from routing table computation", instance);


### PR DESCRIPTION
Fix the bug where marking an instance as shutting down would correctly
remove it from the routing table, but marking it as not shutting down
would not add it back to the routing table if there was more than one
server node in the cluster. Add integration test that catches this
particular edge case.