### PR TITLE
Entity to entity mapping table for root cause analysis

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/DAORegistry.java
@@ -9,6 +9,7 @@ import com.linkedin.thirdeye.datalayer.bao.DataCompletenessConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.DetectionStatusManager;
 import com.linkedin.thirdeye.datalayer.bao.EmailConfigurationManager;
+import com.linkedin.thirdeye.datalayer.bao.EntityToEntityMappingManager;
 import com.linkedin.thirdeye.datalayer.bao.EventManager;
 import com.linkedin.thirdeye.datalayer.bao.AutotuneConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.IngraphDashboardConfigManager;
@@ -28,6 +29,7 @@ import com.linkedin.thirdeye.datalayer.bao.jdbc.DataCompletenessConfigManagerImp
 import com.linkedin.thirdeye.datalayer.bao.jdbc.DatasetConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.DetectionStatusManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.EmailConfigurationManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.EntityToEntityMappingManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.EventManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AutotuneConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.IngraphDashboardConfigManagerImpl;
@@ -157,5 +159,9 @@ public class DAORegistry {
 
   public AutometricsConfigManager getAutometricsConfigDAO() {
     return DaoProviderUtil.getInstance(AutometricsConfigManagerImpl.class);
+  }
+
+  public EntityToEntityMappingManager getEntityToEntityMappingDAO() {
+    return DaoProviderUtil.getInstance(EntityToEntityMappingManagerImpl.class);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -11,6 +11,7 @@ import com.linkedin.thirdeye.dashboard.resources.DataCompletenessResource;
 import com.linkedin.thirdeye.dashboard.resources.DatasetConfigResource;
 import com.linkedin.thirdeye.dashboard.resources.EmailResource;
 import com.linkedin.thirdeye.dashboard.resources.EntityManagerResource;
+import com.linkedin.thirdeye.dashboard.resources.EntityMappingResource;
 import com.linkedin.thirdeye.dashboard.resources.IngraphDashboardConfigResource;
 import com.linkedin.thirdeye.dashboard.resources.IngraphMetricConfigResource;
 import com.linkedin.thirdeye.dashboard.resources.JobResource;
@@ -25,6 +26,7 @@ import com.linkedin.thirdeye.dashboard.resources.v2.EventResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.TimeSeriesResource;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
+
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -84,6 +86,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new OnboardResource());
     env.jersey().register(new EventResource(config));
     env.jersey().register(new DataCompletenessResource(DAO_REGISTRY.getDataCompletenessConfigDAO()));
+    env.jersey().register(new EntityMappingResource());
   }
 
   public static void main(String[] args) throws Exception {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/EntityMappingResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/EntityMappingResource.java
@@ -1,0 +1,116 @@
+package com.linkedin.thirdeye.dashboard.resources;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.lang3.StringUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.thirdeye.client.DAORegistry;
+import com.linkedin.thirdeye.datalayer.bao.EntityToEntityMappingManager;
+import com.linkedin.thirdeye.datalayer.dto.EntityToEntityMappingDTO;
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingType;
+
+@Path(value = "/entityMapping")
+@Produces(MediaType.APPLICATION_JSON)
+public class EntityMappingResource {
+
+  private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
+
+  private static final EntityToEntityMappingManager entityMappingDAO = DAO_REGISTRY.getEntityToEntityMappingDAO();
+
+
+  public EntityMappingResource() {
+  }
+
+  @GET
+  @Path("/view")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<EntityToEntityMappingDTO> viewEntityMappings(
+      @QueryParam("fromUrn") String fromUrn,
+      @QueryParam("toUrn") String toUrn,
+      @QueryParam("mappingType") String mappingType) {
+
+    List<EntityToEntityMappingDTO> mappings = new ArrayList<>();
+    if (StringUtils.isBlank(fromUrn) && StringUtils.isBlank(toUrn) && StringUtils.isBlank(mappingType)) {
+      mappings = entityMappingDAO.findAll();
+    } else {
+      Map<String, Object> filters = new HashMap<>();
+      if (StringUtils.isNotBlank(fromUrn)) {
+        filters.put("fromUrn", fromUrn);
+      }
+      if (StringUtils.isNotBlank(toUrn)) {
+        filters.put("toUrn", toUrn);
+      }
+      if (StringUtils.isNotBlank(mappingType)) {
+        filters.put("mappingType", mappingType);
+      }
+      mappings = entityMappingDAO.findByParams(filters);
+    }
+    return mappings;
+  }
+
+  @POST
+  @Path("/create")
+  public void createEntityMapping(String payload) {
+    EntityToEntityMappingDTO entityToEntityMapping = null;
+    try {
+      entityToEntityMapping = OBJECT_MAPPER.readValue(payload, EntityToEntityMappingDTO.class);
+      entityMappingDAO.save(entityToEntityMapping);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid payload " + payload, e);
+    }
+  }
+
+
+  @POST
+  @Path("/update/{id}")
+  public void updateEntityMapping(
+      @PathParam("id") Long id,
+      @QueryParam("fromUrn") String fromUrn,
+      @QueryParam("toUrn") String toUrn,
+      @QueryParam("mappingType") String mappingType,
+      @QueryParam("score") Double score) {
+
+    EntityToEntityMappingDTO entityMappingDTO = entityMappingDAO.findById(id);
+    if (entityMappingDTO != null) {
+      if (StringUtils.isNotBlank(fromUrn)) {
+        entityMappingDTO.setFromUrn(fromUrn);
+      }
+      if (StringUtils.isNotBlank(toUrn)) {
+        entityMappingDTO.setToUrn(toUrn);
+      }
+      if (StringUtils.isNotBlank(mappingType)) {
+        entityMappingDTO.setMappingType(MappingType.valueOf(mappingType));
+      }
+      if (score != null) {
+        entityMappingDTO.setScore(score);
+      }
+      entityMappingDAO.update(entityMappingDTO);
+    }
+  }
+
+
+  @DELETE
+  @Path("/delete/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public void deleteEntityMappings(@PathParam("id") Long id) {
+    EntityToEntityMappingDTO entityMappingDTO = entityMappingDAO.findById(id);
+    if (entityMappingDTO != null) {
+      entityMappingDAO.delete(entityMappingDTO);
+    }
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/EntityToEntityMappingManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/EntityToEntityMappingManager.java
@@ -1,0 +1,15 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import com.linkedin.thirdeye.datalayer.dto.EntityToEntityMappingDTO;
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingType;
+
+import java.util.List;
+
+public interface EntityToEntityMappingManager extends AbstractManager<EntityToEntityMappingDTO> {
+  List<EntityToEntityMappingDTO> findByFromUrn(String fromUrn);
+  List<EntityToEntityMappingDTO> findByToUrn(String toUrn);
+  EntityToEntityMappingDTO findByFromAndToUrn(String fromUrn, String toUrn);
+  List<EntityToEntityMappingDTO> findByMappingType(MappingType mappingType);
+  List<EntityToEntityMappingDTO> findByFromUrnAndMappingType(String fromUrn, MappingType mappingType);
+  List<EntityToEntityMappingDTO> findByToUrnAndMappingType(String toUrn, MappingType mappingType);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/EntityToEntityMappingManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/EntityToEntityMappingManager.java
@@ -6,10 +6,10 @@ import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingTyp
 import java.util.List;
 
 public interface EntityToEntityMappingManager extends AbstractManager<EntityToEntityMappingDTO> {
-  List<EntityToEntityMappingDTO> findByFromUrn(String fromUrn);
-  List<EntityToEntityMappingDTO> findByToUrn(String toUrn);
-  EntityToEntityMappingDTO findByFromAndToUrn(String fromUrn, String toUrn);
+  List<EntityToEntityMappingDTO> findByFromURN(String fromURN);
+  List<EntityToEntityMappingDTO> findByToURN(String toURN);
+  EntityToEntityMappingDTO findByFromAndToURN(String fromURN, String toURN);
   List<EntityToEntityMappingDTO> findByMappingType(MappingType mappingType);
-  List<EntityToEntityMappingDTO> findByFromUrnAndMappingType(String fromUrn, MappingType mappingType);
-  List<EntityToEntityMappingDTO> findByToUrnAndMappingType(String toUrn, MappingType mappingType);
+  List<EntityToEntityMappingDTO> findByFromURNAndMappingType(String fromURN, MappingType mappingType);
+  List<EntityToEntityMappingDTO> findByToURNAndMappingType(String toURN, MappingType mappingType);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/EntityToEntityMappingManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/EntityToEntityMappingManagerImpl.java
@@ -1,0 +1,58 @@
+package com.linkedin.thirdeye.datalayer.bao.jdbc;
+
+import com.linkedin.thirdeye.datalayer.bao.EntityToEntityMappingManager;
+import com.linkedin.thirdeye.datalayer.dto.EntityToEntityMappingDTO;
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean;
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingType;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+
+public class EntityToEntityMappingManagerImpl extends AbstractManagerImpl<EntityToEntityMappingDTO> implements EntityToEntityMappingManager {
+  protected EntityToEntityMappingManagerImpl() {
+    super(EntityToEntityMappingDTO.class, EntityToEntityMappingBean.class);
+  }
+
+  @Override
+  public List<EntityToEntityMappingDTO> findByFromUrn(String fromUrn) {
+    Predicate predicate = Predicate.EQ("fromUrn", fromUrn);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<EntityToEntityMappingDTO> findByToUrn(String toUrn) {
+    Predicate predicate = Predicate.EQ("toUrn", toUrn);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public EntityToEntityMappingDTO findByFromAndToUrn(String fromUrn, String toUrn) {
+    EntityToEntityMappingDTO dto = null;
+    Predicate predicate = Predicate.AND(Predicate.EQ("fromUrn", fromUrn), Predicate.EQ("toUrn", toUrn));
+    List<EntityToEntityMappingDTO> findByPredicate = findByPredicate(predicate);
+    if (CollectionUtils.isNotEmpty(findByPredicate)) {
+      dto = findByPredicate.get(0);
+    }
+    return dto;
+  }
+
+  @Override
+  public List<EntityToEntityMappingDTO> findByMappingType(MappingType mappingType) {
+    Predicate predicate = Predicate.EQ("mappingType", mappingType.toString());
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<EntityToEntityMappingDTO> findByFromUrnAndMappingType(String fromUrn, MappingType mappingType) {
+    Predicate predicate = Predicate.AND(Predicate.EQ("fromUrn", fromUrn), Predicate.EQ("mappingType", mappingType.toString()));
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<EntityToEntityMappingDTO> findByToUrnAndMappingType(String toUrn, MappingType mappingType) {
+    Predicate predicate = Predicate.AND(Predicate.EQ("toUrn", toUrn), Predicate.EQ("mappingType", mappingType.toString()));
+    return findByPredicate(predicate);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/EntityToEntityMappingManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/EntityToEntityMappingManagerImpl.java
@@ -16,21 +16,21 @@ public class EntityToEntityMappingManagerImpl extends AbstractManagerImpl<Entity
   }
 
   @Override
-  public List<EntityToEntityMappingDTO> findByFromUrn(String fromUrn) {
-    Predicate predicate = Predicate.EQ("fromUrn", fromUrn);
+  public List<EntityToEntityMappingDTO> findByFromURN(String fromURN) {
+    Predicate predicate = Predicate.EQ("fromURN", fromURN);
     return findByPredicate(predicate);
   }
 
   @Override
-  public List<EntityToEntityMappingDTO> findByToUrn(String toUrn) {
-    Predicate predicate = Predicate.EQ("toUrn", toUrn);
+  public List<EntityToEntityMappingDTO> findByToURN(String toURN) {
+    Predicate predicate = Predicate.EQ("toURN", toURN);
     return findByPredicate(predicate);
   }
 
   @Override
-  public EntityToEntityMappingDTO findByFromAndToUrn(String fromUrn, String toUrn) {
+  public EntityToEntityMappingDTO findByFromAndToURN(String fromURN, String toURN) {
     EntityToEntityMappingDTO dto = null;
-    Predicate predicate = Predicate.AND(Predicate.EQ("fromUrn", fromUrn), Predicate.EQ("toUrn", toUrn));
+    Predicate predicate = Predicate.AND(Predicate.EQ("fromURN", fromURN), Predicate.EQ("toURN", toURN));
     List<EntityToEntityMappingDTO> findByPredicate = findByPredicate(predicate);
     if (CollectionUtils.isNotEmpty(findByPredicate)) {
       dto = findByPredicate.get(0);
@@ -45,14 +45,14 @@ public class EntityToEntityMappingManagerImpl extends AbstractManagerImpl<Entity
   }
 
   @Override
-  public List<EntityToEntityMappingDTO> findByFromUrnAndMappingType(String fromUrn, MappingType mappingType) {
-    Predicate predicate = Predicate.AND(Predicate.EQ("fromUrn", fromUrn), Predicate.EQ("mappingType", mappingType.toString()));
+  public List<EntityToEntityMappingDTO> findByFromURNAndMappingType(String fromURN, MappingType mappingType) {
+    Predicate predicate = Predicate.AND(Predicate.EQ("fromURN", fromURN), Predicate.EQ("mappingType", mappingType.toString()));
     return findByPredicate(predicate);
   }
 
   @Override
-  public List<EntityToEntityMappingDTO> findByToUrnAndMappingType(String toUrn, MappingType mappingType) {
-    Predicate predicate = Predicate.AND(Predicate.EQ("toUrn", toUrn), Predicate.EQ("mappingType", mappingType.toString()));
+  public List<EntityToEntityMappingDTO> findByToURNAndMappingType(String toURN, MappingType mappingType) {
+    Predicate predicate = Predicate.AND(Predicate.EQ("toURN", toURN), Predicate.EQ("mappingType", mappingType.toString()));
     return findByPredicate(predicate);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -47,6 +47,7 @@ import com.linkedin.thirdeye.datalayer.entity.DataCompletenessConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DatasetConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DetectionStatusIndex;
 import com.linkedin.thirdeye.datalayer.entity.EmailConfigurationIndex;
+import com.linkedin.thirdeye.datalayer.entity.EntityToEntityMappingIndex;
 import com.linkedin.thirdeye.datalayer.entity.GenericJsonEntity;
 import com.linkedin.thirdeye.datalayer.entity.IngraphDashboardConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.IngraphMetricConfigIndex;
@@ -64,6 +65,7 @@ import com.linkedin.thirdeye.datalayer.pojo.DataCompletenessConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.DatasetConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.DetectionStatusBean;
 import com.linkedin.thirdeye.datalayer.pojo.EmailConfigurationBean;
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean;
 import com.linkedin.thirdeye.datalayer.pojo.IngraphDashboardConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.IngraphMetricConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.JobBean;
@@ -125,6 +127,8 @@ public class GenericPojoDao {
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, ClassificationConfigIndex.class));
     pojoInfoMap.put(AutometricsConfigBean.class,
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, AutometricsConfigIndex.class));
+    pojoInfoMap.put(EntityToEntityMappingBean.class,
+        newPojoInfo(DEFAULT_BASE_TABLE_NAME, EntityToEntityMappingIndex.class));
   }
 
   private static PojoInfo newPojoInfo(String baseTableName,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/EntityToEntityMappingDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/EntityToEntityMappingDTO.java
@@ -1,0 +1,7 @@
+package com.linkedin.thirdeye.datalayer.dto;
+
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean;
+
+public class EntityToEntityMappingDTO extends EntityToEntityMappingBean {
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/EntityToEntityMappingIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/EntityToEntityMappingIndex.java
@@ -3,21 +3,21 @@ package com.linkedin.thirdeye.datalayer.entity;
 import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingType;
 
 public class EntityToEntityMappingIndex extends AbstractIndexEntity {
-  String fromUrn;
-  String toUrn;
+  String fromURN;
+  String toURN;
   MappingType mappingType;
 
-  public String getFromUrn() {
-    return fromUrn;
+  public String getFromURN() {
+    return fromURN;
   }
-  public void setFromUrn(String fromUrn) {
-    this.fromUrn = fromUrn;
+  public void setFromURN(String fromURN) {
+    this.fromURN = fromURN;
   }
-  public String getToUrn() {
-    return toUrn;
+  public String getToURN() {
+    return toURN;
   }
-  public void setToUrn(String toUrn) {
-    this.toUrn = toUrn;
+  public void setToURN(String toURN) {
+    this.toURN = toURN;
   }
   public MappingType getMappingType() {
     return mappingType;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/EntityToEntityMappingIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/EntityToEntityMappingIndex.java
@@ -1,0 +1,30 @@
+package com.linkedin.thirdeye.datalayer.entity;
+
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingType;
+
+public class EntityToEntityMappingIndex extends AbstractIndexEntity {
+  String fromUrn;
+  String toUrn;
+  MappingType mappingType;
+
+  public String getFromUrn() {
+    return fromUrn;
+  }
+  public void setFromUrn(String fromUrn) {
+    this.fromUrn = fromUrn;
+  }
+  public String getToUrn() {
+    return toUrn;
+  }
+  public void setToUrn(String toUrn) {
+    this.toUrn = toUrn;
+  }
+  public MappingType getMappingType() {
+    return mappingType;
+  }
+  public void setMappingType(MappingType mappingType) {
+    this.mappingType = mappingType;
+  }
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/EntityToEntityMappingBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/EntityToEntityMappingBean.java
@@ -14,25 +14,26 @@ public class EntityToEntityMappingBean extends AbstractBean {
 
   public enum MappingType {
     METRIC_TO_SERVICE,
+    SERVICE_TO_METRIC,
     METRIC_TO_METRIC,
     DIMENSION_TO_DIMENSION
   }
-  String fromUrn;
-  String toUrn;
+  String fromURN;
+  String toURN;
   MappingType mappingType;
   double score;
 
-  public String getFromUrn() {
-    return fromUrn;
+  public String getFromURN() {
+    return fromURN;
   }
-  public void setFromUrn(String fromUrn) {
-    this.fromUrn = fromUrn;
+  public void setFromURN(String fromURN) {
+    this.fromURN = fromURN;
   }
-  public String getToUrn() {
-    return toUrn;
+  public String getToURN() {
+    return toURN;
   }
-  public void setToUrn(String toUrn) {
-    this.toUrn = toUrn;
+  public void setToURN(String toURN) {
+    this.toURN = toURN;
   }
   public MappingType getMappingType() {
     return mappingType;
@@ -53,15 +54,15 @@ public class EntityToEntityMappingBean extends AbstractBean {
       return false;
     }
     EntityToEntityMappingBean em = (EntityToEntityMappingBean) o;
-    return Objects.equals(fromUrn, em.getFromUrn())
-        && Objects.equals(toUrn, em.getToUrn())
+    return Objects.equals(fromURN, em.getFromURN())
+        && Objects.equals(toURN, em.getToURN())
         && Objects.equals(mappingType, em.getMappingType())
         && Objects.equals(score, em.getScore());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(fromUrn, toUrn, mappingType, score);
+    return Objects.hash(fromURN, toURN, mappingType, score);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/EntityToEntityMappingBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/EntityToEntityMappingBean.java
@@ -1,0 +1,67 @@
+package com.linkedin.thirdeye.datalayer.pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Objects;
+
+/**
+ * This class holds the mapping between entities
+ * We have predefined some valid relations
+ * Each mapping can maintain a score, to say whay it the degree of correlation between the entities
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EntityToEntityMappingBean extends AbstractBean {
+
+  public enum MappingType {
+    METRIC_TO_SERVICE,
+    METRIC_TO_METRIC,
+    DIMENSION_TO_DIMENSION
+  }
+  String fromUrn;
+  String toUrn;
+  MappingType mappingType;
+  double score;
+
+  public String getFromUrn() {
+    return fromUrn;
+  }
+  public void setFromUrn(String fromUrn) {
+    this.fromUrn = fromUrn;
+  }
+  public String getToUrn() {
+    return toUrn;
+  }
+  public void setToUrn(String toUrn) {
+    this.toUrn = toUrn;
+  }
+  public MappingType getMappingType() {
+    return mappingType;
+  }
+  public void setMappingType(MappingType mappingType) {
+    this.mappingType = mappingType;
+  }
+  public double getScore() {
+    return score;
+  }
+  public void setScore(double score) {
+    this.score = score;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof EntityToEntityMappingBean)) {
+      return false;
+    }
+    EntityToEntityMappingBean em = (EntityToEntityMappingBean) o;
+    return Objects.equals(fromUrn, em.getFromUrn())
+        && Objects.equals(toUrn, em.getToUrn())
+        && Objects.equals(mappingType, em.getMappingType())
+        && Objects.equals(score, em.getScore());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fromUrn, toUrn, mappingType, score);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
@@ -29,6 +29,7 @@ import com.linkedin.thirdeye.datalayer.entity.DataCompletenessConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DatasetConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DetectionStatusIndex;
 import com.linkedin.thirdeye.datalayer.entity.EmailConfigurationIndex;
+import com.linkedin.thirdeye.datalayer.entity.EntityToEntityMappingIndex;
 import com.linkedin.thirdeye.datalayer.entity.GenericJsonEntity;
 import com.linkedin.thirdeye.datalayer.entity.IngraphDashboardConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.IngraphMetricConfigIndex;
@@ -143,6 +144,8 @@ public abstract class DaoProviderUtil {
             convertCamelCaseToUnderscore(ClassificationConfigIndex.class.getSimpleName()));
         entityMappingHolder.register(conn, AutometricsConfigIndex.class,
             convertCamelCaseToUnderscore(AutometricsConfigIndex.class.getSimpleName()));
+        entityMappingHolder.register(conn, EntityToEntityMappingIndex.class,
+            convertCamelCaseToUnderscore(EntityToEntityMappingIndex.class.getSimpleName()));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -20,6 +20,7 @@ import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DetectionStatusDTO;
 import com.linkedin.thirdeye.datalayer.dto.EmailConfigurationDTO;
 import com.linkedin.thirdeye.datalayer.dto.AutotuneConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.EntityToEntityMappingDTO;
 import com.linkedin.thirdeye.datalayer.dto.IngraphDashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.IngraphMetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
@@ -28,6 +29,7 @@ import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingType;
 import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
 import com.linkedin.thirdeye.datalayer.util.PersistenceConfig;
 import com.linkedin.thirdeye.detector.email.filter.AlphaBetaAlertFilter;
@@ -71,6 +73,7 @@ public abstract class AbstractManagerTestBase {
   protected AutotuneConfigManager autotuneConfigDAO;
   protected ClassificationConfigManager classificationConfigDAO;
   protected AutometricsConfigManager autometricsConfigDAO;
+  protected EntityToEntityMappingManager entityToEntityMappingDAO;
 
   //  protected TestDBResources testDBResources;
   protected DAORegistry daoRegistry;
@@ -107,6 +110,7 @@ public abstract class AbstractManagerTestBase {
       autotuneConfigDAO = daoRegistry.getAutotuneConfigDAO();
       classificationConfigDAO = daoRegistry.getClassificationConfigDAO();
       autometricsConfigDAO = daoRegistry.getAutometricsConfigDAO();
+      entityToEntityMappingDAO = daoRegistry.getEntityToEntityMappingDAO();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -393,5 +397,14 @@ public abstract class AbstractManagerTestBase {
     classificationConfigDTO.setFunctionIdList(functionIds);
     classificationConfigDTO.setActive(true);
     return classificationConfigDTO;
+  }
+
+  protected EntityToEntityMappingDTO getTestEntityToEntityMapping(String fromUrn, String toUrn, MappingType mappingType) {
+    EntityToEntityMappingDTO dto = new EntityToEntityMappingDTO();
+    dto.setFromUrn(fromUrn);
+    dto.setToUrn(toUrn);
+    dto.setMappingType(mappingType);
+    dto.setScore(1);
+    return dto;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -399,10 +399,10 @@ public abstract class AbstractManagerTestBase {
     return classificationConfigDTO;
   }
 
-  protected EntityToEntityMappingDTO getTestEntityToEntityMapping(String fromUrn, String toUrn, MappingType mappingType) {
+  protected EntityToEntityMappingDTO getTestEntityToEntityMapping(String fromURN, String toURN, MappingType mappingType) {
     EntityToEntityMappingDTO dto = new EntityToEntityMappingDTO();
-    dto.setFromUrn(fromUrn);
-    dto.setToUrn(toUrn);
+    dto.setFromURN(fromURN);
+    dto.setToURN(toURN);
     dto.setMappingType(mappingType);
     dto.setScore(1);
     return dto;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestEntityToEntityMappingManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestEntityToEntityMappingManager.java
@@ -1,0 +1,93 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import com.linkedin.thirdeye.datalayer.dto.EntityToEntityMappingDTO;
+import com.linkedin.thirdeye.datalayer.pojo.EntityToEntityMappingBean.MappingType;
+
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestEntityToEntityMappingManager extends AbstractManagerTestBase {
+  Long testId1 = null;
+  Long testId2 = null;
+  Long testId3 = null;
+  Long testId4 = null;
+  String metricUrn1 = "thirdeye:metric:d1:m1";
+  String metricUrn2 = "thirdeye:metric:d1:m2";
+  String serviceUrn1 = "thirdeye:service:s1";
+  String dimensionUrn1 = "thirdeye:dimension:country:UnitedStates";
+  String dimensionUrn2 = "thirdeye:dimension:country:US";
+
+
+  @BeforeClass
+  void beforeClass() {
+    super.init();
+  }
+
+  @AfterClass(alwaysRun = true)
+  void afterClass() {
+    super.cleanup();
+  }
+
+  @Test
+  public void testCreate() {
+    EntityToEntityMappingDTO dto = getTestEntityToEntityMapping(metricUrn1, metricUrn2, MappingType.METRIC_TO_METRIC);
+    testId1 = entityToEntityMappingDAO.save(dto);
+    Assert.assertNotNull(testId1);
+    dto = getTestEntityToEntityMapping(metricUrn1, serviceUrn1, MappingType.METRIC_TO_SERVICE);
+    testId2 = entityToEntityMappingDAO.save(dto);
+    Assert.assertNotNull(testId2);
+    dto = getTestEntityToEntityMapping(dimensionUrn1, dimensionUrn2, MappingType.DIMENSION_TO_DIMENSION);
+    testId3 = entityToEntityMappingDAO.save(dto);
+    Assert.assertNotNull(testId3);
+  }
+
+  @Test(dependsOnMethods = { "testCreate" })
+  public void testFind() {
+    EntityToEntityMappingDTO dto = entityToEntityMappingDAO.findById(testId1);
+    Assert.assertEquals(dto.getId(), testId1);
+    Assert.assertEquals(dto.getFromUrn(), metricUrn1);
+    Assert.assertEquals(dto.getToUrn(), metricUrn2);
+    Assert.assertEquals(dto.getMappingType(), MappingType.METRIC_TO_METRIC);
+
+    List<EntityToEntityMappingDTO> list = entityToEntityMappingDAO.findAll();
+    Assert.assertEquals(list.size(), 3);
+
+    list = entityToEntityMappingDAO.findByFromUrn(metricUrn1);
+    Assert.assertEquals(list.size(), 2);
+
+    list = entityToEntityMappingDAO.findByToUrn(metricUrn2);
+    Assert.assertEquals(list.size(), 1);
+
+    dto = entityToEntityMappingDAO.findByFromAndToUrn(dimensionUrn1, dimensionUrn2);
+    Assert.assertEquals(dto.getId(), testId3);
+
+    list = entityToEntityMappingDAO.findByMappingType(MappingType.METRIC_TO_SERVICE);
+    Assert.assertEquals(list.size(), 1);
+
+    list = entityToEntityMappingDAO.findByFromUrnAndMappingType(metricUrn1, MappingType.METRIC_TO_METRIC);
+    Assert.assertEquals(list.size(), 1);
+
+    list = entityToEntityMappingDAO.findByToUrnAndMappingType(dimensionUrn2, MappingType.METRIC_TO_METRIC);
+    Assert.assertEquals(list.size(), 0);
+  }
+
+  @Test(dependsOnMethods = { "testFind" })
+  public void testUpdate() {
+    EntityToEntityMappingDTO dto = entityToEntityMappingDAO.findById(testId1);
+    Assert.assertEquals(dto.getScore(), 1d);
+    dto.setScore(10);
+    entityToEntityMappingDAO.update(dto);
+    dto = entityToEntityMappingDAO.findById(testId1);
+    Assert.assertEquals(dto.getScore(), 10d);
+  }
+
+  @Test(dependsOnMethods = { "testUpdate" })
+  public void testDelete() {
+    entityToEntityMappingDAO.deleteById(testId1);
+    EntityToEntityMappingDTO dto = entityToEntityMappingDAO.findById(testId1);
+    Assert.assertNull(dto);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestEntityToEntityMappingManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestEntityToEntityMappingManager.java
@@ -14,11 +14,11 @@ public class TestEntityToEntityMappingManager extends AbstractManagerTestBase {
   Long testId2 = null;
   Long testId3 = null;
   Long testId4 = null;
-  String metricUrn1 = "thirdeye:metric:d1:m1";
-  String metricUrn2 = "thirdeye:metric:d1:m2";
-  String serviceUrn1 = "thirdeye:service:s1";
-  String dimensionUrn1 = "thirdeye:dimension:country:UnitedStates";
-  String dimensionUrn2 = "thirdeye:dimension:country:US";
+  String metricURN1 = "thirdeye:metric:d1:m1";
+  String metricURN2 = "thirdeye:metric:d1:m2";
+  String serviceURN1 = "thirdeye:service:s1";
+  String dimensionURN1 = "thirdeye:dimension:country:UnitedStates";
+  String dimensionURN2 = "thirdeye:dimension:country:US";
 
 
   @BeforeClass
@@ -33,13 +33,13 @@ public class TestEntityToEntityMappingManager extends AbstractManagerTestBase {
 
   @Test
   public void testCreate() {
-    EntityToEntityMappingDTO dto = getTestEntityToEntityMapping(metricUrn1, metricUrn2, MappingType.METRIC_TO_METRIC);
+    EntityToEntityMappingDTO dto = getTestEntityToEntityMapping(metricURN1, metricURN2, MappingType.METRIC_TO_METRIC);
     testId1 = entityToEntityMappingDAO.save(dto);
     Assert.assertNotNull(testId1);
-    dto = getTestEntityToEntityMapping(metricUrn1, serviceUrn1, MappingType.METRIC_TO_SERVICE);
+    dto = getTestEntityToEntityMapping(metricURN1, serviceURN1, MappingType.METRIC_TO_SERVICE);
     testId2 = entityToEntityMappingDAO.save(dto);
     Assert.assertNotNull(testId2);
-    dto = getTestEntityToEntityMapping(dimensionUrn1, dimensionUrn2, MappingType.DIMENSION_TO_DIMENSION);
+    dto = getTestEntityToEntityMapping(dimensionURN1, dimensionURN2, MappingType.DIMENSION_TO_DIMENSION);
     testId3 = entityToEntityMappingDAO.save(dto);
     Assert.assertNotNull(testId3);
   }
@@ -48,29 +48,29 @@ public class TestEntityToEntityMappingManager extends AbstractManagerTestBase {
   public void testFind() {
     EntityToEntityMappingDTO dto = entityToEntityMappingDAO.findById(testId1);
     Assert.assertEquals(dto.getId(), testId1);
-    Assert.assertEquals(dto.getFromUrn(), metricUrn1);
-    Assert.assertEquals(dto.getToUrn(), metricUrn2);
+    Assert.assertEquals(dto.getFromURN(), metricURN1);
+    Assert.assertEquals(dto.getToURN(), metricURN2);
     Assert.assertEquals(dto.getMappingType(), MappingType.METRIC_TO_METRIC);
 
     List<EntityToEntityMappingDTO> list = entityToEntityMappingDAO.findAll();
     Assert.assertEquals(list.size(), 3);
 
-    list = entityToEntityMappingDAO.findByFromUrn(metricUrn1);
+    list = entityToEntityMappingDAO.findByFromURN(metricURN1);
     Assert.assertEquals(list.size(), 2);
 
-    list = entityToEntityMappingDAO.findByToUrn(metricUrn2);
+    list = entityToEntityMappingDAO.findByToURN(metricURN2);
     Assert.assertEquals(list.size(), 1);
 
-    dto = entityToEntityMappingDAO.findByFromAndToUrn(dimensionUrn1, dimensionUrn2);
+    dto = entityToEntityMappingDAO.findByFromAndToURN(dimensionURN1, dimensionURN2);
     Assert.assertEquals(dto.getId(), testId3);
 
     list = entityToEntityMappingDAO.findByMappingType(MappingType.METRIC_TO_SERVICE);
     Assert.assertEquals(list.size(), 1);
 
-    list = entityToEntityMappingDAO.findByFromUrnAndMappingType(metricUrn1, MappingType.METRIC_TO_METRIC);
+    list = entityToEntityMappingDAO.findByFromURNAndMappingType(metricURN1, MappingType.METRIC_TO_METRIC);
     Assert.assertEquals(list.size(), 1);
 
-    list = entityToEntityMappingDAO.findByToUrnAndMappingType(dimensionUrn2, MappingType.METRIC_TO_METRIC);
+    list = entityToEntityMappingDAO.findByToURNAndMappingType(dimensionURN2, MappingType.METRIC_TO_METRIC);
     Assert.assertEquals(list.size(), 0);
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -323,3 +323,17 @@ create index autometrics_config_metric_idx on autometrics_config_index(metric);
 create index autometrics_config_dashboard_idx on autometrics_config_index(dashboard);
 create index autometrics_config_rrd_idx on autometrics_config_index(rrd);
 create index autometrics_config_autometrics_type_idx on autometrics_config_index(autometrics_type);
+
+create table if not exists entity_to_entity_mapping_index (
+    from_urn varchar(500) not null,
+    to_urn varchar(500) not null,
+    mapping_type varchar(500) not null,
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    version int(10)
+) ENGINE=InnoDB;
+ALTER TABLE `entity_to_entity_mapping_index` ADD UNIQUE `entity_mapping_unique_index`(`from_urn`, `to_urn`);
+create index entity_mapping_from_urn_idx on entity_to_entity_mapping_index(from_urn);
+create index entity_mapping_to_urn_idx on entity_to_entity_mapping_index(to_urn);
+create index entity_mapping_type_idx on entity_to_entity_mapping_index(mapping_type);

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
@@ -20,4 +20,5 @@ DROP TABLE IF EXISTS event_index;
 DROP TABLE IF EXISTS detection_status_index;
 DROP TABLE IF EXISTS autotune_config_index;
 DROP TABLE IF EXISTS autometrics_config_index;
+DROP TABLE IF EXISTS entity_to_entity_mapping_index;
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
This PR defines the database bean which will hold mappings between entities, such as metric to metric, metric to service, dimension to dimension. This will help us define static mappings. The endpoints will allow users add/edit mappings. This mapping will be used by the various pipelines such as DimensionRewritePipeline, MetricToServicePipeline