### PR TITLE
[PINOT-4885] Change FixedByteSingleColumnMultiValueReaderWriter to expand header section dynamically

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/FixedByteSingleValueMultiColReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/FixedByteSingleValueMultiColReader.java
@@ -186,7 +186,7 @@ public class FixedByteSingleValueMultiColReader implements Closeable {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     indexDataBuffer.close();
     indexDataBuffer = null;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.io.readerwriter.impl;
 
-import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,19 +23,47 @@ import com.linkedin.pinot.core.io.readerwriter.BaseSingleColumnMultiValueReaderW
 import com.linkedin.pinot.core.io.writer.impl.FixedByteSingleValueMultiColWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
-
 /**
- * Supports both reads and writes using the same data structure.<br>
- * Writes must be strictly sequential, while reads can be random <br>
- * It is very similar to the SingleColumnMultiValue format representation <br>
- * except that the variable size data buffer size is not known up front in case FixedByteSingleColumnMultiValueReaderWriter
- * This class allocates extra memory in chunks as needed.
+ * This class provides expandable off-heap implementation to store a multi-valued column across a number of rows.
+ * The maximum number of values in any row must be known while invoking the constructor. Other than that, this class
+ * allocates additional memory as needed to accommodate any number of rows.
+ *
+ * Writes into the data structure are strictly sequential, but reads can be random.
+ *
+ * Writes are of type:
+ *
+ *   setIntArray(int rowNumber, int[] values)
+ *
+ * It is expected that rowNumber increments by 1 on each invocation, and that it is decided ahead of time that
+ * the class is used to store a certain type of data structure (int arrays, or char arrays, etc.) Mix & match is not
+ * allowed.
+ *
+ * Two kinds of data structures are used in this class.
+ *
+ * 1. A header (essentially an index into the other data structure) that has one entry per row. The entry has 3 integers
+ *   - data buffer ID
+ *   - offset in the data buffer where column values start
+ *   - length (number of values in the multi-valued column).
+ *
+ *   New header structures are added as new rows come in. Each header class holds the same number of rows (for easy lookup)
+ *
+ * 2. A data buffer that has the values for the column that the header points to. Data buffers are added as needed,
+ *    whenever we reach a limitation that we cannot fit the values of a column in the current buffer.
+ *
+ * Note that data buffers and headers grow independently.
+ *
  * Data format
  * <code>
- *  HEADER SECTION
+ *  HEADER SECTION 0
  *    bufferId startIndex EndIndex
  *    bufferId startIndex EndIndex
  *    bufferId startIndex EndIndex
+ *    ...
+ *  HEADER SECTION 1
+ *    bufferId startIndex EndIndex
+ *    bufferId startIndex EndIndex
+ *    bufferId startIndex EndIndex
+ *    ...
  *  Data BUFFER SECTION 0
  *    [set of values of row 0] [set of values of row 1]
  *     .....
@@ -55,7 +82,6 @@ import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
 public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColumnMultiValueReaderWriter {
 
-  public static final int DEFAULT_MAX_NUMBER_OF_MULTIVALUES = 1000;
   /**
    * number of columns is 1, column size is variable but less than maxNumberOfMultiValuesPerRow
    * @param rows
@@ -68,8 +94,10 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   private PinotDataBuffer headerBuffer;
   private List<PinotDataBuffer> dataBuffers = new ArrayList<>();
-  private FixedByteSingleValueMultiColWriter headerWriter;
-  private FixedByteSingleValueMultiColReader headerReader;
+  private List<PinotDataBuffer> headerBuffers = new ArrayList<>();
+  private List<FixedByteSingleValueMultiColReader> headerReaders = new ArrayList<>();
+  private List<FixedByteSingleValueMultiColWriter> headerWriters = new ArrayList<>();
+  private FixedByteSingleValueMultiColWriter curHeaderWriter;
   private List<FixedByteSingleValueMultiColWriter> dataWriters = new ArrayList<FixedByteSingleValueMultiColWriter>();
   private List<FixedByteSingleValueMultiColReader> dataReaders = new ArrayList<FixedByteSingleValueMultiColReader>();
   private FixedByteSingleValueMultiColWriter currentDataWriter;
@@ -79,34 +107,40 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
   private int incrementalCapacity;
   private int columnSizeInBytes;
   private int maxNumberOfMultiValuesPerRow;
+  private final int rowCountPerChunk;
+  private int prevRowStartIndex = 0;  // Offset in the databuffer for the last row added.
+  private int prevRowLength = 0;  // Number of values in the column for the last row added.
 
-  public FixedByteSingleColumnMultiValueReaderWriter(int rows, int columnSizeInBytes, int maxNumberOfMultiValuesPerRow,
-      int avgMultiValueCount)
-      throws IOException {
-    int initialCapacity = Math.max(maxNumberOfMultiValuesPerRow, rows * avgMultiValueCount);
+  public FixedByteSingleColumnMultiValueReaderWriter(int maxNumberOfMultiValuesPerRow, int avgMultiValueCount, int rowCountPerChunk,
+      int columnSizeInBytes) {
+    int initialCapacity = Math.max(maxNumberOfMultiValuesPerRow, rowCountPerChunk * avgMultiValueCount);
     int incrementalCapacity =
         Math.max(maxNumberOfMultiValuesPerRow, (int) (initialCapacity * 1.0f * INCREMENT_PERCENTAGE / 100));
-    init(rows, columnSizeInBytes, maxNumberOfMultiValuesPerRow, initialCapacity, incrementalCapacity);
-  }
-
-  private void init(int rows, int columnSizeInBytes, int maxNumberOfMultiValuesPerRow, int initialCapacity,
-      int incrementalCapacity) throws IOException {
     this.columnSizeInBytes = columnSizeInBytes;
     this.maxNumberOfMultiValuesPerRow = maxNumberOfMultiValuesPerRow;
-    headerSize = rows * SIZE_OF_INT * NUM_COLS_IN_HEADER;
+    headerSize = rowCountPerChunk * SIZE_OF_INT * NUM_COLS_IN_HEADER;
+    this.rowCountPerChunk = rowCountPerChunk;
+    addHeaderBuffers();
+    //at least create space for million entries, which for INT translates into 4mb buffer
+    this.incrementalCapacity = incrementalCapacity;
+    addDataBuffers(initialCapacity);
+    //init(rowCountPerChunk, columnSizeInBytes, maxNumberOfMultiValuesPerRow, initialCapacity, incrementalCapacity);
+  }
+
+  private void addHeaderBuffers() {
     headerBuffer = PinotDataBuffer.allocateDirect(headerSize);
     // We know that these bufffers will not be copied directly into a file (or mapped from a file).
     // So, we can use native byte order here.
     headerBuffer.order(ByteOrder.nativeOrder());
     //dataBufferId, startIndex, length
-    headerWriter =
-        new FixedByteSingleValueMultiColWriter(headerBuffer, rows, 3,
+    curHeaderWriter =
+        new FixedByteSingleValueMultiColWriter(headerBuffer, rowCountPerChunk, 3,
             new int[] { SIZE_OF_INT, SIZE_OF_INT, SIZE_OF_INT });
-    headerReader =
-        new FixedByteSingleValueMultiColReader(headerBuffer, rows, new int[] { SIZE_OF_INT, SIZE_OF_INT, SIZE_OF_INT });
-    //at least create space for million entries, which for INT translates into 4mb buffer
-    this.incrementalCapacity = incrementalCapacity;
-    addCapacity(initialCapacity);
+    FixedByteSingleValueMultiColReader curHeaderReader =
+        new FixedByteSingleValueMultiColReader(headerBuffer, rowCountPerChunk, new int[] { SIZE_OF_INT, SIZE_OF_INT, SIZE_OF_INT });
+    headerBuffers.add(headerBuffer);
+    headerWriters.add(curHeaderWriter);
+    headerReaders.add(curHeaderReader);
   }
 
   /**
@@ -114,11 +148,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
    * @param rowCapacity Additional capacity to be added in terms of number of rows
    * @throws RuntimeException
    */
-  private void addCapacity(int rowCapacity) throws RuntimeException {
+  private void addDataBuffers(int rowCapacity) throws RuntimeException {
     PinotDataBuffer dataBuffer;
     try {
       dataBuffer = PinotDataBuffer.allocateDirect(rowCapacity * columnSizeInBytes);
-      //dataBuffer.order(ByteOrder.nativeOrder());
+      dataBuffer.order(ByteOrder.nativeOrder());
       dataBuffers.add(dataBuffer);
       currentDataWriter =
           new FixedByteSingleValueMultiColWriter(dataBuffer, rowCapacity, 1, new int[] { columnSizeInBytes });
@@ -142,28 +176,42 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
       dataBuffer.close();
     }
     dataBuffers.clear();
-    headerBuffer.close();
+    for (PinotDataBuffer headerBuffer : headerBuffers) {
+      headerBuffer.close();
+    }
+    headerBuffers.clear();
     headerBuffer = null;
   }
 
-  private int updateHeader(int row, int length) {
-    assert (length < maxNumberOfMultiValuesPerRow);
-    int prevRowStartIndex = 0;
-    int prevRowLength = 0;
-    if (row > 0) {
-      prevRowStartIndex = headerReader.getInt(row - 1, 1);
-      prevRowLength = headerReader.getInt(row - 1, 2);
+  private void writeIntoHeader(int row, int dataWriterIndex, int startIndex, int length) {
+    if (row >= headerBuffers.size() * rowCountPerChunk) {
+      addHeaderBuffers();
     }
+    curHeaderWriter.setInt(getRowInCurrentHeader(row), 0, dataWriterIndex);
+    curHeaderWriter.setInt(getRowInCurrentHeader(row), 1, startIndex);
+    curHeaderWriter.setInt(getRowInCurrentHeader(row), 2, length);
+  }
+
+  private final FixedByteSingleValueMultiColReader getCurrentReader(int row) {
+    return headerReaders.get(row/ rowCountPerChunk);
+  }
+
+  private final int getRowInCurrentHeader(int row) {
+    return row % rowCountPerChunk;
+  }
+
+  private int updateHeader(int row, int mvCount) {
+    assert (mvCount <= maxNumberOfMultiValuesPerRow);
     int newStartIndex = prevRowStartIndex + prevRowLength;
-    if (newStartIndex + length > currentCapacity) {
-      addCapacity(incrementalCapacity);
+    if (newStartIndex + mvCount > currentCapacity) {
+      addDataBuffers(incrementalCapacity);
       prevRowStartIndex = 0;
       prevRowLength = 0;
-      newStartIndex = prevRowStartIndex + prevRowLength;
+      newStartIndex = 0;
     }
-    headerWriter.setInt(row, 0, currentDataWriterIndex);
-    headerWriter.setInt(row, 1, newStartIndex);
-    headerWriter.setInt(row, 2, length);
+    writeIntoHeader(row, currentDataWriterIndex, newStartIndex, mvCount);
+    prevRowStartIndex = newStartIndex;
+    prevRowLength = mvCount;
     return newStartIndex;
   }
 
@@ -234,9 +282,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getCharArray(int row, char[] charArray) {
-    int bufferIndex = headerReader.getInt(row, 1);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       charArray[i] = dataReader.getChar(startIndex + i, 0);
@@ -246,9 +296,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getShortArray(int row, short[] shortsArray) {
-    int bufferIndex = headerReader.getInt(row, 1);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       shortsArray[i] = dataReader.getShort(startIndex + i, 0);
@@ -258,9 +310,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getIntArray(int row, int[] intArray) {
-    int bufferIndex = headerReader.getInt(row, 0);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       intArray[i] = dataReader.getInt(startIndex + i, 0);
@@ -270,9 +324,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getLongArray(int row, long[] longArray) {
-    int bufferIndex = headerReader.getInt(row, 0);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       longArray[i] = dataReader.getLong(startIndex + i, 0);
@@ -282,9 +338,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getFloatArray(int row, float[] floatArray) {
-    int bufferIndex = headerReader.getInt(row, 1);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       floatArray[i] = dataReader.getFloat(startIndex + i, 0);
@@ -294,9 +352,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getDoubleArray(int row, double[] doubleArray) {
-    int bufferIndex = headerReader.getInt(row, 1);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       doubleArray[i] = dataReader.getDouble(startIndex + i, 0);
@@ -306,9 +366,11 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getStringArray(int row, String[] stringArray) {
-    int bufferIndex = headerReader.getInt(row, 1);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       stringArray[i] = dataReader.getString(startIndex + i, 0);
@@ -318,14 +380,15 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
 
   @Override
   public int getBytesArray(int row, byte[][] bytesArray) {
-    int bufferIndex = headerReader.getInt(row, 1);
-    int startIndex = headerReader.getInt(row, 1);
-    int length = headerReader.getInt(row, 2);
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(row);
+    int rowInCurrentHeader  = getRowInCurrentHeader(row);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = dataReaders.get(bufferIndex);
     for (int i = 0; i < length; i++) {
       bytesArray[i] = dataReader.getBytes(startIndex + i, 0);
     }
     return length;
   }
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
@@ -34,7 +34,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
    *  @param rows
    * @param columnSizesInBytes
    */
-  public FixedByteSingleColumnSingleValueReaderWriter(int rows, int columnSizesInBytes) throws IOException {
+  public FixedByteSingleColumnSingleValueReaderWriter(int rows, int columnSizesInBytes) {
     rowSize = columnSizesInBytes;
     final int totalSize = rowSize * rows;
     _buffer = PinotDataBuffer.allocateDirect(totalSize);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/FixedByteSingleValueMultiColWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/FixedByteSingleValueMultiColWriter.java
@@ -47,7 +47,7 @@ public class FixedByteSingleValueMultiColWriter {
 
   public FixedByteSingleValueMultiColWriter(PinotDataBuffer dataBuffer, int rows, int cols,
       int[] columnSizes)
-      throws IOException {
+      {
     this.rows = rows;
     this.columnOffsets = new int[cols];
     rowSizeInBytes = 0;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -97,9 +97,15 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   private StarTreeIndexSpec starTreeIndexSpec = null;
   private SegmentPartitionConfig segmentPartitionConfig = null;
 
+  // TODO Dynamcally adjust these variables, maybe on a per column basis
+
+  // For multi-valued column, forward-index.
+  // Maximum number of multi-values per row. We assert on this.
+  private static final int MAX_MULTI_VALUES_PER_ROW = 1000;
+
   public RealtimeSegmentImpl(Schema schema, int capacity, String tableName, String segmentName, String streamName,
       ServerMetrics serverMetrics, List<String> invertedIndexColumns, int avgMultiValueCount)
-      throws IOException {
+      {
     // initial variable setup
     this.segmentName = segmentName;
     this.serverMetrics = serverMetrics;
@@ -145,9 +151,10 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
         columnIndexReaderWriterMap.put(dimension,
             new FixedByteSingleColumnSingleValueReaderWriter(capacity, Integer.SIZE/8));
       } else {
+        // TODO Start with a smaller capacity on FixedByteSingleColumnMultiValueReaderWriter and let it expand
         columnIndexReaderWriterMap.put(dimension,
-            new FixedByteSingleColumnMultiValueReaderWriter(capacity, Integer.SIZE / 8,
-                FixedByteSingleColumnMultiValueReaderWriter.DEFAULT_MAX_NUMBER_OF_MULTIVALUES, avgMultiValueCount));
+            new FixedByteSingleColumnMultiValueReaderWriter(MAX_MULTI_VALUES_PER_ROW, avgMultiValueCount,
+                capacity, Integer.SIZE/8));
       }
     }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
@@ -15,15 +15,15 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 
 
 public class MultiValueDictionaryTest {
   private static final int NROWS = 1000;
-  private static final int MAX_N_VALUES = FixedByteSingleColumnMultiValueReaderWriter.DEFAULT_MAX_NUMBER_OF_MULTIVALUES;
+  private static final int MAX_N_VALUES = 1000;
 
   @Test
   public void testMultiValueIndexing() {
@@ -39,7 +39,7 @@ public class MultiValueDictionaryTest {
       throws Exception {
     final LongOnHeapMutableDictionary dict = new LongOnHeapMutableDictionary();
     final FixedByteSingleColumnMultiValueReaderWriter indexer =
-        new FixedByteSingleColumnMultiValueReaderWriter(NROWS, Integer.SIZE / 8, MAX_N_VALUES, 2);
+        new FixedByteSingleColumnMultiValueReaderWriter(MAX_N_VALUES, MAX_N_VALUES/2, NROWS/3, Integer.SIZE/8);
 
     // Insert rows into the indexer and dictionary
     Random random = new Random(seed);

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
@@ -31,8 +31,18 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     final long seed = r.nextLong();
     try {
       testIntArray(seed);
-    } catch (Exception e) {
+      testWithZeroSize(seed);
+    } catch (Throwable e) {
+      e.printStackTrace();
       Assert.fail("Failed with seed " + seed);
+    }
+    for (int mvs = 10; mvs < 1000; mvs += 10) {
+      try {
+        testIntArrayFixedSize(mvs, seed);
+      } catch (Throwable e) {
+        e.printStackTrace();
+        Assert.fail("Failed with seed " + seed + ", mvs " + mvs);
+      }
     }
   }
 
@@ -43,7 +53,8 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     int columnSizeInBytes = Integer.SIZE / 8;
     int maxNumberOfMultiValuesPerRow = 2000;
     readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(rows, columnSizeInBytes, maxNumberOfMultiValuesPerRow, 2);
+        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 2, rows/2, columnSizeInBytes);
+        //new FixedByteSingleColumnMultiValueReaderWriter(1000, columnSizeInBytes, maxNumberOfMultiValuesPerRow, 2);
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -61,5 +72,63 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
       Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed="+seed);
     }
     readerWriter.close();
+  }
+
+  public void testIntArrayFixedSize(int multiValuesPerRow, long seed)
+      throws IOException {
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter;
+    int rows = 1000;
+    int columnSizeInBytes = Integer.SIZE / 8;
+    readerWriter =
+        new FixedByteSingleColumnMultiValueReaderWriter(multiValuesPerRow, multiValuesPerRow, rows, columnSizeInBytes);
+
+    Random r = new Random(seed);
+    int[][] data = new int[rows][];
+    for (int i = 0; i < rows; i++) {
+      data[i] = new int[multiValuesPerRow];
+      for (int j = 0; j < data[i].length; j++) {
+        data[i][j] = r.nextInt();
+      }
+      readerWriter.setIntArray(i, data[i]);
+    }
+    int[] ret = new int[multiValuesPerRow];
+    for (int i = 0; i < rows; i++) {
+      int length = readerWriter.getIntArray(i, ret);
+      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed="+seed);
+    }
+    readerWriter.close();
+  }
+
+  public void testWithZeroSize(long seed) {
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter;
+    final int maxNumberOfMultiValuesPerRow = 5;
+    int rows = 1000;
+    int columnSizeInBytes = Integer.SIZE / 8;
+    readerWriter =
+        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 3, rows/3, columnSizeInBytes);
+
+    Random r = new Random(seed);
+    int[][] data = new int[rows][];
+    for (int i = 0; i < rows; i++) {
+      if (r.nextInt() > 0) {
+        data[i] = new int[r.nextInt(maxNumberOfMultiValuesPerRow)];
+        for (int j = 0; j < data[i].length; j++) {
+          data[i][j] = r.nextInt();
+        }
+        readerWriter.setIntArray(i, data[i]);
+      } else {
+        data[i] = new int[0];
+        readerWriter.setIntArray(i, data[i]);
+      }
+    }
+    int[] ret = new int[maxNumberOfMultiValuesPerRow];
+    for (int i = 0; i < rows; i++) {
+      int length = readerWriter.getIntArray(i, ret);
+      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
+    }
+    readerWriter.close();
+
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 
 
@@ -54,7 +55,6 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     int maxNumberOfMultiValuesPerRow = 2000;
     readerWriter =
         new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 2, rows/2, columnSizeInBytes);
-        //new FixedByteSingleColumnMultiValueReaderWriter(1000, columnSizeInBytes, maxNumberOfMultiValuesPerRow, 2);
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -79,8 +79,10 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     FixedByteSingleColumnMultiValueReaderWriter readerWriter;
     int rows = 1000;
     int columnSizeInBytes = Integer.SIZE / 8;
+    // Keep the rowsPerChunk as a multiple of multiValuesPerRow to check the cases when both data and header buffers
+    // transition to new ones
     readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(multiValuesPerRow, multiValuesPerRow, rows, columnSizeInBytes);
+        new FixedByteSingleColumnMultiValueReaderWriter(multiValuesPerRow, multiValuesPerRow, multiValuesPerRow * 2, columnSizeInBytes);
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -105,10 +107,10 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     final int maxNumberOfMultiValuesPerRow = 5;
     int rows = 1000;
     int columnSizeInBytes = Integer.SIZE / 8;
-    readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 3, rows/3, columnSizeInBytes);
-
     Random r = new Random(seed);
+    readerWriter =
+        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 3, r.nextInt(rows) + 1, columnSizeInBytes);
+
     int[][] data = new int[rows][];
     for (int i = 0; i < rows; i++) {
       if (r.nextInt() > 0) {
@@ -130,5 +132,162 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     }
     readerWriter.close();
 
+  }
+
+  private FixedByteSingleColumnMultiValueReaderWriter createReaderWriter(FieldSpec.DataType type, Random r, int rows, int maxNumberOfMultiValuesPerRow) {
+    final int columnSize = sizeForType(type);
+    final int avgMultiValueCount = r.nextInt(maxNumberOfMultiValuesPerRow) + 1;
+    final int rowCountPerChunk = r.nextInt(rows) + 1;
+
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter =
+        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, avgMultiValueCount,
+            rowCountPerChunk, columnSize);
+
+    return readerWriter;
+  }
+
+  private int sizeForType(FieldSpec.DataType type) {
+    int size;
+    switch (type) {
+      case SHORT_ARRAY:
+        size = Short.SIZE/8;
+        break;
+      case LONG_ARRAY:
+        size = Long.SIZE/8;
+        break;
+      case FLOAT_ARRAY:
+        size = Float.SIZE/8;
+        break;
+      case DOUBLE_ARRAY:
+        size = Double.SIZE/8;
+        break;
+      default:
+        throw new UnsupportedOperationException();
+    }
+    return size;
+  }
+
+  private long generateSeed() {
+    Random r = new Random();
+    return r.nextLong();
+  }
+
+  @Test
+  public void testLongArray() throws Exception {
+    final long seed = generateSeed();
+    Random r = new Random(seed);
+    int rows = 1000;
+    final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.LONG_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
+
+    long[][] data = new long[rows][];
+    for (int i = 0; i < rows; i++) {
+      if (r.nextInt() > 0) {
+        data[i] = new long[r.nextInt(maxNumberOfMultiValuesPerRow)];
+        for (int j = 0; j < data[i].length; j++) {
+          data[i][j] = r.nextLong();
+        }
+        readerWriter.setLongArray(i, data[i]);
+      } else {
+        data[i] = new long[0];
+        readerWriter.setLongArray(i, data[i]);
+      }
+    }
+    long[] ret = new long[maxNumberOfMultiValuesPerRow];
+    for (int i = 0; i < rows; i++) {
+      int length = readerWriter.getLongArray(i, ret);
+      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
+    }
+    readerWriter.close();
+  }
+  @Test
+  public void testFloatArray() throws Exception {
+    final long seed = generateSeed();
+    Random r = new Random(seed);
+    int rows = 1000;
+    final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.FLOAT_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
+
+    float[][] data = new float[rows][];
+    for (int i = 0; i < rows; i++) {
+      if (r.nextInt() > 0) {
+        data[i] = new float[r.nextInt(maxNumberOfMultiValuesPerRow)];
+        for (int j = 0; j < data[i].length; j++) {
+          data[i][j] = r.nextFloat();
+        }
+        readerWriter.setFloatArray(i, data[i]);
+      } else {
+        data[i] = new float[0];
+        readerWriter.setFloatArray(i, data[i]);
+      }
+    }
+    float[] ret = new float[maxNumberOfMultiValuesPerRow];
+    for (int i = 0; i < rows; i++) {
+      int length = readerWriter.getFloatArray(i, ret);
+      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
+    }
+    readerWriter.close();
+  }
+
+  @Test
+  public void testDoubleArray() throws Exception {
+    final long seed = generateSeed();
+    Random r = new Random(seed);
+    int rows = 1000;
+    final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.DOUBLE_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
+
+    double[][] data = new double[rows][];
+    for (int i = 0; i < rows; i++) {
+      if (r.nextInt() > 0) {
+        data[i] = new double[r.nextInt(maxNumberOfMultiValuesPerRow)];
+        for (int j = 0; j < data[i].length; j++) {
+          data[i][j] = r.nextDouble();
+        }
+        readerWriter.setDoubleArray(i, data[i]);
+      } else {
+        data[i] = new double[0];
+        readerWriter.setDoubleArray(i, data[i]);
+      }
+    }
+    double[] ret = new double[maxNumberOfMultiValuesPerRow];
+    for (int i = 0; i < rows; i++) {
+      int length = readerWriter.getDoubleArray(i, ret);
+      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
+    }
+    readerWriter.close();
+  }
+
+  @Test
+  public void testShortArray() throws Exception {
+    final long seed = generateSeed();
+    Random r = new Random(seed);
+    int rows = 1000;
+    final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.SHORT_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
+
+    short[][] data = new short[rows][];
+    for (int i = 0; i < rows; i++) {
+      if (r.nextInt() > 0) {
+        data[i] = new short[r.nextInt(maxNumberOfMultiValuesPerRow)];
+        for (int j = 0; j < data[i].length; j++) {
+          data[i][j] = (short)r.nextInt(Short.MAX_VALUE);
+        }
+        readerWriter.setShortArray(i, data[i]);
+      } else {
+        data[i] = new short[0];
+        readerWriter.setShortArray(i, data[i]);
+      }
+    }
+    short[] ret = new short[maxNumberOfMultiValuesPerRow];
+    for (int i = 0; i < rows; i++) {
+      int length = readerWriter.getShortArray(i, ret);
+      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
+    }
+    readerWriter.close();
   }
 }


### PR DESCRIPTION
Changed FixedByteSingleColumnMultiValueReaderWriter so that the header sections also expands like the data
section, so that we don't have to allocate data for max number of rows in the beginning.

For now, the same allocation is maintained so that we don't see any change in the behavior in production.

This, and the next few PRs should help us limit consumption by memory (instead of by number of rows) or time,
making it easier to configure real-time service in pinot.