### PR TITLE
Fix brokerHost argument being ignored

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -76,16 +76,26 @@ public class HelixBrokerStarter {
 
   public HelixBrokerStarter(String helixClusterName, String zkServer, Configuration pinotHelixProperties)
       throws Exception {
+    this(null, helixClusterName, zkServer, pinotHelixProperties);
+  }
+
+  public HelixBrokerStarter(String brokerHost, String helixClusterName, String zkServer, Configuration pinotHelixProperties)
+      throws Exception {
     LOGGER.info("Starting Pinot broker");
 
     _liveInstancesListener = new LiveInstancesChangeListenerImpl(helixClusterName);
 
     _pinotHelixProperties = DefaultHelixBrokerConfig.getDefaultBrokerConf(pinotHelixProperties);
+
+    if (brokerHost == null) {
+      brokerHost = NetUtil.getHostAddress();
+    }
+
     final String brokerId =
         _pinotHelixProperties.getString(
                 CommonConstants.Helix.Instance.INSTANCE_ID_KEY,
                 CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE
-                        + NetUtil.getHostAddress()
+                        + brokerHost
                         + "_"
                         + _pinotHelixProperties.getInt(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT,
                     CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT));
@@ -243,7 +253,7 @@ public class HelixBrokerStarter {
     configuration.addProperty("pinot.broker.timeoutMs", 500 * 1000L);
 
     final HelixBrokerStarter pinotHelixBrokerStarter =
-        new HelixBrokerStarter("quickstart", "localhost:2122", configuration);
+        new HelixBrokerStarter(null, "quickstart", "localhost:2122", configuration);
     return pinotHelixBrokerStarter;
   }
 

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/StartBrokerCommand.java
@@ -107,10 +107,6 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
   @Override
   public boolean execute() throws Exception {
     try {
-      if (_brokerHost == null) {
-        _brokerHost = NetUtil.getHostAddress();
-      }
-
       Configuration configuration = readConfigFromFile(_configFileName);
       if (configuration == null) {
         if (_configFileName != null) {
@@ -124,7 +120,8 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
       }
 
       LOGGER.info("Executing command: " + toString());
-      final HelixBrokerStarter pinotHelixBrokerStarter = new HelixBrokerStarter(_clusterName, _zkAddress, configuration);
+      final HelixBrokerStarter pinotHelixBrokerStarter =
+          new HelixBrokerStarter(_brokerHost, _clusterName, _zkAddress, configuration);
 
       String pidFile = ".pinotAdminBroker-" + String.valueOf(System.currentTimeMillis()) + ".pid";
       savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);


### PR DESCRIPTION
When starting the Pinot broker with the brokerHost argument, this
argument was previously ignored and was not used to build the broker
id. This patch fixes this issue.