### PR TITLE
Implement lock-free thread safe on-heap mutable dictionaries

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeMultiValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeMultiValueBlock.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
-
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.core.common.Block;
@@ -28,22 +26,23 @@ import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import com.linkedin.pinot.core.operator.docvalsets.RealtimeMultiValueSet;
-import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
 
 public class RealtimeMultiValueBlock implements Block {
 
   private final MutableRoaringBitmap filteredBitmap;
   final FieldSpec spec;
-  private final MutableDictionaryReader dictionary;
+  private final BaseOnHeapMutableDictionary dictionary;
   final int docIdSearchableOffset;
   final FixedByteSingleColumnMultiValueReaderWriter reader;
   private Predicate p;
   private final int maxNumberOfMultiValues;
 
-  public RealtimeMultiValueBlock(FieldSpec spec, MutableDictionaryReader dictionary,
-      MutableRoaringBitmap filteredDocids, int docIdOffset, int maxNumberOfMultiValues,
-      FixedByteSingleColumnMultiValueReaderWriter indexReader) {
+  public RealtimeMultiValueBlock(FieldSpec spec, BaseOnHeapMutableDictionary dictionary, MutableRoaringBitmap filteredDocids,
+      int docIdOffset, int maxNumberOfMultiValues, FixedByteSingleColumnMultiValueReaderWriter indexReader) {
     this.spec = spec;
     this.dictionary = dictionary;
     this.filteredBitmap = filteredDocids;
@@ -147,5 +146,4 @@ public class RealtimeMultiValueBlock implements Block {
       }
     };
   }
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
-
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.core.common.Block;
@@ -28,20 +26,22 @@ import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.operator.docvalsets.RealtimeSingleValueSet;
-import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class RealtimeSingleValueBlock implements Block {
 
   private final MutableRoaringBitmap filteredBitmap;
   final FieldSpec spec;
-  private final MutableDictionaryReader dictionary;
+  private final BaseOnHeapMutableDictionary dictionary;
   final int docIdSearchableOffset;
   final FixedByteSingleColumnSingleValueReaderWriter reader;
   private Predicate p;
 
-  public RealtimeSingleValueBlock(MutableRoaringBitmap filteredBitmap, FieldSpec spec,
-      MutableDictionaryReader dictionary, int offset, FixedByteSingleColumnSingleValueReaderWriter indexReader) {
+  public RealtimeSingleValueBlock(MutableRoaringBitmap filteredBitmap, FieldSpec spec, BaseOnHeapMutableDictionary dictionary,
+      int offset, FixedByteSingleColumnSingleValueReaderWriter indexReader) {
     this.spec = spec;
     this.dictionary = dictionary;
     this.filteredBitmap = filteredBitmap;
@@ -142,7 +142,7 @@ public class RealtimeSingleValueBlock implements Block {
       }
 
       @Override
-      public com.linkedin.pinot.core.segment.index.readers.Dictionary getDictionary() {
+      public Dictionary getDictionary() {
         return dictionary;
       }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
@@ -25,7 +25,7 @@ import com.linkedin.pinot.core.common.predicate.NotInPredicate;
 import com.linkedin.pinot.core.common.predicate.RangePredicate;
 import com.linkedin.pinot.core.common.predicate.RegexpLikePredicate;
 import com.linkedin.pinot.core.query.exception.BadQueryRequestException;
-import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 
@@ -53,7 +53,7 @@ public class PredicateEvaluatorProvider {
                   (ImmutableDictionaryReader) dictionary);
             } else {
               return RangePredicateEvaluatorFactory.newRealtimeDictionaryBasedEvaluator((RangePredicate) predicate,
-                  (MutableDictionaryReader) dictionary);
+                  (BaseOnHeapMutableDictionary) dictionary);
             }
           case REGEXP_LIKE:
             return RegexpLikePredicateEvaluatorFactory.newDictionaryBasedEvaluator((RegexpLikePredicate) predicate,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.core.operator.filter.predicate;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.predicate.RangePredicate;
-import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -53,7 +53,7 @@ public class RangePredicateEvaluatorFactory {
    * @return Dictionary based equality _predicate evaluator
    */
   public static PredicateEvaluator newRealtimeDictionaryBasedEvaluator(RangePredicate predicate,
-      MutableDictionaryReader dictionary) {
+      BaseOnHeapMutableDictionary dictionary) {
     return new RealtimeDictionaryBasedPredicateEvaluator(predicate, dictionary);
   }
 
@@ -94,8 +94,7 @@ public class RangePredicateEvaluatorFactory {
     private int _rangeEndIndex = 0;
     int _matchingSize;
 
-    public OfflineDictionaryBasedPredicateEvaluator(RangePredicate predicate,
-        ImmutableDictionaryReader dictionary) {
+    public OfflineDictionaryBasedPredicateEvaluator(RangePredicate predicate, ImmutableDictionaryReader dictionary) {
       this._predicate = predicate;
 
       final boolean incLower = predicate.includeLowerBoundary();
@@ -188,8 +187,7 @@ public class RangePredicateEvaluatorFactory {
     private IntSet _dictIdSet;
     private RangePredicate _predicate;
 
-    public RealtimeDictionaryBasedPredicateEvaluator(RangePredicate predicate,
-        MutableDictionaryReader dictionary) {
+    public RealtimeDictionaryBasedPredicateEvaluator(RangePredicate predicate, BaseOnHeapMutableDictionary dictionary) {
       this._predicate = predicate;
       List<Integer> ids = new ArrayList<>();
       String rangeStart;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionFetcher.java
@@ -15,13 +15,9 @@
  */
 package com.linkedin.pinot.core.query.selection;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.Block;
-import com.linkedin.pinot.core.operator.blocks.MultiValueBlock;
-import com.linkedin.pinot.core.operator.blocks.RealtimeMultiValueBlock;
-import com.linkedin.pinot.core.operator.blocks.RealtimeSingleValueBlock;
-import com.linkedin.pinot.core.operator.blocks.SortedSingleValueBlock;
-import com.linkedin.pinot.core.operator.blocks.UnSortedSingleValueBlock;
 import com.linkedin.pinot.core.query.selection.iterator.DoubleArraySelectionColumnIterator;
 import com.linkedin.pinot.core.query.selection.iterator.DoubleSelectionColumnIterator;
 import com.linkedin.pinot.core.query.selection.iterator.FloatArraySelectionColumnIterator;
@@ -34,17 +30,8 @@ import com.linkedin.pinot.core.query.selection.iterator.SelectionColumnIterator;
 import com.linkedin.pinot.core.query.selection.iterator.SelectionSingleValueColumnWithDictIterator;
 import com.linkedin.pinot.core.query.selection.iterator.StringArraySelectionColumnIterator;
 import com.linkedin.pinot.core.query.selection.iterator.StringSelectionColumnIterator;
-import com.linkedin.pinot.core.realtime.impl.dictionary.DoubleMutableDictionary;
-import com.linkedin.pinot.core.realtime.impl.dictionary.FloatMutableDictionary;
-import com.linkedin.pinot.core.realtime.impl.dictionary.IntMutableDictionary;
-import com.linkedin.pinot.core.realtime.impl.dictionary.LongMutableDictionary;
-import com.linkedin.pinot.core.realtime.impl.dictionary.StringMutableDictionary;
-import com.linkedin.pinot.core.segment.index.readers.DoubleDictionary;
-import com.linkedin.pinot.core.segment.index.readers.FloatDictionary;
-import com.linkedin.pinot.core.segment.index.readers.IntDictionary;
-import com.linkedin.pinot.core.segment.index.readers.LongDictionary;
-import com.linkedin.pinot.core.segment.index.readers.StringDictionary;
 import java.io.Serializable;
+
 
 /**
  * Selection fetcher is used for querying rows from given blocks and schema.
@@ -53,103 +40,78 @@ import java.io.Serializable;
  *
  */
 public class SelectionFetcher {
-  private final int length;
-  private final SelectionColumnIterator[] selectionColumnIterators;
+  private final int _numColumns;
+  private final SelectionColumnIterator[] _selectionColumnIterators;
 
   public SelectionFetcher(Block[] blocks, DataSchema dataSchema) {
-    this.length = blocks.length;
-    selectionColumnIterators = new SelectionColumnIterator[blocks.length];
-    for (int i = 0; i < dataSchema.size(); ++i) {
-      if (blocks[i] instanceof RealtimeSingleValueBlock && blocks[i].getMetadata().hasDictionary()) {
-        switch (dataSchema.getColumnType(i)) {
+    _numColumns = blocks.length;
+    _selectionColumnIterators = new SelectionColumnIterator[_numColumns];
+
+    for (int i = 0; i < _numColumns; i++) {
+      Block block = blocks[i];
+      FieldSpec.DataType columnType = dataSchema.getColumnType(i);
+      if (block.getMetadata().hasDictionary()) {
+        // With dictionary
+
+        switch (columnType) {
+          // Single value
           case INT:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Integer, IntMutableDictionary>(blocks[i]);
-            break;
-          case FLOAT:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Float, FloatMutableDictionary>(blocks[i]);
-            break;
           case LONG:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Long, LongMutableDictionary>(blocks[i]);
-            break;
-          case DOUBLE:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Double, DoubleMutableDictionary>(blocks[i]);
-            break;
-          case STRING:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<String, StringMutableDictionary>(blocks[i]);
-            break;
-          default:
-            break;
-        }
-      } else if ((blocks[i] instanceof UnSortedSingleValueBlock || blocks[i] instanceof SortedSingleValueBlock) && blocks[i].getMetadata().hasDictionary()) {
-        switch (dataSchema.getColumnType(i)) {
-          case INT:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Integer, IntDictionary>(blocks[i]);
-            break;
           case FLOAT:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Float, FloatDictionary>(blocks[i]);
-            break;
-          case LONG:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Long, LongDictionary>(blocks[i]);
-            break;
           case DOUBLE:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<Double, DoubleDictionary>(blocks[i]);
-            break;
           case STRING:
-            selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator<String, StringDictionary>(blocks[i]);
+            _selectionColumnIterators[i] = new SelectionSingleValueColumnWithDictIterator(block);
             break;
-          default:
-            break;
-        }
-      } else if (blocks[i] instanceof RealtimeMultiValueBlock || blocks[i] instanceof MultiValueBlock) {
-        switch (dataSchema.getColumnType(i)) {
+          // Multi value
           case INT_ARRAY:
-            selectionColumnIterators[i] = new IntArraySelectionColumnIterator(blocks[i]);
+            _selectionColumnIterators[i] = new IntArraySelectionColumnIterator(block);
             break;
           case FLOAT_ARRAY:
-            selectionColumnIterators[i] = new FloatArraySelectionColumnIterator(blocks[i]);
+            _selectionColumnIterators[i] = new FloatArraySelectionColumnIterator(block);
             break;
           case LONG_ARRAY:
-            selectionColumnIterators[i] = new LongArraySelectionColumnIterator(blocks[i]);
+            _selectionColumnIterators[i] = new LongArraySelectionColumnIterator(block);
             break;
           case DOUBLE_ARRAY:
-            selectionColumnIterators[i] = new DoubleArraySelectionColumnIterator(blocks[i]);
+            _selectionColumnIterators[i] = new DoubleArraySelectionColumnIterator(block);
             break;
           case STRING_ARRAY:
-            selectionColumnIterators[i] = new StringArraySelectionColumnIterator(blocks[i]);
+            _selectionColumnIterators[i] = new StringArraySelectionColumnIterator(block);
             break;
           default:
-            break;
-        }
-      } else if (!blocks[i].getMetadata().hasDictionary()) {
-        switch (dataSchema.getColumnType(i)) {
-          case INT:
-            selectionColumnIterators[i] = new IntSelectionColumnIterator(blocks[i]);
-            break;
-          case FLOAT:
-            selectionColumnIterators[i] = new FloatSelectionColumnIterator(blocks[i]);
-            break;
-          case LONG:
-            selectionColumnIterators[i] = new LongSelectionColumnIterator(blocks[i]);
-            break;
-          case DOUBLE:
-            selectionColumnIterators[i] = new DoubleSelectionColumnIterator(blocks[i]);
-            break;
-          case STRING:
-            selectionColumnIterators[i] = new StringSelectionColumnIterator(blocks[i]);
-            break;
-          default:
-            break;
+            throw new UnsupportedOperationException();
         }
       } else {
-        throw new UnsupportedOperationException("Failed to get SelectionColumnIterator on Block - " + blocks[i] + " with index - " + i);
+        // No dictionary
+
+        switch (columnType) {
+          case INT:
+            _selectionColumnIterators[i] = new IntSelectionColumnIterator(block);
+            break;
+          case LONG:
+            _selectionColumnIterators[i] = new LongSelectionColumnIterator(block);
+            break;
+          case FLOAT:
+            _selectionColumnIterators[i] = new FloatSelectionColumnIterator(block);
+            break;
+          case DOUBLE:
+            _selectionColumnIterators[i] = new DoubleSelectionColumnIterator(block);
+            break;
+          case STRING:
+            _selectionColumnIterators[i] = new StringSelectionColumnIterator(block);
+            break;
+          // TODO: add multi value support
+          default:
+            throw new UnsupportedOperationException();
+        }
       }
     }
   }
 
   public Serializable[] getRow(int docId) {
-    final Serializable[] row = new Serializable[length];
-    for (int i = 0; i < length; ++i) {
-      row[i] = selectionColumnIterators[i].getValue(docId);
+    final Serializable[] row = new Serializable[_numColumns];
+    for (int i = 0; i < _numColumns; i++) {
+      row[i] = _selectionColumnIterators[i].getValue(docId);
     }
     return row;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionSingleValueColumnWithDictIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/iterator/SelectionSingleValueColumnWithDictIterator.java
@@ -15,30 +15,29 @@
  */
 package com.linkedin.pinot.core.query.selection.iterator;
 
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.io.Serializable;
 
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.common.BlockSingleValIterator;
-import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+
 
 /**
  * Iterator on single-value column with dictionary for selection query.
  *
  */
-public class SelectionSingleValueColumnWithDictIterator<T extends Serializable, DICT extends Dictionary> implements SelectionColumnIterator {
-  protected BlockSingleValIterator bvIter;
-  protected DICT dict;
+public class SelectionSingleValueColumnWithDictIterator implements SelectionColumnIterator {
+  protected BlockSingleValIterator _blockSingleValIterator;
+  protected Dictionary _dictionary;
 
-  @SuppressWarnings("unchecked")
   public SelectionSingleValueColumnWithDictIterator(Block block) {
-    bvIter = (BlockSingleValIterator) block.getBlockValueSet().iterator();
-    dict = (DICT) block.getMetadata().getDictionary();
+    _blockSingleValIterator = (BlockSingleValIterator) block.getBlockValueSet().iterator();
+    _dictionary = block.getMetadata().getDictionary();
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public Serializable getValue(int docId) {
-    bvIter.skipTo(docId);
-    return (T) ((DICT) dict).get(bvIter.nextIntVal());
+    _blockSingleValIterator.skipTo(docId);
+    return (Serializable) _dictionary.get(_blockSingleValIterator.nextIntVal());
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.realtime.converter.stats;
 
 import com.linkedin.pinot.common.config.ColumnPartitionConfig;
@@ -25,7 +24,7 @@ import com.linkedin.pinot.core.data.partition.PartitionFunctionFactory;
 import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.operator.blocks.RealtimeSingleValueBlock;
 import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
-import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
 import java.util.Arrays;
 import java.util.List;
@@ -42,14 +41,15 @@ public class RealtimeColumnStatistics implements ColumnStatistics {
 
   private final RealtimeColumnDataSource _dataSource;
   private final int[] _sortedDocIdIterationOrder;
-  private final MutableDictionaryReader _dictionaryReader;
+  private final BaseOnHeapMutableDictionary _dictionaryReader;
   private final Block _block;
   private PartitionFunction partitionFunction;
   private int numPartitions;
   private int partitionRangeStart = Integer.MAX_VALUE;
   private int partitionRangeEnd = Integer.MIN_VALUE;
 
-  public RealtimeColumnStatistics(RealtimeColumnDataSource dataSource, int[] sortedDocIdIterationOrder, ColumnPartitionConfig columnPartitionConfig) {
+  public RealtimeColumnStatistics(RealtimeColumnDataSource dataSource, int[] sortedDocIdIterationOrder,
+      ColumnPartitionConfig columnPartitionConfig) {
     _dataSource = dataSource;
     _sortedDocIdIterationOrder = sortedDocIdIterationOrder;
     _dictionaryReader = dataSource.getDictionary();
@@ -146,7 +146,7 @@ public class RealtimeColumnStatistics implements ColumnStatistics {
       int[] dictionaryIds = new int[getMaxNumberOfMultiValues()];
 
       BlockMultiValIterator valIterator = (BlockMultiValIterator) _block.getBlockValueSet().iterator();
-      while(valIterator.hasNext()) {
+      while (valIterator.hasNext()) {
         multivalueEntryCount += valIterator.nextIntVal(dictionaryIds);
       }
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.core.realtime.impl.datasource;
 
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
-
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
@@ -32,10 +30,10 @@ import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiVa
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.operator.blocks.RealtimeMultiValueBlock;
 import com.linkedin.pinot.core.operator.blocks.RealtimeSingleValueBlock;
-import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionaryReader;
+import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import com.linkedin.pinot.core.realtime.impl.invertedIndex.RealtimeInvertedIndex;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
-import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class RealtimeColumnDataSource extends DataSource {
@@ -54,10 +52,10 @@ public class RealtimeColumnDataSource extends DataSource {
   private final RealtimeInvertedIndex invertedIndex;
   private final int offset;
   private final int maxNumberOfMultiValues;
-  private final MutableDictionaryReader dictionary;
+  private final BaseOnHeapMutableDictionary dictionary;
 
   public RealtimeColumnDataSource(FieldSpec spec, DataFileReader indexReader, RealtimeInvertedIndex invertedIndex,
-      int searchOffset, int maxNumberOfMultivalues, Schema schema, MutableDictionaryReader dictionary) {
+      int searchOffset, int maxNumberOfMultivalues, Schema schema, BaseOnHeapMutableDictionary dictionary) {
     this.fieldSpec = spec;
     this.indexReader = indexReader;
     this.invertedIndex = invertedIndex;
@@ -76,9 +74,8 @@ public class RealtimeColumnDataSource extends DataSource {
       blockReturned = true;
       isPredicateEvaluated = true;
       if (fieldSpec.isSingleValueField()) {
-        Block SvBlock =
-            new RealtimeSingleValueBlock(filteredDocIdBitmap, fieldSpec, dictionary, offset,
-                (FixedByteSingleColumnSingleValueReaderWriter) indexReader);
+        Block SvBlock = new RealtimeSingleValueBlock(filteredDocIdBitmap, fieldSpec, dictionary, offset,
+            (FixedByteSingleColumnSingleValueReaderWriter) indexReader);
         return SvBlock;
       } else {
         Block mvBlock =
@@ -127,7 +124,6 @@ public class RealtimeColumnDataSource extends DataSource {
       return Double.longBitsToDouble(1L);
     }
     return Double.longBitsToDouble(bitsValue - 1);
-
   }
 
   private double getSmallerDoubleValue(double value) {
@@ -192,7 +188,7 @@ public class RealtimeColumnDataSource extends DataSource {
   }
 
   @Override
-  public MutableDictionaryReader getDictionary() {
+  public BaseOnHeapMutableDictionary getDictionary() {
     return dictionary;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOnHeapMutableDictionary.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
+
+
+/**
+ * The class <code>BaseOnHeapMutableDictionary</code> is the implementation of the mutable dictionary required by
+ * REALTIME consuming segments.
+ * <p>The implementation needs to be thread safe for single writer multiple readers scenario.
+ * <p>We can assume the readers always first get the dictionary id for a value, then use the dictionary id to fetch the
+ * value later, but not reversely. So whenever we return a valid dictionary id for a value, we need to ensure the value
+ * can be fetched by the dictionary id returned.
+ */
+public abstract class BaseOnHeapMutableDictionary implements Dictionary {
+  private static final int SHIFT_OFFSET = 13;  // INITIAL_DICTIONARY_SIZE = 8192
+  private static final int INITIAL_DICTIONARY_SIZE = 1 << SHIFT_OFFSET;
+  private static final int MASK = 0xFFFFFFFF >>> (Integer.SIZE - SHIFT_OFFSET);
+
+  private final Map<Object, Integer> _valueToDictId = new ConcurrentHashMap<>(INITIAL_DICTIONARY_SIZE);
+  private final Object[][] _dictIdToValue = new Object[INITIAL_DICTIONARY_SIZE][];
+  private int _entriesIndexed = 0;
+
+  /**
+   * For performance, we don't validate the dictId passed in. It should be returned by index() or indexOf().
+   */
+  @Nonnull
+  @Override
+  public Object get(int dictId) {
+    return _dictIdToValue[dictId >>> SHIFT_OFFSET][dictId & MASK];
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    return get(dictId).toString();
+  }
+
+  @Override
+  public int length() {
+    return _entriesIndexed;
+  }
+
+  @Override
+  public void readIntValues(int[] dictIds, int startPos, int limit, int[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getIntValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readLongValues(int[] dictIds, int startPos, int limit, long[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getLongValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readFloatValues(int[] dictIds, int startPos, int limit, float[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getFloatValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readDoubleValues(int[] dictIds, int startPos, int limit, double[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getDoubleValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readStringValues(int[] dictIds, int startPos, int limit, String[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getStringValue(dictIds[i]);
+    }
+  }
+
+  public boolean isEmpty() {
+    return _entriesIndexed == 0;
+  }
+
+  public abstract void index(@Nonnull Object rawValue);
+
+  public abstract boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare,
+      boolean includeLower, boolean includeUpper);
+
+  @Nonnull
+  public abstract Object getMinVal();
+
+  @Nonnull
+  public abstract Object getMaxVal();
+
+  @Nonnull
+  public abstract Object getSortedValues();
+
+  /**
+   * Index a single value.
+   * <p>This method will only be called by a single writer thread.
+   *
+   * @param value single value already converted to correct type.
+   */
+  protected void indexValue(@Nonnull Object value) {
+    if (!_valueToDictId.containsKey(value)) {
+      int arrayIndex = _entriesIndexed >>> SHIFT_OFFSET;
+      int arrayOffset = _entriesIndexed & MASK;
+
+      // Create a new array if necessary
+      if (arrayOffset == 0) {
+        _dictIdToValue[arrayIndex] = new Object[INITIAL_DICTIONARY_SIZE];
+      }
+
+      // First update dictId to value map then value to dictId map
+      // Ensure we can always fetch value by dictId returned by index() or indexOf()
+      _dictIdToValue[arrayIndex][arrayOffset] = value;
+      _valueToDictId.put(value, _entriesIndexed);
+      _entriesIndexed++;
+    }
+  }
+
+  /**
+   * Get the dictId of a single value.
+   * <p>This method will only be called by a single writer thread.
+   *
+   * @param value single value already converted to correct type.
+   * @return dictId of the value.
+   */
+  protected int getDictId(@Nonnull Object value) {
+    Integer dictId = _valueToDictId.get(value);
+    if (dictId == null) {
+      return NULL_VALUE_INDEX;
+    } else {
+      return dictId;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+
+
+public class DoubleOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
+  private double _min = Double.MAX_VALUE;
+  private double _max = Double.MIN_VALUE;
+
+  @Override
+  public int indexOf(Object rawValue) {
+    if (rawValue instanceof String) {
+      return getDictId(Double.valueOf((String) rawValue));
+    } else {
+      return getDictId(rawValue);
+    }
+  }
+
+  @Override
+  public void index(@Nonnull Object rawValue) {
+    if (rawValue instanceof Double) {
+      // Single value
+      indexValue(rawValue);
+      updateMinMax((Double) rawValue);
+    } else {
+      // Multi value
+      Object[] values = (Object[]) rawValue;
+      for (Object value : values) {
+        indexValue(value);
+        updateMinMax((Double) value);
+      }
+    }
+  }
+
+  @SuppressWarnings("Duplicates")
+  @Override
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+      boolean includeUpper) {
+    double lowerDouble = Double.parseDouble(lower);
+    double upperDouble = Double.parseDouble(upper);
+    double valueToCompare = (Double) get(dictIdToCompare);
+
+    if (includeLower) {
+      if (valueToCompare < lowerDouble) {
+        return false;
+      }
+    } else {
+      if (valueToCompare <= lowerDouble) {
+        return false;
+      }
+    }
+
+    if (includeUpper) {
+      if (valueToCompare > upperDouble) {
+        return false;
+      }
+    } else {
+      if (valueToCompare >= upperDouble) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Nonnull
+  @Override
+  public Double getMinVal() {
+    return _min;
+  }
+
+  @Nonnull
+  @Override
+  public Double getMaxVal() {
+    return _max;
+  }
+
+  @Nonnull
+  @Override
+  public double[] getSortedValues() {
+    int numValues = length();
+    double[] sortedValues = new double[numValues];
+
+    for (int i = 0; i < numValues; i++) {
+      sortedValues[i] = (Double) get(i);
+    }
+
+    Arrays.sort(sortedValues);
+    return sortedValues;
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    return ((Double) get(dictId)).intValue();
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    return ((Double) get(dictId)).longValue();
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    return ((Double) get(dictId)).floatValue();
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    return (Double) get(dictId);
+  }
+
+  private void updateMinMax(double value) {
+    if (value < _min) {
+      _min = value;
+    }
+    if (value > _max) {
+      _max = value;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatBiMapDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatBiMapDictionary.java
@@ -18,12 +18,12 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 import java.util.Arrays;
 
 
-public class LongMutableDictionary extends MutableDictionaryReader {
+public class FloatBiMapDictionary extends MutableDictionaryReader {
 
-  private Long min = Long.MAX_VALUE;
-  private Long max = Long.MIN_VALUE;
+  private Float min = Float.MAX_VALUE;
+  private Float max = Float.MIN_VALUE;
 
-  public LongMutableDictionary(String column) {
+  public FloatBiMapDictionary(String column) {
     super(column);
   }
 
@@ -33,38 +33,38 @@ public class LongMutableDictionary extends MutableDictionaryReader {
       hasNull = true;
       return;
     }
-
     if (rawValue instanceof String) {
-      Long e = Long.parseLong(rawValue.toString());
+      Float e = Float.parseFloat(rawValue.toString());
       addToDictionaryBiMap(e);
       updateMinMax(e);
       return;
     }
 
-    if (rawValue instanceof Long) {
+    if (rawValue instanceof Float) {
       addToDictionaryBiMap(rawValue);
-      updateMinMax((Long) rawValue);
+      updateMinMax((Float) rawValue);
       return;
     }
 
     if (rawValue instanceof Object[]) {
+
       for (Object o : (Object[]) rawValue) {
         if (o instanceof String) {
-          final Long longValue = Long.parseLong(o.toString());
-          addToDictionaryBiMap(longValue);
-          updateMinMax(longValue);
+          final Float floatValue = Float.parseFloat(o.toString());
+          addToDictionaryBiMap(floatValue);
+          updateMinMax(floatValue);
           continue;
         }
 
-        if (o instanceof Long) {
+        if (o instanceof Float) {
           addToDictionaryBiMap(o);
-          updateMinMax((Long) o);
+          updateMinMax((Float) o);
         }
       }
     }
   }
 
-  private void updateMinMax(Long entry) {
+  private void updateMinMax(Float entry) {
     if (entry < min) {
       min = entry;
     }
@@ -79,7 +79,7 @@ public class LongMutableDictionary extends MutableDictionaryReader {
       return hasNull;
     }
     if (rawValue instanceof String) {
-      return dictionaryIdBiMap.inverse().containsKey(Long.parseLong((String) rawValue));
+      return dictionaryIdBiMap.inverse().containsKey(Float.parseFloat(rawValue.toString()));
     }
     return dictionaryIdBiMap.inverse().containsKey(rawValue);
   }
@@ -87,7 +87,7 @@ public class LongMutableDictionary extends MutableDictionaryReader {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getIndexOfFromBiMap(Long.parseLong(rawValue.toString()));
+      return getIndexOfFromBiMap(Float.parseFloat(rawValue.toString()));
     }
     return getIndexOfFromBiMap(rawValue);
   }
@@ -99,57 +99,51 @@ public class LongMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public long getLongValue(int dictionaryId) {
-    return (Long) getRawValueFromBiMap(dictionaryId);
+    return ((Float) getRawValueFromBiMap(dictionaryId)).longValue();
   }
 
   @Override
   public double getDoubleValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).doubleValue();
+    return ((Float) getRawValueFromBiMap(dictionaryId)).doubleValue();
   }
 
   @Override
   public int getIntValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).intValue();
+    return ((Float) getRawValueFromBiMap(dictionaryId)).intValue();
   }
 
   @Override
   public float getFloatValue(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).floatValue();
+    return ((Float) getRawValueFromBiMap(dictionaryId));
   }
-
-  @Override
-  public String toString(int dictionaryId) {
-    return ((Long) getRawValueFromBiMap(dictionaryId)).toString();
-  }
-
 
   @Override
   public boolean inRange(String lower, String upper, int indexOfValueToCompare, boolean includeLower,
       boolean includeUpper) {
 
-    long lowerInLong = Long.parseLong(lower);
-    long upperInLong = Long.parseLong(upper);
+    float lowerInFloat = Float.parseFloat(lower);
+    float upperInFloat = Float.parseFloat(upper);
 
-    long valueToCompare = getLong(indexOfValueToCompare);
+    float valueToCompare = getFloat(indexOfValueToCompare);
 
     boolean ret = true;
 
     if (includeLower) {
-      if (valueToCompare < lowerInLong) {
+      if (valueToCompare < lowerInFloat) {
         ret = false;
       }
     } else {
-      if (valueToCompare <= lowerInLong) {
+      if (valueToCompare <= lowerInFloat) {
         ret = false;
       }
     }
 
     if (includeUpper) {
-      if (valueToCompare > upperInLong) {
+      if (valueToCompare > upperInFloat) {
         ret = false;
       }
     } else {
-      if (valueToCompare >= upperInLong) {
+      if (valueToCompare >= upperInFloat) {
         ret = false;
       }
     }
@@ -160,10 +154,10 @@ public class LongMutableDictionary extends MutableDictionaryReader {
   @Override
   public Object getSortedValues() {
     int valueCount = length();
-    long[] values = new long[valueCount];
+    float[] values = new float[valueCount];
 
     for (int i = 0; i < valueCount; i++) {
-      values[i] = getLongValue(i);
+      values[i] = getFloatValue(i);
     }
 
     Arrays.sort(values);
@@ -173,11 +167,11 @@ public class LongMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public String getStringValue(int dictionaryId) {
-    return getRawValueFromBiMap(dictionaryId).toString();
+    return (getRawValueFromBiMap(dictionaryId)).toString();
   }
 
-  private long getLong(int dictionaryId) {
-    return (Long) dictionaryIdBiMap.get(dictionaryId);
+  private float getFloat(int dictionaryId) {
+    return (Float) dictionaryIdBiMap.get(dictionaryId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+
+
+public class FloatOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
+  private float _min = Float.MAX_VALUE;
+  private float _max = Float.MIN_VALUE;
+
+  @Override
+  public int indexOf(Object rawValue) {
+    if (rawValue instanceof String) {
+      return getDictId(Float.valueOf((String) rawValue));
+    } else {
+      return getDictId(rawValue);
+    }
+  }
+
+  @Override
+  public void index(@Nonnull Object rawValue) {
+    if (rawValue instanceof Float) {
+      // Single value
+      indexValue(rawValue);
+      updateMinMax((Float) rawValue);
+    } else {
+      // Multi value
+      Object[] values = (Object[]) rawValue;
+      for (Object value : values) {
+        indexValue(value);
+        updateMinMax((Float) value);
+      }
+    }
+  }
+
+  @SuppressWarnings("Duplicates")
+  @Override
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+      boolean includeUpper) {
+    float lowerFloat = Float.parseFloat(lower);
+    float upperFloat = Float.parseFloat(upper);
+    float valueToCompare = (Float) get(dictIdToCompare);
+
+    if (includeLower) {
+      if (valueToCompare < lowerFloat) {
+        return false;
+      }
+    } else {
+      if (valueToCompare <= lowerFloat) {
+        return false;
+      }
+    }
+
+    if (includeUpper) {
+      if (valueToCompare > upperFloat) {
+        return false;
+      }
+    } else {
+      if (valueToCompare >= upperFloat) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Nonnull
+  @Override
+  public Float getMinVal() {
+    return _min;
+  }
+
+  @Nonnull
+  @Override
+  public Float getMaxVal() {
+    return _max;
+  }
+
+  @Nonnull
+  @Override
+  public float[] getSortedValues() {
+    int numValues = length();
+    float[] sortedValues = new float[numValues];
+
+    for (int i = 0; i < numValues; i++) {
+      sortedValues[i] = (Float) get(i);
+    }
+
+    Arrays.sort(sortedValues);
+    return sortedValues;
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    return ((Float) get(dictId)).intValue();
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    return ((Float) get(dictId)).longValue();
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    return (Float) get(dictId);
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    return (Float) get(dictId);
+  }
+
+  private void updateMinMax(float value) {
+    if (value < _min) {
+      _min = value;
+    }
+    if (value > _max) {
+      _max = value;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+
+
+public class IntOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
+  private int _min = Integer.MAX_VALUE;
+  private int _max = Integer.MIN_VALUE;
+
+  @Override
+  public int indexOf(Object rawValue) {
+    if (rawValue instanceof String) {
+      return getDictId(Integer.valueOf((String) rawValue));
+    } else {
+      return getDictId(rawValue);
+    }
+  }
+
+  @Override
+  public void index(@Nonnull Object rawValue) {
+    if (rawValue instanceof Integer) {
+      // Single value
+      indexValue(rawValue);
+      updateMinMax((Integer) rawValue);
+    } else {
+      // Multi value
+      Object[] values = (Object[]) rawValue;
+      for (Object value : values) {
+        indexValue(value);
+        updateMinMax((Integer) value);
+      }
+    }
+  }
+
+  @SuppressWarnings("Duplicates")
+  @Override
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+      boolean includeUpper) {
+    int lowerInt = Integer.parseInt(lower);
+    int upperInt = Integer.parseInt(upper);
+    int valueToCompare = (Integer) get(dictIdToCompare);
+
+    if (includeLower) {
+      if (valueToCompare < lowerInt) {
+        return false;
+      }
+    } else {
+      if (valueToCompare <= lowerInt) {
+        return false;
+      }
+    }
+
+    if (includeUpper) {
+      if (valueToCompare > upperInt) {
+        return false;
+      }
+    } else {
+      if (valueToCompare >= upperInt) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Nonnull
+  @Override
+  public Integer getMinVal() {
+    return _min;
+  }
+
+  @Nonnull
+  @Override
+  public Integer getMaxVal() {
+    return _max;
+  }
+
+  @Nonnull
+  @Override
+  public int[] getSortedValues() {
+    int numValues = length();
+    int[] sortedValues = new int[numValues];
+
+    for (int i = 0; i < numValues; i++) {
+      sortedValues[i] = (Integer) get(i);
+    }
+
+    Arrays.sort(sortedValues);
+    return sortedValues;
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    return (Integer) get(dictId);
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    return (Integer) get(dictId);
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    return (Integer) get(dictId);
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    return (Integer) get(dictId);
+  }
+
+  private void updateMinMax(int value) {
+    if (value < _min) {
+      _min = value;
+    }
+    if (value > _max) {
+      _max = value;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongBiMapDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongBiMapDictionary.java
@@ -18,12 +18,12 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 import java.util.Arrays;
 
 
-public class FloatMutableDictionary extends MutableDictionaryReader {
+public class LongBiMapDictionary extends MutableDictionaryReader {
 
-  private Float min = Float.MAX_VALUE;
-  private Float max = Float.MIN_VALUE;
+  private Long min = Long.MAX_VALUE;
+  private Long max = Long.MIN_VALUE;
 
-  public FloatMutableDictionary(String column) {
+  public LongBiMapDictionary(String column) {
     super(column);
   }
 
@@ -33,38 +33,38 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
       hasNull = true;
       return;
     }
+
     if (rawValue instanceof String) {
-      Float e = Float.parseFloat(rawValue.toString());
+      Long e = Long.parseLong(rawValue.toString());
       addToDictionaryBiMap(e);
       updateMinMax(e);
       return;
     }
 
-    if (rawValue instanceof Float) {
+    if (rawValue instanceof Long) {
       addToDictionaryBiMap(rawValue);
-      updateMinMax((Float) rawValue);
+      updateMinMax((Long) rawValue);
       return;
     }
 
     if (rawValue instanceof Object[]) {
-
       for (Object o : (Object[]) rawValue) {
         if (o instanceof String) {
-          final Float floatValue = Float.parseFloat(o.toString());
-          addToDictionaryBiMap(floatValue);
-          updateMinMax(floatValue);
+          final Long longValue = Long.parseLong(o.toString());
+          addToDictionaryBiMap(longValue);
+          updateMinMax(longValue);
           continue;
         }
 
-        if (o instanceof Float) {
+        if (o instanceof Long) {
           addToDictionaryBiMap(o);
-          updateMinMax((Float) o);
+          updateMinMax((Long) o);
         }
       }
     }
   }
 
-  private void updateMinMax(Float entry) {
+  private void updateMinMax(Long entry) {
     if (entry < min) {
       min = entry;
     }
@@ -79,7 +79,7 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
       return hasNull;
     }
     if (rawValue instanceof String) {
-      return dictionaryIdBiMap.inverse().containsKey(Float.parseFloat(rawValue.toString()));
+      return dictionaryIdBiMap.inverse().containsKey(Long.parseLong((String) rawValue));
     }
     return dictionaryIdBiMap.inverse().containsKey(rawValue);
   }
@@ -87,7 +87,7 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getIndexOfFromBiMap(Float.parseFloat(rawValue.toString()));
+      return getIndexOfFromBiMap(Long.parseLong(rawValue.toString()));
     }
     return getIndexOfFromBiMap(rawValue);
   }
@@ -99,56 +99,51 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public long getLongValue(int dictionaryId) {
-    return ((Float) getRawValueFromBiMap(dictionaryId)).longValue();
+    return (Long) getRawValueFromBiMap(dictionaryId);
   }
 
   @Override
   public double getDoubleValue(int dictionaryId) {
-    return ((Float) getRawValueFromBiMap(dictionaryId)).doubleValue();
+    return ((Long) getRawValueFromBiMap(dictionaryId)).doubleValue();
   }
 
   @Override
   public int getIntValue(int dictionaryId) {
-    return ((Float) getRawValueFromBiMap(dictionaryId)).intValue();
+    return ((Long) getRawValueFromBiMap(dictionaryId)).intValue();
   }
 
   @Override
   public float getFloatValue(int dictionaryId) {
-    return ((Float) getRawValueFromBiMap(dictionaryId));
-  }
-
-  @Override
-  public String toString(int dictionaryId) {
-    return (getRawValueFromBiMap(dictionaryId)).toString();
+    return ((Long) getRawValueFromBiMap(dictionaryId)).floatValue();
   }
 
   @Override
   public boolean inRange(String lower, String upper, int indexOfValueToCompare, boolean includeLower,
       boolean includeUpper) {
 
-    float lowerInFloat = Float.parseFloat(lower);
-    float upperInFloat = Float.parseFloat(upper);
+    long lowerInLong = Long.parseLong(lower);
+    long upperInLong = Long.parseLong(upper);
 
-    float valueToCompare = getFloat(indexOfValueToCompare);
+    long valueToCompare = getLong(indexOfValueToCompare);
 
     boolean ret = true;
 
     if (includeLower) {
-      if (valueToCompare < lowerInFloat) {
+      if (valueToCompare < lowerInLong) {
         ret = false;
       }
     } else {
-      if (valueToCompare <= lowerInFloat) {
+      if (valueToCompare <= lowerInLong) {
         ret = false;
       }
     }
 
     if (includeUpper) {
-      if (valueToCompare > upperInFloat) {
+      if (valueToCompare > upperInLong) {
         ret = false;
       }
     } else {
-      if (valueToCompare >= upperInFloat) {
+      if (valueToCompare >= upperInLong) {
         ret = false;
       }
     }
@@ -159,10 +154,10 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
   @Override
   public Object getSortedValues() {
     int valueCount = length();
-    float[] values = new float[valueCount];
+    long[] values = new long[valueCount];
 
     for (int i = 0; i < valueCount; i++) {
-      values[i] = getFloatValue(i);
+      values[i] = getLongValue(i);
     }
 
     Arrays.sort(values);
@@ -172,11 +167,11 @@ public class FloatMutableDictionary extends MutableDictionaryReader {
 
   @Override
   public String getStringValue(int dictionaryId) {
-    return (getRawValueFromBiMap(dictionaryId)).toString();
+    return getRawValueFromBiMap(dictionaryId).toString();
   }
 
-  private float getFloat(int dictionaryId) {
-    return (Float) dictionaryIdBiMap.get(dictionaryId);
+  private long getLong(int dictionaryId) {
+    return (Long) dictionaryIdBiMap.get(dictionaryId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+
+
+public class LongOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
+  private long _min = Long.MAX_VALUE;
+  private long _max = Long.MIN_VALUE;
+
+  @Override
+  public int indexOf(Object rawValue) {
+    if (rawValue instanceof String) {
+      return getDictId(Long.valueOf((String) rawValue));
+    } else {
+      return getDictId(rawValue);
+    }
+  }
+
+  @Override
+  public void index(@Nonnull Object rawValue) {
+    if (rawValue instanceof Long) {
+      // Single value
+      indexValue(rawValue);
+      updateMinMax((Long) rawValue);
+    } else {
+      // Multi value
+      Object[] values = (Object[]) rawValue;
+      for (Object value : values) {
+        indexValue(value);
+        updateMinMax((Long) value);
+      }
+    }
+  }
+
+  @SuppressWarnings("Duplicates")
+  @Override
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+      boolean includeUpper) {
+    long lowerLong = Long.parseLong(lower);
+    long upperLong = Long.parseLong(upper);
+    long valueToCompare = (Long) get(dictIdToCompare);
+
+    if (includeLower) {
+      if (valueToCompare < lowerLong) {
+        return false;
+      }
+    } else {
+      if (valueToCompare <= lowerLong) {
+        return false;
+      }
+    }
+
+    if (includeUpper) {
+      if (valueToCompare > upperLong) {
+        return false;
+      }
+    } else {
+      if (valueToCompare >= upperLong) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Nonnull
+  @Override
+  public Long getMinVal() {
+    return _min;
+  }
+
+  @Nonnull
+  @Override
+  public Long getMaxVal() {
+    return _max;
+  }
+
+  @Nonnull
+  @Override
+  public long[] getSortedValues() {
+    int numValues = length();
+    long[] sortedValues = new long[numValues];
+
+    for (int i = 0; i < numValues; i++) {
+      sortedValues[i] = (Long) get(i);
+    }
+
+    Arrays.sort(sortedValues);
+    return sortedValues;
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    return ((Long) get(dictId)).intValue();
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    return (Long) get(dictId);
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    return (Long) get(dictId);
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    return (Long) get(dictId);
+  }
+
+  private void updateMinMax(long value) {
+    if (value < _min) {
+      _min = value;
+    }
+    if (value > _max) {
+      _max = value;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
@@ -18,23 +18,24 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 import com.linkedin.pinot.common.data.FieldSpec;
 
 
-public class RealtimeDictionaryProvider {
+public class MutableDictionaryFactory {
+  private MutableDictionaryFactory() {
+  }
 
-  public static MutableDictionaryReader getDictionaryFor(FieldSpec spec) {
-    String column = spec.getName();
-    switch (spec.getDataType()) {
+  public static BaseOnHeapMutableDictionary getMutableDictionary(FieldSpec.DataType dataType) {
+    switch (dataType) {
       case INT:
-        return new IntBiMapDictionary(column);
+        return new IntOnHeapMutableDictionary();
       case LONG:
-        return new LongBiMapDictionary(column);
+        return new LongOnHeapMutableDictionary();
       case FLOAT:
-        return new FloatBiMapDictionary(column);
+        return new FloatOnHeapMutableDictionary();
       case DOUBLE:
-        return new DoubleBiMapDictionary(column);
-      case BOOLEAN:
+        return new DoubleOnHeapMutableDictionary();
       case STRING:
-        return new StringBiMapDictionary(column);
+        return new StringOnHeapMutableDictionary();
+      default:
+        throw new UnsupportedOperationException();
     }
-    throw new UnsupportedOperationException();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryReader.java
@@ -172,9 +172,6 @@ public abstract class MutableDictionaryReader implements Dictionary {
   @Override
   public abstract float getFloatValue(int dictionaryId);
 
-  @Override
-  public abstract String toString(int dictionaryId);
-
   public void print() {
     System.out.println("************* printing dictionary for column : " + column + " ***************");
     for (Integer key : dictionaryIdBiMap.keySet()) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringBiMapDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringBiMapDictionary.java
@@ -18,12 +18,12 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 import java.util.Arrays;
 
 
-public class StringMutableDictionary extends MutableDictionaryReader {
+public class StringBiMapDictionary extends MutableDictionaryReader {
 
   private String min = null;
   private String max = null;
 
-  public StringMutableDictionary(String column) {
+  public StringBiMapDictionary(String column) {
     super(column);
   }
 
@@ -93,11 +93,6 @@ public class StringMutableDictionary extends MutableDictionaryReader {
   @Override
   public float getFloatValue(int dictionaryId) {
     return -1;
-  }
-
-  @Override
-  public String toString(int dictionaryId) {
-    return (String) getRawValueFromBiMap(dictionaryId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+
+
+public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
+  private String _min = null;
+  private String _max = null;
+
+  @Override
+  public int indexOf(Object rawValue) {
+    return getDictId(rawValue);
+  }
+
+  @Override
+  public void index(@Nonnull Object rawValue) {
+    if (rawValue instanceof String) {
+      // Single value
+      indexValue(rawValue);
+      updateMinMax((String) rawValue);
+    } else {
+      // Multi value
+      Object[] values = (Object[]) rawValue;
+      for (Object value : values) {
+        indexValue(value);
+        updateMinMax((String) value);
+      }
+    }
+  }
+
+  @Override
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+      boolean includeUpper) {
+    String valueToCompare = (String) get(dictIdToCompare);
+
+    if (includeLower) {
+      if (valueToCompare.compareTo(lower) < 0) {
+        return false;
+      }
+    } else {
+      if (valueToCompare.compareTo(lower) <= 0) {
+        return false;
+      }
+    }
+
+    if (includeUpper) {
+      if (valueToCompare.compareTo(upper) > 0) {
+        return false;
+      }
+    } else {
+      if (valueToCompare.compareTo(upper) >= 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Nonnull
+  @Override
+  public String getMinVal() {
+    return _min;
+  }
+
+  @Nonnull
+  @Override
+  public String getMaxVal() {
+    return _max;
+  }
+
+  @Nonnull
+  @Override
+  public String[] getSortedValues() {
+    int numValues = length();
+    String[] sortedValues = new String[numValues];
+
+    for (int i = 0; i < numValues; i++) {
+      sortedValues[i] = (String) get(i);
+    }
+
+    Arrays.sort(sortedValues);
+    return sortedValues;
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  private void updateMinMax(String value) {
+    if (_min == null) {
+      _min = value;
+      _max = value;
+    } else {
+      if (value.compareTo(_min) < 0) {
+        _min = value;
+      }
+      if (value.compareTo(_max) > 0) {
+        _max = value;
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
@@ -39,8 +39,6 @@ public interface Dictionary {
 
   int getIntValue(int dictionaryId);
 
-  String toString(int dictionaryId);
-
   int length();
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/DoubleDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/DoubleDictionary.java
@@ -52,11 +52,6 @@ public class DoubleDictionary extends ImmutableDictionaryReader  {
   }
 
   @Override
-  public String toString(int dictionaryId) {
-    return Double.toString(getDoubleValue(dictionaryId));
-  }
-
-  @Override
   public String getStringValue(int dictionaryId) {
     return Double.toString(getDoubleValue(dictionaryId));
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/FloatDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/FloatDictionary.java
@@ -52,11 +52,6 @@ public class FloatDictionary extends ImmutableDictionaryReader {
   }
 
   @Override
-  public String toString(int dictionaryId) {
-    return Float.toString(getFloat(dictionaryId));
-  }
-
-  @Override
   public String getStringValue(int dictionaryId) {
     return Float.toString(getFloat(dictionaryId));
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
@@ -67,9 +67,6 @@ public abstract class ImmutableDictionaryReader implements Dictionary {
   @Override
   public abstract double getDoubleValue(int dictionaryId);
 
-  @Override
-  public abstract String toString(int dictionaryId);
-
   public void close() throws IOException {
     dataFileReader.close();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/IntDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/IntDictionary.java
@@ -67,11 +67,6 @@ public class IntDictionary extends ImmutableDictionaryReader {
   }
 
   @Override
-  public String toString(int dictionaryId) {
-    return Integer.toString(getInt(dictionaryId));
-  }
-
-  @Override
   public void readIntValues(int[] dictionaryIds, int startPos, int limit, int[] outValues, int outStartPos) {
     dataFileReader.readIntValues(dictionaryIds, 0 /*column*/, startPos, limit, outValues, outStartPos);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/LongDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/LongDictionary.java
@@ -65,11 +65,6 @@ public class LongDictionary extends ImmutableDictionaryReader {
     return (int) getLong(dictionaryId);
   }
 
-  @Override
-  public String toString(int dictionaryId) {
-    return Long.toString(getLong(dictionaryId));
-  }
-
   private long getLong(int dictionaryId) {
     return dataFileReader.getLong(dictionaryId, 0);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
@@ -90,11 +90,6 @@ public class StringDictionary extends ImmutableDictionaryReader {
   }
 
   @Override
-  public String toString(int dictionaryId) {
-    return get(dictionaryId);
-  }
-
-  @Override
   public void readIntValues(int[] dictionaryIds, int startPos, int limit, int[] outValues, int outStartPos) {
     throw new RuntimeException("Can not convert string to int");
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/DictionaryPerfRunner.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/DictionaryPerfRunner.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+/**
+ * Test the performance on {@link IntOnHeapMutableDictionary} vs {@link IntBiMapDictionary}.
+ */
+public class DictionaryPerfRunner {
+  private static final Runtime RUNTIME = Runtime.getRuntime();
+  private static final int NUM_VALUES = 5_000_000;
+  private static final int NUM_READERS = 5;
+  private static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(NUM_READERS);
+
+  /**
+   * Test the performance for value indexing, dictId fetching and value fetching.
+   * <p>We first index all values into the dictionary, then fetch dictIds and values from it.
+   * <p>Test both CPU (including random) and memory usage.
+   */
+  private static void readWritePerfOnCardinality(int cardinality) {
+    IntBiMapDictionary intBiMapDictionary = new IntBiMapDictionary("DummyColumn");
+    IntOnHeapMutableDictionary intOnHeapMutableDictionary = new IntOnHeapMutableDictionary();
+
+    System.out.println("Starting read write perf on cardinality: " + cardinality + " for " + NUM_VALUES + " values");
+    RUNTIME.gc();
+
+    long usedMemory = RUNTIME.totalMemory();
+    long start = System.currentTimeMillis();
+    for (int i = 0; i < NUM_VALUES; i++) {
+      intBiMapDictionary.index(i % cardinality);
+    }
+    System.out.println("Index time for IntBiMapDictionary: " + (System.currentTimeMillis() - start));
+    start = System.currentTimeMillis();
+    for (int i = 0; i < NUM_VALUES; i++) {
+      intBiMapDictionary.indexOf(i % cardinality);
+    }
+    System.out.println("DictId fetching time for IntBiMapDictionary: " + (System.currentTimeMillis() - start));
+    start = System.currentTimeMillis();
+    for (int i = 0; i < NUM_VALUES; i++) {
+      intBiMapDictionary.get(i % cardinality);
+    }
+    System.out.println("Value fetching time for IntBiMapDictionary: " + (System.currentTimeMillis() - start));
+    System.out.println("Memory usage for IntBiMapDictionary: " + (RUNTIME.totalMemory() - usedMemory));
+
+    System.out.println("--------------------------------------------------------------------------------");
+    usedMemory = RUNTIME.totalMemory();
+    start = System.currentTimeMillis();
+    for (int i = 0; i < NUM_VALUES; i++) {
+      intOnHeapMutableDictionary.index(i % cardinality);
+    }
+    System.out.println("Index time for IntOnHeapMutableDictionary: " + (System.currentTimeMillis() - start));
+    start = System.currentTimeMillis();
+    for (int i = 0; i < NUM_VALUES; i++) {
+      intOnHeapMutableDictionary.indexOf(i % cardinality);
+    }
+    System.out.println("DictId fetching time for IntOnHeapMutableDictionary: " + (System.currentTimeMillis() - start));
+    start = System.currentTimeMillis();
+    for (int i = 0; i < NUM_VALUES; i++) {
+      intOnHeapMutableDictionary.get(i % cardinality);
+    }
+    System.out.println("Value fetching time for IntOnHeapMutableDictionary: " + (System.currentTimeMillis() - start));
+    System.out.println("Memory usage for IntOnHeapMutableDictionary: " + (RUNTIME.totalMemory() - usedMemory));
+  }
+
+  /**
+   * Test the performance for multi-readers dictId fetching and value fetching.
+   * <p>We first index all values into the dictionary, then fetch dictIds and values from it.
+   */
+  private static void multiReadersPerfOnCardinality(final int cardinality)
+      throws InterruptedException {
+    final IntBiMapDictionary intBiMapDictionary = new IntBiMapDictionary("DummyColumn");
+    final IntOnHeapMutableDictionary intOnHeapMutableDictionary = new IntOnHeapMutableDictionary();
+
+    System.out.println(
+        "Starting multi-readers perf on cardinality: " + cardinality + " for " + NUM_VALUES + " values with "
+            + NUM_READERS + " readers");
+
+    // Index all values
+    for (int i = 0; i < cardinality; i++) {
+      intBiMapDictionary.index(i);
+      intOnHeapMutableDictionary.index(i);
+    }
+
+    // Count dictId and value fetching time
+    countMultiReadersFetchingTime(cardinality, intBiMapDictionary);
+    System.out.println("--------------------------------------------------------------------------------");
+    countMultiReadersFetchingTime(cardinality, intOnHeapMutableDictionary);
+  }
+
+  private static void countMultiReadersFetchingTime(final int cardinality, final Dictionary dictionary)
+      throws InterruptedException {
+    final CountDownLatch countDownLatch = new CountDownLatch(NUM_READERS);
+    final AtomicLong dictIdFetchingTime = new AtomicLong();
+    final AtomicLong valueFetchingTime = new AtomicLong();
+    for (int i = 0; i < NUM_READERS; i++) {
+      EXECUTOR_SERVICE.execute(new Runnable() {
+        @Override
+        public void run() {
+          long start = System.currentTimeMillis();
+          for (int i = 0; i < NUM_VALUES; i++) {
+            dictionary.indexOf(i % cardinality);
+          }
+          dictIdFetchingTime.addAndGet(System.currentTimeMillis() - start);
+          start = System.currentTimeMillis();
+          for (int i = 0; i < NUM_VALUES; i++) {
+            dictionary.get(i % cardinality);
+          }
+          valueFetchingTime.addAndGet(System.currentTimeMillis() - start);
+          countDownLatch.countDown();
+        }
+      });
+    }
+    countDownLatch.await();
+    System.out.println(
+        "Total dictId fetching time for " + dictionary.getClass().getSimpleName() + ": " + dictIdFetchingTime);
+    System.out.println(
+        "Total value fetching time for " + dictionary.getClass().getSimpleName() + ": " + valueFetchingTime);
+  }
+
+  public static void main(String[] args)
+      throws InterruptedException {
+    int cardinality = Integer.parseInt(args[0]);
+
+    System.out.println("--------------------------------------------------------------------------------");
+    readWritePerfOnCardinality(cardinality);
+    System.out.println("--------------------------------------------------------------------------------");
+    System.out.println("--------------------------------------------------------------------------------");
+    multiReadersPerfOnCardinality(cardinality);
+    System.out.println("--------------------------------------------------------------------------------");
+
+    EXECUTOR_SERVICE.shutdown();
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
@@ -15,16 +15,13 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.common.data.DimensionFieldSpec;
-import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 
 
 public class MultiValueDictionaryTest {
-  private static final String COL_NAME = "greek";
   private static final int NROWS = 1000;
   private static final int MAX_N_VALUES = FixedByteSingleColumnMultiValueReaderWriter.DEFAULT_MAX_NUMBER_OF_MULTIVALUES;
 
@@ -38,10 +35,9 @@ public class MultiValueDictionaryTest {
     }
   }
 
-  public void testMultiValueIndexing(final long seed)
+  private void testMultiValueIndexing(final long seed)
       throws Exception {
-    final FieldSpec mvIntFs = new DimensionFieldSpec(COL_NAME, FieldSpec.DataType.LONG, false);
-    final LongMutableDictionary dict = new LongMutableDictionary(COL_NAME);
+    final LongOnHeapMutableDictionary dict = new LongOnHeapMutableDictionary();
     final FixedByteSingleColumnMultiValueReaderWriter indexer =
         new FixedByteSingleColumnMultiValueReaderWriter(NROWS, Integer.SIZE / 8, MAX_N_VALUES, 2);
 


### PR DESCRIPTION
The dictionaries are thread safe under two conditions:
1. Single writer multiple readers
2. Reader always first get the dictId for a value, then use the dictId to fetch the value later

Enabled the ConcurrentReadWriteDictionaryTest

Added a DictionaryPerfRunner to perf both versions performance.
Here are sample results for cardinality 100, 10000 and 1000000, new implementation is leading on both CPU and memory usage.

--------------------------------------------------------------------------------
Starting read write perf on cardinality: 100 for 5000000 values
--------------------------------------------------------------------------------
Index time for IntBiMapDictionary: 111
DictId fetching time for IntBiMapDictionary: 146
Value fetching time for IntBiMapDictionary: 65
Memory usage for IntBiMapDictionary: 0
Index time for IntOnHeapMutableDictionary: 103
DictId fetching time for IntOnHeapMutableDictionary: 95
Value fetching time for IntOnHeapMutableDictionary: 46
Memory usage for IntOnHeapMutableDictionary: 0

Starting multi-readers perf on cardinality: 100 for 5000000 values with 5 readers
--------------------------------------------------------------------------------
Total dictId fetching time for IntBiMapDictionary: 695
Total value fetching time for IntBiMapDictionary: 507
Total dictId fetching time for IntOnHeapMutableDictionary: 768
Total value fetching time for IntOnHeapMutableDictionary: 393

--------------------------------------------------------------------------------
Starting read write perf on cardinality: 10000 for 5000000 values
--------------------------------------------------------------------------------

Index time for IntBiMapDictionary: 206
DictId fetching time for IntBiMapDictionary: 157
Value fetching time for IntBiMapDictionary: 85
Memory usage for IntBiMapDictionary: 45088768
Index time for IntOnHeapMutableDictionary: 128
DictId fetching time for IntOnHeapMutableDictionary: 107
Value fetching time for IntOnHeapMutableDictionary: 45
Memory usage for IntOnHeapMutableDictionary: 26738688

Starting multi-readers perf on cardinality: 10000 for 5000000 values with 5 readers
--------------------------------------------------------------------------------
Total dictId fetching time for IntBiMapDictionary: 1037
Total value fetching time for IntBiMapDictionary: 646
Total dictId fetching time for IntOnHeapMutableDictionary: 884
Total value fetching time for IntOnHeapMutableDictionary: 370

--------------------------------------------------------------------------------
Starting read write perf on cardinality: 1000000 for 5000000 values
--------------------------------------------------------------------------------

Index time for IntBiMapDictionary: 666
DictId fetching time for IntBiMapDictionary: 270
Value fetching time for IntBiMapDictionary: 173
Memory usage for IntBiMapDictionary: 62914560
Index time for IntOnHeapMutableDictionary: 473
DictId fetching time for IntOnHeapMutableDictionary: 155
Value fetching time for IntOnHeapMutableDictionary: 47
Memory usage for IntOnHeapMutableDictionary: 51380224

Starting multi-readers perf on cardinality: 1000000 for 5000000 values with 5 readers
--------------------------------------------------------------------------------
Total dictId fetching time for IntBiMapDictionary: 2003
Total value fetching time for IntBiMapDictionary: 955
Total dictId fetching time for IntOnHeapMutableDictionary: 865
Total value fetching time for IntOnHeapMutableDictionary: 258

--------------------------------------------------------------------------------