### PR TITLE
Make auto onboard service generic to onboard from all data sources

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -20,7 +20,8 @@ import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
 import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeExecutor;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorJobScheduler;
 import com.linkedin.thirdeye.anomaly.task.TaskDriver;
-import com.linkedin.thirdeye.autoload.pinot.metrics.AutoLoadPinotMetricsService;
+import com.linkedin.thirdeye.auto.onboard.AutoOnboardPinotDataSource;
+import com.linkedin.thirdeye.auto.onboard.AutoOnboardService;
 import com.linkedin.thirdeye.common.BaseThirdEyeApplication;
 import com.linkedin.thirdeye.completeness.checker.DataCompletenessScheduler;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
@@ -40,7 +41,7 @@ public class ThirdEyeAnomalyApplication
   private AlertJobSchedulerV2 alertJobSchedulerV2;
   private AnomalyFunctionFactory anomalyFunctionFactory = null;
   private AnomalyMergeExecutor anomalyMergeExecutor = null;
-  private AutoLoadPinotMetricsService autoLoadPinotMetricsService = null;
+  private AutoOnboardService autoOnboardService = null;
   private DataCompletenessScheduler dataCompletenessScheduler = null;
   private AlertFilterFactory alertFilterFactory = null;
   private AlertFilterAutotuneFactory alertFilterAutotuneFactory = null;
@@ -127,8 +128,8 @@ public class ThirdEyeAnomalyApplication
           anomalyMergeExecutor.start();
         }
         if (config.isAutoload()) {
-          autoLoadPinotMetricsService = new AutoLoadPinotMetricsService(config);
-          autoLoadPinotMetricsService.start();
+          autoOnboardService = new AutoOnboardService(config);
+          autoOnboardService.start();
         }
         if (config.isDataCompleteness()) {
           dataCompletenessScheduler = new DataCompletenessScheduler();
@@ -159,7 +160,7 @@ public class ThirdEyeAnomalyApplication
           anomalyMergeExecutor.stop();
         }
         if (config.isAutoload()) {
-          autoLoadPinotMetricsService.shutdown();
+          autoOnboardService.shutdown();
         }
         if (config.isDataCompleteness()) {
           dataCompletenessScheduler.shutdown();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.anomaly;
 
 import com.linkedin.thirdeye.anomaly.monitor.MonitorConfiguration;
 import com.linkedin.thirdeye.anomaly.task.TaskDriverConfiguration;
+import com.linkedin.thirdeye.auto.onboard.AutoOnboardConfiguration;
 import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
 
 public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
@@ -18,6 +19,7 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
   private String dashboardHost;
   private SmtpConfiguration smtpConfiguration;
   private MonitorConfiguration monitorConfiguration = new MonitorConfiguration();
+  private AutoOnboardConfiguration autoOnboardConfiguration = new AutoOnboardConfiguration();
   private TaskDriverConfiguration taskDriverConfiguration = new TaskDriverConfiguration();
   private String failureFromAddress;
   private String failureToAddress;
@@ -68,6 +70,16 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
 
   public void setMonitorConfiguration(MonitorConfiguration monitorConfiguration) {
     this.monitorConfiguration = monitorConfiguration;
+  }
+
+
+
+  public AutoOnboardConfiguration getAutoOnboardConfiguration() {
+    return autoOnboardConfiguration;
+  }
+
+  public void setAutoOnboardConfiguration(AutoOnboardConfiguration autoOnboardConfiguration) {
+    this.autoOnboardConfiguration = autoOnboardConfiguration;
   }
 
   public TaskDriverConfiguration getTaskDriverConfiguration() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboard.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboard.java
@@ -1,0 +1,23 @@
+package com.linkedin.thirdeye.auto.onboard;
+
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
+
+/**
+ * This is the abstract parent class for all auto onboard services for various datasources
+ */
+public abstract class AutoOnboard {
+  private DataSourceConfig dataSourceConfig;
+
+  public AutoOnboard(DataSourceConfig dataSourceConfig) {
+    this.dataSourceConfig = dataSourceConfig;
+  }
+
+  public DataSourceConfig getDataSourceConfig() {
+    return dataSourceConfig;
+  }
+
+  /**
+   * Method which contains implementation of what needs to be done as part of onboarding for this data source
+   */
+  public abstract void run();
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardConfiguration.java
@@ -1,0 +1,20 @@
+package com.linkedin.thirdeye.auto.onboard;
+
+import java.util.concurrent.TimeUnit;
+
+import com.linkedin.thirdeye.api.TimeGranularity;
+
+public class AutoOnboardConfiguration {
+
+  private TimeGranularity runFrequency = new TimeGranularity(15, TimeUnit.MINUTES);
+
+  public TimeGranularity getRunFrequency() {
+    return runFrequency;
+  }
+
+  public void setRunFrequency(TimeGranularity runFrequency) {
+    this.runFrequency = runFrequency;
+  }
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
@@ -48,6 +48,7 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
   public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig) {
     super(dataSourceConfig);
     autoLoadPinotMetricsUtils = new AutoOnboardPinotMetricsUtils(dataSourceConfig);
+    LOG.info("Created {}", AutoOnboardPinotDataSource.class.getName());
   }
 
   public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig, AutoOnboardPinotMetricsUtils utils) {
@@ -56,6 +57,7 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
   }
 
   public void run() {
+    LOG.info("Running auto load for {}", AutoOnboardPinotDataSource.class.getSimpleName());
     try {
       loadDatasets();
       LOG.info("Checking all datasets");

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
@@ -1,14 +1,10 @@
-package com.linkedin.thirdeye.autoload.pinot.metrics;
+package com.linkedin.thirdeye.auto.onboard;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,26 +16,23 @@ import com.linkedin.pinot.client.ResultSetGroup;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
-import com.linkedin.thirdeye.datalayer.bao.DashboardConfigManager;
-import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
-import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.datasource.pinot.PinotQuery;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 /**
  * This is a service to onboard datasets automatically to thirdeye from pinot
- * This service runs periodically and checks for new tables in pinot, to add to thirdeye
+ * The run method is invoked periodically by the AutoOnboardService, and it checks for new tables in pinot, to add to thirdeye
  * If the table is an ingraph table, it loads metrics from the ingraph table
  * It also looks for any changes in dimensions or metrics to the existing tables
  */
-public class AutoLoadPinotMetricsService implements Runnable {
-  private static final Logger LOG = LoggerFactory.getLogger(AutoLoadPinotMetricsService.class);
+public class AutoOnboardPinotDataSource extends AutoOnboard {
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardPinotDataSource.class);
 
 
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
@@ -47,33 +40,25 @@ public class AutoLoadPinotMetricsService implements Runnable {
   private static final String DEFAULT_INGRAPH_METRIC_NAMES_COLUMN = "metricName";
   private static final String DEFAULT_INGRAPH_METRIC_VALUES_COLUMN = "value";
 
-  private ScheduledExecutorService scheduledExecutorService;
-  private AutoLoadPinotMetricsUtils autoLoadPinotMetricsUtils;
+  private AutoOnboardPinotMetricsUtils autoLoadPinotMetricsUtils;
 
   private List<String> allDatasets = new ArrayList<>();
   private Map<String, Schema> allSchemas = new HashMap<>();
 
-  public AutoLoadPinotMetricsService() {
+  public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig) {
+    super(dataSourceConfig);
+    autoLoadPinotMetricsUtils = new AutoOnboardPinotMetricsUtils(dataSourceConfig);
   }
 
-  public AutoLoadPinotMetricsService(ThirdEyeConfiguration config) {
-
-    autoLoadPinotMetricsUtils = new AutoLoadPinotMetricsUtils(config);
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-  }
-
-  public void start() {
-    scheduledExecutorService.scheduleAtFixedRate(this, 0, 4, TimeUnit.HOURS);
-  }
-
-  public void shutdown() {
-    scheduledExecutorService.shutdown();
+  public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig, AutoOnboardPinotMetricsUtils utils) {
+    super(dataSourceConfig);
+    autoLoadPinotMetricsUtils = utils;
   }
 
   public void run() {
     try {
       loadDatasets();
-
+      LOG.info("Checking all datasets");
       for (String dataset : allDatasets) {
         LOG.info("Checking dataset {}", dataset);
 
@@ -237,6 +222,7 @@ public class AutoLoadPinotMetricsService implements Runnable {
   private void loadDatasets() throws IOException {
 
     JsonNode tables = autoLoadPinotMetricsUtils.getAllTablesFromPinot();
+    LOG.info("Getting all schemas");
     for (JsonNode table : tables) {
       String dataset = table.asText();
       Schema schema = autoLoadPinotMetricsUtils.getSchemaFromPinot(dataset);
@@ -251,6 +237,7 @@ public class AutoLoadPinotMetricsService implements Runnable {
     }
   }
 
+  // TODO: when all ingraph traces are cleaned, remove these checks for ingraphs
   private boolean isIngraphDataset(Schema schema) {
     boolean isIngraphDataset = false;
     if ((schema.getDimensionNames().contains(DEFAULT_INGRAPH_METRIC_NAMES_COLUMN)

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -1,4 +1,4 @@
-package com.linkedin.thirdeye.autoload.pinot.metrics;
+package com.linkedin.thirdeye.auto.onboard;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,12 +17,10 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
-import com.linkedin.thirdeye.datasource.DataSources;
-import com.linkedin.thirdeye.datasource.DataSourcesLoader;
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSourceConfig;
 
-public class AutoLoadPinotMetricsUtils {
+public class AutoOnboardPinotMetricsUtils {
   private static final String PINOT_TABLES_ENDPOINT = "tables/";
   private static final String PINOT_SCHEMA_ENDPOINT = "schemas/%s";
   private static final String PINOT_SCHEMA_ENDPOINT_TEMPLATE = "tables/%s/schema";
@@ -31,22 +29,13 @@ public class AutoLoadPinotMetricsUtils {
   private CloseableHttpClient pinotControllerClient;
   private HttpHost pinotControllerHost;
 
-  private static final Logger LOG = LoggerFactory.getLogger(AutoLoadPinotMetricsUtils.class);
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardPinotMetricsUtils.class);
 
-  public AutoLoadPinotMetricsUtils(ThirdEyeConfiguration config) {
-    try {
-      String dataSourcesPath = config.getDataSourcesPath();
-      DataSources dataSources = DataSourcesLoader.fromDataSourcesPath(dataSourcesPath);
-      if (dataSources == null) {
-        throw new IllegalStateException("Could not create data sources config from path " + dataSourcesPath);
-      }
-      PinotThirdEyeDataSourceConfig pinotThirdeyeDataSourceConfig = PinotThirdEyeDataSourceConfig.createPinotThirdeyeDataSourceConfig(dataSources);
+  public AutoOnboardPinotMetricsUtils(DataSourceConfig dataSourceConfig) {
+      PinotThirdEyeDataSourceConfig pinotThirdeyeDataSourceConfig = PinotThirdEyeDataSourceConfig.createPinotThirdeyeDataSourceConfig(dataSourceConfig);
       this.pinotControllerClient = HttpClients.createDefault();
       this.pinotControllerHost = new HttpHost(pinotThirdeyeDataSourceConfig.getControllerHost(),
           pinotThirdeyeDataSourceConfig.getControllerPort());
-    } catch (Exception e) {
-     LOG.error("Exception in creating pinot controller http host", e);
-    }
   }
 
   public JsonNode getAllTablesFromPinot() throws IOException {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardService.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardService.java
@@ -5,13 +5,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
+import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
+import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
 import com.linkedin.thirdeye.datasource.DataSources;
 import com.linkedin.thirdeye.datasource.DataSourcesLoader;
@@ -27,12 +26,14 @@ public class AutoOnboardService implements Runnable {
   private ScheduledExecutorService scheduledExecutorService;
   private DataSources dataSources;
   private List<AutoOnboard> autoOnboardServices = new ArrayList<>();
+  private TimeGranularity runFrequency;
 
   /**
    * Reads data sources configs and instantiates the constructors for auto load of all data sources, if availble
    * @param config
    */
-  public AutoOnboardService(ThirdEyeConfiguration config) {
+  public AutoOnboardService(ThirdEyeAnomalyConfiguration config) {
+    this.runFrequency = config.getAutoOnboardConfiguration().getRunFrequency();
     scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     String dataSourcesPath = config.getDataSourcesPath();
@@ -55,7 +56,7 @@ public class AutoOnboardService implements Runnable {
   }
 
   public void start() {
-    scheduledExecutorService.scheduleAtFixedRate(this, 0, 15, TimeUnit.MINUTES);
+    scheduledExecutorService.scheduleAtFixedRate(this, 0, runFrequency.getSize(), runFrequency.getUnit());
   }
 
   public void shutdown() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardService.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardService.java
@@ -1,0 +1,71 @@
+package com.linkedin.thirdeye.auto.onboard;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.DataSources;
+import com.linkedin.thirdeye.datasource.DataSourcesLoader;
+
+/**
+ * This is a service to onboard datasets automatically to thirdeye from the different data sources
+ * This service runs periodically and runs auto load for each data source
+ */
+public class AutoOnboardService implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardService.class);
+
+
+  private ScheduledExecutorService scheduledExecutorService;
+  private DataSources dataSources;
+  private List<AutoOnboard> autoOnboardServices = new ArrayList<>();
+
+  /**
+   * Reads data sources configs and instantiates the constructors for auto load of all data sources, if availble
+   * @param config
+   */
+  public AutoOnboardService(ThirdEyeConfiguration config) {
+    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+    String dataSourcesPath = config.getDataSourcesPath();
+    dataSources = DataSourcesLoader.fromDataSourcesPath(dataSourcesPath);
+    if (dataSources == null) {
+      throw new IllegalStateException("Could not create data sources config from path " + dataSourcesPath);
+    }
+    for (DataSourceConfig dataSourceConfig : dataSources.getDataSourceConfigs()) {
+      String autoLoadClassName = dataSourceConfig.getAutoLoadClassName();
+      if (StringUtils.isNotBlank(autoLoadClassName)) {
+        try {
+          Constructor<?> constructor = Class.forName(autoLoadClassName).getConstructor(DataSourceConfig.class);
+          AutoOnboard autoOnboardConstructor = (AutoOnboard) constructor.newInstance(dataSourceConfig);
+          autoOnboardServices.add(autoOnboardConstructor);
+        } catch (Exception e) {
+          LOG.error("Exception in creating autoload constructor {}", autoLoadClassName);
+        }
+      }
+    }
+  }
+
+  public void start() {
+    scheduledExecutorService.scheduleAtFixedRate(this, 0, 15, TimeUnit.MINUTES);
+  }
+
+  public void shutdown() {
+    scheduledExecutorService.shutdown();
+  }
+
+  public void run() {
+    for (AutoOnboard autoOnboard : autoOnboardServices) {
+      autoOnboard.run();
+    }
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/ConfigGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/ConfigGenerator.java
@@ -1,4 +1,4 @@
-package com.linkedin.thirdeye.autoload.pinot.metrics;
+package com.linkedin.thirdeye.auto.onboard;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardDatasetMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/OnboardDatasetMetricResource.java
@@ -121,7 +121,7 @@ public class OnboardDatasetMetricResource {
    *
    *    curl -H "Content-Type: application/json" -X POST -d <payload> <url>
    *    Eg: curl -H "Content-Type: application/json" -X POST -d
-   *            '{"datasetName":"xyz","metricName":"xyz", "dataSource":"abc", "properties": { "prop1":"1", "prop2":"2"}}'
+   *            '{"datasetName":"xyz","metricName":"xyz", "dataSource":"PinotThirdeyeDataSource", "properties": { "prop1":"1", "prop2":"2"}}'
    *                http://localhost:8080/onboard/create
    * @param payload
    */

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSourceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DataSourceConfig.java
@@ -12,14 +12,16 @@ public class DataSourceConfig {
 
   private String className;
   private Map<String, String> properties;
+  private String autoLoadClassName = null;
 
 
   public DataSourceConfig() {
 
   }
-  public DataSourceConfig(String className, Map<String, String> properties) {
+  public DataSourceConfig(String className, Map<String, String> properties, String autoLoadClassName) {
     this.className = className;
     this.properties = properties;
+    this.autoLoadClassName = autoLoadClassName;
   }
 
   public String getClassName() {
@@ -34,7 +36,12 @@ public class DataSourceConfig {
   public void setProperties(Map<String, String> properties) {
     this.properties = properties;
   }
-
+  public String getAutoLoadClassName() {
+    return autoLoadClassName;
+  }
+  public void setAutoLoadClassName(String autoLoadClassName) {
+    this.autoLoadClassName = autoLoadClassName;
+  }
   @Override
   public String toString() {
     return ToStringBuilder.reflectionToString(this);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
@@ -91,30 +91,49 @@ public class PinotThirdEyeDataSourceConfig {
     for (DataSourceConfig dataSourceConfig : dataSources.getDataSourceConfigs()) {
       if (dataSourceConfig.getClassName().equals(PinotThirdEyeDataSource.class.getCanonicalName())) {
         if (pinotDataSourceConfig == null) {
-          Map<String, String> properties = dataSourceConfig.getProperties();
-          String controllerHost = properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue());
-          int controllerPort = Integer.valueOf(properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue()));
-          String clusterName = properties.get(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue());
-          String zookeeperUrl = properties.get(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue());
-          String brokerUrl = properties.get(PinotThirdeyeDataSourceProperties.BROKER_URL.getValue());
-          String tag = properties.get(PinotThirdeyeDataSourceProperties.TAG.getValue());
-
-          pinotDataSourceConfig = new PinotThirdEyeDataSourceConfig();
-          pinotDataSourceConfig.setControllerHost(controllerHost);
-          pinotDataSourceConfig.setControllerPort(controllerPort);
-          pinotDataSourceConfig.setClusterName(clusterName);
-          pinotDataSourceConfig.setZookeeperUrl(zookeeperUrl);
-          if (StringUtils.isNotBlank(brokerUrl)) {
-            pinotDataSourceConfig.setBrokerUrl(brokerUrl);
-          }
-          if (StringUtils.isNotBlank(tag)) {
-            pinotDataSourceConfig.setTag(tag);
-          }
+          pinotDataSourceConfig = createPinotDataSourceFromProperties(dataSourceConfig.getProperties());
         } else {
           throw new IllegalStateException("Found another data source of type PinotThirdEyeDataSource. "
               + "There can only be ONE data source of each type" + dataSources);
         }
       }
+    }
+    return pinotDataSourceConfig;
+  }
+
+  /**
+   * Returns pinot thirdeye datasource config given datasource config. There can be only ONE datasource of pinot type
+   * @param dataSources
+   * @return
+   */
+  public static PinotThirdEyeDataSourceConfig createPinotThirdeyeDataSourceConfig(DataSourceConfig dataSourceConfig) {
+    if (dataSourceConfig == null ||
+        !dataSourceConfig.getClassName().equals(PinotThirdEyeDataSource.class.getCanonicalName())) {
+      throw new IllegalStateException("Data source config is not of type pinot " + dataSourceConfig);
+    }
+    return createPinotDataSourceFromProperties(dataSourceConfig.getProperties());
+  }
+
+  private static PinotThirdEyeDataSourceConfig createPinotDataSourceFromProperties(Map<String, String> properties) {
+    PinotThirdEyeDataSourceConfig pinotDataSourceConfig = null;
+
+    String controllerHost = properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue());
+    int controllerPort = Integer.valueOf(properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue()));
+    String clusterName = properties.get(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue());
+    String zookeeperUrl = properties.get(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue());
+    String brokerUrl = properties.get(PinotThirdeyeDataSourceProperties.BROKER_URL.getValue());
+    String tag = properties.get(PinotThirdeyeDataSourceProperties.TAG.getValue());
+
+    pinotDataSourceConfig = new PinotThirdEyeDataSourceConfig();
+    pinotDataSourceConfig.setControllerHost(controllerHost);
+    pinotDataSourceConfig.setControllerPort(controllerPort);
+    pinotDataSourceConfig.setClusterName(clusterName);
+    pinotDataSourceConfig.setZookeeperUrl(zookeeperUrl);
+    if (StringUtils.isNotBlank(brokerUrl)) {
+      pinotDataSourceConfig.setBrokerUrl(brokerUrl);
+    }
+    if (StringUtils.isNotBlank(tag)) {
+      pinotDataSourceConfig.setTag(tag);
     }
     return pinotDataSourceConfig;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsServiceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsServiceTest.java
@@ -1,4 +1,4 @@
-package com.linkedin.thirdeye.autoload.pinot.metrics;
+package com.linkedin.thirdeye.auto.onboard;
 
 import com.google.common.collect.Sets;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
@@ -6,6 +6,7 @@ import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
+import com.linkedin.thirdeye.auto.onboard.AutoOnboardPinotDataSource;
 import com.linkedin.thirdeye.datalayer.bao.AbstractManagerTestBase;
 import com.linkedin.thirdeye.datalayer.dto.DashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
@@ -21,16 +22,16 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class AutoloadPinotMetricsServiceTest  extends AbstractManagerTestBase {
+public class AutoOnboardPinotMetricsServiceTest  extends AbstractManagerTestBase {
 
-  private AutoLoadPinotMetricsService testAutoLoadPinotMetricsService;
+  private AutoOnboardPinotDataSource testAutoLoadPinotMetricsService;
   private String dataset = "test-collection";
   private Schema schema;
 
   @BeforeMethod
   void beforeMethod() throws Exception {
     super.init();
-    testAutoLoadPinotMetricsService = new AutoLoadPinotMetricsService();
+    testAutoLoadPinotMetricsService = new AutoOnboardPinotDataSource(null, null);
     schema = Schema.fromInputSteam(ClassLoader.getSystemResourceAsStream("sample-pinot-schema.json"));
     testAutoLoadPinotMetricsService.addPinotDataset(dataset, schema, null);
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
-import com.linkedin.thirdeye.autoload.pinot.metrics.ConfigGenerator;
+import com.linkedin.thirdeye.auto.onboard.ConfigGenerator;
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
 import com.linkedin.thirdeye.datalayer.bao.ClassificationConfigManager;


### PR DESCRIPTION
AutoLoadPinot service has changed to autoLoadService. Each data source config, can specify an auto onboard class. The AutoLoadService will periodically run each data source's autoload.