### PR TITLE
Fix segment deletion manager to handle deleted directory correctly

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManager.java
@@ -124,6 +124,8 @@ public class RetentionManager {
         LOGGER.info("Finished update segment metadata for entire cluster!");
         scanSegmentMetadataAndPurge();
         LOGGER.info("Finished segment purge for entire cluster!");
+        removeAgedDeletedSegments();
+        LOGGER.info("Finished remove aged deleted segments!");
       } else {
         LOGGER.info("Not leader of the controller, sleep!");
       }
@@ -177,10 +179,12 @@ public class RetentionManager {
         LOGGER.info("Trying to delete {} segments for table {}", segmentsToDelete.size(), tableName);
         _pinotHelixResourceManager.deleteSegments(tableName, segmentsToDelete);
       }
-
-      // Trigger clean-up for deleted segments from the deleted directory
-      _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_deletedSegmentsRetentionInDays);
     }
+  }
+
+  private void removeAgedDeletedSegments() {
+    // Trigger clean-up for deleted segments from the deleted directory
+    _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_deletedSegmentsRetentionInDays);
   }
 
   private boolean shouldDeleteInProgressLLCSegment(final String segmentId, final IdealState idealState, RealtimeSegmentZKMetadata segmentZKMetadata) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -195,15 +195,30 @@ public class SegmentDeletionManagerTest {
     tempDir.deleteOnExit();
     FakeDeletionManager deletionManager = new FakeDeletionManager(tempDir.getAbsolutePath(), helixAdmin, propertyStore);
 
+    // Test delete when deleted segments directory does not exists
+    deletionManager.removeAgedDeletedSegments(1);
+
     // Create deleted directory
     String deletedDirectoryPath = tempDir + File.separator + "Deleted_Segments";
     File deletedDirectory = new File(deletedDirectoryPath);
     deletedDirectory.mkdir();
 
+    // Test delete when deleted segments directory is empty
+    deletionManager.removeAgedDeletedSegments(1);
+
     // Create dummy directories and files
     File dummyDir1 = new File(deletedDirectoryPath + File.separator + "dummy1");
     dummyDir1.mkdir();
     File dummyDir2 = new File(deletedDirectoryPath + File.separator + "dummy2");
+    dummyDir2.mkdir();
+
+    // Test delete when there is no files but some directories exist
+    deletionManager.removeAgedDeletedSegments(1);
+    Assert.assertEquals(dummyDir1.exists(), false);
+    Assert.assertEquals(dummyDir2.exists(), false);
+
+    // Create dummy directories and files
+    dummyDir1.mkdir();
     dummyDir2.mkdir();
 
     // Create dummy files


### PR DESCRIPTION
When deleted segment directory does not exist, segment deletion manager throws the NullPointerException because it does not check if the deleted directory path exists.
- Added check for deleted directory path
- Added unit test for checking when deleted segment directory does not exist