### PR TITLE
[TE] Fix the decoration for filter set when query mixes non and additive datasets

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeRequest.java
@@ -1,18 +1,13 @@
 package com.linkedin.thirdeye.datasource;
 
-import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
-import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -254,66 +249,7 @@ public class ThirdEyeRequest {
     }
 
     public ThirdEyeRequest build(String requestReference) {
-      String dataset = null;
-      // Since we don't have dataset anymore, we are using the first metric function, to derive the dataset name
-      // and then using that dataset to figure out if non additive
-      try {
-        if (CollectionUtils.isNotEmpty(metricFunctions)) {
-          dataset = ThirdEyeUtils.getDatasetFromMetricFunction(metricFunctions.get(0));
-          DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(dataset);
-
-          if (!datasetConfig.isAdditive()) {
-            List<String> collectionDimensionNames = datasetConfig.getDimensions();
-            decorateFilterSetForPrecomputedDataset(filterSet, groupBy, collectionDimensionNames,
-                datasetConfig.getDimensionsHaveNoPreAggregation(), datasetConfig.getPreAggregatedKeyword());
-          }
-        }
-      } catch (Exception e) {
-        LOG.debug("Collection config for collection {} does not exist", dataset);
-      }
       return new ThirdEyeRequest(requestReference, this);
-    }
-
-    /**
-     * Definition of Pre-Computed Data: the data that has been pre-calculated or pre-aggregated, and does not require
-     * further aggregation (i.e., aggregation function of Pinot should do no-op). For such data, we assume that there
-     * exists a dimension value named "all", which is user-definable keyword in collection configuration, that stores
-     * the pre-aggregated value.
-     *
-     * By default, when a query does not specify any value on a certain dimension, Pinot aggregates all values at that
-     * dimension, which is an undesirable behavior for pre-computed data. Therefore, this method modifies the request's
-     * dimension filters such that the filter could pick out the "all" value for that dimension.
-     *
-     * Example: Suppose that we have a dataset with 3 dimensions: country, pageName, and osName, and the pre-aggregated
-     * keyword is 'all'. Further assume that the original request's filter = {'country'='US, IN'} and GroupBy dimension =
-     * pageName, then the decorated request has the new filter = {'country'='US, IN', 'osName' = 'all'}.
-     *
-     * @param filterSet the original filterSet. <dt><b>Postconditions:</b><dd> filterSet is decorated with additional
-     * filters for filtering out the pre-aggregated value on the unspecified dimensions.
-     */
-    public static void decorateFilterSetForPrecomputedDataset(Multimap<String, String> filterSet,
-        List<String> groupByDimensions, List<String> allDimensions, List<String> dimensionsHaveNoPreAggregation,
-        String preAggregatedKeyword) {
-      Set<String> preComputedDimensionNames = new HashSet<>(allDimensions);
-
-      if (dimensionsHaveNoPreAggregation.size() != 0) {
-        preComputedDimensionNames.removeAll(dimensionsHaveNoPreAggregation);
-      }
-
-      Set<String> filterDimensions = filterSet.asMap().keySet();
-      if (filterDimensions.size() != 0) {
-        preComputedDimensionNames.removeAll(filterDimensions);
-      }
-
-      if (groupByDimensions.size() != 0) {
-        preComputedDimensionNames.removeAll(groupByDimensions);
-      }
-
-      if (preComputedDimensionNames.size() != 0) {
-        for (String preComputedDimensionName : preComputedDimensionNames) {
-          filterSet.put(preComputedDimensionName, preAggregatedKeyword);
-        }
-      }
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
@@ -42,12 +42,11 @@ public class PqlUtils {
    * Due to the summation, all metric column values can be assumed to be doubles.
    * @throws ExecutionException
    */
-  public static String getPql(ThirdEyeRequest request, MetricFunction metricFunction, TimeSpec dataTimeSpec)
-      throws ExecutionException {
+  public static String getPql(ThirdEyeRequest request, MetricFunction metricFunction,
+      Multimap<String, String> filterSet, TimeSpec dataTimeSpec) throws ExecutionException {
     // TODO handle request.getFilterClause()
 
-    return getPql(metricFunction,
-        request.getStartTimeInclusive(), request.getEndTimeExclusive(), request.getFilterSet(),
+    return getPql(metricFunction, request.getStartTimeInclusive(), request.getEndTimeExclusive(), filterSet,
         request.getGroupBy(), request.getGroupByTimeGranularity(), dataTimeSpec);
   }
 
@@ -100,12 +99,11 @@ public class PqlUtils {
    * and the metric values are all in a single value column
    * @param request
    * @param dataTimeSpec
-   * @param collectionConfig
    * @return
    * @throws Exception
    */
   public static String getMetricAsDimensionPql(ThirdEyeRequest request, MetricFunction metricFunction,
-      TimeSpec dataTimeSpec, DatasetConfigDTO datasetConfig) throws Exception {
+      Multimap<String, String> filterSet, TimeSpec dataTimeSpec, DatasetConfigDTO datasetConfig) throws Exception {
 
     // select sum(metric_values_column) from collection
     // where time_clause and metric_names_column=function.getMetricName
@@ -113,7 +111,7 @@ public class PqlUtils {
     String metricNamesColumn = datasetConfig.getMetricNamesColumn();
 
     String metricAsDimensionPql = getMetricAsDimensionPql(metricFunction,
-        request.getStartTimeInclusive(), request.getEndTimeExclusive(), request.getFilterSet(),
+        request.getStartTimeInclusive(), request.getEndTimeExclusive(), filterSet,
         request.getGroupBy(), request.getGroupByTimeGranularity(), dataTimeSpec,
         metricValuesColumn, metricNamesColumn);
 


### PR DESCRIPTION
Fix the filter decoration when the query mixes metrics from non-additive and additive datasets. Usually, this kind of queries is used for calculating the derived metric.

Problem:
Previous code assumes that all metric comes from the same dataset. Therefore, it applies the same filter decoration among all metrics in the same query.

Fix:
The current fix checks the origin dataset for each metric and decorate the filter accordingly.

Tested on local dashboard and compared the data with rApTOr.