### PR TITLE
[TE] Enhancing search by metric name to search by name or alias

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -190,7 +190,7 @@ public class DataResource {
   public List<MetricConfigDTO> getMetricsWhereNameLike(@QueryParam("name") String name) {
     List<MetricConfigDTO> metricConfigs = Collections.emptyList();
     if (StringUtils.isNotBlank(name)) {
-      metricConfigs = metricConfigDAO.findWhereNameLikeAndActive("%" + name + "%");
+      metricConfigs = metricConfigDAO.findWhereNameOrAliasLikeAndActive("%" + name + "%");
     }
     return metricConfigs;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MetricConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MetricConfigManager.java
@@ -11,7 +11,7 @@ public interface MetricConfigManager extends AbstractManager<MetricConfigDTO> {
   MetricConfigDTO findByMetricAndDataset(String metricName, String dataset);
   MetricConfigDTO findByAliasAndDataset(String alias, String dataset);
   List<MetricConfigDTO> findActiveByDataset(String dataset);
-  List<MetricConfigDTO> findWhereNameLikeAndActive(String name);
+  List<MetricConfigDTO> findWhereNameOrAliasLikeAndActive(String name);
   List<MetricConfigDTO> findByMetricName(String metricName);
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MetricConfigManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MetricConfigManagerImpl.java
@@ -69,7 +69,7 @@ public class MetricConfigManagerImpl extends AbstractManagerImpl<MetricConfigDTO
   }
 
   @Override
-  public List<MetricConfigDTO> findWhereNameLikeAndActive(String name) {
+  public List<MetricConfigDTO> findWhereNameOrAliasLikeAndActive(String name) {
     Map<String, Object> parameterMap = new HashMap<>();
     parameterMap.put("name", name);
     parameterMap.put("active", true);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MetricConfigManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MetricConfigManagerImpl.java
@@ -17,7 +17,7 @@ import com.linkedin.thirdeye.datalayer.util.Predicate;
 public class MetricConfigManagerImpl extends AbstractManagerImpl<MetricConfigDTO>
     implements MetricConfigManager {
 
-  private static final String FIND_BY_NAME_LIKE = " WHERE active = :active and name like :name";
+  private static final String FIND_BY_NAME_OR_ALIAS_LIKE = " WHERE active = :active and (alias like :name or name like :name)";
 
   public MetricConfigManagerImpl() {
     super(MetricConfigDTO.class, MetricConfigBean.class);
@@ -74,7 +74,7 @@ public class MetricConfigManagerImpl extends AbstractManagerImpl<MetricConfigDTO
     parameterMap.put("name", name);
     parameterMap.put("active", true);
     List<MetricConfigBean> list =
-        genericPojoDao.executeParameterizedSQL(FIND_BY_NAME_LIKE, parameterMap, MetricConfigBean.class);
+        genericPojoDao.executeParameterizedSQL(FIND_BY_NAME_OR_ALIAS_LIKE, parameterMap, MetricConfigBean.class);
     List<MetricConfigDTO> result = new ArrayList<>();
     for (MetricConfigBean bean : list) {
       result.add(MODEL_MAPPER.map(bean, MetricConfigDTO.class));

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMetricConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMetricConfigManager.java
@@ -68,13 +68,13 @@ public class TestMetricConfigManager extends AbstractManagerTestBase {
 
   @Test(dependsOnMethods = { "testFind" })
   public void testFindLike() {
-    List<MetricConfigDTO> metricConfigs = metricConfigDAO.findWhereNameLikeAndActive("%m%");
+    List<MetricConfigDTO> metricConfigs = metricConfigDAO.findWhereNameOrAliasLikeAndActive("%m%");
     Assert.assertEquals(metricConfigs.size(), 2);
-    metricConfigs = metricConfigDAO.findWhereNameLikeAndActive("%2%");
+    metricConfigs = metricConfigDAO.findWhereNameOrAliasLikeAndActive("%2%");
     Assert.assertEquals(metricConfigs.size(), 1);
-    metricConfigs = metricConfigDAO.findWhereNameLikeAndActive("%1%");
-    Assert.assertEquals(metricConfigs.size(), 0);
-    metricConfigs = metricConfigDAO.findWhereNameLikeAndActive("%p%");
+    metricConfigs = metricConfigDAO.findWhereNameOrAliasLikeAndActive("%1%");
+    Assert.assertEquals(metricConfigs.size(), 1);
+    metricConfigs = metricConfigDAO.findWhereNameOrAliasLikeAndActive("%p%");
     Assert.assertEquals(metricConfigs.size(), 0);
   }
 


### PR DESCRIPTION
Currently, we only search by metric name. Some of the metric names are too generic and appear in too many tables/datasets. Since alias includes the dataset name, using alias along with metric name will help users to get to the right metric faster.