### PR TITLE
[TE] fix pagination for anomalyIds

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/controllers/AnomalyResultController.js
@@ -69,7 +69,7 @@ AnomalyResultController.prototype = {
       filter.selectedFilters = params.searchFilters;
       this.anomalyFilterController.resetModel();
       this.anomalyFilterController.handleAppEvent(filter);
-      this.updateFilters(hasSearchFilters);
+      this.updateFilters(hasSearchFilters, params.pageNumber);
     });
   },
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
@@ -50,12 +50,14 @@ AnomalyResultModel.prototype = {
 
     // Check that the params are tab or rand
     // and is the same as the HASH_PARAMS
-    return Object.keys(params).every((key) => {
-      const isWhiteListedParam = ['tab', 'rand', 'searchFilters', 'pageNumber'].includes(key);
-      const isParamSameAsHash = HASH_PARAMS.isSame(key, params[key], this[key]);
+    return Object.keys(params)
+      .filter(key => params[key])
+      .every((key) => {
+        const isWhiteListedParam = ['tab', 'rand', 'searchFilters', 'pageNumber'].includes(key);
+        const isParamSameAsHash = HASH_PARAMS.isSame(key, params[key], this[key]);
 
-      return isParamSameAsHash || isWhiteListedParam;
-    });
+        return isParamSameAsHash || isWhiteListedParam;
+      });
   },
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
@@ -396,9 +396,9 @@ AnomalyResultView.prototype = {
       delete anomaliesParams.startDate;
       delete anomaliesParams.endDate;
     } else if (anomaliesSearchMode == constants.MODE_GROUPID) {
-        anomaliesParams.anomalyGroupIds = $('#anomalies-search-group-input').val().join();
-        delete anomaliesParams.startDate;
-        delete anomaliesParams.endDate;
+      anomaliesParams.anomalyGroupIds = $('#anomalies-search-group-input').val().join();
+      delete anomaliesParams.startDate;
+      delete anomaliesParams.endDate;
     }
 
     return anomaliesParams;


### PR DESCRIPTION
### What's new: 
- fixing a bug introduced in the dimension filter PRS: when searching by anomalyIds, clicking page '2' would keep the UI on page 1

### QA/Test: 
Tested Locally