### PR TITLE
Broker side ZK metadata based segment pruner.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/PartitionZKMetadataPruner.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/PartitionZKMetadataPruner.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.pruner;
+
+import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.request.FilterOperator;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.core.data.partition.PartitionFunction;
+import com.linkedin.pinot.core.data.partition.PartitionFunctionFactory;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang.math.IntRange;
+
+
+/**
+ * Implementation of {@link SegmentZKMetadataPruner} that prunes segment based on
+ * partition information:
+ * <ul>
+ *   <li> Walks the filter query tree and compares segment partition id against predicate for all partitioned columns.</li>
+ *   <li> Prunes segment when its partition id cannot satisfy the predicate(s) in the query.</li>
+ * </ul>
+ */
+public class PartitionZKMetadataPruner implements SegmentZKMetadataPruner {
+
+  @Override
+  public boolean prune(SegmentZKMetadata segmentZKMetadata, SegmentPrunerContext prunerContext) {
+    SegmentPartitionMetadata partitionMetadata = segmentZKMetadata.getPartitionMetadata();
+    if (partitionMetadata == null) {
+      return false;
+    }
+
+    Map<String, ColumnPartitionMetadata> columnPartitionMap = partitionMetadata.getColumnPartitionMap();
+    FilterQueryTree filterQueryTree = prunerContext.getFilterQueryTree();
+    return pruneSegment(filterQueryTree, columnPartitionMap);
+  }
+
+  /**
+   * Helper method to prune a segment based on the filter query tree and partition metadata.
+   *
+   * @param filterQueryTree Filter tree for the predicates in the query
+   * @param columnMetadataMap Map of column name to partition metadata for the column.
+   *
+   * @return True if the segment can be pruned, false otherwise.
+   */
+  private boolean pruneSegment(FilterQueryTree filterQueryTree,
+      Map<String, ColumnPartitionMetadata> columnMetadataMap) {
+    List<FilterQueryTree> children = filterQueryTree.getChildren();
+
+    // Non-leaf node
+    if (children != null && !children.isEmpty()) {
+      return pruneNonLeaf(filterQueryTree, columnMetadataMap);
+    }
+
+    // TODO: Enhance partition based pruning for RANGE operator.
+    if (filterQueryTree.getOperator() != FilterOperator.EQUALITY) {
+      return false;
+    }
+
+    // Leaf node
+    String column = filterQueryTree.getColumn();
+    ColumnPartitionMetadata metadata = columnMetadataMap.get(column);
+    if (metadata == null) {
+      return false;
+    }
+
+    List<IntRange> partitionRanges = metadata.getPartitionRanges();
+    if (partitionRanges == null || partitionRanges.isEmpty()) {
+      return false;
+    }
+
+    String value = filterQueryTree.getValue().get(0);
+    PartitionFunction partitionFunction =
+        PartitionFunctionFactory.getPartitionFunction(metadata.getFunctionName(), metadata.getNumPartitions());
+    int partition = partitionFunction.getPartition(value);
+
+    for (IntRange partitionRange : partitionRanges) {
+      if (partitionRange.containsInteger(partition)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Given a non leaf filter query tree node prunes it as follows:
+   * <ul>
+   *   <li> For 'AND', node is pruned as long as at least one child can prune it. </li>
+   *   <li> For 'OR', node is pruned as long as all children can prune it. </li>
+   * </ul>
+   *
+   * @param filterQueryTree Non leaf node in the filter query tree.
+   * @param columnMetadataMap Map for column metadata.
+   *
+   * @return True to prune, false otherwise
+   */
+  @SuppressWarnings("Duplicates")
+  private boolean pruneNonLeaf(@Nonnull FilterQueryTree filterQueryTree,
+      @Nonnull Map<String, ColumnPartitionMetadata> columnMetadataMap) {
+    List<FilterQueryTree> children = filterQueryTree.getChildren();
+
+    if (children.isEmpty()) {
+      return false;
+    }
+
+    FilterOperator filterOperator = filterQueryTree.getOperator();
+    switch (filterOperator) {
+      case AND:
+        for (FilterQueryTree child : children) {
+          if (pruneSegment(child, columnMetadataMap)) {
+            return true;
+          }
+        }
+        return false;
+
+      case OR:
+        for (FilterQueryTree child : children) {
+          if (!pruneSegment(child, columnMetadataMap)) {
+            return false;
+          }
+        }
+        return true;
+
+      default:
+        throw new IllegalStateException("Unsupported filter operator: " + filterOperator);
+    }
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentPrunerContext.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentPrunerContext.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.pruner;
+
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+
+
+/**
+ * Class to represent context information for pruner. This is a place holder for
+ * information that does not need to be recomputed over and over again for each segment
+ * for a given query. For example, we don't want to re-generate the same filter query tree for
+ * each segment being pruned.
+ */
+public class SegmentPrunerContext {
+  BrokerRequest _brokerRequest;
+  FilterQueryTree _filterQueryTree;
+
+  public SegmentPrunerContext(BrokerRequest brokerRequest) {
+    _brokerRequest = brokerRequest;
+    _filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+  }
+
+  public BrokerRequest getBrokerRequest() {
+    return _brokerRequest;
+  }
+
+  public FilterQueryTree getFilterQueryTree() {
+    return _filterQueryTree;
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPruner.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPruner.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.pruner;
+
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+
+
+/**
+ * Interface for SegmentZKMetadata based pruner.
+ */
+public interface SegmentZKMetadataPruner {
+
+  /**
+   * Prunes the segment based on the segment's ZK metadata.
+   *
+   * @param segmentZKMetadata ZK metadata of the segment.
+   * @param prunerContext Context for the pruner.
+   *
+   * @return True if the segment can be pruned out, false otherwise.
+   */
+  boolean prune(SegmentZKMetadata segmentZKMetadata, SegmentPrunerContext prunerContext);
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPrunerProvider.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPrunerProvider.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.pruner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Provider class for SegmentZKMetadataPruners.
+ */
+public class SegmentZKMetadataPrunerProvider {
+  private SegmentZKMetadataPrunerProvider() {
+  }
+
+  private static final Map<String, Class<? extends SegmentZKMetadataPruner>> PRUNER_MAP = new HashMap<>();
+
+  static {
+    PRUNER_MAP.put("partitionzkmetadatapruner", PartitionZKMetadataPruner.class);
+  }
+
+  /**
+   * Returns ZK metadata based segment pruner.
+   *
+   * @param prunerClassName Class name for the desired pruner.
+   * @return Instance of pruner with the specified name.
+   */
+  public static SegmentZKMetadataPruner getSegmentPruner(String prunerClassName) {
+    try {
+      Class<? extends SegmentZKMetadataPruner> aClass = PRUNER_MAP.get(prunerClassName.toLowerCase());
+      if (aClass != null) {
+        return aClass.newInstance();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Exception caught while instantiating segment ZK metadata based pruner: " + prunerClassName, e);
+    }
+    throw new IllegalArgumentException("Unsupported segment ZK metadata based pruner: " + prunerClassName);
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPrunerService.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPrunerService.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.pruner;
+
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class provides the ZK metadata based segment pruning service.
+ */
+public class SegmentZKMetadataPrunerService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentZKMetadataPrunerService.class);
+  List<SegmentZKMetadataPruner> _pruners;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param prunerNames Names of pruners to register with the service.
+   */
+  public SegmentZKMetadataPrunerService(@Nonnull String[] prunerNames) {
+    _pruners = new ArrayList<>(prunerNames.length);
+
+    for (String prunerName : prunerNames) {
+      LOGGER.info("Adding segment ZK metadata based pruner: '{}'", prunerName);
+      _pruners.add(SegmentZKMetadataPrunerProvider.getSegmentPruner(prunerName));
+    }
+  }
+
+  /**
+   * This method applies all registered pruners on a given segment metadata.
+   * Returns true if any of the pruners deems the segment prune-able, false otherwise.
+   *
+   * @param metadata Segment ZK metadata
+   * @param prunerContext Pruner context
+   * @return True if segment can be pruned, false otherwise.
+   */
+  public boolean prune(SegmentZKMetadata metadata, SegmentPrunerContext prunerContext) {
+    for (SegmentZKMetadataPruner pruner : _pruners) {
+      if (pruner.prune(metadata, prunerContext)) {
+        LOGGER.debug("Pruned segment '{}'", metadata.getSegmentName());
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.broker.requesthandler;
 
 import com.google.common.base.Splitter;
+import com.linkedin.pinot.broker.pruner.SegmentZKMetadataPrunerService;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.BrokerMeter;
@@ -87,6 +88,7 @@ public class BrokerRequestHandler {
   private static final String DEFAULT_BROKER_ID;
   public static final String BROKER_ID_CONFIG_KEY = "pinot.broker.id";
   private static final ResponseType DEFAULT_BROKER_RESPONSE_TYPE = ResponseType.BROKER_RESPONSE_TYPE_NATIVE;
+  private final SegmentZKMetadataPrunerService _segmentPrunerService;
 
   static {
     String defaultBrokerId = "";
@@ -112,8 +114,8 @@ public class BrokerRequestHandler {
   private RoundRobinReplicaSelection _replicaSelection;
 
   public BrokerRequestHandler(RoutingTable table, TimeBoundaryService timeBoundaryService,
-      ScatterGather scatterGatherer, ReduceServiceRegistry reduceServiceRegistry, BrokerMetrics brokerMetrics,
-      Configuration config) {
+      ScatterGather scatterGatherer, ReduceServiceRegistry reduceServiceRegistry,
+      SegmentZKMetadataPrunerService segmentPrunerService, BrokerMetrics brokerMetrics, Configuration config) {
     _routingTable = table;
     _timeBoundaryService = timeBoundaryService;
     _reduceServiceRegistry = reduceServiceRegistry;
@@ -125,6 +127,8 @@ public class BrokerRequestHandler {
     _queryResponseLimit = config.getInt(BROKER_QUERY_RESPONSE_LIMIT_CONFIG, DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
     _brokerTimeOutMs = config.getLong(BROKER_TIME_OUT_CONFIG, DEFAULT_BROKER_TIME_OUT_MS);
     _brokerId = config.getString(BROKER_ID_CONFIG_KEY, DEFAULT_BROKER_ID);
+    _segmentPrunerService = segmentPrunerService;
+
     LOGGER.info("Broker response limit is: " + _queryResponseLimit);
     LOGGER.info("Broker timeout is - " + _brokerTimeOutMs + " ms");
     LOGGER.info("Broker id: " + _brokerId);

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPrunerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/pruner/SegmentZKMetadataPrunerTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.pruner;
+
+import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import junit.framework.Assert;
+import org.apache.commons.lang.math.IntRange;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link SegmentZKMetadataPruner}
+ */
+public class SegmentZKMetadataPrunerTest {
+
+  private static final int NUM_PARTITION = 11;
+  private static final String PARTITION_COLUMN = "partition";
+  private static final String PARTITION_FUNCTION_NAME = "modulo";
+  private static final String PRUNER_NAME = "partitionzkmetadatapruner";
+
+  @Test
+  public void testPruner() {
+    SegmentZKMetadata metadata = new OfflineSegmentZKMetadata();
+    Map<String, ColumnPartitionMetadata> columnPartitionMap = new HashMap<>();
+
+    int expectedPartition = 3;
+    columnPartitionMap.put(PARTITION_COLUMN, new ColumnPartitionMetadata(PARTITION_FUNCTION_NAME, NUM_PARTITION,
+        Collections.singletonList(new IntRange(expectedPartition))));
+
+    SegmentZKMetadataPrunerService prunerService = new SegmentZKMetadataPrunerService(new String[]{PRUNER_NAME});
+    SegmentPartitionMetadata segmentPartitionMetadata = new SegmentPartitionMetadata(columnPartitionMap);
+    metadata.setPartitionMetadata(segmentPartitionMetadata);
+
+    Pql2Compiler compiler = new Pql2Compiler();
+    for (int actualPartition = 0; actualPartition < NUM_PARTITION; actualPartition++) {
+      String query = "select count(*) from myTable where " + PARTITION_COLUMN + " = " + actualPartition;
+      BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+      SegmentPrunerContext prunerContext = new SegmentPrunerContext(brokerRequest);
+      Assert.assertEquals(prunerService.prune(metadata, prunerContext), (actualPartition != expectedPartition));
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/ModuloPartitionFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/ModuloPartitionFunction.java
@@ -38,10 +38,19 @@ public class ModuloPartitionFunction implements PartitionFunction {
     _numPartitions = numPartitions;
   }
 
+  /**
+   * Returns partition id for a given value. Assumes that the passed in object
+   * is either an Integer, or a string representation of an Integer.
+   *
+   * @param value Value for which to determine the partition id.
+   * @return Partition id for the given value.
+   */
   @Override
   public int getPartition(Object value) {
     if (value instanceof Integer) {
       return ((Integer) value) % _numPartitions;
+    } else if (value instanceof String) {
+      return ((Integer.parseInt((String) value)) % _numPartitions);
     } else {
       throw new IllegalArgumentException(
           "Illegal argument for partitioning, expected Integer, got: " + value.getClass().getName());


### PR DESCRIPTION
Segments can be pruned out at broker side, before routing queries
to server. Pruning at broker side can only happen based on
information available in SegmentZKMetadata.

1. SegmentZKMetadataPrunerService is initialized at the time of
   starting the broker. It configures pruners specified in the config.

2. Added SegmentZkMetadataPruner interface for all ZK metadata based
   pruners. Added one implementation of this interface PartitionZkMetadataPruner
   that prunes segments based on partition metadata.

3. Added unit test for new functionality.

Pruning is not yet hooked up in scatter/gather code yet. Two options there are:
1. Prune segments upfront, and dynamically build routing table for selected segments.
   This approach requires building routing table dynamically for each query.

2. Prune segments after getting one of the pre-computed routing tables.
   This approach may not yeild balanced routing tables, number of segements
   to process may be skewed for different servers.