### PR TITLE
Shorten hostnames in server response time stats logs

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AbstractCompositeListenableFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AbstractCompositeListenableFuture.java
@@ -177,7 +177,7 @@ public abstract class AbstractCompositeListenableFuture<K, T> implements KeyedFu
    * @param durationMillis
    * @return true if processing done
    */
-  protected abstract boolean processFutureResult(String name, Map<K, T> responses, Map<K, Throwable> error,
+  protected abstract boolean processFutureResult(K name, Map<K, T> responses, Map<K, Throwable> error,
       long durationMillis);
 
   protected void addResponseFutureListener(KeyedFuture<K, T> future) {
@@ -217,7 +217,7 @@ public abstract class AbstractCompositeListenableFuture<K, T> implements KeyedFu
 
       // Since the future is done, it is safe to look at error results
       Map<K, Throwable> error = _future.getError();
-      boolean done = processFutureResult(_future.getName(), response, error, _future.getDurationMillis());
+      boolean done = processFutureResult(_future.getKey(), response, error, _future.getDurationMillis());
 
       if (done) {
         setDone(State.DONE);

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
@@ -327,6 +327,10 @@ public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T>
     return _key.toString();
   }
 
+  public K getKey() {
+    return _key;
+  }
+
   public State getState() {
     return _state;
   }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.response.ServerInstance;
 
 
 /**
@@ -183,7 +184,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
     return Collections.unmodifiableMap(_responseTimeMap);
   }
   @Override
-  protected boolean processFutureResult(String name, Map<K, V> response, Map<K, Throwable> error, long durationMillis) {
+  protected boolean processFutureResult(K name, Map<K, V> response, Map<K, Throwable> error, long durationMillis) {
     // Get the response time and create another map that can be invoked to get the end time when responses were received for each server.
     boolean ret = false;
     if (null != response) {
@@ -198,13 +199,18 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
       }
     }
     // TODO May be limit the number of entries here to 10? We don't want to create too much garbage on the broker.
-    _responseTimeMap.put(name, durationMillis);
+    _responseTimeMap.put(((ServerInstance)(name)).getShortHostName(), durationMillis);
     return ret;
   }
 
   @Override
   public String getName() {
     return _name;
+  }
+
+  @Override
+  public K getKey() {
+    return null;
   }
 
   public int getNumFutures() {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/KeyedFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/KeyedFuture.java
@@ -51,6 +51,8 @@ public interface KeyedFuture<K, V> extends ListenableFuture<Map<K, V>> {
    */
   public String getName();
 
+  public K getKey();
+
   /**
    * Returns the duration between when the future was created and when its result was available.
    * @return

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SelectingFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SelectingFuture.java
@@ -142,7 +142,7 @@ public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, 
   }
 
   @Override
-  protected boolean processFutureResult(String name, Map<K, T> response, Map<K, Throwable> error, long durationMillis) {
+  protected boolean processFutureResult(K name, Map<K, T> response, Map<K, Throwable> error, long durationMillis) {
     // Add an argument here to get the time of completion of the future.
     boolean done = false;
     if ((null != response)) {
@@ -162,5 +162,10 @@ public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, 
   @Override
   public String getName() {
     return _name;
+  }
+
+  @Override
+  public K getKey() {
+    return null;
   }
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGatherImpl.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGatherImpl.java
@@ -110,14 +110,6 @@ public class ScatterGatherImpl implements ScatterGather {
     return scatterGather(scatterGatherRequest, scatterGatherStats, null, brokerMetrics);
   }
 
-  private String shortenHostName(String fqdn) {
-    int firstDot = fqdn.indexOf('.');
-    if (firstDot <= 0) {
-      return fqdn;
-    }
-    return fqdn.substring(0, firstDot);
-  }
-
   /**
    *
    * Helper Function to send scatter-request. This method should be called after the servers are selected
@@ -144,7 +136,7 @@ public class ScatterGatherImpl implements ScatterGather {
 
     for (Entry<ServerInstance, SegmentIdSet> e : mp.entrySet()) {
       ServerInstance server = e.getKey();
-      String shortServerName = shortenHostName(server.toString());
+      String shortServerName = server.getShortHostName();
       if (isOfflineTable != null) {
         if (isOfflineTable) {
           shortServerName += ScatterGatherStats.OFFLINE_TABLE_SUFFIX;
@@ -174,7 +166,7 @@ public class ScatterGatherImpl implements ScatterGather {
           new ArrayList<KeyedFuture<ServerInstance, ByteBuf>>();
       for (SingleRequestHandler h : handlers) {
         responseFutures.add(h.getResponseFuture());
-        String shortServerName = shortenHostName(h.getServer().toString());
+        String shortServerName = h.getServer().getShortHostName();t commit
         if (isOfflineTable != null) {
           if (isOfflineTable) {
             shortServerName += ScatterGatherStats.OFFLINE_TABLE_SUFFIX;

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGatherImpl.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGatherImpl.java
@@ -166,7 +166,7 @@ public class ScatterGatherImpl implements ScatterGather {
           new ArrayList<KeyedFuture<ServerInstance, ByteBuf>>();
       for (SingleRequestHandler h : handlers) {
         responseFutures.add(h.getResponseFuture());
-        String shortServerName = h.getServer().getShortHostName();t commit
+        String shortServerName = h.getServer().getShortHostName();
         if (isOfflineTable != null) {
           if (isOfflineTable) {
             shortServerName += ScatterGatherStats.OFFLINE_TABLE_SUFFIX;


### PR DESCRIPTION
Right now we get FQDNs in the logs while logging server response time. It is useful to shorten this to
just the leading part of the domain name, so as to reduce the log size.