### PR TITLE
Throw exception when failed to load segment in both retry and no retry case

### DIFF
--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -201,11 +201,10 @@ public class SegmentFetcherAndLoader {
             }
           }
         }
-        if (_segmentLoadMaxRetryCount <= retryCount) {
-          String msg =
-              "Failed to download segment " + segmentId + " (table " + tableName + " after " + retryCount + " retries";
-          LOGGER.error(msg);
-          throw new RuntimeException(msg);
+        if (retryCount == maxRetryCount) {
+          throw new RuntimeException(
+              "Failed to download and load segment " + segmentId + " (table " + tableName + " after " + retryCount
+                  + " retries");
         }
       } else {
         LOGGER.info("Got already loaded segment {} of table {} crc {} again, will do nothing.", segmentId, tableName, localSegmentMetadata.getCrc());


### PR DESCRIPTION
Note: Helix message itself does not have default retry unless explicitly set.
For customized message, will trigger the onError() callback when handleMessage() throws exception. 