### PR TITLE
[TE] Fix week-over-week values for ratio metrics

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricSchema.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricSchema.java
@@ -61,6 +61,10 @@ public class MetricSchema {
     return types.get(mapping.get(name));
   }
 
+  public Integer getMetricIndex(String name) {
+    return mapping.get(name);
+  }
+
   public List<MetricType> getTypes() {
     return types;
   }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/libs/handlebarsHelpers.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/libs/handlebarsHelpers.js
@@ -15,12 +15,10 @@ Handlebars.registerHelper('formatPercent', function (percentValue) {
 });
 
 Handlebars.registerHelper('formatDouble', function (doubleValue) {
-  if(doubleValue >= 0){
-    return "" + doubleValue.toFixed(1);
-  } else {
-    return "" + doubleValue.toFixed(1);
-  }
+  var value = Number(doubleValue);
+  return Number.isNaN(value) ? '' : d3.format('.3r')(doubleValue);
 });
+
 Handlebars.registerHelper('formatDelta', function (a, b) {
   delta = a - b;
   if(delta >= 0){


### PR DESCRIPTION
Problem:
Current week-over-week values on detailed anomalies page does not show ratio metric properly when the metric is a derived metric. The reason is that the module always get the first metric from the response of Pinot, which might be a metric that is used to calculate the derived metric.

Fix:
1. We use metric name to calculate the index of the derived or raw metric in the Pinot's response and returns it. The results of the first metric is returned only when the index cannot be retrieved without any errors or exceptions.
2. Increase number of significant digit to show ratio metrics beautifully in WoW module.

Tested on local dashboard with known week-over-week values and other metrics that are previously working correctly.