### PR TITLE
Reuse JVM for pinot-api and pinot-common tests

### DIFF
--- a/pinot-api/pom.xml
+++ b/pinot-api/pom.xml
@@ -31,6 +31,18 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.testng</groupId>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -40,7 +40,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
+          <reuseForks>true</reuseForks>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Reuse the JVM for unit tests in pinot-api and pinot-common, saves
about 30s per build.