### PR TITLE
[TE] Shade or exclude commonly used jars in other projects from TE Hadoop fat jar

### DIFF
--- a/thirdeye/thirdeye-hadoop/pom.xml
+++ b/thirdeye/thirdeye-hadoop/pom.xml
@@ -129,6 +129,12 @@
                                     <mainClass>com.linkedin.thirdeye.hadoop.ThirdEyeJob</mainClass>
                                 </transformer>
                             </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.thrift</pattern>
+                                    <shadedPattern>org.apache.pinot.thrift</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/thirdeye/thirdeye-hadoop/pom.xml
+++ b/thirdeye/thirdeye-hadoop/pom.xml
@@ -20,6 +20,16 @@
     <dependency>
       <groupId>com.linkedin.pinot</groupId>
       <artifactId>pinot-core</artifactId>
+      <exclusions>
+          <exclusion>
+              <groupId>org.apache.thrift</groupId>
+              <artifactId>libthrift</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -131,8 +141,8 @@
                             </transformers>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.apache.thrift</pattern>
-                                    <shadedPattern>org.apache.pinot.thrift</shadedPattern>
+                                    <pattern>com.fasterxml.jackson.databind</pattern>
+                                    <shadedPattern>com.fasterxml.jackson.databind.pinot</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
Shade old version of Thrift library, which is a dependency of pinot-core, to allow other libraries that depends on ThirdEye jar could use newer version of Thrift.