### PR TITLE
Reuse metrics during realtime ingestion

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
@@ -181,12 +181,31 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * @param unitCount The number of units to add to the meter
    */
   public void addMeteredGlobalValue(final M meter, final long unitCount) {
-    final String fullMeterName;
-    String meterName = meter.getMeterName();
-    fullMeterName = _metricPrefix + meterName;
-    final MetricName metricName = new MetricName(_clazz, fullMeterName);
+    addMeteredGlobalValue(meter, unitCount, null);
+  }
 
-    MetricsHelper.newMeter(_metricsRegistry, metricName, meter.getUnit(), TimeUnit.SECONDS).mark(unitCount);
+  /**
+   * Logs a value to a meter.
+   *
+   * @param meter The meter to use
+   * @param unitCount The number of units to add to the meter
+   * @param reusedMeter The meter to reuse
+   */
+  public com.yammer.metrics.core.Meter addMeteredGlobalValue(final M meter, final long unitCount, com.yammer.metrics.core.Meter reusedMeter) {
+    if (reusedMeter != null) {
+      reusedMeter.mark(unitCount);
+      return reusedMeter;
+    } else {
+      final String fullMeterName;
+      String meterName = meter.getMeterName();
+      fullMeterName = _metricPrefix + meterName;
+      final MetricName metricName = new MetricName(_clazz, fullMeterName);
+
+      final com.yammer.metrics.core.Meter newMeter =
+          MetricsHelper.newMeter(_metricsRegistry, metricName, meter.getUnit(), TimeUnit.SECONDS);
+      newMeter.mark(unitCount);
+      return newMeter;
+    }
   }
 
   /**
@@ -197,12 +216,31 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * @param unitCount The number of units to add to the meter
    */
   public void addMeteredTableValue(final String tableName, final M meter, final long unitCount) {
-    final String fullMeterName;
-    String meterName = meter.getMeterName();
-    fullMeterName = _metricPrefix + getTableName(tableName) + "." + meterName;
-    final MetricName metricName = new MetricName(_clazz, fullMeterName);
+    addMeteredTableValue(tableName, meter, unitCount, null);
+  }
 
-    MetricsHelper.newMeter(_metricsRegistry, metricName, meter.getUnit(), TimeUnit.SECONDS).mark(unitCount);
+  /**
+   * Logs a value to a table-level meter.
+   * @param tableName The table name
+   * @param meter The meter to use
+   * @param unitCount The number of units to add to the meter
+   * @param reusedMeter The meter to reuse
+   */
+  public com.yammer.metrics.core.Meter addMeteredTableValue(final String tableName, final M meter, final long unitCount, com.yammer.metrics.core.Meter reusedMeter) {
+    if (reusedMeter != null) {
+      reusedMeter.mark(unitCount);
+      return reusedMeter;
+    } else {
+      final String fullMeterName;
+      String meterName = meter.getMeterName();
+      fullMeterName = _metricPrefix + getTableName(tableName) + "." + meterName;
+      final MetricName metricName = new MetricName(_clazz, fullMeterName);
+
+      final com.yammer.metrics.core.Meter newMeter =
+          MetricsHelper.newMeter(_metricsRegistry, metricName, meter.getUnit(), TimeUnit.SECONDS);
+      newMeter.mark(unitCount);
+      return newMeter;
+    }
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelConsumerStreamProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaHighLevelConsumerStreamProvider.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.realtime.impl.kafka;
 
 import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.yammer.metrics.core.Meter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.core.data.GenericRow;
@@ -47,6 +48,9 @@ public class KafkaHighLevelConsumerStreamProvider implements StreamProvider {
   private String tableAndStreamName;
   private long currentCount = 0L;
 
+  private Meter tableAndStreamRowsConsumed = null;
+  private Meter tableRowsConsumed = null;
+
   @Override
   public void init(StreamProviderConfig streamProviderConfig, String tableName, ServerMetrics serverMetrics)
       throws Exception {
@@ -76,8 +80,8 @@ public class KafkaHighLevelConsumerStreamProvider implements StreamProvider {
     if (kafkaIterator.hasNext()) {
       try {
         destination = decoder.decode(kafkaIterator.next().message(), destination);
-        serverMetrics.addMeteredTableValue(tableAndStreamName, ServerMeter.REALTIME_ROWS_CONSUMED, 1L);
-        serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_ROWS_CONSUMED, 1L);
+        tableAndStreamRowsConsumed = serverMetrics.addMeteredTableValue(tableAndStreamName, ServerMeter.REALTIME_ROWS_CONSUMED, 1L, tableAndStreamRowsConsumed);
+        tableRowsConsumed = serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_ROWS_CONSUMED, 1L, tableRowsConsumed);
         ++currentCount;
 
         final long now = System.currentTimeMillis();


### PR DESCRIPTION
Add an API to reuse meters instead of allocating new ones on every
metric update. Reuse metrics for the main loop of the realtime
ingestion as to avoid a lot of garbage generated during realtime
indexing.