### PR TITLE
Avoid query execution path for simple count(*) queries.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableBuilder.java
@@ -80,6 +80,7 @@ import javax.annotation.Nonnull;
 // TODO:   2. Use one dictionary for all columns (save space).
 // TODO:   3. Given a data schema, write all values one by one instead of using rowId and colId to position (save time).
 public class DataTableBuilder {
+  private static final String COUNT_STAR = "count_star";
   private final DataSchema _dataSchema;
   private final int[] _columnOffsets;
   private final int _rowSizeInBytes;
@@ -358,5 +359,32 @@ public class DataTableBuilder {
       dataTableBuilder.finishRow();
       return dataTableBuilder.build();
     }
+  }
+
+  /**
+   * Builds a Data table for count(*) with the provided value.
+   *
+   * @param count Value of count(*)
+   * @return DataTable for count(*)
+   *
+   * @throws IOException
+   */
+  public static DataTable buildCountStarDataTable(long count)
+      throws IOException {
+    String[] aggregationColumnNames = new String[]{COUNT_STAR};
+    FieldSpec.DataType[] dataTypes = new FieldSpec.DataType[] {FieldSpec.DataType.LONG};
+
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(aggregationColumnNames, dataTypes));
+    dataTableBuilder.startRow();
+    dataTableBuilder.setColumn(0, count);
+    dataTableBuilder.finishRow();
+    DataTable dataTable = dataTableBuilder.build();
+    Map<String, String> metadata = dataTable.getMetadata();
+
+    // Set num docs scanned as well, for backward compatibility.
+    String totalDocs = Long.toString(count);
+    metadata.put(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, totalDocs);
+    metadata.put(DataTable.TOTAL_DOCS_METADATA_KEY, totalDocs);
+    return dataTable;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -23,7 +23,9 @@ import com.linkedin.pinot.common.metrics.ServerQueryPhase;
 import com.linkedin.pinot.common.query.QueryExecutor;
 import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.context.TimerContext;
+import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.request.FilterQuery;
 import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.core.common.datatable.DataTableBuilder;
@@ -35,6 +37,7 @@ import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.plan.Plan;
 import com.linkedin.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import com.linkedin.pinot.core.plan.maker.PlanMaker;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
 import com.linkedin.pinot.core.query.config.QueryExecutorConfig;
 import com.linkedin.pinot.core.query.exception.BadQueryRequestException;
 import com.linkedin.pinot.core.query.pruner.SegmentPrunerService;
@@ -115,6 +118,12 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       long totalRawDocs = pruneSegments(tableDataManager, queryableSegmentDataManagerList, queryRequest);
       segmentPruneTimer.stopAndRecord();
 
+      // Short-circuit the simple count(*) query without any predicates and group-by's.
+      if (isCountAllDocsQuery(brokerRequest)) {
+        queryProcessingTimer.stopAndRecord();
+        return DataTableBuilder.buildCountStarDataTable(totalRawDocs);
+      }
+
       int numSegmentsMatched = queryableSegmentDataManagerList.size();
       queryRequest.setSegmentCountAfterPruning(numSegmentsMatched);
       LOGGER.debug("Matched {} segments", numSegmentsMatched);
@@ -191,6 +200,29 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       }
       TraceContext.unregister(instanceRequest);
     }
+  }
+
+  /**
+   * Helper method to identify if a query is simple count(*) query without any predicates and group by's.
+   *
+   * @param brokerRequest Broker request for the query
+   * @return True if simple count star query, false otherwise.
+   */
+  private static boolean isCountAllDocsQuery(BrokerRequest brokerRequest) {
+    FilterQuery filterQuery = brokerRequest.getFilterQuery();
+    if (filterQuery != null) {
+      return false;
+    }
+
+    List<AggregationInfo> aggregationsInfo = brokerRequest.getAggregationsInfo();
+    if (aggregationsInfo != null && aggregationsInfo.size() == 1 && !brokerRequest.isSetGroupBy()) {
+      if (aggregationsInfo.get(0)
+          .getAggregationType()
+          .equalsIgnoreCase(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
For count(*) queries without filters and group by's, we can simply add
up total.raw.docs from all segments, instead of going through the query
planning/execution path which is very expensive for such queries.

This does not help for hybrid usecases, as time filter is added
internally before sending to the OFFLINE/REALTIME tables.