### PR TITLE
[TE] Combine filterset and anomaly dimension

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -911,7 +911,7 @@ public class AnomaliesResource {
     // Combine dimension map and filter set to construct a new filter set for the time series query of this anomaly
     Multimap<String, String> newFilterSet = generateFilterSetForTimeSeriesQuery(mergedAnomaly);
     try {
-      anomalyDetails.setAnomalyFunctionDimension(OBJECT_MAPPER.writeValueAsString(newFilterSet));
+      anomalyDetails.setAnomalyFunctionDimension(OBJECT_MAPPER.writeValueAsString(newFilterSet.asMap()));
     } catch (JsonProcessingException e) {
       LOG.warn("Failed to convert the dimension info ({}) to a JSON string; the original dimension info ({}) is used.",
           newFilterSet, mergedAnomaly.getDimensions());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -924,6 +924,18 @@ public class AnomaliesResource {
     return anomalyDetails;
   }
 
+  /**
+   * Returns the filter set to query the time series on UI. The filter set is constructed by combining the dimension
+   * information of the given anomaly and the filter set from its corresponding anomaly function.
+   *
+   * For instance, assume that the dimension from the detected anomaly is {"country":"US"} and the filter on its
+   * anomaly function is {"country":["US", "IN"],"page_key":["p1,p2"]}, then the returned filter set for querying
+   * is {"country":["US"],"page_key":["p1,p2"]}.
+   *
+   * @param mergedAnomaly the target anomaly for which we want to generate the query filter set.
+   *
+   * @return the filter set for querying the time series that produce the anomaly.
+   */
   private static Multimap<String, String> generateFilterSetForTimeSeriesQuery(MergedAnomalyResultDTO mergedAnomaly) {
     AnomalyFunctionDTO anomalyFunctionDTO = mergedAnomaly.getFunction();
     Multimap<String, String> filterSet = anomalyFunctionDTO.getFilterSet();

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -65,12 +65,7 @@ InvestigateView.prototype = {
     const parsedDimensions = JSON.parse(anomalyFunctionDimension);
     const dimensionKeys = Object.keys(parsedDimensions);
     const dimension = dimensionKeys.length ? dimensionKeys[0] : 'All';
-
-    dimensionKeys.forEach((key) => {
-      filters[key] = filters[key] || [];
-      filters[key].push(parsedDimensions[key]);
-    });
-
+    
     return wowResults
       .filter(wow => wow.compareMode !== 'Wo4W')
       .map((wow) => {
@@ -85,7 +80,7 @@ InvestigateView.prototype = {
             `compareMode=${wow.compareMode}&filters={}&granularity=${granularity}&` +
             `heatMapCurrentStart=${heatMapCurrentStart.valueOf()}&` +
             `heatMapCurrentEnd=${heatMapCurrentEnd.valueOf()}&heatMapBaselineStart=${heatMapBaselineStart.valueOf()}&` +
-            `heatMapBaselineEnd=${heatMapBaselineEnd.valueOf()}&filters=${JSON.stringify(filters)}&heatMapFilters=${JSON.stringify(filters)}`;
+            `heatMapBaselineEnd=${heatMapBaselineEnd.valueOf()}&filters=${anomalyFunctionDimension}&heatMapFilters=${anomalyFunctionDimension}`;
         return wow;
       });
   },


### PR DESCRIPTION
Problem:
Current queries for the time series of anomalies on UI do not include the dimension information (i.e., filter set) that is specified by their corresponding anomaly function. Consequently, the time series on UI is inconsistent with the time series that is used for anomaly detection.

Fix:
We construct the filter set by combining the dimension information from both anomalies and its corresponding anomaly functions. Therefore, the filter set of the queries could retrieve the correct time series that is used to produce the anomalies.

Tested on local dashboard.