### PR TITLE
For whole table reload, send table level message instead of segment level message

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadataLoader;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
@@ -49,7 +50,11 @@ public interface DataManager {
 
   SegmentMetadataLoader getSegmentMetadataLoader();
 
-  SegmentMetadata getSegmentMetadata(String tableName, String segmentName);
+  @Nonnull
+  List<SegmentMetadata> getAllSegmentsMetadata(@Nonnull String tableNameWithType);
+
+  @Nullable
+  SegmentMetadata getSegmentMetadata(@Nonnull String tableNameWithType, @Nonnull String segmentName);
 
   boolean isStarted();
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/messages/SegmentReloadMessage.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/messages/SegmentReloadMessage.java
@@ -17,6 +17,8 @@ package com.linkedin.pinot.common.messages;
 
 import com.google.common.base.Preconditions;
 import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.helix.model.Message;
 
 
@@ -27,10 +29,12 @@ import org.apache.helix.model.Message;
 public class SegmentReloadMessage extends Message {
   public static final String RELOAD_SEGMENT_MSG_SUB_TYPE = "RELOAD_SEGMENT";
 
-  public SegmentReloadMessage(String tableName, String segmentName) {
+  public SegmentReloadMessage(@Nonnull String tableNameWithType, @Nullable String segmentName) {
     super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
-    setResourceName(tableName);
-    setPartitionName(segmentName);
+    setResourceName(tableNameWithType);
+    if (segmentName != null) {
+      setPartitionName(segmentName);
+    }
     setMsgSubType(RELOAD_SEGMENT_MSG_SUB_TYPE);
     // Give it infinite time to process the message, as long as session is alive
     setExecutionTimeout(-1);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
@@ -30,6 +30,7 @@ import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import java.io.File;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -221,14 +222,17 @@ public class FileBasedInstanceDataManager implements InstanceDataManager {
     return _segmentMetadataLoader;
   }
 
+  @Nonnull
   @Override
-  public SegmentMetadata getSegmentMetadata(String table, String segmentName) {
-    if (_tableDataManagerMap.containsKey(table)) {
-      if (_tableDataManagerMap.get(table).acquireSegment(segmentName) != null) {
-        return _tableDataManagerMap.get(table).acquireSegment(segmentName).getSegment().getSegmentMetadata();
-      }
-    }
-    return null;
+  public List<SegmentMetadata> getAllSegmentsMetadata(@Nonnull String tableNameWithType) {
+    throw new UnsupportedOperationException(
+        "Unsupported getting all segments' metadata in FileBasedInstanceDataManager");
+  }
+
+  @Nullable
+  @Override
+  public SegmentMetadata getSegmentMetadata(@Nonnull String tableNameWithType, @Nonnull String segmentName) {
+    throw new UnsupportedOperationException("Unsupported getting segment metadata in FileBasedInstanceDataManager");
   }
 
   @Override


### PR DESCRIPTION
Currently for whole table reload, we send segment level messgaes, which is causing problem for big tables.
Added table level reload message, which can significantly reduce the number of messages sent.