### PR TITLE
[PINOT-4889] Preparation for off-heap mutable dictionary for Realtime consuming segments.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeMultiValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeMultiValueBlock.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.core.common.Block;
@@ -26,22 +27,21 @@ import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import com.linkedin.pinot.core.operator.docvalsets.RealtimeMultiValueSet;
-import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class RealtimeMultiValueBlock implements Block {
 
   private final MutableRoaringBitmap filteredBitmap;
   final FieldSpec spec;
-  private final BaseOnHeapMutableDictionary dictionary;
+  private final MutableDictionary dictionary;
   final int docIdSearchableOffset;
   final FixedByteSingleColumnMultiValueReaderWriter reader;
   private Predicate p;
   private final int maxNumberOfMultiValues;
 
-  public RealtimeMultiValueBlock(FieldSpec spec, BaseOnHeapMutableDictionary dictionary, MutableRoaringBitmap filteredDocids,
+  public RealtimeMultiValueBlock(FieldSpec spec, MutableDictionary dictionary, MutableRoaringBitmap filteredDocids,
       int docIdOffset, int maxNumberOfMultiValues, FixedByteSingleColumnMultiValueReaderWriter indexReader) {
     this.spec = spec;
     this.dictionary = dictionary;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/RealtimeSingleValueBlock.java
@@ -28,7 +28,7 @@ import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.operator.docvalsets.RealtimeFixedWidthRawValueSet;
 import com.linkedin.pinot.core.operator.docvalsets.RealtimeSingleValueSet;
-import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 
 
@@ -36,12 +36,12 @@ public class RealtimeSingleValueBlock implements Block {
 
   private final MutableRoaringBitmap filteredBitmap;
   final FieldSpec spec;
-  private final BaseOnHeapMutableDictionary dictionary;
+  private final MutableDictionary dictionary;
   final int docIdSearchableOffset;
   final FixedByteSingleColumnSingleValueReaderWriter reader;
   private Predicate p;
 
-  public RealtimeSingleValueBlock(MutableRoaringBitmap filteredBitmap, FieldSpec spec, BaseOnHeapMutableDictionary dictionary,
+  public RealtimeSingleValueBlock(MutableRoaringBitmap filteredBitmap, FieldSpec spec, MutableDictionary dictionary,
       int offset, FixedByteSingleColumnSingleValueReaderWriter indexReader) {
     this.spec = spec;
     this.dictionary = dictionary;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
@@ -25,7 +25,7 @@ import com.linkedin.pinot.core.common.predicate.NotInPredicate;
 import com.linkedin.pinot.core.common.predicate.RangePredicate;
 import com.linkedin.pinot.core.common.predicate.RegexpLikePredicate;
 import com.linkedin.pinot.core.query.exception.BadQueryRequestException;
-import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 
@@ -53,7 +53,7 @@ public class PredicateEvaluatorProvider {
                   (ImmutableDictionaryReader) dictionary);
             } else {
               return RangePredicateEvaluatorFactory.newRealtimeDictionaryBasedEvaluator((RangePredicate) predicate,
-                  (BaseOnHeapMutableDictionary) dictionary);
+                  (MutableDictionary) dictionary);
             }
           case REGEXP_LIKE:
             return RegexpLikePredicateEvaluatorFactory.newDictionaryBasedEvaluator((RegexpLikePredicate) predicate,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -15,14 +15,14 @@
  */
 package com.linkedin.pinot.core.operator.filter.predicate;
 
+import java.util.ArrayList;
+import java.util.List;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.predicate.RangePredicate;
-import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**
@@ -53,7 +53,7 @@ public class RangePredicateEvaluatorFactory {
    * @return Dictionary based equality _predicate evaluator
    */
   public static PredicateEvaluator newRealtimeDictionaryBasedEvaluator(RangePredicate predicate,
-      BaseOnHeapMutableDictionary dictionary) {
+      MutableDictionary dictionary) {
     return new RealtimeDictionaryBasedPredicateEvaluator(predicate, dictionary);
   }
 
@@ -187,7 +187,7 @@ public class RangePredicateEvaluatorFactory {
     private IntSet _dictIdSet;
     private RangePredicate _predicate;
 
-    public RealtimeDictionaryBasedPredicateEvaluator(RangePredicate predicate, BaseOnHeapMutableDictionary dictionary) {
+    public RealtimeDictionaryBasedPredicateEvaluator(RangePredicate predicate, MutableDictionary dictionary) {
       this._predicate = predicate;
       List<Integer> ids = new ArrayList<>();
       String rangeStart;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
@@ -29,7 +29,7 @@ import com.linkedin.pinot.core.data.partition.PartitionFunctionFactory;
 import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.operator.blocks.RealtimeSingleValueBlock;
 import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
-import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
 import com.linkedin.pinot.core.segment.creator.ColumnStatistics;
 
 
@@ -41,7 +41,7 @@ public class RealtimeColumnStatistics implements ColumnStatistics {
 
   private final RealtimeColumnDataSource _dataSource;
   private final int[] _sortedDocIdIterationOrder;
-  private final BaseOnHeapMutableDictionary _dictionaryReader;
+  private final MutableDictionary _dictionaryReader;
   private final Block _block;
   private PartitionFunction partitionFunction;
   private int numPartitions;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/datasource/RealtimeColumnDataSource.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.impl.datasource;
 
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
@@ -30,10 +31,9 @@ import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiVa
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.operator.blocks.RealtimeMultiValueBlock;
 import com.linkedin.pinot.core.operator.blocks.RealtimeSingleValueBlock;
-import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
 import com.linkedin.pinot.core.realtime.impl.invertedIndex.RealtimeInvertedIndex;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class RealtimeColumnDataSource extends DataSource {
@@ -52,10 +52,10 @@ public class RealtimeColumnDataSource extends DataSource {
   private final RealtimeInvertedIndex invertedIndex;
   private final int offset;
   private final int maxNumberOfMultiValues;
-  private final BaseOnHeapMutableDictionary dictionary;
+  private final MutableDictionary dictionary;
 
   public RealtimeColumnDataSource(FieldSpec spec, DataFileReader indexReader, RealtimeInvertedIndex invertedIndex,
-      int searchOffset, int maxNumberOfMultivalues, Schema schema, BaseOnHeapMutableDictionary dictionary) {
+      int searchOffset, int maxNumberOfMultivalues, Schema schema, MutableDictionary dictionary) {
     this.fieldSpec = spec;
     this.indexReader = indexReader;
     this.invertedIndex = invertedIndex;
@@ -188,7 +188,7 @@ public class RealtimeColumnDataSource extends DataSource {
   }
 
   @Override
-  public BaseOnHeapMutableDictionary getDictionary() {
+  public MutableDictionary getDictionary() {
     return dictionary;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOnHeapMutableDictionary.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
  * value later, but not reversely. So whenever we return a valid dictionary id for a value, we need to ensure the value
  * can be fetched by the dictionary id returned.
  */
-public abstract class BaseOnHeapMutableDictionary implements Dictionary {
+public abstract class BaseOnHeapMutableDictionary extends MutableDictionary {
   private static final int SHIFT_OFFSET = 13;  // INITIAL_DICTIONARY_SIZE = 8192
   private static final int INITIAL_DICTIONARY_SIZE = 1 << SHIFT_OFFSET;
   private static final int MASK = 0xFFFFFFFF >>> (Integer.SIZE - SHIFT_OFFSET);
@@ -48,72 +48,16 @@ public abstract class BaseOnHeapMutableDictionary implements Dictionary {
   }
 
   @Override
-  public String getStringValue(int dictId) {
-    return get(dictId).toString();
-  }
-
-  @Override
   public int length() {
     return _entriesIndexed;
-  }
-
-  @Override
-  public void readIntValues(int[] dictIds, int startPos, int limit, int[] outValues, int outStartPos) {
-    int endPos = startPos + limit;
-    for (int i = startPos; i < endPos; i++) {
-      outValues[outStartPos++] = getIntValue(dictIds[i]);
-    }
-  }
-
-  @Override
-  public void readLongValues(int[] dictIds, int startPos, int limit, long[] outValues, int outStartPos) {
-    int endPos = startPos + limit;
-    for (int i = startPos; i < endPos; i++) {
-      outValues[outStartPos++] = getLongValue(dictIds[i]);
-    }
-  }
-
-  @Override
-  public void readFloatValues(int[] dictIds, int startPos, int limit, float[] outValues, int outStartPos) {
-    int endPos = startPos + limit;
-    for (int i = startPos; i < endPos; i++) {
-      outValues[outStartPos++] = getFloatValue(dictIds[i]);
-    }
-  }
-
-  @Override
-  public void readDoubleValues(int[] dictIds, int startPos, int limit, double[] outValues, int outStartPos) {
-    int endPos = startPos + limit;
-    for (int i = startPos; i < endPos; i++) {
-      outValues[outStartPos++] = getDoubleValue(dictIds[i]);
-    }
-  }
-
-  @Override
-  public void readStringValues(int[] dictIds, int startPos, int limit, String[] outValues, int outStartPos) {
-    int endPos = startPos + limit;
-    for (int i = startPos; i < endPos; i++) {
-      outValues[outStartPos++] = getStringValue(dictIds[i]);
-    }
   }
 
   public boolean isEmpty() {
     return _entriesIndexed == 0;
   }
 
-  public abstract void index(@Nonnull Object rawValue);
-
-  public abstract boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare,
-      boolean includeLower, boolean includeUpper);
-
-  @Nonnull
-  public abstract Object getMinVal();
-
-  @Nonnull
-  public abstract Object getMaxVal();
-
-  @Nonnull
-  public abstract Object getSortedValues();
+  public void close() throws IOException {
+  }
 
   /**
    * Index a single value.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.io.Closeable;
+import java.io.IOException;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import javax.annotation.Nonnull;
+
+
+public abstract class MutableDictionary implements Dictionary, Closeable {
+
+ @Override
+  public String getStringValue(int dictId) {
+    return get(dictId).toString();
+  }
+
+  @Override
+  public void readIntValues(int[] dictIds, int startPos, int limit, int[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getIntValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readLongValues(int[] dictIds, int startPos, int limit, long[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getLongValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readFloatValues(int[] dictIds, int startPos, int limit, float[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getFloatValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readDoubleValues(int[] dictIds, int startPos, int limit, double[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getDoubleValue(dictIds[i]);
+    }
+  }
+
+  @Override
+  public void readStringValues(int[] dictIds, int startPos, int limit, String[] outValues, int outStartPos) {
+    int endPos = startPos + limit;
+    for (int i = startPos; i < endPos; i++) {
+      outValues[outStartPos++] = getStringValue(dictIds[i]);
+    }
+  }
+
+  public abstract void index(@Nonnull Object rawValue);
+
+  public abstract boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare,
+      boolean includeLower, boolean includeUpper);
+
+  @Nonnull
+  public abstract Object getMinVal();
+
+  @Nonnull
+  public abstract Object getMaxVal();
+
+  @Nonnull
+  public abstract Object getSortedValues();
+
+  public abstract boolean isEmpty();
+
+  public abstract void close() throws IOException;
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
@@ -22,7 +22,7 @@ public class MutableDictionaryFactory {
   private MutableDictionaryFactory() {
   }
 
-  public static BaseOnHeapMutableDictionary getMutableDictionary(FieldSpec.DataType dataType) {
+  public static MutableDictionary getMutableDictionary(FieldSpec.DataType dataType) {
     switch (dataType) {
       case INT:
         return new IntOnHeapMutableDictionary();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/utils/RealtimeDimensionsSerDe.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/utils/RealtimeDimensionsSerDe.java
@@ -15,25 +15,25 @@
  */
 package com.linkedin.pinot.core.realtime.utils;
 
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.core.data.GenericRow;
-import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOnHeapMutableDictionary;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
 
 
 public class RealtimeDimensionsSerDe {
 
   private final List<String> dimensionsList;
   private final Schema dataSchema;
-  private final Map<String, BaseOnHeapMutableDictionary> dictionaryMap;
+  private final Map<String, MutableDictionary> dictionaryMap;
 
   public RealtimeDimensionsSerDe(List<String> dimensionName, Schema schema,
-      Map<String, BaseOnHeapMutableDictionary> dictionary) {
+      Map<String, MutableDictionary> dictionary) {
     this.dimensionsList = dimensionName;
     this.dataSchema = schema;
     this.dictionaryMap = dictionary;


### PR DESCRIPTION
Introduce a new base class MutableDictionary that gets exported whether the underlying implementation is
on-heap or off-heap.

Added a close() method to the dictionary, since the off-heap structures need to be released when the segment
is destroyed. Added a call to close() in the destroy() method for RealtimeSegmentImpl