### PR TITLE
Fixed ColumnarToStarTreeConverter to correctly load the config file.

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/ColumnarToStarTreeConverter.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/ColumnarToStarTreeConverter.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.tools.segment.converter;
 
+import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.data.readers.FileFormat;
@@ -28,6 +29,7 @@ import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import java.io.File;
 import java.lang.reflect.Field;
 import org.apache.commons.io.FileUtils;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
@@ -37,6 +39,7 @@ import org.kohsuke.args4j.Option;
  */
 public class ColumnarToStarTreeConverter {
   private static final String TMP_DIR_PREFIX = "_tmp_";
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Option(name = "-inputDir", required = true, usage = "Path to input directory containing Pinot segments")
   private String _inputDirName = null;
@@ -117,6 +120,10 @@ public class ColumnarToStarTreeConverter {
     config.setOutDir(_outputDirName);
     config.setStarTreeIndexSpecFile(_starTreeConfigFileName);
     config.setOverwrite(_overwrite);
+
+    // Load the StarTreeSpec object from the config file.
+    StarTreeIndexSpec starTreeIndexSpec = objectMapper.readValue(new File(_starTreeConfigFileName), StarTreeIndexSpec.class);
+    config.setStarTreeIndexSpec(starTreeIndexSpec);
 
     // Read the segment and table name from the segment's metadata.
     SegmentMetadata metadata = new SegmentMetadataImpl(columnarSegment);


### PR DESCRIPTION
Because loadConfigFiles() is deprecated, StarTreeIndexSpec is not loaded correctly and the converter would always use the default settings even if the config file for the StarTree index is given.