### PR TITLE
Split actual integration tests from BaseClusterIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestWithQueryGenerator.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestWithQueryGenerator.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.integration.tests;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public abstract class BaseClusterIntegrationTestWithQueryGenerator extends BaseClusterIntegrationTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseClusterIntegrationTestWithQueryGenerator.class);
+
+  /**
+   * NOTE:
+   * <p>
+   * For queries with <code>LIMIT</code> or <code>TOP</code>, need to remove limit or add <code>LIMIT 10000</code> to
+   * the H2 SQL query because the comparison only works on exhausted result with at most 10000 rows.
+   * <ul>
+   *   <li>Eg. <code>SELECT a FROM table LIMIT 15 -> [SELECT a FROM table LIMIT 10000]</code></li>
+   * </ul>
+   * <p>
+   * For queries with multiple aggregation functions, need to split each of them into a separate H2 SQL query.
+   * <ul>
+   *   <li>Eg. <code>SELECT SUM(a), MAX(b) FROM table -> [SELECT SUM(a) FROM table, SELECT MAX(b) FROM table]</code></li>
+   * </ul>
+   * <p>
+   * For group-by queries, need to add group-by columns to the select clause for H2 SQL query.
+   * <ul>
+   *   <li>Eg. <code>SELECT SUM(a) FROM table GROUP BY b -> [SELECT b, SUM(a) FROM table GROUP BY b]</code></li>
+   * </ul>
+   *
+   * @throws Exception
+   */
+  @Test(enabled = false)
+  public void testHardcodedQueries()
+      throws Exception {
+    // Here are some sample queries.
+    String query;
+    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch = 16312 AND Carrier = 'DL'";
+    runQuery(query, Collections.singletonList(query));
+    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = 'DL'";
+    runQuery(query, Collections.singletonList(query));
+    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch > 16312 AND Carrier = 'DL'";
+    runQuery(query, Collections.singletonList(query));
+    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch >= 16312 AND Carrier = 'DL'";
+    runQuery(query, Collections.singletonList(query));
+    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch < 16312 AND Carrier = 'DL'";
+    runQuery(query, Collections.singletonList(query));
+    query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch <= 16312 AND Carrier = 'DL'";
+    runQuery(query, Collections.singletonList(query));
+    query = "SELECT MAX(ArrTime), MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 16312";
+    runQuery(query, Arrays.asList("SELECT MAX(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312",
+        "SELECT MIN(ArrTime) FROM mytable WHERE DaysSinceEpoch >= 15312"));
+  }
+
+  @Test
+  public void testHardcodedQuerySet()
+      throws Exception {
+    URL resourceUrl = BaseClusterIntegrationTest.class.getClassLoader()
+        .getResource("On_Time_On_Time_Performance_2014_100k_subset.test_queries_10K");
+    Assert.assertNotNull(resourceUrl);
+    File queriesFile = new File(resourceUrl.getFile());
+    Random random = new Random();
+
+    try (BufferedReader reader = new BufferedReader(new FileReader(queriesFile))) {
+      while (true) {
+        // Skip up to MAX_NUM_QUERIES_SKIPPED queries.
+        int numQueriesSkipped = random.nextInt(MAX_NUM_QUERIES_SKIPPED);
+        for (int i = 0; i < numQueriesSkipped; i++) {
+          reader.readLine();
+        }
+
+        String queryString = reader.readLine();
+        // Reach end of file.
+        if (queryString == null) {
+          return;
+        }
+
+        JSONObject query = new JSONObject(queryString);
+        String pqlQuery = query.getString("pql");
+        JSONArray hsqls = query.getJSONArray("hsqls");
+        List<String> sqlQueries = new ArrayList<>();
+        int length = hsqls.length();
+        for (int i = 0; i < length; i++) {
+          sqlQueries.add(hsqls.getString(i));
+        }
+        runQuery(pqlQuery, sqlQueries);
+      }
+    }
+  }
+
+  // This is disabled because testGeneratedQueriesWithMultiValues covers the same thing.
+  @Test(enabled = false)
+  public void testGeneratedQueriesWithoutMultiValues()
+      throws Exception {
+    testGeneratedQueries(false);
+  }
+
+  @Test
+  public void testGeneratedQueriesWithMultiValues()
+      throws Exception {
+    testGeneratedQueries(true);
+  }
+
+  protected void testGeneratedQueries(boolean withMultiValues)
+      throws Exception {
+    _queryGenerator.setSkipMultiValuePredicates(!withMultiValues);
+    int generatedQueryCount = getGeneratedQueryCount();
+    for (int i = 0; i < generatedQueryCount; i++) {
+      QueryGenerator.Query query = _queryGenerator.generateQuery();
+      String pqlQuery = query.generatePql();
+      LOGGER.debug("Running query: {}", pqlQuery);
+      runQuery(pqlQuery, query.generateH2Sql());
+    }
+  }
+
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/DefaultColumnsClusterIntegrationTest.java
@@ -53,7 +53,7 @@ import org.testng.annotations.Test;
  *   <li>"newAddedStringDimension", DIMENSION, STRING, multi-value, "newAdded"</li>
  * </ul>
  */
-public class DefaultColumnsClusterIntegrationTest extends BaseClusterIntegrationTest {
+public class DefaultColumnsClusterIntegrationTest extends BaseClusterIntegrationTestWithQueryGenerator {
   protected static final String SCHEMA_WITH_EXTRA_COLUMNS =
       "On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_extra_columns.schema";
   private static final File TMP_DIR = new File("/tmp/DefaultColumnsClusterIntegrationTest");

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -66,7 +66,7 @@ import kafka.server.KafkaServerStartable;
  * two month overlap).
  *
  */
-public class HybridClusterIntegrationTest extends BaseClusterIntegrationTest {
+public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestWithQueryGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeClusterIntegrationTest.class);
   private static final String TENANT_NAME = "TestTenant";
   protected final File _tmpDir = new File("/tmp/HybridClusterIntegrationTest");

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -53,7 +53,7 @@ import static org.testng.Assert.assertEquals;
  * Integration test that converts Avro data for 12 segments and runs queries against it.
  */
 @Test
-public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTest {
+public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestWithQueryGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(OfflineClusterIntegrationTest.class);
 
   private final File _tmpDir = new File("/tmp/OfflineClusterIntegrationTest");

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -36,7 +36,7 @@ import kafka.server.KafkaServerStartable;
  * Integration test that creates a Kafka broker, creates a Pinot cluster that consumes from Kafka and queries Pinot.
  *
  */
-public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTest {
+public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestWithQueryGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeClusterIntegrationTest.class);
   private final File _tmpDir = new File("/tmp/RealtimeClusterIntegrationTest");
   protected static final String KAFKA_TOPIC = "realtime-integration-test";

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/UploadRefreshDeleteIntegrationTest.java
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
  *
  * @author jfim
  */
-public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTest {
+public class UploadRefreshDeleteIntegrationTest extends BaseClusterIntegrationTestWithQueryGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(UploadRefreshDeleteIntegrationTest.class);
   protected final File _tmpDir = new File("/tmp/" + getClass().getSimpleName());
   protected final File _segmentsDir = new File(_tmpDir, "segments");


### PR DESCRIPTION
@jfim 

Split the query generation piece of BaseClusterIntegrationTest into
another subclass so that it is possible to inherit from
BaseClusterIntegrationTest without also inheriting the auto-generated
query tests.