### PR TITLE
[TE] Change pom file of te-hadoop to produce thin jar

### DIFF
--- a/thirdeye/thirdeye-hadoop/pom.xml
+++ b/thirdeye/thirdeye-hadoop/pom.xml
@@ -111,6 +111,7 @@
                     <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
+            <!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -162,7 +163,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin>-->
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Remove maven-shade-plugin to produce thin jar for urgent dependency fix.

TODO: Add plugin to generate both fat and thin jars.

Tested on local build.