### PR TITLE
Add partiton metadata into SegmentZkMetadata.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/ColumnPartitionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/ColumnPartitionConfig.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.common.config;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -91,6 +92,17 @@ public class ColumnPartitionConfig {
   }
 
   /**
+   * Helper method to convert ranges (one or more) in string form (eg "[1 2],[3 4]") into a
+   * list of {@link IntRange}. Expects string is formatted correctly.
+   *
+   * @param input String representation of ranges.
+   * @return List of IntRange's for the specified string.
+   */
+  public static List<IntRange> rangesFromString(String input) {
+    return rangesFromString(input.split(PARTITION_VALUE_DELIMITER));
+  }
+
+  /**
    * Helper method to convert a list of {@link IntRange} to a delimited string.
    * The delimiter used is {@link #PARTITION_VALUE_DELIMITER}
    * @param ranges List of ranges to be converted to String.
@@ -113,5 +125,24 @@ public class ColumnPartitionConfig {
       }
     }
     return builder.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ColumnPartitionConfig that = (ColumnPartitionConfig) o;
+    return (_numPartitions == that._numPartitions) &&  _functionName.equals(that._functionName);
+  }
+
+  @Override
+  public int hashCode() {
+    return EqualityUtils.hashCodeOf(_functionName.hashCode(), _numPartitions);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/ColumnPartitionMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/ColumnPartitionMetadata.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.metadata.segment;
+
+import com.linkedin.pinot.common.config.ColumnPartitionConfig;
+import com.linkedin.pinot.common.utils.EqualityUtils;
+import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang.math.IntRange;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.DeserializationContext;
+import org.codehaus.jackson.map.JsonDeserializer;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.annotate.JsonDeserialize;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+
+
+/**
+ * Class for partition related column metadata:
+ * <ul>
+ *   <li> Partition function.</li>
+ *   <li> Number of partitions. </li>
+ *   <li> List of partition ranges. </li>
+ * </ul>
+
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ColumnPartitionMetadata extends ColumnPartitionConfig {
+
+  @JsonSerialize(using = PartitionRangesSerializer.class)
+  @JsonDeserialize(using = PartitionRangesDeserializer.class)
+  @JsonProperty("partitionRanges")
+  private final List<IntRange> _partitionRanges;
+
+  /**
+   * Constructor for the class.
+   * @param functionName Name of the partition function.
+   * @param numPartitions Number of partitions for this column.
+   * @param partitionRanges Partition ranges for the column.
+   */
+  public ColumnPartitionMetadata(@Nonnull @JsonProperty("functionName") String functionName,
+      @JsonProperty("numPartitions") int numPartitions,
+      @JsonProperty("partitionRanges") List<IntRange> partitionRanges) {
+    super(functionName, numPartitions);
+    _partitionRanges = partitionRanges;
+  }
+
+  /**
+   * Returns the list of partition ranges.
+   *
+   * @return List of partition ranges.
+   */
+  public List<IntRange> getPartitionRanges() {
+    return _partitionRanges;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ColumnPartitionMetadata that = (ColumnPartitionMetadata) o;
+    return super.equals(that) && (_partitionRanges != null ? _partitionRanges.equals(that._partitionRanges)
+        : that._partitionRanges == null);
+  }
+
+  @Override
+  public int hashCode() {
+    int hashCode = _partitionRanges != null ? _partitionRanges.hashCode() : 0;
+    return EqualityUtils.hashCodeOf(super.hashCode(), hashCode);
+  }
+
+  /**
+   * Custom Json serializer for list of IntRange's.
+   */
+  public static class PartitionRangesSerializer extends JsonSerializer<List<IntRange>> {
+
+    @Override
+    public void serialize(List<IntRange> value, JsonGenerator jsonGenerator, SerializerProvider provider)
+        throws IOException {
+      jsonGenerator.writeString(ColumnPartitionConfig.rangesToString(value));
+    }
+  }
+
+  /**
+   * Custom Json de-serializer for list of IntRange's.
+   */
+  public static class PartitionRangesDeserializer extends JsonDeserializer<List<IntRange>> {
+
+    @Override
+    public List<IntRange> deserialize(JsonParser jsonParser, DeserializationContext context)
+        throws IOException {
+      return ColumnPartitionConfig.rangesFromString(jsonParser.getText());
+    }
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentPartitionMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/SegmentPartitionMetadata.java
@@ -1,0 +1,151 @@
+package com.linkedin.pinot.common.metadata.segment;
+
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.math.IntRange;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.ObjectMapper;
+
+
+/**
+ * Class for partition metadata for a segment.
+ */
+@SuppressWarnings("unused") // Suppress incorrect warning, as methods are used for json ser/de.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SegmentPartitionMetadata {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public static final int INVALID_NUM_PARTITIONS = -1;
+  private final Map<String, ColumnPartitionMetadata> _columnPartitionMap;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param columnPartitionMap Column name to ColumnPartitionMetadata map.
+   */
+  public SegmentPartitionMetadata(
+      @Nonnull @JsonProperty("columnPartitionMap") Map<String, ColumnPartitionMetadata> columnPartitionMap) {
+    Preconditions.checkNotNull(columnPartitionMap);
+    _columnPartitionMap = columnPartitionMap;
+  }
+
+  /**
+   * Returns the map from column name to column's partition metadata.
+   *
+   * @return Map from column name to its partition metadata.
+   */
+  public Map<String, ColumnPartitionMetadata> getColumnPartitionMap() {
+    return _columnPartitionMap;
+  }
+
+  /**
+   * Returns the partition function for the given column, null if there isn't one.
+   *
+   * @param column Column for which to return the partition function.
+   * @return Partition function for the column.
+   */
+  @Nullable
+  public String getFunctionName(@Nonnull String column) {
+    ColumnPartitionMetadata columnPartitionMetadata = _columnPartitionMap.get(column);
+    return (columnPartitionMetadata != null) ? columnPartitionMetadata.getFunctionName() : null;
+  }
+
+  /**
+   * Set the number of partitions for the specified column.
+   *
+   * @param column Column for which to set the number of partitions.
+   * @param numPartitions Number of partitions to set.
+   */
+  @JsonIgnore
+  public void setNumPartitions(String column, int numPartitions) {
+    ColumnPartitionMetadata columnPartitionMetadata = _columnPartitionMap.get(column);
+    columnPartitionMetadata.setNumPartitions(numPartitions);
+  }
+
+  /**
+   * Given a JSON string, de-serialize and return an instance of {@link SegmentPartitionMetadata}
+   *
+   * @param jsonString Input JSON string
+   * @return Instance of {@link SegmentPartitionMetadata} built from the input string.
+   * @throws IOException
+   */
+  public static SegmentPartitionMetadata fromJsonString(String jsonString)
+      throws IOException {
+    return OBJECT_MAPPER.readValue(jsonString, SegmentPartitionMetadata.class);
+  }
+
+  /**
+   * Returns the JSON equivalent of the object.
+   *
+   * @return JSON string equivalent of the object.
+   * @throws IOException
+   */
+  public String toJsonString()
+      throws IOException {
+    return OBJECT_MAPPER.writeValueAsString(this);
+  }
+
+  /**
+   * Returns the number of partitions for the specified column.
+   * Returns {@link #INVALID_NUM_PARTITIONS} if it does not exist for the column.
+   *
+   * @param column Column for which to get number of partitions.
+   * @return Number of partitions of the column.
+   */
+  public int getNumPartitions(String column) {
+    ColumnPartitionMetadata columnPartitionMetadata = _columnPartitionMap.get(column);
+    return (columnPartitionMetadata != null) ? columnPartitionMetadata.getNumPartitions() : INVALID_NUM_PARTITIONS;
+  }
+
+  /**
+   * Returns the list of partition ranges for the specified column.
+   * Returns null if the column is not partitioned.
+   *
+   * @param column Column for which to return the list of partition ranges.
+   * @return List of partition ranges for the specified column.
+   */
+  public List<IntRange> getPartitionRanges(String column) {
+    ColumnPartitionMetadata columnPartitionMetadata = _columnPartitionMap.get(column);
+    return (columnPartitionMetadata != null) ? columnPartitionMetadata.getPartitionRanges() : null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SegmentPartitionMetadata that = (SegmentPartitionMetadata) o;
+    return _columnPartitionMap.equals(that._columnPartitionMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return _columnPartitionMap != null ? _columnPartitionMap.hashCode() : 0;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -257,6 +257,7 @@ public class CommonConstants {
     public static final String CRC = "segment.crc";
     public static final String CREATION_TIME = "segment.creation.time";
     public static final String FLUSH_THRESHOLD_SIZE = "segment.flush.threshold.size";
+    public static final String PARTITION_METADATA = "segment.partition.metadata";
 
     public static final String SEGMENT_BACKUP_DIR_SUFFIX = ".segment.bak";
     public static final String SEGMENT_TEMP_DIR_SUFFIX = ".segment.tmp";

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentPartitionTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentPartitionTest.java
@@ -20,10 +20,8 @@ import com.linkedin.pinot.common.config.SegmentPartitionConfig;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.FilterOperator;
-import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.common.utils.request.RequestUtils;
@@ -112,8 +110,7 @@ public class SegmentPartitionTest {
 
     List<IntRange> partitionValues = columnMetadata.getPartitionRanges();
     Assert.assertEquals(partitionValues.size(), 1);
-    List<IntRange> expectedPartitionValues = ColumnPartitionConfig.rangesFromString(
-        EXPECTED_PARTITION_VALUE_STRING.split(ColumnPartitionConfig.PARTITION_VALUE_DELIMITER));
+    List<IntRange> expectedPartitionValues = ColumnPartitionConfig.rangesFromString(EXPECTED_PARTITION_VALUE_STRING);
 
     IntRange actualValue = partitionValues.get(0);
     IntRange expectedPartitionValue = expectedPartitionValues.get(0);


### PR DESCRIPTION
1. Added SegmentPartitionMetadata class that contains
ColumnPartitionMetadata for each column that the data is partitioned on.

2. SegmentPartitionMetadata is built from SegmentMetadata and is JSON
serialzed and stored as a simple filed in the ZnRecord of
SegmentZkMetadata. The JSON string gets appropriately de-serialized when
building SegmentZkMetadata from ZnRecord.

3. Added unit test for the new code.