### PR TITLE
[TE] Add UI and email template for grouped anomaly

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
@@ -188,6 +188,7 @@ public class AnomalyReportGenerator {
       templateData.put("reportGenerationTimeMillis", System.currentTimeMillis());
       templateData.put("dashboardHost", configuration.getDashboardHost());
       templateData.put("anomalyIds", Joiner.on(",").join(anomalyIds));
+//      templateData.put("isGroupedAnomaly", true or false);
       if(precisionRecallEvaluator.getTotalResponses() > 0) {
         templateData.put("precision", precisionRecallEvaluator.getPrecisionInResponse());
         templateData.put("recall", precisionRecallEvaluator.getRecall());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
@@ -92,11 +92,21 @@ public class AnomalyReportGenerator {
 
   public void buildReport(List<MergedAnomalyResultDTO> anomalies,
       ThirdEyeAnomalyConfiguration configuration, AlertConfigDTO alertConfig) {
-    buildReport(anomalies, configuration, alertConfig.getRecipients(), alertConfig.getFromAddress(),
+    buildReport(null, anomalies, configuration, alertConfig.getRecipients(), alertConfig.getFromAddress(),
         alertConfig.getName());
   }
 
-  public void buildReport(List<MergedAnomalyResultDTO> anomalies,
+  /**
+   * Build report/alert for the given list of anomalies, which could belong to a grouped anomaly if groupId is not null.
+   *
+   * @param groupId the group id of the list of anomalies; null means they does not belong to any grouped anomaly.
+   * @param anomalies the list of anomalies to be put in the report/alert.
+   * @param configuration the configuration that contains the information of ThirdEye host.
+   * @param recipients the recipients of this (group) list of anomalies.
+   * @param fromAddress the source email address of this report/alert.
+   * @param alertConfigName the name of this alert configuration.
+   */
+  public void buildReport(Long groupId, List<MergedAnomalyResultDTO> anomalies,
       ThirdEyeAnomalyConfiguration configuration, String recipients, String fromAddress, String alertConfigName) {
     String subject = "Thirdeye Alert : " + alertConfigName;
     long startTime = System.currentTimeMillis();
@@ -109,14 +119,14 @@ public class AnomalyReportGenerator {
         endTime = anomaly.getEndTime();
       }
     }
-    buildReport(startTime, endTime, anomalies, subject, configuration, false,
+    buildReport(startTime, endTime, groupId, anomalies, subject, configuration, false,
         recipients, fromAddress, alertConfigName, false);
   }
 
 
 
 
-  public void buildReport(long startTime, long endTime, List<MergedAnomalyResultDTO> anomalies,
+  public void buildReport(long startTime, long endTime, Long groupId, List<MergedAnomalyResultDTO> anomalies,
       String subject, ThirdEyeAnomalyConfiguration configuration, boolean includeSentAnomaliesOnly,
       String emailRecipients, String fromEmail, String alertConfigName, boolean includeSummary) {
     if (anomalies == null || anomalies.size() == 0) {
@@ -188,7 +198,13 @@ public class AnomalyReportGenerator {
       templateData.put("reportGenerationTimeMillis", System.currentTimeMillis());
       templateData.put("dashboardHost", configuration.getDashboardHost());
       templateData.put("anomalyIds", Joiner.on(",").join(anomalyIds));
-//      templateData.put("isGroupedAnomaly", true or false);
+      if (groupId != null) {
+        templateData.put("isGroupedAnomaly", true);
+        templateData.put("groupId", groupId);
+      } else {
+        templateData.put("isGroupedAnomaly", false);
+        templateData.put("groupId", -1);
+      }
       if(precisionRecallEvaluator.getTotalResponses() > 0) {
         templateData.put("precision", precisionRecallEvaluator.getPrecisionInResponse());
         templateData.put("recall", precisionRecallEvaluator.getRecall());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
@@ -200,10 +200,10 @@ public class AnomalyReportGenerator {
       templateData.put("anomalyIds", Joiner.on(",").join(anomalyIds));
       if (groupId != null) {
         templateData.put("isGroupedAnomaly", true);
-        templateData.put("groupId", groupId);
+        templateData.put("groupId", Long.toString(groupId));
       } else {
         templateData.put("isGroupedAnomaly", false);
-        templateData.put("groupId", -1);
+        templateData.put("groupId", Long.toString(-1));
       }
       if(precisionRecallEvaluator.getTotalResponses() > 0) {
         templateData.put("precision", precisionRecallEvaluator.getPrecisionInResponse());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/EmailResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/EmailResource.java
@@ -216,7 +216,7 @@ public class EmailResource {
     String emailSub = Strings.isNullOrEmpty(subject) ? "Thirdeye Anomaly Report" : subject;
 
     anomalyReportGenerator
-        .buildReport(startTime, endTime, anomalies, emailSub, configuration,
+        .buildReport(startTime, endTime, null, anomalies, emailSub, configuration,
             includeSentAnomaliesOnly, toAddr, fromAddr, "Thirdeye Anomaly Report", true);
     return Response.ok().build();
   }
@@ -282,7 +282,7 @@ public class EmailResource {
     configuration.setPhantomJsPath(phantomJsPath);
     String emailSub = Strings.isNullOrEmpty(subject) ? "Thirdeye Anomaly Report" : subject;
     anomalyReportGenerator
-        .buildReport(startTime, endTime, anomalies, emailSub, configuration,
+        .buildReport(startTime, endTime, null, anomalies, emailSub, configuration,
             includeSentAnomaliesOnly, toAddr, fromAddr, "Thirdeye Anomaly Report", true);
     return Response.ok().build();
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -33,6 +33,8 @@ import com.linkedin.thirdeye.datalayer.dto.DashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.datalayer.bao.GroupedAnomalyResultsManager;
+import com.linkedin.thirdeye.datalayer.dto.GroupedAnomalyResultsDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
 import com.linkedin.thirdeye.datasource.DAORegistry;
@@ -109,6 +111,7 @@ public class AnomaliesResource {
 
   private final MetricConfigManager metricConfigDAO;
   private final MergedAnomalyResultManager mergedAnomalyResultDAO;
+  private final GroupedAnomalyResultsManager groupedAnomalyResultsDAO;
   private final OverrideConfigManager overrideConfigDAO;
   private final AnomalyFunctionManager anomalyFunctionDAO;
   private final DashboardConfigManager dashboardConfigDAO;
@@ -120,6 +123,7 @@ public class AnomaliesResource {
   public AnomaliesResource(AnomalyFunctionFactory anomalyFunctionFactory, AlertFilterFactory alertFilterFactory) {
     metricConfigDAO = DAO_REGISTRY.getMetricConfigDAO();
     mergedAnomalyResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
+    groupedAnomalyResultsDAO = DAO_REGISTRY.getGroupedAnomalyResultsDAO();
     overrideConfigDAO = DAO_REGISTRY.getOverrideConfigDAO();
     anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
     dashboardConfigDAO = DAO_REGISTRY.getDashboardConfigDAO();
@@ -387,8 +391,10 @@ public class AnomaliesResource {
       }
       if (groupId != null) {
         // TODO: Read anomalies from the grouped anomaly (Need to ensure that groupId is actually a "group id")
-        ArrayList<Long> anomaliesIdOfGroup = new ArrayList<>();
-        anomalyIdSet.addAll(anomaliesIdOfGroup);
+        GroupedAnomalyResultsDTO groupedAnomalyResultsDTO = groupedAnomalyResultsDAO.findById(groupId);
+        AnomaliesWrapper anomaliesWrapper = constructAnomaliesWrapperFromMergedAnomalies(groupedAnomalyResultsDTO.getAnomalyResults(), pageNumber);
+        return anomaliesWrapper;
+//        anomalyIdSet.addAll(anomaliesIdOfGroup);
       }
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -368,7 +368,7 @@ public class AnomaliesResource {
    * @throws Exception
    */
   @GET
-  @Path("search/anomalyIds/{startTime}/{endTime}/{pageNumber}")
+  @Path("search/groupIds/{startTime}/{endTime}/{pageNumber}")
   public AnomaliesWrapper getAnomaliesByGroupIds(
       @PathParam("startTime") Long startTime,
       @PathParam("endTime") Long endTime,
@@ -379,13 +379,16 @@ public class AnomaliesResource {
     String[] groupIds = groupIdsString.split(COMMA_SEPARATOR);
     Set<Long> anomalyIdSet = new HashSet<>();
     for (String idString : groupIds) {
+      Long groupId = null;
       try {
-        Long groupId = Long.parseLong(idString);
-        // TODO: read anomalies from the grouped anomaly
+        groupId = Long.parseLong(idString);
+      } catch (Exception e) {
+        LOG.info("Skipping group id {} due to parsing error: {}", idString, e);
+      }
+      if (groupId != null) {
+        // TODO: Read anomalies from the grouped anomaly (Need to ensure that groupId is actually a "group id")
         ArrayList<Long> anomaliesIdOfGroup = new ArrayList<>();
         anomalyIdSet.addAll(anomaliesIdOfGroup);
-      } catch (Exception e) {
-        LOG.info("Skipping group id {} due to error: {}", idString, e);
       }
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -365,25 +365,25 @@ public class AnomaliesResource {
    *
    * @param startTime not used.
    * @param endTime not used.
-   * @param groupIdsString a list of group ids that are separated by commas.
+   * @param anomalyGroupIdsString a list of anomaly group ids that are separated by commas.
    * @param functionName not used.
    *
    * @return A list of detailed anomalies in the specified page.
    * @throws Exception
    */
   @GET
-  @Path("search/groupIds/{startTime}/{endTime}/{pageNumber}")
+  @Path("search/anomalyGroupIds/{startTime}/{endTime}/{pageNumber}")
   public AnomaliesWrapper getAnomaliesByGroupIds(
       @PathParam("startTime") Long startTime,
       @PathParam("endTime") Long endTime,
       @PathParam("pageNumber") int pageNumber,
-      @QueryParam("groupIds") String groupIdsString,
+      @QueryParam("anomalyGroupIds") String anomalyGroupIdsString,
       @QueryParam("functionName") String functionName) throws Exception {
 
-    String[] groupIds = groupIdsString.split(COMMA_SEPARATOR);
+    String[] anomalyGroupIdsStrings = anomalyGroupIdsString.split(COMMA_SEPARATOR);
     Set<Long> anomalyIdSet = new HashSet<>();
     List<MergedAnomalyResultDTO> mergedAnomalies = new ArrayList<>();
-    for (String idString : groupIds) {
+    for (String idString : anomalyGroupIdsStrings) {
       Long groupId = null;
       try {
         groupId = Long.parseLong(idString);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -53,9 +53,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -350,6 +352,45 @@ public class AnomaliesResource {
       metricIds.add(Long.valueOf(metricId));
     }
     List<MergedAnomalyResultDTO> mergedAnomalies = getAnomaliesForMetricIdsInRange(metricIds, startTime, endTime);
+    AnomaliesWrapper anomaliesWrapper = constructAnomaliesWrapperFromMergedAnomalies(mergedAnomalies, pageNumber);
+    return anomaliesWrapper;
+  }
+
+  /**
+   * Find anomalies by anomaly group ids.
+   *
+   * @param startTime not used.
+   * @param endTime not used.
+   * @param groupIdsString a list of group ids that are separated by commas.
+   * @param functionName not used.
+   *
+   * @return A list of detailed anomalies in the specified page.
+   * @throws Exception
+   */
+  @GET
+  @Path("search/anomalyIds/{startTime}/{endTime}/{pageNumber}")
+  public AnomaliesWrapper getAnomaliesByGroupIds(
+      @PathParam("startTime") Long startTime,
+      @PathParam("endTime") Long endTime,
+      @PathParam("pageNumber") int pageNumber,
+      @QueryParam("groupIds") String groupIdsString,
+      @QueryParam("functionName") String functionName) throws Exception {
+
+    String[] groupIds = groupIdsString.split(COMMA_SEPARATOR);
+    Set<Long> anomalyIdSet = new HashSet<>();
+    for (String idString : groupIds) {
+      try {
+        Long groupId = Long.parseLong(idString);
+        // TODO: read anomalies from the grouped anomaly
+        ArrayList<Long> anomaliesIdOfGroup = new ArrayList<>();
+        anomalyIdSet.addAll(anomaliesIdOfGroup);
+      } catch (Exception e) {
+        LOG.info("Skipping group id {} due to error: {}", idString, e);
+      }
+    }
+
+    List<Long> anomalyIdList = new ArrayList<>(anomalyIdSet);
+    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByIdList(anomalyIdList, false);
     AnomaliesWrapper anomaliesWrapper = constructAnomaliesWrapperFromMergedAnomalies(mergedAnomalies, pageNumber);
     return anomaliesWrapper;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -9,6 +9,10 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   MergedAnomalyResultDTO findById(Long id, boolean loadRawAnomalies);
 
+  List<MergedAnomalyResultDTO> findByIdList(List<Long> idList);
+
+  List<MergedAnomalyResultDTO> findByIdList(List<Long> idList, boolean loadRawAnomalies);
+
   List<MergedAnomalyResultDTO> getAllByTimeEmailIdAndNotifiedFalse(long startTime, long endTime,
       long emailId, boolean loadRawAnomalies);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -97,6 +97,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
       return genericPojoDao.update(mergeAnomalyBean);
     }
   }
+
   public MergedAnomalyResultDTO findById(Long id, boolean loadRawAnomalies) {
     MergedAnomalyResultBean mergedAnomalyResultBean = genericPojoDao.get(id, MergedAnomalyResultBean.class);
     if (mergedAnomalyResultBean != null) {
@@ -108,8 +109,24 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     }
   }
 
+  public List<MergedAnomalyResultDTO> findByIdList(List<Long> idList, boolean loadRawAnomalies) {
+    List<MergedAnomalyResultBean> mergedAnomalyResultBeanList =
+        genericPojoDao.get(idList, MergedAnomalyResultBean.class);
+    if (CollectionUtils.isNotEmpty(mergedAnomalyResultBeanList)) {
+      List<MergedAnomalyResultDTO> mergedAnomalyResultDTOList =
+          batchConvertMergedAnomalyBean2DTO(mergedAnomalyResultBeanList, loadRawAnomalies);
+      return mergedAnomalyResultDTOList;
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
   public MergedAnomalyResultDTO findById(Long id) {
     return findById(id, true);
+  }
+
+  public List<MergedAnomalyResultDTO> findByIdList(List<Long> idList) {
+    return findByIdList(idList, true);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -114,7 +114,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
         genericPojoDao.get(idList, MergedAnomalyResultBean.class);
     if (CollectionUtils.isNotEmpty(mergedAnomalyResultBeanList)) {
       List<MergedAnomalyResultDTO> mergedAnomalyResultDTOList =
-          batchConvertMergedAnomalyBean2DTO(mergedAnomalyResultBeanList, loadRawAnomalies);
+          convertMergedAnomalyBean2DTO(mergedAnomalyResultBeanList, loadRawAnomalies);
       return mergedAnomalyResultDTOList;
     } else {
       return Collections.emptyList();

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/Constants.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/Constants.js
@@ -16,7 +16,7 @@ function Constants() {
   this.SEARCH_ANOMALIES_DASHBOARDID = '/anomalies/search/dashboardId/';
   this.SEARCH_ANOMALIES_ANOMALYIDS = '/anomalies/search/anomalyIds/';
   this.SEARCH_ANOMALIES_TIME = '/anomalies/search/time/';
-  this.SEARCH_ANOMALIES_GROUPIDS = '/anomalies/search/groupIds/';
+  this.SEARCH_ANOMALIES_GROUPIDS = '/anomalies/search/anomalyGroupIds/';
   this.UPDATE_ANOMALY_FEEDBACK = '/anomalies/updateFeedback/';
   this.METRIC_GRANULARITY = '/data/agg/granularity/metric/';
   this.METRIC_DIMENSION = '/data/autocomplete/dimensions/metric/';

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/Constants.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/Constants.js
@@ -16,6 +16,7 @@ function Constants() {
   this.SEARCH_ANOMALIES_DASHBOARDID = '/anomalies/search/dashboardId/';
   this.SEARCH_ANOMALIES_ANOMALYIDS = '/anomalies/search/anomalyIds/';
   this.SEARCH_ANOMALIES_TIME = '/anomalies/search/time/';
+  this.SEARCH_ANOMALIES_GROUPIDS = '/anomalies/search/groupIds/';
   this.UPDATE_ANOMALY_FEEDBACK = '/anomalies/updateFeedback/';
   this.METRIC_GRANULARITY = '/data/agg/granularity/metric/';
   this.METRIC_DIMENSION = '/data/autocomplete/dimensions/metric/';
@@ -38,6 +39,7 @@ function Constants() {
   this.MODE_METRIC = 'metric';
   this.MODE_DASHBOARD = 'dashboard';
   this.MODE_ID = 'id';
+  this.MODE_GROUPID = 'groupId'
   this.MODE_TIME = 'time';
   this.DASHBOARD_MODE_METRIC_SUMMARY = 'MetricSummary';
   this.DASHBOARD_MODE_ANOMALY_SUMMARY = 'AnomalySummary';

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
@@ -117,6 +117,16 @@ DataService.prototype = {
       };
       this.getDataAsynchronous(url, data, callback, spinner);
     },
+
+    // Fetch anomalies for group ids in array
+    fetchAnomaliesforGroupIds(startTime, endTime, pageNumber, groupIds, functionName, callback) {
+      const url = constants.SEARCH_ANOMALIES_GROUPIDS + startTime + this.URL_SEPARATOR + endTime + this.URL_SEPARATOR + pageNumber;
+      var data = {
+        groupIds
+      };
+      this.getDataAsynchronous(url, data, callback, 'anomaly-spin-area');
+    },
+
     // Fetch anomalies for anomaly ids in array in time range
     fetchAnomaliesForTime : function(startTime, endTime, pageNumber, callback) {
       var url = constants.SEARCH_ANOMALIES_TIME + startTime + this.URL_SEPARATOR + endTime + this.URL_SEPARATOR + pageNumber;

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/DataService.js
@@ -119,10 +119,10 @@ DataService.prototype = {
     },
 
     // Fetch anomalies for group ids in array
-    fetchAnomaliesforGroupIds(startTime, endTime, pageNumber, groupIds, functionName, callback) {
+    fetchAnomaliesforGroupIds(startTime, endTime, pageNumber, anomalyGroupIds, functionName, callback) {
       const url = constants.SEARCH_ANOMALIES_GROUPIDS + startTime + this.URL_SEPARATOR + endTime + this.URL_SEPARATOR + pageNumber;
       var data = {
-        groupIds
+        anomalyGroupIds
       };
       this.getDataAsynchronous(url, data, callback, 'anomaly-spin-area');
     },

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
@@ -13,6 +13,7 @@ function HashParams() {
   this.ANOMALIES_METRIC_IDS = 'metricIds';
   this.ANOMALIES_DASHBOARD_ID = 'dashboardId';
   this.ANOMALIES_ANOMALY_IDS = 'anomalyIds';
+  this.ANOMALIES_GROUP_IDS = 'groupIds';
   this.INVESTIGATE_ANOMALY_ID = 'anomalyId';
 
   this.ANALYSIS_METRIC_ID = 'metricId';
@@ -97,6 +98,7 @@ HashParams.prototype = {
       paramNamesToDefaultValuesMap[this.ANOMALIES_PAGE_NUMBER] = 1;
       paramNamesToDefaultValuesMap[this.ANOMALIES_METRIC_IDS] = undefined;
       paramNamesToDefaultValuesMap[this.ANOMALIES_DASHBOARD_ID] = undefined;
+      paramNamesToDefaultValuesMap[this.ANOMALIES_GROUP_IDS] = undefined;
       paramNamesToDefaultValuesMap[this.ANOMALIES_ANOMALY_IDS] = undefined;
       this.controllerNameToParamNamesMap[this.ANOMALIES_CONTROLLER] = paramNamesToDefaultValuesMap;
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/HashParams.js
@@ -13,7 +13,7 @@ function HashParams() {
   this.ANOMALIES_METRIC_IDS = 'metricIds';
   this.ANOMALIES_DASHBOARD_ID = 'dashboardId';
   this.ANOMALIES_ANOMALY_IDS = 'anomalyIds';
-  this.ANOMALIES_GROUP_IDS = 'groupIds';
+  this.ANOMALIES_GROUP_IDS = 'anomalyGroupIds';
   this.INVESTIGATE_ANOMALY_ID = 'anomalyId';
 
   this.ANALYSIS_METRIC_ID = 'metricId';

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
@@ -6,7 +6,7 @@ function AnomalyResultModel() {
   this.dashboardId = null;
   this.previousDashboardId = null;
   this.anomalyIds = null;
-  this.groupIds = null;
+  this.anomalyGroupIds = null;
   this.previousAnomalyIds = null
 
   this.previousStartDate = null;
@@ -50,7 +50,7 @@ AnomalyResultModel.prototype = {
     this.metricIds = null;
     this.dashboardId = null;
     this.anomalyIds = null;
-    this.groupIds = null;
+    this.anomalyGroupIds = null;
     this.functionName = null;
     this.pageNumber = 1;
 
@@ -71,7 +71,7 @@ AnomalyResultModel.prototype = {
         this.anomalyIds = params[HASH_PARAMS.ANOMALIES_ANOMALY_IDS];
       }
 
-      this.groupIds = params[HASH_PARAMS.ANOMALIES_GROUP_IDS] || this.groupIds;
+      this.anomalyGroupIds = params[HASH_PARAMS.ANOMALIES_GROUP_IDS] || this.anomalyGroupIds;
 
       if (params[HASH_PARAMS.ANOMALIES_START_DATE] != undefined) {
         this.startDate = params[HASH_PARAMS.ANOMALIES_START_DATE];
@@ -105,8 +105,8 @@ AnomalyResultModel.prototype = {
           this.startDate, this.endDate, this.pageNumber, this.anomalyIds, this.functionName, this.updateModelAndNotifyView.bind(this));
     } else if (this.anomaliesSearchMode == constants.MODE_TIME) {
       dataService.fetchAnomaliesForTime(this.startDate, this.endDate, this.pageNumber, this.updateModelAndNotifyView.bind(this));
-    } else if (this.anomaliesSearchMode == constants.MODE_GROUPID && this.groupIds != undefined && this.groupIds.length > 0) {
-      dataService.fetchAnomaliesforGroupIds(this.startDate, this.endDate, this.pageNumber, this.groupIds, this.functionName, this.updateModelAndNotifyView.bind(this));
+    } else if (this.anomaliesSearchMode == constants.MODE_GROUPID && this.anomalyGroupIds != undefined && this.anomalyGroupIds.length > 0) {
+      dataService.fetchAnomaliesforGroupIds(this.startDate, this.endDate, this.pageNumber, this.anomalyGroupIds, this.functionName, this.updateModelAndNotifyView.bind(this));
     }
   },
   updateModelAndNotifyView : function(anomaliesWrapper) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
@@ -6,6 +6,7 @@ function AnomalyResultModel() {
   this.dashboardId = null;
   this.previousDashboardId = null;
   this.anomalyIds = null;
+  this.groupIds = null;
   this.previousAnomalyIds = null
 
   this.previousStartDate = null;
@@ -49,6 +50,7 @@ AnomalyResultModel.prototype = {
     this.metricIds = null;
     this.dashboardId = null;
     this.anomalyIds = null;
+    this.groupIds = null;
     this.functionName = null;
     this.pageNumber = 1;
 
@@ -68,6 +70,9 @@ AnomalyResultModel.prototype = {
       if (params[HASH_PARAMS.ANOMALIES_ANOMALY_IDS] != undefined) {
         this.anomalyIds = params[HASH_PARAMS.ANOMALIES_ANOMALY_IDS];
       }
+
+      this.groupIds = params[HASH_PARAMS.ANOMALIES_GROUP_IDS] || this.groupIds;
+
       if (params[HASH_PARAMS.ANOMALIES_START_DATE] != undefined) {
         this.startDate = params[HASH_PARAMS.ANOMALIES_START_DATE];
       }
@@ -100,6 +105,8 @@ AnomalyResultModel.prototype = {
           this.startDate, this.endDate, this.pageNumber, this.anomalyIds, this.functionName, this.updateModelAndNotifyView.bind(this));
     } else if (this.anomaliesSearchMode == constants.MODE_TIME) {
       dataService.fetchAnomaliesForTime(this.startDate, this.endDate, this.pageNumber, this.updateModelAndNotifyView.bind(this));
+    } else if (this.anomaliesSearchMode == constants.MODE_GROUPID && this.groupIds != undefined && this.groupIds.length > 0) {
+      dataService.fetchAnomaliesforGroupIds(this.startDate, this.endDate, this.pageNumber, this.groupIds, this.functionName, this.updateModelAndNotifyView.bind(this));
     }
   },
   updateModelAndNotifyView : function(anomaliesWrapper) {

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
@@ -326,7 +326,7 @@ AnomalyResultView.prototype = {
       var metricIds = undefined;
       var dashboardId = undefined;
       var anomalyIds = undefined;
-      var groupIds = undefined;
+      var anomalyGroupIds = undefined;
 
       var functionName = $('#anomaly-function-dropdown').val();
       var startDate = $('#anomalies-time-range-start').data('daterangepicker').startDate;
@@ -349,7 +349,7 @@ AnomalyResultView.prototype = {
         delete anomaliesParams.startDate;
         delete anomaliesParams.endDate;
       } else if (anomaliesSearchMode == constants.MODE_GROUPID) {
-        anomaliesParams.groupIds = $('#anomalies-search-group-input').val().join();
+        anomaliesParams.anomalyGroupIds = $('#anomalies-search-group-input').val().join();
         delete anomaliesParams.startDate;
         delete anomaliesParams.endDate;
       }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
@@ -74,6 +74,13 @@ function AnomalyResultView(anomalyResultModel) {
       placeholder : "Search for anomaly ID",
       tags: true
     };
+  this.groupSearchConfig = {
+      theme : "bootstrap",
+      width: '100%',
+      allowClear: true,
+      placeholder : "Search for group ID",
+      tags: true
+    };
   this.timeSearchConfig = {
       theme : "bootstrap",
       width: '100%',
@@ -211,17 +218,20 @@ AnomalyResultView.prototype = {
   showSearchBarBasedOnMode : function() {
     var anomaliesSearchMode = $('#anomalies-search-mode').val();
     $('#anomalies-search-dashboard-container').hide();
-    $('#anomalies-search-anomaly-container').hide()
+    $('#anomalies-search-anomaly-container').hide();
     $('#anomalies-search-metrics-container').hide();
     $('#anomalies-search-time-container').hide();
+    $('#anomalies-search-group-container').hide();
     if (anomaliesSearchMode == constants.MODE_METRIC) {
       $('#anomalies-search-metrics-container').show();
     } else if (anomaliesSearchMode == constants.MODE_DASHBOARD) {
       $('#anomalies-search-dashboard-container').show();
     } else if (anomaliesSearchMode == constants.MODE_ID) {
-      $('#anomalies-search-anomaly-container').show()
+      $('#anomalies-search-anomaly-container').show();
     } else if (anomaliesSearchMode == constants.MODE_TIME) {
-      $('#anomalies-search-time-container').show()
+      $('#anomalies-search-time-container').show();
+    } else if (anomaliesSearchMode == constants.MODE_GROUPID) {
+      $('#anomalies-search-group-container').show();
     }
   },
   setupSearchBar : function() {
@@ -231,9 +241,10 @@ AnomalyResultView.prototype = {
     });
     $('#anomalies-search-anomaly-input').select2(this.anomalySearchConfig).on("select2:select", function(e) {
     });
+    $('#anomalies-search-group-input').select2(this.groupSearchConfig).on("select2:select", function(e) {
+    });
     $('#anomalies-search-time-input').select2(this.timeSearchConfig).on("select2:select", function(e) {
     });
-
   },
 
   renderAnomaliesTab : function(anomaliesWrapper) {
@@ -315,6 +326,7 @@ AnomalyResultView.prototype = {
       var metricIds = undefined;
       var dashboardId = undefined;
       var anomalyIds = undefined;
+      var groupIds = undefined;
 
       var functionName = $('#anomaly-function-dropdown').val();
       var startDate = $('#anomalies-time-range-start').data('daterangepicker').startDate;
@@ -334,6 +346,10 @@ AnomalyResultView.prototype = {
         anomaliesParams.dashboardId = $('#anomalies-search-dashboard-input').val();
       } else if (anomaliesSearchMode == constants.MODE_ID) {
         anomaliesParams.anomalyIds = $('#anomalies-search-anomaly-input').val().join();
+        delete anomaliesParams.startDate;
+        delete anomaliesParams.endDate;
+      } else if (anomaliesSearchMode == constants.MODE_GROUPID) {
+        anomaliesParams.groupIds = $('#anomalies-search-group-input').val().join();
         delete anomaliesParams.startDate;
         delete anomaliesParams.endDate;
       }

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomalies.ftl
@@ -10,6 +10,7 @@
             <option value="dashboard">Dashboard</option>
             <option value="id">Anomaly ID</option>
             <option value="time" selected>Time</option>
+            <option value="groupId">Group ID</option>
           </select>
         </div>
 
@@ -25,6 +26,10 @@
           </div>
           <div id="anomalies-search-time-container" class=""  style="overflow:hidden; display: none;">
             <select id="anomalies-search-time-input" class="label-large-light"></select>
+          </div>
+
+          <div id="anomalies-search-group-container" class=""  style="overflow:hidden; display: none;">
+            <select id="anomalies-search-group-input" class="label-large-light" multiple="multiple"></select>
           </div>
         </div>
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
@@ -19,7 +19,7 @@
           <td style="padding: 0 24px;" colspan="2">
               <p style="font-size: 20px; margin-bottom: 8px;">Hi,</p> <br>
               <#if isGroupedAnomaly>
-                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupedAnomaly&groupIds=${groupId}">here</a></strong> for the up-to-dated view of this group of anomalies.</p>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupId&groupIds=${groupId}">here</a></strong> for the up-to-dated view of this group of anomalies.</p>
               <#else>
                 <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds=${anomalyIds}">here</a></strong> for a detailed view.</p>
               </#if>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
@@ -19,7 +19,7 @@
           <td style="padding: 0 24px;" colspan="2">
               <p style="font-size: 20px; margin-bottom: 8px;">Hi,</p> <br>
               <#if isGroupedAnomaly == 1>
-                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupedAnomaly&groupIds="${groupId}">here</a></strong> for a detailed and up-to-dated view.</p>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupedAnomaly&groupIds="${groupId}">here</a></strong> for the up-to-dated view of this group of anomalies.</p>
               <#else>
                 <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds="${anomalyIds}">here</a></strong> for a detailed view.</p>
               </#if>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
@@ -18,11 +18,14 @@
         <tr>
           <td style="padding: 0 24px;" colspan="2">
               <p style="font-size: 20px; margin-bottom: 8px;">Hi,</p> <br>
-              <#if isGroupedAnomaly>
-                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupId&groupIds=${groupId}">here</a></strong> for the up-to-dated view of this group of anomalies.</p>
-              <#else>
-                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds=${anomalyIds}">here</a></strong> for a detailed view.</p>
-              </#if>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong>
+                  <#if isGroupedAnomaly>
+                    <a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupId&anomalyGroupIds=${groupId}">here</a>
+                  <#else>
+                    <a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds=${anomalyIds}">here</a>
+                  </#if>
+                  </strong> for a detailed view.
+                </p>
             </p>
           </td>
         </tr>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
@@ -19,7 +19,7 @@
           <td style="padding: 0 24px;" colspan="2">
               <p style="font-size: 20px; margin-bottom: 8px;">Hi,</p> <br>
               <#if isGroupedAnomaly == 1>
-                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=group&groupIds="${groupedIds}">here</a></strong> for a detailed and up-to-dated view.</p>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupedAnomaly&groupIds="${groupId}">here</a></strong> for a detailed and up-to-dated view.</p>
               <#else>
                 <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds="${anomalyIds}">here</a></strong> for a detailed view.</p>
               </#if>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
@@ -18,10 +18,10 @@
         <tr>
           <td style="padding: 0 24px;" colspan="2">
               <p style="font-size: 20px; margin-bottom: 8px;">Hi,</p> <br>
-              <#if isGroupedAnomaly == 1>
-                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupedAnomaly&groupIds="${groupId}">here</a></strong> for the up-to-dated view of this group of anomalies.</p>
+              <#if isGroupedAnomaly>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=groupedAnomaly&groupIds=${groupId}">here</a></strong> for the up-to-dated view of this group of anomalies.</p>
               <#else>
-                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds="${anomalyIds}">here</a></strong> for a detailed view.</p>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds=${anomalyIds}">here</a></strong> for a detailed view.</p>
               </#if>
             </p>
           </td>

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/detector/multiple-anomalies-email-template.ftl
@@ -18,7 +18,11 @@
         <tr>
           <td style="padding: 0 24px;" colspan="2">
               <p style="font-size: 20px; margin-bottom: 8px;">Hi,</p> <br>
-              <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds=${anomalyIds}">here</a></strong> for a detailed view.</p>
+              <#if isGroupedAnomaly == 1>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=group&groupIds="${groupedIds}">here</a></strong> for a detailed and up-to-dated view.</p>
+              <#else>
+                <p style="color: rgba(0,0,0,0.55); margin-top: 0px;"> ThirdEye has detected <strong style="color: black;">${anomalyCount} ${(anomalyCount == 1)?string("anomaly", "anomalies")}</strong>. Below is a summary, please go <strong><a style="color:#33aada;" href="${dashboardHost}/thirdeye#anomalies?anomaliesSearchMode=id&anomalyIds="${anomalyIds}">here</a></strong> for a detailed view.</p>
+              </#if>
             </p>
           </td>
         </tr>


### PR DESCRIPTION
1. Add a search UI for grouped anomaly. The page maps from a list of group ids to a list of merged anomalies.

2. Add email template for grouped anomaly. The template checks if the alert is a grouped anomaly or a list of merged anomalies. It embeds a link to group anomaly UI for the former case and the original link for the latter case.

Tested on local controller.