### PR TITLE
Add MetadataBasedAggregationPlanNode and Operator.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.operator.query;
+
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.core.common.Block;
+import com.linkedin.pinot.core.common.BlockId;
+import com.linkedin.pinot.core.common.Operator;
+import com.linkedin.pinot.core.operator.BaseOperator;
+import com.linkedin.pinot.core.operator.ExecutionStatistics;
+import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
+import com.linkedin.pinot.core.query.aggregation.AggregationFunctionContext;
+import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
+import com.linkedin.pinot.core.query.aggregation.DoubleAggregationResultHolder;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Aggregation operator that utilizes metadata for serving aggregation queries.
+ */
+public class MetadataBasedAggregationOperator implements Operator {
+  private final AggregationFunctionContext[] _aggregationFunctionContexts;
+  private final Map<String, BaseOperator> _dataSourceMap;
+  private final SegmentMetadata _segmentMetadata;
+  private ExecutionStatistics _executionStatistics;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param aggregationFunctionContexts Aggregation function contexts.
+   * @param segmentMetadata Segment metadata.
+   * @param dataSourceMap Map of column to its data source.
+   */
+  public MetadataBasedAggregationOperator(AggregationFunctionContext[] aggregationFunctionContexts,
+      SegmentMetadata segmentMetadata, Map<String, BaseOperator> dataSourceMap) {
+    _aggregationFunctionContexts = aggregationFunctionContexts;
+
+    // Datasource is currently not used, but will start getting used as we add support for aggregation
+    // functions other than count(*).
+    _dataSourceMap = dataSourceMap;
+    _segmentMetadata = segmentMetadata;
+  }
+
+  @Override
+  public boolean open() {
+    for (BaseOperator operator : _dataSourceMap.values()) {
+      operator.open();
+    }
+    return true;
+  }
+
+  @Override
+  public Block nextBlock() {
+    int numAggregationFunctions = _aggregationFunctionContexts.length;
+    List<Object> aggregationResults = new ArrayList<>(numAggregationFunctions);
+    int totalRawDocs = _segmentMetadata.getTotalRawDocs();
+
+    for (AggregationFunctionContext aggregationFunctionContext : _aggregationFunctionContexts) {
+      AggregationFunction function = aggregationFunctionContext.getAggregationFunction();
+      AggregationFunctionFactory.AggregationFunctionType functionType =
+          AggregationFunctionFactory.AggregationFunctionType.valueOf(function.getName().toUpperCase());
+
+      // TODO: Add support for more aggregation functions that can be served with metadata.
+      AggregationResultHolder resultHolder;
+      switch (functionType) {
+        case COUNT:
+          resultHolder = new DoubleAggregationResultHolder(totalRawDocs);
+          break;
+
+        default:
+          throw new UnsupportedOperationException(
+              "Metadata based aggregation operator does not support function " + function.getName());
+      }
+      aggregationResults.add(function.extractAggregationResult(resultHolder));
+    }
+
+    // Create execution statistics. Set numDocsScanned to totalRawDocs for backward compatibility.
+    _executionStatistics =
+        new ExecutionStatistics(totalRawDocs, 0/*numEntriesScannedInFilter*/, 0/*numEntriesScannedPostFilter*/,
+            totalRawDocs);
+
+    // Build intermediate result block based on aggregation result from the executor.
+    return new IntermediateResultsBlock(_aggregationFunctionContexts, aggregationResults, false);
+  }
+
+  @Override
+  public Block nextBlock(BlockId blockId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean close() {
+    for (BaseOperator operator : _dataSourceMap.values()) {
+      operator.close();
+    }
+    return true;
+  }
+
+  @Override
+  public ExecutionStatistics getExecutionStatistics() {
+    return _executionStatistics;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ColumnarDataSourcePlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ColumnarDataSourcePlanNode.java
@@ -18,8 +18,6 @@ package com.linkedin.pinot.core.plan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.BaseOperator;
 
@@ -38,15 +36,9 @@ public class ColumnarDataSourcePlanNode implements PlanNode {
     _columnName = columnName;
   }
 
-  public ColumnarDataSourcePlanNode(IndexSegment indexSegment, String columnName, DocIdSetPlanNode docIdSetPlanNode) {
-    _indexSegment = indexSegment;
-    _columnName = columnName;
-  }
-
   @Override
   public BaseOperator run() {
-    DataSource dataSource = _indexSegment.getDataSource(_columnName);
-    return dataSource;
+    return _indexSegment.getDataSource(_columnName);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/MetadataBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/MetadataBasedAggregationPlanNode.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.plan;
+
+import com.linkedin.pinot.common.request.AggregationInfo;
+import com.linkedin.pinot.core.common.Operator;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.operator.BaseOperator;
+import com.linkedin.pinot.core.operator.query.MetadataBasedAggregationOperator;
+import com.linkedin.pinot.core.query.aggregation.AggregationFunctionContext;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Metadata based aggregation plan node.
+ */
+public class MetadataBasedAggregationPlanNode implements PlanNode {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetadataBasedAggregationPlanNode.class);
+
+  private final Map<String, ColumnarDataSourcePlanNode> _dataSourcePlanNodeMap;
+  private final AggregationFunctionContext[] _aggregationFunctionContexts;
+  private IndexSegment _indexSegment;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param indexSegment Segment to process
+   * @param aggregationInfos List of aggregation context info.
+   */
+  public MetadataBasedAggregationPlanNode(IndexSegment indexSegment, List<AggregationInfo> aggregationInfos) {
+    _indexSegment = indexSegment;
+    _dataSourcePlanNodeMap = new HashMap<>();
+
+    _aggregationFunctionContexts =
+        AggregationFunctionUtils.getAggregationFunctionContexts(aggregationInfos, indexSegment.getSegmentMetadata());
+
+    for (AggregationFunctionContext aggregationFunctionContext : _aggregationFunctionContexts) {
+      String column = aggregationFunctionContext.getAggregationColumnName();
+
+      if (!_dataSourcePlanNodeMap.containsKey(column)) {
+        // For count(*), there's no column to have the metadata for.
+        if (!aggregationFunctionContext.getAggregationFunction()
+            .getName()
+            .equalsIgnoreCase(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+          _dataSourcePlanNodeMap.put(column, new ColumnarDataSourcePlanNode(indexSegment, column));
+        }
+      }
+    }
+  }
+
+  @Override
+  public Operator run() {
+    Map<String, BaseOperator> dataSourceMap = new HashMap<>();
+
+    for (String column : _dataSourcePlanNodeMap.keySet()) {
+      ColumnarDataSourcePlanNode columnarDataSourcePlanNode = _dataSourcePlanNodeMap.get(column);
+      BaseOperator operator = columnarDataSourcePlanNode.run();
+      dataSourceMap.put(column, operator);
+    }
+
+    return new MetadataBasedAggregationOperator(_aggregationFunctionContexts, _indexSegment.getSegmentMetadata(),
+        dataSourceMap);
+  }
+
+  @Override
+  public void showTree(String prefix) {
+    LOGGER.debug("{} Segment Level Inner-Segment Plan Node:", prefix);
+    LOGGER.debug("{} Operator: MetadataBasedAggregationOperator", prefix);
+    LOGGER.debug("{} IndexSegment: {}", prefix, _indexSegment.getSegmentName());
+
+    int i = 0;
+    for (String column : _dataSourcePlanNodeMap.keySet()) {
+      LOGGER.debug("{} Argument {}: DataSourceOperator", prefix, (i + 1));
+      _dataSourcePlanNodeMap.get(column).showTree(prefix + "    ");
+      i++;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ProjectionPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ProjectionPlanNode.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
@@ -37,14 +36,14 @@ public class ProjectionPlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProjectionPlanNode.class);
 
   private final Map<String, ColumnarDataSourcePlanNode> _dataSourcePlanNodeMap =
-      new HashMap<String, ColumnarDataSourcePlanNode>();
+      new HashMap<>();
   private final DocIdSetPlanNode _docIdSetPlanNode;
   private MProjectionOperator _projectionOperator = null;
 
   public ProjectionPlanNode(IndexSegment indexSegment, String[] columns, DocIdSetPlanNode docIdSetPlanNode) {
     _docIdSetPlanNode = docIdSetPlanNode;
     for (String column : columns) {
-      _dataSourcePlanNodeMap.put(column, new ColumnarDataSourcePlanNode(indexSegment, column, docIdSetPlanNode));
+      _dataSourcePlanNodeMap.put(column, new ColumnarDataSourcePlanNode(indexSegment, column));
     }
   }
 
@@ -52,7 +51,7 @@ public class ProjectionPlanNode implements PlanNode {
   public Operator run() {
     long start = System.currentTimeMillis();
     if (_projectionOperator == null) {
-      Map<String, BaseOperator> dataSourceMap = new HashMap<String, BaseOperator>();
+      Map<String, BaseOperator> dataSourceMap = new HashMap<>();
       BReusableFilteredDocIdSetOperator docIdSetOperator = (BReusableFilteredDocIdSetOperator) _docIdSetPlanNode.run();
       for (String column : _dataSourcePlanNodeMap.keySet()) {
         ColumnarDataSourcePlanNode columnarDataSourcePlanNode = _dataSourcePlanNodeMap.get(column);
@@ -77,9 +76,5 @@ public class ProjectionPlanNode implements PlanNode {
       _dataSourcePlanNodeMap.get(column).showTree(prefix + "    ");
       i++;
     }
-  }
-
-  public ColumnarDataSourcePlanNode getDataSourcePlanNode(String column) {
-    return _dataSourcePlanNodeMap.get(column);
   }
 }


### PR DESCRIPTION
Several queries can be served without the need scanning documents, ie
either by using metadata or dictionary. This PR lays the groundwork to
facilitate that. This replaces the implementation in PR-1452.

In the current PR, only count(*) queries will use the metadata based
operator. But this is easily extensible to other aggregation functions
such as min/max/distinct.

Existing unit tests for count(*) provide all the required coverage.