### PR TITLE
[TE] Add OnboardDatasetMetric entity, for onboarding of datasets and metrics to data sources

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -15,6 +15,7 @@ import com.linkedin.thirdeye.dashboard.resources.IngraphDashboardConfigResource;
 import com.linkedin.thirdeye.dashboard.resources.IngraphMetricConfigResource;
 import com.linkedin.thirdeye.dashboard.resources.JobResource;
 import com.linkedin.thirdeye.dashboard.resources.MetricConfigResource;
+import com.linkedin.thirdeye.dashboard.resources.OnboardDatasetMetricResource;
 import com.linkedin.thirdeye.dashboard.resources.OnboardResource;
 import com.linkedin.thirdeye.dashboard.resources.OverrideConfigResource;
 import com.linkedin.thirdeye.dashboard.resources.SummaryResource;
@@ -123,6 +124,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new DataCompletenessResource(DAO_REGISTRY.getDataCompletenessConfigDAO()));
     env.jersey().register(new EntityMappingResource());
     env.jersey().register(new RootCauseResource(makeRCAFramework(config), makeRCAFormatters(config)));
+    env.jersey().register(new OnboardDatasetMetricResource());
   }
 
   private static RCAFramework makeRCAFramework(ThirdEyeDashboardConfiguration config) throws Exception {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardDatasetMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardDatasetMetricResource.java
@@ -1,0 +1,158 @@
+package com.linkedin.thirdeye.dashboard.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.thirdeye.datalayer.bao.OnboardDatasetMetricManager;
+import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Endpoints for adding datasets and metrics to be read by data sources
+ */
+@Path(value = "/onboard")
+@Produces(MediaType.APPLICATION_JSON)
+public class OnboardDatasetMetricResource {
+
+  private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
+  private static final OnboardDatasetMetricManager onboardDatasetMetricDAO = DAO_REGISTRY.getOnboardDatasetMetricDAO();
+
+
+  public OnboardDatasetMetricResource() {
+  }
+
+  @GET
+  @Path("/view")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OnboardDatasetMetricDTO> viewOnboardConfigs(
+      @QueryParam("datasetName") String datasetName,
+      @QueryParam("metricName") String metricName,
+      @QueryParam("dataSource") String dataSource,
+      @QueryParam("onboarded") Boolean onboarded) {
+
+    List<OnboardDatasetMetricDTO> dtos = new ArrayList<>();
+    if (StringUtils.isBlank(datasetName) && StringUtils.isBlank(metricName) && StringUtils.isBlank(dataSource)
+        && onboarded == null) {
+      dtos = onboardDatasetMetricDAO.findAll();
+    } else {
+      Map<String, Object> filters = new HashMap<>();
+      if (StringUtils.isNotBlank(datasetName)) {
+        filters.put("datasetName", datasetName);
+      }
+      if (StringUtils.isNotBlank(metricName)) {
+        filters.put("metricName", metricName);
+      }
+      if (StringUtils.isNotBlank(dataSource)) {
+        filters.put("dataSource", dataSource);
+      }
+      if (onboarded != null) {
+        filters.put("onboarded", onboarded);
+      }
+      dtos = onboardDatasetMetricDAO.findByParams(filters);
+    }
+    return dtos;
+  }
+
+
+  @GET
+  @Path("/view/all")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OnboardDatasetMetricDTO> viewAllOnboardConfigs() {
+    List<OnboardDatasetMetricDTO> configs = onboardDatasetMetricDAO.findAll();
+    return configs;
+  }
+
+  @GET
+  @Path("/view/datasetName/{datasetName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OnboardDatasetMetricDTO> viewOnboardConfigsByDataset(@PathParam("datasetName") String datasetName) {
+    List<OnboardDatasetMetricDTO> dtos = onboardDatasetMetricDAO.findByDataset(datasetName);
+    return dtos;
+  }
+
+
+  @GET
+  @Path("/view/metricName/{metricName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OnboardDatasetMetricDTO> viewOnboardConfigsByMetric(@PathParam("metricName") String metricName) {
+    List<OnboardDatasetMetricDTO> dtos = onboardDatasetMetricDAO.findByMetric(metricName);
+    return dtos;
+  }
+
+
+  @GET
+  @Path("/view/dataSource/{dataSource}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OnboardDatasetMetricDTO> viewOnboardConfigsByDatasource(@PathParam("dataSource") String dataSource) {
+    List<OnboardDatasetMetricDTO> dtos = onboardDatasetMetricDAO.findByDataSource(dataSource);
+    return dtos;
+  }
+
+
+  @GET
+  @Path("/view/dataSource/{dataSource}/onboarded/{onboarded}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<OnboardDatasetMetricDTO> viewOnboardConfigsByDatasourceAndOnboarded(
+      @PathParam("dataSource") String dataSource, @PathParam("onboarded") boolean onboarded) {
+    List<OnboardDatasetMetricDTO> dtos = onboardDatasetMetricDAO.findByDataSourceAndOnboarded(dataSource, onboarded);
+    return dtos;
+  }
+
+
+  /**
+   * Create this by providing json payload as follows:
+   *
+   *    curl -H "Content-Type: application/json" -X POST -d <payload> <url>
+   *    Eg: curl -H "Content-Type: application/json" -X POST -d
+   *            '{"datasetName":"xyz","metricName":"xyz", "dataSource":"abc", "properties": { "prop1":"1", "prop2":"2"}}'
+   *                http://localhost:8080/onboard/create
+   * @param payload
+   */
+  @POST
+  @Path("/create")
+  public Response createOnboardConfig(String payload) {
+    OnboardDatasetMetricDTO onboardConfig = null;
+    Response response = null;
+    try {
+      onboardConfig = OBJECT_MAPPER.readValue(payload, OnboardDatasetMetricDTO.class);
+      Long id = onboardDatasetMetricDAO.save(onboardConfig);
+      response = Response.status(Status.OK).entity(String.format("Created config with id %d", id)).build();
+    } catch (Exception e) {
+      response = Response.status(Status.INTERNAL_SERVER_ERROR)
+          .entity(String.format("Invalid payload %s %s",  payload, e)).build();
+    }
+    return response;
+  }
+
+
+  @DELETE
+  @Path("/delete/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response deleteOnboardConfig(@PathParam("id") Long id) {
+    Response response = Response.status(Status.NOT_FOUND).build();
+    OnboardDatasetMetricDTO dto = onboardDatasetMetricDAO.findById(id);
+    if (dto != null) {
+      onboardDatasetMetricDAO.delete(dto);
+      response = Response.ok().build();
+    }
+    return response;
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/OnboardDatasetMetricManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/OnboardDatasetMetricManager.java
@@ -1,0 +1,19 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
+
+import java.util.List;
+
+public interface OnboardDatasetMetricManager extends AbstractManager<OnboardDatasetMetricDTO> {
+
+  List<OnboardDatasetMetricDTO> findByDataSource(String dataSource);
+  List<OnboardDatasetMetricDTO> findByDataSourceAndOnboarded(String dataSource, boolean onboarded);
+  List<OnboardDatasetMetricDTO> findByDataset(String datasetName);
+  List<OnboardDatasetMetricDTO> findByDatasetAndOnboarded(String datasetName, boolean onboarded);
+  List<OnboardDatasetMetricDTO> findByMetric(String metricName);
+  List<OnboardDatasetMetricDTO> findByMetricAndOnboarded(String metricName, boolean onboarded);
+  List<OnboardDatasetMetricDTO> findByDatasetAndDatasource(String datasetName, String dataSource);
+  List<OnboardDatasetMetricDTO> findByDatasetAndDatasourceAndOnboarded(String datasetName, String dataSource, boolean onboarded);
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/OnboardDatasetMetricManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/OnboardDatasetMetricManagerImpl.java
@@ -1,0 +1,83 @@
+package com.linkedin.thirdeye.datalayer.bao.jdbc;
+
+import com.google.inject.Singleton;
+import com.linkedin.thirdeye.datalayer.bao.OnboardDatasetMetricManager;
+import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
+import com.linkedin.thirdeye.datalayer.pojo.OnboardDatasetMetricBean;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+
+import java.util.List;
+
+@Singleton
+public class OnboardDatasetMetricManagerImpl extends AbstractManagerImpl<OnboardDatasetMetricDTO>
+    implements OnboardDatasetMetricManager {
+
+  public OnboardDatasetMetricManagerImpl() {
+    super(OnboardDatasetMetricDTO.class, OnboardDatasetMetricBean.class);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByDataSource(String dataSource) {
+    Predicate dataSourcePredicate = Predicate.EQ("dataSource", dataSource);
+    return findByPredicate(dataSourcePredicate);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByDataSourceAndOnboarded(String dataSource,
+      boolean onboarded) {
+    Predicate dataSourcePredicate = Predicate.EQ("dataSource", dataSource);
+    Predicate onboardedPredicate = Predicate.EQ("onboarded", onboarded);
+    Predicate predicate = Predicate.AND(dataSourcePredicate, onboardedPredicate);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByDataset(String datasetName) {
+    Predicate predicate = Predicate.EQ("datasetName", datasetName);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByDatasetAndOnboarded(String datasetName,
+      boolean onboarded) {
+    Predicate datasetNamePredicate = Predicate.EQ("datasetName", datasetName);
+    Predicate onboardedPredicate = Predicate.EQ("onboarded", onboarded);
+    Predicate predicate = Predicate.AND(datasetNamePredicate, onboardedPredicate);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByMetric(String metricName) {
+    Predicate predicate = Predicate.EQ("metricName", metricName);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByMetricAndOnboarded(String metricName, boolean onboarded) {
+    Predicate metricNamePredicate = Predicate.EQ("metricName", metricName);
+    Predicate onboardedPredicate = Predicate.EQ("onboarded", onboarded);
+    Predicate predicate = Predicate.AND(metricNamePredicate, onboardedPredicate);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByDatasetAndDatasource(String datasetName,
+      String dataSource) {
+    Predicate datasetNamePredicate = Predicate.EQ("datasetName", datasetName);
+    Predicate dataSourcePredicate = Predicate.EQ("dataSource", dataSource);
+    Predicate predicate = Predicate.AND(datasetNamePredicate, dataSourcePredicate);
+    return findByPredicate(predicate);
+  }
+
+  @Override
+  public List<OnboardDatasetMetricDTO> findByDatasetAndDatasourceAndOnboarded(String datasetName,
+      String dataSource, boolean onboarded) {
+    Predicate datasetNamePredicate = Predicate.EQ("datasetName", datasetName);
+    Predicate dataSourcePredicate = Predicate.EQ("dataSource", dataSource);
+    Predicate onboardedPredicate = Predicate.EQ("onboarded", onboarded);
+    Predicate predicate = Predicate.AND(datasetNamePredicate, dataSourcePredicate, onboardedPredicate);
+    return findByPredicate(predicate);
+  }
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -55,6 +55,7 @@ import com.linkedin.thirdeye.datalayer.entity.IngraphMetricConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.JobIndex;
 import com.linkedin.thirdeye.datalayer.entity.MergedAnomalyResultIndex;
 import com.linkedin.thirdeye.datalayer.entity.MetricConfigIndex;
+import com.linkedin.thirdeye.datalayer.entity.OnboardDatasetMetricIndex;
 import com.linkedin.thirdeye.datalayer.entity.RawAnomalyResultIndex;
 import com.linkedin.thirdeye.datalayer.entity.TaskIndex;
 import com.linkedin.thirdeye.datalayer.pojo.AbstractBean;
@@ -71,6 +72,7 @@ import com.linkedin.thirdeye.datalayer.pojo.IngraphMetricConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.JobBean;
 import com.linkedin.thirdeye.datalayer.pojo.MergedAnomalyResultBean;
 import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
+import com.linkedin.thirdeye.datalayer.pojo.OnboardDatasetMetricBean;
 import com.linkedin.thirdeye.datalayer.pojo.RawAnomalyResultBean;
 import com.linkedin.thirdeye.datalayer.pojo.TaskBean;
 import com.linkedin.thirdeye.datalayer.util.GenericResultSetMapper;
@@ -129,6 +131,8 @@ public class GenericPojoDao {
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, EntityToEntityMappingIndex.class));
     pojoInfoMap.put(GroupedAnomalyResultsBean.class,
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, GroupedAnomalyResultsIndex.class));
+    pojoInfoMap.put(OnboardDatasetMetricBean.class,
+        newPojoInfo(DEFAULT_BASE_TABLE_NAME, OnboardDatasetMetricIndex.class));
   }
 
   private static PojoInfo newPojoInfo(String baseTableName,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/OnboardDatasetMetricDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/OnboardDatasetMetricDTO.java
@@ -1,0 +1,7 @@
+package com.linkedin.thirdeye.datalayer.dto;
+
+import com.linkedin.thirdeye.datalayer.pojo.OnboardDatasetMetricBean;
+
+public class OnboardDatasetMetricDTO extends OnboardDatasetMetricBean {
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/OnboardDatasetMetricIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/OnboardDatasetMetricIndex.java
@@ -1,0 +1,34 @@
+package com.linkedin.thirdeye.datalayer.entity;
+
+public class OnboardDatasetMetricIndex extends AbstractIndexEntity {
+  String datasetName;
+  String metricName;
+  String dataSource;
+  boolean onboarded;
+
+  public String getDatasetName() {
+    return datasetName;
+  }
+  public void setDatasetName(String datasetName) {
+    this.datasetName = datasetName;
+  }
+  public String getMetricName() {
+    return metricName;
+  }
+  public void setMetricName(String metricName) {
+    this.metricName = metricName;
+  }
+  public String getDataSource() {
+    return dataSource;
+  }
+  public void setDataSource(String dataSource) {
+    this.dataSource = dataSource;
+  }
+  public boolean isOnboarded() {
+    return onboarded;
+  }
+  public void setOnboarded(boolean onboarded) {
+    this.onboarded = onboarded;
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/OnboardDatasetMetricBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/OnboardDatasetMetricBean.java
@@ -1,0 +1,87 @@
+package com.linkedin.thirdeye.datalayer.pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+/**
+ * This table will be the entry point for users, to add new datasets to Thirdeye or new metrics to datasets in Thirdeye
+ * Each data source will keep polling this table, for new entries to onboard
+ * The properties will be used to supply things required by the data sources to setup these datasets or metrics
+ * Once the entry has been onboarded, we will not check it again
+ */
+public class OnboardDatasetMetricBean extends AbstractBean {
+
+  private String datasetName;
+
+  private String metricName;
+
+  private String dataSource;
+
+  private Map<String, String> properties;
+
+  private boolean onboarded = false;
+
+
+  public String getDatasetName() {
+    return datasetName;
+  }
+
+  public void setDatasetName(String datasetName) {
+    this.datasetName = datasetName;
+  }
+
+  public String getMetricName() {
+    return metricName;
+  }
+
+  public void setMetricName(String metricName) {
+    this.metricName = metricName;
+  }
+
+  public String getDataSource() {
+    return dataSource;
+  }
+
+  public void setDataSource(String dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+
+  public boolean isOnboarded() {
+    return onboarded;
+  }
+
+  public void setOnboarded(boolean onboarded) {
+    this.onboarded = onboarded;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof OnboardDatasetMetricBean)) {
+      return false;
+    }
+    OnboardDatasetMetricBean oc = (OnboardDatasetMetricBean) o;
+    return Objects.equals(getId(), oc.getId())
+        && Objects.equals(datasetName, oc.getDatasetName())
+        && Objects.equals(metricName, oc.getMetricName())
+        && Objects.equals(dataSource, oc.getDataSource())
+        && Objects.equals(properties, oc.getProperties())
+        && Objects.equals(onboarded, oc.isOnboarded());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), datasetName, metricName, dataSource, properties, onboarded);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
@@ -36,6 +36,7 @@ import com.linkedin.thirdeye.datalayer.entity.IngraphMetricConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.JobIndex;
 import com.linkedin.thirdeye.datalayer.entity.MergedAnomalyResultIndex;
 import com.linkedin.thirdeye.datalayer.entity.MetricConfigIndex;
+import com.linkedin.thirdeye.datalayer.entity.OnboardDatasetMetricIndex;
 import com.linkedin.thirdeye.datalayer.entity.RawAnomalyResultIndex;
 import com.linkedin.thirdeye.datalayer.entity.TaskIndex;
 
@@ -146,6 +147,8 @@ public abstract class DaoProviderUtil {
             convertCamelCaseToUnderscore(EntityToEntityMappingIndex.class.getSimpleName()));
         entityMappingHolder.register(conn, GroupedAnomalyResultsIndex.class,
             convertCamelCaseToUnderscore(GroupedAnomalyResultsIndex.class.getSimpleName()));
+        entityMappingHolder.register(conn, OnboardDatasetMetricIndex.class,
+            convertCamelCaseToUnderscore(OnboardDatasetMetricIndex.class.getSimpleName()));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DAORegistry.java
@@ -17,6 +17,7 @@ import com.linkedin.thirdeye.datalayer.bao.IngraphMetricConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.JobManager;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.OnboardDatasetMetricManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
@@ -37,6 +38,7 @@ import com.linkedin.thirdeye.datalayer.bao.jdbc.IngraphMetricConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.JobManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.MergedAnomalyResultManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.MetricConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.OnboardDatasetMetricManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.OverrideConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.RawAnomalyResultManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.TaskManagerImpl;
@@ -163,5 +165,9 @@ public class DAORegistry {
 
   public GroupedAnomalyResultsManager getGroupedAnomalyResultsDAO() {
     return DaoProviderUtil.getInstance(GroupedAnomalyResultsManagerImpl.class);
+  }
+
+  public OnboardDatasetMetricManager getOnboardDatasetMetricDAO() {
+    return DaoProviderUtil.getInstance(OnboardDatasetMetricManagerImpl.class);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -23,6 +23,7 @@ import com.linkedin.thirdeye.datalayer.dto.IngraphDashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.IngraphMetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
 import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
@@ -68,6 +69,7 @@ public abstract class AbstractManagerTestBase {
   protected ClassificationConfigManager classificationConfigDAO;
   protected EntityToEntityMappingManager entityToEntityMappingDAO;
   protected GroupedAnomalyResultsManager groupedAnomalyResultsDAO;
+  protected OnboardDatasetMetricManager onboardDatasetMetricDAO;
 
   //  protected TestDBResources testDBResources;
   protected DAORegistry daoRegistry;
@@ -105,6 +107,7 @@ public abstract class AbstractManagerTestBase {
       classificationConfigDAO = daoRegistry.getClassificationConfigDAO();
       entityToEntityMappingDAO = daoRegistry.getEntityToEntityMappingDAO();
       groupedAnomalyResultsDAO = daoRegistry.getGroupedAnomalyResultsDAO();
+      onboardDatasetMetricDAO = daoRegistry.getOnboardDatasetMetricDAO();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -386,6 +389,14 @@ public abstract class AbstractManagerTestBase {
     dto.setToURN(toURN);
     dto.setMappingType(mappingType);
     dto.setScore(1);
+    return dto;
+  }
+
+  protected OnboardDatasetMetricDTO getTestOnboardConfig(String datasetName, String metricName, String dataSource) {
+    OnboardDatasetMetricDTO dto = new OnboardDatasetMetricDTO();
+    dto.setDatasetName(datasetName);
+    dto.setMetricName(metricName);
+    dto.setDataSource(dataSource);
     return dto;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestOnboardDatasetMetricManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestOnboardDatasetMetricManager.java
@@ -1,0 +1,87 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.linkedin.thirdeye.datalayer.dto.IngraphDashboardConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
+
+public class TestOnboardDatasetMetricManager extends AbstractManagerTestBase {
+
+  private Long id1 = null;
+  private Long id2 = null;
+  private Long id3 = null;
+  private static String dataSource1 = "ds1";
+  private static String dataSource2 = "ds2";
+  private static String dataset1 = "d1";
+  private static String dataset2 = "d2";
+  private static String metric1 = "m1";
+  private static String metric2 = "m2";
+  private static String metric3 = "m3";
+
+  @BeforeClass
+  void beforeClass() {
+    super.init();
+  }
+
+  @AfterClass(alwaysRun = true)
+  void afterClass() {
+    super.cleanup();
+  }
+
+  @Test
+  public void testCreateOnboardConfig() {
+    // create just a dataset
+    OnboardDatasetMetricDTO dto = getTestOnboardConfig(dataset1, null, dataSource1);
+    id1 = onboardDatasetMetricDAO.save(dto);
+    Assert.assertNotNull(id1);
+
+    // create metric + dataset
+    dto = getTestOnboardConfig(dataset2, metric2, dataSource2);
+    id2 = onboardDatasetMetricDAO.save(dto);
+    Assert.assertNotNull(id2);
+
+    // add metric to existing dataset
+    dto = getTestOnboardConfig(dataset2, metric3, dataSource2);
+    id3 = onboardDatasetMetricDAO.save(dto);
+    Assert.assertNotNull(id3);
+
+  }
+
+  @Test(dependsOnMethods = {"testCreateOnboardConfig"})
+  public void testFindOnboardConfig() {
+    List<OnboardDatasetMetricDTO> dtos = onboardDatasetMetricDAO.findAll();
+    Assert.assertEquals(dtos.size(), 3);
+    dtos = onboardDatasetMetricDAO.findByDataSource(dataSource1);
+    Assert.assertEquals(dtos.size(), 1);
+    dtos = onboardDatasetMetricDAO.findByDataset(dataset2);
+    Assert.assertEquals(dtos.size(), 2);
+    dtos = onboardDatasetMetricDAO.findByMetric(metric1);
+    Assert.assertEquals(dtos.size(), 0);
+    dtos = onboardDatasetMetricDAO.findByDatasetAndDatasource(dataset1, dataSource1);
+    Assert.assertEquals(dtos.size(), 1);
+  }
+
+  @Test(dependsOnMethods = { "testFindOnboardConfig" })
+  public void testUpdateOnboardConfig() {
+    OnboardDatasetMetricDTO dto = onboardDatasetMetricDAO.findById(id1);
+    Assert.assertFalse(dto.isOnboarded());
+    dto.setOnboarded(true);
+    onboardDatasetMetricDAO.update(dto);
+    List<OnboardDatasetMetricDTO> dtos = onboardDatasetMetricDAO.findByDataSourceAndOnboarded(dataSource1, true);
+    Assert.assertEquals(dtos.size(), 1);
+    Assert.assertTrue(dtos.get(0).isOnboarded());
+
+  }
+
+  @Test(dependsOnMethods = { "testUpdateOnboardConfig" })
+  public void testDeleteOnboardConfig() {
+    onboardDatasetMetricDAO.deleteById(id1);
+    OnboardDatasetMetricDTO dto = onboardDatasetMetricDAO.findById(id1);
+    Assert.assertNull(dto);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -326,3 +326,18 @@ create table if not exists grouped_anomaly_results_index (
     version int(10)
 ) ENGINE=InnoDB;
 create index grouped_anomaly_results_alert_config_id on grouped_anomaly_results_index(alert_config_id);
+
+create table if not exists onboard_dataset_metric_index (
+  dataset_name varchar(200) not null,
+  metric_name varchar(500),
+  data_source varchar(500) not null,
+  onboarded boolean,
+  base_id bigint(20) not null,
+  create_time timestamp,
+  update_time timestamp default current_timestamp,
+  version int(10)
+) ENGINE=InnoDB;
+create index onboard_dataset_idx on onboard_dataset_metric_index(dataset_name);
+create index onboard_metric_idx on onboard_dataset_metric_index(metric_name);
+create index onboard_datasource_idx on onboard_dataset_metric_index(data_source);
+create index onboard_onboarded_idx on onboard_dataset_metric_index(onboarded);

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
@@ -21,4 +21,5 @@ DROP TABLE IF EXISTS detection_status_index;
 DROP TABLE IF EXISTS autotune_config_index;
 DROP TABLE IF EXISTS entity_to_entity_mapping_index;
 DROP TABLE IF EXISTS grouped_anomaly_results_index;
+DROP TABLE IF EXISTS onboard_dataset_metric_index;
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Creatign a new entity, OnboardDatasetMetric config. This is where users will enter the name of the dataset or metric they want to onboard, for a datasource. The data sources will have load tools, which will read this table and decide how to setup the datasets and metrics.