### PR TITLE
Enhance Schema setter and getter annotation

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DimensionFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DimensionFieldSpec.java
@@ -39,6 +39,7 @@ public final class DimensionFieldSpec extends FieldSpec {
   }
 
   @JsonIgnore
+  @Nonnull
   @Override
   public FieldType getFieldType() {
     return FieldType.DIMENSION;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.common.data;
 
-import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.DataSchema;
 import javax.annotation.Nonnull;
 import org.apache.avro.Schema.Type;
@@ -58,8 +57,6 @@ public abstract class FieldSpec {
   }
 
   public FieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField) {
-    Preconditions.checkNotNull(name);
-
     _name = name;
     _dataType = dataType.getStoredType();
     _isSingleValueField = isSingleValueField;
@@ -67,26 +64,25 @@ public abstract class FieldSpec {
 
   public FieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
       @Nonnull Object defaultNullValue) {
-    Preconditions.checkNotNull(name);
-
     _name = name;
     _dataType = dataType.getStoredType();
     _isSingleValueField = isSingleValueField;
     _stringDefaultNullValue = defaultNullValue.toString();
   }
 
+  @Nonnull
   public abstract FieldType getFieldType();
 
+  @Nonnull
   public String getName() {
     return _name;
   }
 
   public void setName(@Nonnull String name) {
-    Preconditions.checkNotNull(name);
-
     _name = name;
   }
 
+  @Nonnull
   public DataType getDataType() {
     return _dataType;
   }
@@ -104,6 +100,7 @@ public abstract class FieldSpec {
     _isSingleValueField = isSingleValueField;
   }
 
+  @Nonnull
   public Object getDefaultNullValue() {
     FieldType fieldType = getFieldType();
     if (_cachedDefaultNullValue == null) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
@@ -56,10 +56,8 @@ public final class MetricFieldSpec extends FieldSpec {
       @Nonnull DerivedMetricType derivedMetricType) {
     super(name, dataType, true);
     Preconditions.checkArgument(fieldSize > 0, "Field size must be a positive number.");
-    Preconditions.checkNotNull(derivedMetricType);
-
-    this._fieldSize = fieldSize;
-    this._derivedMetricType = derivedMetricType;
+    _fieldSize = fieldSize;
+    _derivedMetricType = derivedMetricType;
   }
 
   // For derived metric fields.
@@ -67,10 +65,8 @@ public final class MetricFieldSpec extends FieldSpec {
       @Nonnull DerivedMetricType derivedMetricType, @Nonnull Object defaultNullValue) {
     super(name, dataType, true, defaultNullValue);
     Preconditions.checkArgument(fieldSize > 0, "Field size must be a positive number.");
-    Preconditions.checkNotNull(derivedMetricType);
-
-    this._fieldSize = fieldSize;
-    this._derivedMetricType = derivedMetricType;
+    _fieldSize = fieldSize;
+    _derivedMetricType = derivedMetricType;
   }
 
   public int getFieldSize() {
@@ -83,19 +79,21 @@ public final class MetricFieldSpec extends FieldSpec {
 
   // Required by JSON de-serializer. DO NOT REMOVE.
   public void setFieldSize(int fieldSize) {
-    this._fieldSize = fieldSize;
+    _fieldSize = fieldSize;
   }
 
-  public @Nullable DerivedMetricType getDerivedMetricType() {
+  @Nullable
+  public DerivedMetricType getDerivedMetricType() {
     return _derivedMetricType;
   }
 
   // Required by JSON de-serializer. DO NOT REMOVE.
   public void setDerivedMetricType(@Nonnull DerivedMetricType derivedMetricType) {
-    this._derivedMetricType = derivedMetricType;
+    _derivedMetricType = derivedMetricType;
   }
 
   @JsonIgnore
+  @Nonnull
   @Override
   public FieldType getFieldType() {
     return FieldType.METRIC;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -15,6 +15,10 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.data.FieldSpec.DataType;
+import com.linkedin.pinot.common.data.FieldSpec.FieldType;
+import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,17 +30,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.common.base.Preconditions;
-import com.linkedin.pinot.common.data.FieldSpec.DataType;
-import com.linkedin.pinot.common.data.FieldSpec.FieldType;
-import com.linkedin.pinot.common.utils.EqualityUtils;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
 
 /**
  * The <code>Schema</code> class is defined for each table to describe the details of the table's fields (columns).
@@ -53,73 +54,77 @@ public final class Schema {
   private static final Logger LOGGER = LoggerFactory.getLogger(Schema.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private String schemaName;
-  private final List<DimensionFieldSpec> dimensionFieldSpecs = new ArrayList<>();
-  private final List<MetricFieldSpec> metricFieldSpecs = new ArrayList<>();
-  private TimeFieldSpec timeFieldSpec;
-  private final Map<String, FieldSpec> fieldSpecMap = new HashMap<>();
-  private final Set<String> dimensionSet = new HashSet<>();
-  private final Set<String> metricSet = new HashSet<>();
-  private final List<String> dimensionList = new ArrayList<>();
-  private final List<String> metricList = new ArrayList<>();
+  private String _schemaName;
+  private final List<DimensionFieldSpec> _dimensionFieldSpecs = new ArrayList<>();
+  private final List<MetricFieldSpec> _metricFieldSpecs = new ArrayList<>();
+  private TimeFieldSpec _timeFieldSpec;
+  private final Map<String, FieldSpec> _fieldSpecMap = new HashMap<>();
+  private final Set<String> _dimensionSet = new HashSet<>();
+  private final Set<String> _metricSet = new HashSet<>();
+  private final List<String> _dimensionList = new ArrayList<>();
+  private final List<String> _metricList = new ArrayList<>();
 
-  private transient String jsonSchema;
+  private transient String _jsonSchema;
 
+  @Nonnull
   public static Schema fromFile(@Nonnull File schemaFile)
       throws IOException {
     return MAPPER.readValue(schemaFile, Schema.class);
   }
 
+  @Nonnull
   public static Schema fromString(@Nonnull String schemaString)
       throws IOException {
     return MAPPER.readValue(schemaString, Schema.class);
   }
 
+  @Nonnull
   public static Schema fromInputSteam(@Nonnull InputStream schemaInputStream)
       throws IOException {
     return MAPPER.readValue(schemaInputStream, Schema.class);
   }
 
+  @Nonnull
   public String getSchemaName() {
-    return schemaName;
+    return _schemaName;
   }
 
   public void setSchemaName(@Nonnull String schemaName) {
-    Preconditions.checkNotNull(schemaName);
-
-    this.schemaName = schemaName;
+    _schemaName = schemaName;
   }
 
+  @Nonnull
   public List<DimensionFieldSpec> getDimensionFieldSpecs() {
-    return dimensionFieldSpecs;
+    return _dimensionFieldSpecs;
   }
 
   public void setDimensionFieldSpecs(@Nonnull List<DimensionFieldSpec> dimensionFieldSpecs) {
-    Preconditions.checkState(this.dimensionFieldSpecs.isEmpty());
+    Preconditions.checkState(_dimensionFieldSpecs.isEmpty());
 
     for (DimensionFieldSpec dimensionFieldSpec : dimensionFieldSpecs) {
       addField(dimensionFieldSpec);
     }
   }
 
+  @Nonnull
   public List<MetricFieldSpec> getMetricFieldSpecs() {
-    return metricFieldSpecs;
+    return _metricFieldSpecs;
   }
 
   public void setMetricFieldSpecs(@Nonnull List<MetricFieldSpec> metricFieldSpecs) {
-    Preconditions.checkState(this.metricFieldSpecs.isEmpty());
+    Preconditions.checkState(_metricFieldSpecs.isEmpty());
 
     for (MetricFieldSpec metricFieldSpec : metricFieldSpecs) {
       addField(metricFieldSpec);
     }
   }
 
-  public @Nullable TimeFieldSpec getTimeFieldSpec() {
-    return timeFieldSpec;
+  @Nullable
+  public TimeFieldSpec getTimeFieldSpec() {
+    return _timeFieldSpec;
   }
 
-  public void setTimeFieldSpec(@Nonnull TimeFieldSpec timeFieldSpec) {
-    // This check is for JSON de-serializer. For normal use case, should not set null.
+  public void setTimeFieldSpec(@Nullable TimeFieldSpec timeFieldSpec) {
     if (timeFieldSpec != null) {
       addField(timeFieldSpec);
     }
@@ -129,34 +134,34 @@ public final class Schema {
     Preconditions.checkNotNull(fieldSpec);
     String columnName = fieldSpec.getName();
     Preconditions.checkNotNull(columnName);
-    Preconditions.checkState(!fieldSpecMap.containsKey(columnName),
+    Preconditions.checkState(!_fieldSpecMap.containsKey(columnName),
         "Field spec already exists for column: " + columnName);
 
     FieldType fieldType = fieldSpec.getFieldType();
     switch (fieldType) {
       case DIMENSION:
-        if (!dimensionSet.contains(columnName)) {
-          dimensionSet.add(columnName);
-          dimensionList.add(columnName);
+        if (!_dimensionSet.contains(columnName)) {
+          _dimensionSet.add(columnName);
+          _dimensionList.add(columnName);
         }
-        dimensionFieldSpecs.add((DimensionFieldSpec) fieldSpec);
+        _dimensionFieldSpecs.add((DimensionFieldSpec) fieldSpec);
         break;
       case METRIC:
-        if (!metricSet.contains(columnName)) {
-          metricSet.add(columnName);
-          metricList.add(columnName);
+        if (!_metricSet.contains(columnName)) {
+          _metricSet.add(columnName);
+          _metricList.add(columnName);
         }
-        metricFieldSpecs.add((MetricFieldSpec) fieldSpec);
+        _metricFieldSpecs.add((MetricFieldSpec) fieldSpec);
         break;
       case TIME:
-        Preconditions.checkState(timeFieldSpec == null, "Already defined the time column: " + timeFieldSpec);
-        timeFieldSpec = (TimeFieldSpec) fieldSpec;
+        Preconditions.checkState(_timeFieldSpec == null, "Already defined the time column: " + _timeFieldSpec);
+        _timeFieldSpec = (TimeFieldSpec) fieldSpec;
         break;
       default:
         throw new UnsupportedOperationException("Unsupported field type: " + fieldType);
     }
 
-    fieldSpecMap.put(columnName, fieldSpec);
+    _fieldSpecMap.put(columnName, fieldSpec);
   }
 
   @Deprecated
@@ -166,36 +171,41 @@ public final class Schema {
   }
 
   public boolean hasColumn(@Nonnull String columnName) {
-    return fieldSpecMap.containsKey(columnName);
+    return _fieldSpecMap.containsKey(columnName);
   }
 
   @JsonIgnore
+  @Nonnull
   public Map<String, FieldSpec> getFieldSpecMap() {
-    return fieldSpecMap;
+    return _fieldSpecMap;
   }
 
   @JsonIgnore
+  @Nonnull
   public Collection<String> getColumnNames() {
-    return fieldSpecMap.keySet();
+    return _fieldSpecMap.keySet();
   }
 
   @JsonIgnore
+  @Nonnull
   public Collection<FieldSpec> getAllFieldSpecs() {
-    return fieldSpecMap.values();
+    return _fieldSpecMap.values();
   }
 
   public int size() {
-    return fieldSpecMap.size();
+    return _fieldSpecMap.size();
   }
 
   @JsonIgnore
-  public @Nullable FieldSpec getFieldSpecFor(String columnName) {
-    return fieldSpecMap.get(columnName);
+  @Nullable
+  public FieldSpec getFieldSpecFor(@Nonnull String columnName) {
+    return _fieldSpecMap.get(columnName);
   }
 
   @JsonIgnore
-  public @Nullable MetricFieldSpec getMetricSpec(String metricName) {
-    FieldSpec fieldSpec = fieldSpecMap.get(metricName);
+  @Nullable
+  public MetricFieldSpec getMetricSpec(@Nonnull String metricName) {
+    FieldSpec fieldSpec = _fieldSpecMap.get(metricName);
     if (fieldSpec != null && fieldSpec.getFieldType() == FieldType.METRIC) {
       return (MetricFieldSpec) fieldSpec;
     }
@@ -203,8 +213,9 @@ public final class Schema {
   }
 
   @JsonIgnore
-  public @Nullable DimensionFieldSpec getDimensionSpec(String dimensionName) {
-    FieldSpec fieldSpec = fieldSpecMap.get(dimensionName);
+  @Nullable
+  public DimensionFieldSpec getDimensionSpec(@Nonnull String dimensionName) {
+    FieldSpec fieldSpec = _fieldSpecMap.get(dimensionName);
     if (fieldSpec != null && fieldSpec.getFieldType() == FieldType.DIMENSION) {
       return (DimensionFieldSpec) fieldSpec;
     }
@@ -212,40 +223,46 @@ public final class Schema {
   }
 
   @JsonIgnore
+  @Nonnull
   public List<String> getDimensionNames() {
-    return dimensionList;
+    return _dimensionList;
   }
 
   @JsonIgnore
+  @Nonnull
   public List<String> getMetricNames() {
-    return metricList;
+    return _metricList;
   }
 
   @JsonIgnore
-  public @Nullable String getTimeColumnName() {
-    return (timeFieldSpec != null) ? timeFieldSpec.getName() : null;
+  @Nullable
+  public String getTimeColumnName() {
+    return (_timeFieldSpec != null) ? _timeFieldSpec.getName() : null;
   }
 
   @JsonIgnore
-  public @Nullable TimeUnit getIncomingTimeUnit() {
-    return (timeFieldSpec != null) ? timeFieldSpec.getIncomingGranularitySpec().getTimeType() : null;
+  @Nullable
+  public TimeUnit getIncomingTimeUnit() {
+    return (_timeFieldSpec != null) ? _timeFieldSpec.getIncomingGranularitySpec().getTimeType() : null;
   }
 
   @JsonIgnore
-  public @Nullable TimeUnit getOutgoingTimeUnit() {
-    return (timeFieldSpec != null) ? timeFieldSpec.getOutgoingGranularitySpec().getTimeType() : null;
+  @Nullable
+  public TimeUnit getOutgoingTimeUnit() {
+    return (_timeFieldSpec != null) ? _timeFieldSpec.getOutgoingGranularitySpec().getTimeType() : null;
   }
 
   @JsonIgnore
+  @Nonnull
   public String getJSONSchema() {
-    if (jsonSchema == null) {
+    if (_jsonSchema == null) {
       try {
-        jsonSchema = MAPPER.writeValueAsString(this);
+        _jsonSchema = MAPPER.writeValueAsString(this);
       } catch (IOException e) {
         throw new RuntimeException("Caught exception while writing Schema as JSON format string.", e);
       }
     }
-    return jsonSchema;
+    return _jsonSchema;
   }
 
   /**
@@ -264,7 +281,7 @@ public final class Schema {
     boolean isValid = true;
 
     // Log ALL the schema errors that may be present.
-    for (FieldSpec fieldSpec : fieldSpecMap.values()) {
+    for (FieldSpec fieldSpec : _fieldSpecMap.values()) {
       FieldType fieldType = fieldSpec.getFieldType();
       DataType dataType = fieldSpec.getDataType();
       String fieldName = fieldSpec.getName();
@@ -318,78 +335,78 @@ public final class Schema {
   }
 
   public static class SchemaBuilder {
-    private Schema schema;
+    private Schema _schema;
 
     public SchemaBuilder() {
-      schema = new Schema();
+      _schema = new Schema();
     }
 
     public SchemaBuilder setSchemaName(@Nonnull String schemaName) {
-      schema.setSchemaName(schemaName);
+      _schema.setSchemaName(schemaName);
       return this;
     }
 
     public SchemaBuilder addSingleValueDimension(@Nonnull String dimensionName, @Nonnull DataType dataType) {
-      schema.addField(new DimensionFieldSpec(dimensionName, dataType, true));
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true));
       return this;
     }
 
     public SchemaBuilder addSingleValueDimension(@Nonnull String dimensionName, @Nonnull DataType dataType,
         @Nonnull Object defaultNullValue) {
-      schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue));
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue));
       return this;
     }
 
     public SchemaBuilder addMultiValueDimension(@Nonnull String dimensionName, @Nonnull DataType dataType) {
-      schema.addField(new DimensionFieldSpec(dimensionName, dataType, false));
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false));
       return this;
     }
 
     public SchemaBuilder addMultiValueDimension(@Nonnull String dimensionName, @Nonnull DataType dataType,
         @Nonnull Object defaultNullValue) {
-      schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
       return this;
     }
 
     public SchemaBuilder addMetric(@Nonnull String metricName, @Nonnull DataType dataType) {
-      schema.addField(new MetricFieldSpec(metricName, dataType));
+      _schema.addField(new MetricFieldSpec(metricName, dataType));
       return this;
     }
 
     public SchemaBuilder addMetric(@Nonnull String metricName, @Nonnull DataType dataType,
         @Nonnull Object defaultNullValue) {
-      schema.addField(new MetricFieldSpec(metricName, dataType, defaultNullValue));
+      _schema.addField(new MetricFieldSpec(metricName, dataType, defaultNullValue));
       return this;
     }
 
     public SchemaBuilder addMetric(@Nonnull String name, @Nonnull DataType dataType, int fieldSize,
         @Nonnull MetricFieldSpec.DerivedMetricType derivedMetricType) {
-      schema.addField(new MetricFieldSpec(name, dataType, fieldSize, derivedMetricType));
+      _schema.addField(new MetricFieldSpec(name, dataType, fieldSize, derivedMetricType));
       return this;
     }
 
     public SchemaBuilder addMetric(@Nonnull String name, @Nonnull DataType dataType, int fieldSize,
         @Nonnull MetricFieldSpec.DerivedMetricType derivedMetricType, @Nonnull Object defaultNullValue) {
-      schema.addField(new MetricFieldSpec(name, dataType, fieldSize, derivedMetricType, defaultNullValue));
+      _schema.addField(new MetricFieldSpec(name, dataType, fieldSize, derivedMetricType, defaultNullValue));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType) {
-      schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit));
+      _schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType, @Nonnull Object defaultNullValue) {
-      schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, defaultNullValue));
+      _schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, defaultNullValue));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType, @Nonnull String outgoingName, @Nonnull TimeUnit outgoingTimeUnit,
         @Nonnull DataType outgoingDataType) {
-      schema.addField(
+      _schema.addField(
           new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, outgoingName, outgoingDataType,
               outgoingTimeUnit));
       return this;
@@ -398,7 +415,7 @@ public final class Schema {
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType, @Nonnull String outgoingName, @Nonnull TimeUnit outgoingTimeUnit,
         @Nonnull DataType outgoingDataType, @Nonnull Object defaultNullValue) {
-      schema.addField(
+      _schema.addField(
           new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, outgoingName, outgoingDataType,
               outgoingTimeUnit, defaultNullValue));
       return this;
@@ -406,13 +423,13 @@ public final class Schema {
 
     public SchemaBuilder addTime(@Nonnull String incomingName, int incomingTimeUnitSize,
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType) {
-      schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit));
+      _schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull String incomingName, int incomingTimeUnitSize,
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType, @Nonnull Object defaultNullValue) {
-      schema.addField(
+      _schema.addField(
           new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit, defaultNullValue));
       return this;
     }
@@ -420,7 +437,7 @@ public final class Schema {
     public SchemaBuilder addTime(@Nonnull String incomingName, int incomingTimeUnitSize,
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType, @Nonnull String outgoingName,
         int outgoingTimeUnitSize, @Nonnull TimeUnit outgoingTimeUnit, @Nonnull DataType outgoingDataType) {
-      schema.addField(
+      _schema.addField(
           new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit, outgoingName,
               outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit));
       return this;
@@ -430,40 +447,40 @@ public final class Schema {
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType, @Nonnull String outgoingName,
         int outgoingTimeUnitSize, @Nonnull TimeUnit outgoingTimeUnit, @Nonnull DataType outgoingDataType,
         @Nonnull Object defaultNullValue) {
-      schema.addField(
+      _schema.addField(
           new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit, outgoingName,
               outgoingDataType, outgoingTimeUnitSize, outgoingTimeUnit, defaultNullValue));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec) {
-      schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec));
+      _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec,
         @Nonnull Object defaultNullValue) {
-      schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, defaultNullValue));
+      _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, defaultNullValue));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec,
         @Nonnull TimeGranularitySpec outgoingTimeGranularitySpec) {
-      schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec));
+      _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec));
       return this;
     }
 
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec,
         @Nonnull TimeGranularitySpec outgoingTimeGranularitySpec, @Nonnull Object defaultNullValue) {
-      schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec, defaultNullValue));
+      _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec, defaultNullValue));
       return this;
     }
 
     public Schema build() {
-      if (!schema.validate(LOGGER)) {
+      if (!_schema.validate(LOGGER)) {
         throw new RuntimeException("Invalid schema");
       }
-      return schema;
+      return _schema;
     }
   }
 
@@ -479,13 +496,13 @@ public final class Schema {
     }
     if (object instanceof Schema) {
       Schema that = (Schema) object;
-      return schemaName.equals(that.schemaName) && fieldSpecMap.equals(that.fieldSpecMap);
+      return _schemaName.equals(that._schemaName) && _fieldSpecMap.equals(that._fieldSpecMap);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return EqualityUtils.hashCodeOf(schemaName.hashCode(), fieldSpecMap);
+    return EqualityUtils.hashCodeOf(_schemaName.hashCode(), _fieldSpecMap);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
@@ -108,8 +108,6 @@ public final class TimeFieldSpec extends FieldSpec {
   public TimeFieldSpec(@Nonnull TimeGranularitySpec incomingGranularitySpec,
       @Nonnull TimeGranularitySpec outgoingGranularitySpec) {
     super(outgoingGranularitySpec.getName(), outgoingGranularitySpec.getDataType(), true);
-    Preconditions.checkNotNull(incomingGranularitySpec);
-
     _incomingGranularitySpec = incomingGranularitySpec;
     _outgoingGranularitySpec = outgoingGranularitySpec;
   }
@@ -117,13 +115,12 @@ public final class TimeFieldSpec extends FieldSpec {
   public TimeFieldSpec(@Nonnull TimeGranularitySpec incomingGranularitySpec,
       @Nonnull TimeGranularitySpec outgoingGranularitySpec, @Nonnull Object defaultNullValue) {
     super(outgoingGranularitySpec.getName(), outgoingGranularitySpec.getDataType(), true, defaultNullValue);
-    Preconditions.checkNotNull(incomingGranularitySpec);
-
     _incomingGranularitySpec = incomingGranularitySpec;
     _outgoingGranularitySpec = outgoingGranularitySpec;
   }
 
   @JsonIgnore
+  @Nonnull
   @Override
   public FieldType getFieldType() {
     return FieldType.TIME;
@@ -145,29 +142,31 @@ public final class TimeFieldSpec extends FieldSpec {
   }
 
   @JsonIgnore
+  @Nonnull
   public String getIncomingTimeColumnName() {
     return _incomingGranularitySpec.getName();
   }
 
   @JsonIgnore
+  @Nonnull
   public String getOutgoingTimeColumnName() {
     return getName();
   }
 
-  @JsonIgnore
-  @Deprecated
   // For third-eye backward compatible.
+  @Deprecated
+  @JsonIgnore
+  @Nonnull
   public String getOutGoingTimeColumnName() {
     return getName();
   }
 
+  @Nonnull
   public TimeGranularitySpec getIncomingGranularitySpec() {
     return _incomingGranularitySpec;
   }
 
   public void setIncomingGranularitySpec(@Nonnull TimeGranularitySpec incomingGranularitySpec) {
-    Preconditions.checkNotNull(incomingGranularitySpec);
-
     _incomingGranularitySpec = incomingGranularitySpec;
     if (_outgoingGranularitySpec == null) {
       super.setName(incomingGranularitySpec.getName());
@@ -175,6 +174,7 @@ public final class TimeFieldSpec extends FieldSpec {
     }
   }
 
+  @Nonnull
   public TimeGranularitySpec getOutgoingGranularitySpec() {
     if (_outgoingGranularitySpec == null) {
       return _incomingGranularitySpec;
@@ -184,8 +184,6 @@ public final class TimeFieldSpec extends FieldSpec {
   }
 
   public void setOutgoingGranularitySpec(@Nonnull TimeGranularitySpec outgoingGranularitySpec) {
-    Preconditions.checkNotNull(outgoingGranularitySpec);
-
     _outgoingGranularitySpec = outgoingGranularitySpec;
     super.setName(outgoingGranularitySpec.getName());
     super.setDataType(outgoingGranularitySpec.getDataType());

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
@@ -44,7 +44,8 @@ public class SchemaTest {
   }
 
   @Test
-  public void testValidation() throws Exception {
+  public void testValidation()
+      throws Exception {
     Schema schemaToValidate;
 
     schemaToValidate = Schema.fromString(makeSchema(FieldSpec.DataType.LONG, FieldSpec.DataType.STRING, true));
@@ -133,7 +134,7 @@ public class SchemaTest {
     Assert.assertNotNull(fieldSpec);
     Assert.assertEquals(fieldSpec.isSingleValueField(), true);
     Assert.assertEquals(fieldSpec.getDataType(), FieldSpec.DataType.LONG);
-    Assert.assertEquals(fieldSpec.getDefaultNullValue(), new Long(0));
+    Assert.assertEquals(fieldSpec.getDefaultNullValue(), 0L);
 
     fieldSpec = schema.getMetricSpec("derivedMetricWithDefault");
     Assert.assertNotNull(fieldSpec);
@@ -261,14 +262,13 @@ public class SchemaTest {
     Assert.assertEquals(newSchema, schema);
     Assert.assertEquals(newSchema.hashCode(), schema.hashCode());
   }
-  
+
   @Test
   public void testSimpleDateFormat() throws IOException {
     TimeGranularitySpec incomingTimeGranularitySpec = new TimeGranularitySpec(DataType.STRING, 1,
         TimeUnit.DAYS, TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd" , "Date");
     TimeGranularitySpec outgoingTimeGranularitySpec = new TimeGranularitySpec(DataType.STRING, 1,
         TimeUnit.DAYS, TimeFormat.SIMPLE_DATE_FORMAT + ":yyyyMMdd", "Date");
-//    System.out.println(incomingTimeGranularitySpec);
     Schema schema = new Schema.SchemaBuilder().setSchemaName("testSchema")
         .addTime(incomingTimeGranularitySpec, outgoingTimeGranularitySpec).build();
     String jsonSchema = schema.getJSONSchema();


### PR DESCRIPTION
When enabling runtime assertions for not-null annotation, fix the failure in SchemaTest
The failure is caused by the null derivedMetricType in the schema string

Return value for getter and argument for setter should have the same annotation.
Also change member variable name for Schema to follow the coding style.