### PR TITLE
Add support for Star Tree realtime segment generation.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,6 +41,7 @@ public class IndexingConfig {
   private String _starTreeFormat;
   private String _columnMinMaxValueGeneratorMode;
   private List<String> _noDictionaryColumns;
+  private StarTreeIndexSpec _starTreeIndexSpec;
   private SegmentPartitionConfig _segmentPartitionConfig;
 
 
@@ -121,6 +123,14 @@ public class IndexingConfig {
 
   public void setNoDictionaryColumns(List<String> noDictionaryColumns) {
     _noDictionaryColumns = noDictionaryColumns;
+  }
+
+  public void setStarTreeIndexSpec(StarTreeIndexSpec starTreeIndexSpec) {
+    _starTreeIndexSpec = starTreeIndexSpec;
+  }
+
+  public StarTreeIndexSpec getStarTreeIndexSpec() {
+    return _starTreeIndexSpec;
   }
 
   public void setSegmentPartitionConfig(SegmentPartitionConfig config) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
@@ -20,7 +20,10 @@ import com.google.common.base.Objects;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StarTreeIndexSpec {
   public static final Integer DEFAULT_MAX_LEAF_RECORDS = 100000; // TODO: determine a good number via experiment
   public static final int DEFAULT_SKIP_MATERIALIZATION_CARDINALITY_THRESHOLD = 10000;

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
@@ -15,11 +15,15 @@
  */
 package com.linkedin.pinot.common.config;
 
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONException;
@@ -84,5 +88,55 @@ public class IndexingConfigTest {
       Assert.assertEquals(actualPartitionConfig.getNumPartitions(column),
           expectedPartitionConfig.getNumPartitions(column));
     }
+  }
+
+  /**
+   * Unit test to check get and set of star tree index spec on IndexingConfig.
+   * <ul>
+   *   <li> Creates a StarTreeIndexSpec and sets it into the IndexingConfig. </li>
+   *   <li> Indexing config is first serialized into a string, and then read back from string. </li>
+   *   <li> Test to ensure star tree index spec values are correct after serialization and de-serialization. </li>
+   * </ul>
+   * @throws IOException
+   */
+  @Test
+  public void testStarTreeSpec()
+      throws IOException {
+    Random random = new Random(System.nanoTime());
+    StarTreeIndexSpec expectedStarTreeSpec = new StarTreeIndexSpec();
+
+    List<String> expectedDimensionSplitOrder = Arrays.asList("col1", "col2", "col3");
+    expectedStarTreeSpec.setDimensionsSplitOrder(expectedDimensionSplitOrder);
+
+    Integer expectedMaxLeafRecords = random.nextInt();
+    expectedStarTreeSpec.setMaxLeafRecords(expectedMaxLeafRecords);
+
+    int expectedSkipMaterializationThreshold = random.nextInt();
+    expectedStarTreeSpec.setSkipMaterializationCardinalityThreshold(expectedSkipMaterializationThreshold);
+
+    Set<String> expectedSkipMaterializationDimensions = new HashSet<>(Arrays.asList(new String[]{"col4", "col5"}));
+    expectedStarTreeSpec.setSkipMaterializationForDimensions(expectedSkipMaterializationDimensions);
+
+    Set<String> expectedSkipStarNodeCreationForDimension = new HashSet<>(Arrays.asList(new String[]{"col6", "col7"}));
+    expectedStarTreeSpec.setSkipStarNodeCreationForDimensions(expectedSkipStarNodeCreationForDimension);
+
+    IndexingConfig expectedIndexingConfig = new IndexingConfig();
+    expectedIndexingConfig.setStarTreeIndexSpec(expectedStarTreeSpec);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String indexingConfigString = objectMapper.writeValueAsString(expectedIndexingConfig);
+
+    IndexingConfig actualIndexingConfig = objectMapper.readValue(indexingConfigString, IndexingConfig.class);
+    StarTreeIndexSpec actualStarTreeSpec = actualIndexingConfig.getStarTreeIndexSpec();
+
+    Assert.assertEquals(actualStarTreeSpec.getDimensionsSplitOrder(), expectedDimensionSplitOrder);
+    Assert.assertEquals(actualStarTreeSpec.getMaxLeafRecords(), expectedMaxLeafRecords);
+
+    Assert.assertEquals(actualStarTreeSpec.getskipMaterializationCardinalityThreshold(),
+        expectedSkipMaterializationThreshold);
+    Assert.assertEquals(actualStarTreeSpec.getskipMaterializationForDimensions(),
+        expectedSkipMaterializationDimensions);
+    Assert.assertEquals(actualStarTreeSpec.getSkipStarNodeCreationForDimensions(),
+        expectedSkipStarNodeCreationForDimension);
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -262,7 +262,7 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
               new RealtimeSegmentConverter(realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
                   segmentMetadata.getTableName(), segmentMetadata.getSegmentName(), sortedColumn,
                   HLRealtimeSegmentDataManager.this.invertedIndexColumns,
-                  noDictionaryColumns);
+                  noDictionaryColumns, null/*StarTreeIndexSpec*/); // Star tree not supported for HLC.
 
           segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
@@ -173,6 +174,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   private final String _tableName;
   private final List<String> _invertedIndexColumns;
   private final List<String> _noDictionaryColumns;
+  private final StarTreeIndexSpec _starTreeIndexSpec;
   private final String _sortedColumn;
   private Logger segmentLogger = LOGGER;
   private final String _tableStreamName;
@@ -533,7 +535,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
     RealtimeSegmentConverter converter =
         new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
             _segmentZKMetadata.getTableName(), _segmentZKMetadata.getSegmentName(), _sortedColumn,
-            _invertedIndexColumns, _noDictionaryColumns);
+            _invertedIndexColumns, _noDictionaryColumns, _starTreeIndexSpec);
     logStatistics();
     segmentLogger.info("Trying to build segment");
     final long buildStartTime = now();
@@ -819,6 +821,9 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
 
     // No dictionary Columns
     _noDictionaryColumns = new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns());
+
+    // Read the star tree config
+    _starTreeIndexSpec = indexingConfig.getStarTreeIndexSpec();
 
     // Read the max number of rows
     int segmentMaxRowCount = kafkaStreamProviderConfig.getSizeThresholdToFlushSegment();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.config.SegmentPartitionConfig;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ServerMeter;
@@ -45,6 +46,7 @@ import com.linkedin.pinot.core.realtime.impl.invertedIndex.TimeInvertedIndex;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.startree.StarTree;
+import com.linkedin.pinot.core.startree.StarTreeBuilderConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,6 +96,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
 
   private final ServerMetrics serverMetrics;
   private final String tableAndStreamName;
+  private StarTreeIndexSpec starTreeIndexSpec = null;
   private SegmentPartitionConfig segmentPartitionConfig = null;
 
   public RealtimeSegmentImpl(Schema schema, int capacity, String tableName, String segmentName, String streamName,


### PR DESCRIPTION
1. Added support in IndexingConfig to specify StarTreeIndexSpec.
2. Added code that picks up star tree index spec from IndexingConfig
   and passes it to segment generation.
3. Only enabled for LLC, as HLC will be phased out.
4. Added unit test for serialization/deserialization of star tree
   spec using IndexingConfig.