### PR TITLE
Exit Pinot when a top-level exception is caught

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartBrokerCommand.java
@@ -106,27 +106,33 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
 
   @Override
   public boolean execute() throws Exception {
-    if (_brokerHost == null) {
-      _brokerHost = NetUtil.getHostAddress();
-    }
-
-    Configuration configuration = readConfigFromFile(_configFileName);
-    if (configuration == null) {
-      if (_configFileName != null) {
-        LOGGER.error("Error: Unable to find file {}.", _configFileName);
-        return false;
+    try {
+      if (_brokerHost == null) {
+        _brokerHost = NetUtil.getHostAddress();
       }
 
-      configuration = new PropertiesConfiguration();
-      configuration.addProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, _brokerPort);
-      configuration.setProperty("pinot.broker.routing.table.builder.class", "random");
-    }
+      Configuration configuration = readConfigFromFile(_configFileName);
+      if (configuration == null) {
+        if (_configFileName != null) {
+          LOGGER.error("Error: Unable to find file {}.", _configFileName);
+          return false;
+        }
 
-    LOGGER.info("Executing command: " + toString());
-    final HelixBrokerStarter pinotHelixBrokerStarter = new HelixBrokerStarter(_clusterName, _zkAddress, configuration);
-    
-    String pidFile = ".pinotAdminBroker-" + String.valueOf(System.currentTimeMillis()) + ".pid";
-    savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
-    return true;
+        configuration = new PropertiesConfiguration();
+        configuration.addProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, _brokerPort);
+        configuration.setProperty("pinot.broker.routing.table.builder.class", "random");
+      }
+
+      LOGGER.info("Executing command: " + toString());
+      final HelixBrokerStarter pinotHelixBrokerStarter = new HelixBrokerStarter(_clusterName, _zkAddress, configuration);
+
+      String pidFile = ".pinotAdminBroker-" + String.valueOf(System.currentTimeMillis()) + ".pid";
+      savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while starting broker, exiting", e);
+      System.exit(-1);
+      return false;
+    }
   }
 }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartControllerCommand.java
@@ -123,40 +123,46 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
 
   @Override
   public boolean execute() throws Exception {
-    if (_controllerHost == null) {
-      _controllerHost = NetUtil.getHostAddress();
-    }
-
-    ControllerConf conf = readConfigFromFile(_configFileName);
-    if (conf == null) {
-      if (_configFileName != null) {
-        LOGGER.error("Error: Unable to find file {}.", _configFileName);
-        return false;
+    try {
+      if (_controllerHost == null) {
+        _controllerHost = NetUtil.getHostAddress();
       }
 
-      conf = new ControllerConf();
+      ControllerConf conf = readConfigFromFile(_configFileName);
+      if (conf == null) {
+        if (_configFileName != null) {
+          LOGGER.error("Error: Unable to find file {}.", _configFileName);
+          return false;
+        }
 
-      conf.setControllerHost(_controllerHost);
-      conf.setControllerPort(_controllerPort);
-      conf.setDataDir(_dataDir);
-      conf.setZkStr(_zkAddress);
+        conf = new ControllerConf();
 
-      conf.setHelixClusterName(_clusterName);
-      conf.setControllerVipHost(_controllerHost);
-      conf.setTenantIsolationEnabled(_tenantIsolation);
+        conf.setControllerHost(_controllerHost);
+        conf.setControllerPort(_controllerPort);
+        conf.setDataDir(_dataDir);
+        conf.setZkStr(_zkAddress);
 
-      conf.setRetentionControllerFrequencyInSeconds(3600 * 6);
-      conf.setValidationControllerFrequencyInSeconds(3600);
+        conf.setHelixClusterName(_clusterName);
+        conf.setControllerVipHost(_controllerHost);
+        conf.setTenantIsolationEnabled(_tenantIsolation);
+
+        conf.setRetentionControllerFrequencyInSeconds(3600 * 6);
+        conf.setValidationControllerFrequencyInSeconds(3600);
+      }
+
+      LOGGER.info("Executing command: " + toString());
+      final ControllerStarter starter = new ControllerStarter(conf);
+
+      starter.start();
+
+      String pidFile = ".pinotAdminController-" + String.valueOf(System.currentTimeMillis()) + ".pid";
+      savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while starting controller, exiting.", e);
+      System.exit(-1);
+      return false;
     }
-
-    LOGGER.info("Executing command: " + toString());
-    final ControllerStarter starter = new ControllerStarter(conf);
-
-    starter.start();
-
-    String pidFile = ".pinotAdminController-" + String.valueOf(System.currentTimeMillis()) + ".pid";
-    savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
-    return true;
   }
 
   @Override

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartServerCommand.java
@@ -126,28 +126,34 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
 
   @Override
   public boolean execute() throws Exception {
-    if (_serverHost == null) {
-      _serverHost = NetUtil.getHostAddress();
-    }
-
-    Configuration configuration = readConfigFromFile(_configFileName);
-    if (configuration == null) {
-      if (_configFileName != null) {
-        LOGGER.error("Error: Unable to find file {}.", _configFileName);
-        return false;
+    try {
+      if (_serverHost == null) {
+        _serverHost = NetUtil.getHostAddress();
       }
 
-      configuration = new PropertiesConfiguration();
-      configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, _serverHost);
-      configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, _serverPort);
-      configuration.addProperty("pinot.server.instance.dataDir", _dataDir + _serverPort + "/index");
-      configuration.addProperty("pinot.server.instance.segmentTarDir", _segmentDir + _serverPort + "/segmentTar");
-    }
+      Configuration configuration = readConfigFromFile(_configFileName);
+      if (configuration == null) {
+        if (_configFileName != null) {
+          LOGGER.error("Error: Unable to find file {}.", _configFileName);
+          return false;
+        }
 
-    LOGGER.info("Executing command: " + toString());
-    final HelixServerStarter pinotHelixStarter = new HelixServerStarter(_clusterName, _zkAddress, configuration);
-    String pidFile = ".pinotAdminServer-" + String.valueOf(System.currentTimeMillis()) + ".pid";
-    savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
-    return true;
+        configuration = new PropertiesConfiguration();
+        configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, _serverHost);
+        configuration.addProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, _serverPort);
+        configuration.addProperty("pinot.server.instance.dataDir", _dataDir + _serverPort + "/index");
+        configuration.addProperty("pinot.server.instance.segmentTarDir", _segmentDir + _serverPort + "/segmentTar");
+      }
+
+      LOGGER.info("Executing command: " + toString());
+      final HelixServerStarter pinotHelixStarter = new HelixServerStarter(_clusterName, _zkAddress, configuration);
+      String pidFile = ".pinotAdminServer-" + String.valueOf(System.currentTimeMillis()) + ".pid";
+      savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while starting Pinot server, exiting.", e);
+      System.exit(-1);
+      return false;
+    }
   }
 }


### PR DESCRIPTION
Exit Pinot commands when a top-level exception is caught, so that Pinot
properly exits when a startup issue occurs (eg. cannot connect to ZK)