### PR TITLE
Removed parameterization of K for KeyedFuture interface.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/LiveInstancesChangeListenerImpl.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/LiveInstancesChangeListenerImpl.java
@@ -37,13 +37,13 @@ public class LiveInstancesChangeListenerImpl implements LiveInstanceChangeListen
 
   private long timeout;
   private final Map<String, String> liveInstanceToSessionIdMap;
-  private KeyedPool<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> connectionPool;
+  private KeyedPool<PooledNettyClientResourceManager.PooledClientConnection> connectionPool;
 
   public LiveInstancesChangeListenerImpl(String clusterName) {
     this.liveInstanceToSessionIdMap = new HashMap<String, String>();
   }
 
-  public void init(final KeyedPool<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> connectionPool, final long timeout) {
+  public void init(final KeyedPool<PooledNettyClientResourceManager.PooledClientConnection> connectionPool, final long timeout) {
     this.connectionPool = connectionPool;
     this.timeout = timeout;
   }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AbstractCompositeListenableFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AbstractCompositeListenableFuture.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.response.ServerInstance;
 
 
-public abstract class AbstractCompositeListenableFuture<T> implements KeyedFuture<T> {
+public abstract class AbstractCompositeListenableFuture<T> implements ServerResponseFuture<T> {
   protected static Logger LOGGER = LoggerFactory.getLogger(CompositeFuture.class);
 
   /**
@@ -181,7 +181,7 @@ public abstract class AbstractCompositeListenableFuture<T> implements KeyedFutur
   protected abstract boolean processFutureResult(String name, Map<ServerInstance, T> responses, Map<ServerInstance, Throwable> error,
       long durationMillis);
 
-  protected void addResponseFutureListener(KeyedFuture<T> future) {
+  protected void addResponseFutureListener(ServerResponseFuture<T> future) {
     future.addListener(new ResponseFutureListener(future), null); // no need for separate Executors
   }
 
@@ -189,9 +189,9 @@ public abstract class AbstractCompositeListenableFuture<T> implements KeyedFutur
    * Underlying Response future listener. This will count down the latch.
    */
   private class ResponseFutureListener implements Runnable {
-    private final KeyedFuture<T> _future;
+    private final ServerResponseFuture<T> _future;
 
-    public ResponseFutureListener(KeyedFuture<T> future) {
+    public ResponseFutureListener(ServerResponseFuture<T> future) {
       _future = future;
     }
 

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AbstractCompositeListenableFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AbstractCompositeListenableFuture.java
@@ -26,9 +26,10 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.response.ServerInstance;
 
 
-public abstract class AbstractCompositeListenableFuture<K, T> implements KeyedFuture<K, T> {
+public abstract class AbstractCompositeListenableFuture<T> implements KeyedFuture<T> {
   protected static Logger LOGGER = LoggerFactory.getLogger(CompositeFuture.class);
 
   /**
@@ -177,10 +178,10 @@ public abstract class AbstractCompositeListenableFuture<K, T> implements KeyedFu
    * @param durationMillis
    * @return true if processing done
    */
-  protected abstract boolean processFutureResult(String name, Map<K, T> responses, Map<K, Throwable> error,
+  protected abstract boolean processFutureResult(String name, Map<ServerInstance, T> responses, Map<ServerInstance, Throwable> error,
       long durationMillis);
 
-  protected void addResponseFutureListener(KeyedFuture<K, T> future) {
+  protected void addResponseFutureListener(KeyedFuture<T> future) {
     future.addListener(new ResponseFutureListener(future), null); // no need for separate Executors
   }
 
@@ -188,9 +189,9 @@ public abstract class AbstractCompositeListenableFuture<K, T> implements KeyedFu
    * Underlying Response future listener. This will count down the latch.
    */
   private class ResponseFutureListener implements Runnable {
-    private final KeyedFuture<K, T> _future;
+    private final KeyedFuture<T> _future;
 
-    public ResponseFutureListener(KeyedFuture<K, T> future) {
+    public ResponseFutureListener(KeyedFuture<T> future) {
       _future = future;
     }
 
@@ -206,7 +207,7 @@ public abstract class AbstractCompositeListenableFuture<K, T> implements KeyedFu
         _futureLock.unlock();
       }
 
-      Map<K, T> response = null;
+      Map<ServerInstance, T> response = null;
       try {
         response = _future.get();
       } catch (InterruptedException e) {
@@ -216,7 +217,7 @@ public abstract class AbstractCompositeListenableFuture<K, T> implements KeyedFu
       }
 
       // Since the future is done, it is safe to look at error results
-      Map<K, Throwable> error = _future.getError();
+      Map<ServerInstance, Throwable> error = _future.getError();
       boolean done = processFutureResult(_future.getName(), response, error, _future.getDurationMillis());
 
       if (done) {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
@@ -29,15 +29,16 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.response.ServerInstance;
 
 
-public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T> {
+public class AsyncResponseFuture<T> implements Callback<T>, KeyedFuture<T> {
   protected static Logger LOGGER = LoggerFactory.getLogger(AsyncResponseFuture.class);
 
   private Cancellable _cancellable;
 
   // Id for this future
-  private final K _key;
+  private final ServerInstance _key;
 
   // Lock for mutex
   private final Lock _futureLock = new ReentrantLock();
@@ -59,8 +60,8 @@ public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T>
   private final List<Executor> _pendingRunnableExecutors = new ArrayList<Executor>();
 
   // Cached response/errors
-  private volatile Map<K, T> _responseMap;
-  private volatile Map<K, Throwable> _errorMap;
+  private volatile Map<ServerInstance, T> _responseMap;
+  private volatile Map<ServerInstance, Throwable> _errorMap;
 
   // For  debug
   private final String _ctxt;
@@ -83,7 +84,7 @@ public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T>
   // State of the future
   private State _state;
 
-  public AsyncResponseFuture(K key, String ctxt) {
+  public AsyncResponseFuture(ServerInstance key, String ctxt) {
     _key = key;
     _state = State.PENDING;
     _cancellable = new NoopCancellable();
@@ -91,7 +92,7 @@ public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T>
     _startTime = System.currentTimeMillis();
   }
 
-  public AsyncResponseFuture(K key, Throwable t, String ctxt) {
+  public AsyncResponseFuture(ServerInstance key, Throwable t, String ctxt) {
     _key = key;
     _state = State.DONE;
     _error = t;
@@ -167,7 +168,7 @@ public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T>
   }
 
   @Override
-  public Map<K, T> get() throws InterruptedException, ExecutionException {
+  public Map<ServerInstance, T> get() throws InterruptedException, ExecutionException {
     try {
       _futureLock.lock();
       while (!_state.isCompleted()) {
@@ -224,12 +225,12 @@ public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T>
   }
 
   @Override
-  public Map<K, Throwable> getError() {
+  public Map<ServerInstance, Throwable> getError() {
     if ((null == _errorMap) && (null != _error)) {
       try {
         _futureLock.lock();
         if ((null == _errorMap) && (null != _error)) {
-          _errorMap = new HashMap<K, Throwable>();
+          _errorMap = new HashMap<ServerInstance, Throwable>();
           _errorMap.put(_key, _error);
         }
       } finally {
@@ -241,13 +242,13 @@ public class AsyncResponseFuture<K, T> implements Callback<T>, KeyedFuture<K, T>
 
   private void setResponseMap() {
     if (null != _delayedResponse) {
-      _responseMap = new HashMap<K, T>();
+      _responseMap = new HashMap<ServerInstance, T>();
       _responseMap.put(_key, _delayedResponse);
     }
   }
 
   @Override
-  public Map<K, T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+  public Map<ServerInstance, T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
     try {
       _futureLock.lock();
       while (!_state.isCompleted()) {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.response.ServerInstance;
 
 
-public class AsyncResponseFuture<T> implements Callback<T>, KeyedFuture<T> {
+public class AsyncResponseFuture<T> implements Callback<T>, ServerResponseFuture<T> {
   protected static Logger LOGGER = LoggerFactory.getLogger(AsyncResponseFuture.class);
 
   private Cancellable _cancellable;

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
@@ -56,7 +56,7 @@ public class CompositeFuture<V> extends AbstractCompositeListenableFuture<V> {
     AND,
   };
 
-  private final Collection<KeyedFuture<V>> _futures;
+  private final Collection<ServerResponseFuture<V>> _futures;
 
   // Composite Response
   private final ConcurrentMap<ServerInstance, V> _delayedResponseMap;
@@ -73,7 +73,7 @@ public class CompositeFuture<V> extends AbstractCompositeListenableFuture<V> {
 
   public CompositeFuture(String name, GatherModeOnError mode) {
     _name = name;
-    _futures = new ArrayList<KeyedFuture<V>>();
+    _futures = new ArrayList<ServerResponseFuture<V>>();
     _delayedResponseMap = new ConcurrentHashMap<ServerInstance, V>();
     _errorMap = new ConcurrentHashMap<ServerInstance, Throwable>();
     _gatherMode = mode;
@@ -83,7 +83,7 @@ public class CompositeFuture<V> extends AbstractCompositeListenableFuture<V> {
    * Start the future. This will add listener to the underlying futures. This method needs to be called
    * as soon the composite future is constructed and before any other method is invoked.
    */
-  public void start(Collection<KeyedFuture<V>> futureList) {
+  public void start(Collection<ServerResponseFuture<V>> futureList) {
     boolean started = super.start();
 
     if (!started) {
@@ -99,7 +99,7 @@ public class CompositeFuture<V> extends AbstractCompositeListenableFuture<V> {
     } else {
       _latch = new CountDownLatch(0);
     }
-    for (KeyedFuture<V> entry : _futures) {
+    for (ServerResponseFuture<V> entry : _futures) {
       if (null != entry) {
         addResponseFutureListener(entry);
       }
@@ -112,7 +112,7 @@ public class CompositeFuture<V> extends AbstractCompositeListenableFuture<V> {
    */
   @Override
   protected void cancelUnderlyingFutures() {
-    for (KeyedFuture<V> entry : _futures) {
+    for (ServerResponseFuture<V> entry : _futures) {
       entry.cancel(true);
     }
   }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.response.ServerInstance;
 
 
 /**
@@ -43,10 +44,9 @@ import org.slf4j.LoggerFactory;
  *
  * This future's value will be a map of each future's key and the corresponding underlying future's value.
  *
- * @param <K> Key to locate the specific future's value
  * @param <V> Value type of the underlying future
  */
-public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, V> {
+public class CompositeFuture<V> extends AbstractCompositeListenableFuture<V> {
   protected static Logger LOGGER = LoggerFactory.getLogger(CompositeFuture.class);
 
   public static enum GatherModeOnError {
@@ -56,15 +56,15 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
     AND,
   };
 
-  private final Collection<KeyedFuture<K, V>> _futures;
+  private final Collection<KeyedFuture<V>> _futures;
 
   // Composite Response
-  private final ConcurrentMap<K, V> _delayedResponseMap;
+  private final ConcurrentMap<ServerInstance, V> _delayedResponseMap;
 
   private final ConcurrentMap<String, Long> _responseTimeMap = new ConcurrentHashMap<>(10);
 
   // Exception in case of error
-  private final ConcurrentMap<K, Throwable> _errorMap;
+  private final ConcurrentMap<ServerInstance, Throwable> _errorMap;
 
   private final GatherModeOnError _gatherMode;
 
@@ -73,9 +73,9 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
 
   public CompositeFuture(String name, GatherModeOnError mode) {
     _name = name;
-    _futures = new ArrayList<KeyedFuture<K, V>>();
-    _delayedResponseMap = new ConcurrentHashMap<K, V>();
-    _errorMap = new ConcurrentHashMap<K, Throwable>();
+    _futures = new ArrayList<KeyedFuture<V>>();
+    _delayedResponseMap = new ConcurrentHashMap<ServerInstance, V>();
+    _errorMap = new ConcurrentHashMap<ServerInstance, Throwable>();
     _gatherMode = mode;
   }
 
@@ -83,7 +83,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
    * Start the future. This will add listener to the underlying futures. This method needs to be called
    * as soon the composite future is constructed and before any other method is invoked.
    */
-  public void start(Collection<KeyedFuture<K, V>> futureList) {
+  public void start(Collection<KeyedFuture<V>> futureList) {
     boolean started = super.start();
 
     if (!started) {
@@ -99,7 +99,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
     } else {
       _latch = new CountDownLatch(0);
     }
-    for (KeyedFuture<K, V> entry : _futures) {
+    for (KeyedFuture<V> entry : _futures) {
       if (null != entry) {
         addResponseFutureListener(entry);
       }
@@ -112,7 +112,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
    */
   @Override
   protected void cancelUnderlyingFutures() {
-    for (KeyedFuture<K, V> entry : _futures) {
+    for (KeyedFuture<V> entry : _futures) {
       entry.cancel(true);
     }
   }
@@ -121,7 +121,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
   /**
    *
    */
-  public Map<K, V> get() throws InterruptedException, ExecutionException {
+  public Map<ServerInstance, V> get() throws InterruptedException, ExecutionException {
     _latch.await();
     return _delayedResponseMap;
   }
@@ -150,7 +150,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
   }
 
   @Override
-  public Map<K, Throwable> getError() {
+  public Map<ServerInstance, Throwable> getError() {
     return _errorMap;
   }
 
@@ -169,7 +169,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
   }
 
   @Override
-  public Map<K, V> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+  public Map<ServerInstance, V> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
     _latch.await(timeout, unit);
     return _delayedResponseMap;
   }
@@ -183,7 +183,7 @@ public class CompositeFuture<K, V> extends AbstractCompositeListenableFuture<K, 
     return Collections.unmodifiableMap(_responseTimeMap);
   }
   @Override
-  protected boolean processFutureResult(String name, Map<K, V> response, Map<K, Throwable> error, long durationMillis) {
+  protected boolean processFutureResult(String name, Map<ServerInstance, V> response, Map<ServerInstance, Throwable> error, long durationMillis) {
     // Get the response time and create another map that can be invoked to get the end time when responses were received for each server.
     boolean ret = false;
     if (null != response) {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/KeyedFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/KeyedFuture.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import com.linkedin.pinot.common.response.ServerInstance;
 
 
 /**
@@ -39,10 +40,9 @@ import com.google.common.util.concurrent.ListenableFuture;
  * request dispatch with speculative (duplicate) request dispatching.
  *
  *
- * @param <K> Key type to identify a result/error
  * @param <V> Response Type
  */
-public interface KeyedFuture<K, V> extends ListenableFuture<Map<K, V>> {
+public interface KeyedFuture<V> extends ListenableFuture<Map<ServerInstance, V>> {
 
   /**
    * Returns a name of the future. The name of the future is not expected
@@ -87,5 +87,5 @@ public interface KeyedFuture<K, V> extends ListenableFuture<Map<K, V>> {
    * for the future to complete. It will just return the current error results
    * @return
    */
-  public Map<K, Throwable> getError();
+  public Map<ServerInstance, Throwable> getError();
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SelectingFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SelectingFuture.java
@@ -44,7 +44,7 @@ import com.linkedin.pinot.common.response.ServerInstance;
 public class SelectingFuture<T> extends AbstractCompositeListenableFuture<T> {
   protected static Logger LOGGER = LoggerFactory.getLogger(SelectingFuture.class);
 
-  private final List<KeyedFuture<T>> _futuresList;
+  private final List<ServerResponseFuture<T>> _futuresList;
 
   // First successful Response
   private volatile Map<ServerInstance, T> _delayedResponse;
@@ -58,7 +58,7 @@ public class SelectingFuture<T> extends AbstractCompositeListenableFuture<T> {
 
   public SelectingFuture(String name) {
     _name = name;
-    _futuresList = new ArrayList<KeyedFuture<T>>();
+    _futuresList = new ArrayList<ServerResponseFuture<T>>();
     _delayedResponse = null;
     _error = null;
   }
@@ -67,7 +67,7 @@ public class SelectingFuture<T> extends AbstractCompositeListenableFuture<T> {
    * Start the future. This will add listener to the underlying futures. This method needs to be called
    * as soon the composite future is constructed and before any other method is invoked.
    */
-  public void start(Collection<KeyedFuture<T>> futuresList) {
+  public void start(Collection<ServerResponseFuture<T>> futuresList) {
     boolean started = super.start();
 
     if (!started) {
@@ -78,7 +78,7 @@ public class SelectingFuture<T> extends AbstractCompositeListenableFuture<T> {
 
     _futuresList.addAll(futuresList);
     _latch = new CountDownLatch(futuresList.size());
-    for (KeyedFuture<T> entry : _futuresList) {
+    for (ServerResponseFuture<T> entry : _futuresList) {
       if (null != entry) {
         addResponseFutureListener(entry);
       }
@@ -91,7 +91,7 @@ public class SelectingFuture<T> extends AbstractCompositeListenableFuture<T> {
    */
   @Override
   protected void cancelUnderlyingFutures() {
-    for (KeyedFuture<T> entry : _futuresList) {
+    for (ServerResponseFuture<T> entry : _futuresList) {
       entry.cancel(true);
     }
   }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SelectingFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SelectingFuture.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.response.ServerInstance;
 
 
 /**
@@ -38,19 +39,18 @@ import org.slf4j.LoggerFactory;
  *
  * This future holds the first successfully completed future that notified (if any present) or
  * the last error (if all underlying futures failed)
- * @param <K> Key type used in underlying response futures
  * @param <T> Response object.
  */
-public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, T> {
+public class SelectingFuture<T> extends AbstractCompositeListenableFuture<T> {
   protected static Logger LOGGER = LoggerFactory.getLogger(SelectingFuture.class);
 
-  private final List<KeyedFuture<K, T>> _futuresList;
+  private final List<KeyedFuture<T>> _futuresList;
 
   // First successful Response
-  private volatile Map<K, T> _delayedResponse;
+  private volatile Map<ServerInstance, T> _delayedResponse;
 
   // Last Exception in case of error
-  private volatile Map<K, Throwable> _error;
+  private volatile Map<ServerInstance, Throwable> _error;
 
   private final String _name;
 
@@ -58,7 +58,7 @@ public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, 
 
   public SelectingFuture(String name) {
     _name = name;
-    _futuresList = new ArrayList<KeyedFuture<K, T>>();
+    _futuresList = new ArrayList<KeyedFuture<T>>();
     _delayedResponse = null;
     _error = null;
   }
@@ -67,7 +67,7 @@ public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, 
    * Start the future. This will add listener to the underlying futures. This method needs to be called
    * as soon the composite future is constructed and before any other method is invoked.
    */
-  public void start(Collection<KeyedFuture<K, T>> futuresList) {
+  public void start(Collection<KeyedFuture<T>> futuresList) {
     boolean started = super.start();
 
     if (!started) {
@@ -78,7 +78,7 @@ public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, 
 
     _futuresList.addAll(futuresList);
     _latch = new CountDownLatch(futuresList.size());
-    for (KeyedFuture<K, T> entry : _futuresList) {
+    for (KeyedFuture<T> entry : _futuresList) {
       if (null != entry) {
         addResponseFutureListener(entry);
       }
@@ -91,24 +91,24 @@ public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, 
    */
   @Override
   protected void cancelUnderlyingFutures() {
-    for (KeyedFuture<K, T> entry : _futuresList) {
+    for (KeyedFuture<T> entry : _futuresList) {
       entry.cancel(true);
     }
   }
 
   @Override
-  public Map<K, T> get() throws InterruptedException, ExecutionException {
+  public Map<ServerInstance, T> get() throws InterruptedException, ExecutionException {
     _latch.await();
     return _delayedResponse;
   }
 
   @Override
-  public Map<K, Throwable> getError() {
+  public Map<ServerInstance, Throwable> getError() {
     return _error;
   }
 
   @Override
-  public Map<K, T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+  public Map<ServerInstance, T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
     _latch.await(timeout, unit);
     return _delayedResponse;
   }
@@ -142,7 +142,7 @@ public class SelectingFuture<K, T> extends AbstractCompositeListenableFuture<K, 
   }
 
   @Override
-  protected boolean processFutureResult(String name, Map<K, T> response, Map<K, Throwable> error, long durationMillis) {
+  protected boolean processFutureResult(String name, Map<ServerInstance, T> response, Map<ServerInstance, Throwable> error, long durationMillis) {
     // Add an argument here to get the time of completion of the future.
     boolean done = false;
     if ((null != response)) {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/ServerResponseFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/ServerResponseFuture.java
@@ -42,7 +42,7 @@ import com.linkedin.pinot.common.response.ServerInstance;
  *
  * @param <V> Response Type
  */
-public interface KeyedFuture<V> extends ListenableFuture<Map<ServerInstance, V>> {
+public interface ServerResponseFuture<V> extends ListenableFuture<Map<ServerInstance, V>> {
 
   /**
    * Returns a name of the future. The name of the future is not expected

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyClientConnection.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyClientConnection.java
@@ -121,7 +121,7 @@ public abstract class NettyClientConnection {
    * Future Handle provided to the request sender to asynchronously wait for response.
    * We use guava API for implementing Futures.
    */
-  public static class ResponseFuture extends AsyncResponseFuture<ServerInstance, ByteBuf> {
+  public static class ResponseFuture extends AsyncResponseFuture<ByteBuf> {
 
     public ResponseFuture(ServerInstance key, String ctxt) {
       super(key, ctxt);

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/PooledNettyClientResourceManager.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/PooledNettyClientResourceManager.java
@@ -27,11 +27,11 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.util.Timer;
 
 
-public class PooledNettyClientResourceManager implements PooledResourceManager<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> {
+public class PooledNettyClientResourceManager implements PooledResourceManager<PooledNettyClientResourceManager.PooledClientConnection> {
 
   protected static Logger LOGGER = LoggerFactory.getLogger(PooledNettyClientResourceManager.class);
 
-  private KeyedPool<ServerInstance, PooledClientConnection> _pool;
+  private KeyedPool<PooledClientConnection> _pool;
   private final EventLoopGroup _eventLoop;
   private final NettyClientMetrics _metrics;
   private final Timer _timer;
@@ -42,7 +42,7 @@ public class PooledNettyClientResourceManager implements PooledResourceManager<S
     _timer = timer;
   }
 
-  public void setPool(KeyedPool<ServerInstance, PooledClientConnection> pool) {
+  public void setPool(KeyedPool<PooledClientConnection> pool) {
     _pool = pool;
   }
 
@@ -87,10 +87,10 @@ public class PooledNettyClientResourceManager implements PooledResourceManager<S
    *
    */
   public class PooledClientConnection extends NettyTCPClientConnection implements Callback<NoneType> {
-    private final KeyedPool<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> _pool;
+    private final KeyedPool<PooledNettyClientResourceManager.PooledClientConnection> _pool;
     private boolean _destroyed = false;
 
-    public PooledClientConnection(KeyedPool<ServerInstance, PooledClientConnection> pool, ServerInstance server,
+    public PooledClientConnection(KeyedPool<PooledClientConnection> pool, ServerInstance server,
         EventLoopGroup eventGroup, Timer timer, NettyClientMetrics metric) {
       super(server, eventGroup, timer, metric);
       _pool = pool;

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/AsyncPoolResourceManagerAdapter.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/AsyncPoolResourceManagerAdapter.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linkedin.pinot.common.metrics.LatencyMetric;
 import com.linkedin.pinot.common.metrics.MetricsHelper;
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.Callback;
 import com.linkedin.pinot.transport.metrics.PoolStats.LifecycleStats;
 import com.linkedin.pinot.transport.pool.AsyncPool.Lifecycle;
@@ -32,16 +33,16 @@ import com.yammer.metrics.core.MetricsRegistry;
 
 // The create() and destoy() methods in this class are ONLY called from
 // AsyncPoolImpl when a connection needs to be created or destroyed.
-public class AsyncPoolResourceManagerAdapter<K, T> implements Lifecycle<T> {
+public class AsyncPoolResourceManagerAdapter<T> implements Lifecycle<T> {
   private static final Logger LOGGER = LoggerFactory.getLogger(AsyncPoolResourceManagerAdapter.class);
 
-  private final PooledResourceManager<K, T> _resourceManager;
+  private final PooledResourceManager<T> _resourceManager;
   private final ExecutorService _executor;
-  private final K _key;
+  private final ServerInstance _key;
   private final Histogram _histogram;
   private boolean _isShuttingDown = false;
 
-  public AsyncPoolResourceManagerAdapter(K key, PooledResourceManager<K, T> resourceManager,
+  public AsyncPoolResourceManagerAdapter(ServerInstance key, PooledResourceManager<T> resourceManager,
       ExecutorService executorService, MetricsRegistry registry) {
     _resourceManager = resourceManager;
     _executor = executorService;

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPool.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPool.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.transport.pool;
 
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
 import com.linkedin.pinot.transport.common.KeyedFuture;
 import com.linkedin.pinot.transport.common.NoneType;
@@ -32,7 +33,7 @@ import com.yammer.metrics.core.Histogram;
  *
  * @param <T>
  */
-public interface KeyedPool<K, T> extends PoolStatsProvider<Histogram> {
+public interface KeyedPool<T> extends PoolStatsProvider<Histogram> {
 
   /**
    * Start the pool.
@@ -60,7 +61,7 @@ public interface KeyedPool<K, T> extends PoolStatsProvider<Histogram> {
    * @param key the key identifying the inner pool which manages the resources.
    * @return A {@link AsyncResponseFuture} whose get() method will return the actual resource
    */
-  public KeyedFuture<K, T> checkoutObject(K key);
+  public KeyedFuture<T> checkoutObject(ServerInstance key);
 
   /**
    * Validates all object in the pool with key.
@@ -70,7 +71,7 @@ public interface KeyedPool<K, T> extends PoolStatsProvider<Histogram> {
    * @param recreate recreates invalid objects
    * @return
    */
-  public boolean validatePool(K key, boolean recreate);
+  public boolean validatePool(ServerInstance key, boolean recreate);
 
   /**
    * Return a previously checked out object to the pool.  It is an error to return an object to
@@ -78,7 +79,7 @@ public interface KeyedPool<K, T> extends PoolStatsProvider<Histogram> {
    *
    * @param object the object to be returned
    */
-  public void checkinObject(K key, T object);
+  public void checkinObject(ServerInstance key, T object);
 
   /**
    * Dispose of a checked out object which is not operating correctly.  It is an error to
@@ -87,7 +88,7 @@ public interface KeyedPool<K, T> extends PoolStatsProvider<Histogram> {
    * @param key the key identifying the inner pool
    * @param object the object to be disposed
    */
-  public void destroyObject(K key, T object);
+  public void destroyObject(ServerInstance key, T object);
 
   /**
    * Initiate an orderly shutdown of the pool.  The pool will immediately stop accepting
@@ -99,5 +100,5 @@ public interface KeyedPool<K, T> extends PoolStatsProvider<Histogram> {
    *
    * @return composite Future which you can call get() to wait for shutdown.
    */
-  public KeyedFuture<K, NoneType> shutdown();
+  public KeyedFuture<NoneType> shutdown();
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPool.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPool.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.transport.pool;
 
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
-import com.linkedin.pinot.transport.common.KeyedFuture;
+import com.linkedin.pinot.transport.common.ServerResponseFuture;
 import com.linkedin.pinot.transport.common.NoneType;
 import com.linkedin.pinot.transport.metrics.PoolStatsProvider;
 import com.yammer.metrics.core.Histogram;
@@ -61,7 +61,7 @@ public interface KeyedPool<T> extends PoolStatsProvider<Histogram> {
    * @param key the key identifying the inner pool which manages the resources.
    * @return A {@link AsyncResponseFuture} whose get() method will return the actual resource
    */
-  public KeyedFuture<T> checkoutObject(ServerInstance key);
+  public ServerResponseFuture<T> checkoutObject(ServerInstance key);
 
   /**
    * Validates all object in the pool with key.
@@ -100,5 +100,5 @@ public interface KeyedPool<T> extends PoolStatsProvider<Histogram> {
    *
    * @return composite Future which you can call get() to wait for shutdown.
    */
-  public KeyedFuture<NoneType> shutdown();
+  public ServerResponseFuture<NoneType> shutdown();
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
 import com.linkedin.pinot.transport.common.Callback;
 import com.linkedin.pinot.transport.common.Cancellable;
@@ -39,7 +40,7 @@ import com.yammer.metrics.core.Histogram;
 import com.yammer.metrics.core.MetricsRegistry;
 
 
-public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
+public class KeyedPoolImpl<T> implements KeyedPool<T> {
 
   protected static Logger LOGGER = LoggerFactory.getLogger(KeyedPoolImpl.class);
 
@@ -68,13 +69,13 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
   private final ScheduledExecutorService _timeoutExecutor;
 
   //Resource Manager Callback
-  private final PooledResourceManager<K, T> _resourceManager;
+  private final PooledResourceManager<T> _resourceManager;
 
   // Executor Service for creating/removing resources
   private final ExecutorService _executorService;
 
   // Shutdown Future
-  private CompositeFuture<K, NoneType> _shutdownFuture;
+  private CompositeFuture<NoneType> _shutdownFuture;
 
   private final MetricsRegistry _metricRegistry;
 
@@ -83,9 +84,9 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
   /**
    * Map of AsyncPools
    */
-  private final ConcurrentMap<K, AsyncPool<T>> _keyedPool;
+  private final ConcurrentMap<ServerInstance, AsyncPool<T>> _keyedPool;
 
-  private final ConcurrentMap<K, AsyncPoolResourceManagerAdapter<K, T>> _pooledResourceManagerMap;
+  private final ConcurrentMap<ServerInstance, AsyncPoolResourceManagerAdapter<T>> _pooledResourceManagerMap;
 
   /**
    * All modifications of _keyedPool and all access to _state must be locked on _mutex.
@@ -94,10 +95,10 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
   private final Object _mutex = new Object();
 
   public KeyedPoolImpl(int minResourcesPerKey, int maxResourcesPerKey, long idleTimeoutMs,
-      int maxPendingCheckoutRequests, PooledResourceManager<K, T> resourceManager,
+      int maxPendingCheckoutRequests, PooledResourceManager<T> resourceManager,
       ScheduledExecutorService timeoutExecutorService, ExecutorService executorService, MetricsRegistry registry) {
-    _keyedPool = new ConcurrentHashMap<K, AsyncPool<T>>();
-    _pooledResourceManagerMap = new ConcurrentHashMap<K, AsyncPoolResourceManagerAdapter<K, T>>();
+    _keyedPool = new ConcurrentHashMap<ServerInstance, AsyncPool<T>>();
+    _pooledResourceManagerMap = new ConcurrentHashMap<ServerInstance, AsyncPoolResourceManagerAdapter<T>>();
     _minResourcesPerKey = minResourcesPerKey;
     _maxResourcesPerKey = maxResourcesPerKey;
     _idleTimeoutMs = idleTimeoutMs;
@@ -116,7 +117,7 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
   }
 
   @Override
-  public KeyedFuture<K, T> checkoutObject(K key) {
+  public KeyedFuture<T> checkoutObject(ServerInstance key) {
     AsyncPool<T> pool = _keyedPool.get(key);
 
     if (null == pool) {
@@ -124,8 +125,8 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
         pool = _keyedPool.get(key);
         if (null == pool) {
           String poolName = "Pool for (" + key + ")";
-          AsyncPoolResourceManagerAdapter<K, T> rmAdapter =
-              new AsyncPoolResourceManagerAdapter<K, T>(key, _resourceManager, _executorService, _metricRegistry);
+          AsyncPoolResourceManagerAdapter<T> rmAdapter =
+              new AsyncPoolResourceManagerAdapter<T>(key, _resourceManager, _executorService, _metricRegistry);
           pool = new AsyncPoolImpl<T>(poolName, rmAdapter, _maxResourcesPerKey, _idleTimeoutMs, _timeoutExecutor,
               _executorService, _maxPendingCheckoutRequests, Strategy.LRU, _minResourcesPerKey, _metricRegistry);
           _keyedPool.put(key, pool);
@@ -136,14 +137,14 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
       }
     }
 
-    AsyncResponseFuture<K, T> future = new AsyncResponseFuture<K, T>(key, "Checkout future for key " + key);
+    AsyncResponseFuture<T> future = new AsyncResponseFuture<T>(key, "Checkout future for key " + key);
     Cancellable cancellable = pool.get(future);
     future.setCancellable(cancellable);
     return future;
   }
 
   @Override
-  public void checkinObject(K key, T object) {
+  public void checkinObject(ServerInstance key, T object) {
     AsyncPool<T> pool = _keyedPool.get(key);
     if (null != pool) {
       pool.put(object);
@@ -154,7 +155,7 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
   }
 
   @Override
-  public void destroyObject(K key, T object) {
+  public void destroyObject(ServerInstance key, T object) {
     AsyncPool<T> pool = _keyedPool.get(key);
     LOGGER.info("Destroying object for the key (" + key + ") object :" + object);
     if (null != pool) {
@@ -166,7 +167,7 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
   }
 
   @Override
-  public KeyedFuture<K, NoneType> shutdown() {
+  public KeyedFuture<NoneType> shutdown() {
     synchronized (_mutex) {
       if ((_state == State.SHUTTING_DOWN) || (_state == State.SHUTDOWN)) {
         return _shutdownFuture;
@@ -174,9 +175,9 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
 
       _state = State.SHUTTING_DOWN;
 
-      List<KeyedFuture<K, NoneType>> futureList = new ArrayList<KeyedFuture<K, NoneType>>();
-      for (Entry<K, AsyncPool<T>> poolEntry : _keyedPool.entrySet()) {
-        AsyncResponseFuture<K, NoneType> shutdownFuture = new AsyncResponseFuture<K, NoneType>(poolEntry.getKey(),
+      List<KeyedFuture< NoneType>> futureList = new ArrayList<KeyedFuture<NoneType>>();
+      for (Entry<ServerInstance, AsyncPool<T>> poolEntry : _keyedPool.entrySet()) {
+        AsyncResponseFuture<NoneType> shutdownFuture = new AsyncResponseFuture<NoneType>(poolEntry.getKey(),
             "Shutdown future for pool entry " + poolEntry.getKey());
         poolEntry.getValue().shutdown(shutdownFuture);
         futureList.add(shutdownFuture);
@@ -190,7 +191,7 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
           poolEntry.getValue().shutdown(shutdownFuture);
         }
       }
-      _shutdownFuture = new CompositeFuture<K, NoneType>("Shutdown For Pool", GatherModeOnError.AND);
+      _shutdownFuture = new CompositeFuture<NoneType>("Shutdown For Pool", GatherModeOnError.AND);
       _shutdownFuture.start(futureList);
       _shutdownFuture.addListener(new Runnable() {
 
@@ -211,7 +212,7 @@ public class KeyedPoolImpl<K, T> implements KeyedPool<K, T> {
   }
 
   @Override
-  public boolean validatePool(K key, boolean recreate) {
+  public boolean validatePool(ServerInstance key, boolean recreate) {
     AsyncPool<T> pool = _keyedPool.get(key);
     if (pool != null) {
       return pool.validate(recreate);

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
@@ -31,7 +31,7 @@ import com.linkedin.pinot.transport.common.Callback;
 import com.linkedin.pinot.transport.common.Cancellable;
 import com.linkedin.pinot.transport.common.CompositeFuture;
 import com.linkedin.pinot.transport.common.CompositeFuture.GatherModeOnError;
-import com.linkedin.pinot.transport.common.KeyedFuture;
+import com.linkedin.pinot.transport.common.ServerResponseFuture;
 import com.linkedin.pinot.transport.common.NoneType;
 import com.linkedin.pinot.transport.metrics.AggregatedPoolStats;
 import com.linkedin.pinot.transport.metrics.PoolStats;
@@ -117,7 +117,7 @@ public class KeyedPoolImpl<T> implements KeyedPool<T> {
   }
 
   @Override
-  public KeyedFuture<T> checkoutObject(ServerInstance key) {
+  public ServerResponseFuture<T> checkoutObject(ServerInstance key) {
     AsyncPool<T> pool = _keyedPool.get(key);
 
     if (null == pool) {
@@ -167,7 +167,7 @@ public class KeyedPoolImpl<T> implements KeyedPool<T> {
   }
 
   @Override
-  public KeyedFuture<NoneType> shutdown() {
+  public ServerResponseFuture<NoneType> shutdown() {
     synchronized (_mutex) {
       if ((_state == State.SHUTTING_DOWN) || (_state == State.SHUTDOWN)) {
         return _shutdownFuture;
@@ -175,7 +175,7 @@ public class KeyedPoolImpl<T> implements KeyedPool<T> {
 
       _state = State.SHUTTING_DOWN;
 
-      List<KeyedFuture< NoneType>> futureList = new ArrayList<KeyedFuture<NoneType>>();
+      List<ServerResponseFuture< NoneType>> futureList = new ArrayList<ServerResponseFuture<NoneType>>();
       for (Entry<ServerInstance, AsyncPool<T>> poolEntry : _keyedPool.entrySet()) {
         AsyncResponseFuture<NoneType> shutdownFuture = new AsyncResponseFuture<NoneType>(poolEntry.getKey(),
             "Shutdown future for pool entry " + poolEntry.getKey());

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/PooledResourceManager.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/PooledResourceManager.java
@@ -15,23 +15,25 @@
  */
 package com.linkedin.pinot.transport.pool;
 
+import com.linkedin.pinot.common.response.ServerInstance;
+
+
 /**
  *
  * Interface to create/destroy and validate pooled resource
  * The implementation is expected to be thread-safe as concurrent request to create connection for same/different servers
  * is possible.
  *
- * @param <K>
  * @param <T>
  */
-public interface PooledResourceManager<K, T> {
+public interface PooledResourceManager<T> {
 
   /**
    * Create a new resource
    * @param key to identify the pool which will host the resource
    * @return future for the resource creation
    */
-  public T create(K key);
+  public T create(ServerInstance key);
 
   /**
    * Destroy the pooled resource
@@ -40,7 +42,7 @@ public interface PooledResourceManager<K, T> {
    * @param resource Resource to be destroyed
    * @return true if successfully destroyed the resource, false otherwise
    */
-  public boolean destroy(K key, boolean isBad, T resource);
+  public boolean destroy(ServerInstance key, boolean isBad, T resource);
 
   /**
    * Validate if the resource is good.
@@ -49,6 +51,6 @@ public interface PooledResourceManager<K, T> {
    * @param resource
    * @return
    */
-  public boolean validate(K key, T resource);
+  public boolean validate(ServerInstance key, T resource);
 
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGather.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGather.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.transport.scattergather;
 
 import com.linkedin.pinot.common.metrics.BrokerMetrics;
-import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.CompositeFuture;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
@@ -52,13 +51,13 @@ public interface ScatterGather {
    * Hence, the client is responsible for calling release() on the response.
    */
   @Nonnull
-  CompositeFuture<ServerInstance, ByteBuf> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
+  CompositeFuture<ByteBuf> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
       @Nonnull ScatterGatherStats scatterGatherStats, @Nullable Boolean isOfflineTable,
       @Nonnull BrokerMetrics brokerMetrics)
       throws InterruptedException;
 
   @Nonnull
-  CompositeFuture<ServerInstance, ByteBuf> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
+  CompositeFuture<ByteBuf> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
       @Nonnull ScatterGatherStats scatterGatherStats, @Nonnull BrokerMetrics brokerMetrics)
       throws InterruptedException;
 }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/CompositeFutureTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/CompositeFutureTest.java
@@ -24,12 +24,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.CompositeFuture.GatherModeOnError;
 
 
@@ -42,18 +41,18 @@ public class CompositeFutureTest {
    * @throws Exception
    */
   public void testMultiFutureComposite1() throws Exception {
-    List<String> keys = new ArrayList<String>();
+    List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
-    Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
-    Map<String, String> expectedMessages = new HashMap<String, String>();
+    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+    Map<ServerInstance, String> expectedMessages = new HashMap<>();
     for (int i = 0; i < numFutures; i++) {
-      String key = "key_" + i;
+      ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key, "");
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key, "");
       futureMap.put(key, future);
     }
-    CompositeFuture<String, String> compositeFuture =
-        new CompositeFuture<String, String>("test", GatherModeOnError.AND);
+    CompositeFuture<String> compositeFuture =
+        new CompositeFuture<String>("test", GatherModeOnError.AND);
     compositeFuture.start(futureMap.values());
     ResponseCompositeFutureClientRunnerListener runner =
         new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -69,8 +68,8 @@ public class CompositeFutureTest {
     // Send response for underlying futures
     for (int i = 0; i < numFutures; i++) {
       String message = "dummy Message_" + i;
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       future.onSuccess(message);
       expectedMessages.put(k, message);
     }
@@ -80,12 +79,12 @@ public class CompositeFutureTest {
     Assert.assertTrue(runner.isDone(), "Composite Is Done ? ");
     Assert.assertTrue(runner.getError().isEmpty(), "Composite No Error :");
 
-    Map<String, String> runnerResponse = runner.getMessage();
-    Map<String, String> listenerResponse = listener.getMessage();
+    Map<ServerInstance, String> runnerResponse = runner.getMessage();
+    Map<ServerInstance, String> listenerResponse = listener.getMessage();
 
     for (int i = 0; i < numFutures; i++) {
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       Assert.assertFalse(future.isCancelled(), "Cancelled ?");
       Assert.assertTrue(future.isDone(), "Is Done ? ");
       Assert.assertEquals(future.getOne(), expectedMessages.get(k), "Reponse :");
@@ -106,17 +105,17 @@ public class CompositeFutureTest {
    * @throws Exception
    */
   public void testMultiFutureComposite2() throws Exception {
-    List<String> keys = new ArrayList<String>();
+    List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
-    Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
-    Map<String, Exception> expectedErrors = new HashMap<String, Exception>();
+    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+    Map<ServerInstance, Exception> expectedErrors = new HashMap<>();
     for (int i = 0; i < numFutures; i++) {
-      String key = "key_" + i;
+      ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key, "");
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key, "");
       futureMap.put(key, future);
     }
-    CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+    CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
     compositeFuture.start(futureMap.values());
     ResponseCompositeFutureClientRunnerListener runner =
         new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -132,9 +131,9 @@ public class CompositeFutureTest {
     // Send response for underlying futures
     for (int i = 0; i < numFutures; i++) {
       Exception expectedError = new Exception("error processing_" + i);
-      String k = "key_" + i;
-      KeyedFuture<String, String> future = futureMap.get(k);
-      ((AsyncResponseFuture<String, String>) future).onError(expectedError);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      KeyedFuture<String> future = futureMap.get(k);
+      ((AsyncResponseFuture<String>) future).onError(expectedError);
       expectedErrors.put(k, expectedError);
     }
 
@@ -143,12 +142,12 @@ public class CompositeFutureTest {
     Assert.assertTrue(runner.isDone(), "Composite Is Done ? ");
     Assert.assertTrue(runner.getMessage().isEmpty(), "Composite No Response :");
 
-    Map<String, Throwable> runnerException = runner.getError();
-    Map<String, Throwable> listenerException = listener.getError();
+    Map<ServerInstance, Throwable> runnerException = runner.getError();
+    Map<ServerInstance, Throwable> listenerException = listener.getError();
 
     for (int i = 0; i < numFutures; i++) {
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       Assert.assertFalse(future.isCancelled(), "Cancelled ?");
       Assert.assertTrue(future.isDone(), "Is Done ? ");
       Assert.assertEquals(future.getError().values().iterator().next(), expectedErrors.get(k), "Error :");
@@ -170,17 +169,17 @@ public class CompositeFutureTest {
    */
   public void testMultiFutureComposite3() throws Exception {
 
-    List<String> keys = new ArrayList<String>();
+    List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
     int numSuccessFutures = 50;
-    Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
+    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
     for (int i = 0; i < numFutures; i++) {
-      String key = "key_" + i;
+      ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key, "");
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<String>(key, "");
       futureMap.put(key, future);
     }
-    CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+    CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
     compositeFuture.start(futureMap.values());
     ResponseCompositeFutureClientRunnerListener runner =
         new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -198,16 +197,16 @@ public class CompositeFutureTest {
     // Send response for some of the underlying futures
     for (int i = 0; i < numSuccessFutures; i++) {
       String message = "dummy Message_" + i;
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       future.onSuccess(message);
     }
 
     // Send exception for some of the underlying futures
     for (int i = numSuccessFutures; i < numFutures; i++) {
       Exception expectedError = new Exception("error processing_" + i);
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       future.onError(expectedError);
     }
 
@@ -218,8 +217,8 @@ public class CompositeFutureTest {
     Assert.assertTrue(runner.getError().isEmpty(), "Composite No Error :");
 
     for (int i = 0; i < numFutures; i++) {
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       Assert.assertTrue(future.isCancelled(), "Cancelled ?");
       Assert.assertTrue(future.isDone(), "Is Done ? ");
       Assert.assertNull(future.get(), "No Reponse :");
@@ -240,20 +239,20 @@ public class CompositeFutureTest {
    * @throws Exception
    */
   public void testMultiFutureComposite4() throws Exception {
-    List<String> keys = new ArrayList<String>();
+    List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
     int numSuccessFutures = 5;
-    Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
-    Map<String, String> expectedMessages = new HashMap<String, String>();
+    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+    Map<ServerInstance, String> expectedMessages = new HashMap<>();
 
     for (int i = 0; i < numFutures; i++) {
-      String key = "key_" + i;
+      ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key, "");
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key, "");
       futureMap.put(key, future);
     }
-    CompositeFuture<String, String> compositeFuture =
-        new CompositeFuture<String, String>("a", GatherModeOnError.SHORTCIRCUIT_AND); //stopOnError = true
+    CompositeFuture<String> compositeFuture =
+        new CompositeFuture<>("a", GatherModeOnError.SHORTCIRCUIT_AND); //stopOnError = true
     compositeFuture.start(futureMap.values());
     ResponseCompositeFutureClientRunnerListener runner =
         new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -269,16 +268,16 @@ public class CompositeFutureTest {
     // Send response for underlying futures
     for (int i = 0; i < numSuccessFutures; i++) {
       String message = "dummy Message_" + i;
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       future.onSuccess(message);
       expectedMessages.put(k, message);
     }
 
     // Send error. This should complete the future/.
-    String errorKey = "key_" + numSuccessFutures;
+    ServerInstance errorKey = new ServerInstance("localhost:" + numSuccessFutures);
     Exception expectedException = new Exception("Exception");
-    AsyncResponseFuture<String, String> f = (AsyncResponseFuture<String, String>) futureMap.get(errorKey);
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) futureMap.get(errorKey);
     f.onError(expectedException);
     runner.waitForDone();
 
@@ -287,14 +286,14 @@ public class CompositeFutureTest {
     Assert.assertFalse(listener.isCancelled(), "listener Cancelled ?");
     Assert.assertTrue(listener.isDone(), "listener Is Done ? ");
 
-    Map<String, Throwable> runnerException = runner.getError();
-    Map<String, String> runnerMessages = runner.getMessage();
-    Map<String, String> listenerMessages = listener.getMessage();
-    Map<String, Throwable> listenerException = listener.getError();
+    Map<ServerInstance, Throwable> runnerException = runner.getError();
+    Map<ServerInstance, String> runnerMessages = runner.getMessage();
+    Map<ServerInstance, String> listenerMessages = listener.getMessage();
+    Map<ServerInstance, Throwable> listenerException = listener.getError();
 
     for (int i = 0; i < numSuccessFutures; i++) {
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       Assert.assertFalse(future.isCancelled(), "Cancelled ?");
       Assert.assertTrue(future.isDone(), "Is Done ? ");
       Assert.assertEquals(future.getOne(), expectedMessages.get(k), "Reponse :");
@@ -303,8 +302,8 @@ public class CompositeFutureTest {
       Assert.assertEquals(listenerMessages.get(k), expectedMessages.get(k), "Message_" + i);
     }
 
-    String key1 = "key_" + numSuccessFutures;
-    f = (AsyncResponseFuture<String, String>) futureMap.get(key1);
+    ServerInstance key1 = new ServerInstance("localhost:" + numSuccessFutures);
+    f = (AsyncResponseFuture<String>) futureMap.get(key1);
     Assert.assertFalse(f.isCancelled(), "Cancelled ?");
     Assert.assertTrue(f.isDone(), "Is Done ? ");
     Assert.assertEquals(f.getError().values().iterator().next(), expectedException, "Exception :");
@@ -313,8 +312,8 @@ public class CompositeFutureTest {
     Assert.assertEquals(listenerException.get(key1), expectedException, "Exception_" + numSuccessFutures);
 
     for (int i = numSuccessFutures + 1; i < numFutures; i++) {
-      String k = "key_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureMap.get(k);
+      ServerInstance k = new ServerInstance("localhost:" + i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureMap.get(k);
       Assert.assertTrue(future.isCancelled(), "Cancelled ?");
       Assert.assertTrue(future.isDone(), "Is Done ? ");
       Assert.assertNull(future.get(), "No Reponse :");
@@ -335,15 +334,15 @@ public class CompositeFutureTest {
    */
   public void testSingleFutureComposite() throws Exception {
 
-    String key1 = "localhost:8080";
+    ServerInstance key1 = new ServerInstance("localhost:8080");
 
     //Cancelled Future. Future Client calls get() and another listens before cancel().
     // A response and exception arrives after cancel but they should be discarded.
     {
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key1, "");
-      Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
+      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
-      CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+      CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
       ResponseCompositeFutureClientRunnerListener runner =
           new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -381,10 +380,10 @@ public class CompositeFutureTest {
     //Cancelled Future. Future Client calls get() and another listens after cancel()
     // A response and exception arrives after cancel but they should be discarded.
     {
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key1, "");
-      Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
+      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
-      CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+      CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
       ResponseCompositeFutureClientRunnerListener runner =
           new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -422,10 +421,10 @@ public class CompositeFutureTest {
     // Throw Exception. Future Client calls get() and another listens before exception
     // A response and cancellation arrives after exception but they should be discarded.
     {
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key1, "");
-      Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
+      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
-      CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+      CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
       ResponseCompositeFutureClientRunnerListener runner =
           new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -463,10 +462,10 @@ public class CompositeFutureTest {
     // Throw Exception. Future Client calls get() and another listens after exception
     // A response and cancellation arrives after exception but they should be discarded.
     {
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key1, "");
-      Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
+      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
-      CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+      CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
       ResponseCompositeFutureClientRunnerListener runner =
           new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -504,10 +503,10 @@ public class CompositeFutureTest {
     // Get Response. Future Client calls get() and another listens before response
     // An exception and cancellation arrives after exception but they should be discarded.
     {
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key1, "");
-      Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
+      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
-      CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+      CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
       ResponseCompositeFutureClientRunnerListener runner =
           new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -545,10 +544,10 @@ public class CompositeFutureTest {
     // Get Response. Future Client calls get() and another listens after response
     // An exception and cancellation arrives after exception but they should be discarded.
     {
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key1, "");
-      Map<String, KeyedFuture<String, String>> futureMap = new HashMap<String, KeyedFuture<String, String>>();
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
+      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
-      CompositeFuture<String, String> compositeFuture = new CompositeFuture<String, String>("a", GatherModeOnError.AND);
+      CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
       ResponseCompositeFutureClientRunnerListener runner =
           new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -590,13 +589,13 @@ public class CompositeFutureTest {
   private static class ResponseCompositeFutureClientRunnerListener implements Runnable {
     private boolean _isDone;
     private boolean _isCancelled;
-    private Map<String, String> _message;
-    private Map<String, Throwable> _errorMap;
-    private final CompositeFuture<String, String> _future;
+    private Map<ServerInstance, String> _message;
+    private Map<ServerInstance, Throwable> _errorMap;
+    private final CompositeFuture<String> _future;
     private final CountDownLatch _latch = new CountDownLatch(1);
     private final CountDownLatch _endLatch = new CountDownLatch(1);
 
-    public ResponseCompositeFutureClientRunnerListener(CompositeFuture<String, String> f) {
+    public ResponseCompositeFutureClientRunnerListener(CompositeFuture<String> f) {
       _future = f;
     }
 
@@ -612,7 +611,7 @@ public class CompositeFutureTest {
     public synchronized void run() {
       LOGGER.info("Running Future runner !!");
 
-      Map<String, String> message = null;
+      Map<ServerInstance, String> message = null;
 
       try {
         _latch.countDown();
@@ -644,15 +643,15 @@ public class CompositeFutureTest {
       return _isCancelled;
     }
 
-    public Map<String, String> getMessage() {
+    public Map<ServerInstance, String> getMessage() {
       return _message;
     }
 
-    public Map<String, Throwable> getError() {
+    public Map<ServerInstance, Throwable> getError() {
       return _errorMap;
     }
 
-    public CompositeFuture<String, String> getFuture() {
+    public CompositeFuture<String> getFuture() {
       return _future;
     }
   }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/CompositeFutureTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/CompositeFutureTest.java
@@ -43,7 +43,7 @@ public class CompositeFutureTest {
   public void testMultiFutureComposite1() throws Exception {
     List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
-    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+    Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
     Map<ServerInstance, String> expectedMessages = new HashMap<>();
     for (int i = 0; i < numFutures; i++) {
       ServerInstance key = new ServerInstance("localhost:" + i);
@@ -107,7 +107,7 @@ public class CompositeFutureTest {
   public void testMultiFutureComposite2() throws Exception {
     List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
-    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+    Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
     Map<ServerInstance, Exception> expectedErrors = new HashMap<>();
     for (int i = 0; i < numFutures; i++) {
       ServerInstance key = new ServerInstance("localhost:" + i);
@@ -132,7 +132,7 @@ public class CompositeFutureTest {
     for (int i = 0; i < numFutures; i++) {
       Exception expectedError = new Exception("error processing_" + i);
       ServerInstance k = new ServerInstance("localhost:" + i);
-      KeyedFuture<String> future = futureMap.get(k);
+      ServerResponseFuture<String> future = futureMap.get(k);
       ((AsyncResponseFuture<String>) future).onError(expectedError);
       expectedErrors.put(k, expectedError);
     }
@@ -172,7 +172,7 @@ public class CompositeFutureTest {
     List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
     int numSuccessFutures = 50;
-    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+    Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
     for (int i = 0; i < numFutures; i++) {
       ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
@@ -242,7 +242,7 @@ public class CompositeFutureTest {
     List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 100;
     int numSuccessFutures = 5;
-    Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+    Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
     Map<ServerInstance, String> expectedMessages = new HashMap<>();
 
     for (int i = 0; i < numFutures; i++) {
@@ -340,7 +340,7 @@ public class CompositeFutureTest {
     // A response and exception arrives after cancel but they should be discarded.
     {
       AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
-      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+      Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
       CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
@@ -381,7 +381,7 @@ public class CompositeFutureTest {
     // A response and exception arrives after cancel but they should be discarded.
     {
       AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
-      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+      Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
       CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
@@ -422,7 +422,7 @@ public class CompositeFutureTest {
     // A response and cancellation arrives after exception but they should be discarded.
     {
       AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
-      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+      Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
       CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
@@ -463,7 +463,7 @@ public class CompositeFutureTest {
     // A response and cancellation arrives after exception but they should be discarded.
     {
       AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
-      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+      Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
       CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
@@ -504,7 +504,7 @@ public class CompositeFutureTest {
     // An exception and cancellation arrives after exception but they should be discarded.
     {
       AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
-      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+      Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
       CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());
@@ -545,7 +545,7 @@ public class CompositeFutureTest {
     // An exception and cancellation arrives after exception but they should be discarded.
     {
       AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key1, "");
-      Map<ServerInstance, KeyedFuture<String>> futureMap = new HashMap<>();
+      Map<ServerInstance, ServerResponseFuture<String>> futureMap = new HashMap<>();
       futureMap.put(key1, future);
       CompositeFuture<String> compositeFuture = new CompositeFuture<>("a", GatherModeOnError.AND);
       compositeFuture.start(futureMap.values());

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/ResponseFutureTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/ResponseFutureTest.java
@@ -44,7 +44,7 @@ public class ResponseFutureTest {
    * Future Handle provided to the request sender to asynchronously wait for response.
    * We use guava API for implementing Futures.
    */
-  public static class ResponseFuture extends AsyncResponseFuture<ServerInstance, ByteBuf> {
+  public static class ResponseFuture extends AsyncResponseFuture<ByteBuf> {
 
     public ResponseFuture(ServerInstance key) {
       super(key, "");

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/SelectingFutureTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/SelectingFutureTest.java
@@ -23,11 +23,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.common.response.ServerInstance;
 
 
 public class SelectingFutureTest {
@@ -39,17 +39,17 @@ public class SelectingFutureTest {
    * @throws Exception
    */
   public void testMultiFutureComposite1() throws Exception {
-    List<String> keys = new ArrayList<String>();
+    List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 3;
-    List<KeyedFuture<String, String>> futureList = new ArrayList<KeyedFuture<String, String>>();
+    List<KeyedFuture<String>> futureList = new ArrayList<>();
     String expectedMessage = null;
     for (int i = 0; i < numFutures; i++) {
-      String key = "key_" + i;
+      ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key, "");
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key, "");
       futureList.add(future);
     }
-    SelectingFuture<String, String> compositeFuture = new SelectingFuture<String, String>("test");
+    SelectingFuture<String> compositeFuture = new SelectingFuture<>("test");
     compositeFuture.start(futureList);
     ResponseCompositeFutureClientRunnerListener runner =
         new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -65,7 +65,7 @@ public class SelectingFutureTest {
     // Send response for underlying futures. Key : key_0 first
     for (int i = 0; i < numFutures; i++) {
       String message = "dummy Message_" + i;
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureList.get(i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureList.get(i);
       future.onSuccess(message);
     }
     expectedMessage = "dummy Message_0";
@@ -92,16 +92,16 @@ public class SelectingFutureTest {
    * @throws Exception
    */
   public void testMultiFutureComposite2() throws Exception {
-    List<String> keys = new ArrayList<String>();
+    List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 3;
-    List<KeyedFuture<String, String>> futureList = new ArrayList<KeyedFuture<String, String>>();
+    List<KeyedFuture<String>> futureList = new ArrayList<>();
     for (int i = 0; i < numFutures; i++) {
-      String key = "key_" + i;
+      ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key, "");
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key, "");
       futureList.add(future);
     }
-    SelectingFuture<String, String> compositeFuture = new SelectingFuture<String, String>("abc");
+    SelectingFuture<String> compositeFuture = new SelectingFuture<>("abc");
     compositeFuture.start(futureList);
     ResponseCompositeFutureClientRunnerListener runner =
         new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -119,7 +119,7 @@ public class SelectingFutureTest {
     for (int i = 0; i < numFutures; i++) {
       String message = "dummy Message_" + i;
       error = new Exception(message);
-      AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureList.get(i);
+      AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureList.get(i);
       future.onError(error);
     }
     Throwable expectedError = error;
@@ -133,7 +133,8 @@ public class SelectingFutureTest {
     Assert.assertFalse(futureList.get(2).isCancelled(), "Third response not cancelled");
     Assert.assertNotNull(futureList.get(0).getError());
     Assert.assertNotNull(futureList.get(1).getError());
-    Assert.assertEquals(futureList.get(2).getError().get("key_2"), runner.getError());
+    ServerInstance key2 = new ServerInstance("localhost:2");
+    Assert.assertEquals(futureList.get(2).getError().get(key2), runner.getError());
     Assert.assertNull(futureList.get(0).get());
     Assert.assertNull(futureList.get(1).get());
     Assert.assertNull(futureList.get(2).get());
@@ -147,16 +148,16 @@ public class SelectingFutureTest {
    * @throws Exception
    */
   public void testMultiFutureComposite3() throws Exception {
-    List<String> keys = new ArrayList<String>();
+    List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 3;
-    List<KeyedFuture<String, String>> futureList = new ArrayList<KeyedFuture<String, String>>();
+    List<KeyedFuture<String>> futureList = new ArrayList<>();
     for (int i = 0; i < numFutures; i++) {
-      String key = "key_" + i;
+      ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
-      AsyncResponseFuture<String, String> future = new AsyncResponseFuture<String, String>(key, "");
+      AsyncResponseFuture<String> future = new AsyncResponseFuture<>(key, "");
       futureList.add(future);
     }
-    SelectingFuture<String, String> compositeFuture = new SelectingFuture<String, String>("test");
+    SelectingFuture<String> compositeFuture = new SelectingFuture<>("test");
     compositeFuture.start(futureList);
     ResponseCompositeFutureClientRunnerListener runner =
         new ResponseCompositeFutureClientRunnerListener(compositeFuture);
@@ -174,18 +175,18 @@ public class SelectingFutureTest {
     String message = "dummy Message_" + 0;
     // First future gets an error
     Throwable error = new Exception(message);
-    AsyncResponseFuture<String, String> future = (AsyncResponseFuture<String, String>) futureList.get(0);
+    AsyncResponseFuture<String> future = (AsyncResponseFuture<String>) futureList.get(0);
     future.onError(error);
     //Second future gets a response
     message = "dummy Message_" + 1;
-    future = (AsyncResponseFuture<String, String>) futureList.get(1);
+    future = (AsyncResponseFuture<String>) futureList.get(1);
     future.onSuccess(message);
     expectedMessage = message;
 
     // Third future gets a response
     message = "dummy Message_" + 2;
     error = new Exception(message);
-    future = (AsyncResponseFuture<String, String>) futureList.get(2);
+    future = (AsyncResponseFuture<String>) futureList.get(2);
     future.onError(error);
 
     runner.waitForDone();
@@ -213,11 +214,11 @@ public class SelectingFutureTest {
     private boolean _isCancelled;
     private String _message;
     private Throwable _error;
-    private final SelectingFuture<String, String> _future;
+    private final SelectingFuture<String> _future;
     private final CountDownLatch _latch = new CountDownLatch(1);
     private final CountDownLatch _endLatch = new CountDownLatch(1);
 
-    public ResponseCompositeFutureClientRunnerListener(SelectingFuture<String, String> f) {
+    public ResponseCompositeFutureClientRunnerListener(SelectingFuture<String> f) {
       _future = f;
     }
 
@@ -252,7 +253,7 @@ public class SelectingFutureTest {
       if (null != message) {
         _message = message;
       }
-      Map<String, Throwable> t = _future.getError();
+      Map<ServerInstance, Throwable> t = _future.getError();
       if ((null != t) && (!t.isEmpty())) {
         _error = t.values().iterator().next();
       }
@@ -276,7 +277,7 @@ public class SelectingFutureTest {
       return _error;
     }
 
-    public SelectingFuture<String, String> getFuture() {
+    public SelectingFuture<String> getFuture() {
       return _future;
     }
   }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/SelectingFutureTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/SelectingFutureTest.java
@@ -41,7 +41,7 @@ public class SelectingFutureTest {
   public void testMultiFutureComposite1() throws Exception {
     List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 3;
-    List<KeyedFuture<String>> futureList = new ArrayList<>();
+    List<ServerResponseFuture<String>> futureList = new ArrayList<>();
     String expectedMessage = null;
     for (int i = 0; i < numFutures; i++) {
       ServerInstance key = new ServerInstance("localhost:" + i);
@@ -94,7 +94,7 @@ public class SelectingFutureTest {
   public void testMultiFutureComposite2() throws Exception {
     List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 3;
-    List<KeyedFuture<String>> futureList = new ArrayList<>();
+    List<ServerResponseFuture<String>> futureList = new ArrayList<>();
     for (int i = 0; i < numFutures; i++) {
       ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);
@@ -150,7 +150,7 @@ public class SelectingFutureTest {
   public void testMultiFutureComposite3() throws Exception {
     List<ServerInstance> keys = new ArrayList<>();
     int numFutures = 3;
-    List<KeyedFuture<String>> futureList = new ArrayList<>();
+    List<ServerResponseFuture<String>> futureList = new ArrayList<>();
     for (int i = 0; i < numFutures; i++) {
       ServerInstance key = new ServerInstance("localhost:" + i);
       keys.add(key);

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -15,6 +15,19 @@
  */
 package com.linkedin.pinot.transport.netty;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.commons.lang.RandomStringUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
@@ -35,19 +48,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import org.apache.commons.lang.RandomStringUtils;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 
 public class NettySingleConnectionIntegrationTest {
@@ -161,7 +161,7 @@ public class NettySingleConnectionIntegrationTest {
 
     String serverName = "server";
     MetricsRegistry metricsRegistry = new MetricsRegistry();
-    AsyncPoolResourceManagerAdapter<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> rmAdapter =
+    AsyncPoolResourceManagerAdapter<PooledNettyClientResourceManager.PooledClientConnection> rmAdapter =
         new AsyncPoolResourceManagerAdapter<>(_clientServer, resourceManager, executorService, metricsRegistry);
     AsyncPool<PooledNettyClientResourceManager.PooledClientConnection> pool = new AsyncPoolImpl<>(serverName, rmAdapter,
      /*maxSize=*/5, /*idleTimeoutMs=*/100000L, timeoutExecutor, executorService, /*maxWaiters=*/10,
@@ -179,7 +179,7 @@ public class NettySingleConnectionIntegrationTest {
       Assert.assertEquals(stats.getCheckedOut(), 0);
 
       // Test one connection, it should not destroy anything
-      AsyncResponseFuture<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> responseFuture =
+      AsyncResponseFuture<PooledNettyClientResourceManager.PooledClientConnection> responseFuture =
           new AsyncResponseFuture<>(_clientServer, null);
       pool.get(responseFuture);
       Assert.assertNotNull(responseFuture.getOne());
@@ -225,7 +225,7 @@ public class NettySingleConnectionIntegrationTest {
     ExecutorService executorService = Executors.newCachedThreadPool();
     ScheduledExecutorService timeoutExecutor = new ScheduledThreadPoolExecutor(5);
 
-    KeyedPool<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> keyedPool =
+    KeyedPool<PooledNettyClientResourceManager.PooledClientConnection> keyedPool =
         new KeyedPoolImpl<>(/*minSize=*/2, /*maxSize=*/3, /*idleTimeoutMs=*/100000L, /*maxPending=*/1, resourceManager,
             timeoutExecutor, executorService, new MetricsRegistry());
     resourceManager.setPool(keyedPool);
@@ -268,7 +268,7 @@ public class NettySingleConnectionIntegrationTest {
 
       // Try to get one more connection
       // We should get an exception because we don't have a free connection to the server
-      KeyedFuture<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> keyedFuture =
+      KeyedFuture<PooledNettyClientResourceManager.PooledClientConnection> keyedFuture =
           keyedPool.checkoutObject(_clientServer);
       try {
         keyedFuture.getOne(1, TimeUnit.SECONDS);

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -32,7 +32,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
 import com.linkedin.pinot.transport.common.Callback;
-import com.linkedin.pinot.transport.common.KeyedFuture;
+import com.linkedin.pinot.transport.common.ServerResponseFuture;
 import com.linkedin.pinot.transport.common.LinkedDequeue;
 import com.linkedin.pinot.transport.common.NoneType;
 import com.linkedin.pinot.transport.metrics.NettyClientMetrics;
@@ -268,10 +268,10 @@ public class NettySingleConnectionIntegrationTest {
 
       // Try to get one more connection
       // We should get an exception because we don't have a free connection to the server
-      KeyedFuture<PooledNettyClientResourceManager.PooledClientConnection> keyedFuture =
+      ServerResponseFuture<PooledNettyClientResourceManager.PooledClientConnection> serverResponseFuture =
           keyedPool.checkoutObject(_clientServer);
       try {
-        keyedFuture.getOne(1, TimeUnit.SECONDS);
+        serverResponseFuture.getOne(1, TimeUnit.SECONDS);
         Assert.fail("Get connection even no connections available");
       } catch (TimeoutException e) {
         // PASS
@@ -281,7 +281,7 @@ public class NettySingleConnectionIntegrationTest {
       Assert.assertEquals(stats.getIdleCount(), 0);
       Assert.assertEquals(stats.getCheckedOut(), 3);
       Assert.assertEquals(waitersQueue.size(), 1);
-      keyedFuture.cancel(true);
+      serverResponseFuture.cancel(true);
       Assert.assertEquals(waitersQueue.size(), 0);
 
       // If the server goes down, we should release all 3 connections and be able to get new connections

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/AsyncPoolResourceManagerAdapterTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/AsyncPoolResourceManagerAdapterTest.java
@@ -19,6 +19,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.Callback;
 
 
@@ -29,11 +30,11 @@ public class AsyncPoolResourceManagerAdapterTest {
 
     // Success
     {
-      String key = "localhost:8080";
+      ServerInstance key = new ServerInstance("localhost:8080");
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(true, value);
-      AsyncPoolResourceManagerAdapter<String, String> adapter =
-          new AsyncPoolResourceManagerAdapter<String, String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+      AsyncPoolResourceManagerAdapter<String> adapter =
+          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
       MyCallback callback = new MyCallback();
 
       adapter.create(callback);
@@ -46,10 +47,10 @@ public class AsyncPoolResourceManagerAdapterTest {
 
     //Error
     {
-      String key = "localhost:8080";
+      ServerInstance key = new ServerInstance("localhost:8080");
       MyPooledResourceManager rm = new MyPooledResourceManager(true, null);
-      AsyncPoolResourceManagerAdapter<String, String> adapter =
-          new AsyncPoolResourceManagerAdapter<String, String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+      AsyncPoolResourceManagerAdapter<String> adapter =
+          new AsyncPoolResourceManagerAdapter<String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
       MyCallback callback = new MyCallback();
 
       adapter.create(callback);
@@ -65,11 +66,11 @@ public class AsyncPoolResourceManagerAdapterTest {
   public void testValidate() {
     //Success
     {
-      String key = "localhost:8080";
+      ServerInstance key = new ServerInstance("localhost:8080");
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(true, null);
-      AsyncPoolResourceManagerAdapter<String, String> adapter =
-          new AsyncPoolResourceManagerAdapter<String, String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+      AsyncPoolResourceManagerAdapter<String> adapter =
+          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
 
       boolean ret = adapter.validateGet(value);
       Assert.assertTrue(ret, "Validate Return");
@@ -86,11 +87,11 @@ public class AsyncPoolResourceManagerAdapterTest {
 
     //Error
     {
-      String key = "localhost:8080";
+      ServerInstance key = new ServerInstance("localhost:8080");
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(false, null);
-      AsyncPoolResourceManagerAdapter<String, String> adapter =
-          new AsyncPoolResourceManagerAdapter<String, String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+      AsyncPoolResourceManagerAdapter<String> adapter =
+          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
 
       boolean ret = adapter.validateGet(value);
       Assert.assertFalse(ret, "Validate Return");
@@ -112,11 +113,11 @@ public class AsyncPoolResourceManagerAdapterTest {
 
     // Success
     {
-      String key = "localhost:8080";
+      ServerInstance key = new ServerInstance("localhost:8080");
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(true, null);
-      AsyncPoolResourceManagerAdapter<String, String> adapter =
-          new AsyncPoolResourceManagerAdapter<String, String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+      AsyncPoolResourceManagerAdapter<String> adapter =
+          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
       MyCallback callback = new MyCallback();
 
       adapter.destroy(value, true, callback);
@@ -130,11 +131,11 @@ public class AsyncPoolResourceManagerAdapterTest {
 
     // Error
     {
-      String key = "localhost:8080";
+      ServerInstance key = new ServerInstance("localhost:8080");
       String value = "dummy";
       MyPooledResourceManager rm = new MyPooledResourceManager(false, null);
-      AsyncPoolResourceManagerAdapter<String, String> adapter =
-          new AsyncPoolResourceManagerAdapter<String, String>(key, rm, MoreExecutors.sameThreadExecutor(), null);
+      AsyncPoolResourceManagerAdapter<String> adapter =
+          new AsyncPoolResourceManagerAdapter<>(key, rm, MoreExecutors.sameThreadExecutor(), null);
       MyCallback callback = new MyCallback();
 
       adapter.destroy(value, true, callback);
@@ -147,13 +148,13 @@ public class AsyncPoolResourceManagerAdapterTest {
     }
   }
 
-  public static class MyPooledResourceManager implements PooledResourceManager<String, String> {
-    private String _createKey;
+  public static class MyPooledResourceManager implements PooledResourceManager<String> {
+    private ServerInstance _createKey;
     private final String _createReturnValue;
     private String _resourceForDestroy;
     private String _resourceForValidate;
-    private String _keyForDestroy;
-    private String _keyForValidate;
+    private ServerInstance _keyForDestroy;
+    private ServerInstance _keyForValidate;
     private final boolean _boolReturnVal;
 
     public MyPooledResourceManager(boolean returnVal, String createReturnValue) {
@@ -162,26 +163,26 @@ public class AsyncPoolResourceManagerAdapterTest {
     }
 
     @Override
-    public String create(String key) {
+    public String create(ServerInstance key) {
       _createKey = key;
       return _createReturnValue;
     }
 
     @Override
-    public boolean destroy(String key, boolean isBad, String resource) {
+    public boolean destroy(ServerInstance key, boolean isBad, String resource) {
       _keyForDestroy = key;
       _resourceForDestroy = resource;
       return _boolReturnVal;
     }
 
     @Override
-    public boolean validate(String key, String resource) {
+    public boolean validate(ServerInstance key, String resource) {
       _keyForValidate = key;
       _resourceForValidate = resource;
       return _boolReturnVal;
     }
 
-    public String getCreateKey() {
+    public ServerInstance getCreateKey() {
       return _createKey;
     }
 
@@ -193,11 +194,11 @@ public class AsyncPoolResourceManagerAdapterTest {
       return _resourceForValidate;
     }
 
-    public String getKeyForDestroy() {
+    public ServerInstance getKeyForDestroy() {
       return _keyForDestroy;
     }
 
-    public String getKeyForValidate() {
+    public ServerInstance getKeyForValidate() {
       return _keyForValidate;
     }
   }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/KeyedPoolImplTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/KeyedPoolImplTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
-import com.linkedin.pinot.transport.common.KeyedFuture;
+import com.linkedin.pinot.transport.common.ServerResponseFuture;
 import com.linkedin.pinot.transport.common.NoneType;
 import com.linkedin.pinot.transport.metrics.AggregatedPoolStats;
 
@@ -234,7 +234,7 @@ public class KeyedPoolImplTest {
     // checkout and checkin back all
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
         String resource = rFuture.getOne();
       }
     }
@@ -292,7 +292,7 @@ public class KeyedPoolImplTest {
     int c = 1;
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
         String resource = rFuture.getOne();
         Assert.assertEquals(resource, getResource(i, j));
         s.refresh();
@@ -317,7 +317,7 @@ public class KeyedPoolImplTest {
     c = 1;
     int d = 1;
     for (int i = 0; i < numKeys; i++) {
-      KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+      ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
       String resource = rFuture.getOne();
       Assert.assertEquals(resource, getResource(i, 0));
       CountDownLatch latch = new CountDownLatch(1);
@@ -368,7 +368,7 @@ public class KeyedPoolImplTest {
     int c = 1;
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
         String resource = rFuture.getOne();
         Assert.assertEquals(resource, getResource(i, j));
         s.refresh();
@@ -391,7 +391,7 @@ public class KeyedPoolImplTest {
     // Check out 1 object for each key
     c = 1;
     for (int i = 0; i < numKeys; i++) {
-      KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+      ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
       String resource = rFuture.getOne();
       Assert.assertEquals(resource, getResource(i, 0));
       s.refresh();

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/KeyedPoolImplTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/KeyedPoolImplTest.java
@@ -36,6 +36,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
 import com.linkedin.pinot.transport.common.KeyedFuture;
 import com.linkedin.pinot.transport.common.NoneType;
@@ -52,14 +53,14 @@ public class KeyedPoolImplTest {
     ExecutorService service = new ThreadPoolExecutor(1, 1, 1, TimeUnit.DAYS, new LinkedBlockingDeque<Runnable>());
     int numKeys = 1;
     int numResourcesPerKey = 1;
-    Map<String, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
+    Map<ServerInstance, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
     BlockingTestResourceManager rm = new BlockingTestResourceManager(resources, null, null, null);
 
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
 
     kPool.start();
-    AsyncResponseFuture<String, String> f = (AsyncResponseFuture<String, String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
     boolean isTimedout = false;
     try {
       f.get(2, TimeUnit.SECONDS);
@@ -82,14 +83,14 @@ public class KeyedPoolImplTest {
     ExecutorService service = new ThreadPoolExecutor(1, 1, 1, TimeUnit.DAYS, new LinkedBlockingDeque<Runnable>());
     int numKeys = 1;
     int numResourcesPerKey = 1;
-    Map<String, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
+    Map<ServerInstance, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
     TestResourceManager rm = new TestResourceManager(resources, null, null, null);
 
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
 
     kPool.start();
-    AsyncResponseFuture<String, String> f = (AsyncResponseFuture<String, String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
     String s1 = f.getOne();
 
     // checkin with invalid key
@@ -117,14 +118,14 @@ public class KeyedPoolImplTest {
     ExecutorService service = new ThreadPoolExecutor(1, 1, 1, TimeUnit.DAYS, new LinkedBlockingDeque<Runnable>());
     int numKeys = 1;
     int numResourcesPerKey = 1;
-    Map<String, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
+    Map<ServerInstance, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
     BlockingTestResourceManager rm = new BlockingTestResourceManager(resources, null, null, null);
 
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
 
     kPool.start();
-    AsyncResponseFuture<String, String> f = (AsyncResponseFuture<String, String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
     boolean isTimedout = false;
     try {
       f.get(2, TimeUnit.SECONDS);
@@ -152,13 +153,13 @@ public class KeyedPoolImplTest {
     ExecutorService service = MoreExecutors.sameThreadExecutor();
     int numKeys = 1;
     int numResourcesPerKey = 1;
-    Map<String, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
+    Map<ServerInstance, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
 
     TestResourceManager rm = new TestResourceManager(resources, resources, null, null);
 
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
-    AsyncResponseFuture<String, String> f = (AsyncResponseFuture<String, String>) kPool.checkoutObject(getKey(0));
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
     Assert.assertTrue(f.isDone());
     Assert.assertNull(f.get());
     Assert.assertNotNull(f.getError());
@@ -175,13 +176,13 @@ public class KeyedPoolImplTest {
     ExecutorService service = MoreExecutors.sameThreadExecutor();
     int numKeys = 1;
     int numResourcesPerKey = 1;
-    Map<String, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
+    Map<ServerInstance, List<String>> resources = buildCreateMap(numKeys, numResourcesPerKey);
 
     TestResourceManager rm = new TestResourceManager(resources, null, resources, null);
 
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(0, 5, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
-    AsyncResponseFuture<String, String> f = (AsyncResponseFuture<String, String>) kPool.checkoutObject(getKey(0));
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(0, 5, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
     String r = f.getOne();
     Assert.assertTrue(f.isDone());
     Assert.assertNull(f.getError());
@@ -220,8 +221,8 @@ public class KeyedPoolImplTest {
     TestResourceManager rm = new TestResourceManager(buildCreateMap(numKeys, numResourcesPerKey), null, null, null);
 
     // Idle Timeout 1 second
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(0, 5, 1000L, 100, rm, timedExecutor, service, null);
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(0, 5, 1000L, 100, rm, timedExecutor, service, null);
 
     // Create a countdown latch that waits for all resources to be deleted
     CountDownLatch latch = new CountDownLatch(numKeys * numResourcesPerKey);
@@ -233,7 +234,7 @@ public class KeyedPoolImplTest {
     // checkout and checkin back all
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        KeyedFuture<String, String> rFuture = kPool.checkoutObject(getKey(i));
+        KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
         String resource = rFuture.getOne();
       }
     }
@@ -251,7 +252,7 @@ public class KeyedPoolImplTest {
     Assert.assertEquals(s.getTotalTimedOut(), 5);
 
     //Verify all objects are destroyed
-    Map<String, List<String>> destroyedMap = rm.getDestroyedMap();
+    Map<ServerInstance, List<String>> destroyedMap = rm.getDestroyedMap();
 
     Assert.assertEquals(destroyedMap.keySet().size(), numKeys);
     for (int i = 0; i < numKeys; i++) {
@@ -263,7 +264,7 @@ public class KeyedPoolImplTest {
     }
 
     // Proper shutdown
-    Future<Map<String, NoneType>> f = kPool.shutdown();
+    Future<Map<ServerInstance, NoneType>> f = kPool.shutdown();
     f.get();
   }
 
@@ -282,8 +283,8 @@ public class KeyedPoolImplTest {
     int numKeys = 5;
     int numResourcesPerKey = 5;
     TestResourceManager rm = new TestResourceManager(buildCreateMap(numKeys, numResourcesPerKey), null, null, null);
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(5, 5, 1000 * 60 * 60L, 100, rm, timedExecutor, service, null);
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(5, 5, 1000 * 60 * 60L, 100, rm, timedExecutor, service, null);
 
     kPool.start();
     AggregatedPoolStats s = (AggregatedPoolStats) kPool.getStats();
@@ -291,7 +292,7 @@ public class KeyedPoolImplTest {
     int c = 1;
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        KeyedFuture<String, String> rFuture = kPool.checkoutObject(getKey(i));
+        KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
         String resource = rFuture.getOne();
         Assert.assertEquals(resource, getResource(i, j));
         s.refresh();
@@ -316,7 +317,7 @@ public class KeyedPoolImplTest {
     c = 1;
     int d = 1;
     for (int i = 0; i < numKeys; i++) {
-      KeyedFuture<String, String> rFuture = kPool.checkoutObject(getKey(i));
+      KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
       String resource = rFuture.getOne();
       Assert.assertEquals(resource, getResource(i, 0));
       CountDownLatch latch = new CountDownLatch(1);
@@ -328,10 +329,10 @@ public class KeyedPoolImplTest {
       Assert.assertEquals(s.getCheckedOut(), 0);
       Assert.assertEquals(s.getTotalDestroyed(), d++);
     }
-    Future<Map<String, NoneType>> f = kPool.shutdown();
+    Future<Map<ServerInstance, NoneType>> f = kPool.shutdown();
     f.get();
     //Verify all objects are destroyed
-    Map<String, List<String>> destroyedMap = rm.getDestroyedMap();
+    Map<ServerInstance, List<String>> destroyedMap = rm.getDestroyedMap();
 
     Assert.assertEquals(destroyedMap.keySet().size(), numKeys);
     for (int i = 0; i < numKeys; i++) {
@@ -359,15 +360,15 @@ public class KeyedPoolImplTest {
     int numKeys = 5;
     int numResourcesPerKey = 5;
     TestResourceManager rm = new TestResourceManager(buildCreateMap(numKeys, numResourcesPerKey), null, null, null);
-    KeyedPool<String, String> kPool =
-        new KeyedPoolImpl<String, String>(5, 5, 1000 * 60 * 60L, 100, rm, timedExecutor, service, null);
+    KeyedPool<String> kPool =
+        new KeyedPoolImpl<>(5, 5, 1000 * 60 * 60L, 100, rm, timedExecutor, service, null);
 
     kPool.start();
     AggregatedPoolStats s = (AggregatedPoolStats) kPool.getStats();
     int c = 1;
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        KeyedFuture<String, String> rFuture = kPool.checkoutObject(getKey(i));
+        KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
         String resource = rFuture.getOne();
         Assert.assertEquals(resource, getResource(i, j));
         s.refresh();
@@ -390,7 +391,7 @@ public class KeyedPoolImplTest {
     // Check out 1 object for each key
     c = 1;
     for (int i = 0; i < numKeys; i++) {
-      KeyedFuture<String, String> rFuture = kPool.checkoutObject(getKey(i));
+      KeyedFuture<String> rFuture = kPool.checkoutObject(getKey(i));
       String resource = rFuture.getOne();
       Assert.assertEquals(resource, getResource(i, 0));
       s.refresh();
@@ -401,8 +402,8 @@ public class KeyedPoolImplTest {
     Assert.assertEquals(s.getIdleCount(), (numKeys * numResourcesPerKey) - 5);
 
     // SHutdown but it should not be done.
-    Future<Map<String, NoneType>> f = kPool.shutdown();
-    FutureReader<Map<String, NoneType>> reader = new FutureReader<Map<String, NoneType>>(f);
+    Future<Map<ServerInstance, NoneType>> f = kPool.shutdown();
+    FutureReader<Map<ServerInstance, NoneType>> reader = new FutureReader<Map<ServerInstance, NoneType>>(f);
     reader.start();
     reader.getBeginLatch().await();
     Assert.assertTrue(reader.isStarted());
@@ -430,10 +431,10 @@ public class KeyedPoolImplTest {
     Assert.assertTrue(reader.isDone());
 
     // Do one more shutdown call
-    Future<Map<String, NoneType>> f2 = kPool.shutdown();
+    Future<Map<ServerInstance, NoneType>> f2 = kPool.shutdown();
     f2.get();
     //Verify all objects are destroyed
-    Map<String, List<String>> destroyedMap = rm.getDestroyedMap();
+    Map<ServerInstance, List<String>> destroyedMap = rm.getDestroyedMap();
 
     Assert.assertEquals(destroyedMap.keySet().size(), numKeys);
     for (int i = 0; i < numKeys; i++) {
@@ -445,10 +446,10 @@ public class KeyedPoolImplTest {
     }
   }
 
-  private Map<String, List<String>> buildCreateMap(int numKeys, int numResourcesPerKey) {
-    Map<String, List<String>> createdMap = new HashMap<String, List<String>>();
+  private Map<ServerInstance, List<String>> buildCreateMap(int numKeys, int numResourcesPerKey) {
+    Map<ServerInstance, List<String>> createdMap = new HashMap<>();
     for (int i = 0; i < numKeys; i++) {
-      String key = getKey(i);
+      ServerInstance key = getKey(i);
       List<String> list = new ArrayList<String>();
       for (int j = 0; j < numKeys; j++) {
         list.add(getResource(i, j));
@@ -458,12 +459,12 @@ public class KeyedPoolImplTest {
     return createdMap;
   }
 
-  private String getKey(int id) {
-    return "key_" + id;
+  private ServerInstance getKey(int id) {
+    return new ServerInstance("key:" + id);
   }
 
   private String getResource(int key, int resource) {
-    String k = getKey(key);
+    ServerInstance k = getKey(key);
     return k + "_resource_" + resource;
   }
 
@@ -471,14 +472,14 @@ public class KeyedPoolImplTest {
     // Latch to block creating resource
     private final CountDownLatch _createBlockLatch = new CountDownLatch(1);
 
-    public BlockingTestResourceManager(Map<String, List<String>> createdMap,
-        Map<String, List<String>> failCreateResources, Map<String, List<String>> failDestroyResources,
-        Map<String, List<String>> failValidationResources) {
+    public BlockingTestResourceManager(Map<ServerInstance, List<String>> createdMap,
+        Map<ServerInstance, List<String>> failCreateResources, Map<ServerInstance, List<String>> failDestroyResources,
+        Map<ServerInstance, List<String>> failValidationResources) {
       super(createdMap, failCreateResources, failDestroyResources, failValidationResources);
     }
 
     @Override
-    public String create(String key) {
+    public String create(ServerInstance key) {
       try {
         _createBlockLatch.await();
       } catch (InterruptedException e) {
@@ -494,17 +495,17 @@ public class KeyedPoolImplTest {
 
   }
 
-  public static class TestResourceManager implements PooledResourceManager<String, String> {
+  public static class TestResourceManager implements PooledResourceManager<String> {
     // input related
-    public Map<String, List<String>> _createdMap = new HashMap<String, List<String>>();
-    public Map<String, List<String>> _failCreateResources = new HashMap<String, List<String>>();
-    public Map<String, List<String>> _failDestroyResources = new HashMap<String, List<String>>();
-    public Map<String, List<String>> _failValidationResources = new HashMap<String, List<String>>();
+    public Map<ServerInstance, List<String>> _createdMap = new HashMap<>();
+    public Map<ServerInstance, List<String>> _failCreateResources = new HashMap<>();
+    public Map<ServerInstance, List<String>> _failDestroyResources = new HashMap<>();
+    public Map<ServerInstance, List<String>> _failValidationResources = new HashMap<>();
 
     // output related
-    public Map<String, Integer> _createdIndex = new HashMap<String, Integer>();
-    public Map<String, List<String>> _destroyedMap = new HashMap<String, List<String>>();
-    public Map<String, List<String>> _validatedMap = new HashMap<String, List<String>>();
+    public Map<ServerInstance, Integer> _createdIndex = new HashMap<>();
+    public Map<ServerInstance, List<String>> _destroyedMap = new HashMap<>();
+    public Map<ServerInstance, List<String>> _validatedMap = new HashMap<>();
 
     private CountDownLatch _latch = null;
 
@@ -512,8 +513,8 @@ public class KeyedPoolImplTest {
       _latch = latch;
     }
 
-    public TestResourceManager(Map<String, List<String>> createdMap, Map<String, List<String>> failCreateResources,
-        Map<String, List<String>> failDestroyResources, Map<String, List<String>> failValidationResources) {
+    public TestResourceManager(Map<ServerInstance, List<String>> createdMap, Map<ServerInstance, List<String>> failCreateResources,
+        Map<ServerInstance, List<String>> failDestroyResources, Map<ServerInstance, List<String>> failValidationResources) {
       if (null != createdMap) {
         _createdMap.putAll(createdMap);
       }
@@ -532,7 +533,7 @@ public class KeyedPoolImplTest {
     }
 
     @Override
-    public String create(String key) {
+    public String create(ServerInstance key) {
 
       Integer index = _createdIndex.get(key);
 
@@ -550,7 +551,7 @@ public class KeyedPoolImplTest {
     }
 
     @Override
-    public boolean destroy(String key, boolean isBad, String resource) {
+    public boolean destroy(ServerInstance key, boolean isBad, String resource) {
       boolean fail = false;
       List<String> fails = _failDestroyResources.get(key);
       if (null != fails) {
@@ -569,7 +570,7 @@ public class KeyedPoolImplTest {
     }
 
     @Override
-    public boolean validate(String key, String resource) {
+    public boolean validate(ServerInstance key, String resource) {
       boolean fail = false;
       List<String> fails = _failValidationResources.get(key);
       if (null != fails) {
@@ -584,15 +585,15 @@ public class KeyedPoolImplTest {
       return !fail;
     }
 
-    public Map<String, Integer> getCreatedIndex() {
+    public Map<ServerInstance, Integer> getCreatedIndex() {
       return _createdIndex;
     }
 
-    public Map<String, List<String>> getDestroyedMap() {
+    public Map<ServerInstance, List<String>> getDestroyedMap() {
       return _destroyedMap;
     }
 
-    public Map<String, List<String>> getValidatedMap() {
+    public Map<ServerInstance, List<String>> getValidatedMap() {
       return _validatedMap;
     }
   }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
@@ -232,8 +232,8 @@ public class ScatterGatherTest {
     NettyClientMetrics clientMetrics = new NettyClientMetrics(registry, "client_");
     PooledNettyClientResourceManager rm =
         new PooledNettyClientResourceManager(eventLoopGroup, new HashedWheelTimer(), clientMetrics);
-    KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> pool =
-        new KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection>(1, 1, 300000, 1, rm, timedExecutor, poolExecutor,
+    KeyedPoolImpl<PooledNettyClientResourceManager.PooledClientConnection> pool =
+        new KeyedPoolImpl<PooledNettyClientResourceManager.PooledClientConnection>(1, 1, 300000, 1, rm, timedExecutor, poolExecutor,
             registry);
     rm.setPool(pool);
 
@@ -254,7 +254,7 @@ public class ScatterGatherTest {
 
     final ScatterGatherStats scatterGatherStats = new ScatterGatherStats();
     BrokerMetrics brokerMetrics = new BrokerMetrics(new MetricsRegistry());
-    CompositeFuture<ServerInstance, ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
+    CompositeFuture<ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
     Map<ServerInstance, ByteBuf> v = fut.get();
     ByteBuf b = v.get(serverInstance1);
     byte[] b2 = new byte[b.readableBytes()];
@@ -300,8 +300,8 @@ public class ScatterGatherTest {
     NettyClientMetrics clientMetrics = new NettyClientMetrics(registry, "client_");
     PooledNettyClientResourceManager rm =
         new PooledNettyClientResourceManager(eventLoopGroup, new HashedWheelTimer(), clientMetrics);
-    KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> pool =
-        new KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection>(1, 1, 300000, 1, rm, timedExecutor, poolExecutor,
+    KeyedPoolImpl<PooledNettyClientResourceManager.PooledClientConnection> pool =
+        new KeyedPoolImpl<PooledNettyClientResourceManager.PooledClientConnection>(1, 1, 300000, 1, rm, timedExecutor, poolExecutor,
             registry);
     rm.setPool(pool);
 
@@ -340,7 +340,7 @@ public class ScatterGatherTest {
     ScatterGatherImpl scImpl = new ScatterGatherImpl(pool, service);
     final ScatterGatherStats scatterGatherStats = new ScatterGatherStats();
     BrokerMetrics brokerMetrics = new BrokerMetrics(new MetricsRegistry());
-    CompositeFuture<ServerInstance, ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
+    CompositeFuture<ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
     Map<ServerInstance, ByteBuf> v = fut.get();
     Assert.assertEquals(v.size(), 4);
 
@@ -405,8 +405,8 @@ public class ScatterGatherTest {
     NettyClientMetrics clientMetrics = new NettyClientMetrics(registry, "client_");
     PooledNettyClientResourceManager rm =
         new PooledNettyClientResourceManager(eventLoopGroup, new HashedWheelTimer(), clientMetrics);
-    KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> pool =
-        new KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection>(1, 1, 300000, 1, rm, timedExecutor, service, registry);
+    KeyedPoolImpl<PooledNettyClientResourceManager.PooledClientConnection> pool =
+        new KeyedPoolImpl<>(1, 1, 300000, 1, rm, timedExecutor, service, registry);
     rm.setPool(pool);
 
     SegmentIdSet pg1 = new SegmentIdSet();
@@ -446,7 +446,7 @@ public class ScatterGatherTest {
     ScatterGatherImpl scImpl = new ScatterGatherImpl(pool, service);
     final ScatterGatherStats scatterGatherStats = new ScatterGatherStats();
     BrokerMetrics brokerMetrics = new BrokerMetrics(new MetricsRegistry());
-    CompositeFuture<ServerInstance, ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
+    CompositeFuture<ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
     Map<ServerInstance, ByteBuf> v = fut.get();
 
     //Only 3 servers return value.
@@ -520,8 +520,8 @@ public class ScatterGatherTest {
     NettyClientMetrics clientMetrics = new NettyClientMetrics(registry, "client_");
     PooledNettyClientResourceManager rm =
         new PooledNettyClientResourceManager(eventLoopGroup, new HashedWheelTimer(), clientMetrics);
-    KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection> pool =
-        new KeyedPoolImpl<ServerInstance, PooledNettyClientResourceManager.PooledClientConnection>(1, 1, 300000, 1, rm, timedExecutor, poolExecutor,
+    KeyedPoolImpl<PooledNettyClientResourceManager.PooledClientConnection> pool =
+        new KeyedPoolImpl<>(1, 1, 300000, 1, rm, timedExecutor, poolExecutor,
             registry);
     rm.setPool(pool);
 
@@ -562,7 +562,7 @@ public class ScatterGatherTest {
     ScatterGatherImpl scImpl = new ScatterGatherImpl(pool, service);
     final ScatterGatherStats scatterGatherStats = new ScatterGatherStats();
     final BrokerMetrics brokerMetrics = new BrokerMetrics(new MetricsRegistry());
-    CompositeFuture<ServerInstance, ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
+    CompositeFuture<ByteBuf> fut = scImpl.scatterGather(req, scatterGatherStats, brokerMetrics);
     Map<ServerInstance, ByteBuf> v = fut.get();
 
     //Only 3 servers return value.


### PR DESCRIPTION
We always use this with ServerInstance (other than for tests), so hard-coded ServerInstance in to make
things easier while navigating. We can also use the interfaces exposed by ServerInstance specifically
in the Future implementations now. (coming in another PR)