### PR TITLE
[Uniform Schema] Use table name to load schema instead of schemaName field in tableConfig

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
@@ -18,7 +18,6 @@ package com.linkedin.pinot.common.data;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadataLoader;
-import com.linkedin.pinot.common.utils.CommonConstants;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,7 +37,7 @@ public interface DataManager {
 
   void removeSegment(String segmentName);
 
-  void reloadSegment(@Nonnull SegmentMetadata segmentMetadata, @Nonnull CommonConstants.Helix.TableType tableType,
+  void reloadSegment(@Nonnull String tableNameWithType, @Nonnull SegmentMetadata segmentMetadata,
       @Nullable TableConfig tableConfig, @Nullable Schema schema)
       throws Exception;
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1024,13 +1024,8 @@ public class PinotHelixResourceManager {
   }
 
   @Nullable
-  public Schema getOfflineTableSchema(@Nonnull String tableName) {
-    return ZKMetadataProvider.getOfflineTableSchema(_propertyStore, tableName);
-  }
-
-  @Nullable
-  public Schema getRealtimeTableSchema(@Nonnull String tableName) {
-    return ZKMetadataProvider.getRealtimeTableSchema(_propertyStore, tableName);
+  public Schema getTableSchema(@Nonnull String tableName) {
+    return ZKMetadataProvider.getTableSchema(_propertyStore, tableName);
   }
 
   public List<String> getSchemaNames() {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/ClusterInfoProvider.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/ClusterInfoProvider.java
@@ -65,13 +65,7 @@ public class ClusterInfoProvider {
    */
   @Nullable
   public Schema getTableSchema(@Nonnull String tableNameWithType) {
-    CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-    Preconditions.checkNotNull(tableType);
-    if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
-      return _pinotHelixResourceManager.getOfflineTableSchema(tableNameWithType);
-    } else {
-      return _pinotHelixResourceManager.getRealtimeTableSchema(tableNameWithType);
-    }
+    return _pinotHelixResourceManager.getTableSchema(tableNameWithType);
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/AutoAddInvertedIndex.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/AutoAddInvertedIndex.java
@@ -23,7 +23,6 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
-import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -155,10 +154,6 @@ public class AutoAddInvertedIndex {
       }
       LOGGER.info("Table: {} matches the table name pattern: {}", tableNameWithType, _tableNamePattern);
 
-      // Get the table type
-      CommonConstants.Helix.TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-      Preconditions.checkNotNull(tableType);
-
       // Get the inverted index config
       TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
       Preconditions.checkNotNull(tableConfig);
@@ -216,7 +211,7 @@ public class AutoAddInvertedIndex {
       }
 
       // Skip tables without a schema
-      Schema tableSchema = getTableSchema(tableNameWithType, tableType);
+      Schema tableSchema = ZKMetadataProvider.getTableSchema(_propertyStore, tableNameWithType);
       if (tableSchema == null) {
         LOGGER.info("Table: {}, skip adding inverted index because it does not have a schema", tableNameWithType);
         continue;
@@ -314,14 +309,6 @@ public class AutoAddInvertedIndex {
           }
         }
       }
-    }
-  }
-
-  private Schema getTableSchema(String tableName, CommonConstants.Helix.TableType tableType) {
-    if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
-      return ZKMetadataProvider.getOfflineTableSchema(_propertyStore, tableName);
-    } else {
-      return ZKMetadataProvider.getRealtimeTableSchema(_propertyStore, tableName);
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
@@ -23,7 +23,6 @@ import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadataLoader;
-import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.core.data.manager.config.FileBasedInstanceDataManagerConfig;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
@@ -202,8 +201,8 @@ public class FileBasedInstanceDataManager implements InstanceDataManager {
   }
 
   @Override
-  public void reloadSegment(@Nonnull SegmentMetadata segmentMetadata,
-      @Nonnull CommonConstants.Helix.TableType tableType, @Nullable TableConfig tableConfig, @Nullable Schema schema) {
+  public void reloadSegment(@Nonnull String tableNameWithType, @Nonnull SegmentMetadata segmentMetadata,
+      @Nullable TableConfig tableConfig, @Nullable Schema schema) {
     throw new UnsupportedOperationException("Unsupported reloading segment in FileBasedInstanceDataManager");
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.data.manager.realtime;
 
 import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
@@ -142,7 +143,8 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
             _segmentsMap.get(segmentName).getClass().getSimpleName());
         return;
       }
-      Schema schema = ZKMetadataProvider.getRealtimeTableSchema(propertyStore, tableName);
+      Schema schema =
+          ZKMetadataProvider.getTableSchema(propertyStore, TableNameBuilder.REALTIME.tableNameWithType(tableName));
       if (!isValid(schema, tableConfig.getIndexingConfig())) {
         LOGGER.error("Not adding segment {}", segmentName);
         throw new RuntimeException("Mismatching schema/table config for " + _tableName);


### PR DESCRIPTION
This will enforce realtime and offline table use the same schema
Keep backward compatible but will log a warning when using deprecated way to load schema