### PR TITLE
[TE] External email recipient provider

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/AlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/AlertGrouper.java
@@ -21,13 +21,4 @@ public interface AlertGrouper {
    * @return groups of anomaly results.
    */
   Map<DimensionMap, GroupedAnomalyResultsDTO> group(List<MergedAnomalyResultDTO> anomalyResults);
-
-  /**
-   * The additional recipients string for this group of anomalies.
-   *
-   * @param alertGroupKey the key of the group
-   *
-   * @return the additional recipients for the given group.
-   */
-  String groupEmailRecipients(DimensionMap alertGroupKey);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouper.java
@@ -111,11 +111,6 @@ public class DimensionalAlertGrouper extends BaseAlertGrouper {
     }
   }
 
-  @Override
-  public String groupEmailRecipients(DimensionMap alertGroupKey) {
-    return EMPTY_RECIPIENTS;
-  }
-
   private DimensionMap constructGroupKey(DimensionMap rawKey) {
     DimensionMap alertGroupKey = new DimensionMap();
     for (String groupByDimensionName : groupByDimensions) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouper.java
@@ -39,23 +39,14 @@ public class DimensionalAlertGrouper extends BaseAlertGrouper {
   private static final DummyAlertGrouper DUMMY_ALERT_GROUPER = new DummyAlertGrouper();
 
   public static final String GROUP_BY_KEY = "dimensions";
-  public static final String AUXILIARY_RECIPIENTS_MAP_KEY = "auxiliaryRecipients";
   public static final String ROLL_UP_SINGLE_DIMENSION_KEY = "rollUp";
   public static final String GROUP_BY_SEPARATOR = ",";
 
   // The dimension names to group the anomalies (e.g., country, page_name)
   private List<String> groupByDimensions = new ArrayList<>();
 
-  // The map from a dimension map to auxiliary email recipients
-  private NavigableMap<DimensionMap, String> auxiliaryEmailRecipients = new TreeMap<>();
-
   // Rollup the groups of anomaly, which contains only one anomaly, to a group
   private boolean doRollUp = false;
-
-  // For testing purpose
-  NavigableMap<DimensionMap, String> getAuxiliaryEmailRecipients() {
-    return auxiliaryEmailRecipients;
-  }
 
   @Override
   public void setParameters(Map<String, String> props) {
@@ -65,20 +56,6 @@ public class DimensionalAlertGrouper extends BaseAlertGrouper {
       String[] dimensions = this.props.get(GROUP_BY_KEY).split(GROUP_BY_SEPARATOR);
       for (String dimension : dimensions) {
         groupByDimensions.add(dimension.trim());
-      }
-    }
-    // Initialize the lookup table for overriding thresholds
-    if (props.containsKey(AUXILIARY_RECIPIENTS_MAP_KEY)) {
-      String recipientsJsonPayLoad = props.get(AUXILIARY_RECIPIENTS_MAP_KEY);
-      try {
-        Map<String, String> rawAuxiliaryRecipientsMap = OBJECT_MAPPER.readValue(recipientsJsonPayLoad, HashMap.class);
-        for (Map.Entry<String, String> auxiliaryRecipientsEntry : rawAuxiliaryRecipientsMap.entrySet()) {
-          DimensionMap dimensionMap = new DimensionMap(auxiliaryRecipientsEntry.getKey());
-          String recipients = auxiliaryRecipientsEntry.getValue();
-          auxiliaryEmailRecipients.put(dimensionMap, recipients);
-        }
-      } catch (IOException e) {
-        LOG.error("Failed to reconstruct auxiliary recipients mappings from this json string: {}", recipientsJsonPayLoad);
       }
     }
     // Initialize roll up parameter
@@ -136,11 +113,7 @@ public class DimensionalAlertGrouper extends BaseAlertGrouper {
 
   @Override
   public String groupEmailRecipients(DimensionMap alertGroupKey) {
-    if (alertGroupKey == null || !auxiliaryEmailRecipients.containsKey(alertGroupKey)) {
-      return EMPTY_RECIPIENTS;
-    } else {
-      return auxiliaryEmailRecipients.get(alertGroupKey);
-    }
+    return EMPTY_RECIPIENTS;
   }
 
   private DimensionMap constructGroupKey(DimensionMap rawKey) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DummyAlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/DummyAlertGrouper.java
@@ -21,9 +21,4 @@ public class DummyAlertGrouper extends BaseAlertGrouper {
     groupMap.put(new DimensionMap(), groupedAnomalyResults);
     return groupMap;
   }
-
-  @Override
-  public String groupEmailRecipients(DimensionMap alertGroupKey) {
-    return BaseAlertGrouper.EMPTY_RECIPIENTS;
-  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/HorizontalDimensionalAlertGrouper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/HorizontalDimensionalAlertGrouper.java
@@ -71,11 +71,6 @@ public class HorizontalDimensionalAlertGrouper extends BaseAlertGrouper {
     }
   }
 
-  @Override
-  public String groupEmailRecipients(DimensionMap alertGroupKey) {
-    return EMPTY_RECIPIENTS;
-  }
-
   private DimensionMap constructGroupKey(DimensionMap rawKey, String dimensionName) {
     DimensionMap alertGroupKey = new DimensionMap();
     if (rawKey.containsKey(dimensionName)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProvider.java
@@ -1,0 +1,27 @@
+package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
+
+import com.linkedin.thirdeye.api.DimensionMap;
+import java.util.Map;
+
+/**
+ * Given a dimension map, a provider returns a list of email recipients (separated by commas) for that dimension.
+ */
+public interface AlertGroupRecipientProvider {
+
+  /**
+   * Sets the properties of this grouper.
+   *
+   * @param props the properties for this grouper.
+   */
+  void setParameters(Map<String, String> props);
+
+  // TODO: Enhance the interface to handle group anomalies for various types of grouping logic, e.g. multi-metric.
+  /**
+   * Returns a list of email recipients (separated by commas) for the given dimension.
+   *
+   * @param dimensions the dimension to look for the recipients.
+   *
+   * @return a list of email recipients (separated by commas).
+   */
+  String getAlertGroupRecipients(DimensionMap dimensions);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactory.java
@@ -1,0 +1,50 @@
+package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+
+public class AlertGroupRecipientProviderFactory {
+  public static final String GROUP_RECIPIENT_PROVIDER_TYPE_KEY = "type";
+  private static final AlertGroupRecipientProvider DUMMY_ALERT_GROUP_RECIPIENT_PROVIDER =
+      new DummyAlertGroupRecipientProvider();
+
+  public enum GroupRecipientProviderType {
+    DUMMY, DIMENSIONAL
+  }
+
+  public static AlertGroupRecipientProvider fromSpec(Map<String, String> spec) {
+    if (MapUtils.isEmpty(spec)) {
+      spec = Collections.emptyMap();
+    }
+    AlertGroupRecipientProvider alertGroupRecipientProvider =
+        fromStringType(spec.get(GROUP_RECIPIENT_PROVIDER_TYPE_KEY));
+    alertGroupRecipientProvider.setParameters(spec);
+
+    return alertGroupRecipientProvider;
+  }
+
+  private static AlertGroupRecipientProvider fromStringType(String type) {
+    if (StringUtils.isBlank(type)) { // backward compatibility
+      return DUMMY_ALERT_GROUP_RECIPIENT_PROVIDER;
+    }
+
+    AlertGroupRecipientProviderFactory.GroupRecipientProviderType providerType = GroupRecipientProviderType.DUMMY;
+    for (GroupRecipientProviderType enumProviderType : GroupRecipientProviderType.values()) {
+      if (enumProviderType.name().compareToIgnoreCase(type) == 0) {
+        providerType = enumProviderType;
+        break;
+      }
+    }
+
+    switch (providerType) {
+    case DUMMY: // speed optimization for most use cases
+      return DUMMY_ALERT_GROUP_RECIPIENT_PROVIDER;
+    case DIMENSIONAL:
+      return new DimensionalAlertGroupRecipientProvider();
+    default:
+      return DUMMY_ALERT_GROUP_RECIPIENT_PROVIDER;
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/BaseAlertGroupRecipientProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/BaseAlertGroupRecipientProvider.java
@@ -1,0 +1,16 @@
+package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
+
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class BaseAlertGroupRecipientProvider implements AlertGroupRecipientProvider {
+  public static String EMPTY_RECIPIENTS = "";
+  public static String RECIPIENTS_SEPARATOR = ",";
+
+  Map<String, String> props = Collections.emptyMap();
+
+  @Override
+  public void setParameters(Map<String, String> props) {
+    this.props = props;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProvider.java
@@ -1,0 +1,54 @@
+package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.thirdeye.api.DimensionMap;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DimensionalAlertGroupRecipientProvider extends BaseAlertGroupRecipientProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(DimensionalAlertGroupRecipientProvider.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final String AUXILIARY_RECIPIENTS_MAP_KEY = "auxiliaryRecipients";
+
+  // The map from a dimension map to auxiliary email recipients
+  private NavigableMap<DimensionMap, String> auxiliaryEmailRecipients = new TreeMap<>();
+
+  // For testing purpose
+  NavigableMap<DimensionMap, String> getAuxiliaryEmailRecipients() {
+    return auxiliaryEmailRecipients;
+  }
+
+  @Override
+  public void setParameters(Map<String, String> props) {
+    super.setParameters(props);
+
+    // Initialize the lookup table for recipients of different dimensions
+    if (props.containsKey(AUXILIARY_RECIPIENTS_MAP_KEY)) {
+      String recipientsJsonPayLoad = props.get(AUXILIARY_RECIPIENTS_MAP_KEY);
+      try {
+        Map<String, String> rawAuxiliaryRecipientsMap = OBJECT_MAPPER.readValue(recipientsJsonPayLoad, HashMap.class);
+        for (Map.Entry<String, String> auxiliaryRecipientsEntry : rawAuxiliaryRecipientsMap.entrySet()) {
+          DimensionMap dimensionMap = new DimensionMap(auxiliaryRecipientsEntry.getKey());
+          String recipients = auxiliaryRecipientsEntry.getValue();
+          auxiliaryEmailRecipients.put(dimensionMap, recipients);
+        }
+      } catch (IOException e) {
+        LOG.error("Failed to reconstruct auxiliary recipients mappings from this json string: {}", recipientsJsonPayLoad);
+      }
+    }
+  }
+
+  @Override
+  public String getAlertGroupRecipients(DimensionMap dimensions) {
+    if (dimensions == null || !auxiliaryEmailRecipients.containsKey(dimensions)) {
+      return EMPTY_RECIPIENTS;
+    } else {
+      return auxiliaryEmailRecipients.get(dimensions);
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DummyAlertGroupRecipientProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DummyAlertGroupRecipientProvider.java
@@ -1,0 +1,10 @@
+package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
+
+import com.linkedin.thirdeye.api.DimensionMap;
+
+public class DummyAlertGroupRecipientProvider extends BaseAlertGroupRecipientProvider {
+  @Override
+  public String getAlertGroupRecipients(DimensionMap dimensions) {
+    return EMPTY_RECIPIENTS;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
@@ -9,6 +9,7 @@ import com.linkedin.thirdeye.anomaly.alert.grouping.DummyAlertGrouper;
 import com.linkedin.thirdeye.anomaly.alert.grouping.filter.AlertGroupFilter;
 import com.linkedin.thirdeye.anomaly.alert.grouping.filter.AlertGroupFilterFactory;
 import com.linkedin.thirdeye.anomaly.alert.grouping.SimpleGroupedAnomalyMerger;
+import com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider.AlertGroupRecipientProvider;
 import com.linkedin.thirdeye.anomaly.alert.template.pojo.MetricDimensionReport;
 import com.linkedin.thirdeye.anomaly.alert.util.AlertFilterHelper;
 import com.linkedin.thirdeye.anomaly.alert.util.AnomalyReportGenerator;
@@ -172,10 +173,10 @@ public class AlertTaskRunnerV2 implements TaskRunner {
           // Append auxiliary recipients for this group
           String recipientsForThisGroup = alertConfig.getRecipients();
           // TODO: Replace with AuxiliaryRecipient provider
-          String auxiliaryRecipients = alertGrouper.groupEmailRecipients(dimensions);
-          if (StringUtils.isNotBlank(auxiliaryRecipients)) {
-            recipientsForThisGroup = recipientsForThisGroup + EmailHelper.EMAIL_ADDRESS_SEPARATOR + auxiliaryRecipients;
-          }
+//          String auxiliaryRecipients = alertGrouper.groupEmailRecipients(dimensions);
+//          if (StringUtils.isNotBlank(auxiliaryRecipients)) {
+//            recipientsForThisGroup = recipientsForThisGroup + EmailHelper.EMAIL_ADDRESS_SEPARATOR + auxiliaryRecipients;
+//          }
           // Append group name after config name if dimensions of this group is not empty
           String emailSubjectName = alertConfig.getName();
           if (dimensions.size() != 0) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
@@ -13,9 +13,7 @@ public class AlertConfigBean extends AbstractBean {
   boolean active;
   EmailConfig emailConfig;
   ReportConfigCollection reportConfigCollection;
-  Map<String, String> groupByConfig = new HashMap<>();
-  Map<String, String> groupFilterConfig = new HashMap<>();
-  Map<String, String> groupTimeBasedMergeConfig = new HashMap<>();
+  AlertGroupConfig alertGroupConfig;
   String recipients;
   String fromAddress;
 
@@ -75,28 +73,12 @@ public class AlertConfigBean extends AbstractBean {
     this.reportConfigCollection = reportConfigCollection;
   }
 
-  public Map<String, String> getGroupByConfig() {
-    return groupByConfig;
+  public AlertGroupConfig getAlertGroupConfig() {
+    return alertGroupConfig;
   }
 
-  public void setGroupByConfig(Map<String, String> groupByConfig) {
-    this.groupByConfig = groupByConfig;
-  }
-
-  public Map<String, String> getGroupFilterConfig() {
-    return groupFilterConfig;
-  }
-
-  public void setGroupFilterConfig(Map<String, String> groupFilterConfig) {
-    this.groupFilterConfig = groupFilterConfig;
-  }
-
-  public Map<String, String> getGroupTimeBasedMergeConfig() {
-    return groupTimeBasedMergeConfig;
-  }
-
-  public void setGroupTimeBasedMergeConfig(Map<String, String> groupTimeBasedMergeConfig) {
-    this.groupTimeBasedMergeConfig = groupTimeBasedMergeConfig;
+  public void setAlertGroupConfig(AlertGroupConfig alertGroupConfig) {
+    this.alertGroupConfig = alertGroupConfig;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -214,6 +196,46 @@ public class AlertConfigBean extends AbstractBean {
           ", enabled=" + enabled +
           ", reportMetricConfigs=" + reportMetricConfigs +
           '}';
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class AlertGroupConfig {
+    Map<String, String> groupByConfig = new HashMap<>();
+    Map<String, String> groupFilterConfig = new HashMap<>();
+    Map<String, String> groupTimeBasedMergeConfig = new HashMap<>();
+    Map<String, String> groupAuxiliaryEmailProvider = new HashMap<>();
+
+    public Map<String, String> getGroupByConfig() {
+      return groupByConfig;
+    }
+
+    public void setGroupByConfig(Map<String, String> groupByConfig) {
+      this.groupByConfig = groupByConfig;
+    }
+
+    public Map<String, String> getGroupFilterConfig() {
+      return groupFilterConfig;
+    }
+
+    public void setGroupFilterConfig(Map<String, String> groupFilterConfig) {
+      this.groupFilterConfig = groupFilterConfig;
+    }
+
+    public Map<String, String> getGroupTimeBasedMergeConfig() {
+      return groupTimeBasedMergeConfig;
+    }
+
+    public void setGroupTimeBasedMergeConfig(Map<String, String> groupTimeBasedMergeConfig) {
+      this.groupTimeBasedMergeConfig = groupTimeBasedMergeConfig;
+    }
+
+    public Map<String, String> getGroupAuxiliaryEmailProvider() {
+      return groupAuxiliaryEmailProvider;
+    }
+
+    public void setGroupAuxiliaryEmailProvider(Map<String, String> groupAuxiliaryEmailProvider) {
+      this.groupAuxiliaryEmailProvider = groupAuxiliaryEmailProvider;
     }
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouperTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/DimensionalAlertGrouperTest.java
@@ -1,26 +1,19 @@
 package com.linkedin.thirdeye.anomaly.alert.grouping;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.thirdeye.api.DimensionMap;
-import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.GroupedAnomalyResultsDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Set;
-import java.util.TreeMap;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class DimensionalAlertGrouperTest {
-  private final static String EMAIL1 = "k1v1.com,k1v1.com2";
-  private final static String EMAIL2 = "k1v2.com,k1v2.com2";
-  private final static String EMAIL_NOT_USED = "k1v1k2v3.com";
   private final static String GROUP_BY_DIMENSION_NAME = "K1";
 
   private DimensionalAlertGrouper alertGrouper;
@@ -31,35 +24,8 @@ public class DimensionalAlertGrouperTest {
     props.put(DimensionalAlertGrouper.ROLL_UP_SINGLE_DIMENSION_KEY, "true");
     props.put(DimensionalAlertGrouper.GROUP_BY_KEY, GROUP_BY_DIMENSION_NAME);
 
-    Map<DimensionMap, String> auxiliaryRecipients = new TreeMap<>();
-    DimensionMap dimensionMap1 = new DimensionMap();
-    dimensionMap1.put(GROUP_BY_DIMENSION_NAME, "V1");
-    auxiliaryRecipients.put(dimensionMap1, EMAIL1);
-    DimensionMap dimensionMap2 = new DimensionMap();
-    dimensionMap2.put(GROUP_BY_DIMENSION_NAME, "V2");
-    auxiliaryRecipients.put(dimensionMap2, EMAIL2);
-    DimensionMap dimensionMap3 = new DimensionMap();
-    dimensionMap3.put(GROUP_BY_DIMENSION_NAME, "V1");
-    dimensionMap3.put("K2", "V3");
-    auxiliaryRecipients.put(dimensionMap3, EMAIL_NOT_USED);
-
-    try {
-      ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-      String writeValueAsString = OBJECT_MAPPER.writeValueAsString(auxiliaryRecipients);
-      props.put(DimensionalAlertGrouper.AUXILIARY_RECIPIENTS_MAP_KEY, writeValueAsString);
-
-      alertGrouper = new DimensionalAlertGrouper();
-      alertGrouper.setParameters(props);
-      NavigableMap<DimensionMap, String> auxiliaryRecipientsRecovered = alertGrouper.getAuxiliaryEmailRecipients();
-
-      // Test the map of auxiliary recipients
-      Assert.assertEquals(auxiliaryRecipientsRecovered.get(dimensionMap1), EMAIL1);
-      Assert.assertEquals(auxiliaryRecipientsRecovered.get(dimensionMap2), EMAIL2);
-      Assert.assertEquals(auxiliaryRecipientsRecovered.get(dimensionMap3), EMAIL_NOT_USED);
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-      Assert.fail();
-    }
+    alertGrouper = new DimensionalAlertGrouper();
+    alertGrouper.setParameters(props);
   }
 
   @Test(dependsOnMethods = { "testCreate" })
@@ -111,25 +77,6 @@ public class DimensionalAlertGrouperTest {
       rollUpGroup.addAll(anomalyRollUpGroup);
       Assert.assertEquals(rollUpGroup, expectedRollUpGroup);
     }
-  }
-
-  @Test(dependsOnMethods = { "testCreate", "testConstructGroupKey" })
-  public void testGroupEmailRecipients() {
-    // Test AlertGroupKey to auxiliary recipients
-    DimensionMap alertGroupKey1 = new DimensionMap();
-    alertGroupKey1.put(GROUP_BY_DIMENSION_NAME, "V1");
-    Assert.assertEquals(alertGrouper.groupEmailRecipients(alertGroupKey1), EMAIL1);
-
-    DimensionMap alertGroupKey2 = new DimensionMap();
-    alertGroupKey2.put(GROUP_BY_DIMENSION_NAME, "V1");
-    Assert.assertEquals(alertGrouper.groupEmailRecipients(alertGroupKey2), EMAIL1);
-
-    // Test empty recipients
-    Assert.assertEquals(alertGrouper.groupEmailRecipients(new DimensionMap()), BaseAlertGrouper.EMPTY_RECIPIENTS);
-    Assert.assertEquals(alertGrouper.groupEmailRecipients(null), BaseAlertGrouper.EMPTY_RECIPIENTS);
-    DimensionMap dimensionMapNonExist = new DimensionMap();
-    dimensionMapNonExist.put("K2", "V1");
-    Assert.assertEquals(alertGrouper.groupEmailRecipients(dimensionMapNonExist), BaseAlertGrouper.EMPTY_RECIPIENTS);
   }
 
   @DataProvider(name = "prepareAnomalyGroups")

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactoryTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactoryTest.java
@@ -1,0 +1,22 @@
+package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AlertGroupRecipientProviderFactoryTest {
+  @Test
+  public void testFromSpecNull() throws Exception {
+    AlertGroupRecipientProvider recipientProvider = AlertGroupRecipientProviderFactory.fromSpec(null);
+    Assert.assertEquals(recipientProvider.getClass(), DummyAlertGroupRecipientProvider.class);
+  }
+
+  @Test
+  public void testAlertGrouperCreation() {
+    Map<String, String> spec = new HashMap<>();
+    spec.put(AlertGroupRecipientProviderFactory.GROUP_RECIPIENT_PROVIDER_TYPE_KEY, "diMenSionAL");
+    AlertGroupRecipientProvider alertGrouper = AlertGroupRecipientProviderFactory.fromSpec(spec);
+    Assert.assertEquals(alertGrouper.getClass(), DimensionalAlertGroupRecipientProvider.class);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProviderTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProviderTest.java
@@ -1,0 +1,75 @@
+package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.thirdeye.anomaly.alert.grouping.BaseAlertGrouper;
+import com.linkedin.thirdeye.api.DimensionMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DimensionalAlertGroupRecipientProviderTest {
+  private final static String EMAIL1 = "k1v1.com,k1v1.com2";
+  private final static String EMAIL2 = "k1v2.com,k1v2.com2";
+  private final static String EMAIL_NOT_USED = "k1v1k2v3.com";
+  private final static String GROUP_BY_DIMENSION_NAME = "K1";
+
+  private DimensionalAlertGroupRecipientProvider recipientProvider;
+
+  @Test
+  public void testCreate() {
+    Map<String, String> props = new HashMap<>();
+
+    Map<DimensionMap, String> auxiliaryRecipients = new TreeMap<>();
+    DimensionMap dimensionMap1 = new DimensionMap();
+    dimensionMap1.put(GROUP_BY_DIMENSION_NAME, "V1");
+    auxiliaryRecipients.put(dimensionMap1, EMAIL1);
+    DimensionMap dimensionMap2 = new DimensionMap();
+    dimensionMap2.put(GROUP_BY_DIMENSION_NAME, "V2");
+    auxiliaryRecipients.put(dimensionMap2, EMAIL2);
+    DimensionMap dimensionMap3 = new DimensionMap();
+    dimensionMap3.put(GROUP_BY_DIMENSION_NAME, "V1");
+    dimensionMap3.put("K2", "V3");
+    auxiliaryRecipients.put(dimensionMap3, EMAIL_NOT_USED);
+
+    try {
+      ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+      String writeValueAsString = OBJECT_MAPPER.writeValueAsString(auxiliaryRecipients);
+      props.put(DimensionalAlertGroupRecipientProvider.AUXILIARY_RECIPIENTS_MAP_KEY, writeValueAsString);
+
+      recipientProvider = new DimensionalAlertGroupRecipientProvider();
+      recipientProvider.setParameters(props);
+      NavigableMap<DimensionMap, String> auxiliaryRecipientsRecovered = recipientProvider.getAuxiliaryEmailRecipients();
+
+      // Test the map of auxiliary recipients
+      Assert.assertEquals(auxiliaryRecipientsRecovered.get(dimensionMap1), EMAIL1);
+      Assert.assertEquals(auxiliaryRecipientsRecovered.get(dimensionMap2), EMAIL2);
+      Assert.assertEquals(auxiliaryRecipientsRecovered.get(dimensionMap3), EMAIL_NOT_USED);
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+      Assert.fail();
+    }
+  }
+
+  @Test(dependsOnMethods = { "testCreate" })
+  public void testGroupEmailRecipients() {
+    // Test AlertGroupKey to auxiliary recipients
+    DimensionMap alertGroupKey1 = new DimensionMap();
+    alertGroupKey1.put(GROUP_BY_DIMENSION_NAME, "V1");
+    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(alertGroupKey1), EMAIL1);
+
+    DimensionMap alertGroupKey2 = new DimensionMap();
+    alertGroupKey2.put(GROUP_BY_DIMENSION_NAME, "V1");
+    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(alertGroupKey2), EMAIL1);
+
+    // Test empty recipients
+    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(new DimensionMap()), BaseAlertGrouper.EMPTY_RECIPIENTS);
+    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(null), BaseAlertGrouper.EMPTY_RECIPIENTS);
+    DimensionMap dimensionMapNonExist = new DimensionMap();
+    dimensionMapNonExist.put("K2", "V1");
+    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(dimensionMapNonExist), BaseAlertGrouper.EMPTY_RECIPIENTS);
+  }
+}


### PR DESCRIPTION
1. Remove auxiliary email recipient from AlertGrouper class.
2. Add AlertGroupRecipientProvider class, which provides the recipients depending on the given dimensions.

Tested with unit tests and local integration test (i.e., controller).