### PR TITLE
Eliminate exception due to json parse error of table config zn record

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -360,8 +360,13 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
       } catch (Exception e) {
         // we want to continue setting watches for other tables for any kind of exception here so that
         // errors with one table don't impact others
-        LOGGER.error("Caught exception while processing ZNRecord id: {}. Skipping node to continue setting watches",
-            tableConfigZnRecord.getId(), e);
+        if (tableConfigZnRecord == null) {
+          // Can happen if the table config zn record failed to parse.
+          LOGGER.error("Got null ZN record for table config");
+        } else {
+          LOGGER.error("Caught exception while processing ZNRecord id: {}. Skipping node to continue setting watches",
+              tableConfigZnRecord.getId(), e);
+        }
       }
     }
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -362,7 +362,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         // errors with one table don't impact others
         if (tableConfigZnRecord == null) {
           // Can happen if the table config zn record failed to parse.
-          LOGGER.error("Got null ZN record for table config");
+          LOGGER.error("Got null ZN record for table config", e);
         } else {
           LOGGER.error("Caught exception while processing ZNRecord id: {}. Skipping node to continue setting watches",
               tableConfigZnRecord.getId(), e);


### PR DESCRIPTION
If a table config zn record fails to parse json, it is possible that controller fails to
take over leadership. We scan all table config records in PinotRealtimeSegmentManager.refreshWatchers()
method. One of the ZN records in the list will be null, and will throw an NPE as we iterate over
the list of tables. We do catch the exception, but then attempt to log the table name from
znRecord.getId(), and the log message throws an NPE