### PR TITLE
Add loadRawAnomalies flag for all merged anomaly fetches

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertTaskRunner.java
@@ -99,7 +99,7 @@ public class AlertTaskRunner implements TaskRunner {
     // Get the anomalies in that range
     final List<MergedAnomalyResultDTO> allResults = anomalyMergedResultDAO
         .getAllByTimeEmailIdAndNotifiedFalse(windowStart.getMillis(), windowEnd.getMillis(),
-            alertConfig.getId());
+            alertConfig.getId(), false);
 
     // apply filtration rule
     List<MergedAnomalyResultDTO> results = AlertFilterHelper.applyFiltrationRule(allResults, alertFilterFactory);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
@@ -118,7 +118,7 @@ public class AlertTaskRunnerV2 implements TaskRunner {
       long lastNotifiedAnomaly = emailConfig.getAnomalyWatermark();
       for (Long functionId : functionIds) {
         List<MergedAnomalyResultDTO> resultsForFunction = anomalyMergedResultDAO
-            .findUnNotifiedByFunctionIdAndIdGreaterThan(functionId, lastNotifiedAnomaly);
+            .findUnNotifiedByFunctionIdAndIdGreaterThan(functionId, lastNotifiedAnomaly, false);
         if (CollectionUtils.isNotEmpty(resultsForFunction)) {
           mergedAnomaliesAllResults.addAll(resultsForFunction);
         }
@@ -127,7 +127,7 @@ public class AlertTaskRunnerV2 implements TaskRunner {
         // We should add these again so that these could be included in email if qualified through filtration rule
         List<MergedAnomalyResultDTO> filteredAnomalies = anomalyMergedResultDAO
             .findUnNotifiedByFunctionIdAndIdLesserThanAndEndTimeGreaterThanLastOneDay(functionId,
-                lastNotifiedAnomaly);
+                lastNotifiedAnomaly, false);
         if (CollectionUtils.isNotEmpty(filteredAnomalies)) {
           mergedAnomaliesAllResults.addAll(filteredAnomalies);
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobResource.java
@@ -262,7 +262,7 @@ public class DetectionJobResource {
     // Check if the merged anomaly results have been cleaned up before regeneration
     List<MergedAnomalyResultDTO> mergedResults =
         mergedAnomalyResultDAO.findByStartTimeInRangeAndFunctionId(startTime.getMillis(), endTime.getMillis(),
-            functionId);
+            functionId, true);
     if (CollectionUtils.isNotEmpty(mergedResults) && !forceBackfill) {
       throw new IllegalArgumentException(String.format(
           "[functionId %s] Merged anomaly results should be cleaned up before regeneration", id));
@@ -314,7 +314,7 @@ public class DetectionJobResource {
         return Response.status(Response.Status.NO_CONTENT).entity("Detection job failed").build();
       } else {
         List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByStartTimeInRangeAndFunctionId(
-            0, analysisTime.getMillis(), id);
+            0, analysisTime.getMillis(), id, true);
         for (MergedAnomalyResultDTO mergedAnomaly : mergedAnomalies) {
           anomalyIds.add(mergedAnomaly.getId());
         }
@@ -337,14 +337,14 @@ public class DetectionJobResource {
     StringTokenizer starts = new StringTokenizer(holidayStarts, ",");
     StringTokenizer ends = new StringTokenizer(holidayEnds, ",");
     MergedAnomalyResultManager anomalyMergedResultDAO = DAO_REGISTRY.getMergedAnomalyResultDAO();
-    List<MergedAnomalyResultDTO> totalAnomalies = anomalyMergedResultDAO.findByStartTimeInRangeAndFunctionId(startTime, endTime, functionId);
+    List<MergedAnomalyResultDTO> totalAnomalies = anomalyMergedResultDAO.findByStartTimeInRangeAndFunctionId(startTime, endTime, functionId, true);
     int origSize = totalAnomalies.size();
     long start;
     long end;
     while (starts.hasMoreElements() && ends.hasMoreElements()){
       start = ISODateTimeFormat.dateTimeParser().parseDateTime(starts.nextToken()).getMillis();
       end = ISODateTimeFormat.dateTimeParser().parseDateTime(ends.nextToken()).getMillis();
-      List<MergedAnomalyResultDTO> holidayMergedAnomalies = anomalyMergedResultDAO.findByStartTimeInRangeAndFunctionId(start, end, functionId);
+      List<MergedAnomalyResultDTO> holidayMergedAnomalies = anomalyMergedResultDAO.findByStartTimeInRangeAndFunctionId(start, end, functionId, true);
       totalAnomalies.removeAll(holidayMergedAnomalies);
     }
     if(starts.hasMoreElements() || ends.hasMoreElements()){

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -109,8 +109,8 @@ public class DetectionTaskRunner implements TaskRunner {
     anomalyDetectionInputContextBuilder = anomalyDetectionInputContextBuilder
         .setFunction(anomalyFunctionSpec)
         .fetchTimeSeriesData(windowStart, windowEnd)
-        .fetchExixtingRawAnomalies(windowStart, windowEnd)
-        .fetchExixtingMergedAnomalies(windowStart, windowEnd)
+        .fetchExistingRawAnomalies(windowStart, windowEnd)
+        .fetchExistingMergedAnomalies(windowStart, windowEnd, true)
         .fetchSaclingFactors(windowStart, windowEnd);
     if (anomalyFunctionSpec.isToCalculateGlobalMetric()) {
       anomalyDetectionInputContextBuilder.fetchTimeSeriesGlobalMetric(windowStart, windowEnd);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/events/HistoricalAnomalyEventProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/events/HistoricalAnomalyEventProvider.java
@@ -20,7 +20,7 @@ public class HistoricalAnomalyEventProvider implements EventDataProvider<EventDT
     List<EventDTO> events = new ArrayList<>();
     if (eventFilter.getMetricName() == null) {
       mergedAnomalies =
-          mergedAnomalyDAO.findByTime(eventFilter.getStartTime(), eventFilter.getStartTime());
+          mergedAnomalyDAO.findByTime(eventFilter.getStartTime(), eventFilter.getStartTime(), false);
     } else {
       mergedAnomalies = mergedAnomalyDAO
           .findByMetricTime(eventFilter.getMetricName(), eventFilter.getStartTime(),

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -304,7 +304,7 @@ public class AnomalyMergeExecutor implements Runnable {
       List<MergedAnomalyResultDTO> output) {
     // Now find last MergedAnomalyResult in same category
     MergedAnomalyResultDTO latestMergedResult =
-        mergedResultDAO.findLatestByFunctionIdOnly(function.getId());
+        mergedResultDAO.findLatestByFunctionIdOnly(function.getId(), true);
     // TODO : get mergeConfig from function
     List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
         .mergeAnomalies(latestMergedResult, unmergedResults, mergeConfig.getMaxMergeDurationLength(),
@@ -343,8 +343,8 @@ public class AnomalyMergeExecutor implements Runnable {
       // Moreover, the window start is modified by mergeConfig.getSequentialAllowedGap() in order to allow a gap between
       // anomalies to be merged.
       MergedAnomalyResultDTO latestOverlappedMergedResult =
-          mergedResultDAO.findLatestConflictByFunctionIdDimensions(function.getId(), exploredDimensions.toString(),
-              anomalyWindowStart - mergeConfig.getSequentialAllowedGap(), anomalyWindowEnd);
+          mergedResultDAO.findLatestOverlapByFunctionIdDimensions(function.getId(), exploredDimensions.toString(),
+              anomalyWindowStart - mergeConfig.getSequentialAllowedGap(), anomalyWindowEnd, true);
 
       List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
           .mergeAnomalies(latestOverlappedMergedResult, unmergedResultsByDimensions,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -125,8 +125,8 @@ public class TimeBasedAnomalyMerger {
       // Moreover, the window start is modified by mergeConfig.getSequentialAllowedGap() in order to allow a gap between
       // anomalies to be merged.
       MergedAnomalyResultDTO latestOverlappedMergedResult =
-          mergedResultDAO.findLatestConflictByFunctionIdDimensions(function.getId(), dimensionMap.toString(),
-              anomalyWindowStart - mergeConfig.getSequentialAllowedGap(), anomalyWindowEnd);
+          mergedResultDAO.findLatestOverlapByFunctionIdDimensions(function.getId(), dimensionMap.toString(),
+              anomalyWindowStart - mergeConfig.getSequentialAllowedGap(), anomalyWindowEnd, true);
 
       List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
           .mergeAnomalies(latestOverlappedMergedResult, unmergedResultsByDimensions,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/performanceEvaluation/PerformanceEvaluateHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/performanceEvaluation/PerformanceEvaluateHelper.java
@@ -27,10 +27,10 @@ public class PerformanceEvaluateHelper {
       long functionId, long clonedFunctionId, Interval windowInterval,
       MergedAnomalyResultManager mergedAnomalyResultDAO) {
     PerformanceEvaluate performanceEvaluator = null;
-    List<MergedAnomalyResultDTO> knownAnomalies = mergedAnomalyResultDAO.findAllConflictByFunctionId(functionId,
-        windowInterval.getStartMillis(), windowInterval.getEndMillis());
-    List<MergedAnomalyResultDTO> detectedMergedAnomalies = mergedAnomalyResultDAO.findAllConflictByFunctionId(
-        clonedFunctionId, windowInterval.getStartMillis(), windowInterval.getEndMillis());
+    List<MergedAnomalyResultDTO> knownAnomalies = mergedAnomalyResultDAO.findAllOverlapByFunctionId(functionId,
+        windowInterval.getStartMillis(), windowInterval.getEndMillis(), true);
+    List<MergedAnomalyResultDTO> detectedMergedAnomalies = mergedAnomalyResultDAO.findAllOverlapByFunctionId(
+        clonedFunctionId, windowInterval.getStartMillis(), windowInterval.getEndMillis(), true);
     switch (performanceEvaluationMethod){
       case F1_SCORE:
         performanceEvaluator = new F1ScoreByTimePerformanceEvaluation(knownAnomalies, detectedMergedAnomalies);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -520,7 +520,7 @@ public class AnomalyResource {
    * true if there are labeled anomalies detected by the function
    */
   private boolean containsLabeledAnomalies(long functionId) {
-    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByFunctionId(functionId);
+    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByFunctionId(functionId, true);
 
     for(MergedAnomalyResultDTO mergedAnomaly : mergedAnomalies) {
       AnomalyFeedback feedback = mergedAnomaly.getFeedback();
@@ -596,7 +596,7 @@ public class AnomalyResource {
     }
 
     // merged anomaly mapping
-    List<MergedAnomalyResultDTO> mergedResults = anomalyMergedResultDAO.findByFunctionId(id);
+    List<MergedAnomalyResultDTO> mergedResults = anomalyMergedResultDAO.findByFunctionId(id, true);
     for (MergedAnomalyResultDTO result : mergedResults) {
       anomalyMergedResultDAO.delete(result);
     }
@@ -750,7 +750,7 @@ public class AnomalyResource {
       anomalyDetectionInputContextBuilder.setFunction(anomalyFunctionSpec)
           .fetchTimeSeriesDataByDimension(viewWindowStart, viewWindowEnd, dimensions, false)
           .fetchSaclingFactors(viewWindowStart, viewWindowEnd)
-          .fetchExixtingMergedAnomalies(viewWindowStart, viewWindowEnd);
+          .fetchExistingMergedAnomalies(viewWindowStart, viewWindowEnd, false);
 
       AnomalyDetectionInputContext adInputContext = anomalyDetectionInputContextBuilder.build();
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardResource.java
@@ -220,7 +220,7 @@ public class OnboardResource {
 
     LOG.info("clone merged anomaly results from source anomaly function id {} to id {}", srcId, destId);
 
-    List<MergedAnomalyResultDTO> mergedAnomalyResultDTOs = mergedAnomalyResultDAO.findByFunctionId(srcId);
+    List<MergedAnomalyResultDTO> mergedAnomalyResultDTOs = mergedAnomalyResultDAO.findByFunctionId(srcId, true);
     if (mergedAnomalyResultDTOs == null || mergedAnomalyResultDTOs.isEmpty()) {
       LOG.error("No merged anomaly results found for anomaly function Id: {}", srcId);
       return false;
@@ -273,7 +273,7 @@ public class OnboardResource {
         functionId, anomalyFunction.getCollection(), anomalyFunction.getMetric());
     int mergedAnomaliesDeleted = 0;
     List<MergedAnomalyResultDTO> mergedResults =
-        mergedAnomalyResultDAO.findByStartTimeInRangeAndFunctionId(monitoringWindowStartTime, monitoringWindowEndTime, functionId);
+        mergedAnomalyResultDAO.findByStartTimeInRangeAndFunctionId(monitoringWindowStartTime, monitoringWindowEndTime, functionId, true);
     if (CollectionUtils.isNotEmpty(mergedResults)) {
       mergedAnomaliesDeleted = deleteMergedResults(mergedResults);
     }
@@ -347,7 +347,7 @@ public class OnboardResource {
       return mergedResults;
     }
     mergedResults = mergedAnomalyResultDAO.findByStartTimeInRangeAndFunctionId(monitoringWindowStartTime,
-        monitoringWindowEndTime, functionId);
+        monitoringWindowEndTime, functionId, true);
     return mergedResults;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -257,7 +257,7 @@ public class AnomaliesResource {
       @PathParam("endTime") Long endTime,
       @PathParam("pageNumber") int pageNumber) throws Exception {
 
-    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByTime(startTime, endTime);
+    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByTime(startTime, endTime, false);
     try {
       mergedAnomalies = AlertFilterHelper.applyFiltrationRule(mergedAnomalies, alertFilterFactory);
     } catch (Exception e) {
@@ -708,7 +708,7 @@ public class AnomaliesResource {
         AnomalyDetectionInputContext adInputContext = anomalyDetectionInputContextBuilder
             .setFunction(anomalyFunctionSpec)
             .fetchTimeSeriesDataByDimension(anomalyWindowStart, anomalyWindowEnd, dimensions, true)
-            .fetchExixtingMergedAnomalies(anomalyWindowStart, anomalyWindowEnd).build();
+            .fetchExistingMergedAnomalies(anomalyWindowStart, anomalyWindowEnd, false).build();
 
         MetricTimeSeries metricTimeSeries = adInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -10,11 +10,11 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
   MergedAnomalyResultDTO findById(Long id, boolean loadRawAnomalies);
 
   List<MergedAnomalyResultDTO> getAllByTimeEmailIdAndNotifiedFalse(long startTime, long endTime,
-      long emailId);
+      long emailId, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findAllConflictByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd);
+  List<MergedAnomalyResultDTO> findAllOverlapByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findAllConflictByFunctionIdDimensions(long functionId, long conflictWindowStart, long conflictWindowEnd, String dimensions);
+  List<MergedAnomalyResultDTO> findAllOverlapByFunctionIdDimensions(long functionId, long conflictWindowStart, long conflictWindowEnd, String dimensions, boolean loadRawAnomalies);
 
   List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
       String metric, String dimensions, long startTime, long endTime, boolean loadRawAnomalies);
@@ -29,21 +29,21 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
   List<MergedAnomalyResultDTO> findByCollectionTime(String collection, long startTime,
       long endTime, boolean loadRawAnomalies);
 
-  MergedAnomalyResultDTO findLatestConflictByFunctionIdDimensions(Long functionId, String dimensions,
-      long conflictWindowStart, long conflictWindowEnd);
+  MergedAnomalyResultDTO findLatestOverlapByFunctionIdDimensions(Long functionId, String dimensions,
+      long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies);
 
-  MergedAnomalyResultDTO findLatestByFunctionIdOnly(Long functionId);
+  MergedAnomalyResultDTO findLatestByFunctionIdOnly(Long functionId, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findByFunctionId(Long functionId);
+  List<MergedAnomalyResultDTO> findByFunctionId(Long functionId, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId);
+  List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId, boolean loadRawAnomalies);
 
   List<MergedAnomalyResultDTO> findByStartTimeInRangeAndFunctionId(long startTime, long endTime,
-      long functionId);
+      long functionId, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findByTime(long startTime, long endTime);
+  List<MergedAnomalyResultDTO> findByTime(long startTime, long endTime, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdLesserThanAndEndTimeGreaterThanLastOneDay(long functionId, long anomalyId);
+  List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdLesserThanAndEndTimeGreaterThanLastOneDay(long functionId, long anomalyId, boolean loadRawAnomalies);
 
   void updateAnomalyFeedback(MergedAnomalyResultDTO entity);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -114,7 +114,7 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
   @Override
   public List<MergedAnomalyResultDTO> getAllByTimeEmailIdAndNotifiedFalse(long startTime,
-      long endTime, long emailConfigId) {
+      long endTime, long emailConfigId, boolean loadRawAnomalies) {
     EmailConfigurationBean emailConfigurationBean =
         genericPojoDao.get(emailConfigId, EmailConfigurationBean.class);
     List<Long> functionIds = emailConfigurationBean.getFunctionIds();
@@ -130,55 +130,55 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     );
     List<MergedAnomalyResultBean> list =
         genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, true);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findAllConflictByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd) {
+  public List<MergedAnomalyResultDTO> findAllOverlapByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies) {
     Predicate predicate =
         Predicate.AND(Predicate.LT("startTime", conflictWindowEnd), Predicate.GE("endTime", conflictWindowStart),
             Predicate.EQ("functionId", functionId));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, true);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findAllConflictByFunctionIdDimensions(long functionId, long conflictWindowStart,
-      long conflictWindowEnd, String dimensions) {
+  public List<MergedAnomalyResultDTO> findAllOverlapByFunctionIdDimensions(long functionId, long conflictWindowStart,
+      long conflictWindowEnd, String dimensions, boolean loadRawAnomalies) {
     Predicate predicate =
         Predicate.AND(Predicate.LE("startTime", conflictWindowEnd), Predicate.GE("endTime", conflictWindowStart),
             Predicate.EQ("functionId", functionId), Predicate.EQ("dimensions", dimensions));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, true);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findByFunctionId(Long functionId) {
+  public List<MergedAnomalyResultDTO> findByFunctionId(Long functionId, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("functionId", functionId);
 
     List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(FIND_BY_FUNCTION_ID,
         filterParams, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, true);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId) {
+  public List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdGreaterThan(Long functionId, Long anomalyId, boolean loadRawAnomalies) {
     Predicate predicate = Predicate.AND(Predicate.EQ("functionId", functionId), Predicate.GT("baseId", anomalyId),
         Predicate.EQ("notified", false));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, true);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
 
   @Override
   public List<MergedAnomalyResultDTO> findByStartTimeInRangeAndFunctionId(long startTime, long
-      endTime, long functionId) {
+      endTime, long functionId, boolean loadRawAnomalies) {
     Predicate predicate =
         Predicate.AND(Predicate.GE("startTime", startTime), Predicate.LT("endTime", endTime),
             Predicate.EQ("functionId", functionId));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, true);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
@@ -233,27 +233,27 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findByTime(long startTime, long endTime) {
+  public List<MergedAnomalyResultDTO> findByTime(long startTime, long endTime, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("startTime", startTime);
     filterParams.put("endTime", endTime);
 
     List<MergedAnomalyResultBean> list =
         genericPojoDao.executeParameterizedSQL(FIND_BY_TIME, filterParams, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, false);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
-  public List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdLesserThanAndEndTimeGreaterThanLastOneDay(long functionId, long anomalyId) {
+  public List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdLesserThanAndEndTimeGreaterThanLastOneDay(long functionId, long anomalyId, boolean loadRawAnomalies) {
     Predicate predicate = Predicate
         .AND(Predicate.EQ("functionId", functionId), Predicate.LT("baseId", anomalyId),
             Predicate.EQ("notified", false), Predicate.GT("endTime", System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1)));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
-    return convertMergedAnomalyBean2DTO(list, true);
+    return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
-  public MergedAnomalyResultDTO findLatestConflictByFunctionIdDimensions(Long functionId, String dimensions,
-      long conflictWindowStart, long conflictWindowEnd) {
+  public MergedAnomalyResultDTO findLatestOverlapByFunctionIdDimensions(Long functionId, String dimensions,
+      long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("functionId", functionId);
     filterParams.put("dimensions", dimensions);
@@ -265,19 +265,19 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
 
     if (CollectionUtils.isNotEmpty(list)) {
       MergedAnomalyResultBean mostRecentConflictMergedAnomalyResultBean = list.get(0);
-      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean, true);
+      return convertMergedAnomalyBean2DTO(mostRecentConflictMergedAnomalyResultBean, loadRawAnomalies);
     }
     return null;
   }
 
   @Override
-  public MergedAnomalyResultDTO findLatestByFunctionIdOnly(Long functionId) {
+  public MergedAnomalyResultDTO findLatestByFunctionIdOnly(Long functionId, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();
     filterParams.put("functionId", functionId);
 
     List<MergedAnomalyResultBean> list = genericPojoDao.executeParameterizedSQL(
         FIND_BY_FUNCTION_AND_NULL_DIMENSION, filterParams, MergedAnomalyResultBean.class);
-    List<MergedAnomalyResultDTO> result = convertMergedAnomalyBean2DTO(list, true);
+    List<MergedAnomalyResultDTO> result = convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
     // TODO: Check list size instead of result size?
     if (result.size() > 0) {
       return result.get(0);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -333,7 +333,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
     Assert.assertTrue(rawAnomalies.size() == 0);
 
     // check merged anomalies
-    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByFunctionId(functionId);
+    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByFunctionId(functionId, true);
     Assert.assertTrue(mergedAnomalies.size() > 0);
 
     // THE FOLLOWING TEST MAY FAIL OCCASIONALLY DUE TO MACHINE COMPUTATION POWER

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/FetchMetricDataAndExistingAnomaliesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/FetchMetricDataAndExistingAnomaliesTool.java
@@ -129,7 +129,7 @@ public class FetchMetricDataAndExistingAnomaliesTool {
     }
 
     List<MergedAnomalyResultDTO> mergedResults =
-        mergedAnomalyResultDAO.findByStartTimeInRangeAndFunctionId(startTime.getMillis(), endTime.getMillis(), functionId);
+        mergedAnomalyResultDAO.findByStartTimeInRangeAndFunctionId(startTime.getMillis(), endTime.getMillis(), functionId, true);
     for(MergedAnomalyResultDTO mergedResult : mergedResults){
       ResultNode res = new ResultNode();
       res.functionId = functionId;


### PR DESCRIPTION
This pull request adds a flag for loadRawAnomlies option to all calls to fetch merged anomalies. For operations such as viewing, sending emails, the merged anomalies don't need to return all the raw anomalies, and we can make use of this flag to control that

Thanks @cyenjung  for help in investigating and making the changes