### PR TITLE
[TE] Set historical anomalies in building AnomalyDetectionContext

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/AbstractModularizedAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/AbstractModularizedAnomalyFunction.java
@@ -236,7 +236,7 @@ public abstract class AbstractModularizedAnomalyFunction extends BaseAnomalyFunc
       throws Exception {
     AnomalyDetectionContext anomalyDetectionContext = BackwardAnomalyFunctionUtils
         .buildAnomalyDetectionContext(this, timeSeries, spec.getTopicMetric(), exploredDimensions,
-            spec.getBucketSize(), spec.getBucketUnit(), windowStart, windowEnd);
+            spec.getBucketSize(), spec.getBucketUnit(), windowStart, windowEnd, knownAnomalies);
 
     return this.analyze(anomalyDetectionContext);
   }
@@ -251,7 +251,7 @@ public abstract class AbstractModularizedAnomalyFunction extends BaseAnomalyFunc
       anomalyDetectionContext = BackwardAnomalyFunctionUtils
           .buildAnomalyDetectionContext(this, timeSeries, spec.getTopicMetric(),
               anomalyToUpdated.getDimensions(), spec.getBucketSize(), spec.getBucketUnit(),
-              windowStart, windowEnd);
+              windowStart, windowEnd, knownAnomalies);
     }
 
     updateMergedAnomalyInfo(anomalyDetectionContext, anomalyToUpdated);
@@ -265,7 +265,7 @@ public abstract class AbstractModularizedAnomalyFunction extends BaseAnomalyFunc
     AnomalyDetectionContext anomalyDetectionContext = BackwardAnomalyFunctionUtils
         .buildAnomalyDetectionContext(this, timeSeries, spec.getTopicMetric(), null,
             spec.getBucketSize(), spec.getBucketUnit(), new DateTime(viewWindowStartTime),
-            new DateTime(viewWindowEndTime));
+            new DateTime(viewWindowEndTime), knownAnomalies);
 
     return this.getTimeSeriesView(anomalyDetectionContext, bucketMillis, metric, viewWindowStartTime, viewWindowEndTime,
         knownAnomalies);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
@@ -73,6 +73,7 @@ public class BackwardAnomalyFunctionUtils {
    * @param exploredDimensions the dimension map of the given time series.
    * @param windowStart the start of the interval of the time series.
    * @param windowEnd the end of the interval of the time series.
+   * @param knownAnomalies the list of historical merged anomalies.
    *
    * @return an anomaly detection context from the given information.
    */

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
@@ -7,6 +7,7 @@ import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
 import com.linkedin.thirdeye.anomalydetection.context.TimeSeriesKey;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -78,7 +79,7 @@ public class BackwardAnomalyFunctionUtils {
   public static AnomalyDetectionContext buildAnomalyDetectionContext(
       AnomalyDetectionFunction anomalyFunction, MetricTimeSeries timeSeries, String metric,
       DimensionMap exploredDimensions, int bucketSize, TimeUnit bucketUnit, DateTime windowStart,
-      DateTime windowEnd) {
+      DateTime windowEnd, List<MergedAnomalyResultDTO> knownAnomalies) {
     // Create the anomaly detection context for the new modularized anomaly function
     AnomalyDetectionContext anomalyDetectionContext = new AnomalyDetectionContext();
     anomalyDetectionContext
@@ -90,6 +91,9 @@ public class BackwardAnomalyFunctionUtils {
     timeSeriesKey.setDimensionMap(exploredDimensions);
     timeSeriesKey.setMetricName(metric);
     anomalyDetectionContext.setTimeSeriesKey(timeSeriesKey);
+
+    // set historical anomalies
+    anomalyDetectionContext.setHistoricalAnomalies(knownAnomalies);
 
     // Split time series to observed time series and baselines for each metric
     for (String metricName : anomalyFunction.getSpec().getMetrics()) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/RunAdhocDatabaseQueriesTool.java
@@ -372,7 +372,7 @@ public class RunAdhocDatabaseQueriesTool {
       System.exit(1);
     }
     RunAdhocDatabaseQueriesTool dq = new RunAdhocDatabaseQueriesTool(persistenceFile);
-    dq.disableAllActiveFunction();
+
   }
 
 }


### PR DESCRIPTION
Set historical anomalies to AnomalyDetectionContext, otherwise historical anomalies cannot be removed during detection.