### PR TITLE
Handle bad json format during schema create or update operation

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/request/helper/ControllerRequestBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/request/helper/ControllerRequestBuilder.java
@@ -15,18 +15,15 @@
  */
 package com.linkedin.pinot.common.request.helper;
 
+import com.linkedin.pinot.common.config.Tenant;
+import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
+import com.linkedin.pinot.common.utils.TenantRole;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import com.linkedin.pinot.common.config.Tenant;
-import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
-import com.linkedin.pinot.common.utils.TenantRole;
 
 
 public class ControllerRequestBuilder {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -157,6 +157,19 @@ public class ControllerRequestURLBuilder {
     }
     return url;
   }
+
+  public String forSchemaCreate() {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "schemas");
+  }
+
+  public String forSchemaUpdate(String schemaName) {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "schemas", schemaName);
+  }
+
+  public String forSchemaGet(String schemaName) {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "schemas", schemaName);
+  }
+
   public static void main(String[] args) {
     System.out.println(ControllerRequestURLBuilder.baseUrl("localhost:8089").forResourceCreate());
     System.out.println(ControllerRequestURLBuilder.baseUrl("localhost:8089").forInstanceCreate());

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSchemaRestletResourceTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.api.restlet.resources;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
+import com.linkedin.pinot.controller.helix.ControllerTest;
+import com.linkedin.pinot.controller.helix.ControllerTestUtils;
+import java.io.IOException;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class PinotSchemaRestletResourceTest extends ControllerTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  ControllerRequestURLBuilder urlBuilder = ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL);
+
+ @BeforeClass
+  public void setUp() {
+    startZk();
+    ControllerConf config = ControllerTestUtils.getDefaultControllerConfiguration();
+    config.setTableMinReplicas(1);
+    startController(config);
+  }
+
+  public JSONObject createDefaultSchema()
+      throws JSONException, JsonProcessingException {
+    JSONObject schemaJson = new JSONObject();
+    schemaJson.put("schemaName", "testSchema");
+    JSONArray dimFieldSpec = new JSONArray();
+    schemaJson.put("dimensionFieldSpecs", dimFieldSpec);
+    JSONArray metricFieldSpec = new JSONArray();
+    schemaJson.put("metricFieldSpecs", metricFieldSpec);
+    JSONObject timeFieldSpec = new JSONObject();
+    // schemaJson.put("timeFieldSpec", timeFieldSpec);
+
+    DimensionFieldSpec df = new DimensionFieldSpec("dimA", FieldSpec.DataType.STRING, true, "");
+    dimFieldSpec.put(new JSONObject(objectMapper.writeValueAsString(df)));
+    df = new DimensionFieldSpec("dimB", FieldSpec.DataType.LONG, true, 0);
+    dimFieldSpec.put(new JSONObject(objectMapper.writeValueAsString(df)));
+
+    MetricFieldSpec mf = new MetricFieldSpec("metricA", FieldSpec.DataType.INT, 0);
+    metricFieldSpec.put(new JSONObject(objectMapper.writeValueAsString(mf)));
+
+    mf = new MetricFieldSpec("metricB", FieldSpec.DataType.DOUBLE, -1);
+    metricFieldSpec.put(new JSONObject(objectMapper.writeValueAsString(mf)));
+    return schemaJson;
+  }
+
+  @Test
+  public void testBadContentType()
+      throws JSONException, JsonProcessingException {
+    JSONObject schema = createDefaultSchema();
+    try {
+      sendPostRequest(urlBuilder.forSchemaCreate(), schema.toString());
+    } catch (IOException e) {
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 415"), e.getMessage());
+      return;
+    }
+    // should not reach here
+    Assert.assertTrue(false);
+  }
+
+  @Test
+  public void testCreateUpdateSchema()
+      throws JSONException, IOException {
+    JSONObject schema = createDefaultSchema();
+    String url = urlBuilder.forSchemaCreate();
+    PostMethod postMethod = sendMultipartPostRequest(url, schema.toString());
+    Assert.assertEquals(postMethod.getStatusCode(), 200);
+
+    JSONArray dimSpecs = schema.getJSONArray("dimensionFieldSpecs");
+    DimensionFieldSpec df = new DimensionFieldSpec("NewColumn", FieldSpec.DataType.STRING, true);
+    dimSpecs.put(new JSONObject(objectMapper.writeValueAsString(df)));
+
+    postMethod = sendMultipartPostRequest(url, schema.toString());
+    Assert.assertEquals(postMethod.getStatusCode(), 200);
+
+    final String schemaName = schema.getString("schemaName");
+    String schemaStr = sendGetRequest(urlBuilder.forSchemaGet(schemaName));
+    Schema readSchema = Schema.fromString(schemaStr);
+    Schema inputSchema = Schema.fromString(schema.toString());
+    Assert.assertEquals(readSchema, inputSchema);
+    Assert.assertTrue(readSchema.getFieldSpecMap().containsKey("NewColumn"));
+
+    final String yetAnotherColumn = "YetAnotherColumn";
+    Assert.assertFalse(readSchema.getFieldSpecMap().containsKey(yetAnotherColumn));
+    df = new DimensionFieldSpec(yetAnotherColumn, FieldSpec.DataType.STRING, true);
+    dimSpecs.put(new JSONObject(objectMapper.writeValueAsString(df)));
+    PutMethod putMethod = sendMultipartPutRequest(urlBuilder.forSchemaUpdate(schemaName), schema.toString());
+    Assert.assertEquals(putMethod.getStatusCode(), 200);
+    // verify some more...
+    schemaStr = sendGetRequest(urlBuilder.forSchemaGet(schemaName));
+    readSchema = Schema.fromString(schemaStr);
+    inputSchema = Schema.fromString(schema.toString());
+    Assert.assertEquals(readSchema, inputSchema);
+    Assert.assertTrue(readSchema.getFieldSpecMap().containsKey(yetAnotherColumn));
+
+    // error cases
+    putMethod = sendMultipartPutRequest(urlBuilder.forSchemaUpdate(schemaName), schema.toString().substring(1));
+    // invalid json
+    Assert.assertEquals(putMethod.getStatusCode(), 400);
+
+    schema.put("schemaName", "differentSchemaName");
+    putMethod = sendMultipartPutRequest(urlBuilder.forSchemaUpdate(schemaName), schema.toString());
+    Assert.assertEquals(putMethod.getStatusCode(), 400);
+
+  }
+
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTest.java
@@ -16,6 +16,10 @@
 package com.linkedin.pinot.controller.helix;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.ControllerStarter;
+import com.linkedin.pinot.controller.validation.ValidationManager;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -25,6 +29,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
+import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
+import org.apache.commons.httpclient.methods.multipart.Part;
+import org.apache.commons.httpclient.methods.multipart.StringPart;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
@@ -34,10 +44,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.controller.ControllerConf;
-import com.linkedin.pinot.controller.ControllerStarter;
-import com.linkedin.pinot.controller.validation.ValidationManager;
 
 
 /**
@@ -240,6 +246,29 @@ public abstract class ControllerTest {
       queryResp.append(respLine);
     }
     return queryResp.toString();
+  }
+
+  public static PostMethod sendMultipartPostRequest(String url, String body)
+      throws IOException {
+    HttpClient httpClient = new HttpClient();
+    PostMethod postMethod = new PostMethod(url);
+    // our handlers ignore key...so we can put anything here
+    Part[] parts = { new StringPart("body", body)};
+    postMethod.setRequestEntity(new MultipartRequestEntity(parts, postMethod.getParams()));
+    httpClient.executeMethod(postMethod);
+    return postMethod;
+  }
+
+  public static PutMethod sendMultipartPutRequest(String url, String body)
+      throws IOException {
+    HttpClient httpClient = new HttpClient();
+    PutMethod putMethod = new PutMethod(url);
+    // our handlers ignore key...so we can put anything here
+    Part[] parts = { new StringPart("body", body)};
+    putMethod.setRequestEntity(new MultipartRequestEntity(parts, putMethod.getParams()));
+    httpClient.executeMethod(putMethod);
+    return putMethod;
+
   }
 
   protected String getHelixClusterName() {


### PR DESCRIPTION
Return client bad request error for bad json while creating or updating
a schema. This change refactors the schema restlet handlers to
share code for create and update operations and also adds missing unit tests