### PR TITLE
Misc changes for reducing garbage generation during query execution.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/QueryExecutor.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/QueryExecutor.java
@@ -45,7 +45,7 @@ public interface QueryExecutor {
    *
    * @return
    */
-  DataTable processQuery(QueryRequest queryRequest, ExecutorService executorService);
+  DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService);
 
   void shutDown();
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
@@ -22,6 +22,8 @@ import com.linkedin.pinot.common.query.context.TimerContext;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,10 +35,11 @@ import org.slf4j.LoggerFactory;
  * etc.
  *
  */
-public class QueryRequest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(QueryRequest.class);
+public class ServerQueryRequest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerQueryRequest.class);
 
   private final InstanceRequest instanceRequest;
+  private final FilterQueryTree filterQueryTree;
   // Future to track result of query execution
   private ListenableFuture<DataTable> resultFuture;
   // Timing information for different phases of query execution
@@ -45,10 +48,11 @@ public class QueryRequest {
   private final ServerMetrics serverMetrics;
   private int segmentCountAfterPruning;
 
-  public QueryRequest(InstanceRequest request, ServerMetrics serverMetrics) {
+  public ServerQueryRequest(InstanceRequest request, ServerMetrics serverMetrics) {
     this.instanceRequest = request;
     this.serverMetrics = serverMetrics;
     BrokerRequest brokerRequest = (request == null) ? null : request.getQuery();
+    filterQueryTree = (brokerRequest == null) ? null : RequestUtils.generateFilterQueryTree(brokerRequest);
     timerContext = new TimerContext(brokerRequest, serverMetrics);
   }
 
@@ -71,6 +75,13 @@ public class QueryRequest {
    */
   public BrokerRequest getBrokerRequest() {
     return instanceRequest.getQuery();
+  }
+
+  /**
+   * Returns the filter query tree for the server request.
+   */
+  public FilterQueryTree getFilterQueryTree() {
+    return filterQueryTree;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.core.query.pruner;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.request.FilterOperator;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.common.utils.request.RequestUtils;
@@ -41,8 +41,8 @@ public class ColumnValueSegmentPruner extends AbstractSegmentPruner {
   }
 
   @Override
-  public boolean prune(@Nonnull IndexSegment segment, @Nonnull BrokerRequest brokerRequest) {
-    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+  public boolean prune(@Nonnull IndexSegment segment, @Nonnull ServerQueryRequest queryRequest) {
+    FilterQueryTree filterQueryTree = queryRequest.getFilterQueryTree();
     if (filterQueryTree == null) {
       return false;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/DataSchemaSegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/DataSchemaSegmentPruner.java
@@ -15,11 +15,12 @@
  */
 package com.linkedin.pinot.core.query.pruner;
 
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.common.request.BrokerRequest;
 import org.apache.commons.configuration.Configuration;
 
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.request.AggregationInfo;
-import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.FilterQuery;
 import com.linkedin.pinot.common.request.FilterQueryMap;
 import com.linkedin.pinot.common.request.SelectionSort;
@@ -37,10 +38,13 @@ public class DataSchemaSegmentPruner implements SegmentPruner {
   private static final String COLUMN_KEY = "column";
 
   @Override
-  public boolean prune(IndexSegment segment, BrokerRequest brokerRequest) {
+  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
+    BrokerRequest brokerRequest = queryRequest.getBrokerRequest();
     Schema schema = segment.getSegmentMetadata().getSchema();
+
     // Check filtering columns
-    if (brokerRequest.getFilterQuery() != null && !filterQueryMatchedSchema(schema, brokerRequest.getFilterQuery(), brokerRequest.getFilterSubQueryMap())) {
+    if (brokerRequest.getFilterQuery() != null && !filterQueryMatchedSchema(schema, brokerRequest.getFilterQuery(),
+        brokerRequest.getFilterSubQueryMap())) {
       return true;
     }
     // Check aggregation function columns.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/PartitionSegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/PartitionSegmentPruner.java
@@ -15,10 +15,9 @@
  */
 package com.linkedin.pinot.core.query.pruner;
 
-import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.request.FilterOperator;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
-import com.linkedin.pinot.common.utils.request.RequestUtils;
 import com.linkedin.pinot.core.data.partition.PartitionFunction;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
@@ -39,8 +38,19 @@ public class PartitionSegmentPruner extends AbstractSegmentPruner {
   }
 
   @Override
-  public boolean prune(IndexSegment segment, BrokerRequest brokerRequest) {
-    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
+    FilterQueryTree filterQueryTree = queryRequest.getFilterQueryTree();
+    return prune(segment, filterQueryTree);
+  }
+
+  /**
+   * Version of prune that directly takes filter query tree.
+   *
+   * @param segment Segment to prune
+   * @param filterQueryTree Filter query tree
+   * @return True if segment can be pruned, false otherwise.
+   */
+  public boolean prune(IndexSegment segment, FilterQueryTree filterQueryTree) {
     if (filterQueryTree == null) {
       return false;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPruner.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.core.query.pruner;
 
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import org.apache.commons.configuration.Configuration;
 
-import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 
 
@@ -33,8 +33,8 @@ public interface SegmentPruner {
    * Returns true if the given segment can be pruned
    *
    * @param segment
-   * @param brokerRequest
+   * @param queryRequest
    * @return true if the given segment is pruned.
    */
-  public boolean prune(IndexSegment segment, BrokerRequest brokerRequest);
+  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPrunerService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPrunerService.java
@@ -15,15 +15,15 @@
  */
 package com.linkedin.pinot.core.query.pruner;
 
-import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 
 
 public interface SegmentPrunerService {
   /**
    * @param segment
-   * @param query
+   * @param queryRequest
    * @return
    */
-  public boolean prune(final IndexSegment segment, final BrokerRequest query);
+  public boolean prune(final IndexSegment segment, final ServerQueryRequest queryRequest);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPrunerServiceImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/SegmentPrunerServiceImpl.java
@@ -15,13 +15,13 @@
  */
 package com.linkedin.pinot.core.query.pruner;
 
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.query.config.SegmentPrunerConfig;
 
@@ -52,12 +52,12 @@ public class SegmentPrunerServiceImpl implements SegmentPrunerService {
   }
 
   @Override
-  public boolean prune(IndexSegment segment, BrokerRequest brokerRequest) {
+  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
     if (_segmentPrunerSet == null || _segmentPrunerSet.size() == 0) {
       return false;
     }
     for (SegmentPruner pruner : _segmentPrunerSet) {
-      if (pruner.prune(segment, brokerRequest)) {
+      if (pruner.prune(segment, queryRequest)) {
         LOGGER.debug("pruned segment: {}", segment.getSegmentName());
         return true;
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/ValidSegmentPruner.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/pruner/ValidSegmentPruner.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.pruner;
 
-import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import org.apache.commons.configuration.Configuration;
@@ -37,11 +37,11 @@ public class ValidSegmentPruner implements SegmentPruner {
    * - Empty segment.
    *
    * @param segment
-   * @param brokerRequest
+   * @param queryRequest
    * @return
    */
   @Override
-  public boolean prune(IndexSegment segment, BrokerRequest brokerRequest) {
+  public boolean prune(IndexSegment segment, ServerQueryRequest queryRequest) {
     SegmentMetadata segmentMetadata = segment.getSegmentMetadata();
 
     // Check for empty segment.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/FCFSQueryScheduler.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.linkedin.pinot.common.metrics.ServerQueryPhase;
 import com.linkedin.pinot.common.query.QueryExecutor;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.utils.DataTable;
 import java.util.concurrent.Callable;
 import javax.annotation.Nonnull;
@@ -43,7 +43,7 @@ public class FCFSQueryScheduler extends QueryScheduler {
   }
 
   @Override
-  public ListenableFuture<DataTable> submit(final QueryRequest queryRequest) {
+  public ListenableFuture<DataTable> submit(final ServerQueryRequest queryRequest) {
     Preconditions.checkNotNull(queryRequest);
 
     queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -22,7 +22,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.linkedin.pinot.common.query.QueryExecutor;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.utils.DataTable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -116,7 +116,7 @@ public abstract class QueryScheduler {
   }
 
 
-  public abstract ListenableFuture<DataTable> submit(@Nonnull QueryRequest queryRequest);
+  public abstract ListenableFuture<DataTable> submit(@Nonnull ServerQueryRequest queryRequest);
 
   public @Nullable QueryExecutor getQueryExecutor() {
     return queryExecutor;

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/ApproximateQueryTestUtil.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/ApproximateQueryTestUtil.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.queries;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.QueryExecutor;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.ReduceService;
 import com.linkedin.pinot.common.query.gen.AvroQueryGenerator;
 import com.linkedin.pinot.common.request.BrokerRequest;
@@ -64,7 +64,7 @@ public class ApproximateQueryTestUtil {
     for (String segment : segments) {
       instanceRequest.getSearchSegments().add(segment);
     }
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, metrics);
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, metrics);
     final DataTable instanceResponse = queryExecutor.processQuery(queryRequest, queryRunners);
     final Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/QueriesSentinelTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/QueriesSentinelTest.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.queries;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.QueryExecutor;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.ReduceService;
 import com.linkedin.pinot.common.query.gen.AvroQueryGenerator;
 import com.linkedin.pinot.common.query.gen.AvroQueryGenerator.TestGroupByAggreationQuery;
@@ -181,7 +181,7 @@ public class QueriesSentinelTest {
       InstanceRequest instanceRequest = new InstanceRequest(counter++, brokerRequest);
       instanceRequest.setSearchSegments(new ArrayList<String>());
       instanceRequest.getSearchSegments().add(segmentName);
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
       instanceResponseMap.clear();
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -204,7 +204,7 @@ public class QueriesSentinelTest {
       InstanceRequest instanceRequest = new InstanceRequest(counter++, brokerRequest);
       instanceRequest.setSearchSegments(new ArrayList<String>());
       instanceRequest.getSearchSegments().add(segmentName);
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
       instanceResponseMap.clear();
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -310,7 +310,7 @@ public class QueriesSentinelTest {
     InstanceRequest instanceRequest = new InstanceRequest(1, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -327,7 +327,7 @@ public class QueriesSentinelTest {
     InstanceRequest instanceRequest = new InstanceRequest(1, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -350,7 +350,7 @@ public class QueriesSentinelTest {
     InstanceRequest instanceRequest = new InstanceRequest(1, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -371,7 +371,7 @@ public class QueriesSentinelTest {
     instanceRequest.setEnableTrace(true); // TODO: add trace settings consistency
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/QueryExceptionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/QueryExceptionTest.java
@@ -17,7 +17,7 @@ package com.linkedin.pinot.queries;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.QueryExecutor;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.ReduceService;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.InstanceRequest;
@@ -130,7 +130,7 @@ public class QueryExceptionTest {
     InstanceRequest instanceRequest = new InstanceRequest(1, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -147,7 +147,7 @@ public class QueryExceptionTest {
     InstanceRequest instanceRequest = new InstanceRequest(1, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -165,7 +165,7 @@ public class QueryExceptionTest {
     InstanceRequest instanceRequest = new InstanceRequest(1, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -183,7 +183,7 @@ public class QueryExceptionTest {
     InstanceRequest instanceRequest = new InstanceRequest(1, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add(segmentName);
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     final DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/RealtimeQueriesSentinelTest.java
@@ -40,7 +40,7 @@ import com.linkedin.pinot.common.data.FieldSpec.FieldType;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.QueryExecutor;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.ReduceService;
 import com.linkedin.pinot.common.query.gen.AvroQueryGenerator;
 import com.linkedin.pinot.common.query.gen.AvroQueryGenerator.TestGroupByAggreationQuery;
@@ -121,7 +121,7 @@ public class RealtimeQueriesSentinelTest {
       InstanceRequest instanceRequest = new InstanceRequest(counter++, brokerRequest);
       instanceRequest.setSearchSegments(new ArrayList<String>());
       instanceRequest.getSearchSegments().add("testTable_testTable");
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
       instanceResponseMap.clear();
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -158,7 +158,7 @@ public class RealtimeQueriesSentinelTest {
     InstanceRequest instanceRequest = new InstanceRequest(485, brokerRequest);
     instanceRequest.setSearchSegments(new ArrayList<String>());
     instanceRequest.getSearchSegments().add("testTable_testTable");
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
     instanceResponseMap.clear();
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);
@@ -179,7 +179,7 @@ public class RealtimeQueriesSentinelTest {
       InstanceRequest instanceRequest = new InstanceRequest(counter++, brokerRequest);
       instanceRequest.setSearchSegments(new ArrayList<String>());
       instanceRequest.getSearchSegments().add("testTable_testTable");
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse = QUERY_EXECUTOR.processQuery(queryRequest, queryRunners);
       instanceResponseMap.clear();
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse);

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/executor/BrokerReduceServiceTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/executor/BrokerReduceServiceTest.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.query.executor;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.ReduceService;
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
@@ -155,7 +155,7 @@ public class BrokerReduceServiceTest {
     }
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
     DataTable instanceResponse1 = _queryExecutor.processQuery(queryRequest, queryRunners);
     instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse1);
     DataTable instanceResponse2 = _queryExecutor.processQuery(queryRequest, queryRunners);
@@ -183,7 +183,7 @@ public class BrokerReduceServiceTest {
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse1 = _queryExecutor.processQuery(queryRequest, queryRunners);
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse1);
       DataTable instanceResponse2 = _queryExecutor.processQuery(queryRequest, queryRunners);
@@ -215,7 +215,7 @@ public class BrokerReduceServiceTest {
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse1 = _queryExecutor.processQuery(queryRequest, queryRunners);
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse1);
       DataTable instanceResponse2 = _queryExecutor.processQuery(queryRequest, queryRunners);
@@ -246,7 +246,7 @@ public class BrokerReduceServiceTest {
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse1 = _queryExecutor.processQuery(queryRequest, queryRunners);
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse1);
       DataTable instanceResponse2 = _queryExecutor.processQuery(queryRequest, queryRunners);
@@ -278,7 +278,7 @@ public class BrokerReduceServiceTest {
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse1 = _queryExecutor.processQuery(queryRequest, queryRunners);
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse1);
       DataTable instanceResponse2 = _queryExecutor.processQuery(queryRequest, queryRunners);
@@ -312,7 +312,7 @@ public class BrokerReduceServiceTest {
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse1 = _queryExecutor.processQuery(queryRequest, queryRunners);
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse1);
       DataTable instanceResponse2 = _queryExecutor.processQuery(queryRequest, queryRunners);
@@ -347,7 +347,7 @@ public class BrokerReduceServiceTest {
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       DataTable instanceResponse1 = _queryExecutor.processQuery(queryRequest, queryRunners);
       instanceResponseMap.put(new ServerInstance("localhost:0000"), instanceResponse1);
       DataTable instanceResponse2 = _queryExecutor.processQuery(queryRequest, queryRunners);
@@ -382,7 +382,7 @@ public class BrokerReduceServiceTest {
 
     Map<ServerInstance, DataTable> instanceResponseMap = new HashMap<ServerInstance, DataTable>();
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, TableDataManagerProvider.getServerMetrics());
       instanceResponseMap.put(new ServerInstance("localhost:0000"), _queryExecutor.processQuery(queryRequest,
           queryRunners));
       instanceResponseMap.put(new ServerInstance("localhost:1111"), _queryExecutor.processQuery(queryRequest,

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.query.executor;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.FilterQuery;
@@ -147,7 +147,7 @@ public class QueryExecutorTest {
     for (IndexSegment segment : _indexSegmentList) {
       instanceRequest.getSearchSegments().add(segment.getSegmentName());
     }
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, serverMetrics);
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
     LOGGER.info("InstanceResponse is " + instanceResponse.getLong(0, 0));
     Assert.assertEquals(instanceResponse.getLong(0, 0), 400002L);
@@ -167,7 +167,7 @@ public class QueryExecutorTest {
     for (IndexSegment segment : _indexSegmentList) {
       instanceRequest.getSearchSegments().add(segment.getSegmentName());
     }
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, serverMetrics);
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
     LOGGER.info("InstanceResponse is " + instanceResponse.getDouble(0, 0));
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 40000200000.0);
@@ -188,7 +188,7 @@ public class QueryExecutorTest {
     for (IndexSegment segment : _indexSegmentList) {
       instanceRequest.getSearchSegments().add(segment.getSegmentName());
     }
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, serverMetrics);
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
     LOGGER.info("InstanceResponse is " + instanceResponse.getDouble(0, 0));
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 200000.0);
@@ -208,7 +208,7 @@ public class QueryExecutorTest {
     for (IndexSegment segment : _indexSegmentList) {
       instanceRequest.getSearchSegments().add(segment.getSegmentName());
     }
-    QueryRequest queryRequest = new QueryRequest(instanceRequest, serverMetrics);
+    ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
     DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
     LOGGER.info("InstanceResponse is " + instanceResponse.getDouble(0, 0));
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 0.0);

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
@@ -22,7 +22,7 @@ import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.metrics.ServerQueryPhase;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.context.TimerContext;
 import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.utils.DataTable;
@@ -69,11 +69,11 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
       DataTable result = new DataTableImplV2();
       result.addException(QueryException.INTERNAL_ERROR);
       serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_DESERIALIZATION_EXCEPTIONS, 1);
-      QueryRequest queryRequest = new QueryRequest(null, serverMetrics);
+      ServerQueryRequest queryRequest = new ServerQueryRequest(null, serverMetrics);
       queryRequest.getTimerContext().setQueryArrivalTimeNs(queryStartTimeNs);
       return Futures.immediateFuture(serializeDataTable(queryRequest, result));
     }
-    final QueryRequest queryRequest = new QueryRequest(instanceRequest, serverMetrics);
+    final ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
     final TimerContext timerContext = queryRequest.getTimerContext();
      timerContext.setQueryArrivalTimeNs(queryStartTimeNs);
     TimerContext.Timer deserializationTimer =
@@ -123,7 +123,7 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
     return serializedQueryResponse;
   }
 
-  static byte[] serializeDataTable(QueryRequest queryRequest, DataTable instanceResponse) {
+  static byte[] serializeDataTable(ServerQueryRequest queryRequest, DataTable instanceResponse) {
     byte[] responseByte;
 
     InstanceRequest instanceRequest = queryRequest.getInstanceRequest();

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/integration/InstanceServerStarter.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/integration/InstanceServerStarter.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.server.integration;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
@@ -83,7 +83,7 @@ public class InstanceServerStarter {
     brokerRequest.setQuerySource(querySource);
     InstanceRequest instanceRequest = new InstanceRequest(0, brokerRequest);
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, metrics);
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, metrics);
       DataTable instanceResponse = queryExecutor.processQuery(queryRequest, queryScheduler.getWorkerExecutorService());
       System.out.println(instanceResponse.toString());
       System.out.println("Query Time Used : " + instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/integration/IntegrationTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/integration/IntegrationTest.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.server.integration;
 
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
@@ -146,7 +146,7 @@ public class IntegrationTest {
     searchSegments.add("testTable_0_9_");
     instanceRequest.setSearchSegments(searchSegments);
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
     } catch (Exception e) {
       e.printStackTrace();
@@ -165,7 +165,7 @@ public class IntegrationTest {
     InstanceRequest instanceRequest = new InstanceRequest(0, brokerRequest);
     addTestTableSearchSegmentsToInstanceRequest(instanceRequest);
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
 //      System.out.println(instanceResponse.getLong(0, 0));
 //      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
@@ -190,7 +190,7 @@ public class IntegrationTest {
     InstanceRequest instanceRequest = new InstanceRequest(0, brokerRequest);
     addTestTableSearchSegmentsToInstanceRequest(instanceRequest);
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
 //      System.out.println(instanceResponse.getDouble(0, 0));
 //      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
@@ -212,7 +212,7 @@ public class IntegrationTest {
     InstanceRequest instanceRequest = new InstanceRequest(0, brokerRequest);
     addTestTableSearchSegmentsToInstanceRequest(instanceRequest);
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
 //      System.out.println(instanceResponse.getDouble(0, 0));
 //      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
@@ -232,7 +232,7 @@ public class IntegrationTest {
     InstanceRequest instanceRequest = new InstanceRequest(0, brokerRequest);
     addTestTableSearchSegmentsToInstanceRequest(instanceRequest);
     try {
-      QueryRequest queryRequest = new QueryRequest(instanceRequest, _serverInstance.getServerMetrics());
+      ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, _serverInstance.getServerMetrics());
       DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, queryRunners);
 //      System.out.println(instanceResponse.getDouble(0, 0));
 //      System.out.println(instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/request/ScheduledRequestHandlerTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/request/ScheduledRequestHandlerTest.java
@@ -20,7 +20,7 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.QueryExecutor;
-import com.linkedin.pinot.common.query.QueryRequest;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.utils.DataSchema;
@@ -119,7 +119,7 @@ public class ScheduledRequestHandlerTest {
       throws Exception {
     ScheduledRequestHandler handler = new ScheduledRequestHandler(new QueryScheduler(queryExecutor) {
       @Override
-      public ListenableFuture<DataTable> submit(QueryRequest queryRequest) {
+      public ListenableFuture<DataTable> submit(ServerQueryRequest queryRequest) {
         return queryWorkers.submit(new Callable<DataTable>() {
           @Override
           public DataTable call()
@@ -145,7 +145,7 @@ public class ScheduledRequestHandlerTest {
       throws InterruptedException, ExecutionException, TimeoutException, IOException {
     ScheduledRequestHandler handler = new ScheduledRequestHandler(new QueryScheduler(queryExecutor) {
       @Override
-      public ListenableFuture<DataTable> submit(QueryRequest queryRequest) {
+      public ListenableFuture<DataTable> submit(ServerQueryRequest queryRequest) {
         return queryRunners.submit(new Callable<DataTable>() {
           @Override
           public DataTable call()


### PR DESCRIPTION
1. Used thread local memory during query execution, wherever possible.
2. Cached FilterQueryTree inside QueryRequest, to avoid re-creating
   it over and over again.
3. Renamed QueryRequest to ServerQueryRequest to indicate it is
   server-side query request.