### PR TITLE
Changes to handle external client and external metric properties

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/Client.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/Client.java
@@ -1,0 +1,50 @@
+package com.linkedin.thirdeye.client;
+
+import java.util.Map;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * This class defines the config of a single client used in thirdeye
+ * Eg: PinotThirdEyeClient
+ */
+public class Client {
+
+    private String name;
+    private String className;
+    private Map<String, String> properties;
+
+
+    public Client() {
+
+    }
+    public Client(String name, String className, Map<String, String> properties) {
+      this.name = name;
+      this.className = className;
+      this.properties = properties;
+    }
+    public String getName() {
+      return name;
+    }
+    public void setName(String name) {
+      this.name = name;
+    }
+    public String getClassName() {
+      return className;
+    }
+    public void setClassName(String className) {
+      this.className = className;
+    }
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+    public void setProperties(Map<String, String> properties) {
+      this.properties = properties;
+    }
+
+    @Override
+    public String toString() {
+      return ToStringBuilder.reflectionToString(this);
+    }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ClientConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ClientConfig.java
@@ -1,0 +1,20 @@
+package com.linkedin.thirdeye.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class keeps the client configs for all the clients used in thirdeye
+ */
+public class ClientConfig {
+
+  private List<Client> clients = new ArrayList<>();
+
+  public List<Client> getClients() {
+    return clients;
+  }
+  public void setClients(List<Client> clients) {
+    this.clients = clients;
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricExpression.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricExpression.java
@@ -84,17 +84,18 @@ public class MetricExpression {
       ArrayList<MetricFunction> metricFunctions = new ArrayList<>();
       for (String metricToken : metricTokens) {
         Long metricId = null;
+        MetricConfigDTO metricConfig = null;
         String metricDataset = dataset;
         if (metricToken.equals(COUNT_METRIC_ESCAPED)) {
           metricToken = COUNT_METRIC;
         } else {
           metricId = Long.valueOf(metricToken.replace(MetricConfigBean.DERIVED_METRIC_ID_PREFIX, ""));
-          MetricConfigDTO metricConfig = ThirdEyeUtils.getMetricConfigFromId(metricId);
+          metricConfig = ThirdEyeUtils.getMetricConfigFromId(metricId);
           if (metricConfig != null) {
             metricDataset = metricConfig.getDataset();
           }
         }
-        metricFunctions.add(new MetricFunction(aggFunction, metricToken, metricId, metricDataset));
+        metricFunctions.add(new MetricFunction(aggFunction, metricToken, metricId, metricDataset, metricConfig));
       }
       return metricFunctions;
     } catch (ParseException e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/MetricFunction.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.client;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
+import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 
 public class MetricFunction implements Comparable<MetricFunction> {
 
@@ -10,6 +11,7 @@ public class MetricFunction implements Comparable<MetricFunction> {
   private String metricName;
   private Long metricId;
   private String dataset;
+  private MetricConfigDTO metricConfig;
 
   public MetricFunction() {
 
@@ -17,11 +19,12 @@ public class MetricFunction implements Comparable<MetricFunction> {
 
   public MetricFunction(@JsonProperty("functionName") MetricAggFunction functionName,
       @JsonProperty("metricName") String metricName, @JsonProperty("metricId") Long metricId,
-      @JsonProperty("dataset") String dataset) {
+      @JsonProperty("dataset") String dataset, @JsonProperty("metricConfig") MetricConfigDTO metricConfig) {
     this.functionName = functionName;
     this.metricName = metricName;
     this.metricId = metricId;
     this.dataset = dataset;
+    this.metricConfig = metricConfig;
   }
 
   private String format(String functionName, String metricName) {
@@ -88,6 +91,16 @@ public class MetricFunction implements Comparable<MetricFunction> {
   public void setDataset(String dataset) {
     this.dataset = dataset;
   }
+
+  public MetricConfigDTO getMetricConfig() {
+    return metricConfig;
+  }
+
+  public void setMetricConfig(MetricConfigDTO metricConfig) {
+    this.metricConfig = metricConfig;
+  }
+
+
 
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeCacheRegistry.java
@@ -72,6 +72,8 @@ public class ThirdEyeCacheRegistry {
 
   private static void init(ThirdEyeConfiguration config) {
     try {
+      // TODO: initialize all clients from clients.yml
+      // Create client map and register it with QueryCache
       pinotThirdeyeClientConfig = PinotThirdEyeClientConfig.createThirdEyeClientConfig(config);
       thirdEyeClient = PinotThirdEyeClient.fromClientConfig(pinotThirdeyeClientConfig);
       datasetConfigDAO = DAO_REGISTRY.getDatasetConfigDAO();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/ThirdEyeRequest.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.client;
 
+import com.linkedin.thirdeye.client.pinot.PinotThirdEyeClient;
 import com.linkedin.thirdeye.dashboard.configs.CollectionConfig;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
@@ -41,6 +42,7 @@ public class ThirdEyeRequest {
   private final List<String> groupByDimensions;
   private final TimeGranularity groupByTimeGranularity;
   private final List<String> metricNames;
+  private final String client;
   private final String requestReference;
 
   private ThirdEyeRequest(String requestReference, ThirdEyeRequestBuilder builder) {
@@ -52,6 +54,7 @@ public class ThirdEyeRequest {
     this.filterClause = builder.filterClause;
     this.groupByDimensions = builder.groupBy;
     this.groupByTimeGranularity = builder.groupByTimeGranularity;
+    this.client = builder.client;
     metricNames = new ArrayList<>();
     for (MetricFunction metric : metricFunctions) {
       metricNames.add(metric.toString());
@@ -100,6 +103,11 @@ public class ThirdEyeRequest {
     return groupByDimensions;
   }
 
+
+  public String getClient() {
+    return client;
+  }
+
   @Override
   public int hashCode() {
     // TODO do we intentionally omit request reference here?
@@ -144,11 +152,13 @@ public class ThirdEyeRequest {
     private String filterClause;
     private final List<String> groupBy;
     private TimeGranularity groupByTimeGranularity;
+    private String client;
 
     public ThirdEyeRequestBuilder() {
       this.filterSet = LinkedListMultimap.create();
       this.groupBy = new ArrayList<String>();
       metricFunctions = new ArrayList<>();
+      this.client = PinotThirdEyeClient.CLIENT_NAME;
     }
 
     public ThirdEyeRequestBuilder(ThirdEyeRequest request) {
@@ -159,6 +169,7 @@ public class ThirdEyeRequest {
       this.filterClause = request.getFilterClause();
       this.groupBy = new ArrayList<String>(request.getGroupBy());
       this.groupByTimeGranularity = request.getGroupByTimeGranularity();
+      this.client = request.getClient();
     }
 
     public ThirdEyeRequestBuilder setDatasets(List<String> datasets) {
@@ -247,6 +258,11 @@ public class ThirdEyeRequest {
     public ThirdEyeRequestBuilder setMetricFunctions(List<MetricFunction> metricFunctions) {
       this.metricFunctions = metricFunctions;
       return this;
+    }
+
+
+    public void setClient(String client) {
+      this.client = client;
     }
 
     public ThirdEyeRequest build(String requestReference) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/pinot/PinotThirdEyeClient.java
@@ -46,6 +46,7 @@ public class PinotThirdEyeClient implements ThirdEyeClient {
   public static final String FIXED_COLLECTIONS_PROPERTY_KEY = "fixedCollections";
   public static final String CLUSTER_NAME_PROPERTY_KEY = "clusterName";
   public static final String TAG_PROPERTY_KEY = "tag";
+  public static final String CLIENT_NAME = PinotThirdEyeClient.class.getSimpleName();
 
   String segementZKMetadataRootPath;
   private final HttpHost controllerHost;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -70,7 +70,7 @@ public class Utils {
       String requestReference, List<String> dimensions, DateTime start,
       DateTime end) throws Exception {
 
-    MetricFunction metricFunction = new MetricFunction(MetricAggFunction.COUNT, "*", null, dataset);
+    MetricFunction metricFunction = new MetricFunction(MetricAggFunction.COUNT, "*", null, dataset, null);
 
     List<ThirdEyeRequest> requests =
         generateRequests(dataset, requestReference, metricFunction, dimensions, start, end);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.datalayer.pojo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
+import com.linkedin.thirdeye.client.pinot.PinotThirdEyeClient;
 import com.linkedin.thirdeye.completeness.checker.DataCompletenessConstants.DataCompletenessAlgorithmName;
 import com.linkedin.thirdeye.completeness.checker.Wo4WAvgDataCompletenessAlgorithm;
 
@@ -32,6 +33,9 @@ public class DatasetConfigBean extends AbstractBean {
   private String timeFormat = TimeSpec.SINCE_EPOCH_FORMAT;
 
   private String timezone = TimeSpec.DEFAULT_TIMEZONE;
+
+  /** Introduce this as a dataset property because count* queries will have no metric information **/
+  private String client = PinotThirdEyeClient.CLIENT_NAME;
 
   private boolean metricAsDimension = false;
 
@@ -149,6 +153,14 @@ public class DatasetConfigBean extends AbstractBean {
 
   public void setTimezone(String timezone) {
     this.timezone = timezone;
+  }
+
+  public String getClient() {
+    return client;
+  }
+
+  public void setClient(String client) {
+    this.client = client;
   }
 
   public boolean isMetricAsDimension() {
@@ -291,6 +303,7 @@ public class DatasetConfigBean extends AbstractBean {
         && Objects.equals(timeDuration, dc.getTimeDuration())
         && Objects.equals(timeFormat, dc.getTimeFormat())
         && Objects.equals(timezone, dc.getTimezone())
+        && Objects.equals(client, dc.getClient())
         && Objects.equals(metricAsDimension, dc.isMetricAsDimension())
         && Objects.equals(metricNamesColumn, dc.getMetricNamesColumn())
         && Objects.equals(metricValuesColumn, dc.getMetricValuesColumn())
@@ -310,7 +323,7 @@ public class DatasetConfigBean extends AbstractBean {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getId(), dataset, dimensions, timeColumn, timeUnit, timeDuration, timeFormat, timezone,
+    return Objects.hash(getId(), dataset, dimensions, timeColumn, timeUnit, timeDuration, timeFormat, timezone, client,
         metricAsDimension, metricNamesColumn, metricValuesColumn, autoDiscoverMetrics, active, additive,
         dimensionsHaveNoPreAggregation, preAggregatedKeyword, nonAdditiveBucketSize, nonAdditiveBucketUnit, realtime,
         requiresCompletenessCheck, expectedDelay, dataCompletenessAlgorithmName, expectedCompleteness);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.thirdeye.api.MetricType;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -37,6 +38,8 @@ public class MetricConfigBean extends AbstractBean {
   private Map<String, String> extSourceLinkInfo;
 
   private Map<String, String> extSourceLinkTimeGranularity;
+
+  private Map<String, String> properties = null;
 
 
   public String getName() {
@@ -135,6 +138,14 @@ public class MetricConfigBean extends AbstractBean {
     this.extSourceLinkTimeGranularity = extSourceLinkTimeGranularity;
   }
 
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof MetricConfigBean)) {
@@ -151,12 +162,13 @@ public class MetricConfigBean extends AbstractBean {
         && Objects.equals(inverseMetric, mc.isInverseMetric())
         && Objects.equals(cellSizeExpression, mc.getCellSizeExpression())
         && Objects.equals(active, mc.isActive())
-        && Objects.equals(extSourceLinkInfo, mc.getExtSourceLinkInfo());
+        && Objects.equals(extSourceLinkInfo, mc.getExtSourceLinkInfo())
+        && Objects.equals(properties, mc.getProperties());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), dataset, alias, derived, derivedMetricExpression, rollupThreshold,
-        inverseMetric, cellSizeExpression, active, extSourceLinkInfo);
+        inverseMetric, cellSizeExpression, active, extSourceLinkInfo, properties);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
@@ -39,7 +39,7 @@ public class MetricConfigBean extends AbstractBean {
 
   private Map<String, String> extSourceLinkTimeGranularity;
 
-  private Map<String, String> properties = null;
+  private Map<String, String> metricProperties = null;
 
 
   public String getName() {
@@ -138,12 +138,12 @@ public class MetricConfigBean extends AbstractBean {
     this.extSourceLinkTimeGranularity = extSourceLinkTimeGranularity;
   }
 
-  public Map<String, String> getProperties() {
-    return properties;
+  public Map<String, String> getMetricProperties() {
+    return metricProperties;
   }
 
-  public void setProperties(Map<String, String> properties) {
-    this.properties = properties;
+  public void setMetricProperties(Map<String, String> metricProperties) {
+    this.metricProperties = metricProperties;
   }
 
   @Override
@@ -163,12 +163,12 @@ public class MetricConfigBean extends AbstractBean {
         && Objects.equals(cellSizeExpression, mc.getCellSizeExpression())
         && Objects.equals(active, mc.isActive())
         && Objects.equals(extSourceLinkInfo, mc.getExtSourceLinkInfo())
-        && Objects.equals(properties, mc.getProperties());
+        && Objects.equals(metricProperties, mc.getMetricProperties());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(getId(), dataset, alias, derived, derivedMetricExpression, rollupThreshold,
-        inverseMetric, cellSizeExpression, active, extSourceLinkInfo, properties);
+        inverseMetric, cellSizeExpression, active, extSourceLinkInfo, metricProperties);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/comparison/TimeOnTimeTest.java
@@ -72,7 +72,7 @@ public class TimeOnTimeTest {
     comparisonRequest.setCurrentStart(new DateTime(2016, 4, 8, 00, 00));
     comparisonRequest.setCurrentEnd(new DateTime(2016, 4, 9, 00, 00));
     List<MetricFunction> metricFunctions = new ArrayList<>();
-    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection));
+    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection, null));
     List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metricFunctions);
     metricExpressions.add(new MetricExpression("submit_rate", "submits/impressions"));
     comparisonRequest.setMetricExpressions(metricExpressions);
@@ -94,7 +94,7 @@ public class TimeOnTimeTest {
         Lists.newArrayList("browserName", "contactsOrigin", "deviceName", "continent",
             "countryCode", "environment", "locale", "osName", "pageKey", "source", "sourceApp"));
     List<MetricFunction> metricFunctions = new ArrayList<>();
-    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection));
+    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection, null));
     comparisonRequest.setMetricExpressions(Utils.convertToMetricExpressions(metricFunctions));
     comparisonRequest.setAggregationTimeGranularity(null);
     return comparisonRequest;
@@ -116,7 +116,7 @@ public class TimeOnTimeTest {
     comparisonRequest.setGroupByDimensions(Lists.newArrayList("environment"));
 
     List<MetricFunction> metricFunctions = new ArrayList<>();
-    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection));
+    metricFunctions.add(new MetricFunction(MetricAggFunction.SUM, "__COUNT", null, collection, null));
     comparisonRequest.setMetricExpressions(Utils.convertToMetricExpressions(metricFunctions));
     comparisonRequest.setAggregationTimeGranularity(new TimeGranularity(1, TimeUnit.HOURS));
     return comparisonRequest;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TestTimeSeriesResponseUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TestTimeSeriesResponseUtils.java
@@ -132,7 +132,7 @@ public class TestTimeSeriesResponseUtils {
   private List<MetricFunction> createSumFunctions(String... metricNames) {
     List<MetricFunction> result = new ArrayList<>();
     for (String metricName : metricNames) {
-      result.add(new MetricFunction(MetricAggFunction.SUM, metricName, 0L, "dataset"));
+      result.add(new MetricFunction(MetricAggFunction.SUM, metricName, 0L, "dataset", null));
     }
     return result;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/client/timeseries/TimeSeriesTest.java
@@ -26,7 +26,7 @@ public class TimeSeriesTest {
   private static final String THIRDEYE_ABOOK = "thirdeyeAbook";
   private static final String COUNT = "__COUNT";
   private static final MetricFunction DEFAULT_METRIC_FUNCTION =
-      new MetricFunction(MetricAggFunction.SUM, COUNT, 0L, THIRDEYE_ABOOK);
+      new MetricFunction(MetricAggFunction.SUM, COUNT, 0L, THIRDEYE_ABOOK, null);
   private static final MetricExpression SUBMIT_RATE_EXPRESSION =
       new MetricExpression("submit_rate", "submits/impressions");
   private static final DateTime START = new DateTime(2016, 4, 1, 00, 00);


### PR DESCRIPTION
1) Introduced client in DatasetConfig. This was put in dataset, instead of metric, because for count queries, we don't have any metric information, and hence won't be able to extract client information
2) Introducing properties map in MetricConfig. This will be populated with custom properties, that the external clients can read. 
3) Introducing MetricCOnfig in MetricFunction. This is done so that the metric configs can be passed to the request, and the external clients will operate independently of database access
4) Introducing client in ThirdeyeRequest. The QueryCache currently only understands a single client. This logic can be changed later with the help of client filed in the request. The QueryCache should pick the appropriate client based on the request (TODO).