### PR TITLE
[PINOT-4887] Added support for no-dictionary columns in Realtime consuming segment

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/request/helper/ControllerRequestBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/request/helper/ControllerRequestBuilder.java
@@ -15,15 +15,15 @@
  */
 package com.linkedin.pinot.common.request.helper;
 
-import com.linkedin.pinot.common.config.Tenant;
-import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
-import com.linkedin.pinot.common.utils.TenantRole;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import com.linkedin.pinot.common.config.Tenant;
+import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
+import com.linkedin.pinot.common.utils.TenantRole;
 
 
 public class ControllerRequestBuilder {
@@ -99,16 +99,6 @@ public class ControllerRequestBuilder {
 
   public static JSONObject buildCreateRealtimeTableJSON(String tableName, String serverTenant, String brokerTenant,
       String timeColumnName, String timeType, String retentionTimeUnit, String retentionTimeValue, int numReplicas,
-      String segmentAssignmentStrategy, JSONObject streamConfigs, String schemaName, String sortedColumn)
-      throws JSONException {
-    List<String> invertedIndexColumns = Collections.emptyList();
-    return buildCreateRealtimeTableJSON(tableName, serverTenant, brokerTenant, timeColumnName, timeType, retentionTimeUnit,
-        retentionTimeValue, numReplicas, segmentAssignmentStrategy, streamConfigs, schemaName, sortedColumn,
-        invertedIndexColumns, null, true, null);
-  }
-
-  public static JSONObject buildCreateRealtimeTableJSON(String tableName, String serverTenant, String brokerTenant,
-      String timeColumnName, String timeType, String retentionTimeUnit, String retentionTimeValue, int numReplicas,
       String segmentAssignmentStrategy, JSONObject streamConfigs, String schemaName, String sortedColumn,
       List<String> invertedIndexColumns, String loadMode, boolean isHighLevel)
           throws JSONException {
@@ -124,7 +114,7 @@ public class ControllerRequestBuilder {
       throws JSONException {
     return buildCreateRealtimeTableJSON(tableName, serverTenant, brokerTenant, timeColumnName, timeType,
         retentionTimeUnit, retentionTimeValue, numReplicas, segmentAssignmentStrategy, streamConfigs, schemaName,
-        sortedColumn, invertedIndexColumns, loadMode, isHighLevel, null, null);
+        sortedColumn, invertedIndexColumns, loadMode, isHighLevel, noDictionaryColumns, null);
   }
 
   public static JSONObject buildCreateRealtimeTableJSON(String tableName, String serverTenant, String brokerTenant,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -15,6 +15,17 @@
  */
 package com.linkedin.pinot.core.data.manager.realtime;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.AbstractTableConfig;
 import com.linkedin.pinot.common.data.Schema;
@@ -39,17 +50,6 @@ import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimerTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class HLRealtimeSegmentDataManager extends SegmentDataManager {
@@ -169,7 +169,7 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
     realtimeSegment =
         new RealtimeSegmentImpl(schema, kafkaStreamProviderConfig.getSizeThresholdToFlushSegment(), tableName,
             segmentMetadata.getSegmentName(), kafkaStreamProviderConfig.getStreamName(), serverMetrics,
-            this.invertedIndexColumns, indexLoadingConfig.getRealtimeAvgMultiValueCount());
+            this.invertedIndexColumns, indexLoadingConfig.getRealtimeAvgMultiValueCount(), noDictionaryColumns);
     realtimeSegment.setSegmentMetadata(segmentMetadata, this.schema);
     notifier = realtimeTableDataManager;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -861,7 +861,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
     // Start new realtime segment
     _realtimeSegment = new RealtimeSegmentImpl(schema, _segmentMaxRowCount, tableConfig.getTableName(),
         segmentZKMetadata.getSegmentName(), _kafkaTopic, _serverMetrics, _invertedIndexColumns,
-        indexLoadingConfig.getRealtimeAvgMultiValueCount());
+        indexLoadingConfig.getRealtimeAvgMultiValueCount(), _noDictionaryColumns);
     _realtimeSegment.setSegmentMetadata(segmentZKMetadata, schema);
 
     // Create message decoder

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
@@ -250,9 +250,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
     if (readers.size() == 1) {
       readers.get(0).readValues(rows, rowStartPos, rowSize, values, valuesStartPos);
       return;
-    }
-    else
-    {
+    } else {
       for (int rowIter = rowStartPos, valueIter = valuesStartPos;
           rowIter < rowStartPos + rowSize;
           rowIter++, valueIter++) {
@@ -267,9 +265,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
     if (readers.size() == 1) {
       readers.get(0).readValues(rows, rowStartPos, rowSize, values, valuesStartPos);
       return;
-    }
-    else
-    {
+    } else {
       for (int rowIter = rowStartPos, valueIter = valuesStartPos;
           rowIter < rowStartPos + rowSize;
           rowIter++, valueIter++) {
@@ -284,9 +280,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
     if (readers.size() == 1) {
       readers.get(0).readValues(rows, rowStartPos, rowSize, values, valuesStartPos);
       return;
-    }
-    else
-    {
+    } else {
       for (int rowIter = rowStartPos, valueIter = valuesStartPos;
           rowIter < rowStartPos + rowSize;
           rowIter++, valueIter++) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
@@ -107,20 +107,8 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
       return reader.getShort(row - startRowId, 0);
     }
 
-    public void readValues(int[] rows, int rowStartPos, int rowSize, int[] values, int valuesStartPos) {
-      reader.readIntValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
-    }
-
-    public void readValues(int[] rows, int rowStartPos, int rowSize, long[] values, int valuesStartPos) {
-      reader.readLongValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
-    }
-
-    public void readValues(int[] rows, int rowStartPos, int rowSize, float[] values, int valuesStartPos) {
-      reader.readFloatValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
-    }
-
-    public void readValues(int[] rows, int rowStartPos, int rowSize, double[] values, int valuesStartPos) {
-      reader.readDoubleValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
+    public FixedByteSingleValueMultiColReader getReader() {
+      return reader;
     }
   }
 
@@ -248,7 +236,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
      * increase the number of rows.
      */
     if (readers.size() == 1) {
-      readers.get(0).readValues(rows, rowStartPos, rowSize, values, valuesStartPos);
+      readers.get(0).getReader().readIntValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
       return;
     } else {
       for (int rowIter = rowStartPos, valueIter = valuesStartPos;
@@ -263,7 +251,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
 
   public void readValues(int[] rows, int rowStartPos, int rowSize, long[] values, int valuesStartPos) {
     if (readers.size() == 1) {
-      readers.get(0).readValues(rows, rowStartPos, rowSize, values, valuesStartPos);
+      readers.get(0).getReader().readLongValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
       return;
     } else {
       for (int rowIter = rowStartPos, valueIter = valuesStartPos;
@@ -278,7 +266,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
 
   public void readValues(int[] rows, int rowStartPos, int rowSize, float[] values, int valuesStartPos) {
     if (readers.size() == 1) {
-      readers.get(0).readValues(rows, rowStartPos, rowSize, values, valuesStartPos);
+      readers.get(0).getReader().readFloatValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
       return;
     } else {
       for (int rowIter = rowStartPos, valueIter = valuesStartPos;
@@ -293,7 +281,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
 
   public void readValues(int[] rows, int rowStartPos, int rowSize, double[] values, int valuesStartPos) {
     if (readers.size() == 1) {
-      readers.get(0).readValues(rows, rowStartPos, rowSize, values, valuesStartPos);
+      readers.get(0).getReader().readDoubleValues(rows, 0, rowStartPos, rowSize, values, valuesStartPos);
       return;
     } else {
       for (int rowIter = rowStartPos, valueIter = valuesStartPos; rowIter < rowStartPos + rowSize;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.core.common.Block;
@@ -25,10 +26,10 @@ import com.linkedin.pinot.core.common.BlockMetadata;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.operator.docvalsets.RealtimeFixedWidthRawValueSet;
 import com.linkedin.pinot.core.operator.docvalsets.RealtimeSingleValueSet;
 import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class RealtimeSingleValueBlock implements Block {
@@ -71,6 +72,9 @@ public class RealtimeSingleValueBlock implements Block {
 
   @Override
   public BlockValSet getBlockValueSet() {
+    if (dictionary == null) {
+      return new RealtimeFixedWidthRawValueSet(reader, docIdSearchableOffset + 1, spec.getDataType(), spec.getName());
+    }
     return new RealtimeSingleValueSet(reader, docIdSearchableOffset + 1, spec.getDataType());
   }
 
@@ -118,7 +122,7 @@ public class RealtimeSingleValueBlock implements Block {
 
       @Override
       public boolean hasDictionary() {
-        return true;
+        return dictionary != null;
       }
 
       @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIterator.java
@@ -71,6 +71,36 @@ public final class RealtimeSingleValueIterator extends BlockSingleValIterator {
   }
 
   @Override
+  public long nextLongVal() {
+    if (!hasNext()) {
+      return Constants.EOF;
+    }
+
+    long ret = reader.getLong(counter);
+    return ret;
+  }
+
+  @Override
+  public float nextFloatVal() {
+    if (!hasNext()) {
+      return Constants.EOF;
+    }
+
+    float ret = reader.getFloat(counter);
+    return ret;
+  }
+
+  @Override
+  public double nextDoubleVal() {
+    if (!hasNext()) {
+      return Constants.EOF;
+    }
+
+    double ret = reader.getDouble(counter);
+    return ret;
+  }
+
+  @Override
   public boolean hasNext() {
     return (counter < max);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIterator.java
@@ -77,6 +77,7 @@ public final class RealtimeSingleValueIterator extends BlockSingleValIterator {
     }
 
     long ret = reader.getLong(counter);
+    counter++;
     return ret;
   }
 
@@ -87,6 +88,7 @@ public final class RealtimeSingleValueIterator extends BlockSingleValIterator {
     }
 
     float ret = reader.getFloat(counter);
+    counter++;
     return ret;
   }
 
@@ -97,6 +99,7 @@ public final class RealtimeSingleValueIterator extends BlockSingleValIterator {
     }
 
     double ret = reader.getDouble(counter);
+    counter++;
     return ret;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeFixedWidthRawValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeFixedWidthRawValueSet.java
@@ -40,7 +40,6 @@ public class RealtimeFixedWidthRawValueSet extends BaseBlockValSet {
 
   @Override
   public BlockValIterator iterator() {
-    // throw unimplemented?
     return new RealtimeSingleValueIterator(reader, length, dataType);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeFixedWidthRawValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/RealtimeFixedWidthRawValueSet.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.operator.docvalsets;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.BaseBlockValSet;
+import com.linkedin.pinot.core.common.BlockValIterator;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.operator.docvaliterators.RealtimeSingleValueIterator;
+
+
+public class RealtimeFixedWidthRawValueSet extends BaseBlockValSet {
+  private final FixedByteSingleColumnSingleValueReaderWriter reader;
+  private final int length;
+  private final FieldSpec.DataType dataType;
+  private final String columnName;
+
+  public RealtimeFixedWidthRawValueSet(FixedByteSingleColumnSingleValueReaderWriter reader, int length,
+      FieldSpec.DataType dataType, String columnName) {
+    super();
+    this.reader = reader;
+    this.length = length;
+    this.dataType = dataType;
+    this.columnName = columnName;
+  }
+
+  @Override
+  public BlockValIterator iterator() {
+    // throw unimplemented?
+    return new RealtimeSingleValueIterator(reader, length, dataType);
+  }
+
+  @Override
+  public FieldSpec.DataType getValueType() {
+    return dataType;
+  }
+
+  @Override
+  public void getIntValues(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outValues, int outStartPos) {
+    if (dataType.equals(FieldSpec.DataType.INT)) {
+      reader.readValues(inDocIds, inStartPos, inDocIdsSize, outValues, outStartPos);
+    } else {
+      throw new UnsupportedOperationException("Cannot fetch int values for column: " + columnName);
+    }
+  }
+
+  @Override
+  public void getLongValues(int[] inDocIds, int inStartPos, int inDocIdsSize, long[] outValues, int outStartPos) {
+    int endPos = inStartPos + inDocIdsSize;
+    int outPos = outStartPos;
+    switch (dataType) {
+      case INT:
+        for (int inPos = inStartPos; inPos < endPos; inPos++) {
+          outValues[outPos++] = reader.getInt(inDocIds[inPos]);
+        }
+        break;
+      case LONG:
+        reader.readValues(inDocIds, inStartPos, inDocIdsSize, outValues, outStartPos);
+        break;
+      default:
+        throw new UnsupportedOperationException("Cannot fetch long values for column: " + columnName);
+    }
+  }
+
+  @Override
+  public void getFloatValues(int[] inDocIds, int inStartPos, int inDocIdsSize, float[] outValues, int outStartPos) {
+    int endPos = inStartPos + inDocIdsSize;
+    int outPos = outStartPos;
+    switch (dataType) {
+      case INT:
+        for (int inPos = inStartPos; inPos < endPos; inPos++) {
+          outValues[outPos++] = reader.getInt(inDocIds[inPos]);
+        }
+        break;
+      case LONG:
+        for (int inPos = inStartPos; inPos < endPos; inPos++) {
+          outValues[outPos++] = reader.getLong(inDocIds[inPos]);
+        }
+        break;
+      case FLOAT:
+        reader.readValues(inDocIds, inStartPos, inDocIdsSize, outValues, outStartPos);
+        break;
+      default:
+        throw new UnsupportedOperationException("Cannot fetch float values for column: " + columnName);
+    }
+  }
+
+  @Override
+  public void getDoubleValues(int[] inDocIds, int inStartPos, int inDocIdsSize, double[] outValues, int outStartPos) {
+    int endPos = inStartPos + inDocIdsSize;
+    int outPos = outStartPos;
+    switch (dataType) {
+      case INT:
+        for (int inPos = inStartPos; inPos < endPos; inPos++) {
+          outValues[outPos++] = reader.getInt(inDocIds[inPos]);
+        }
+        break;
+      case LONG:
+        for (int inPos = inStartPos; inPos < endPos; inPos++) {
+          outValues[outPos++] = reader.getLong(inDocIds[inPos]);
+        }
+        break;
+      case FLOAT:
+        for (int inPos = inStartPos; inPos < endPos; inPos++) {
+          outValues[outPos++] = reader.getFloat(inDocIds[inPos]);
+        }
+        break;
+      case DOUBLE:
+        reader.readValues(inDocIds, inStartPos, inDocIdsSize, outValues, outStartPos);
+        break;
+      default:
+        throw new UnsupportedOperationException("Cannot fetch double values for column: " + columnName);
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
@@ -15,6 +15,11 @@
  */
 package com.linkedin.pinot.core.realtime.converter.stats;
 
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang.math.IntRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.config.ColumnPartitionConfig;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.Block;
@@ -26,15 +31,11 @@ import com.linkedin.pinot.core.operator.blocks.RealtimeSingleValueBlock;
 import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
 import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
-import java.util.Arrays;
-import java.util.List;
-import org.apache.commons.lang.math.IntRange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Column statistics for a column coming from an in-memory realtime segment.
+ * TODO Fix this class after we re-factor segment generation code to get some of the stats later on while going through the values
  */
 public class RealtimeColumnStatistics implements ColumnStatistics {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeColumnStatistics.class);
@@ -67,21 +68,64 @@ public class RealtimeColumnStatistics implements ColumnStatistics {
 
   @Override
   public Object getMinValue() {
+    if (_dictionaryReader == null) {
+      switch (_dataSource.getDataSourceMetadata().getDataType()) {
+        case LONG:
+          return Long.MIN_VALUE;
+        case FLOAT:
+          return Float.MIN_VALUE;
+        case DOUBLE:
+          return Double.MIN_VALUE;
+        case INT:
+        default:
+          return Integer.MIN_VALUE;
+      }
+    }
     return _dictionaryReader.getMinVal();
   }
 
   @Override
   public Object getMaxValue() {
+    if (_dictionaryReader == null) {
+      switch (_dataSource.getDataSourceMetadata().getDataType()) {
+        case LONG:
+          return Long.MAX_VALUE;
+        case FLOAT:
+          return Float.MAX_VALUE;
+        case DOUBLE:
+          return Double.MAX_VALUE;
+        case INT:
+        default:
+          return Integer.MAX_VALUE;
+      }
+    }
     return _dictionaryReader.getMaxVal();
   }
 
   @Override
   public Object getUniqueValuesSet() {
+    if (_dictionaryReader == null) {
+      switch (_dataSource.getDataSourceMetadata().getDataType()) {
+        case LONG:
+          return new long[]{Long.MAX_VALUE};
+        case FLOAT:
+          return new float[]{Float.MAX_VALUE};
+        case DOUBLE:
+          return new double[]{Double.MAX_VALUE};
+        case INT:
+          return new int[]{Integer.MAX_VALUE};
+        default:
+          return new String[]{""};
+      }
+    }
     return _dictionaryReader.getSortedValues();
   }
 
   @Override
   public int getCardinality() {
+    if (_dictionaryReader == null) {
+      return 0;
+    }
     return _dictionaryReader.length();
   }
 
@@ -103,6 +147,9 @@ public class RealtimeColumnStatistics implements ColumnStatistics {
 
   @Override
   public boolean isSorted() {
+    if (_dictionaryReader == null) {
+      return false;
+    }
     // Multivalue columns can't be in sorted order
     if (!_block.getMetadata().isSingleValue()) {
       return false;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -97,7 +97,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   private final String tableAndStreamName;
   private StarTreeIndexSpec starTreeIndexSpec = null;
   private SegmentPartitionConfig segmentPartitionConfig = null;
-  private final List<String> noDictionaryColumns;
+  private final List<String> consumingNoDictionaryColumns = new ArrayList<>();
 
   // TODO Dynamcally adjust these variables, maybe on a per column basis
 
@@ -118,7 +118,11 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     maxNumberOfMultivaluesMap = new HashMap<String, Integer>();
     outgoingTimeColumnName = dataSchema.getTimeFieldSpec().getOutgoingTimeColumnName();
 
-    this.noDictionaryColumns = noDictionaryColumns;
+    for (final String column : noDictionaryColumns) {
+      if (canBeNoDictionaryColumnInConsumingSegment(column, invertedIndexColumns)) {
+        consumingNoDictionaryColumns.add(column);
+      }
+    }
     this.capacity = capacity;
 
     for (FieldSpec col : dataSchema.getAllFieldSpecs()) {
@@ -134,7 +138,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
         dataSchema.getFieldSpecFor(outgoingTimeColumnName).getDataType()));
 
     for (String metric : dataSchema.getMetricNames()) {
-      if (!isNoDictionaryFixedWidthColumn(metric)) {
+      if (!consumingNoDictionaryColumns.contains(metric)) {
         dictionaryMap.put(metric, MutableDictionaryFactory.getMutableDictionary(dataSchema.getFieldSpecFor(metric).getDataType()));
       }
     }
@@ -155,12 +159,12 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       }
       if (schema.getFieldSpecFor(dimension).isSingleValueField()) {
         columnIndexReaderWriterMap.put(dimension,
-            new FixedByteSingleColumnSingleValueReaderWriter(capacity, Integer.SIZE/8));
+            new FixedByteSingleColumnSingleValueReaderWriter(capacity, V1Constants.Numbers.INTEGER_SIZE));
       } else {
         // TODO Start with a smaller capacity on FixedByteSingleColumnMultiValueReaderWriter and let it expand
         columnIndexReaderWriterMap.put(dimension,
             new FixedByteSingleColumnMultiValueReaderWriter(MAX_MULTI_VALUES_PER_ROW, avgMultiValueCount,
-                capacity, Integer.SIZE/8));
+                capacity, V1Constants.Numbers.INTEGER_SIZE));
       }
     }
 
@@ -168,8 +172,8 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       if (invertedIndexColumns.contains(metric)) {
         invertedIndexMap.put(metric, new MetricInvertedIndex(metric));
       }
-      int colSize = Integer.SIZE/8;
-      if (isNoDictionaryFixedWidthColumn(metric)) {
+      int colSize = V1Constants.Numbers.INTEGER_SIZE;
+      if (consumingNoDictionaryColumns.contains(metric)) {
         colSize = getColWidth(schema.getFieldSpecFor(metric).getDataType());
       }
       columnIndexReaderWriterMap.put(metric,
@@ -180,9 +184,31 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       invertedIndexMap.put(outgoingTimeColumnName, new TimeInvertedIndex(outgoingTimeColumnName));
     }
     columnIndexReaderWriterMap.put(outgoingTimeColumnName,
-        new FixedByteSingleColumnSingleValueReaderWriter(capacity, Integer.SIZE/8));
+        new FixedByteSingleColumnSingleValueReaderWriter(capacity, V1Constants.Numbers.INTEGER_SIZE));
 
     tableAndStreamName = tableName + "-" + streamName;
+  }
+
+  private boolean canBeNoDictionaryColumnInConsumingSegment(final String column,
+      final List<String> invertedIndexColumns) {
+    if (invertedIndexColumns.contains(column)) {
+      return false;
+    }
+    FieldSpec fieldSpec = dataSchema.getFieldSpecFor(column);
+    FieldSpec.DataType dataType = fieldSpec.getDataType();
+    // For now, we only support metric columns in consuming segment
+    if (!fieldSpec.getFieldType().equals(FieldType.METRIC)) {
+      return false;
+    }
+    switch (dataType) {
+      case INT:
+      case LONG:
+      case DOUBLE:
+      case FLOAT:
+        return true;
+      default:
+        return false;
+    }
   }
 
   private int getColWidth(FieldSpec.DataType dataType) {
@@ -197,42 +223,6 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
         return V1Constants.Numbers.DOUBLE_SIZE;
       default:
         throw new UnsupportedOperationException("Unknown width for datatype " + dataType.toString());
-    }
-  }
-
-  /*
-   * TODO Decide on a mechanism to indicate which columns are no dictionary.
-   * Options are:
-   * - Include metrics in the noDictionary column list
-   *   (con: when schema changes, we need to remember to add new columns to no-dictionary list)
-   * - Introduce a new flag in table config to disable dictionary for all metrics.
-   *   (con: a new config variable)
-   * TODO: In either case we also need to make changes to handle SV float/int/long/double dimensions for no-dict as well.
-   */
-  private boolean isNoDictionaryFixedWidthColumn(String columnName) {
-    return false;
-    /*
-     * TODO Uncomment this line after segment generation for no dictionary columns is implemented.
-    if (!isNoDictionarySupportedForColumn(columnName)) {
-      return false;
-    }
-    if (noDictionaryColumns.contains(columnName)) {
-      return true;
-    }
-    return false;
-    */
-  }
-
-  private boolean isNoDictionarySupportedForColumn(String columnName) {
-    FieldSpec.DataType dataType = dataSchema.getFieldSpecFor(columnName).getDataType();
-    switch (dataType) {
-      case INT:
-      case LONG:
-      case DOUBLE:
-      case FLOAT:
-        return true;
-      default:
-        return false;
     }
   }
 
@@ -309,7 +299,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     }
 
     for (String metric : dataSchema.getMetricNames()) {
-      if (!isNoDictionaryFixedWidthColumn(metric)) {
+      if (!consumingNoDictionaryColumns.contains(metric)) {
         dictionaryMap.get(metric).index(row.getValue(metric));
       }
     }
@@ -363,7 +353,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     for (String metric : dataSchema.getMetricNames()) {
       FixedByteSingleColumnSingleValueReaderWriter readerWriter =
           (FixedByteSingleColumnSingleValueReaderWriter) columnIndexReaderWriterMap.get(metric);
-      if (isNoDictionaryFixedWidthColumn(metric)) {
+      if (consumingNoDictionaryColumns.contains(metric)) {
         switch (dataSchema.getFieldSpecFor(metric).getDataType()) {
           case SHORT:
             readerWriter.setShort(docId, (short)row.getValue(metric));
@@ -481,6 +471,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     throw new UnsupportedOperationException("Not support method: getRecordReader() in RealtimeSegmentImpl");
   }
 
+  // Called only by realtime record reader
   @Override
   public int getAggregateDocumentCount() {
     return docIdGenerator.get() + 1;
@@ -634,6 +625,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
 
   /**
    * Returns the docIds to use for iteration when the data is sorted by <code>columnToSortOn</code>
+   * Called only by realtime record reader
    * @param columnToSortOn The column to use for sorting
    * @return The docIds to use for iteration
    */
@@ -681,6 +673,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     return docIds;
   }
 
+  // Called by record reader.
   @Override
   public GenericRow getRawValueRowAt(int docId, GenericRow row) {
     for (String dimension : dataSchema.getDimensionNames()) {
@@ -703,27 +696,53 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     }
 
     for (String metric : dataSchema.getMetricNames()) {
-      final int dicId =
-          ((FixedByteSingleColumnSingleValueReaderWriter) columnIndexReaderWriterMap.get(metric)).getInt(docId);
-      switch (dataSchema.getFieldSpecFor(metric).getDataType()) {
-        case INT:
-          int intValue = dictionaryMap.get(metric).getIntValue(dicId);
-          row.putField(metric, intValue);
-          break;
-        case FLOAT:
-          float floatValue = dictionaryMap.get(metric).getFloatValue(dicId);
-          row.putField(metric, floatValue);
-          break;
-        case LONG:
-          long longValue = dictionaryMap.get(metric).getLongValue(dicId);
-          row.putField(metric, longValue);
-          break;
-        case DOUBLE:
-          double doubleValue = dictionaryMap.get(metric).getDoubleValue(dicId);
-          row.putField(metric, doubleValue);
-          break;
-        default:
-          throw new UnsupportedOperationException("unsopported metric data type");
+      final FieldSpec.DataType dataType = dataSchema.getFieldSpecFor(metric).getDataType();
+      if (consumingNoDictionaryColumns.contains(metric)) {
+        switch (dataType) {
+          case INT:
+            int intValue = ((FixedByteSingleColumnSingleValueReaderWriter)columnIndexReaderWriterMap.get(metric)).getInt(docId);
+            row.putField(metric, intValue);
+            break;
+          case LONG:
+            long longValue = ((FixedByteSingleColumnSingleValueReaderWriter)columnIndexReaderWriterMap.get(metric)).getLong(
+                docId);
+            row.putField(metric, longValue);
+            break;
+          case FLOAT:
+            float floatValue = ((FixedByteSingleColumnSingleValueReaderWriter)columnIndexReaderWriterMap.get(metric)).getFloat(
+                docId);
+            row.putField(metric, floatValue);
+            break;
+          case DOUBLE:
+            double doubleValue = ((FixedByteSingleColumnSingleValueReaderWriter)columnIndexReaderWriterMap.get(metric)).getDouble(
+                docId);
+            row.putField(metric, doubleValue);
+            break;
+          default:
+            throw new UnsupportedOperationException("unsopported metric data type");
+        }
+      } else {
+        final int dicId = ((FixedByteSingleColumnSingleValueReaderWriter) columnIndexReaderWriterMap.get(metric)).getInt(docId);
+        switch (dataType) {
+          case INT:
+            int intValue = dictionaryMap.get(metric).getIntValue(dicId);
+            row.putField(metric, intValue);
+            break;
+          case FLOAT:
+            float floatValue = dictionaryMap.get(metric).getFloatValue(dicId);
+            row.putField(metric, floatValue);
+            break;
+          case LONG:
+            long longValue = dictionaryMap.get(metric).getLongValue(dicId);
+            row.putField(metric, longValue);
+            break;
+          case DOUBLE:
+            double doubleValue = dictionaryMap.get(metric).getDoubleValue(dicId);
+            row.putField(metric, doubleValue);
+            break;
+          default:
+            throw new UnsupportedOperationException("unsopported metric data type");
+        }
       }
     }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -56,6 +56,7 @@ import com.linkedin.pinot.core.realtime.impl.invertedIndex.DimensionInvertertedI
 import com.linkedin.pinot.core.realtime.impl.invertedIndex.MetricInvertedIndex;
 import com.linkedin.pinot.core.realtime.impl.invertedIndex.RealtimeInvertedIndex;
 import com.linkedin.pinot.core.realtime.impl.invertedIndex.TimeInvertedIndex;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.startree.StarTree;
 
@@ -186,16 +187,14 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
 
   private int getColWidth(FieldSpec.DataType dataType) {
     switch (dataType) {
-      case SHORT:
-        return Short.SIZE/8;
       case INT:
-        return Integer.SIZE/8;
+        return V1Constants.Numbers.INTEGER_SIZE;
       case LONG:
-        return Long.SIZE/8;
+        return V1Constants.Numbers.LONG_SIZE;
       case FLOAT:
-        return Float.SIZE/8;
+        return V1Constants.Numbers.FLOAT_SIZE;
       case DOUBLE:
-        return Double.SIZE/8;
+        return V1Constants.Numbers.DOUBLE_SIZE;
       default:
         throw new UnsupportedOperationException("Unknown width for datatype " + dataType.toString());
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/RealtimeNoDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/RealtimeNoDictionaryTest.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.common;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.operator.BaseOperator;
+import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
+
+
+public class RealtimeNoDictionaryTest {
+  private static final String INT_COL_NAME = "intcol";
+  private static final String LONG_COL_NAME = "longcol";
+  private static final String FLOAT_COL_NAME = "floatcol";
+  private static final String DOUBLE_COL_NAME = "doublecol";
+  private static final int NUM_ROWS = 1000;
+  private int[] _intVals = new int[NUM_ROWS];
+  private long[] _longVals = new long[NUM_ROWS];
+  private float[] _floatVals = new float[NUM_ROWS];
+  private double[] _doubleVals = new double[NUM_ROWS];
+  private Random _random;
+
+  private DataFetcher makeDataFetcher(long seed) {
+    FieldSpec intSpec = new MetricFieldSpec(INT_COL_NAME, FieldSpec.DataType.INT);
+    FieldSpec longSpec = new MetricFieldSpec(LONG_COL_NAME, FieldSpec.DataType.LONG);
+    FieldSpec floatSpec = new MetricFieldSpec(FLOAT_COL_NAME, FieldSpec.DataType.FLOAT);
+    FieldSpec doubleSpec = new MetricFieldSpec(DOUBLE_COL_NAME, FieldSpec.DataType.DOUBLE);
+    _random = new Random(seed);
+
+    FixedByteSingleColumnSingleValueReaderWriter intRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
+        _random.nextInt(NUM_ROWS)+1, Integer.SIZE/8);
+    FixedByteSingleColumnSingleValueReaderWriter longRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
+        _random.nextInt(NUM_ROWS)+1, Long.SIZE/8);
+    FixedByteSingleColumnSingleValueReaderWriter floatRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
+        _random.nextInt(NUM_ROWS)+1, Float.SIZE/8);
+    FixedByteSingleColumnSingleValueReaderWriter doubleRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
+        _random.nextInt(NUM_ROWS)+1, Double.SIZE/8);
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      _intVals[i] = _random.nextInt();
+      intRawIndex.setInt(i, _intVals[i]);
+      _longVals[i]  = _random.nextLong();
+      longRawIndex.setLong(i, _longVals[i]);
+      _floatVals[i] = _random.nextFloat();
+      floatRawIndex.setFloat(i, _floatVals[i]);
+      _doubleVals[i] = _random.nextDouble();
+      doubleRawIndex.setDouble(i, _doubleVals[i]);
+    }
+
+    Map<String, BaseOperator> dataSourceBlock = new HashMap<>();
+    RealtimeColumnDataSource dataSource;
+
+    dataSource = new RealtimeColumnDataSource(intSpec, intRawIndex, null, NUM_ROWS-1, -1, null, null);
+    dataSourceBlock.put(INT_COL_NAME, dataSource);
+
+    dataSource = new RealtimeColumnDataSource(longSpec, longRawIndex, null, NUM_ROWS-1, -1, null, null);
+    dataSourceBlock.put(LONG_COL_NAME, dataSource);
+
+    dataSource = new RealtimeColumnDataSource(floatSpec, floatRawIndex, null, NUM_ROWS-1, -1, null, null);
+    dataSourceBlock.put(FLOAT_COL_NAME, dataSource);
+
+    dataSource = new RealtimeColumnDataSource(doubleSpec, doubleRawIndex, null, NUM_ROWS-1, -1, null, null);
+    dataSourceBlock.put(DOUBLE_COL_NAME, dataSource);
+
+    return new DataFetcher(dataSourceBlock);
+  }
+
+  @Test
+  public void testIntColumn() throws Exception {
+    final long seed = new Random().nextLong();
+    DataFetcher dataFetcher = makeDataFetcher(seed);
+    int[] docIds = new int[NUM_ROWS];
+    final int startIndex = _random.nextInt(NUM_ROWS);
+    final int numDocIds = _random.nextInt(NUM_ROWS-startIndex) + 1;
+    for (int i = 0; i < numDocIds; i++) {
+      docIds[i+startIndex] = _random.nextInt(NUM_ROWS);
+    }
+    try {
+      int valStart = _random.nextInt(NUM_ROWS-numDocIds);
+      int[] intValues = new int[NUM_ROWS];
+      dataFetcher.fetchIntValues(INT_COL_NAME, docIds, startIndex, numDocIds, intValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(intValues[valStart + i], _intVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+      valStart = _random.nextInt(NUM_ROWS-numDocIds);
+      long[] longValues = new long[NUM_ROWS];
+      dataFetcher.fetchLongValues(INT_COL_NAME, docIds, startIndex, numDocIds, longValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(longValues[valStart + i], _intVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+      valStart = _random.nextInt(NUM_ROWS-numDocIds);
+      float[] floatValues = new float[NUM_ROWS];
+      dataFetcher.fetchFloatValues(INT_COL_NAME, docIds, startIndex, numDocIds, floatValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(floatValues[valStart + i], (float)_intVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+      valStart = _random.nextInt(NUM_ROWS-numDocIds);
+      double[] doubleValues = new double[NUM_ROWS];
+      dataFetcher.fetchDoubleValues(INT_COL_NAME, docIds, startIndex, numDocIds, doubleValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(doubleValues[valStart + i], (double)_intVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+    } catch (Throwable t) {
+      t.printStackTrace();
+      Assert.fail("Failed with seed " + seed);
+    }
+  }
+
+  @Test
+  public void testLongValues() throws Exception {
+    final long seed = new Random().nextLong();
+    DataFetcher dataFetcher = makeDataFetcher(seed);
+    int[] docIds = new int[NUM_ROWS];
+    final int startIndex = _random.nextInt(NUM_ROWS);
+    final int numDocIds = _random.nextInt(NUM_ROWS-startIndex) + 1;
+    for (int i = 0; i < numDocIds; i++) {
+      docIds[i+startIndex] = _random.nextInt(NUM_ROWS);
+    }
+    final int valStart = _random.nextInt(NUM_ROWS-numDocIds);
+    try {
+      try {
+        int[] intValues = new int[NUM_ROWS];
+        dataFetcher.fetchIntValues(LONG_COL_NAME, docIds, startIndex, numDocIds, intValues, valStart);
+        Assert.fail("Expected exception converting long to int");
+      } catch (UnsupportedOperationException e) {
+        // We should see an exception
+      }
+
+      long[] longValues = new long[NUM_ROWS];
+      dataFetcher.fetchLongValues(LONG_COL_NAME, docIds, startIndex, numDocIds, longValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(longValues[valStart + i], _longVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+      float[] floatValues = new float[NUM_ROWS];
+      dataFetcher.fetchFloatValues(LONG_COL_NAME, docIds, startIndex, numDocIds, floatValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(floatValues[valStart + i], (float)_longVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+      double[] doubleValues = new double[NUM_ROWS];
+      dataFetcher.fetchDoubleValues(LONG_COL_NAME, docIds, startIndex, numDocIds, doubleValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(doubleValues[valStart + i], (double)_longVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+    } catch (Throwable t) {
+      t.printStackTrace();
+      Assert.fail("Failed with seed " + seed);
+    }
+  }
+
+  @Test
+  public void testFloatValues() throws Exception {
+    final long seed = new Random().nextLong();
+    DataFetcher dataFetcher = makeDataFetcher(seed);
+    int[] docIds = new int[NUM_ROWS];
+    final int startIndex = _random.nextInt(NUM_ROWS);
+    final int numDocIds = _random.nextInt(NUM_ROWS-startIndex) + 1;
+    for (int i = 0; i < numDocIds; i++) {
+      docIds[i+startIndex] = _random.nextInt(NUM_ROWS);
+    }
+    final int valStart = _random.nextInt(NUM_ROWS-numDocIds);
+    try {
+      try {
+        int[] intValues = new int[NUM_ROWS];
+        dataFetcher.fetchIntValues(FLOAT_COL_NAME, docIds, startIndex, numDocIds, intValues, valStart);
+        Assert.fail("Expected exception converting float to int");
+      } catch (UnsupportedOperationException e) {
+        // We should see an exception
+      }
+
+      long[] longValues = new long[NUM_ROWS];
+      try {
+        dataFetcher.fetchLongValues(FLOAT_COL_NAME, docIds, startIndex, numDocIds, longValues, valStart);
+        Assert.fail("Expected exception converting float to long");
+      } catch (UnsupportedOperationException e) {
+        // We should see an exception
+      }
+
+      float[] floatValues = new float[NUM_ROWS];
+      dataFetcher.fetchFloatValues(FLOAT_COL_NAME, docIds, startIndex, numDocIds, floatValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(floatValues[valStart + i], _floatVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+      double[] doubleValues = new double[NUM_ROWS];
+      dataFetcher.fetchDoubleValues(FLOAT_COL_NAME, docIds, startIndex, numDocIds, doubleValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(doubleValues[valStart + i], (double)_floatVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+    } catch (Throwable t) {
+      t.printStackTrace();
+      Assert.fail("Failed with seed " + seed);
+    }
+  }
+
+  @Test
+  public void testDoubleValues() throws Exception {
+    final long seed = new Random().nextLong();
+    DataFetcher dataFetcher = makeDataFetcher(seed);
+    int[] docIds = new int[NUM_ROWS];
+    final int startIndex = _random.nextInt(NUM_ROWS);
+    final int numDocIds = _random.nextInt(NUM_ROWS-startIndex) + 1;
+    for (int i = 0; i < numDocIds; i++) {
+      docIds[i+startIndex] = _random.nextInt(NUM_ROWS);
+    }
+    final int valStart = _random.nextInt(NUM_ROWS-numDocIds);
+    try {
+      try {
+        int[] intValues = new int[NUM_ROWS];
+        dataFetcher.fetchIntValues(DOUBLE_COL_NAME, docIds, startIndex, numDocIds, intValues, valStart);
+        Assert.fail("Expected exception converting double to int");
+      } catch (UnsupportedOperationException e) {
+        // We should see an exception
+      }
+
+      long[] longValues = new long[NUM_ROWS];
+      try {
+        dataFetcher.fetchLongValues(DOUBLE_COL_NAME, docIds, startIndex, numDocIds, longValues, valStart);
+        Assert.fail("Expected exception converting double to long");
+      } catch (UnsupportedOperationException e) {
+        // We should see an exception
+      }
+
+      float[] floatValues = new float[NUM_ROWS];
+      try {
+        dataFetcher.fetchFloatValues(DOUBLE_COL_NAME, docIds, startIndex, numDocIds, floatValues, valStart);
+        Assert.fail("Expected exception converting double to float");
+      } catch (UnsupportedOperationException e) {
+        // We should see an exception
+      }
+
+      double[] doubleValues = new double[NUM_ROWS];
+      dataFetcher.fetchDoubleValues(DOUBLE_COL_NAME, docIds, startIndex, numDocIds, doubleValues, valStart);
+      for (int i = 0; i < numDocIds; i++) {
+        Assert.assertEquals(doubleValues[valStart + i], (double)_doubleVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+      }
+
+    } catch (Throwable t) {
+      t.printStackTrace();
+      Assert.fail("Failed with seed " + seed);
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.operator.docvaliterators;
+
+import java.util.Random;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.common.Constants;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+
+
+public class RealtimeSingleValueIteratorTest {
+  private static final int NUM_ROWS = 1000;
+  private int[] _intVals = new int[NUM_ROWS];
+  private long[] _longVals = new long[NUM_ROWS];
+  private float[] _floatVals = new float[NUM_ROWS];
+  private double[] _doubleVals = new double[NUM_ROWS];
+  FixedByteSingleColumnSingleValueReaderWriter _intReader;
+  FixedByteSingleColumnSingleValueReaderWriter _longReader;
+  FixedByteSingleColumnSingleValueReaderWriter _floatReader;
+  FixedByteSingleColumnSingleValueReaderWriter _doubleReader;
+  private Random _random;
+  private long _seed;
+
+  @BeforeClass
+  public void initData() {
+    final long _seed = new Random().nextLong();
+    _random = new Random(_seed);
+    _intReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.INTEGER_SIZE);
+    _longReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.LONG_SIZE);
+    _floatReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.FLOAT_SIZE);
+    _doubleReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.DOUBLE_SIZE);
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      _intVals[i] = _random.nextInt();
+      _intReader.setInt(i, _intVals[i]);
+      _longVals[i]  = _random.nextLong();
+      _longReader.setLong(i, _longVals[i]);
+      _floatVals[i] = _random.nextFloat();
+      _floatReader.setFloat(i, _floatVals[i]);
+      _doubleVals[i] = _random.nextDouble();
+      _doubleReader.setDouble(i, _doubleVals[i]);
+    }
+  }
+
+
+  @Test
+  public void testIntReader() throws Exception {
+    try {
+      RealtimeSingleValueIterator iterator = new RealtimeSingleValueIterator(_intReader, NUM_ROWS, FieldSpec.DataType.INT);
+      // Test all values
+      iterator.reset();
+      for (int i = 0; i < NUM_ROWS; i++) {
+        Assert.assertEquals(iterator.nextIntVal(), _intVals[i], " at row " + i);
+      }
+      Assert.assertEquals(iterator.nextIntVal(), Constants.EOF);
+
+      final int startDocId = _random.nextInt(NUM_ROWS);
+      iterator.skipTo(startDocId);
+      for (int i = startDocId; i < NUM_ROWS; i++) {
+        Assert.assertEquals(iterator.nextIntVal(), _intVals[i], " at row " + i);
+      }
+      Assert.assertEquals(iterator.nextIntVal(), Constants.EOF);
+    } catch (Throwable t) {
+      t.printStackTrace();
+      Assert.fail("Failed with seed " + _seed);
+    }
+  }
+
+  @Test
+  public void testLongReader() throws Exception {
+    try {
+      RealtimeSingleValueIterator iterator = new RealtimeSingleValueIterator(_longReader, NUM_ROWS, FieldSpec.DataType.LONG);
+      // Test all values
+      iterator.reset();
+      for (int i = 0; i < NUM_ROWS; i++) {
+        Assert.assertEquals(iterator.nextLongVal(), _longVals[i], " at row " + i);
+      }
+      Assert.assertEquals(iterator.nextLongVal(), (long)Constants.EOF);
+
+      final int startDocId = _random.nextInt(NUM_ROWS);
+      iterator.skipTo(startDocId);
+      for (int i = startDocId; i < NUM_ROWS; i++) {
+        Assert.assertEquals(iterator.nextLongVal(), _longVals[i], " at row " + i);
+      }
+      Assert.assertEquals(iterator.nextLongVal(), (long)Constants.EOF);
+    } catch (Throwable t) {
+      t.printStackTrace();
+      Assert.fail("Failed with seed " + _seed);
+    }
+  }
+
+  @Test
+  public void testFloatReader() throws Exception {
+    try {
+      RealtimeSingleValueIterator iterator = new RealtimeSingleValueIterator(_floatReader, NUM_ROWS, FieldSpec.DataType.FLOAT);
+      // Test all values
+      iterator.reset();
+      for (int i = 0; i < NUM_ROWS; i++) {
+        Assert.assertEquals(iterator.nextFloatVal(), _floatVals[i], " at row " + i);
+      }
+      Assert.assertEquals(iterator.nextFloatVal(), (float) Constants.EOF);
+
+      final int startDocId = _random.nextInt(NUM_ROWS);
+      iterator.skipTo(startDocId);
+      for (int i = startDocId; i < NUM_ROWS; i++) {
+        Assert.assertEquals(iterator.nextFloatVal(), _floatVals[i], " at row " + i);
+      }
+      Assert.assertEquals(iterator.nextFloatVal(), (float) Constants.EOF);
+    } catch (Throwable t) {
+      t.printStackTrace();
+      Assert.fail("Failed with seed " + _seed);
+    }
+  }
+
+    @Test
+    public void testDoubleReader() throws Exception {
+      try {
+        RealtimeSingleValueIterator iterator = new RealtimeSingleValueIterator(_doubleReader, NUM_ROWS, FieldSpec.DataType.DOUBLE);
+        // Test all values
+        iterator.reset();
+        for (int i = 0; i < NUM_ROWS; i++) {
+          Assert.assertEquals(iterator.nextDoubleVal(), _doubleVals[i], " at row " + i);
+        }
+        Assert.assertEquals(iterator.nextDoubleVal(), (double)Constants.EOF);
+
+        final int startDocId = _random.nextInt(NUM_ROWS);
+        iterator.skipTo(startDocId);
+        for (int i = startDocId; i < NUM_ROWS; i++) {
+          Assert.assertEquals(iterator.nextDoubleVal(), _doubleVals[i], " at row " + i);
+        }
+        Assert.assertEquals(iterator.nextDoubleVal(), (double)Constants.EOF);
+      } catch (Throwable t) {
+        t.printStackTrace();
+        Assert.fail("Failed with seed " + _seed);
+      }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (C) 2014-2015 LinkedIn Corp. (pinot-core@linkedin.com)
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -87,7 +87,7 @@ public class RealtimeSegmentTest {
     List<String> invertedIdxCols = new ArrayList<>();
     invertedIdxCols.add("count");
     segmentWithInvIdx = new RealtimeSegmentImpl(schema, 100000, tableName, "noSegment", AVRO_DATA, new ServerMetrics(new MetricsRegistry()),
-        invertedIdxCols, 2);
+        invertedIdxCols, 2, new ArrayList<String>());
     segmentWithoutInvIdx = RealtimeSegmentImplTest.createRealtimeSegmentImpl(schema, 100000, tableName, "noSegment",
         AVRO_DATA, new ServerMetrics(new MetricsRegistry()));
     GenericRow row = provider.next(new GenericRow());

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
@@ -37,7 +37,7 @@ public class RealtimeSegmentImplTest {
   public static RealtimeSegmentImpl createRealtimeSegmentImpl(Schema schema, int sizeThresholdToFlushSegment, String tableName, String segmentName, String streamName,
       ServerMetrics serverMetrics) throws IOException {
     return new RealtimeSegmentImpl(schema, sizeThresholdToFlushSegment, tableName, segmentName, streamName, serverMetrics, new ArrayList<String>(),
-        2);
+        2, new ArrayList<String>());
   }
   @Test
   public void testDropInvalidRows() throws Exception {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -328,7 +328,8 @@ public abstract class ClusterTest extends ControllerTest {
 
   protected void addHybridTable(String tableName, String timeColumnName, String timeColumnType, String kafkaZkUrl,
       String kafkaTopic, String schemaName, String serverTenant, String brokerTenant, File avroFile,
-      String sortedColumn, List<String> invertedIndexColumns, String loadMode, boolean useLlc) throws Exception {
+      String sortedColumn, List<String> invertedIndexColumns, String loadMode, boolean useLlc,
+      List<String> noDictionaryColumns) throws Exception {
     int retentionDays = -1;
     String retentionTimeUnit = "";
     if (useLlc) {
@@ -338,7 +339,7 @@ public abstract class ClusterTest extends ControllerTest {
     } else {
       addRealtimeTable(tableName, timeColumnName, timeColumnType, retentionDays, retentionTimeUnit, kafkaZkUrl,
           kafkaTopic, schemaName, serverTenant, brokerTenant, avroFile, getRealtimeSegmentFlushSize(useLlc),
-          sortedColumn, invertedIndexColumns, loadMode, null);
+          sortedColumn, invertedIndexColumns, loadMode, noDictionaryColumns);
     }
     addOfflineTable(timeColumnName, timeColumnType, retentionDays, retentionTimeUnit, brokerTenant, serverTenant,
         invertedIndexColumns, loadMode, tableName, SegmentVersion.v1);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -15,21 +15,11 @@
  */
 package com.linkedin.pinot.integration.tests;
 
-import com.google.common.base.Function;
-import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.FileUploadUtils;
-import com.linkedin.pinot.common.utils.KafkaStarterUtils;
-import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.controller.ControllerConf;
-import com.linkedin.pinot.controller.helix.ControllerTestUtils;
-import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -38,7 +28,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import kafka.server.KafkaServerStartable;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.ExternalViewChangeListener;
 import org.apache.helix.HelixManagerFactory;
@@ -52,6 +41,18 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import com.google.common.base.Function;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.KafkaStarterUtils;
+import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.helix.ControllerTestUtils;
+import com.linkedin.pinot.util.TestUtils;
+import kafka.server.KafkaServerStartable;
 
 
 /**
@@ -124,11 +125,12 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestWith
     addSchema(schemaFile, schema.getSchemaName());
     final List<String> invertedIndexColumns = makeInvertedIndexColumns();
     final String sortedColumn = makeSortedColumn();
+    List<String> noDictionaryColumns = Arrays.asList("NASDelay", "ArrDelayMinutes", "DepDelayMinutes");
 
     // Create Pinot table
     addHybridTable(tableName, "DaysSinceEpoch", "daysSinceEpoch", KafkaStarterUtils.DEFAULT_ZK_STR, KAFKA_TOPIC,
         schema.getSchemaName(), TENANT_NAME, TENANT_NAME, avroFiles.get(0), sortedColumn, invertedIndexColumns, null,
-        false);
+        false, noDictionaryColumns);
     LOGGER.info("Running with Sorted column=" + sortedColumn + " and inverted index columns = " + invertedIndexColumns);
 
     // Create a subset of the first 8 segments (for offline) and the last 6 segments (for realtime)

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
@@ -128,7 +128,7 @@ public abstract class HybridClusterScanComparisonIntegrationTest extends HybridC
     Schema schema = Schema.fromFile(schemaFile);
     addSchema(schemaFile, schema.getSchemaName());
     addHybridTable(tableName, timeColumnName, timeColumnType, kafkaZkUrl, kafkaTopic, schema.getSchemaName(),
-        "TestTenant", "TestTenant", avroFile, sortedColumn, invertedIndexColumns, "MMAP", shouldUseLlc());
+        "TestTenant", "TestTenant", avroFile, sortedColumn, invertedIndexColumns, "MMAP", shouldUseLlc(), null);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterScanComparisonIntegrationTest.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.integration.tests;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -461,7 +460,8 @@ public abstract class HybridClusterScanComparisonIntegrationTest extends HybridC
     // Recreate the realtime table
     addRealtimeTable("mytable", "DaysSinceEpoch", "daysSinceEpoch", 900, "Days", KafkaStarterUtils.DEFAULT_ZK_STR,
         KAFKA_TOPIC, _schema.getSchemaName(), "TestTenant", "TestTenant",
-        _realtimeAvroToSegmentMap.keySet().iterator().next(), 1000000, getSortedColumn(), new ArrayList<String>(), null);
+        _realtimeAvroToSegmentMap.keySet().iterator().next(), 1000000, getSortedColumn(), new ArrayList<String>(), null,
+        null);
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/InvertedIndexRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/InvertedIndexRealtimeIntegrationTest.java
@@ -16,24 +16,24 @@
 package com.linkedin.pinot.integration.tests;
 
 import java.io.File;
-
+import java.util.List;
 import org.testng.annotations.Test;
-
 import com.linkedin.pinot.common.data.Schema;
 /**
  * enables indexes on a bunch of columns 
  *
  */
 @Test
-public class InvertedIndexRealtimeIntegrationTest extends RealtimeClusterIntegrationTest{
+public class InvertedIndexRealtimeIntegrationTest extends RealtimeClusterIntegrationTest {
 
   @Override
   protected void addRealtimeTable(String tableName, String timeColumnName, String timeColumnType, int retentionDays,
       String retentionTimeUnit, String kafkaZkUrl, String kafkaTopic, String schemaName, String serverTenant,
-      String brokerTenant, File avroFile, int realtimeSegmentFlushSize, String sortedColumn) throws Exception {
+      String brokerTenant, File avroFile, int realtimeSegmentFlushSize, String sortedColumn,
+      List<String> invertedIndexColumns, String loadMode, List<String> noDictionaryColumns) throws Exception {
     Schema schema = Schema.fromFile(getSchemaFile());
     super.addRealtimeTable(tableName, timeColumnName, timeColumnType, retentionDays, retentionTimeUnit, kafkaZkUrl,
         kafkaTopic, schemaName, serverTenant, brokerTenant, avroFile, realtimeSegmentFlushSize, sortedColumn,
-        schema.getDimensionNames(), null);
+        schema.getDimensionNames(), null, null);
   }
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCPartitioningIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCPartitioningIntegrationTest.java
@@ -15,14 +15,9 @@
  */
 package com.linkedin.pinot.integration.tests;
 
-import com.linkedin.pinot.client.ConnectionFactory;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.ZkStarter;
-import com.linkedin.pinot.core.data.partition.PartitionFunctionFactory;
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +29,11 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.KafkaStarterUtils;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.core.data.partition.PartitionFunctionFactory;
 
 
 /**
@@ -53,9 +53,10 @@ public class LLCPartitioningIntegrationTest extends RealtimeClusterIntegrationTe
     map.put(KAFKA_PARTITIONING_KEY, PartitionFunctionFactory.PartitionFunctionType.ByteArray.toString());
     timeColumnName = "Date";
     timeColumnType = "MILLISECONDS";
+    List<String> noDictionaryColumns = Arrays.asList("NASDelay", "ArrDelayMinutes", "DepDelayMinutes");
     addLLCRealtimeTable(tableName, timeColumnName, timeColumnType, -1, "", KafkaStarterUtils.DEFAULT_KAFKA_BROKER, kafkaTopic, schema.getSchemaName(),
         null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier", Collections.<String>emptyList(), "mmap",
-        null, map);
+        noDictionaryColumns, map);
   }
 
   protected void createKafkaTopic(String kafkaTopic, String zkStr) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -15,19 +15,19 @@
  */
 package com.linkedin.pinot.integration.tests;
 
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.ZkStarter;
 import java.io.File;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import java.util.List;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkClient;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.KafkaStarterUtils;
+import com.linkedin.pinot.common.utils.ZkStarter;
 
 
 /**
@@ -41,9 +41,10 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
       String kafkaTopic, File schemaFile, File avroFile) throws Exception {
     Schema schema = Schema.fromFile(schemaFile);
     addSchema(schemaFile, schema.getSchemaName());
+    List<String> noDictionaryColumns = Arrays.asList("NASDelay", "ArrDelayMinutes", "DepDelayMinutes");
     addLLCRealtimeTable(tableName, timeColumnName, timeColumnType, -1, "", KafkaStarterUtils.DEFAULT_KAFKA_BROKER, kafkaTopic, schema.getSchemaName(),
         null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier", Collections.<String>emptyList(), "mmap",
-        null, null);
+        noDictionaryColumns, null);
   }
 
   protected void createKafkaTopic(String kafkaTopic, String zkStr) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -50,9 +51,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestWi
       String kafkaTopic, File schemaFile, File avroFile) throws Exception {
     Schema schema = Schema.fromFile(schemaFile);
     addSchema(schemaFile, schema.getSchemaName());
-    // TODO Uncomment the line below when segment generation code for no-dictionary column works right.
-//    List<String> noDictionaryColumns = Collections.singletonList("NASDelay");
-    List<String> noDictionaryColumns = new ArrayList<>();
+    List<String> noDictionaryColumns = Arrays.asList("NASDelay", "ArrDelayMinutes", "DepDelayMinutes");
     addRealtimeTable(tableName, timeColumnName, timeColumnType, -1, "", kafkaZkUrl, kafkaTopic, schema.getSchemaName(),
         null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier", new ArrayList<String>(), null, noDictionaryColumns);
   }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.integration.tests;
 import java.io.File;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -49,8 +50,11 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestWi
       String kafkaTopic, File schemaFile, File avroFile) throws Exception {
     Schema schema = Schema.fromFile(schemaFile);
     addSchema(schemaFile, schema.getSchemaName());
+    // TODO Uncomment the line below when segment generation code for no-dictionary column works right.
+//    List<String> noDictionaryColumns = Collections.singletonList("NASDelay");
+    List<String> noDictionaryColumns = new ArrayList<>();
     addRealtimeTable(tableName, timeColumnName, timeColumnType, -1, "", kafkaZkUrl, kafkaTopic, schema.getSchemaName(),
-        null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier");
+        null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier", new ArrayList<String>(), null, noDictionaryColumns);
   }
 
   protected void startKafka() {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeSchemaChangeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeSchemaChangeIntegrationTest.java
@@ -15,9 +15,8 @@
  */
 package com.linkedin.pinot.integration.tests;
 
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.linkedin.pinot.common.data.Schema;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -25,6 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.linkedin.pinot.common.data.Schema;
 
 
 /**
@@ -46,7 +47,8 @@ public class RealtimeSchemaChangeIntegrationTest extends RealtimeClusterIntegrat
 
     // Create the table with a different schema than the final one
     addRealtimeTable(tableName, timeColumnName, timeColumnType, 900, "Days", kafkaZkUrl, kafkaTopic,
-        schema.getSchemaName(), null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier");
+        schema.getSchemaName(), null, null, avroFile, ROW_COUNT_FOR_REALTIME_SEGMENT_FLUSH, "Carrier",
+        new ArrayList<String>(), null, null);
 
     // Sleep for a little bit to get some events in the realtime table
     Uninterruptibles.sleepUninterruptibly(15L, TimeUnit.SECONDS);


### PR DESCRIPTION
Queries work on no dictionary columns in the consuming segment, but segment generation
is broken because of assumption of presense of a dictionary while getting row values.

Limiting the hanges in this PR to make it smaller. Will submit another PR to get
the segment generation right, and then enable the feature.