### PR TITLE
Reduce number of DNS lookups on the broker

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/LiveInstancesChangeListenerImpl.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/LiveInstancesChangeListenerImpl.java
@@ -76,7 +76,6 @@ public class LiveInstancesChangeListenerImpl implements LiveInstanceChangeListen
         LOGGER.warn("Port for server instance " + instanceId + " does not appear to be numeric", e);
         port = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
       }
-      ServerInstance ins = new ServerInstance(hostName, port);
 
       if (liveInstanceToSessionIdMap.containsKey(instanceId)) {
         // sessionId has changed
@@ -84,6 +83,7 @@ public class LiveInstancesChangeListenerImpl implements LiveInstanceChangeListen
             liveInstanceToSessionIdMap.get(instanceId));
         if (!sessionId.equals(liveInstanceToSessionIdMap.get(instanceId))) {
           try {
+            ServerInstance ins = ServerInstance.forHostPort(hostName, port);
             connectionPool.validatePool(ins, DO_NOT_RECREATE);
             liveInstanceToSessionIdMap.put(instanceId, sessionId);
           } catch (Exception e) {
@@ -95,6 +95,7 @@ public class LiveInstancesChangeListenerImpl implements LiveInstanceChangeListen
         // we don't have this instanceId
         // lets first check if the connection is valid or not
         try {
+          ServerInstance ins = ServerInstance.forHostPort(hostName, port);
           connectionPool.validatePool(ins, DO_NOT_RECREATE);
           liveInstanceToSessionIdMap.put(instanceId, sessionId);
         } catch (Exception e) {

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -618,7 +618,7 @@ public class BrokerRequestHandler {
     for (Entry<ServerInstance, ByteBuf> entry : responseMap.entrySet()) {
       ServerInstance serverInstance = entry.getKey();
       if (!isOfflineTable) {
-        serverInstance = new ServerInstance(serverInstance.getHostname(), serverInstance.getPort(), 1);
+        serverInstance = serverInstance.withSeq(1);
       }
       ByteBuf byteBuf = entry.getValue();
       try {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/ServerToSegmentSetMap.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/ServerToSegmentSetMap.java
@@ -63,7 +63,7 @@ public class ServerToSegmentSetMap {
         port = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
       }
 
-      ServerInstance serverInstance = new ServerInstance(hostName, port);
+      ServerInstance serverInstance = ServerInstance.forHostPort(hostName, port);
       SegmentIdSet segmentIdSet = new SegmentIdSet();
       for (String segmentId : entry.getValue()) {
         segmentIdSet.addSegment(new SegmentId(segmentId));


### PR DESCRIPTION
Reduce the number of DNS lookups done by the broker by reusing the same
values for all future ServerInstance creation. Since we do a DNS lookup
anyway when increasing the size of the broker's connection pool, this
does not cause issues even if the DNS entry changes.

The JVM actually has a cache for DNS entries, but accessing it requires
a synchronization block; as such, this can reduce contention for
accessing the JVM cache. Furthermore, these changes remove a DNS lookup
per server for each result coming from a realtime server during hybrid
queries. This also removes most DNS lookups when processing live
instance changes on the broker.