### PR TITLE
Change anomaly function's default delay time

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -316,11 +316,21 @@ public class AnomalyResource {
     TimeUnit dataGranularityUnit = dataGranularity.getUnit();
 
     // default window delay time = 10 hours
-    int windowDelayTime = 10;
-    TimeUnit windowDelayTimeUnit = TimeUnit.HOURS;
-
-    if(dataGranularityUnit.equals(TimeUnit.MINUTES) || dataGranularityUnit.equals(TimeUnit.HOURS)) {
-      windowDelayTime = 4;
+    int windowDelayTime;
+    TimeUnit windowDelayTimeUnit;
+    switch (dataGranularityUnit) {
+    case MINUTES:
+      windowDelayTime = 30;
+      windowDelayTimeUnit = TimeUnit.MINUTES;
+      break;
+    case DAYS:
+      windowDelayTime = 0;
+      windowDelayTimeUnit = TimeUnit.DAYS;
+      break;
+    case HOURS:
+    default:
+      windowDelayTime = 10;
+      windowDelayTimeUnit = TimeUnit.HOURS;
     }
     anomalyFunctionSpec.setWindowDelayUnit(windowDelayTimeUnit);
     anomalyFunctionSpec.setWindowDelay(windowDelayTime);


### PR DESCRIPTION
Add default delay time for data granularity equals MINUTES and DAYS; the default delay time is used during the creation of anomaly functions.