### PR TITLE
Fix != in query predicates

### DIFF
--- a/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
+++ b/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
@@ -83,7 +83,7 @@ isClause:
 
 comparisonClause:
   expression comparisonOperator expression;
-comparisonOperator: '<' | '>' | '<>' | '<=' | '>=' | '=';
+comparisonOperator: '<' | '>' | '<>' | '<=' | '>=' | '=' | '!=';
 
 betweenClause:
   expression BETWEEN expression AND expression;

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2CompilationException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2CompilationException.java
@@ -15,11 +15,19 @@
  */
 package com.linkedin.pinot.pql.parsers;
 
+import org.antlr.v4.runtime.RecognitionException;
+
+
 /**
  * Exceptions that occur while compiling PQL.
  */
 public class Pql2CompilationException extends RuntimeException {
   public Pql2CompilationException(String message) {
     super(message);
+  }
+
+  public Pql2CompilationException(String msg, Object offendingSymbol, int line, int charPositionInLine,
+      RecognitionException e) {
+    super(line + ":" + charPositionInLine + ": '" + offendingSymbol + "' " + msg, e);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/ComparisonPredicateAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/ComparisonPredicateAstNode.java
@@ -74,7 +74,7 @@ public class ComparisonPredicateAstNode extends PredicateAstNode {
       } else {
         throw new Pql2CompilationException("Comparison is not between a column and a constant");
       }
-    } else if ("<>".equals(_operand)) {
+    } else if ("<>".equals(_operand) || "!=".equals(_operand)) {
       if (_identifier != null && _literal != null) {
         return new FilterQueryTree(_identifier.getName(), Collections.singletonList(_literal.getValueAsString()),
             FilterOperator.NOT, null);


### PR DESCRIPTION
Fix != in query predicates. The previous grammar did not support
C-style inequalities. For some reason, antlr4 is configured by default
to not reject invalid tokens when lexing the input string (!) and
simply logs the offending tokens to the console. Since ! is not a
valid token, a query that had a clause with a C-style inequality (eg.
WHERE foo != 1234) got silently converted to an equality query (eg.
WHERE foo = 1234).

Add a lexer error listener that correctly throws an exception if there
is an unexpected token in the lexing phase. Add a unit test for this
case.

Since C-style inequalities are supported by some databases, add
C-style inequalities as an alias for <>. Add a unit test for the !=
operator.