### PR TITLE
Autometrics config setup

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.client;
 
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
+import com.linkedin.thirdeye.datalayer.bao.AutometricsConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.ClassificationConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.DashboardConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.DataCompletenessConfigManager;
@@ -20,6 +21,7 @@ import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AnomalyFunctionManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.AutometricsConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.ClassificationConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.DashboardConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.DataCompletenessConfigManagerImpl;
@@ -151,5 +153,9 @@ public class DAORegistry {
 
   public ClassificationConfigManager getClassificationConfigDAO() {
     return DaoProviderUtil.getInstance(ClassificationConfigManagerImpl.class);
+  }
+
+  public AutometricsConfigManager getAutometricsConfigDAO() {
+    return DaoProviderUtil.getInstance(AutometricsConfigManagerImpl.class);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AutometricsConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AutometricsConfigManager.java
@@ -1,0 +1,15 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import java.util.List;
+
+import com.linkedin.thirdeye.datalayer.dto.AutometricsConfigDTO;
+
+
+public interface AutometricsConfigManager extends AbstractManager<AutometricsConfigDTO> {
+
+  List<AutometricsConfigDTO> findByDashboard(String dashboard);
+  AutometricsConfigDTO findByDashboardAndMetric(String dashboard, String metric);
+  AutometricsConfigDTO findByRrd(String rrd);
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AutometricsConfigManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AutometricsConfigManagerImpl.java
@@ -1,0 +1,48 @@
+package com.linkedin.thirdeye.datalayer.bao.jdbc;
+
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+
+import com.linkedin.thirdeye.datalayer.bao.AutometricsConfigManager;
+import com.linkedin.thirdeye.datalayer.dto.AutometricsConfigDTO;
+import com.linkedin.thirdeye.datalayer.pojo.AutometricsConfigBean;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+
+public class AutometricsConfigManagerImpl extends AbstractManagerImpl<AutometricsConfigDTO>
+implements AutometricsConfigManager {
+
+  public AutometricsConfigManagerImpl() {
+    super(AutometricsConfigDTO.class, AutometricsConfigBean.class);
+  }
+
+  @Override
+  public List<AutometricsConfigDTO> findByDashboard(String dashboard) {
+    Predicate predicate = Predicate.EQ("dashboard", dashboard);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public AutometricsConfigDTO findByDashboardAndMetric(String dashboard, String metric) {
+    Predicate dashboardPredicate = Predicate.EQ("dashboard", dashboard);
+    Predicate metricPredicate = Predicate.EQ("metric", metric);
+    List<AutometricsConfigBean> list = genericPojoDao.get(Predicate.AND(dashboardPredicate, metricPredicate),
+        AutometricsConfigBean.class);
+    AutometricsConfigDTO result = null;
+    if (CollectionUtils.isNotEmpty(list)) {
+      result = MODEL_MAPPER.map(list.get(0), AutometricsConfigDTO.class);
+    }
+    return result;
+  }
+
+  @Override
+  public AutometricsConfigDTO findByRrd(String rrd) {
+    Predicate rrdPredicate = Predicate.EQ("rrd", rrd);
+    List<AutometricsConfigBean> list = genericPojoDao.get(rrdPredicate, AutometricsConfigBean.class);
+    AutometricsConfigDTO result = null;
+    if (CollectionUtils.isNotEmpty(list)) {
+      result = MODEL_MAPPER.map(list.get(0), AutometricsConfigDTO.class);
+    }
+    return result;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -41,6 +41,7 @@ import com.linkedin.thirdeye.datalayer.entity.AbstractIndexEntity;
 import com.linkedin.thirdeye.datalayer.entity.AbstractJsonEntity;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFeedbackIndex;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFunctionIndex;
+import com.linkedin.thirdeye.datalayer.entity.AutometricsConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DashboardConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DataCompletenessConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DatasetConfigIndex;
@@ -57,6 +58,7 @@ import com.linkedin.thirdeye.datalayer.entity.TaskIndex;
 import com.linkedin.thirdeye.datalayer.pojo.AbstractBean;
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFeedbackBean;
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFunctionBean;
+import com.linkedin.thirdeye.datalayer.pojo.AutometricsConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.DashboardConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.DataCompletenessConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
@@ -121,6 +123,8 @@ public class GenericPojoDao {
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, AutotuneConfigIndex.class));
     pojoInfoMap.put(ClassificationConfigBean.class,
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, ClassificationConfigIndex.class));
+    pojoInfoMap.put(AutometricsConfigBean.class,
+        newPojoInfo(DEFAULT_BASE_TABLE_NAME, AutometricsConfigIndex.class));
   }
 
   private static PojoInfo newPojoInfo(String baseTableName,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AutometricsConfigDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AutometricsConfigDTO.java
@@ -1,0 +1,7 @@
+package com.linkedin.thirdeye.datalayer.dto;
+
+import com.linkedin.thirdeye.datalayer.pojo.AutometricsConfigBean;
+
+public class AutometricsConfigDTO extends AutometricsConfigBean {
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/AutometricsConfigIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/AutometricsConfigIndex.java
@@ -1,0 +1,37 @@
+package com.linkedin.thirdeye.datalayer.entity;
+
+public class AutometricsConfigIndex extends AbstractIndexEntity {
+
+  private String metric;
+  private String dashboard;
+  private String rrd;
+  private String autometricsType;
+
+  public String getMetric() {
+    return metric;
+  }
+  public void setMetric(String metric) {
+    this.metric = metric;
+  }
+  public String getDashboard() {
+    return dashboard;
+  }
+  public void setDashboard(String dashboard) {
+    this.dashboard = dashboard;
+  }
+  public String getRrd() {
+    return rrd;
+  }
+  public void setRrd(String rrd) {
+    this.rrd = rrd;
+  }
+  public String getAutometricsType() {
+    return autometricsType;
+  }
+  public void setAutometricsType(String autometricType) {
+    this.autometricsType = autometricType;
+  }
+
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AutometricsConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AutometricsConfigBean.java
@@ -1,0 +1,121 @@
+package com.linkedin.thirdeye.datalayer.pojo;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+
+/**
+ * Class to represent the autometric definition in thirdeye database
+ */
+public class AutometricsConfigBean extends AbstractBean {
+
+  /** Metric name as in MetricConfig **/
+  private String metric;
+  /** Dashboard name in external dashboard, and dataset name in datasetConfig **/
+  private String dashboard;
+  private String rrd;
+  private String metricDataType;
+  /**  COUNTER or GAUGE **/
+  private String autometricsType;
+  private String container;
+  private String fabricGroup;
+  private boolean active = true;
+
+  public AutometricsConfigBean() {
+  }
+
+  public String getMetric() {
+    return metric;
+  }
+
+  public void setMetric(String metric) {
+    this.metric = metric;
+  }
+
+  public String getDashboard() {
+    return dashboard;
+  }
+
+  public void setDashboard(String dashboard) {
+    this.dashboard = dashboard;
+  }
+
+  public String getRrd() {
+    return rrd;
+  }
+
+  public void setRrd(String rrd) {
+    this.rrd = rrd;
+  }
+
+  public String getMetricDataType() {
+    return metricDataType;
+  }
+
+  public void setMetricDataType(String metricDataType) {
+    this.metricDataType = metricDataType;
+  }
+
+  public String getAutometricsType() {
+    return autometricsType;
+  }
+
+  public void setAutometricsType(String autometricType) {
+    this.autometricsType = autometricType;
+  }
+
+  public String getContainer() {
+    return container;
+  }
+
+  public void setContainer(String container) {
+    this.container = container;
+  }
+
+  public String getFabricGroup() {
+    return fabricGroup;
+  }
+
+  public void setFabricGroup(String fabricGroup) {
+    this.fabricGroup = fabricGroup;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metric, dashboard, rrd, metricDataType, autometricsType, container, fabricGroup, active);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+
+    if (!(o instanceof AutometricsConfigBean)) {
+      return false;
+    }
+    AutometricsConfigBean ac = (AutometricsConfigBean) o;
+    return Objects.equals(getMetric(), ac.getMetric())
+        && Objects.equals(getDashboard(), ac.getDashboard())
+        && Objects.equals(getRrd(), ac.getRrd())
+        && Objects.equals(getMetricDataType(), ac.getMetricDataType())
+        && Objects.equals(getAutometricsType(), ac.getAutometricsType())
+        && Objects.equals(getContainer(), ac.getContainer())
+        && Objects.equals(getFabricGroup(), ac.getFabricGroup())
+        && Objects.equals(isActive(), ac.isActive());
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+  }
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AutometricsConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AutometricsConfigBean.java
@@ -2,9 +2,6 @@ package com.linkedin.thirdeye.datalayer.pojo;
 
 import java.util.Objects;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 
 /**
  * Class to represent the autometric definition in thirdeye database
@@ -111,11 +108,5 @@ public class AutometricsConfigBean extends AbstractBean {
         && Objects.equals(getFabricGroup(), ac.getFabricGroup())
         && Objects.equals(isActive(), ac.isActive());
   }
-
-  @Override
-  public String toString() {
-    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
-  }
-
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
@@ -23,6 +23,7 @@ import com.linkedin.thirdeye.datalayer.bao.jdbc.AbstractManagerImpl;
 import com.linkedin.thirdeye.datalayer.dto.AbstractDTO;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFeedbackIndex;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFunctionIndex;
+import com.linkedin.thirdeye.datalayer.entity.AutometricsConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DashboardConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DataCompletenessConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DatasetConfigIndex;
@@ -140,6 +141,8 @@ public abstract class DaoProviderUtil {
             convertCamelCaseToUnderscore(AutotuneConfigIndex.class.getSimpleName()));
         entityMappingHolder.register(conn, ClassificationConfigIndex.class,
             convertCamelCaseToUnderscore(ClassificationConfigIndex.class.getSimpleName()));
+        entityMappingHolder.register(conn, AutometricsConfigIndex.class,
+            convertCamelCaseToUnderscore(AutometricsConfigIndex.class.getSimpleName()));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -13,6 +13,7 @@ import com.linkedin.thirdeye.constant.MetricAggFunction;
 import com.linkedin.thirdeye.datalayer.ScriptRunner;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.dto.AutometricsConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DataCompletenessConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
@@ -69,6 +70,7 @@ public abstract class AbstractManagerTestBase {
   protected DetectionStatusManager detectionStatusDAO;
   protected AutotuneConfigManager autotuneConfigDAO;
   protected ClassificationConfigManager classificationConfigDAO;
+  protected AutometricsConfigManager autometricsConfigDAO;
 
   //  protected TestDBResources testDBResources;
   protected DAORegistry daoRegistry;
@@ -104,6 +106,7 @@ public abstract class AbstractManagerTestBase {
       detectionStatusDAO = daoRegistry.getDetectionStatusDAO();
       autotuneConfigDAO = daoRegistry.getAutotuneConfigDAO();
       classificationConfigDAO = daoRegistry.getClassificationConfigDAO();
+      autometricsConfigDAO = daoRegistry.getAutometricsConfigDAO();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -280,6 +283,19 @@ public abstract class AbstractManagerTestBase {
     metricConfigDTO.setName(metric);
     metricConfigDTO.setAlias(ThirdEyeUtils.constructMetricAlias(collection, metric));
     return metricConfigDTO;
+  }
+
+
+  protected AutometricsConfigDTO getTestAutometricsConfig(String rrd, String metric, String dashboard) {
+    AutometricsConfigDTO autometricsConfig = new AutometricsConfigDTO();
+    autometricsConfig.setMetric(metric);
+    autometricsConfig.setDashboard(dashboard);
+    autometricsConfig.setRrd(rrd);
+    autometricsConfig.setMetricDataType("DOUBLE");
+    autometricsConfig.setAutometricsType("COUNTER");
+    autometricsConfig.setFabricGroup("corp");
+    autometricsConfig.setContainer("container");
+    return autometricsConfig;
   }
 
   protected IngraphMetricConfigDTO getTestIngraphMetricConfig(String rrd, String metric,

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAutometricsConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAutometricsConfigManager.java
@@ -1,0 +1,89 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.linkedin.thirdeye.datalayer.dto.AutometricsConfigDTO;
+
+public class TestAutometricsConfigManager extends AbstractManagerTestBase {
+
+  private Long autometricsConfigId1 = null;
+  private Long autometricsConfigId2 = null;
+  private static String rrd1 = "rrd1";
+  private static String metric1 = "metric1";
+  private static String rrd2 = "rrd2";
+  private static String metric2 = "metric2";
+  private static String dashboard1 = "dashboard1";
+  private static String dashboard2 = "dashboard2";
+
+  @BeforeClass
+  void beforeClass() {
+    super.init();
+  }
+
+  @AfterClass(alwaysRun = true)
+  void afterClass() {
+    super.cleanup();
+  }
+
+  @Test
+  public void testCreateAutometrics() {
+
+    AutometricsConfigDTO autometricsConfigDTO1 = getTestAutometricsConfig(rrd1, metric1, dashboard1);
+    autometricsConfigId1 = autometricsConfigDAO.save(autometricsConfigDTO1);
+    Assert.assertNotNull(autometricsConfigId1);
+
+    AutometricsConfigDTO autometricsConfigDTO2 = getTestAutometricsConfig(rrd2, metric2, dashboard2);
+    autometricsConfigId2 = autometricsConfigDAO.save(autometricsConfigDTO2);
+    Assert.assertNotNull(autometricsConfigId2);
+
+  }
+
+  @Test(dependsOnMethods = {"testCreateAutometrics"})
+  public void testFindAutometrics() {
+
+    List<AutometricsConfigDTO> autometricsConfigDTOs = autometricsConfigDAO.findAll();
+    Assert.assertEquals(autometricsConfigDTOs.size(), 2);
+
+    autometricsConfigDTOs = autometricsConfigDAO.findByDashboard(dashboard1);
+    Assert.assertEquals(autometricsConfigDTOs.size(), 1);
+
+    AutometricsConfigDTO autometricsConfigDTO = autometricsConfigDAO.
+        findByDashboardAndMetric(dashboard1, metric1);
+    Assert.assertEquals(autometricsConfigDTO.getDashboard(), dashboard1);
+    Assert.assertEquals(autometricsConfigDTO.getMetric(), metric1);
+    Assert.assertEquals(autometricsConfigDTO.getRrd(), rrd1);
+
+    autometricsConfigDTO = autometricsConfigDAO.findByRrd(rrd1);
+    Assert.assertEquals(autometricsConfigDTO.getDashboard(), dashboard1);
+    Assert.assertEquals(autometricsConfigDTO.getMetric(), metric1);
+    Assert.assertEquals(autometricsConfigDTO.getRrd(), rrd1);
+
+  }
+
+  @Test(dependsOnMethods = { "testFindAutometrics" })
+  public void testUpdateAutometrics() {
+    AutometricsConfigDTO autometricsConfigDTO = autometricsConfigDAO.findById(autometricsConfigId1);
+    Assert.assertNotNull(autometricsConfigDTO);
+    Assert.assertEquals(autometricsConfigDTO.getDashboard(), dashboard1);
+    autometricsConfigDTO.setDashboard(dashboard2);
+    autometricsConfigDAO.update(autometricsConfigDTO);
+    autometricsConfigDTO = autometricsConfigDAO.findById(autometricsConfigId1);
+    Assert.assertNotNull(autometricsConfigDTO);
+    Assert.assertEquals(autometricsConfigDTO.getDashboard(), dashboard2);
+
+    List<AutometricsConfigDTO> autometricsConfigDTOs = autometricsConfigDAO.findByDashboard(dashboard2);
+    Assert.assertEquals(autometricsConfigDTOs.size(), 2);
+  }
+
+  @Test(dependsOnMethods = { "testUpdateAutometrics" })
+  public void testDeleteAutometrics() {
+    autometricsConfigDAO.deleteById(autometricsConfigId1);
+    AutometricsConfigDTO autometricsConfigDTO = autometricsConfigDAO.findById(autometricsConfigId1);
+    Assert.assertNull(autometricsConfigDTO);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -307,3 +307,19 @@ create table if not exists classification_config_index (
 ALTER TABLE `classification_config_index` ADD UNIQUE `classification_config_unique_index`(`name`);
 create index classification_config_name_index on classification_config_index(name);
 create index classification_config_function_index on classification_config_index(main_function_id);
+
+create table if not exists autometrics_config_index (
+    metric varchar(500) not null,
+    dashboard varchar(500) not null,
+    rrd varchar(2000) not null,
+    autometrics_type varchar(100) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `autometrics_config_index` ADD UNIQUE `autometrics_config_unique_index`(`dashboard`, `metric`);
+create index autometrics_config_metric_idx on autometrics_config_index(metric);
+create index autometrics_config_dashboard_idx on autometrics_config_index(dashboard);
+create index autometrics_config_rrd_idx on autometrics_config_index(rrd);
+create index autometrics_config_autometrics_type_idx on autometrics_config_index(autometrics_type);

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
@@ -19,4 +19,5 @@ DROP TABLE IF EXISTS dashboard_config_index;
 DROP TABLE IF EXISTS event_index;
 DROP TABLE IF EXISTS detection_status_index;
 DROP TABLE IF EXISTS autotune_config_index;
+DROP TABLE IF EXISTS autometrics_config_index;
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Creating a new table called autometrics config for storing autometrics. This will replace the ingraph_dashboard and ingraph_metrics tables. Created a new one instead of modifying the existing ones, so that this jar can be used in the webapp MP during development, without disturbing the existing setup, and also because the metrics store is actually called autometrics.
This is the table which will be used by the Autometrics client, to get additional information about the metrics it has identified to be from autometrics (which will happen via dataset config flag, or by checking presence of dataset and metric name in autometrics table)