### PR TITLE
[TE] Fix empty group key handling

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/AlertGroupKey.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/AlertGroupKey.java
@@ -43,6 +43,24 @@ public class AlertGroupKey<T> {
     return key;
   }
 
+  /**
+   * Returns raw key's toString method if it is not null.
+   *
+   * @return an empty string if the raw key is null.
+   */
+  public String toGroupName() {
+    if (key != null) {
+      return key.toString();
+    } else {
+      return "";
+    }
+  }
+
+  /**
+   * Returns an empty group key, whose raw key is null.
+   *
+   * @return an empty group key.
+   */
   @SuppressWarnings("unchecked")
   public static final <T> AlertGroupKey<T> emptyKey() {
     return (AlertGroupKey<T>) EMPTY_KEY;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/BaseAlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/BaseAlertGrouper.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.Map;
 
 public abstract class BaseAlertGrouper<T> implements AlertGrouper<T> {
+  public static final String EMPTY_RECIPIENTS = "";
+
   protected Map<String, String> props = Collections.emptyMap();
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouper.java
@@ -136,11 +136,11 @@ public class DimensionalAlertGrouper extends BaseAlertGrouper<DimensionMap> {
 
   @Override
   public String groupEmailRecipients(AlertGroupKey<DimensionMap> alertGroupKey) {
-    DimensionMap dimensionMap = alertGroupKey.getKey();
-    if (auxiliaryEmailRecipients.containsKey(dimensionMap)) {
-      return auxiliaryEmailRecipients.get(dimensionMap);
+    if (alertGroupKey == null || AlertGroupKey.emptyKey().equals(alertGroupKey) || !auxiliaryEmailRecipients
+        .containsKey(alertGroupKey.getKey())) {
+      return EMPTY_RECIPIENTS;
     } else {
-      return "";
+      return auxiliaryEmailRecipients.get(alertGroupKey.getKey());
     }
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DummyAlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DummyAlertGrouper.java
@@ -29,6 +29,6 @@ public class DummyAlertGrouper extends BaseAlertGrouper<DimensionMap> {
 
   @Override
   public String groupEmailRecipients(AlertGroupKey alertGroupKey) {
-    return "";
+    return BaseAlertGrouper.EMPTY_RECIPIENTS;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
@@ -152,11 +152,9 @@ public class AlertTaskRunnerV2 implements TaskRunner {
           }
           // Append group name after config name if the group name is not an empty string or group
           String emailName = alertConfig.getName();
-          if (!AlertGroupKey.emptyKey().equals(entry.getKey())) {
-            String groupName = entry.getKey().toString();
-            if (StringUtils.isNotBlank(groupName)) {
-              emailName = emailName + " " + groupName;
-            }
+          String groupName = entry.getKey().toGroupName();
+          if (StringUtils.isNotBlank(groupName)) {
+            emailName = emailName + " " + groupName;
           }
           // Generate and send out an anomaly report for this group
           AnomalyReportGenerator.getInstance()

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouperTest.java
@@ -129,6 +129,15 @@ public class DimensionalAlertGrouperTest {
     dimensionMap2.put("K2", "V3"); // K2 should not affect group key
     AlertGroupKey<DimensionMap> alertGroupKey2 = alertGrouper.constructGroupKey(dimensionMap2);
     Assert.assertEquals(alertGrouper.groupEmailRecipients(alertGroupKey2), EMAIL1);
+
+    // Test empty recipients
+    Assert.assertEquals(alertGrouper.groupEmailRecipients(AlertGroupKey.<DimensionMap>emptyKey()),
+        BaseAlertGrouper.EMPTY_RECIPIENTS);
+    Assert.assertEquals(alertGrouper.groupEmailRecipients(null), BaseAlertGrouper.EMPTY_RECIPIENTS);
+    DimensionMap dimensionMapNonExist = new DimensionMap();
+    dimensionMapNonExist.put("K2", "V1");
+    AlertGroupKey<DimensionMap> alertGroupKey3 = alertGrouper.constructGroupKey(dimensionMapNonExist);
+    Assert.assertEquals(alertGrouper.groupEmailRecipients(alertGroupKey3), BaseAlertGrouper.EMPTY_RECIPIENTS);
   }
 
   @DataProvider(name = "prepareAnomalyGroups")


### PR DESCRIPTION
1. Fix NPE when querying auxiliary email recipients using an empty group key.
2. Improve the name of group key that shows on email UI.

Tested on local alerter setting.