### PR TITLE
Update the highest kafka offset metric correctly so that we can use it for alerting

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -25,6 +25,7 @@ import com.linkedin.pinot.common.Utils;
 public enum ServerGauge implements AbstractMetrics.Gauge {
   DOCUMENT_COUNT("documents", false),
   SEGMENT_COUNT("segments", false),
+  LLC_PARTITION_CONSUMING("state", false),
   HIGHEST_KAFKA_OFFSET_CONSUMED("messages", false),
   LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS("seconds", false),
   LAST_REALTIME_SEGMENT_INITIAL_CONSUMPTION_DURATION_SECONDS("seconds", false),

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -266,9 +266,9 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   protected boolean consumeLoop() throws Exception {
     _fieldExtractor.resetCounters();
     final long idlePipeSleepTimeMillis = 100;
-    final int maxIdleCountBeforeStatUpdate = 180_000;  // 3 minutes
+    final long maxIdleCountBeforeStatUpdate = (3 * 60 * 1000)/idlePipeSleepTimeMillis;  // 3 minute count
     long lastUpdatedOffset = _currentOffset;  // so that we always update the metric when we enter this method.
-    int idleCount = 0;
+    long idleCount = 0;
 
     final long _endOffset = Long.MAX_VALUE; // No upper limit on Kafka offset
     segmentLogger.info("Starting consumption loop start offset {}, finalOffset {}", _currentOffset, _finalOffset);


### PR DESCRIPTION
We currently have the capability to raise an alert if the metric kafka number of rows consumed goes to 0
in order to indicate a fault in the system that can cause us to stop consuming from Kafka.
However, this metric does not give the correct picture when there are no events in the kafka
pipeline, or when the kafka pipeline is burstly (e.g. pipelines from Samza jobs).

The idea here is to use the Kafka Highest Offset Consumed metric to detect these conditions.

In order for us to use this metric effectively, we need to make sure that this metric is set to 0
when we are not consuming any rows at all.