### PR TITLE
Fix incorrectly reported query processing time when all segments are pruned.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -121,6 +121,9 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       if (numSegmentsMatched == 0) {
         DataTable emptyDataTable = DataTableBuilder.buildEmptyDataTable(brokerRequest);
         emptyDataTable.getMetadata().put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(totalRawDocs));
+
+        // Stop and record the query processing timer for early bailout.
+        queryProcessingTimer.stopAndRecord();
         return emptyDataTable;
       }
 


### PR DESCRIPTION
When all segments are pruned out, the queryProcessTimer is not stopped,
and so we end up getting large negative value for query processing time.
Fixed the issue by stopping the timer before bail-out, when all segments
are pruned out.