### PR TITLE
Refactor TableNameBuilder class

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -15,21 +15,6 @@
  */
 package com.linkedin.pinot.broker.requesthandler;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import org.apache.commons.configuration.Configuration;
-import org.apache.thrift.protocol.TCompactProtocol;
-import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.base.Splitter;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.exception.QueryException;
@@ -66,9 +51,24 @@ import com.linkedin.pinot.transport.scattergather.ScatterGather;
 import com.linkedin.pinot.transport.scattergather.ScatterGatherRequest;
 import com.linkedin.pinot.transport.scattergather.ScatterGatherStats;
 import io.netty.buffer.ByteBuf;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.commons.configuration.Configuration;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -264,11 +264,11 @@ public class BrokerRequestHandler {
     ResponseType responseType = BrokerResponseFactory.getResponseType(brokerRequest.getResponseFormat());
     LOGGER.debug("Broker Response Type: {}", responseType.name());
 
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     if (!_routingTable.routingTableExists(offlineTableName)) {
       offlineTableName = null;
     }
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     if (!_routingTable.routingTableExists(realtimeTableName)) {
       realtimeTableName = null;
     }
@@ -331,7 +331,7 @@ public class BrokerRequestHandler {
   private BrokerRequest getOfflineBrokerRequest(@Nonnull BrokerRequest brokerRequest) {
     BrokerRequest offlineRequest = brokerRequest.deepCopy();
     String hybridTableName = brokerRequest.getQuerySource().getTableName();
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(hybridTableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(hybridTableName);
     offlineRequest.getQuerySource().setTableName(offlineTableName);
     attachTimeBoundary(hybridTableName, offlineRequest, true);
     return offlineRequest;
@@ -347,7 +347,7 @@ public class BrokerRequestHandler {
   private BrokerRequest getRealtimeBrokerRequest(@Nonnull BrokerRequest brokerRequest) {
     BrokerRequest realtimeRequest = brokerRequest.deepCopy();
     String hybridTableName = brokerRequest.getQuerySource().getTableName();
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(hybridTableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(hybridTableName);
     realtimeRequest.getQuerySource().setTableName(realtimeTableName);
     attachTimeBoundary(hybridTableName, realtimeRequest, false);
     return realtimeRequest;
@@ -362,8 +362,8 @@ public class BrokerRequestHandler {
    */
   private void attachTimeBoundary(@Nonnull String hybridTableName, @Nonnull BrokerRequest brokerRequest,
       boolean isOfflineRequest) {
-    TimeBoundaryInfo timeBoundaryInfo = _timeBoundaryService.getTimeBoundaryInfoFor(
-        TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(hybridTableName));
+    TimeBoundaryInfo timeBoundaryInfo =
+        _timeBoundaryService.getTimeBoundaryInfoFor(TableNameBuilder.OFFLINE.tableNameWithType(hybridTableName));
     if (timeBoundaryInfo == null || timeBoundaryInfo.getTimeColumn() == null
         || timeBoundaryInfo.getTimeValue() == null) {
       LOGGER.warn("No time boundary attached for table: {}", hybridTableName);

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/servlet/PinotBrokerTimeBoundaryDebugServlet.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/servlet/PinotBrokerTimeBoundaryDebugServlet.java
@@ -16,17 +16,17 @@
 
 package com.linkedin.pinot.broker.servlet;
 
-import java.io.IOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.routing.TimeBoundaryService;
+import java.io.IOException;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /*
@@ -62,7 +62,7 @@ public class PinotBrokerTimeBoundaryDebugServlet extends HttpServlet {
       if (!tableName.isEmpty()) {
         CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
         if (tableType == null) {
-          tableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+          tableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
         }
         TimeBoundaryService.TimeBoundaryInfo tbInfo = _timeBoundaryService.getTimeBoundaryInfoFor(tableName);
         if (tbInfo != null) {

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -16,6 +16,20 @@
 package com.linkedin.pinot.broker.broker;
 
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.linkedin.pinot.broker.broker.helix.DefaultHelixBrokerConfig;
+import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
+import com.linkedin.pinot.controller.helix.starter.HelixConfig;
+import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
+import com.linkedin.pinot.routing.HelixExternalViewBasedRouting;
+import com.linkedin.pinot.routing.ServerToSegmentSetMap;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
@@ -38,20 +52,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.broker.broker.helix.DefaultHelixBrokerConfig;
-import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
-import com.linkedin.pinot.common.config.AbstractTableConfig;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
-import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
-import com.linkedin.pinot.controller.helix.starter.HelixConfig;
-import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
-import com.linkedin.pinot.routing.HelixExternalViewBasedRouting;
-import com.linkedin.pinot.routing.ServerToSegmentSetMap;
 
 
 public class HelixBrokerStarterTest {
@@ -60,8 +60,8 @@ public class HelixBrokerStarterTest {
   private static final int SEGMENT_COUNT = 6;
   private PinotHelixResourceManager _pinotResourceManager;
   private final static String HELIX_CLUSTER_NAME = "TestHelixBrokerStarter";
-  private final static String DINING_TABLE_NAME = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable("dining");
-  private final static String COFFEE_TABLE_NAME = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable("coffee");
+  private final static String DINING_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType("dining");
+  private final static String COFFEE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType("coffee");
 
   private ZkClient _zkClient;
   private HelixManager _helixZkManager;
@@ -102,9 +102,8 @@ public class HelixBrokerStarterTest {
     for (int i = 1; i <= 5; i++) {
       addOneSegment(tableName);
       Thread.sleep(2000);
-      final ExternalView externalView =
-          _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME,
-              TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName));
+      final ExternalView externalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME,
+          TableNameBuilder.OFFLINE.tableNameWithType(tableName));
       Assert.assertEquals(externalView.getPartitionSet().size(), i);
     }
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/AbstractTableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/AbstractTableConfig.java
@@ -46,10 +46,9 @@ public abstract class AbstractTableConfig {
   protected @Nullable QuotaConfig quotaConfig;
 
   protected AbstractTableConfig(String tableName, String tableType,
-      SegmentsValidationAndRetentionConfig validationConfig,
-      TenantConfig tenantConfig, TableCustomConfig customConfigs,
+      SegmentsValidationAndRetentionConfig validationConfig, TenantConfig tenantConfig, TableCustomConfig customConfigs,
       @Nullable QuotaConfig quotaConfig) {
-    this.tableName = new TableNameBuilder(TableType.valueOf(tableType.toUpperCase())).forTable(tableName);
+    this.tableName = TableNameBuilder.forType(TableType.valueOf(tableType.toUpperCase())).tableNameWithType(tableName);
     this.tableType = tableType;
     this.validationConfig = validationConfig;
     this.tenantConfig = tenantConfig;
@@ -60,8 +59,8 @@ public abstract class AbstractTableConfig {
   public static AbstractTableConfig init(String jsonString) throws JSONException, IOException {
     JSONObject tableJson = new JSONObject(jsonString);
     String tableType = tableJson.getString("tableType").toLowerCase();
-    String tableName =
-        new TableNameBuilder(TableType.valueOf(tableType.toUpperCase())).forTable(tableJson.getString("tableName"));
+    String tableName = TableNameBuilder.forType(TableType.valueOf(tableType.toUpperCase()))
+        .tableNameWithType(tableJson.getString("tableName"));
     SegmentsValidationAndRetentionConfig validationConfig =
         loadSegmentsConfig(new ObjectMapper().readTree(tableJson.getJSONObject("segmentsConfig").toString()));
     TenantConfig tenantConfig = loadTenantsConfig(new ObjectMapper().readTree(tableJson.getJSONObject("tenants").toString()));

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableNameBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableNameBuilder.java
@@ -18,52 +18,105 @@ package com.linkedin.pinot.common.config;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.common.utils.SegmentName;
-import com.linkedin.pinot.common.utils.StringUtil;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 public class TableNameBuilder {
+  public static final TableNameBuilder OFFLINE = new TableNameBuilder(TableType.OFFLINE);
+  public static final TableNameBuilder REALTIME = new TableNameBuilder(TableType.REALTIME);
 
-  public static final TableNameBuilder OFFLINE_TABLE_NAME_BUILDER = new TableNameBuilder(TableType.OFFLINE);
-  public static final TableNameBuilder REALTIME_TABLE_NAME_BUILDER = new TableNameBuilder(TableType.REALTIME);
+  private static final String TYPE_SUFFIX_SEPARATOR = "_";
 
-  TableType type;
+  private final String _typeSuffix;
 
-  public TableNameBuilder(TableType type) {
-    this.type = type;
+  private TableNameBuilder(@Nonnull TableType tableType) {
+    _typeSuffix = TYPE_SUFFIX_SEPARATOR + tableType.toString();
   }
 
-  public String forTable(@Nonnull String tableName) {
-    Preconditions.checkNotNull(tableName);
-    Preconditions.checkArgument(!tableName.contains(SegmentName.SEPARATOR),
-        "Table name(" + tableName + ") cannot contain two consecutive underscore characters");
-
-    if (needsPostfix(tableName)) {
-      return StringUtil.join("_", tableName, type.toString().toUpperCase());
+  /**
+   * Get the table name builder for the given table type.
+   * @param tableType Table type
+   * @return Table name builder for the given table type
+   */
+  @Nonnull
+  public static TableNameBuilder forType(@Nonnull TableType tableType) {
+    if (tableType == TableType.OFFLINE) {
+      return OFFLINE;
+    } else {
+      return REALTIME;
     }
-    return tableName;
   }
 
-  public boolean needsPostfix(String tableName) {
-    return !tableName.endsWith(type.toString().toUpperCase());
+  /**
+   * Get the table name with type suffix.
+   *
+   * @param tableName Table name with or without type suffix
+   * @return Table name with type suffix
+   */
+  @Nonnull
+  public String tableNameWithType(@Nonnull String tableName) {
+    Preconditions.checkArgument(!tableName.contains(SegmentName.SEPARATOR),
+        "Table name: %s cannot contain two consecutive underscore characters", tableName);
+
+    if (tableName.endsWith(_typeSuffix)) {
+      return tableName;
+    } else {
+      return tableName + _typeSuffix;
+    }
   }
 
-  public static TableType getTableTypeFromTableName(String tableName) {
-    for (TableType tableType : TableType.values()) {
-      if (tableName.endsWith("_" + tableType.toString())) {
-        return tableType;
-      }
+  /**
+   * Return Whether the table has type suffix that matches the builder type.
+   *
+   * @param tableName Table name with or without type suffix
+   * @return Whether the table has type suffix that matches the builder type
+   */
+  public boolean tableHasTypeSuffix(@Nonnull String tableName) {
+    return tableName.endsWith(_typeSuffix);
+  }
+
+  /**
+   * Get the table type based on the given table name with type suffix.
+   *
+   * @param tableName Table name with or without type suffix
+   * @return Table type for the given table name, null if cannot be determined by table name
+   */
+  @Nullable
+  public static TableType getTableTypeFromTableName(@Nonnull String tableName) {
+    if (OFFLINE.tableHasTypeSuffix(tableName)) {
+      return TableType.OFFLINE;
+    }
+    if (REALTIME.tableHasTypeSuffix(tableName)) {
+      return TableType.REALTIME;
     }
     return null;
   }
 
-  public static String extractRawTableName(String tableName) {
-    for (TableType tableType : TableType.values()) {
-      if (tableName.endsWith("_" + tableType.toString())) {
-        return tableName.substring(0, tableName.lastIndexOf("_" + tableType.toString()));
-      }
+  /**
+   * Extract the raw table name from the given table name with type suffix.
+   *
+   * @param tableName Table name with or without type suffix
+   * @return Table name without type suffix
+   */
+  @Nonnull
+  public static String extractRawTableName(@Nonnull String tableName) {
+    if (OFFLINE.tableHasTypeSuffix(tableName)) {
+      return tableName.substring(0, tableName.length() - OFFLINE._typeSuffix.length());
+    }
+    if (REALTIME.tableHasTypeSuffix(tableName)) {
+      return tableName.substring(0, tableName.length() - REALTIME._typeSuffix.length());
     }
     return tableName;
   }
 
+  /**
+   * Return whether the given resource name represents a table resource.
+   *
+   * @param resourceName Resource name
+   * @return Whether the resource name represents a table resource
+   */
+  public static boolean isTableResource(@Nonnull String resourceName) {
+    return OFFLINE.tableHasTypeSuffix(resourceName) || REALTIME.tableHasTypeSuffix(resourceName);
+  }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -121,22 +121,24 @@ public class ZKMetadataProvider {
     }
   }
 
-  public static void setOfflineSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore, OfflineSegmentZKMetadata offlineSegmentZKMetadata) {
+  public static void setOfflineSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      OfflineSegmentZKMetadata offlineSegmentZKMetadata) {
     propertyStore.set(constructPropertyStorePathForSegment(
-        TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(offlineSegmentZKMetadata.getTableName()), offlineSegmentZKMetadata.getSegmentName()),
-        offlineSegmentZKMetadata.toZNRecord(), AccessOption.PERSISTENT);
+        TableNameBuilder.OFFLINE.tableNameWithType(offlineSegmentZKMetadata.getTableName()),
+        offlineSegmentZKMetadata.getSegmentName()), offlineSegmentZKMetadata.toZNRecord(), AccessOption.PERSISTENT);
   }
 
-  public static void setRealtimeSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore, RealtimeSegmentZKMetadata realtimeSegmentZKMetadata) {
+  public static void setRealtimeSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      RealtimeSegmentZKMetadata realtimeSegmentZKMetadata) {
     propertyStore.set(constructPropertyStorePathForSegment(
-        TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(realtimeSegmentZKMetadata.getTableName()), realtimeSegmentZKMetadata.getSegmentName()),
-        realtimeSegmentZKMetadata.toZNRecord(), AccessOption.PERSISTENT);
+        TableNameBuilder.REALTIME.tableNameWithType(realtimeSegmentZKMetadata.getTableName()),
+        realtimeSegmentZKMetadata.getSegmentName()), realtimeSegmentZKMetadata.toZNRecord(), AccessOption.PERSISTENT);
   }
 
   @Nullable
   public static OfflineSegmentZKMetadata getOfflineSegmentZKMetadata(
       @Nonnull ZkHelixPropertyStore<ZNRecord> propertyStore, @Nonnull String tableName, @Nonnull String segmentName) {
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     ZNRecord znRecord = propertyStore.get(constructPropertyStorePathForSegment(offlineTableName, segmentName), null,
         AccessOption.PERSISTENT);
     if (znRecord == null) {
@@ -148,7 +150,7 @@ public class ZKMetadataProvider {
   @Nullable
   public static RealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(
       @Nonnull ZkHelixPropertyStore<ZNRecord> propertyStore, @Nonnull String tableName, @Nonnull String segmentName) {
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     ZNRecord znRecord = propertyStore.get(constructPropertyStorePathForSegment(realtimeTableName, segmentName), null,
         AccessOption.PERSISTENT);
     // It is possible that the segment metadata has just been deleted due to retention.
@@ -165,7 +167,7 @@ public class ZKMetadataProvider {
   @Nullable
   public static AbstractTableConfig getOfflineTableConfig(@Nonnull ZkHelixPropertyStore<ZNRecord> propertyStore,
       @Nonnull String tableName) {
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     ZNRecord znRecord =
         propertyStore.get(constructPropertyStorePathForResourceConfig(offlineTableName), null, AccessOption.PERSISTENT);
     if (znRecord == null) {
@@ -182,7 +184,7 @@ public class ZKMetadataProvider {
   @Nullable
   public static AbstractTableConfig getRealtimeTableConfig(@Nonnull ZkHelixPropertyStore<ZNRecord> propertyStore,
       @Nonnull String tableName) {
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     ZNRecord znRecord = propertyStore.get(constructPropertyStorePathForResourceConfig(realtimeTableName), null,
         AccessOption.PERSISTENT);
     if (znRecord == null) {
@@ -216,7 +218,7 @@ public class ZKMetadataProvider {
       @Nonnull String tableName) {
     // TODO: After uniform schema, always use raw table name
 
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     // First try to get schema using offline table name
     Schema schema = getSchema(propertyStore, offlineTableName);
     if (schema != null) {
@@ -232,7 +234,7 @@ public class ZKMetadataProvider {
       @Nonnull String tableName) {
     // TODO: After uniform schema, get schema using raw table name
 
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     try {
       AbstractTableConfig realtimeTableConfig = getRealtimeTableConfig(propertyStore, realtimeTableName);
       if (realtimeTableConfig == null) {
@@ -247,14 +249,17 @@ public class ZKMetadataProvider {
     }
   }
 
-  public static List<OfflineSegmentZKMetadata> getOfflineSegmentZKMetadataListForTable(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
-    List<OfflineSegmentZKMetadata> resultList = new ArrayList<OfflineSegmentZKMetadata>();
+  public static List<OfflineSegmentZKMetadata> getOfflineSegmentZKMetadataListForTable(
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String tableName) {
+    List<OfflineSegmentZKMetadata> resultList = new ArrayList<>();
     if (propertyStore == null) {
       return resultList;
     }
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     if (propertyStore.exists(constructPropertyStorePathForResource(offlineTableName), AccessOption.PERSISTENT)) {
-      List<ZNRecord> znRecordList = propertyStore.getChildren(constructPropertyStorePathForResource(offlineTableName), null, AccessOption.PERSISTENT);
+      List<ZNRecord> znRecordList =
+          propertyStore.getChildren(constructPropertyStorePathForResource(offlineTableName), null,
+              AccessOption.PERSISTENT);
       if (znRecordList != null) {
         for (ZNRecord record : znRecordList) {
           resultList.add(new OfflineSegmentZKMetadata(record));
@@ -264,14 +269,17 @@ public class ZKMetadataProvider {
     return resultList;
   }
 
-  public static List<RealtimeSegmentZKMetadata> getRealtimeSegmentZKMetadataListForTable(ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
-    List<RealtimeSegmentZKMetadata> resultList = new ArrayList<RealtimeSegmentZKMetadata>();
+  public static List<RealtimeSegmentZKMetadata> getRealtimeSegmentZKMetadataListForTable(
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
+    List<RealtimeSegmentZKMetadata> resultList = new ArrayList<>();
     if (propertyStore == null) {
       return resultList;
     }
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(resourceName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(resourceName);
     if (propertyStore.exists(constructPropertyStorePathForResource(realtimeTableName), AccessOption.PERSISTENT)) {
-      List<ZNRecord> znRecordList = propertyStore.getChildren(constructPropertyStorePathForResource(realtimeTableName), null, AccessOption.PERSISTENT);
+      List<ZNRecord> znRecordList =
+          propertyStore.getChildren(constructPropertyStorePathForResource(realtimeTableName), null,
+              AccessOption.PERSISTENT);
       if (znRecordList != null) {
         for (ZNRecord record : znRecordList) {
           resultList.add(new RealtimeSegmentZKMetadata(record));

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/instance/InstanceZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/instance/InstanceZKMetadata.java
@@ -15,19 +15,17 @@
  */
 package com.linkedin.pinot.common.metadata.instance;
 
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadata;
+import com.linkedin.pinot.common.utils.StringUtil;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.ZNRecord;
+
 import static com.linkedin.pinot.common.utils.EqualityUtils.hashCodeOf;
 import static com.linkedin.pinot.common.utils.EqualityUtils.isEqual;
 import static com.linkedin.pinot.common.utils.EqualityUtils.isNullOrNotSameClass;
 import static com.linkedin.pinot.common.utils.EqualityUtils.isSameReference;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.helix.ZNRecord;
-
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.metadata.ZKMetadata;
-import com.linkedin.pinot.common.utils.StringUtil;
 
 
 public final class InstanceZKMetadata implements ZKMetadata {
@@ -96,19 +94,19 @@ public final class InstanceZKMetadata implements ZKMetadata {
   }
 
   public String getGroupId(String resourceName) {
-    return _groupIdMap.get(TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(resourceName));
+    return _groupIdMap.get(TableNameBuilder.REALTIME.tableNameWithType(resourceName));
   }
 
   public void setGroupId(String resourceName, String groupId) {
-    _groupIdMap.put(TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(resourceName), groupId);
+    _groupIdMap.put(TableNameBuilder.REALTIME.tableNameWithType(resourceName), groupId);
   }
 
   public String getPartition(String resourceName) {
-    return _partitionMap.get(TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(resourceName));
+    return _partitionMap.get(TableNameBuilder.REALTIME.tableNameWithType(resourceName));
   }
 
   public void setPartition(String resourceName, String partition) {
-    _partitionMap.put(TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(resourceName), partition);
+    _partitionMap.put(TableNameBuilder.REALTIME.tableNameWithType(resourceName), partition);
   }
 
   public void removeResource(String resourceName) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -15,9 +15,6 @@
  */
 package com.linkedin.pinot.common.utils;
 
-import com.google.common.collect.Sets;
-import java.util.Collections;
-import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -63,12 +60,6 @@ public class CommonConstants {
         public static final String ERROR = "ERROR";
       }
     }
-
-    /**
-     * Resources names that are not Pinot resources (such as broker resource)
-     */
-    public static final Set<String> NON_PINOT_RESOURCE_RESOURCE_NAMES =
-        Collections.unmodifiableSet(Sets.newHashSet(BROKER_RESOURCE_INSTANCE));
 
     public static class DataSource {
       public static final String SCHEMA = "schema";

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResource.java
@@ -22,15 +22,15 @@ import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metrics.ControllerMeter;
-import com.linkedin.pinot.common.restlet.swagger.Response;
-import com.linkedin.pinot.common.restlet.swagger.Responses;
-import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
-import com.linkedin.pinot.controller.api.ControllerRestApplication;
 import com.linkedin.pinot.common.restlet.swagger.HttpVerb;
 import com.linkedin.pinot.common.restlet.swagger.Parameter;
 import com.linkedin.pinot.common.restlet.swagger.Paths;
+import com.linkedin.pinot.common.restlet.swagger.Response;
+import com.linkedin.pinot.common.restlet.swagger.Responses;
 import com.linkedin.pinot.common.restlet.swagger.Summary;
 import com.linkedin.pinot.common.restlet.swagger.Tags;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.controller.api.ControllerRestApplication;
 import com.linkedin.pinot.controller.helix.core.PinotResourceManagerResponse;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -194,7 +194,7 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
     JSONArray ret = new JSONArray();
     if ((tableType == null || TableType.REALTIME.name().equalsIgnoreCase(tableType))
         && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-      String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
       JSONObject realtime = new JSONObject();
       realtime.put(TABLE_NAME, realtimeTableName);
       realtime.put("segments", new ObjectMapper().writeValueAsString(_pinotHelixResourceManager
@@ -205,7 +205,7 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
 
     if ((tableType == null || TableType.OFFLINE.name().equalsIgnoreCase(tableType))
         && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
-      String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
       JSONObject offline = new JSONObject();
       offline.put(TABLE_NAME, offlineTableName);
       offline.put("segments", new ObjectMapper().writeValueAsString(_pinotHelixResourceManager
@@ -242,8 +242,8 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
       @Parameter(name = "type", in = "query", description = "Type of table {offline|realtime}",
           required = false) String tableType)
       throws JsonProcessingException, JSONException {
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     List<String> offlineSegments = _pinotHelixResourceManager.getAllSegmentsForResource(offlineTableName);
     List<String> realtimeSegments = _pinotHelixResourceManager.getAllSegmentsForResource(realtimeTableName);
 
@@ -298,8 +298,8 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
 
     JSONArray ret = new JSONArray();
     List<String> segmentsToToggle = new ArrayList<>();
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     String tableNameWithType = "";
     List<String> realtimeSegments = _pinotHelixResourceManager.getAllSegmentsForResource(realtimeTableName);
     List<String> offlineSegments = _pinotHelixResourceManager.getAllSegmentsForResource(offlineTableName);
@@ -396,13 +396,13 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
     JSONArray ret = new JSONArray();
     if ((tableType == null || TableType.OFFLINE.name().equalsIgnoreCase(tableType))
         && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
-      String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
       ret.put(getSegmentMetaData(offlineTableName, segmentName, TableType.OFFLINE));
     }
 
     if ((tableType == null || TableType.REALTIME.name().equalsIgnoreCase(tableType))
         && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-      String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
       ret.put(getSegmentMetaData(realtimeTableName, segmentName, TableType.REALTIME));
     }
 
@@ -463,12 +463,12 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
     int numReloadMessagesSent = 0;
 
     if ((tableType == null) || TableType.OFFLINE.name().equalsIgnoreCase(tableType)) {
-      String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
       numReloadMessagesSent += _pinotHelixResourceManager.reloadSegment(offlineTableName, segmentName);
     }
 
     if ((tableType == null) || TableType.REALTIME.name().equalsIgnoreCase(tableType)) {
-      String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
       numReloadMessagesSent += _pinotHelixResourceManager.reloadSegment(realtimeTableName, segmentName);
     }
 
@@ -488,12 +488,12 @@ public class PinotSegmentRestletResource extends BasePinotControllerRestletResou
     int numReloadMessagesSent = 0;
 
     if ((tableType == null) || TableType.OFFLINE.name().equalsIgnoreCase(tableType)) {
-      String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
       numReloadMessagesSent += _pinotHelixResourceManager.reloadAllSegments(offlineTableName);
     }
 
     if ((tableType == null) || TableType.REALTIME.name().equalsIgnoreCase(tableType)) {
-      String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
       numReloadMessagesSent += _pinotHelixResourceManager.reloadAllSegments(realtimeTableName);
     }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -211,8 +211,8 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
 
     final JSONArray ret = new JSONArray();
 
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
 
     String tableNameWithType;
     if (CommonConstants.Helix.TableType.valueOf(tableType).toString().equals("REALTIME")) {
@@ -634,9 +634,8 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
       @Nonnull OfflineTableConfig offlineTableConfig) {
     TableSizeReader tableSizeReader = new TableSizeReader(executor, connectionManager, _pinotHelixResourceManager);
     StorageQuotaChecker quotaChecker = new StorageQuotaChecker(offlineTableConfig, tableSizeReader);
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(metadata.getTableName());
-    return quotaChecker.isSegmentStorageWithinQuota(segmentFile, offlineTableName,
-        metadata.getName(), _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(metadata.getTableName());
+    return quotaChecker.isSegmentStorageWithinQuota(segmentFile, offlineTableName, metadata.getName(),
+        _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
   }
-
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableSizeReader.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableSizeReader.java
@@ -88,13 +88,13 @@ public class TableSizeReader {
     TableSizeDetails tableSizeDetails = new TableSizeDetails(tableName);
 
     if (hasRealtimeTable) {
-      String realtimeTableName = new TableNameBuilder(CommonConstants.Helix.TableType.REALTIME).forTable(tableName);
+      String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
       tableSizeDetails.realtimeSegments = getTableSubtypeSize(realtimeTableName, timeoutMsec);
       tableSizeDetails.reportedSizeInBytes += tableSizeDetails.realtimeSegments.reportedSizeInBytes;
       tableSizeDetails.estimatedSizeInBytes += tableSizeDetails.realtimeSegments.estimatedSizeInBytes;
     }
     if (hasOfflineTable) {
-      String offlineTableName = new TableNameBuilder(CommonConstants.Helix.TableType.OFFLINE).forTable(tableName);
+      String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
       tableSizeDetails.offlineSegments = getTableSubtypeSize(offlineTableName, timeoutMsec);
       tableSizeDetails.reportedSizeInBytes += tableSizeDetails.offlineSegments.reportedSizeInBytes;
       tableSizeDetails.estimatedSizeInBytes += tableSizeDetails.offlineSegments.estimatedSizeInBytes;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableViews.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/TableViews.java
@@ -161,30 +161,32 @@ public class TableViews extends BasePinotControllerRestletResource {
     return tableView;
   }
 
-  public @Nullable
-  Map<String, Map<String, String>> getIdealState(@Nonnull String tableNameOptType,
-      @Parameter(name = "tableType", in="query", description = "Table type", required = false)@Nullable TableType tableType) {
-    String tableName = getTableName(tableNameOptType, tableType);
+  @Nullable
+  public Map<String, Map<String, String>> getIdealState(@Nonnull String tableNameOptType,
+      @Parameter(name = "tableType", in = "query", description = "Table type", required = false) @Nullable TableType tableType) {
+    String tableNameWithType = getTableNameWithType(tableNameOptType, tableType);
     IdealState resourceIdealState = _pinotHelixResourceManager.getHelixAdmin()
-        .getResourceIdealState(_pinotHelixResourceManager.getHelixClusterName(), tableName);
+        .getResourceIdealState(_pinotHelixResourceManager.getHelixClusterName(), tableNameWithType);
     return resourceIdealState == null ? null : resourceIdealState.getRecord().getMapFields();
   }
 
-  public @Nullable Map<String, Map<String, String>> getExternalView(@Nonnull String tableNameOptType, TableType tableType) {
-    String tableName = getTableName(tableNameOptType, tableType);
+  @Nullable
+  public Map<String, Map<String, String>> getExternalView(@Nonnull String tableNameOptType, TableType tableType) {
+    String tableNameWithType = getTableNameWithType(tableNameOptType, tableType);
     ExternalView resourceEV = _pinotHelixResourceManager.getHelixAdmin()
-        .getResourceExternalView(_pinotHelixResourceManager.getHelixClusterName(), tableName);
+        .getResourceExternalView(_pinotHelixResourceManager.getHelixClusterName(), tableNameWithType);
     return resourceEV == null ? null : resourceEV.getRecord().getMapFields();
   }
 
-  private String getTableName(@Nonnull String tableNameOptType, @Nullable TableType tableType) {
-    String tableName = tableNameOptType;
-    if (tableType != null && tableType == CommonConstants.Helix.TableType.OFFLINE) {
-      tableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableNameOptType);
-    } else if (tableType != null && tableType == CommonConstants.Helix.TableType.REALTIME) {
-      tableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableNameOptType);
+  private String getTableNameWithType(@Nonnull String tableNameOptType, @Nullable TableType tableType) {
+    if (tableType != null) {
+      if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
+        return TableNameBuilder.OFFLINE.tableNameWithType(tableNameOptType);
+      } else {
+        return TableNameBuilder.REALTIME.tableNameWithType(tableNameOptType);
+      }
+    } else {
+      return tableNameOptType;
     }
-    return tableName;
   }
-
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
@@ -120,10 +120,12 @@ public class ControllerRequestBuilderUtil {
           .registerStateModelFactory(EmptySegmentOnlineOfflineStateModelFactory.getStateModelDef(), stateModelFactory);
       helixZkManager.connect();
       if (isSingleTenant) {
-        helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId,
-            TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
-        helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId,
-            TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
+        helixZkManager.getClusterManagmentTool()
+            .addInstanceTag(helixClusterName, instanceId,
+                TableNameBuilder.OFFLINE.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
+        helixZkManager.getClusterManagmentTool()
+            .addInstanceTag(helixClusterName, instanceId,
+                TableNameBuilder.REALTIME.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
       } else {
         helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId, UNTAGGED_SERVER_INSTANCE);
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class PinotHelixTaskResourceManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotHelixTaskResourceManager.class);
 
+  // Do not change this because Helix uses the same separator
   public static final String TASK_NAME_SEPARATOR = "_";
 
   private static final String TASK_QUEUE_PREFIX = "TaskQueue" + TASK_NAME_SEPARATOR;
@@ -169,7 +170,7 @@ public class PinotHelixTaskResourceManager {
    */
   @Nonnull
   private static String getHelixJobName(@Nonnull String taskType, @Nonnull String pinotTaskName) {
-    return TASK_QUEUE_PREFIX + taskType + "_" + pinotTaskName;
+    return TASK_QUEUE_PREFIX + taskType + TASK_NAME_SEPARATOR + pinotTaskName;
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/TaskGeneratorRegistry.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/TaskGeneratorRegistry.java
@@ -44,7 +44,8 @@ public class TaskGeneratorRegistry {
   public void registerTaskGenerator(@Nonnull PinotTaskGenerator pinotTaskGenerator) {
     // Task type cannot contain the task name separator
     String taskType = pinotTaskGenerator.getTaskType();
-    Preconditions.checkArgument(!taskType.contains(PinotHelixTaskResourceManager.TASK_NAME_SEPARATOR));
+    Preconditions.checkArgument(!taskType.contains(PinotHelixTaskResourceManager.TASK_NAME_SEPARATOR),
+        "Task type: %s cannot contain underscore character", taskType);
 
     _taskGeneratorRegistry.put(taskType, pinotTaskGenerator);
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -479,7 +479,7 @@ public class PinotLLCRealtimeSegmentManager {
    */
   public boolean commitSegment(String rawTableName, final String committingSegmentNameStr, long nextOffset) {
     final long now = System.currentTimeMillis();
-    final String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(rawTableName);
+    final String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
 
     final LLCRealtimeSegmentZKMetadata oldSegMetadata = getRealtimeSegmentZKMetadata(realtimeTableName,
         committingSegmentNameStr);
@@ -926,7 +926,7 @@ public class PinotLLCRealtimeSegmentManager {
   */
   public void segmentStoppedConsuming(final LLCSegmentName segmentName, final String instance) {
     String rawTableName = segmentName.getTableName();
-    String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(rawTableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
     final String segmentNameStr = segmentName.getSegmentName();
     try {
       HelixHelper.updateIdealState(_helixManager, realtimeTableName, new Function<IdealState, IdealState>() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -16,6 +16,14 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime;
 
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.metrics.ControllerMeter;
+import com.linkedin.pinot.common.metrics.ControllerMetrics;
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.controller.ControllerConf;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -26,14 +34,6 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
-import com.linkedin.pinot.common.metrics.ControllerMeter;
-import com.linkedin.pinot.common.metrics.ControllerMetrics;
-import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.LLCSegmentName;
-import com.linkedin.pinot.controller.ControllerConf;
 
 
 /**
@@ -114,9 +114,9 @@ public class SegmentCompletionManager {
       ZNRecord segment;
       try {
         // TODO if we keep a list of last few committed segments, we don't need to go to zk for this.
-        final String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(segmentName.getTableName());
-        LLCRealtimeSegmentZKMetadata segmentMetadata = _segmentManager.getRealtimeSegmentZKMetadata(
-            realtimeTableName, segmentName.getSegmentName());
+        final String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(segmentName.getTableName());
+        LLCRealtimeSegmentZKMetadata segmentMetadata =
+            _segmentManager.getRealtimeSegmentZKMetadata(realtimeTableName, segmentName.getSegmentName());
         if (segmentMetadata.getStatus().equals(CommonConstants.Segment.Realtime.Status.DONE)) {
           // Best to go through the state machine for this case as well, so that all code regarding state handling is in one place
           // Also good for synchronization, because it is possible that multiple threads take this path, and we don't want

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
@@ -45,10 +45,10 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
     String serverTenantName;
     String tableName;
     if ("realtime".equalsIgnoreCase(segmentMetadata.getIndexType())) {
-      tableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(segmentMetadata.getTableName());
+      tableName = TableNameBuilder.REALTIME.tableNameWithType(segmentMetadata.getTableName());
       serverTenantName = ControllerTenantNameBuilder.getRealtimeTenantNameForTenant(tenantName);
     } else {
-      tableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(segmentMetadata.getTableName());
+      tableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
       serverTenantName = ControllerTenantNameBuilder.getOfflineTenantNameForTenant(tenantName);
     }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/AutoAddInvertedIndex.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/AutoAddInvertedIndex.java
@@ -145,7 +145,7 @@ public class AutoAddInvertedIndex {
 
     for (String tableName : resourcesInCluster) {
       // Skip non-table resources
-      if (!tableName.endsWith("_OFFLINE") && !tableName.endsWith("_REALTIME")) {
+      if (!TableNameBuilder.isTableResource(tableName)) {
         continue;
       }
 
@@ -157,6 +157,7 @@ public class AutoAddInvertedIndex {
 
       // Get the table type
       CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+      Preconditions.checkNotNull(tableType);
 
       // Get the inverted index config
       AbstractTableConfig tableConfig = getTableConfig(tableName, tableType);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -16,21 +16,6 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.model.IdealState;
-import org.joda.time.Interval;
-import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
@@ -48,6 +33,22 @@ import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.yammer.metrics.core.MetricsRegistry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.joda.time.Interval;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
 import static org.mockito.Mockito.*;
 
 
@@ -603,7 +604,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       final int maxSeq = 10;
       final long now = System.currentTimeMillis();
       final String tableName = "table";
-      final String realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      final String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
       final IdealState idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName,
           19);
       int nIncompleteCommits = 0;
@@ -661,7 +662,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       segmentManager._tableIdealState = idealState;
       segmentManager._existingSegmentMetadata = existingSegmentMetadata;
 
-      segmentManager.completeCommittingSegments(TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName));
+      segmentManager.completeCommittingSegments(TableNameBuilder.REALTIME.tableNameWithType(tableName));
 
       Assert.assertEquals(segmentManager._nCallsToUpdateHelix, nIncompleteCommits, "Failed with seed " + seed);
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
@@ -15,33 +15,6 @@
  */
 package com.linkedin.pinot.controller.helix.retention;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import org.apache.commons.io.FileUtils;
-import org.apache.helix.AccessOption;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.manager.zk.ZkClient;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.joda.time.Duration;
-import org.joda.time.Interval;
-import org.json.JSONException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 import com.alibaba.fastjson.JSONObject;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
@@ -66,7 +39,34 @@ import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.AccessOption;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZkClient;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.joda.time.Duration;
+import org.joda.time.Interval;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 
 public class RetentionManagerTest {
@@ -88,8 +88,8 @@ public class RetentionManagerTest {
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
   private String _testTableName = "testTable";
-  private String _offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(_testTableName);
-  private String _realtimeTableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(_testTableName);
+  private String _offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(_testTableName);
+  private String _realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(_testTableName);
 
   private RetentionManager _retentionManager;
   private ZkStarter.ZookeeperInstance _zookeeperInstance;

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/sharding/SegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/sharding/SegmentAssignmentStrategyTest.java
@@ -15,10 +15,18 @@
  */
 package com.linkedin.pinot.controller.helix.sharding;
 
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
+import com.linkedin.pinot.controller.helix.starter.HelixConfig;
+import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
@@ -29,16 +37,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-import com.linkedin.pinot.common.config.AbstractTableConfig;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
-import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
-import com.linkedin.pinot.controller.helix.starter.HelixConfig;
-import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
 
 
 public class SegmentAssignmentStrategyTest {
@@ -115,7 +113,7 @@ public class SegmentAssignmentStrategyTest {
         instance2NumSegmentsMap.put(instance, 0);
       }
       final ExternalView externalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME,
-          TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(TABLE_NAME_RANDOM));
+          TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME_RANDOM));
       Assert.assertEquals(externalView.getPartitionSet().size(), i + 1);
       for (final String segmentId : externalView.getPartitionSet()) {
         Assert.assertEquals(externalView.getStateMap(segmentId).size(), numReplicas);
@@ -146,7 +144,7 @@ public class SegmentAssignmentStrategyTest {
       instance2NumSegmentsMap.put(instance, 0);
     }
     final ExternalView externalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME,
-        TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(TABLE_NAME_BALANCED));
+        TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME_BALANCED));
     for (final String segmentId : externalView.getPartitionSet()) {
       for (final String instance : externalView.getStateMap(segmentId).keySet()) {
         instance2NumSegmentsMap.put(instance, instance2NumSegmentsMap.get(instance) + 1);
@@ -164,8 +162,7 @@ public class SegmentAssignmentStrategyTest {
       Assert.assertTrue(instance2NumSegmentsMap.get(instance) <= maxNumSegmentsPerInstance,
           "expected <=" + maxNumSegmentsPerInstance + " actual:" + instance2NumSegmentsMap.get(instance));
     }
-    _helixAdmin.dropResource(HELIX_CLUSTER_NAME,
-        TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(TABLE_NAME_BALANCED));
+    _helixAdmin.dropResource(HELIX_CLUSTER_NAME, TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME_BALANCED));
   }
 
   private void addOneSegment(String tableName) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -16,10 +16,16 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.base.Function;
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.KafkaStarterUtils;
+import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
+import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.ControllerTestUtils;
+import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -32,33 +38,20 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import kafka.server.KafkaServerStartable;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.ExternalViewChangeListener;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.InstanceConfig;
 import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.FileUploadUtils;
-import com.linkedin.pinot.common.utils.KafkaStarterUtils;
-import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.util.TestUtils;
-import kafka.server.KafkaServerStartable;
 
 
 /**
@@ -330,11 +323,13 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestWith
     if (getTableName() != null) {
       Assert.assertNotNull(getDebugInfo("debug/timeBoundary" + ""));
       Assert.assertNotNull(getDebugInfo("debug/timeBoundary/" + tableName));
-      Assert.assertNotNull(getDebugInfo("debug/timeBoundary/" + TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName)));
-      Assert.assertNotNull(getDebugInfo("debug/timeBoundary/" + TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName)));
+      Assert.assertNotNull(getDebugInfo("debug/timeBoundary/" + TableNameBuilder.OFFLINE.tableNameWithType(tableName)));
+      Assert.assertNotNull(
+          getDebugInfo("debug/timeBoundary/" + TableNameBuilder.REALTIME.tableNameWithType(tableName)));
       Assert.assertNotNull(getDebugInfo("debug/routingTable/" + tableName));
-      Assert.assertNotNull(getDebugInfo("debug/routingTable/" + TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName)));
-      Assert.assertNotNull(getDebugInfo("debug/routingTable/" + TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName)));
+      Assert.assertNotNull(getDebugInfo("debug/routingTable/" + TableNameBuilder.OFFLINE.tableNameWithType(tableName)));
+      Assert.assertNotNull(
+          getDebugInfo("debug/routingTable/" + TableNameBuilder.REALTIME.tableNameWithType(tableName)));
     }
   }
 

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -162,9 +162,9 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       LOGGER.debug("Trying to add segment with Metadata: " + segmentMetadata.toString());
     }
     if (segmentMetadata.getIndexType().equalsIgnoreCase("realtime")) {
-      tableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      tableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     } else {
-      tableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      tableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     }
     if (!_tableDataManagerMap.containsKey(tableName)) {
       LOGGER.info("Trying to add TableDataManager for OFFLINE table: {}", tableName);
@@ -187,9 +187,9 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       LOGGER.debug("Trying to add segment with Metadata: " + segmentZKMetadata.toString());
     }
     if (segmentZKMetadata instanceof RealtimeSegmentZKMetadata) {
-      tableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      tableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     } else {
-      tableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      tableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     }
     if (!_tableDataManagerMap.containsKey(tableName)) {
       LOGGER.info("Trying to add TableDataManager for REALTIME table: {}", tableName);
@@ -234,9 +234,9 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     String segmentName = segmentMetadata.getName();
     String tableName = segmentMetadata.getTableName();
     if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
-      tableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+      tableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     } else {
-      tableName = TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(tableName);
+      tableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     }
     LOGGER.info("Reloading segment: {} in table: {}", segmentName, tableName);
 

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -231,9 +231,9 @@ public class HelixServerStarter {
     if (instanceTags == null || instanceTags.size() == 0) {
       if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_helixManager.getHelixPropertyStore())) {
         _helixAdmin.addInstanceTag(clusterName, instanceName,
-            TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
+            TableNameBuilder.OFFLINE.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
         _helixAdmin.addInstanceTag(clusterName, instanceName,
-            TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
+            TableNameBuilder.REALTIME.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
       } else {
         _helixAdmin.addInstanceTag(clusterName, instanceName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE);
       }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotNumReplicaChanger.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotNumReplicaChanger.java
@@ -16,18 +16,18 @@
 
 package com.linkedin.pinot.tools;
 
-import java.util.Map;
-import java.util.Set;
-import org.apache.helix.model.IdealState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.helix.model.IdealState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class PinotNumReplicaChanger extends PinotZKChanger {
@@ -49,7 +49,7 @@ public class PinotNumReplicaChanger extends PinotZKChanger {
   public void changeNumReplicas(final String tableName)
       throws Exception {
     // Get the number of replicas in the tableconfig.
-    final String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    final String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     final AbstractTableConfig offlineTableConfig =
         ZKMetadataProvider.getOfflineTableConfig(propertyStore, offlineTableName);
     final int newNumReplicas = Integer.parseInt(offlineTableConfig.getValidationConfig().getReplication());

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
@@ -15,20 +15,6 @@
  */
 package com.linkedin.pinot.tools;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
-import org.apache.helix.controller.stages.ClusterDataCache;
-import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.IdealState;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
@@ -37,7 +23,21 @@ import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
+import org.apache.helix.controller.stages.ClusterDataCache;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class PinotSegmentRebalancer extends PinotZKChanger {
@@ -161,8 +161,7 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
     }
     AutoRebalanceStrategy rebalanceStrategy = new AutoRebalanceStrategy(tableName, partitions, states);
 
-    TableNameBuilder builder = new TableNameBuilder(tableType);
-    String serverTenant = builder.forTable(tenantName);
+    String serverTenant = TableNameBuilder.forType(tableType).tableNameWithType(tenantName);
     List<String> instancesInClusterWithTag = helixAdmin.getInstancesInClusterWithTag(clusterName, serverTenant);
     List<String> enabledInstancesWithTag =
         HelixHelper.getEnabledInstancesWithTag(helixAdmin, clusterName, serverTenant);

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/HelixExternalViewBasedRouting.java
@@ -17,9 +17,21 @@
 package com.linkedin.pinot.routing;
 
 import com.google.common.collect.Sets;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metrics.BrokerMeter;
+import com.linkedin.pinot.common.metrics.BrokerMetrics;
+import com.linkedin.pinot.common.metrics.BrokerTimer;
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.EqualityUtils;
+import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
+import com.linkedin.pinot.routing.builder.BalancedRandomRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.KafkaHighLevelConsumerBasedRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.KafkaLowLevelConsumerRoutingTableBuilder;
 import com.linkedin.pinot.routing.builder.LargeClusterRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.RoutingTableBuilder;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,18 +57,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.metrics.BrokerMeter;
-import com.linkedin.pinot.common.metrics.BrokerMetrics;
-import com.linkedin.pinot.common.metrics.BrokerTimer;
-import com.linkedin.pinot.common.response.ServerInstance;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.NetUtil;
-import com.linkedin.pinot.routing.builder.BalancedRandomRoutingTableBuilder;
-import com.linkedin.pinot.routing.builder.KafkaHighLevelConsumerBasedRoutingTableBuilder;
-import com.linkedin.pinot.routing.builder.KafkaLowLevelConsumerRoutingTableBuilder;
-import com.linkedin.pinot.routing.builder.RoutingTableBuilder;
-import com.linkedin.pinot.transport.common.SegmentIdSet;
 
 
 /*
@@ -444,7 +444,7 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
       if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
         // Does a realtime table exist?
         String realtimeTableName =
-            TableNameBuilder.REALTIME_TABLE_NAME_BUILDER.forTable(TableNameBuilder.extractRawTableName(tableName));
+            TableNameBuilder.REALTIME.tableNameWithType(TableNameBuilder.extractRawTableName(tableName));
         if (_brokerRoutingTable.containsKey(realtimeTableName)) {
           tableForTimeBoundaryUpdate = tableName;
           externalViewForTimeBoundaryUpdate = externalView;
@@ -454,7 +454,7 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
       if (tableType == CommonConstants.Helix.TableType.REALTIME) {
         // Does an offline table exist?
         String offlineTableName =
-            TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(TableNameBuilder.extractRawTableName(tableName));
+            TableNameBuilder.OFFLINE.tableNameWithType(TableNameBuilder.extractRawTableName(tableName));
         if (_brokerRoutingTable.containsKey(offlineTableName)) {
           // Is there no time boundary?
           if (_timeBoundaryService.getTimeBoundaryInfoFor(offlineTableName) == null) {

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/TimeBoundaryServiceTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/common/TimeBoundaryServiceTest.java
@@ -15,9 +15,17 @@
  */
 package com.linkedin.pinot.transport.common;
 
+import com.linkedin.pinot.common.config.AbstractTableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.routing.HelixExternalViewBasedTimeBoundaryService;
+import com.linkedin.pinot.routing.TimeBoundaryService.TimeBoundaryInfo;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
@@ -31,16 +39,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-import com.linkedin.pinot.common.config.AbstractTableConfig;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
-import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
-import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
-import com.linkedin.pinot.common.utils.StringUtil;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.routing.HelixExternalViewBasedTimeBoundaryService;
-import com.linkedin.pinot.routing.TimeBoundaryService.TimeBoundaryInfo;
 
 
 public class TimeBoundaryServiceTest {
@@ -162,7 +160,7 @@ public class TimeBoundaryServiceTest {
     metadata.put("customConfigs", customConfigs);
     offlineTableConfigJson.put("metadata", metadata);
     AbstractTableConfig offlineTableConfig = AbstractTableConfig.init(offlineTableConfigJson.toString());
-    String offlineTableName = TableNameBuilder.OFFLINE_TABLE_NAME_BUILDER.forTable(tableName);
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     ZKMetadataProvider.setOfflineTableConfig(_propertyStore, offlineTableName,
         AbstractTableConfig.toZnRecord(offlineTableConfig));
   }


### PR DESCRIPTION
1. Removed public constructor to prevent creating redundant instance
2. Added hasTypeSuffix() method to check the table type
3. Added isTableNameWithType() method to check the resource name
4. Modified the usage of TableNameBuilder to follow the new convention
5. Fixed a bug in PinotTableRestletResource updateTableConfig where CLIENT_ERROR_BAD_REQUEST is not thrown out properly