### PR TITLE
[TE] Issue type classifier for anomalies from multiple metrics

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -1,7 +1,7 @@
 package com.linkedin.thirdeye.anomaly;
 
 import com.linkedin.thirdeye.anomaly.alert.v2.AlertJobSchedulerV2;
-import com.linkedin.thirdeye.anomaly.grouping.GroupingJobScheduler;
+import com.linkedin.thirdeye.anomaly.classification.ClassificationJobScheduler;
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.dashboard.resources.AnomalyFunctionResource;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
@@ -20,7 +20,6 @@ import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
 import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeExecutor;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorJobScheduler;
 import com.linkedin.thirdeye.anomaly.task.TaskDriver;
-import com.linkedin.thirdeye.auto.onboard.AutoOnboardPinotDataSource;
 import com.linkedin.thirdeye.auto.onboard.AutoOnboardService;
 import com.linkedin.thirdeye.common.BaseThirdEyeApplication;
 import com.linkedin.thirdeye.completeness.checker.DataCompletenessScheduler;
@@ -45,7 +44,7 @@ public class ThirdEyeAnomalyApplication
   private DataCompletenessScheduler dataCompletenessScheduler = null;
   private AlertFilterFactory alertFilterFactory = null;
   private AlertFilterAutotuneFactory alertFilterAutotuneFactory = null;
-  private GroupingJobScheduler groupingJobScheduler = null;
+  private ClassificationJobScheduler classificationJobScheduler = null;
 
   public static void main(final String[] args) throws Exception {
 
@@ -136,8 +135,8 @@ public class ThirdEyeAnomalyApplication
           dataCompletenessScheduler.start();
         }
         if (config.isGrouper()) {
-          groupingJobScheduler = new GroupingJobScheduler();
-          groupingJobScheduler.start();
+          classificationJobScheduler = new ClassificationJobScheduler();
+          classificationJobScheduler.start();
         }
       }
 
@@ -166,7 +165,7 @@ public class ThirdEyeAnomalyApplication
           dataCompletenessScheduler.shutdown();
         }
         if (config.isGrouper()) {
-          groupingJobScheduler.shutdown();
+          classificationJobScheduler.shutdown();
         }
       }
     });

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.anomaly;
 
 import com.linkedin.thirdeye.anomaly.alert.v2.AlertJobSchedulerV2;
 import com.linkedin.thirdeye.anomaly.classification.ClassificationJobScheduler;
+import com.linkedin.thirdeye.anomaly.classification.classifier.AnomalyClassifierFactory;
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.dashboard.resources.AnomalyFunctionResource;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
@@ -43,6 +44,7 @@ public class ThirdEyeAnomalyApplication
   private AutoOnboardService autoOnboardService = null;
   private DataCompletenessScheduler dataCompletenessScheduler = null;
   private AlertFilterFactory alertFilterFactory = null;
+  private AnomalyClassifierFactory anomalyClassifierFactory = null;
   private AlertFilterAutotuneFactory alertFilterAutotuneFactory = null;
   private ClassificationJobScheduler classificationJobScheduler = null;
 
@@ -89,8 +91,9 @@ public class ThirdEyeAnomalyApplication
         if (config.isWorker()) {
           anomalyFunctionFactory = new AnomalyFunctionFactory(config.getFunctionConfigPath());
           alertFilterFactory = new AlertFilterFactory(config.getAlertFilterConfigPath());
+          anomalyClassifierFactory = new AnomalyClassifierFactory(config.getAnomalyClassifierConfigPath());
 
-          taskDriver = new TaskDriver(config, anomalyFunctionFactory, alertFilterFactory);
+          taskDriver = new TaskDriver(config, anomalyFunctionFactory, alertFilterFactory, anomalyClassifierFactory);
           taskDriver.start();
         }
         if (config.isScheduler()) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -137,7 +137,7 @@ public class ThirdEyeAnomalyApplication
           dataCompletenessScheduler = new DataCompletenessScheduler();
           dataCompletenessScheduler.start();
         }
-        if (config.isGrouper()) {
+        if (config.isClassifier()) {
           classificationJobScheduler = new ClassificationJobScheduler();
           classificationJobScheduler.start();
         }
@@ -167,7 +167,7 @@ public class ThirdEyeAnomalyApplication
         if (config.isDataCompleteness()) {
           dataCompletenessScheduler.shutdown();
         }
-        if (config.isGrouper()) {
+        if (config.isClassifier()) {
           classificationJobScheduler.shutdown();
         }
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
@@ -13,7 +13,7 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
   private boolean merger = false;
   private boolean autoload = false;
   private boolean dataCompleteness = false;
-  private boolean grouper = false;
+  private boolean classifier = false;
 
   private long id;
   private String dashboardHost;
@@ -126,12 +126,12 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
     this.dataCompleteness = dataCompleteness;
   }
 
-  public boolean isGrouper() {
-    return grouper;
+  public boolean isClassifier() {
+    return classifier;
   }
 
-  public void setGrouper(boolean grouper) {
-    this.grouper = grouper;
+  public void setClassifier(boolean classifier) {
+    this.classifier = classifier;
   }
 
   public void setSmtpConfiguration(SmtpConfiguration smtpConfiguration) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/AlertJobRunner.java
@@ -100,6 +100,7 @@ public class AlertJobRunner implements Job {
     try {
       JobDTO jobSpec = new JobDTO();
       jobSpec.setJobName(alertJobContext.getJobName());
+      jobSpec.setConfigId(alertJobContext.getAlertConfigId());
       jobSpec.setWindowStartTime(monitoringWindowStartTime.getMillis());
       jobSpec.setWindowEndTime(monitoringWindowEndTime.getMillis());
       jobSpec.setScheduleStartTime(System.currentTimeMillis());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertJobRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertJobRunnerV2.java
@@ -91,6 +91,7 @@ public class AlertJobRunnerV2 implements Job {
     try {
       JobDTO jobSpec = new JobDTO();
       jobSpec.setJobName(alertJobContext.getJobName());
+      jobSpec.setConfigId(alertJobContext.getAlertConfigId());
       jobSpec.setWindowStartTime(monitoringWindowStartTime.getMillis());
       jobSpec.setWindowEndTime(monitoringWindowEndTime.getMillis());
       jobSpec.setScheduleStartTime(System.currentTimeMillis());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobConfig.java
@@ -3,9 +3,11 @@ package com.linkedin.thirdeye.anomaly.classification;
 
 public class ClassificationJobConfig {
   private long maxLookbackLength;
+  private boolean forceSyncDetectionJobs;
 
   public ClassificationJobConfig() {
     maxLookbackLength = 259200000L; // 3 days
+    forceSyncDetectionJobs = false;
   }
 
   public long getMaxLookbackLength() {
@@ -14,5 +16,13 @@ public class ClassificationJobConfig {
 
   public void setMaxLookbackLength(long maxLookbackLength) {
     this.maxLookbackLength = maxLookbackLength;
+  }
+
+  public boolean getForceSyncDetectionJobs() {
+    return forceSyncDetectionJobs;
+  }
+
+  public void setForceSyncDetectionJobs(boolean forceSyncDetectionJobs) {
+    this.forceSyncDetectionJobs = forceSyncDetectionJobs;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobConfig.java
@@ -1,10 +1,10 @@
-package com.linkedin.thirdeye.anomaly.grouping;
+package com.linkedin.thirdeye.anomaly.classification;
 
 
-public class GroupingConfiguration {
+public class ClassificationJobConfig {
   private long maxLookbackLength;
 
-  public GroupingConfiguration() {
+  public ClassificationJobConfig() {
     maxLookbackLength = 259200000L; // 3 days
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobConfig.java
@@ -2,20 +2,20 @@ package com.linkedin.thirdeye.anomaly.classification;
 
 
 public class ClassificationJobConfig {
-  private long maxLookbackLength;
+  private long maxMonitoringWindowInMS;
   private boolean forceSyncDetectionJobs;
 
   public ClassificationJobConfig() {
-    maxLookbackLength = 259200000L; // 3 days
+    maxMonitoringWindowInMS = 259200000L; // 3 days
     forceSyncDetectionJobs = false;
   }
 
-  public long getMaxLookbackLength() {
-    return maxLookbackLength;
+  public long getMaxMonitoringWindowSizeInMS() {
+    return maxMonitoringWindowInMS;
   }
 
-  public void setMaxLookbackLength(long maxLookbackLength) {
-    this.maxLookbackLength = maxLookbackLength;
+  public void setMaxMonitoringWindowInMS(long maxMonitoringWindowInMS) {
+    this.maxMonitoringWindowInMS = maxMonitoringWindowInMS;
   }
 
   public boolean getForceSyncDetectionJobs() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobContext.java
@@ -1,8 +1,8 @@
-package com.linkedin.thirdeye.anomaly.grouping;
+package com.linkedin.thirdeye.anomaly.classification;
 
 import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
 
-public class GroupingJobContext {
+public class ClassificationJobContext {
   private ClassificationConfigDTO configDTO;
   private long windowStartTime;
   private long windowEndTime;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobResource.java
@@ -1,0 +1,4 @@
+package com.linkedin.thirdeye.anomaly.classification;
+
+public class ClassificationJobResource {
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
@@ -1,4 +1,4 @@
-package com.linkedin.thirdeye.anomaly.grouping;
+package com.linkedin.thirdeye.anomaly.classification;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
@@ -18,14 +18,14 @@ import org.slf4j.LoggerFactory;
 
 import static com.linkedin.thirdeye.dashboard.resources.EntityManagerResource.OBJECT_MAPPER;
 
-public class GroupingJobRunner implements JobRunner {
-  private static final Logger LOG = LoggerFactory.getLogger(GroupingJobRunner.class);
+public class ClassificationJobRunner implements JobRunner {
+  private static final Logger LOG = LoggerFactory.getLogger(ClassificationJobRunner.class);
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
   private static final JobManager jobDAO = DAO_REGISTRY.getJobDAO();
-  private GroupingJobContext jobContext;
+  private ClassificationJobContext jobContext;
   private TaskGenerator taskGenerator = new TaskGenerator();
 
-  public GroupingJobRunner(GroupingJobContext classificationJobContext) {
+  public ClassificationJobRunner(ClassificationJobContext classificationJobContext) {
     this.jobContext = classificationJobContext;
   }
 
@@ -57,15 +57,15 @@ public class GroupingJobRunner implements JobRunner {
 
     try {
       LOG.info("Creating classification tasks");
-      List<GroupingTaskInfo> taskInfos = taskGenerator
+      List<ClassificationTaskInfo> taskInfos = taskGenerator
           .createGroupingTasks(jobContext, jobContext.getWindowStartTime(), jobContext.getWindowEndTime());
       LOG.info("Classification tasks {}", taskInfos);
-      for (GroupingTaskInfo taskInfo : taskInfos) {
+      for (ClassificationTaskInfo taskInfo : taskInfos) {
         String taskInfoJson = null;
         try {
           taskInfoJson = OBJECT_MAPPER.writeValueAsString(taskInfo);
         } catch (JsonProcessingException e) {
-          LOG.error("Exception when converting GroupingTaskInfo {} to jsonString", taskInfo, e);
+          LOG.error("Exception when converting ClassificationTaskInfo {} to jsonString", taskInfo, e);
         }
 
         TaskDTO taskSpec = new TaskDTO();
@@ -95,7 +95,7 @@ public class GroupingJobRunner implements JobRunner {
     }
   }
 
-  private static String createJobName(GroupingJobContext jobContext) {
+  private static String createJobName(ClassificationJobContext jobContext) {
     long configId = jobContext.getConfigDTO().getId();
     String configName = jobContext.getConfigDTO().getName();
     long startTimes = jobContext.getWindowStartTime();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
@@ -44,7 +44,7 @@ public class ClassificationJobRunner implements JobRunner {
       Long jobExecutionId = jobDAO.save(jobSpec);
       jobContext.setJobName(jobName);
       jobContext.setJobExecutionId(jobExecutionId);
-      LOG.info("Created anomalyJobSpec {} with jobExecutionId {}", jobSpec, jobExecutionId);
+      LOG.info("Created classification job spec {} with jobExecutionId {}", jobSpec, jobExecutionId);
       return jobExecutionId;
     } catch (Exception e) {
       LOG.error("Exception in creating classification job", e);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
@@ -35,6 +35,7 @@ public class ClassificationJobRunner implements JobRunner {
       JobDTO jobSpec = new JobDTO();
       String jobName = createJobName(jobContext);
       jobSpec.setJobName(jobName);
+      jobSpec.setConfigId(jobContext.getConfigDTO().getId());
       jobSpec.setWindowStartTime(jobContext.getWindowStartTime());
       jobSpec.setWindowEndTime(jobContext.getWindowEndTime());
       jobSpec.setScheduleStartTime(System.currentTimeMillis());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
@@ -39,7 +39,7 @@ public class ClassificationJobRunner implements JobRunner {
       jobSpec.setWindowEndTime(jobContext.getWindowEndTime());
       jobSpec.setScheduleStartTime(System.currentTimeMillis());
       jobSpec.setStatus(JobConstants.JobStatus.SCHEDULED);
-      jobSpec.setTaskType(TaskConstants.TaskType.GROUPING);
+      jobSpec.setTaskType(TaskConstants.TaskType.CLASSIFICATION);
       Long jobExecutionId = jobDAO.save(jobSpec);
       jobContext.setJobName(jobName);
       jobContext.setJobExecutionId(jobExecutionId);
@@ -69,7 +69,7 @@ public class ClassificationJobRunner implements JobRunner {
         }
 
         TaskDTO taskSpec = new TaskDTO();
-        taskSpec.setTaskType(TaskConstants.TaskType.GROUPING);
+        taskSpec.setTaskType(TaskConstants.TaskType.CLASSIFICATION);
         taskSpec.setJobName(jobContext.getJobName());
         taskSpec.setStatus(TaskConstants.TaskStatus.WAITING);
         taskSpec.setStartTime(System.currentTimeMillis());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobRunner.java
@@ -44,7 +44,8 @@ public class ClassificationJobRunner implements JobRunner {
       Long jobExecutionId = jobDAO.save(jobSpec);
       jobContext.setJobName(jobName);
       jobContext.setJobExecutionId(jobExecutionId);
-      LOG.info("Created classification job spec {} with jobExecutionId {}", jobSpec, jobExecutionId);
+      LOG.info("Created classification job spec {} with jobExecutionId {}, window start {} and end {}", jobSpec,
+          jobExecutionId, jobContext.getWindowStartTime(), jobContext.getWindowEndTime());
       return jobExecutionId;
     } catch (Exception e) {
       LOG.error("Exception in creating classification job", e);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobScheduler.java
@@ -27,13 +27,13 @@ public class ClassificationJobScheduler implements Runnable {
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
   private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-  private long maxLookbackLength = 259_200_000L; // 3 days
+  private long maxMonitoringWindowSizeInMS = 259_200_000L; // 3 days
   private boolean forceSyncDetectionJobs = false;
 
   public ClassificationJobScheduler() { }
 
   public ClassificationJobScheduler(ClassificationJobConfig classificationJobConfig) {
-    this.maxLookbackLength = classificationJobConfig.getMaxLookbackLength();
+    this.maxMonitoringWindowSizeInMS = classificationJobConfig.getMaxMonitoringWindowSizeInMS();
     this.forceSyncDetectionJobs = classificationJobConfig.getForceSyncDetectionJobs();
   }
 
@@ -94,7 +94,7 @@ public class ClassificationJobScheduler implements Runnable {
     // classification job does not exists or was executed long time ago.
     //   minTimeBoundary is the start time of the boundary window.
     long currentMillis = System.currentTimeMillis();
-    long minTimeBoundary = currentMillis - maxLookbackLength;
+    long minTimeBoundary = currentMillis - maxMonitoringWindowSizeInMS;
 
     // Check the latest detection time among all anomaly functions in this classification config.
     // If an activated anomaly function does not have any detection jobs that are executed within the time window

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobScheduler.java
@@ -116,7 +116,7 @@ public class ClassificationJobScheduler implements Runnable {
 
     long startTime = minTimeBoundary;
     // Get the most recent classification job and continue from previous completed classification job
-    JobDTO classificationJobDTO = jobDAO.findLatestCompletedGroupingJobById(classificationConfig.getId());
+    JobDTO classificationJobDTO = jobDAO.findLatestCompletedClassificationJobById(classificationConfig.getId());
     if (classificationJobDTO != null) {
       startTime = Math.max(startTime, classificationJobDTO.getWindowEndTime());
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskInfo.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskInfo.java
@@ -1,18 +1,18 @@
-package com.linkedin.thirdeye.anomaly.grouping;
+package com.linkedin.thirdeye.anomaly.classification;
 
 import com.linkedin.thirdeye.anomaly.task.TaskInfo;
 import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
 
-public class GroupingTaskInfo implements TaskInfo {
+public class ClassificationTaskInfo implements TaskInfo {
   private long jobexecutionId;
   private long windowStartTime;
   private long windowEndTime;
   private ClassificationConfigDTO classificationConfigDTO;
 
-  public GroupingTaskInfo() {
+  public ClassificationTaskInfo() {
   }
 
-  public GroupingTaskInfo(long jobexecutionId, long windowStartTime, long windowEndTime,
+  public ClassificationTaskInfo(long jobexecutionId, long windowStartTime, long windowEndTime,
       ClassificationConfigDTO classificationConfigDTO) {
     this.jobexecutionId = jobexecutionId;
     this.windowStartTime = windowStartTime;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -1,17 +1,161 @@
 package com.linkedin.thirdeye.anomaly.classification;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.linkedin.thirdeye.anomaly.task.TaskContext;
 import com.linkedin.thirdeye.anomaly.task.TaskInfo;
 import com.linkedin.thirdeye.anomaly.task.TaskResult;
 import com.linkedin.thirdeye.anomaly.task.TaskRunner;
+import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
+import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilter;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * This class determines the issue type of the anomalies from main anomaly function in two steps:
+ * 1. Get anomalies for all anomaly functions.
+ *    There are two cases to consider: A. activated anomaly functions and B. deactivated functions.
+ *    We read the anomalies in the window from DB for case A and trigger adhoc anomaly detection for case B.
+ * 2. Afterwards, a classification logic takes as input the anomalies and updates the issue type of the anomalies
+ *    from main anomaly function.
+ */
 public class ClassificationTaskRunner implements TaskRunner {
+  private static final Logger LOG = LoggerFactory.getLogger(ClassificationTaskRunner.class);
+  private AnomalyFunctionManager anomalyFunctionDAO = DAORegistry.getInstance().getAnomalyFunctionDAO();
+  private MergedAnomalyResultManager mergedAnomalyDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
+
+  private long windowStart;
+  private long windowEnd;
+  private ClassificationConfigDTO classificationConfig;
+  private AnomalyFunctionFactory anomalyFunctionFactory;
+  private AlertFilterFactory alertFilterFactory;
+
+  Map<Long, AnomalyFunctionDTO> anomalyFunctionConfigMap = new HashMap<>();
+  Map<Long, AlertFilter> alertFilterMap = new HashMap<>();
+
   @Override
   public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
     List<TaskResult> taskResults = new ArrayList<>();
 
+    LOG.info("Setting up task {}", taskInfo);
+    setupTask(taskInfo, taskContext);
+
+    runTask(windowStart, windowEnd);
+
     return taskResults;
+  }
+
+  private void setupTask(TaskInfo taskInfo, TaskContext taskContext) {
+    ClassificationTaskInfo classificationTaskInfo = (ClassificationTaskInfo) taskInfo;
+    windowStart = classificationTaskInfo.getWindowStartTime();
+    windowEnd = classificationTaskInfo.getWindowEndTime();
+    classificationConfig = classificationTaskInfo.getClassificationConfigDTO();
+    anomalyFunctionFactory = taskContext.getAnomalyFunctionFactory();
+    alertFilterFactory = taskContext.getAlertFilterFactory();
+  }
+
+  private void runTask(long windowStart, long windowEnd) {
+    long mainFunctionId = classificationConfig.getMainFunctionId();
+    addAnomalyFunctionAndAlertConfig(mainFunctionId);
+    AlertFilter alertFilter = alertFilterMap.get(mainFunctionId);
+
+    // Get the anomalies from the main anomaly function
+    List<MergedAnomalyResultDTO> mainAnomalies =
+        mergedAnomalyDAO.findAllOverlapByFunctionId(mainFunctionId, windowStart, windowEnd, false);
+    List<MergedAnomalyResultDTO> filteredMainAnomalies = filterAnomalies(alertFilter, mainAnomalies);
+
+    // Sort merged anomalies by the natural order of the end time
+    Collections.sort(filteredMainAnomalies, new MergeAnomalyEndTimeComparator());
+    // Run classifier for each dimension of the anomalies
+    ListMultimap<DimensionMap, MergedAnomalyResultDTO> updatedMainAnomaliesByDimension =
+        dimensionalShuffleAndUnifyClassification(filteredMainAnomalies);
+
+  }
+
+  private ListMultimap<DimensionMap, MergedAnomalyResultDTO> dimensionalShuffleAndUnifyClassification(
+      List<MergedAnomalyResultDTO> mainAnomalies) {
+
+    ListMultimap<DimensionMap, MergedAnomalyResultDTO> updatedMainAnomaliesByDimension = ArrayListMultimap.create();
+    // Terminate if the main anomaly function has not detected any anomalies in the given window
+    if (CollectionUtils.isEmpty(mainAnomalies)) {
+      return updatedMainAnomaliesByDimension;
+    }
+
+    // Sort anomalies by their dimensions
+    ListMultimap<DimensionMap, MergedAnomalyResultDTO> mainAnomaliesByDimension = ArrayListMultimap.create();
+    for (MergedAnomalyResultDTO mainAnomaly : mainAnomalies) {
+      mainAnomaliesByDimension.put(mainAnomaly.getDimensions(), mainAnomaly);
+    }
+
+    // Set up maps of function id to anomaly function config and alert filter
+    List<Long> functionIds = classificationConfig.getFunctionIdList();
+    for (Long functionId : functionIds) {
+      addAnomalyFunctionAndAlertConfig(functionId);
+    }
+
+    // For each dimension, we get the anomalies from the correlated metric
+    for (DimensionMap dimensionMap : mainAnomaliesByDimension.keySet()) {
+      Map<Long, List<MergedAnomalyResultDTO>> functionIdToAnomalyResult = new HashMap<>();
+
+      // Get the anomalies from other anomaly function that are activated
+      for (Long functionId : functionIds) {
+        AnomalyFunctionDTO anomalyFunctionDTO = anomalyFunctionConfigMap.get(functionId);
+        AlertFilter alertFilter = alertFilterMap.get(functionId);
+        if (anomalyFunctionDTO.getIsActive()) {
+          List<MergedAnomalyResultDTO> anomalies = mergedAnomalyDAO
+              .findAllOverlapByFunctionIdDimensions(functionId, windowStart, windowEnd, dimensionMap.toString(), false);
+          List<MergedAnomalyResultDTO> filteredAnomalies = filterAnomalies(alertFilter, anomalies);
+          Collections.sort(filteredAnomalies, new MergeAnomalyEndTimeComparator());
+          functionIdToAnomalyResult.put(functionId, filteredAnomalies);
+        } else {
+          // TODO: Trigger adhoc anomaly detection
+        }
+      }
+
+      // TODO: Invoke classification logic for this dimension
+
+    }
+
+    return updatedMainAnomaliesByDimension;
+  }
+
+  private void addAnomalyFunctionAndAlertConfig(long functionId) {
+    AnomalyFunctionDTO anomalyFunctionDTO = anomalyFunctionDAO.findById(functionId);
+    anomalyFunctionConfigMap.put(functionId, anomalyFunctionDTO);
+    AlertFilter alertFilter = alertFilterFactory.fromSpec(anomalyFunctionDTO.getAlertFilter());
+    alertFilterMap.put(functionId, alertFilter);
+  }
+
+  private static List<MergedAnomalyResultDTO> filterAnomalies(AlertFilter alertFilter,
+      List<MergedAnomalyResultDTO> anomalies) {
+    List<MergedAnomalyResultDTO> filteredMainAnomalies = new ArrayList<>();
+    for (MergedAnomalyResultDTO mainAnomaly : anomalies) {
+      if (alertFilter.isQualified(mainAnomaly)) {
+        filteredMainAnomalies.add(mainAnomaly);
+      }
+    }
+    return filteredMainAnomalies;
+  }
+
+  private static class MergeAnomalyEndTimeComparator implements Comparator<MergedAnomalyResultDTO> {
+    @Override
+    public int compare(MergedAnomalyResultDTO lhs, MergedAnomalyResultDTO rhs) {
+      return (int) (lhs.getEndTime() - rhs.getEndTime());
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -1,4 +1,4 @@
-package com.linkedin.thirdeye.anomaly.grouping;
+package com.linkedin.thirdeye.anomaly.classification;
 
 import com.linkedin.thirdeye.anomaly.task.TaskContext;
 import com.linkedin.thirdeye.anomaly.task.TaskInfo;
@@ -7,7 +7,7 @@ import com.linkedin.thirdeye.anomaly.task.TaskRunner;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GroupingTaskRunner implements TaskRunner {
+public class ClassificationTaskRunner implements TaskRunner {
   @Override
   public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
     List<TaskResult> taskResults = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -87,6 +87,18 @@ public class ClassificationTaskRunner implements TaskRunner {
 
   }
 
+  /**
+   * For each dimension of the main anomalies, this method collects its correlated anomalies from other metrics and
+   * invokes the classification logic on those anomalies. The correlated anomalies could come from activated or
+   * deactivated functions. For the former functions, this method retrieves its anomalies from backend DB. For the
+   * latter one, it invokes adhoc anomaly detections on the time window of main anomalies. The time window is determined
+   * by the min. start time and max. end time of main anomalies; in addition, the window is bounded by the start and
+   * end time of this classification job just in case of long main anomalies.
+   *
+   * @param mainAnomalies the collection of main anomalies.
+   *
+   * @return a collection of main anomalies, which has issue type updated, that is grouped by dimensions.
+   */
   private ListMultimap<DimensionMap, MergedAnomalyResultDTO> dimensionalShuffleAndUnifyClassification(
       List<MergedAnomalyResultDTO> mainAnomalies) {
 
@@ -145,6 +157,11 @@ public class ClassificationTaskRunner implements TaskRunner {
     return updatedMainAnomaliesByDimension;
   }
 
+  /**
+   * Initiates anomaly function spec and alert filter config for the given function id.
+   *
+   * @param functionId the id of the function to be initiated.
+   */
   private void addAnomalyFunctionAndAlertConfig(long functionId) {
     AnomalyFunctionDTO anomalyFunctionDTO = anomalyFunctionDAO.findById(functionId);
     anomalyFunctionConfigMap.put(functionId, anomalyFunctionDTO);
@@ -152,6 +169,14 @@ public class ClassificationTaskRunner implements TaskRunner {
     alertFilterMap.put(functionId, alertFilter);
   }
 
+  /**
+   * Filter the list of anomalies by the given alert filter.
+   *
+   * @param alertFilter the filter to apply on the list of anomalies.
+   * @param anomalies a list of anomalies.
+   *
+   * @return a list of anomalies that pass through the alert filter.
+   */
   private static List<MergedAnomalyResultDTO> filterAnomalies(AlertFilter alertFilter,
       List<MergedAnomalyResultDTO> anomalies) {
     List<MergedAnomalyResultDTO> filteredMainAnomalies = new ArrayList<>();
@@ -163,6 +188,9 @@ public class ClassificationTaskRunner implements TaskRunner {
     return filteredMainAnomalies;
   }
 
+  /**
+   * A comparator to sort merged anomalies in the natural order of their end time.
+   */
   private static class MergeAnomalyEndTimeComparator implements Comparator<MergedAnomalyResultDTO> {
     @Override
     public int compare(MergedAnomalyResultDTO lhs, MergedAnomalyResultDTO rhs) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifier.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifier.java
@@ -1,0 +1,24 @@
+package com.linkedin.thirdeye.anomaly.classification.classifier;
+
+import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import java.util.List;
+import java.util.Map;
+
+public interface AnomalyClassifier {
+  /**
+   * Sets the properties of this classifier.
+   *
+   * @param props the properties for this classifier.
+   */
+  void setParameters(Map<String, String> props);
+
+  /**
+   * Returns a list of main anomalies that have issue type updated.
+   *
+   * @param anomalies the collection of main and correlated anomalies for this classification task.
+   *
+   * @return a list of main anomalies that have issue type updated.
+   */
+  List<MergedAnomalyResultDTO> classify(Map<Long, List<MergedAnomalyResultDTO>> anomalies, ClassificationConfigDTO classificationConfig);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifierFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifierFactory.java
@@ -1,0 +1,133 @@
+package com.linkedin.thirdeye.anomaly.classification.classifier;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AnomalyClassifierFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(AnomalyClassifierFactory.class);
+  private static final AnomalyClassifier DUMMY_ANOMALY_CLASSIFIER = new DummyAnomalyClassifier();
+  public static final String ANOMALY_CLASSIFIER_TYPE_KEY = "type";
+
+  private final Properties props = new Properties();
+
+  /**
+   * Instantiates a default factory which only has the implementation of internal classes in ThirdEye project.
+   */
+  public AnomalyClassifierFactory() {
+  }
+
+  /**
+   * Instantiates a factory that has the configuration file, which is given by a file path, to external classes.
+   */
+  public AnomalyClassifierFactory(String configPath) {
+    try {
+      InputStream input = new FileInputStream(configPath);
+      loadPropertiesFromInputStream(input);
+    } catch (FileNotFoundException e) {
+      LOG.warn(
+          "Property file ({}) to external classifier is not found; Only internal implementations will be available in this factory.",
+          configPath, e);
+    }
+  }
+
+  /**
+   * Instantiates a factory that has the configuration file, which is given as an input stream, to external classes.
+   */
+  public AnomalyClassifierFactory(InputStream input) {
+    loadPropertiesFromInputStream(input);
+  }
+
+  /**
+   * Loads the configuration file to external classes.
+   *
+   * @param input the input steam of the configuration file.
+   */
+  private void loadPropertiesFromInputStream(InputStream input) {
+    try {
+      props.load(input);
+    } catch (IOException e) {
+      LOG.error("Error loading the alert filters from config", e);
+    } finally {
+      IOUtils.closeQuietly(input);
+    }
+  }
+
+  /**
+   * Given a spec, which is a map of string to a string, of the anomaly classifier, returns a anomaly classifier
+   * instance. The implementation of the instance could be located in an external package or ThirdEye project.
+   *
+   * If the type of provider exists in both the external package and ThirdEye project, then the implementation from
+   * external package will be used.
+   *
+   * @param spec a map of string to a string.
+   *
+   * @return a anomaly classifier instance.
+   */
+  public AnomalyClassifier fromSpec(Map<String, String> spec) {
+    if (spec == null) {
+      spec = Collections.emptyMap();
+    }
+    // the default recipient provider is a dummy recipient provider
+    AnomalyClassifier anomalyClassifier = DUMMY_ANOMALY_CLASSIFIER;
+    if (spec.containsKey(ANOMALY_CLASSIFIER_TYPE_KEY)) {
+      String recipientProviderType = spec.get(ANOMALY_CLASSIFIER_TYPE_KEY);
+      // We first check if the implementation (class) of this provider comes from external packages
+      if(props.containsKey(recipientProviderType.toUpperCase())) {
+        String className = props.getProperty(recipientProviderType.toUpperCase());
+        try {
+          anomalyClassifier = (AnomalyClassifier) Class.forName(className).newInstance();
+        } catch (Exception e) {
+          LOG.warn(e.getMessage());
+        }
+      } else { // otherwise, we try to look for the implementation from internal classes
+        anomalyClassifier = fromStringType(spec.get(ANOMALY_CLASSIFIER_TYPE_KEY));
+      }
+    }
+    anomalyClassifier.setParameters(spec);
+
+    return anomalyClassifier;
+  }
+
+  /**
+   * The available classifier type in ThirdEye project.
+   */
+  public enum AnomalyClassifierType {
+    DUMMY
+  }
+
+  /**
+   * The methods returns the instance of anomaly classifier whose implementation is located in ThirdEye project.
+   *
+   * @param type the type name of the provider.
+   *
+   * @return a instance of anomaly classifier.
+   */
+  private static AnomalyClassifier fromStringType(String type) {
+    if (StringUtils.isBlank(type)) { // safety check and backward compatibility
+      return DUMMY_ANOMALY_CLASSIFIER;
+    }
+
+    AnomalyClassifierType providerType = AnomalyClassifierType.DUMMY;
+    for (AnomalyClassifierType enumProviderType : AnomalyClassifierType.values()) {
+      if (enumProviderType.name().compareToIgnoreCase(type) == 0) {
+        providerType = enumProviderType;
+        break;
+      }
+    }
+
+    switch (providerType) {
+    case DUMMY: // speed optimization for most use cases
+    default:
+      return DUMMY_ANOMALY_CLASSIFIER;
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifierFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifierFactory.java
@@ -79,10 +79,10 @@ public class AnomalyClassifierFactory {
     // the default recipient provider is a dummy recipient provider
     AnomalyClassifier anomalyClassifier = DUMMY_ANOMALY_CLASSIFIER;
     if (spec.containsKey(ANOMALY_CLASSIFIER_TYPE_KEY)) {
-      String recipientProviderType = spec.get(ANOMALY_CLASSIFIER_TYPE_KEY);
+      String classifierType = spec.get(ANOMALY_CLASSIFIER_TYPE_KEY);
       // We first check if the implementation (class) of this provider comes from external packages
-      if(props.containsKey(recipientProviderType.toUpperCase())) {
-        String className = props.getProperty(recipientProviderType.toUpperCase());
+      if(props.containsKey(classifierType.toUpperCase())) {
+        String className = props.getProperty(classifierType.toUpperCase());
         try {
           anomalyClassifier = (AnomalyClassifier) Class.forName(className).newInstance();
         } catch (Exception e) {
@@ -116,15 +116,15 @@ public class AnomalyClassifierFactory {
       return DUMMY_ANOMALY_CLASSIFIER;
     }
 
-    AnomalyClassifierType providerType = AnomalyClassifierType.DUMMY;
-    for (AnomalyClassifierType enumProviderType : AnomalyClassifierType.values()) {
-      if (enumProviderType.name().compareToIgnoreCase(type) == 0) {
-        providerType = enumProviderType;
+    AnomalyClassifierType classifierType = AnomalyClassifierType.DUMMY;
+    for (AnomalyClassifierType enumClassifierType : AnomalyClassifierType.values()) {
+      if (enumClassifierType.name().compareToIgnoreCase(type) == 0) {
+        classifierType = enumClassifierType;
         break;
       }
     }
 
-    switch (providerType) {
+    switch (classifierType) {
     case DUMMY: // speed optimization for most use cases
     default:
       return DUMMY_ANOMALY_CLASSIFIER;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/BaseAnomalyClassifier.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/BaseAnomalyClassifier.java
@@ -1,0 +1,13 @@
+package com.linkedin.thirdeye.anomaly.classification.classifier;
+
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class BaseAnomalyClassifier implements AnomalyClassifier {
+  protected Map<String, String> props = Collections.emptyMap();
+
+  @Override
+  public void setParameters(Map<String, String> props) {
+    this.props = props;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/DummyAnomalyClassifier.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/DummyAnomalyClassifier.java
@@ -1,0 +1,20 @@
+package com.linkedin.thirdeye.anomaly.classification.classifier;
+
+import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DummyAnomalyClassifier extends BaseAnomalyClassifier {
+  @Override
+  public void setParameters(Map<String, String> props) {
+    // Does nothing
+  }
+
+  @Override
+  public List<MergedAnomalyResultDTO> classify(Map<Long, List<MergedAnomalyResultDTO>> anomalies,
+      ClassificationConfigDTO classificationConfig) {
+    return Collections.emptyList();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobRunner.java
@@ -113,7 +113,7 @@ public class DetectionJobRunner {
       jobSpec.setScheduleStartTime(System.currentTimeMillis());
       jobSpec.setStatus(JobStatus.SCHEDULED);
       jobSpec.setTaskType(TaskType.ANOMALY_DETECTION);
-      jobSpec.setAnomalyFunctionId(functionId);
+      jobSpec.setConfigId(functionId);
       jobExecutionId = DAO_REGISTRY.getJobDAO().save(jobSpec);
 
       LOG.info("Created anomalyJobSpec {} with jobExecutionId {}", jobSpec, jobExecutionId);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionJobScheduler.java
@@ -449,7 +449,7 @@ public class DetectionJobScheduler implements Runnable {
     JobManager jobDAO = DAO_REGISTRY.getJobDAO();
     JobDTO jobDTO;
     List<TaskDTO> scheduledTaskDTO = taskDAO.findByJobIdStatusNotIn(jobExecutionId, TaskStatus.COMPLETED);
-    long functionId = jobDAO.findById(jobExecutionId).getAnomalyFunctionId();
+    long functionId = jobDAO.findById(jobExecutionId).getConfigId();
 
     while (scheduledTaskDTO.size() > 0) {
       List<Long> failedTaskIds = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/grouping/GroupingJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/grouping/GroupingJobResource.java
@@ -1,4 +1,0 @@
-package com.linkedin.thirdeye.anomaly.grouping;
-
-public class GroupingJobResource {
-}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorJobRunner.java
@@ -63,6 +63,7 @@ public class MonitorJobRunner implements JobRunner {
       jobSpec.setScheduleStartTime(System.currentTimeMillis());
       jobSpec.setStatus(JobStatus.SCHEDULED);
       jobSpec.setTaskType(TaskType.MONITOR);
+      jobSpec.setConfigId(0); // Monitor job does not have a config id
       jobExecutionId = jobDAO.save(jobSpec);
       LOG.info("Created JobSpec {} with jobExecutionId {}", jobSpec,
           jobExecutionId);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskConstants.java
@@ -10,7 +10,7 @@ public class TaskConstants {
     ALERT2,
     MONITOR,
     DATA_COMPLETENESS,
-    GROUPING,
+    CLASSIFICATION,
     // TODO: deprecate NULL task type after old task are deleted from current (as of 4/4/2017) database
     NULL // for backward compatibility
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskContext.java
@@ -1,23 +1,16 @@
 package com.linkedin.thirdeye.anomaly.task;
 
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
-import com.linkedin.thirdeye.datalayer.bao.DataCompletenessConfigManager;
-import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
-import com.linkedin.thirdeye.datalayer.bao.JobManager;
-import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
-import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
-import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
-import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
-import com.linkedin.thirdeye.datalayer.bao.TaskManager;
+import com.linkedin.thirdeye.anomaly.classification.classifier.AnomalyClassifierFactory;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 
 public class TaskContext {
 
+  private ThirdEyeAnomalyConfiguration thirdEyeAnomalyConfiguration;
   private AnomalyFunctionFactory anomalyFunctionFactory;
   private AlertFilterFactory alertFilterFactory;
-
-  private ThirdEyeAnomalyConfiguration thirdEyeAnomalyConfiguration;
+  private AnomalyClassifierFactory anomalyClassifierFactory;
 
   public ThirdEyeAnomalyConfiguration getThirdEyeAnomalyConfiguration() {
     return thirdEyeAnomalyConfiguration;
@@ -40,5 +33,13 @@ public class TaskContext {
 
   public void setAlertFilterFactory(AlertFilterFactory alertFilterFactory){
     this.alertFilterFactory = alertFilterFactory;
+  }
+
+  public AnomalyClassifierFactory getAnomalyClassifierFactory() {
+    return anomalyClassifierFactory;
+  }
+
+  public void setAnomalyClassifierFactory(AnomalyClassifierFactory anomalyClassifierFactory) {
+    this.anomalyClassifierFactory = anomalyClassifierFactory;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.anomaly.task;
 
+import com.linkedin.thirdeye.anomaly.classification.classifier.AnomalyClassifierFactory;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 
@@ -41,7 +42,8 @@ public class TaskDriver {
   private volatile boolean shutdown = false;
 
   public TaskDriver(ThirdEyeAnomalyConfiguration thirdEyeAnomalyConfiguration,
-      AnomalyFunctionFactory anomalyFunctionFactory, AlertFilterFactory alertFilterFactory) {
+      AnomalyFunctionFactory anomalyFunctionFactory, AlertFilterFactory alertFilterFactory,
+      AnomalyClassifierFactory anomalyClassifierFactory) {
     driverConfiguration = thirdEyeAnomalyConfiguration.getTaskDriverConfiguration();
     workerId = thirdEyeAnomalyConfiguration.getId();
     anomalyTaskDAO = DAO_REGISTRY.getTaskDAO();
@@ -50,6 +52,7 @@ public class TaskDriver {
     taskContext.setAnomalyFunctionFactory(anomalyFunctionFactory);
     taskContext.setThirdEyeAnomalyConfiguration(thirdEyeAnomalyConfiguration);
     taskContext.setAlertFilterFactory(alertFilterFactory);
+    taskContext.setAnomalyClassifierFactory(anomalyClassifierFactory);
     allowedOldTaskStatus.add(TaskStatus.FAILED);
     allowedOldTaskStatus.add(TaskStatus.WAITING);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskGenerator.java
@@ -1,7 +1,7 @@
 package com.linkedin.thirdeye.anomaly.task;
 
-import com.linkedin.thirdeye.anomaly.grouping.GroupingJobContext;
-import com.linkedin.thirdeye.anomaly.grouping.GroupingTaskInfo;
+import com.linkedin.thirdeye.anomaly.classification.ClassificationJobContext;
+import com.linkedin.thirdeye.anomaly.classification.ClassificationTaskInfo;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
 import java.util.ArrayList;
@@ -100,16 +100,16 @@ public class TaskGenerator {
     return tasks;
   }
 
-  public List<GroupingTaskInfo> createGroupingTasks(GroupingJobContext groupingJobContext,
+  public List<ClassificationTaskInfo> createGroupingTasks(ClassificationJobContext classificationJobContext,
       long monitoringWindowStartTime, long monitoringWindowEndTime) throws Exception {
-    long jobexecutionId = groupingJobContext.getJobExecutionId();
-    ClassificationConfigDTO groupingConfig = groupingJobContext.getConfigDTO();
-    GroupingTaskInfo groupingTaskInfo =
-        new GroupingTaskInfo(jobexecutionId, monitoringWindowStartTime, monitoringWindowEndTime,
+    long jobexecutionId = classificationJobContext.getJobExecutionId();
+    ClassificationConfigDTO groupingConfig = classificationJobContext.getConfigDTO();
+    ClassificationTaskInfo classificationTaskInfo =
+        new ClassificationTaskInfo(jobexecutionId, monitoringWindowStartTime, monitoringWindowEndTime,
             groupingConfig);
 
-    List<GroupingTaskInfo> tasks = new ArrayList<>();
-    tasks.add(groupingTaskInfo);
+    List<ClassificationTaskInfo> tasks = new ArrayList<>();
+    tasks.add(classificationTaskInfo);
     return tasks;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskInfoFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskInfoFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.anomaly.task;
 
+import com.linkedin.thirdeye.anomaly.classification.ClassificationTaskInfo;
 import java.io.IOException;
 
 import org.slf4j.Logger;
@@ -23,8 +24,7 @@ public class TaskInfoFactory {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Logger LOG = LoggerFactory.getLogger(TaskInfoFactory.class);
 
-  public static TaskInfo getTaskInfoFromTaskType(TaskType taskType, String taskInfoString)
-      throws JsonParseException, JsonMappingException, IOException {
+  public static TaskInfo getTaskInfoFromTaskType(TaskType taskType, String taskInfoString) throws IOException {
     TaskInfo taskInfo = null;
     try {
       switch(taskType) {
@@ -44,8 +44,11 @@ public class TaskInfoFactory {
         case DATA_COMPLETENESS:
           taskInfo = OBJECT_MAPPER.readValue(taskInfoString, DataCompletenessTaskInfo.class);
           break;
+        case CLASSIFICATION:
+          taskInfo = OBJECT_MAPPER.readValue(taskInfoString, ClassificationTaskInfo.class);
+          break;
         default:
-          LOG.error("TaskType must be one of ANOMALY_DETECTION, MONITOR, ALERT, ALERT2, DATA_COMPLETENESS");
+          LOG.error("TaskType must be one of ANOMALY_DETECTION, MONITOR, ALERT, ALERT2, DATA_COMPLETENESS, CLASSIFICATION");
           break;
       }
     } catch (Exception e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskRunnerFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskRunnerFactory.java
@@ -3,7 +3,7 @@ package com.linkedin.thirdeye.anomaly.task;
 import com.linkedin.thirdeye.anomaly.alert.AlertTaskRunner;
 import com.linkedin.thirdeye.anomaly.alert.v2.AlertTaskRunnerV2;
 import com.linkedin.thirdeye.anomaly.detection.DetectionTaskRunner;
-import com.linkedin.thirdeye.anomaly.grouping.GroupingTaskRunner;
+import com.linkedin.thirdeye.anomaly.classification.ClassificationTaskRunner;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorTaskRunner;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants.TaskType;
 import com.linkedin.thirdeye.completeness.checker.DataCompletenessTaskRunner;
@@ -34,7 +34,7 @@ public class TaskRunnerFactory {
       taskRunner = new AlertTaskRunnerV2();
       break;
     case GROUPING:
-      taskRunner = new GroupingTaskRunner();
+      taskRunner = new ClassificationTaskRunner();
       break;
     default:
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskRunnerFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskRunnerFactory.java
@@ -33,7 +33,7 @@ public class TaskRunnerFactory {
     case ALERT2:
       taskRunner = new AlertTaskRunnerV2();
       break;
-    case GROUPING:
+    case CLASSIFICATION:
       taskRunner = new ClassificationTaskRunner();
       break;
     default:

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/common/ThirdEyeConfiguration.java
@@ -77,6 +77,10 @@ public abstract class ThirdEyeConfiguration extends Configuration {
     return getRootDir() + "/detector-config/anomaly-functions/alertGroupRecipientProvider.properties";
   }
 
+  public String getAnomalyClassifierConfigPath() {
+    return getRootDir() + "/detector-config/anomaly-functions/anomalyClassifier.properties";
+  }
+
   public String getSmtpHost() {
     return smtpHost;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessJobRunner.java
@@ -86,6 +86,7 @@ public class DataCompletenessJobRunner implements JobRunner {
       jobSpec.setScheduleStartTime(System.currentTimeMillis());
       jobSpec.setStatus(JobStatus.SCHEDULED);
       jobSpec.setTaskType(TaskType.DATA_COMPLETENESS);
+      jobSpec.setConfigId(0); // Data completeness job does not have a config id
       jobExecutionId = DAO_REGISTRY.getJobDAO().save(jobSpec);
       LOG.info("Created JobSpec {} with jobExecutionId {}", jobSpec,
           jobExecutionId);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/JobManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/JobManager.java
@@ -23,5 +23,5 @@ public interface JobManager extends AbstractManager<JobDTO>{
 
   JobDTO findLatestCompletedDetectionJobByFunctionId(long functionId);
 
-  JobDTO findLatestCompletedGroupingJobById(long functionId);
+  JobDTO findLatestCompletedClassificationJobById(long functionId);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/JobManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/JobManager.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import com.linkedin.thirdeye.anomaly.task.TaskConstants;
 import java.util.List;
 import java.util.Set;
 
@@ -7,7 +8,7 @@ import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
 
 
-public interface JobManager extends AbstractManager<JobDTO>{
+public interface JobManager extends AbstractManager<JobDTO> {
 
   List<JobDTO> findByStatus(JobStatus status);
 
@@ -21,7 +22,5 @@ public interface JobManager extends AbstractManager<JobDTO>{
 
   JobDTO findLatestBackfillScheduledJobByFunctionId(long functionId, long backfillWindowStart, long backfillWindowEnd);
 
-  JobDTO findLatestCompletedDetectionJobByFunctionId(long functionId);
-
-  JobDTO findLatestCompletedClassificationJobById(long functionId);
+  List<JobDTO> findRecentScheduledJobByTypeAndConfigId(TaskConstants.TaskType taskType, long configId, long minScheduledTime);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/JobManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/JobManagerImpl.java
@@ -128,9 +128,9 @@ public class JobManagerImpl extends AbstractManagerImpl<JobDTO> implements JobMa
   }
 
   @Override
-  public JobDTO findLatestCompletedGroupingJobById(long functionId) {
+  public JobDTO findLatestCompletedClassificationJobById(long functionId) {
     HashMap<String, Object> parameterMap = new HashMap<>();
-    parameterMap.put("type", TaskConstants.TaskType.GROUPING);
+    parameterMap.put("type", TaskConstants.TaskType.CLASSIFICATION);
     parameterMap.put("status", JobStatus.COMPLETED);
     List<JobBean> list = genericPojoDao
         .executeParameterizedSQL(FIND_LATEST_COMPLETED_GROUPING_JOB_BY_FUNCTION_ID, parameterMap, JobBean.class);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/JobIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/JobIndex.java
@@ -6,7 +6,7 @@ public class JobIndex extends AbstractIndexEntity {
   String name;
   String status;
   TaskConstants.TaskType type;
-  long anomalyFunctionId;
+  long configId;
   long scheduleStartTime;
   long scheduleEndTime;
 
@@ -35,12 +35,12 @@ public class JobIndex extends AbstractIndexEntity {
     this.type = type;
   }
 
-  public long getAnomalyFunctionId() {
-    return anomalyFunctionId;
+  public long getConfigId() {
+    return configId;
   }
 
-  public void setAnomalyFunctionId(long anomalyFunctionId) {
-    this.anomalyFunctionId = anomalyFunctionId;
+  public void setConfigId(long configId) {
+    this.configId = configId;
   }
 
   public String getName() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/ClassificationConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/ClassificationConfigBean.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The configuration for a classification job.
@@ -9,10 +12,12 @@ import java.util.List;
  * anomaly function ids whose anomalies are used for determining the issue type during the classification.
  */
 public class ClassificationConfigBean extends AbstractBean {
-  private String name;
+  private String name = "";
   private long mainFunctionId;
-  private List<Long> functionIdList;
+  private List<Long> functionIdList = new ArrayList<>();
   private boolean active;
+  private Map<String, String> classifierConfig = new HashMap<>();
+
 
   /**
    * Returns the name of this classification configuration.
@@ -86,5 +91,23 @@ public class ClassificationConfigBean extends AbstractBean {
    */
   public void setActive(boolean active) {
     this.active = active;
+  }
+
+  /**
+   * Returns the configuration, which is given by a map of strings to strings, of classifier.
+   *
+   * @return the configuration, which is given by a map of strings to strings, of classifier.
+   */
+  public Map<String, String> getClassifierConfig() {
+    return classifierConfig;
+  }
+
+  /**
+   * Sets the configuration, which should be given by a map of strings to strings, of classifier.
+   *
+   * @param classifierConfig the configuration, which should be given by a map of strings to strings, of classifier.
+   */
+  public void setClassifierConfig(Map<String, String> classifierConfig) {
+    this.classifierConfig = classifierConfig;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/ClassificationConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/ClassificationConfigBean.java
@@ -17,6 +17,7 @@ public class ClassificationConfigBean extends AbstractBean {
   private List<Long> functionIdList = new ArrayList<>();
   private boolean active;
   private Map<String, String> classifierConfig = new HashMap<>();
+  private long endTimeWatermark = 0L;
 
 
   /**
@@ -109,5 +110,13 @@ public class ClassificationConfigBean extends AbstractBean {
    */
   public void setClassifierConfig(Map<String, String> classifierConfig) {
     this.classifierConfig = classifierConfig;
+  }
+
+  public long getEndTimeWatermark() {
+    return endTimeWatermark;
+  }
+
+  public void setEndTimeWatermark(long endTimeWatermark) {
+    this.endTimeWatermark = endTimeWatermark;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/JobBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/JobBean.java
@@ -19,7 +19,10 @@ public class JobBean extends AbstractBean {
   private long windowStartTime;
   private long windowEndTime;
   private Timestamp lastModified;
-  private long anomalyFunctionId; // 0 if this job is not a detection job
+  // The id of the job configuration, which could be a detection, alert, or classification job, that triggers
+  // this job. If this job is not triggered from a job config (e.g., monitor job), then it is 0.
+  // For example, this config id is the function id when this job is an anomaly detection.
+  private long configId;
 
   public String getJobName() {
     return jobName;
@@ -85,12 +88,12 @@ public class JobBean extends AbstractBean {
     this.lastModified = lastModified;
   }
 
-  public long getAnomalyFunctionId() {
-    return anomalyFunctionId;
+  public long getConfigId() {
+    return configId;
   }
 
-  public void setAnomalyFunctionId(long anomalyFunctionId) {
-    this.anomalyFunctionId = anomalyFunctionId;
+  public void setConfigId(long configId) {
+    this.configId = configId;
   }
 
   @Override
@@ -101,11 +104,11 @@ public class JobBean extends AbstractBean {
     JobBean af = (JobBean) o;
     return Objects.equals(getId(), af.getId()) && Objects.equals(jobName, af.getJobName()) && Objects
         .equals(status, af.getStatus()) && Objects.equals(scheduleStartTime, af.getScheduleStartTime())
-        && Objects.equals(taskType, af.getTaskType()) && Objects.equals(anomalyFunctionId, af.getAnomalyFunctionId());
+        && Objects.equals(taskType, af.getTaskType()) && Objects.equals(configId, af.getConfigId());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getId(), jobName, status, scheduleStartTime, taskType, anomalyFunctionId);
+    return Objects.hash(getId(), jobName, status, scheduleStartTime, taskType, configId);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/AbstractManagerTestBase.java
@@ -231,7 +231,7 @@ public abstract class AbstractManagerTestBase {
 
   protected ClassificationConfigDTO getTestGroupingConfiguration(long mainFunctionId) {
     ClassificationConfigDTO configDTO = new ClassificationConfigDTO();
-    configDTO.setName("groupingJob");
+    configDTO.setName("classificationJob");
     configDTO.setMainFunctionId(mainFunctionId);
     configDTO.setFunctionIdList(Collections.singletonList(mainFunctionId));
     configDTO.setActive(true);
@@ -259,6 +259,7 @@ public abstract class AbstractManagerTestBase {
     jobSpec.setScheduleStartTime(System.currentTimeMillis());
     jobSpec.setWindowStartTime(new DateTime().minusHours(20).getMillis());
     jobSpec.setWindowEndTime(new DateTime().minusHours(10).getMillis());
+    jobSpec.setConfigId(100);
     return jobSpec;
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestClassificationJobConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestClassificationJobConfigManager.java
@@ -9,7 +9,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-public class TestClassificationConfigManager extends AbstractManagerTestBase {
+public class TestClassificationJobConfigManager extends AbstractManagerTestBase {
   private static final long MAIN_FUNCTION_ID = 101L;
 
   private static final String NAME1 = "test classification name1";

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -6,7 +6,7 @@ import com.linkedin.pinot.client.ResultSetGroup;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.alert.AlertJobScheduler;
 import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
-import com.linkedin.thirdeye.anomaly.grouping.GroupingJobScheduler;
+import com.linkedin.thirdeye.anomaly.classification.ClassificationJobScheduler;
 import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorConfiguration;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorJobScheduler;
@@ -70,7 +70,7 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
   private MonitorJobScheduler monitorJobScheduler = null;
   private AlertJobScheduler alertJobScheduler = null;
   private DataCompletenessScheduler dataCompletenessScheduler = null;
-  private GroupingJobScheduler groupingJobScheduler = null;
+  private ClassificationJobScheduler classificationJobScheduler = null;
   private AnomalyFunctionFactory anomalyFunctionFactory = null;
   private AlertFilterFactory alertFilterFactory = null;
   private ThirdEyeCacheRegistry cacheRegistry = ThirdEyeCacheRegistry.getInstance();
@@ -114,8 +114,8 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
     if (dataCompletenessScheduler != null) {
       dataCompletenessScheduler.shutdown();
     }
-    if (groupingJobScheduler != null) {
-      groupingJobScheduler.shutdown();
+    if (classificationJobScheduler != null) {
+      classificationJobScheduler.shutdown();
     }
   }
 
@@ -375,8 +375,8 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
   }
 
   private void startGrouper() {
-    groupingJobScheduler = new GroupingJobScheduler();
-    groupingJobScheduler.start();
+    classificationJobScheduler = new ClassificationJobScheduler();
+    classificationJobScheduler.start();
   }
 
   private void startMonitor() {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
@@ -314,7 +314,7 @@ public class RunAdhocDatabaseQueriesTool {
       String[] names = name.split("-");
       try {
         long anomalyFunctionId = Long.parseLong(names[0]);
-        jobDTO.setAnomalyFunctionId(anomalyFunctionId);
+        jobDTO.setConfigId(anomalyFunctionId);
         jobDTO.setTaskType(TaskConstants.TaskType.ANOMALY_DETECTION);
         jobDTO.setLastModified(new Timestamp(System.currentTimeMillis()));
         jobDAO.save(jobDTO);

--- a/thirdeye/thirdeye-pinot/src/test/resources/sample-classifier.properties
+++ b/thirdeye/thirdeye-pinot/src/test/resources/sample-classifier.properties
@@ -1,0 +1,1 @@
+DUMMY = com.linkedin.thirdeye.anomaly.classification.classifier.DummyAnomalyClassifier

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -46,7 +46,7 @@ create table if not exists job_index (
     name varchar(200) not null,
     status varchar(100) not null,
     type varchar(100) not null,
-    anomaly_function_id bigint(20),
+    config_id bigint(20),
     schedule_start_time bigint(20) not null,
     schedule_end_time bigint(20) not null,
     base_id bigint(20) not null,
@@ -56,7 +56,7 @@ create table if not exists job_index (
 ) ENGINE=InnoDB;
 create index job_status_idx on job_index(status);
 create index job_type_idx on job_index(type);
-create index job_anomaly_function_id_idx on job_index(anomaly_function_id);
+create index job_config_id_idx on job_index(config_id);
 
 create table if not exists task_index (
     name varchar(200) not null,


### PR DESCRIPTION
This PR provides an execution flow for multi-metrics classifier, which determines the issue type of anomalies. Since issue types are determined through anomalies, the multi-metrics that are involved in the classification job are given through anomaly function ID.

The anomalies for classification could come from either activated or deactivated anomaly function. Therefore, the job provides this guarantee for the set of former functions: The classification window is always the overlapped area of the detection windows among all activated anomaly functions. The guarantee could be disabled through configuration.
(Future work): For the set of latter anomaly functions, this job triggers adhoc anomaly detection on the window of all anomalies from the main anomaly function.

After main anomalies and correlated anomalies are collected, we trigger classifier in order to update the issue type of main anomalies. This PR includes a very simple implementation of classifier (i.e., DummyClassifier).

Tested on local setup.