### PR TITLE
[TE] Refine recipient provider factory for external providers

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactory.java
@@ -40,14 +40,14 @@ public class AlertGroupRecipientProviderFactory {
    * The constructor that instantiates a factory that has the configuration file to external classes. The configuration
    * file is given by its path.
    */
-  public AlertGroupRecipientProviderFactory(String AlertGroupRecipientProviderConfigPath) {
+  public AlertGroupRecipientProviderFactory(String alertGroupRecipientProviderConfigPath) {
     try {
-      InputStream input = new FileInputStream(AlertGroupRecipientProviderConfigPath);
+      InputStream input = new FileInputStream(alertGroupRecipientProviderConfigPath);
       loadPropertiesFromInputStream(input);
     } catch (FileNotFoundException e) {
       LOG.warn(
           "Property file ({}) to external recipient provider is not found; Only internal implementations will be available in this factory.",
-          AlertGroupRecipientProviderConfigPath, e);
+          alertGroupRecipientProviderConfigPath, e);
     }
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactory.java
@@ -1,32 +1,128 @@
 package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.Map;
-import org.apache.commons.collections.MapUtils;
+import java.util.Properties;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * This factory instantiates the implementation (class) of AlertGroupRecipientProvider from two sources: 1. The
+ * classes that are specified from a configuration file. 2. The classes in ThirdEye open source project. Given
+ * the type of recipient provider, this class tries the first type of classes using Java reflection; if it fails,
+ * then it looks for the internal classes.
+ *
+ * The configuration file to external classes is formatted in the following form:
+ *   SHORT_TYPE_NAME1=the.full.class.name1
+ *   SHORT_TYPE_NAME2=the.full.class.name2
+ *   ...
+ */
 public class AlertGroupRecipientProviderFactory {
-  public static final String GROUP_RECIPIENT_PROVIDER_TYPE_KEY = "type";
+  private static final Logger LOG = LoggerFactory.getLogger(AlertGroupRecipientProviderFactory.class);
   private static final AlertGroupRecipientProvider DUMMY_ALERT_GROUP_RECIPIENT_PROVIDER =
       new DummyAlertGroupRecipientProvider();
+  public static final String GROUP_RECIPIENT_PROVIDER_TYPE_KEY = "type";
+
+  private final Properties props = new Properties();
+
+  /**
+   * The default constructor that instantiates a factory that does not have the configuration file to external classes.
+   */
+  public AlertGroupRecipientProviderFactory() { }
+
+  /**
+   * The constructor that instantiates a factory that has the configuration file to external classes. The configuration
+   * file is given by its path.
+   */
+  public AlertGroupRecipientProviderFactory(String AlertGroupRecipientProviderConfigPath) {
+    try {
+      InputStream input = new FileInputStream(AlertGroupRecipientProviderConfigPath);
+      loadPropertiesFromInputStream(input);
+    } catch (FileNotFoundException e) {
+      LOG.warn(
+          "Property file ({}) to external recipient provider is not found; Only internal implementations will be available in this factory.",
+          AlertGroupRecipientProviderConfigPath, e);
+    }
+  }
+
+  /**
+   * The constructor that instantiates a factory that has the configuration file to external classes. The configuration
+   * file is given as an input stream.
+   */
+  public AlertGroupRecipientProviderFactory(InputStream input) {
+    loadPropertiesFromInputStream(input);
+  }
+
+  /**
+   * Loads the configuration file to external classes.
+   *
+   * @param input the input steam of the configuration file.
+   */
+  private void loadPropertiesFromInputStream(InputStream input) {
+    try {
+      props.load(input);
+    } catch (IOException e) {
+      LOG.error("Error loading the alert filters from config", e);
+    } finally {
+      IOUtils.closeQuietly(input);
+    }
+  }
+
+  /**
+   * Given a spec, which is a map of string to a string, of the recipient provider, returns a recipient provider
+   * instance. The implementation of the instance could be located in an external package or ThirdEye project.
+   *
+   * If the type of provider exists in both the external package and ThirdEye project, then the implementation from
+   * external package will be used.
+   *
+   * @param spec a map of string to a string.
+   *
+   * @return a recipient provider instance.
+   */
+  public AlertGroupRecipientProvider fromSpec(Map<String, String> spec) {
+    if (spec == null) {
+      spec = Collections.emptyMap();
+    }
+    // the default recipient provider is a dummy recipient provider
+    AlertGroupRecipientProvider recipientProvider = DUMMY_ALERT_GROUP_RECIPIENT_PROVIDER;
+    if (spec.containsKey(GROUP_RECIPIENT_PROVIDER_TYPE_KEY)) {
+      String recipientProviderType = spec.get(GROUP_RECIPIENT_PROVIDER_TYPE_KEY);
+      // We first check if the implementation (class) of this provider comes from external packages
+      if(props.containsKey(recipientProviderType.toUpperCase())) {
+        String className = props.getProperty(recipientProviderType.toUpperCase());
+        try {
+          recipientProvider = (AlertGroupRecipientProvider) Class.forName(className).newInstance();
+        } catch (Exception e) {
+          LOG.warn(e.getMessage());
+        }
+      } else { // otherwise, we try to look for the implementation from internal classes
+        recipientProvider = fromStringType(spec.get(GROUP_RECIPIENT_PROVIDER_TYPE_KEY));
+      }
+    }
+    recipientProvider.setParameters(spec);
+
+    return recipientProvider;
+  }
 
   public enum GroupRecipientProviderType {
     DUMMY, DIMENSIONAL
   }
 
-  public static AlertGroupRecipientProvider fromSpec(Map<String, String> spec) {
-    if (MapUtils.isEmpty(spec)) {
-      spec = Collections.emptyMap();
-    }
-    AlertGroupRecipientProvider alertGroupRecipientProvider =
-        fromStringType(spec.get(GROUP_RECIPIENT_PROVIDER_TYPE_KEY));
-    alertGroupRecipientProvider.setParameters(spec);
-
-    return alertGroupRecipientProvider;
-  }
-
+  /**
+   * The methods returns the instance of recipient provider whose implementation is located in ThirdEye project.
+   *
+   * @param type the type name of the provider.
+   *
+   * @return a instance of recipient provider.
+   */
   private static AlertGroupRecipientProvider fromStringType(String type) {
-    if (StringUtils.isBlank(type)) { // backward compatibility
+    if (StringUtils.isBlank(type)) { // safety check and backward compatibility
       return DUMMY_ALERT_GROUP_RECIPIENT_PROVIDER;
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
@@ -74,6 +74,7 @@ public class AlertTaskRunnerV2 implements TaskRunner {
   private AlertConfigDTO alertConfig;
   private ThirdEyeAnomalyConfiguration thirdeyeConfig;
   private AlertFilterFactory alertFilterFactory;
+  private AlertGroupRecipientProviderFactory alertGroupRecipientProviderFactory;
   private final String MAX_ALLOWED_MERGE_GAP_KEY = "maxAllowedMergeGap";
   private final long DEFAULT_MAX_ALLOWED_MERGE_GAP = 14400000L;
 
@@ -92,6 +93,8 @@ public class AlertTaskRunnerV2 implements TaskRunner {
     alertConfig = alertTaskInfo.getAlertConfigDTO();
     thirdeyeConfig = taskContext.getThirdEyeAnomalyConfiguration();
     alertFilterFactory = new AlertFilterFactory(thirdeyeConfig.getAlertFilterConfigPath());
+    alertGroupRecipientProviderFactory =
+        new AlertGroupRecipientProviderFactory(thirdeyeConfig.getAlertGroupRecipientProviderConfigPath());
 
     try {
       LOG.info("Begin executing task {}", taskInfo);
@@ -177,7 +180,7 @@ public class AlertTaskRunnerV2 implements TaskRunner {
           String recipientsForThisGroup = alertConfig.getRecipients();
           //   Get auxiliary email recipient from provider
           AlertGroupRecipientProvider recipientProvider =
-            AlertGroupRecipientProviderFactory.fromSpec(alertGroupConfig.getGroupAuxiliaryEmailProvider());
+              alertGroupRecipientProviderFactory.fromSpec(alertGroupConfig.getGroupAuxiliaryEmailProvider());
           String auxiliaryRecipients = recipientProvider.getAlertGroupRecipients(dimensions);
           if (StringUtils.isNotBlank(auxiliaryRecipients)) {
             recipientsForThisGroup = recipientsForThisGroup + EmailHelper.EMAIL_ADDRESS_SEPARATOR + auxiliaryRecipients;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
@@ -73,6 +73,10 @@ public abstract class ThirdEyeConfiguration extends Configuration {
     return getRootDir() + "/detector-config/anomaly-functions/alertFilterAutotune.properties";
   }
 
+  public String getAlertGroupRecipientProviderConfigPath() {
+    return getRootDir() + "/detector-config/anomaly-functions/alertGroupRecipientProvider.properties";
+  }
+
   public String getSmtpHost() {
     return smtpHost;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactoryTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProviderFactoryTest.java
@@ -8,15 +8,17 @@ import org.testng.annotations.Test;
 public class AlertGroupRecipientProviderFactoryTest {
   @Test
   public void testFromSpecNull() throws Exception {
-    AlertGroupRecipientProvider recipientProvider = AlertGroupRecipientProviderFactory.fromSpec(null);
+    AlertGroupRecipientProviderFactory alertGroupRecipientProviderFactory = new AlertGroupRecipientProviderFactory();
+    AlertGroupRecipientProvider recipientProvider = alertGroupRecipientProviderFactory.fromSpec(null);
     Assert.assertEquals(recipientProvider.getClass(), DummyAlertGroupRecipientProvider.class);
   }
 
   @Test
-  public void testAlertGrouperCreation() {
+  public void testDimensionalAlertGroupRecipientProviderCreation() {
+    AlertGroupRecipientProviderFactory alertGroupRecipientProviderFactory = new AlertGroupRecipientProviderFactory();
     Map<String, String> spec = new HashMap<>();
     spec.put(AlertGroupRecipientProviderFactory.GROUP_RECIPIENT_PROVIDER_TYPE_KEY, "diMenSionAL");
-    AlertGroupRecipientProvider alertGrouper = AlertGroupRecipientProviderFactory.fromSpec(spec);
+    AlertGroupRecipientProvider alertGrouper = alertGroupRecipientProviderFactory.fromSpec(spec);
     Assert.assertEquals(alertGrouper.getClass(), DimensionalAlertGroupRecipientProvider.class);
   }
 }


### PR DESCRIPTION
Recipient provider factory now could instantiate both external and internal recipient providers. It first check the property file (if it exists) and try to instantiate the provider using the given class. If it fails, then it try to instantiate the provider using internal classes. If both fails, then a dummy provider is used.

Tested on local controller.