### PR TITLE
[TE] Refactor classifier interface to simplify implementation

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobScheduler.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationJobScheduler.java
@@ -39,7 +39,7 @@ public class ClassificationJobScheduler implements Runnable {
 
   public void start() {
     LOG.info("Starting anomaly classification service");
-    this.scheduledExecutorService.scheduleWithFixedDelay(this, 0, 1, TimeUnit.MINUTES);
+    this.scheduledExecutorService.scheduleWithFixedDelay(this, 0, 15, TimeUnit.MINUTES);
   }
 
   public void shutdown() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -229,8 +229,7 @@ public class ClassificationTaskRunner implements TaskRunner {
         }
         // Get and update issue type for the current main anomalies
         String issueType = anomalyClassifier.classify(mainAnomalyResult, auxiliaryAnomalies);
-        boolean updated = updateIssueTypeForAnomalyResult(mainAnomalyResult, issueType);
-        if (updated) {
+        if (updateIssueTypeForAnomalyResult(mainAnomalyResult, issueType)) {
           updatedMainAnomaliesByDimension.add(mainAnomalyResult);
         }
       }
@@ -254,7 +253,6 @@ public class ClassificationTaskRunner implements TaskRunner {
       return false;
     }
 
-    boolean updated = false;
     Map<String, String> anomalyProperties = mainAnomaly.getProperties();
     if (anomalyProperties == null) {
       anomalyProperties = new HashMap<>();
@@ -266,9 +264,9 @@ public class ClassificationTaskRunner implements TaskRunner {
     }
     if (!Objects.equals(issueType, originalIssueType)) {
       anomalyProperties.put(ISSUE_TYPE_KEY, issueType);
-      updated = true;
+      return true;
     }
-    return updated;
+    return false;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.CollectionUtils;
@@ -54,6 +55,8 @@ public class ClassificationTaskRunner implements TaskRunner {
   private static final Logger LOG = LoggerFactory.getLogger(ClassificationTaskRunner.class);
   private static final MergeAnomalyEndTimeComparator MERGE_ANOMALY_END_TIME_COMPARATOR =
       new MergeAnomalyEndTimeComparator();
+  private static final String ISSUE_TYPE_KEY = "issue_type";
+
   private AnomalyFunctionManager anomalyFunctionDAO = DAORegistry.getInstance().getAnomalyFunctionDAO();
   private MergedAnomalyResultManager mergedAnomalyDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
   private ClassificationConfigManager classificationConfigDAO = DAORegistry.getInstance().getClassificationConfigDAO();
@@ -168,8 +171,8 @@ public class ClassificationTaskRunner implements TaskRunner {
 
       }
 
-      Map<Long, List<MergedAnomalyResultDTO>> functionIdToAnomalyResult = new HashMap<>();
-      functionIdToAnomalyResult.put(classificationConfig.getMainFunctionId(), mainAnomaliesByDimension);
+      Map<String, List<MergedAnomalyResultDTO>> functionIdToAnomalyResult = new HashMap<>();
+
       // Get the anomalies from other anomaly function that are activated
       for (Long functionId : functionIds) {
         AnomalyFunctionDTO anomalyFunctionDTO = anomalyFunctionSpecMap.get(functionId);
@@ -195,19 +198,77 @@ public class ClassificationTaskRunner implements TaskRunner {
         List<MergedAnomalyResultDTO> filteredAnomalies = filterAnomalies(alertFilter, anomalies);
         if (CollectionUtils.isNotEmpty(filteredAnomalies)) {
           Collections.sort(filteredAnomalies, MERGE_ANOMALY_END_TIME_COMPARATOR);
-          functionIdToAnomalyResult.put(functionId, filteredAnomalies);
+          functionIdToAnomalyResult.put(anomalyFunctionDTO.getMetric(), filteredAnomalies);
         }
       }
 
-      // Invoke classification logic for this dimension
-      Map<String, String> classifierConfig = classificationConfig.getClassifierConfig();
-      AnomalyClassifier anomalyClassifier = anomalyClassifierFactory.fromSpec(classifierConfig);
-      List<MergedAnomalyResultDTO> updatedAnomalyResults =
-          anomalyClassifier.classify(classificationConfig, anomalyFunctionSpecMap, functionIdToAnomalyResult);
-      updatedMainAnomaliesByDimension.addAll(updatedAnomalyResults);
+      // Invoke classification logic for each main anomaly of this dimension
+      for (MergedAnomalyResultDTO mainAnomalyResult : mainAnomaliesByDimension) {
+        // Initiate classifier
+        Map<String, String> classifierConfig = new HashMap<>(classificationConfig.getClassifierConfig());
+        AnomalyClassifier anomalyClassifier = anomalyClassifierFactory.fromSpec(classifierConfig);
+        anomalyClassifier.setParameters(classifierConfig);
+        // Construct map of metric name to auxiliary anomalies
+        Map<String, List<MergedAnomalyResultDTO>> auxiliaryAnomalies = new HashMap<>();
+        for (Map.Entry<String, List<MergedAnomalyResultDTO>> metricName2AuxAnomalyList : functionIdToAnomalyResult
+            .entrySet()) {
+          List<MergedAnomalyResultDTO> overlappedAuxAnomalies = new ArrayList<>();
+          for (MergedAnomalyResultDTO auxAnomalyResult : metricName2AuxAnomalyList.getValue()) {
+            if (auxAnomalyResult.getEndTime() > mainAnomalyResult.getStartTime()
+                && auxAnomalyResult.getStartTime() < mainAnomalyResult.getEndTime()) {
+              overlappedAuxAnomalies.add(auxAnomalyResult);
+            }
+          }
+          String metricName = metricName2AuxAnomalyList.getKey();
+          if (auxiliaryAnomalies.containsKey(metricName)) {
+            List<MergedAnomalyResultDTO> existingOverlappedAuxAnomalies = auxiliaryAnomalies.get(metricName);
+            existingOverlappedAuxAnomalies.addAll(overlappedAuxAnomalies);
+          } else {
+            auxiliaryAnomalies.put(metricName, overlappedAuxAnomalies);
+          }
+        }
+        // Get and update issue type for the current main anomalies
+        String issueType = anomalyClassifier.classify(mainAnomalyResult, auxiliaryAnomalies);
+        boolean updated = updateIssueTypeForAnomalyResult(mainAnomalyResult, issueType);
+        if (updated) {
+          updatedMainAnomaliesByDimension.add(mainAnomalyResult);
+        }
+      }
     }
 
     return updatedMainAnomaliesByDimension;
+  }
+
+  /**
+   * Adds or updates the issue type to the property field of the given anomaly. If the given issue type is null, then
+   * no addition or update is performed.
+   *
+   * @param mainAnomaly the anomaly to be updated.
+   * @param issueType   the issue type to be added or updated to the given anomaly. If the given issue type is null,
+   *                    then no addition or update is performed.
+   *
+   * @return if the issue type is added/updated successfully, i.e., if the anomaly should be written back to DB.
+   */
+  private boolean updateIssueTypeForAnomalyResult(MergedAnomalyResultDTO mainAnomaly, String issueType) {
+    if (mainAnomaly == null || issueType == null) {
+      return false;
+    }
+
+    boolean updated = false;
+    Map<String, String> anomalyProperties = mainAnomaly.getProperties();
+    if (anomalyProperties == null) {
+      anomalyProperties = new HashMap<>();
+      mainAnomaly.setProperties(anomalyProperties);
+    }
+    String originalIssueType = null;
+    if (anomalyProperties.containsKey(ISSUE_TYPE_KEY)) {
+      originalIssueType = anomalyProperties.get(ISSUE_TYPE_KEY);
+    }
+    if (!Objects.equals(issueType, originalIssueType)) {
+      anomalyProperties.put(ISSUE_TYPE_KEY, issueType);
+      updated = true;
+    }
+    return updated;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifier.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/AnomalyClassifier.java
@@ -1,7 +1,5 @@
 package com.linkedin.thirdeye.anomaly.classification.classifier;
 
-import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
-import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.List;
 import java.util.Map;
@@ -15,14 +13,14 @@ public interface AnomalyClassifier {
   void setParameters(Map<String, String> props);
 
   /**
-   * Returns a list of main anomalies that have issue type updated.
+   * Given a main anomaly and lists of auxiliary anomalies, which could be retrieve through its corresponding metric
+   * name, this method returns the issue type for the main anomaly. The issue type will be stored in the property field
+   * of anomalies.
    *
-   * @param classificationConfig the configuration of the current classification job that triggers this method.
-   * @param anomalyFunctionSpecMap the anomaly function of the main and correlated anomalies.
-   * @param anomalies the collection of main and correlated anomalies for this classification task.
+   * @param mainAnomaly the main anomaly for which the issue typed is determined.
+   * @param auxAnomalies   the auxiliary anomalies for determining the issue type of the main anomaly.
    *
-   * @return a list of main anomalies that have issue type updated.
+   * @return the issue type to be stored in the property field of the anomaly. Return null to do no-op.
    */
-  List<MergedAnomalyResultDTO> classify(ClassificationConfigDTO classificationConfig,
-      Map<Long, AnomalyFunctionDTO> anomalyFunctionSpecMap, Map<Long, List<MergedAnomalyResultDTO>> anomalies);
+  String classify(MergedAnomalyResultDTO mainAnomaly, Map<String, List<MergedAnomalyResultDTO>> auxAnomalies);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/DummyAnomalyClassifier.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/classifier/DummyAnomalyClassifier.java
@@ -1,9 +1,6 @@
 package com.linkedin.thirdeye.anomaly.classification.classifier;
 
-import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
-import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -14,8 +11,7 @@ public class DummyAnomalyClassifier extends BaseAnomalyClassifier {
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> classify(ClassificationConfigDTO classificationConfig,
-      Map<Long, AnomalyFunctionDTO> anomalyFunctionSpecMap, Map<Long, List<MergedAnomalyResultDTO>> anomalies) {
-    return Collections.emptyList();
+  public String classify(MergedAnomalyResultDTO mainAnomaly, Map<String, List<MergedAnomalyResultDTO>> auxAnomalies) {
+    return null;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
@@ -62,24 +62,23 @@ public class TaskDriver {
       Callable callable = new Callable() {
         @Override public Object call() throws Exception {
           while (!shutdown) {
-            LOG.info(Thread.currentThread().getId() + " : Finding next task to execute for threadId:{}",
-                Thread.currentThread().getId());
+            LOG.info("Thread {} : Finding next task to execute.", Thread.currentThread().getId());
 
             // select a task to execute, and update it to RUNNING
             TaskDTO anomalyTaskSpec = TaskDriver.this.acquireTask();
 
             if (anomalyTaskSpec != null) { // a task has acquired and we must finish executing it before termination
               try {
-                LOG.info(Thread.currentThread().getId() + " : Executing task: {} {}", anomalyTaskSpec.getId(),
+                LOG.info("Thread {} : Executing task: {} {}", Thread.currentThread().getId(), anomalyTaskSpec.getId(),
                     anomalyTaskSpec.getTaskInfo());
 
                 // execute the selected task
                 TaskType taskType = anomalyTaskSpec.getTaskType();
                 TaskRunner taskRunner = TaskRunnerFactory.getTaskRunnerFromTaskType(taskType);
                 TaskInfo taskInfo = TaskInfoFactory.getTaskInfoFromTaskType(taskType, anomalyTaskSpec.getTaskInfo());
-                LOG.info(Thread.currentThread().getId() + " : Task Info {}", taskInfo);
+                LOG.info("Thread {} : Task Info {}", Thread.currentThread().getId(), taskInfo);
                 List<TaskResult> taskResults = taskRunner.execute(taskInfo, taskContext);
-                LOG.info(Thread.currentThread().getId() + " : DONE Executing task: {}", anomalyTaskSpec.getId());
+                LOG.info("Thread {} : DONE Executing task: {}", Thread.currentThread().getId(), anomalyTaskSpec.getId());
                 // update status to COMPLETED
                 TaskDriver.this.updateStatusAndTaskEndTime(anomalyTaskSpec.getId(), TaskStatus.RUNNING, TaskStatus.COMPLETED);
               } catch (Exception e) {
@@ -112,7 +111,7 @@ public class TaskDriver {
    * @return null if system is shutting down.
    */
   private TaskDTO acquireTask() {
-    LOG.info("{} : Trying to find a task to execute", Thread.currentThread().getId());
+    LOG.info("Thread {} : Trying to find a task to execute", Thread.currentThread().getId());
     while (!shutdown) {
       List<TaskDTO> anomalyTasks = new ArrayList<>();
       boolean hasFetchError = false;
@@ -128,25 +127,24 @@ public class TaskDriver {
       }
 
       if (CollectionUtils.isNotEmpty(anomalyTasks)) {
-        LOG.info(Thread.currentThread().getId() + " : Found {} tasks in waiting state", anomalyTasks.size());
+        LOG.info("Thread {} : Found {} tasks in waiting state", Thread.currentThread().getId(), anomalyTasks.size());
 
         for (int i = 0; i < anomalyTasks.size() && !shutdown; i++) {
           TaskDTO anomalyTaskSpec = anomalyTasks.get(i);
-          LOG.info(Thread.currentThread().getId() + " : Trying to acquire task : {}", anomalyTaskSpec.getId());
 
           boolean success = false;
           try {
             success = anomalyTaskDAO
                 .updateStatusAndWorkerId(workerId, anomalyTaskSpec.getId(), allowedOldTaskStatus,
                     TaskStatus.RUNNING, anomalyTaskSpec.getVersion());
-            LOG.info("Thread - [{}] : trying to acquire task id [{}], success status: [{}] with version [{}]",
+            LOG.info("Thread {} : Trying to acquire task id [{}], success status: [{}] with version [{}]",
                 Thread.currentThread().getId(), anomalyTaskSpec.getId(), success, anomalyTaskSpec.getVersion());
           } catch (Exception e) {
-            LOG.warn("exception : [{}] in acquiring task by threadId {} and workerId {}",
-                e.getClass().getSimpleName(), Thread.currentThread().getId(), workerId);
+            LOG.warn("Thread {} : Got exception when acquiring task. (Worker Id: {})", Thread.currentThread().getId(),
+                workerId, e);
           }
           if (success) {
-            LOG.info(Thread.currentThread().getId() + " : Acquired task ======" + anomalyTaskSpec);
+            LOG.info("Thread {} has acquired task: {}", Thread.currentThread().getId(), anomalyTaskSpec);
             return anomalyTaskSpec;
           }
         }
@@ -177,12 +175,11 @@ public class TaskDriver {
 
   private void updateStatusAndTaskEndTime(long taskId, TaskStatus oldStatus, TaskStatus newStatus)
       throws Exception {
-    LOG.info("{} : Starting updateStatus {}", Thread.currentThread().getId(),
-        Thread.currentThread().getId());
+    LOG.info("Thread {} : Starting updateStatus for task id {}", Thread.currentThread().getId(), taskId);
     try {
       anomalyTaskDAO
           .updateStatusAndTaskEndTime(taskId, oldStatus, newStatus, System.currentTimeMillis());
-      LOG.info("{} : updated status {}", Thread.currentThread().getId(), newStatus);
+      LOG.info("Thread {} : Updated status {}", Thread.currentThread().getId(), newStatus);
     } catch (Exception e) {
       LOG.error("Exception in updating status and task end time", e);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
@@ -96,7 +96,7 @@ public class TaskDriver {
         }
       };
       taskExecutorService.submit(callable);
-      LOG.info(Thread.currentThread().getId() + " : Started task driver");
+      LOG.info("Thread {} : Started task driver", Thread.currentThread().getId());
     }
   }
 


### PR DESCRIPTION
The refactoring has two purpose:
1. Users do not need to update anomaly result manually: The classify method now returns only the issue type for the given anomaly. The update is performed by classification pipeline.
2. Simplify the implementation of classify method because it takes one main anomaly at at time. Therefore, users do not need to manually go through the list of main anomaly.

Test on local controllers.