### PR TITLE
Fix broken star tree index viewer due to migration to segment v3 format.

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.tools;
 
+import com.linkedin.pinot.core.segment.store.SegmentDirectoryPaths;
 import com.linkedin.pinot.core.startree.StarTreeIndexNodeInterf;
 import com.linkedin.pinot.core.startree.StarTreeInterf;
 import com.linkedin.pinot.core.startree.StarTreeSerDe;
@@ -88,7 +89,7 @@ public class StarTreeIndexViewer {
       valueIterators.put(columnName, itr);
       dictionaries.put(columnName, dataSource.getDictionary());
     }
-    File starTreeFile = new File(segmentDir, V1Constants.STAR_TREE_INDEX_FILE);
+    File starTreeFile = SegmentDirectoryPaths.findStarTreeFile(segmentDir);
     StarTreeInterf tree = StarTreeSerDe.fromFile(starTreeFile, ReadMode.mmap);
     dimensionNameToIndexMap = tree.getDimensionNameToIndexMap();
     StarTreeJsonNode jsonRoot = new StarTreeJsonNode("ROOT");


### PR DESCRIPTION
The star tree index viewer code assumed v1 segment format, and expected
star tree file to be present in a specific path. Fixed it by calling
segment version agnostic api to get the star tree file.