### PR TITLE
[TE] Frontend timeseries resampling

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -35,21 +35,17 @@ import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.rootcause.Pipeline;
 import com.linkedin.thirdeye.rootcause.RCAFramework;
 import com.linkedin.thirdeye.rootcause.impl.RCAFrameworkLoader;
-
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.Executors;
-
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
-
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +60,7 @@ public class ThirdEyeDashboardApplication
     return "Thirdeye Dashboard";
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public void initialize(Bootstrap<ThirdEyeDashboardConfiguration> bootstrap) {
     bootstrap.addBundle(new ViewBundle());
@@ -118,7 +115,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new OverrideConfigResource());
     env.jersey().register(new DataResource(anomalyFunctionFactory, alertFilterFactory));
     env.jersey().register(new AnomaliesResource(anomalyFunctionFactory, alertFilterFactory));
-    env.jersey().register(new TimeSeriesResource());
+    env.jersey().register(new TimeSeriesResource(Executors.newFixedThreadPool(10)));
     env.jersey().register(new OnboardResource());
     env.jersey().register(new EventResource(config));
     env.jersey().register(new DataCompletenessResource(DAO_REGISTRY.getDataCompletenessConfigDAO()));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.dashboard.resources.v2;
 
 import com.google.common.base.Strings;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.dashboard.resources.v2.pojo.TimeSeriesCompareMetricView;
@@ -13,22 +14,32 @@ import com.linkedin.thirdeye.dashboard.views.contributor.ContributorViewResponse
 import com.linkedin.thirdeye.dashboard.views.tabular.TabularViewHandler;
 import com.linkedin.thirdeye.dashboard.views.tabular.TabularViewRequest;
 import com.linkedin.thirdeye.dashboard.views.tabular.TabularViewResponse;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DataFrameUtils;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.Series;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.datasource.MetricExpression;
+import com.linkedin.thirdeye.datasource.MetricFunction;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
+import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
+import com.linkedin.thirdeye.datasource.ThirdEyeResponse;
 import com.linkedin.thirdeye.datasource.cache.QueryCache;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
-
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -37,7 +48,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -58,6 +68,209 @@ public class TimeSeriesResource {
       .getCollectionMaxDataTimeCache();
   private QueryCache queryCache = CACHE_REGISTRY_INSTANCE.getQueryCache();
 
+  private static final long TIMEOUT = 60000;
+  private static final String COL_TIME = DataFrameUtils.COL_TIME;
+  private static final String COL_VALUE = DataFrameUtils.COL_VALUE;
+
+  private final ExecutorService executor;
+
+  public TimeSeriesResource(ExecutorService executor) {
+    this.executor = executor;
+  }
+
+  @GET
+  @Path("/query")
+  public Map<String, List<Double>> getTimeSeries(
+      @QueryParam("metricIds") String metricIds,
+      @QueryParam("start") Long start,
+      @QueryParam("end") Long end,
+      @QueryParam("filters") String filterString,
+      @QueryParam("granularity") String granularityString) throws Exception {
+
+    // validate input
+    if (metricIds == null) {
+      throw new IllegalArgumentException("Must provide metricId");
+    }
+
+    if (start == null) {
+      throw new IllegalArgumentException("Must provide start timestamp");
+    }
+
+    if (end == null) {
+      throw new IllegalArgumentException("Must provide end timestamp");
+    }
+
+    TimeGranularity granularity = null;
+    if (granularityString != null) {
+      granularity = TimeGranularity.fromString(granularityString);
+    }
+
+    Multimap<String, String> filters = null;
+    if (filterString != null) {
+      filters = ThirdEyeUtils.convertToMultiMap(filterString);
+    }
+
+    // make requests
+    Map<String, Future<DataFrame>> requests = new HashMap<>();
+    String[] ids = metricIds.split(",");
+    LOG.info("Requesting {} time series from {} to {} with granularity '{}'", ids.length, start, end, granularity);
+
+    for (String id : ids) {
+      long metricId = Long.valueOf(id);
+      requests.put(id, fetchMetricTimeSeriesAsync(metricId, start, end, granularity, filters));
+    }
+
+    // collect results
+    Map<String, List<Double>> output = new HashMap<>();
+    for (String id : ids) {
+      DataFrame df = requests.get(id).get(TIMEOUT, TimeUnit.MILLISECONDS);
+      if (!output.containsKey(COL_TIME)) {
+        output.put(COL_TIME, df.getDoubles(COL_TIME).toList());
+      }
+      output.put(id, df.getDoubles(COL_VALUE).toList());
+    }
+
+    return output;
+  }
+
+  /**
+   * Asynchronous call to {@code fetchMetricTimeSeries}
+   * @see TimeSeriesResource#fetchMetricTimeSeries
+   */
+  private Future<DataFrame> fetchMetricTimeSeriesAsync(final long metricId, final long start,
+      final long end, final TimeGranularity granularity, final Multimap<String, String> filters) throws Exception {
+    return this.executor.submit(new Callable<DataFrame>() {
+      @Override
+      public DataFrame call() throws Exception {
+        return fetchMetricTimeSeries(metricId, start, end, granularity, filters);
+      }
+    });
+  }
+
+  /**
+   * Returns the metric time series for a given time range and filter set, with a specified
+   * time granularity. If the underlying time series resolution does not correspond to the desired
+   * time granularity, it is up-sampled (via forward fill) or down-sampled (via sum if additive, or
+   * last value otherwise) transparently.
+   *
+   * <br/><b>NOTE:</b> if the start timestamp does not align with the time
+   * resolution, it is aligned with the nearest lower time stamp.
+   *
+   * @param metricId metric id in thirdeye database
+   * @param start start time stamp (inclusive, in millis)
+   * @param end end time stamp (exclusive, in millis)
+   * @param granularity time granularity
+   * @param filters filter set
+   * @return dataframe with aligned timestamps and values
+   */
+  private static DataFrame fetchMetricTimeSeries(long metricId, long start, long end,
+      TimeGranularity granularity, Multimap<String, String> filters) throws Exception {
+
+    // fetch meta data
+    MetricConfigDTO metric = DAO_REGISTRY.getMetricConfigDAO().findById(metricId);
+    if (metric == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve metric id %d", metricId));
+    }
+
+    DatasetConfigDTO dataset = DAO_REGISTRY.getDatasetConfigDAO().findByDataset(metric.getDataset());
+    if (dataset == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve dataset '%s'", metric.getDataset()));
+    }
+
+    if (granularity == null) {
+      granularity = dataset.bucketTimeGranularity();
+    }
+
+    List<MetricFunction> functions = new ArrayList<>();
+    List<MetricExpression> expressions = Arrays.asList(ThirdEyeUtils.getMetricExpressionFromMetricConfig(metric));
+    for(MetricExpression exp : expressions) {
+      functions.addAll(exp.computeMetricFunctions());
+    }
+
+    // aligned timestamps
+    // NOTE: the method over-fetches data in front of the time series to fill-forward correctly
+    final long alignedStart = granularity.toMillis(granularity.convertToUnit(start));
+    final long dataAlignedStart = dataset.bucketTimeGranularity().toMillis(
+        dataset.bucketTimeGranularity().convertToUnit(start));
+
+    // build request
+    ThirdEyeRequest.ThirdEyeRequestBuilder builder = ThirdEyeRequest.newBuilder()
+        .setStartTimeInclusive(dataAlignedStart)
+        .setEndTimeExclusive(end)
+        .setMetricFunctions(functions)
+        .setGroupBy(dataset.getTimeColumn())
+        .setGroupByTimeGranularity(granularity)
+        .setDataSource(dataset.getDataSource());
+
+    if (filters != null) {
+      builder.setFilterSet(filters);
+    }
+
+    ThirdEyeRequest request = builder.build("ref");
+
+    // fetch result
+    ThirdEyeResponse response = CACHE_REGISTRY_INSTANCE.getQueryCache().getQueryResult(request);
+
+    DataFrame df = DataFrameUtils.parseResponse(response);
+    DataFrameUtils.evaluateExpressions(df, expressions);
+
+    // enforce time granularity
+    DataFrame output = new DataFrame();
+    output.addSeries(COL_TIME, makeTimeRangeIndex(dataAlignedStart, end, granularity));
+    output.setIndex(COL_TIME);
+
+    LOG.info("Metric id {} has {} data points for time range {}-{}, need {} for time range {}-{}", metricId, df.size(), dataAlignedStart, end, output.size(), alignedStart, end);
+
+    // align values and time stamps
+    DataFrame grouped = null;
+    if(dataset.isAdditive()) {
+      grouped = df.groupByValue(COL_TIME).aggregate(COL_VALUE, DoubleSeries.SUM);
+    } else {
+      grouped = df.groupByValue(COL_TIME).aggregate(COL_VALUE, DoubleSeries.FIRST);
+    }
+
+    DataFrame joined = output.joinLeft(grouped);
+
+    // fill gaps
+    output.addSeries(COL_VALUE, joined.getDoubles(COL_VALUE).fillNullForward());
+
+    // project onto (aligned) start timestamp
+    int fromIndex = (int) granularity.convertToUnit(alignedStart - dataAlignedStart);
+
+    if (fromIndex > 0) {
+      LOG.info("Metric id {} resampling over-generated {} data points (out of {}). Truncating.", metricId, fromIndex, output.size());
+
+      output = output.sliceFrom(fromIndex);
+
+      final long minValue = output.getLongs(COL_TIME).min();
+      output.mapInPlace(new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          return values[0] - minValue;
+        }
+      }, COL_TIME);
+    }
+
+    return output;
+  }
+
+  /**
+   * Returns a LongSeries with length {@code N}, where {@code N} corresponds to the number of time
+   * buckets between {@code start} and {@code end} with the given time granularity.
+   *
+   * @param start start timestamp (inclusive, in millis)
+   * @param end end timestamp (exclusive, in millis)
+   * @param granularity time granularity
+   * @return long series
+   */
+  private static LongSeries makeTimeRangeIndex(long start, long end, TimeGranularity granularity) {
+    int maxCount = (int) granularity.convertToUnit(end - start);
+    long[] values = new long[maxCount];
+    for(int i=0; i<maxCount; i++) {
+      values[i] = i;
+    }
+    return LongSeries.buildFrom(values);
+  }
 
   @GET
   @Path("/compare/{metricId}/{currentStart}/{currentEnd}/{baselineStart}/{baselineEnd}")
@@ -409,4 +622,5 @@ public class TimeSeriesResource {
     }
     return timeSeriesCompareView;
   }
+
 }


### PR DESCRIPTION
* endpoint for fetching time series for a set of metric ids, aligned by timestamp

* support on-the-fly data transformation

    * foward fill

    * cumulative sum

    * millisecond timestamps

* support on-the-fly re-sampling to arbitrary time granularity

    * handle up-sampling (via forward fill transformation)

    * handle down-sampling (via time stamp grouping)
