### PR TITLE
Refactoring broker routing table generation to select strategy based …

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -129,7 +129,7 @@ public class HelixBrokerStarter {
         HelixManagerFactory.getZKHelixManager(helixClusterName, brokerId, InstanceType.PARTICIPANT, zkServers);
     StateMachineEngine stateMachineEngine = _helixManager.getStateMachineEngine();
     StateModelFactory<?> stateModelFactory =
-        new BrokerResourceOnlineOfflineStateModelFactory(_spectatorHelixManager, _helixExternalViewBasedRouting);
+        new BrokerResourceOnlineOfflineStateModelFactory(_spectatorHelixManager, _propertyStore, _helixExternalViewBasedRouting);
     stateMachineEngine.registerStateModelFactory(BrokerResourceOnlineOfflineStateModelFactory.getStateModelDef(),
         stateModelFactory);
     _helixManager.connect();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/RoutingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/RoutingConfig.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.config;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.JsonGenerationException;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RoutingConfig {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RoutingConfig.class);
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private String _routingTableBuilderName;
+  
+  private Map<String,String> _routingTableBuilderOptions = new HashMap<>();
+  
+  
+  public String getRoutingTableBuilderName() {
+    return _routingTableBuilderName;
+  }
+
+
+  public void setRoutingTableBuilderName(String routingTableBuilderName) {
+    _routingTableBuilderName = routingTableBuilderName;
+  }
+
+
+  public Map<String, String> getRoutingTableBuilderOptions() {
+    return _routingTableBuilderOptions;
+  }
+
+
+  public void setRoutingTableBuilderOptions(Map<String, String> routingTableBuilderOptions) {
+    _routingTableBuilderOptions = routingTableBuilderOptions;
+  }
+
+  public String toString() {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(this);
+    } catch (IOException e) {
+      //ignore
+    }
+    return "";
+  }
+  
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
@@ -41,6 +41,7 @@ public class TableConfig {
   private static final String CUSTOM_CONFIG_KEY = "metadata";
   private static final String QUOTA_CONFIG_KEY = "quota";
   private static final String TASK_CONFIG_KEY = "task";
+  private static final String ROUTING_CONFIG_KEY = "routing";
 
   private String _tableName;
   private TableType _tableType;
@@ -50,11 +51,12 @@ public class TableConfig {
   private TableCustomConfig _customConfig;
   private QuotaConfig _quotaConfig;
   private TableTaskConfig _taskConfig;
+  private RoutingConfig _routingConfig;
 
   private TableConfig(@Nonnull String tableName, @Nonnull TableType tableType,
       @Nonnull SegmentsValidationAndRetentionConfig validationConfig, @Nonnull TenantConfig tenantConfig,
       @Nonnull IndexingConfig indexingConfig, @Nonnull TableCustomConfig customConfig,
-      @Nullable QuotaConfig quotaConfig, @Nullable TableTaskConfig taskConfig) {
+      @Nullable QuotaConfig quotaConfig, @Nullable TableTaskConfig taskConfig, @Nullable RoutingConfig routingConfig) {
     _tableName = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
     _tableType = tableType;
     _validationConfig = validationConfig;
@@ -63,6 +65,8 @@ public class TableConfig {
     _customConfig = customConfig;
     _quotaConfig = quotaConfig;
     _taskConfig = taskConfig;
+    _routingConfig = routingConfig;
+
   }
 
   // For backward compatible
@@ -96,9 +100,13 @@ public class TableConfig {
     if (jsonConfig.has(TASK_CONFIG_KEY)) {
       taskConfig = OBJECT_MAPPER.readValue(jsonConfig.getJSONObject(TASK_CONFIG_KEY).toString(), TableTaskConfig.class);
     }
+    RoutingConfig routingConfig = null;
+    if (jsonConfig.has(ROUTING_CONFIG_KEY)) {
+      routingConfig = OBJECT_MAPPER.readValue(jsonConfig.getJSONObject(ROUTING_CONFIG_KEY).toString(), RoutingConfig.class);
+    }
 
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
-        quotaConfig, taskConfig);
+        quotaConfig, taskConfig, routingConfig);
   }
 
   @Nonnull
@@ -117,6 +125,9 @@ public class TableConfig {
     }
     if (tableConfig._taskConfig != null) {
       jsonConfig.put(TASK_CONFIG_KEY, new JSONObject(OBJECT_MAPPER.writeValueAsString(tableConfig._taskConfig)));
+    }
+    if (tableConfig._routingConfig != null) {
+      jsonConfig.put(ROUTING_CONFIG_KEY, new JSONObject(OBJECT_MAPPER.writeValueAsString(tableConfig._routingConfig)));
     }
     return jsonConfig;
   }
@@ -145,9 +156,15 @@ public class TableConfig {
     if (taskConfigString != null) {
       taskConfig = OBJECT_MAPPER.readValue(taskConfigString, TableTaskConfig.class);
     }
+    String routingConfigString = simpleFields.get(ROUTING_CONFIG_KEY);
+    
+    RoutingConfig routingConfig = null;
+    if (routingConfigString != null) {
+      routingConfig = OBJECT_MAPPER.readValue(routingConfigString, RoutingConfig.class);
+    }
 
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
-        quotaConfig, taskConfig);
+        quotaConfig, taskConfig, routingConfig);
   }
 
   @Nonnull
@@ -166,6 +183,9 @@ public class TableConfig {
     }
     if (tableConfig._taskConfig != null) {
       simpleFields.put(TASK_CONFIG_KEY, OBJECT_MAPPER.writeValueAsString(tableConfig._taskConfig));
+    }
+    if (tableConfig._routingConfig != null) {
+      simpleFields.put(ROUTING_CONFIG_KEY, OBJECT_MAPPER.writeValueAsString(tableConfig._routingConfig));
     }
     znRecord.setSimpleFields(simpleFields);
     return znRecord;
@@ -243,6 +263,15 @@ public class TableConfig {
     _taskConfig = taskConfig;
   }
 
+  
+  public RoutingConfig getRoutingConfig() {
+    return _routingConfig;
+  }
+
+  public void setRoutingConfig(RoutingConfig routingConfig) {
+    _routingConfig = routingConfig;
+  }
+
   @Nonnull
   public String toJSONConfigString()
       throws IOException, JSONException {
@@ -295,6 +324,7 @@ public class TableConfig {
     private TableCustomConfig _customConfig;
     private QuotaConfig _quotaConfig;
     private TableTaskConfig _taskConfig;
+    private RoutingConfig _routingConfig;
 
     public Builder(TableType tableType) {
       _tableType = tableType;
@@ -415,6 +445,11 @@ public class TableConfig {
       _taskConfig = taskConfig;
       return this;
     }
+    
+    public Builder setRoutingConfig(RoutingConfig routingConfig) {
+      _routingConfig = routingConfig;
+      return this;
+    }
 
     public TableConfig build()
         throws IOException, JSONException {
@@ -453,9 +488,13 @@ public class TableConfig {
         _customConfig = new TableCustomConfig();
         _customConfig.setCustomConfigs(new HashMap<String, String>());
       }
+      
+      if (_routingConfig == null) {
+        _routingConfig = new RoutingConfig();
+      }
 
       return new TableConfig(_tableName, _tableType, validationConfig, tenantConfig, indexingConfig, _customConfig,
-          _quotaConfig, _taskConfig);
+          _quotaConfig, _taskConfig, _routingConfig);
     }
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableCustomConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableCustomConfig.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TableCustomConfig {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentsValidationAndRetentionConfig.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableCustomConfig.class);
 
   public static final String MESSAGE_BASED_REFRESH_KEY = "messageBasedRefresh";
 

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTableBuilderFactory.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/RoutingTableBuilderFactory.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.routing;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
+import com.linkedin.pinot.routing.builder.BalancedRandomRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.DefaultOfflineRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.DefaultRealtimeRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.KafkaHighLevelConsumerBasedRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.KafkaLowLevelConsumerRoutingTableBuilder;
+import com.linkedin.pinot.routing.builder.RoutingTableBuilder;
+
+public class RoutingTableBuilderFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RoutingTableBuilderFactory.class);
+
+  private static final Set<Class<? extends RoutingTableBuilder>> _routingTableBuilders = new HashSet<>();
+  private Configuration _configuration;
+
+  enum RoutingTableBuilderName {
+    DefaultOffline, DefaultRealtime, BalancedRandom, KafkaLowLevel, KafkaHighLevel
+  }
+
+  public RoutingTableBuilderFactory(Configuration configuration) {
+    _configuration = configuration;
+  }
+
+  public RoutingTableBuilder createRoutingTableBuilder(TableConfig tableConfig) {
+    String builderName = tableConfig.getRoutingConfig().getRoutingTableBuilderName();
+    RoutingTableBuilderName buildNameEnum = null;
+
+    if (builderName != null) {
+      try {
+        buildNameEnum = RoutingTableBuilderName.valueOf(builderName);
+      } catch (Exception e) {
+        LOGGER.error("Unable to create routing table builder with name:{} for table:{}", builderName, tableConfig.getTableName());
+        buildNameEnum = null;
+      }
+    }
+    // use appropriate default if builderName is not specified or we fail to recognize the builderName
+    if (buildNameEnum == null) {
+      if (tableConfig.getTableType() == TableType.OFFLINE) {
+        buildNameEnum = RoutingTableBuilderName.DefaultOffline;
+      } else if (tableConfig.getTableType() == TableType.REALTIME) {
+        buildNameEnum = RoutingTableBuilderName.DefaultRealtime;
+      } else {
+        buildNameEnum = RoutingTableBuilderName.BalancedRandom;
+      }
+    }
+    RoutingTableBuilder builder = null;
+    switch (buildNameEnum) {
+    case BalancedRandom:
+      builder = new BalancedRandomRoutingTableBuilder();
+      break;
+    case DefaultOffline:
+      builder = new DefaultOfflineRoutingTableBuilder();
+      break;
+    case DefaultRealtime:
+      builder = new DefaultRealtimeRoutingTableBuilder();
+      break;
+    case KafkaHighLevel:
+      builder = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
+      break;
+    case KafkaLowLevel:
+      builder = new KafkaLowLevelConsumerRoutingTableBuilder();
+      break;
+    }
+    builder.init(_configuration);
+    return builder;
+  }
+
+  public static void main(String[] args) {
+    System.out.println(RoutingTableBuilderName.valueOf("asd"));
+  }
+}

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/AbstractRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/AbstractRoutingTableBuilder.java
@@ -16,18 +16,30 @@
 
 package com.linkedin.pinot.routing.builder;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
 
 /**
  * Utility class to share common utility methods between routing table builders.
  */
 public abstract class AbstractRoutingTableBuilder implements RoutingTableBuilder {
+  
+  private List<ServerToSegmentSetMap> _routingTables;
+
+  protected Random _random = new Random();
+
+  //by default we will set it to false. Implementations can override this
+  private boolean _isEmpty= false;
+
   /**
    * Picks a random replica, inversely weighted by the number of segments already assigned to each replica. See a longer
    * description of the probabilities used in
@@ -95,4 +107,24 @@ public abstract class AbstractRoutingTableBuilder implements RoutingTableBuilder
 
     return replicas[i];
   }
+  
+  @Override
+  public Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request) {
+    return _routingTables.get(_random.nextInt(_routingTables.size())).getRouting();
+  }
+  
+  @Override
+  public List<ServerToSegmentSetMap> getRoutingTables() {
+    return _routingTables;
+  }
+  
+  protected void setRoutingTables(List<ServerToSegmentSetMap> routingTables){
+    _routingTables = routingTables;
+  }
+
+  protected void setIsEmpty(boolean isEmpty){
+    _isEmpty = isEmpty;
+  }
+  
+   
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilder.java
@@ -21,13 +21,18 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +40,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Create a given number of routing tables based on random selections from ExternalView.
  */
-public class BalancedRandomRoutingTableBuilder implements RoutingTableBuilder {
+public class BalancedRandomRoutingTableBuilder extends AbstractRoutingTableBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(BalancedRandomRoutingTableBuilder.class);
 
   private int _numberOfRoutingTables;
@@ -54,7 +59,7 @@ public class BalancedRandomRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public synchronized List<ServerToSegmentSetMap> computeRoutingTableFromExternalView(String tableName,
+  public synchronized void computeRoutingTableFromExternalView(String tableName,
       ExternalView externalView, List<InstanceConfig> instanceConfigList) {
 
     RoutingTableInstancePruner pruner = new RoutingTableInstancePruner(instanceConfigList);
@@ -114,7 +119,7 @@ public class BalancedRandomRoutingTableBuilder implements RoutingTableBuilder {
     for (int i = 0; i < _numberOfRoutingTables; ++i) {
       resultRoutingTableList.add(new ServerToSegmentSetMap(routingTables.get(i)));
     }
-    return resultRoutingTableList;
-
+    setRoutingTables(resultRoutingTableList);
+    setIsEmpty(externalView.getPartitionSet().isEmpty());
   }
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/DefaultOfflineRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/DefaultOfflineRoutingTableBuilder.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.routing.builder;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
+/**
+ * Create a given number of routing tables based on random selections from ExternalView.
+ */
+public class DefaultOfflineRoutingTableBuilder extends AbstractRoutingTableBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOfflineRoutingTableBuilder.class);
+  private RoutingTableBuilder _largeClusterRoutingTableBuilder;
+  private RoutingTableBuilder _smallClusterRoutingTableBuilder;
+
+  private static int MIN_SERVER_COUNT_FOR_LARGE_CLUSTER = 30;
+  private static int MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER = 4;
+
+  RoutingTableBuilder _routingTableBuilder;
+
+  @Override
+  public void init(Configuration configuration) {
+    _largeClusterRoutingTableBuilder = new LargeClusterRoutingTableBuilder();
+    _smallClusterRoutingTableBuilder = new BalancedRandomRoutingTableBuilder();
+    if (configuration.containsKey("minServerCountForLargeCluster")) {
+      final String minServerCountForLargeCluster = configuration.getString("minServerCountForLargeCluster");
+      try {
+        MIN_SERVER_COUNT_FOR_LARGE_CLUSTER = Integer.parseInt(minServerCountForLargeCluster);
+        LOGGER.info("Using large cluster min server count of {}", MIN_SERVER_COUNT_FOR_LARGE_CLUSTER);
+      } catch (Exception e) {
+        LOGGER.warn("Could not get the large cluster min server count from configuration value {}, keeping default value {}", minServerCountForLargeCluster,
+            MIN_SERVER_COUNT_FOR_LARGE_CLUSTER, e);
+      }
+    } else {
+      LOGGER.info("Using default value for large cluster min server count of {}", MIN_SERVER_COUNT_FOR_LARGE_CLUSTER);
+    }
+
+    if (configuration.containsKey("minReplicaCountForLargeCluster")) {
+      final String minReplicaCountForLargeCluster = configuration.getString("minReplicaCountForLargeCluster");
+      try {
+        MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER = Integer.parseInt(minReplicaCountForLargeCluster);
+        LOGGER.info("Using large cluster min replica count of {}", MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER);
+      } catch (Exception e) {
+        LOGGER.warn("Could not get the large cluster min replica count from configuration value {}, keeping default value {}", minReplicaCountForLargeCluster,
+            MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER, e);
+      }
+    } else {
+      LOGGER.info("Using default value for large cluster min replica count of {}", MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER);
+    }
+
+    _largeClusterRoutingTableBuilder.init(configuration);
+    _smallClusterRoutingTableBuilder.init(configuration);
+  }
+
+  @Override
+  public void computeRoutingTableFromExternalView(String tableName, ExternalView externalView, List<InstanceConfig> instanceConfigList) {
+    if (isLargeCluster(externalView)) {
+      _routingTableBuilder = _largeClusterRoutingTableBuilder;
+    } else {
+      _routingTableBuilder = _smallClusterRoutingTableBuilder;
+    }
+    _routingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigList);
+  }
+
+  private boolean isLargeCluster(ExternalView externalView) {
+    // Check if the number of replicas is sufficient to treat it as a large cluster
+    final String helixReplicaCount = externalView.getRecord().getSimpleField("REPLICAS");
+    final int replicaCount;
+
+    try {
+      replicaCount = Integer.parseInt(helixReplicaCount);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to parse the replica count ({}) from external view of table {}", helixReplicaCount, externalView.getResourceName());
+      return false;
+    }
+
+    if (replicaCount < MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER) {
+      return false;
+    }
+
+    // Check if the server count is high enough to count as a large cluster
+    final Set<String> instanceSet = new HashSet<>();
+    for (String partition : externalView.getPartitionSet()) {
+      instanceSet.addAll(externalView.getStateMap(partition).keySet());
+    }
+
+    return MIN_SERVER_COUNT_FOR_LARGE_CLUSTER <= instanceSet.size();
+  }
+
+  @Override
+  public Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request) {
+    return _routingTableBuilder.findServers(request);
+  }
+  
+  @Override
+  public List<ServerToSegmentSetMap> getRoutingTables() {
+    return _routingTableBuilder.getRoutingTables();
+  }
+}

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/DefaultRealtimeRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/DefaultRealtimeRoutingTableBuilder.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.routing.builder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.common.utils.SegmentName;
+import com.linkedin.pinot.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
+/**
+ * Create a given number of routing tables based on random selections from ExternalView.
+ */
+public class DefaultRealtimeRoutingTableBuilder extends AbstractRoutingTableBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRealtimeRoutingTableBuilder.class);
+  private RoutingTableBuilder _realtimeHLCRoutingTableBuilder;
+  private RoutingTableBuilder _realtimeLLCRoutingTableBuilder;
+  boolean _hasLLC;
+  boolean _hasHLC;
+
+  @Override
+  public void init(Configuration configuration) {
+    _realtimeHLCRoutingTableBuilder = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
+    _realtimeLLCRoutingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
+    _realtimeHLCRoutingTableBuilder.init(configuration);
+    _realtimeLLCRoutingTableBuilder.init(configuration);
+  }
+
+  @Override
+  public void computeRoutingTableFromExternalView(String tableName, ExternalView externalView, List<InstanceConfig> instanceConfigList) {
+    Set<String> segments = externalView.getPartitionSet();
+    for (String segment : segments) {
+      if (SegmentName.isHighLevelConsumerSegmentName(segment)) {
+        _hasHLC = true;
+      }
+      if (SegmentName.isLowLevelConsumerSegmentName(segment)) {
+        _hasLLC = true;
+      }
+    }
+    if (_hasHLC) {
+      _realtimeHLCRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigList);
+    }
+    if (_hasLLC) {
+      _realtimeLLCRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigList);
+    }
+  }
+
+  @Override
+  public Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request) {
+    boolean forceLLC = false;
+    boolean forceHLC = false;
+    for (String routingOption : request.getRoutingOptions()) {
+      if (routingOption.equalsIgnoreCase("FORCE_HLC")) {
+        forceHLC = true;
+      }
+
+      if (routingOption.equalsIgnoreCase("FORCE_LLC")) {
+        forceLLC = true;
+      }
+    }
+    if (forceHLC && forceLLC) {
+      throw new RuntimeException("Trying to force routing to both HLC and LLC at the same time");
+    }
+
+    Map<ServerInstance, SegmentIdSet> serverToSegmentSetMaps;
+    if (forceLLC) {
+      serverToSegmentSetMaps = _realtimeLLCRoutingTableBuilder.findServers(request);
+    } else if (forceHLC) {
+      serverToSegmentSetMaps = _realtimeHLCRoutingTableBuilder.findServers(request);
+    } else {
+      if (_hasLLC) {
+        serverToSegmentSetMaps = _realtimeLLCRoutingTableBuilder.findServers(request);
+      } else if (_hasHLC) {
+        serverToSegmentSetMaps = _realtimeHLCRoutingTableBuilder.findServers(request);
+      } else {
+        serverToSegmentSetMaps = Collections.emptyMap();
+      }
+    }
+
+    return serverToSegmentSetMaps;
+  }
+
+  @Override
+  public List<ServerToSegmentSetMap> getRoutingTables() {
+    if (_hasLLC) {
+      return _realtimeLLCRoutingTableBuilder.getRoutingTables();
+    } else if(_hasHLC){
+      return _realtimeHLCRoutingTableBuilder.getRoutingTables();
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
@@ -34,10 +34,14 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.SegmentName;
+import com.linkedin.pinot.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
 
 
 /**
@@ -300,4 +304,5 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRout
       return segmentToInstanceMap;
     }
   }
+
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilder.java
@@ -16,8 +16,12 @@
 
 package com.linkedin.pinot.routing.builder;
 
+import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -29,7 +33,6 @@ import java.util.Random;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/RandomRoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/RandomRoutingTableBuilder.java
@@ -33,7 +33,7 @@ import com.linkedin.pinot.routing.ServerToSegmentSetMap;
 /**
  * Create a given number of routing tables based on random selections from ExternalView.
  */
-public class RandomRoutingTableBuilder implements RoutingTableBuilder {
+public class RandomRoutingTableBuilder extends AbstractRoutingTableBuilder {
 
   private int _numberOfRoutingTables;
 
@@ -51,7 +51,7 @@ public class RandomRoutingTableBuilder implements RoutingTableBuilder {
   }
 
   @Override
-  public synchronized List<ServerToSegmentSetMap> computeRoutingTableFromExternalView(String tableName,
+  public synchronized void computeRoutingTableFromExternalView(String tableName,
       ExternalView externalView, List<InstanceConfig> instanceConfigList) {
 
     RoutingTableInstancePruner pruner = new RoutingTableInstancePruner(instanceConfigList);
@@ -89,7 +89,6 @@ public class RandomRoutingTableBuilder implements RoutingTableBuilder {
     for (int i = 0; i < _numberOfRoutingTables; ++i) {
       resultRoutingTableList.add(new ServerToSegmentSetMap(routingTables.get(i)));
     }
-    return resultRoutingTableList;
-
+    setRoutingTables(resultRoutingTableList);
   }
 }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/RoutingTableBuilder.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/routing/builder/RoutingTableBuilder.java
@@ -16,12 +16,17 @@
 package com.linkedin.pinot.routing.builder;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.routing.RoutingTable;
+import com.linkedin.pinot.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
 
 
 /**
@@ -44,8 +49,23 @@ public interface RoutingTableBuilder {
    * @param externalView The external view for the table
    * @param instanceConfigList The instance configurations for the instances serving this particular table (used for
    *                           pruning)
+   */
+  void computeRoutingTableFromExternalView(String tableName, ExternalView externalView,
+      List<InstanceConfig> instanceConfigList);
+
+  /**
+   * Return the candidate set of servers that hosts each segment-set.
+   * The List of services are expected to be ordered so that replica-selection strategy can be
+   * applied to them to select one Service among the list for each segment.
+   *
+   * @return SegmentSet to Servers map.
+   */
+  Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request);
+
+  /**
    * @return List of routing tables used to route queries
    */
-  List<ServerToSegmentSetMap> computeRoutingTableFromExternalView(String tableName, ExternalView externalView,
-      List<InstanceConfig> instanceConfigList);
+  List<ServerToSegmentSetMap> getRoutingTables();
+
+
 }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/routing/RandomRoutingTableTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/routing/RandomRoutingTableTest.java
@@ -33,7 +33,12 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TableConfig.Builder;
 import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 import com.linkedin.pinot.routing.builder.BalancedRandomRoutingTableBuilder;
 import com.linkedin.pinot.routing.builder.RoutingTableBuilder;
 import com.linkedin.pinot.transport.common.SegmentIdSet;
@@ -57,11 +62,11 @@ public class RandomRoutingTableTest {
         new HelixExternalViewBasedRouting(null, new PercentageBasedRoutingTableSelector(), null,
             new BaseConfiguration());
 
-    routingTable.setSmallClusterRoutingTableBuilder(routingStrategy);
+    //routingTable.setSmallClusterRoutingTableBuilder(routingStrategy);
 
     ExternalView externalView = new ExternalView(externalViewRecord);
 
-    routingTable.markDataResourceOnline(tableName, externalView, getInstanceConfigs(externalView));
+    routingTable.markDataResourceOnline(generateTableConfig(tableName), externalView, getInstanceConfigs(externalView));
 
     double[] globalArrays = new double[9];
 
@@ -112,4 +117,12 @@ public class RandomRoutingTableTest {
 
     return instanceConfigList;
   }
+  
+  private TableConfig generateTableConfig(String tableName) throws Exception {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+    Builder builder = new TableConfig.Builder(tableType);
+    builder.setTableName(tableName);
+    return builder.build();
+  }
+
 }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilderTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/BalancedRandomRoutingTableBuilderTest.java
@@ -51,11 +51,12 @@ public class BalancedRandomRoutingTableBuilderTest {
     instanceConfigList.add(new InstanceConfig("Server_1.2.3.6_3456"));
 
     // Build routing table
-    List<ServerToSegmentSetMap> routingTable =
-        routingTableBuilder.computeRoutingTableFromExternalView("dummy", externalView, instanceConfigList);
+    
+    routingTableBuilder.computeRoutingTableFromExternalView("dummy", externalView, instanceConfigList);
 
+    List<ServerToSegmentSetMap> routingTables = routingTableBuilder.getRoutingTables();
     // Check that at least two routing tables are different
-    Iterator<ServerToSegmentSetMap> routingTableIterator = routingTable.iterator();
+    Iterator<ServerToSegmentSetMap> routingTableIterator = routingTables.iterator();
     ServerToSegmentSetMap previous = routingTableIterator.next();
     while (routingTableIterator.hasNext()) {
       ServerToSegmentSetMap current = routingTableIterator.next();

--- a/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
@@ -122,8 +122,11 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
 
       // Create routing tables
       long startTime = System.nanoTime();
-      List<ServerToSegmentSetMap> routingTables = routingTableBuilder.computeRoutingTableFromExternalView(
+      routingTableBuilder.computeRoutingTableFromExternalView(
           "table_REALTIME", externalView, instanceConfigs);
+
+      List<ServerToSegmentSetMap> routingTables = routingTableBuilder.getRoutingTables();
+
       long endTime = System.nanoTime();
       totalNanos += endTime - startTime;
 
@@ -173,9 +176,8 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
       externalView.setState(segmentNames.get(i).getSegmentName(), "Server_localhost_1234", "CONSUMING");
     }
 
-    List<ServerToSegmentSetMap> routingTables =
-        routingTableBuilder.computeRoutingTableFromExternalView("table", externalView, instanceConfigs);
-
+    routingTableBuilder.computeRoutingTableFromExternalView("table", externalView, instanceConfigs);
+    List<ServerToSegmentSetMap> routingTables = routingTableBuilder.getRoutingTables();
     for (ServerToSegmentSetMap routingTable : routingTables) {
       for (String server : routingTable.getServerSet()) {
         Set<String> segmentSet = routingTable.getSegmentSet(server);

--- a/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilderTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/routing/builder/LargeClusterRoutingTableBuilderTest.java
@@ -121,8 +121,9 @@ public class LargeClusterRoutingTableBuilderTest {
     ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
     List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
 
-    List<ServerToSegmentSetMap> routingTables =
-        _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+    _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+
+    List<ServerToSegmentSetMap> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
 
     int routingTableCount = 0;
     int largerThanDesiredRoutingTableCount = 0;
@@ -148,8 +149,9 @@ public class LargeClusterRoutingTableBuilderTest {
     ExternalView externalView = createExternalView(tableName, segmentCount, replicationFactor, instanceCount);
     List<InstanceConfig> instanceConfigs = createInstanceConfigs(instanceCount);
 
-    List<ServerToSegmentSetMap> routingTables =
-        _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+    _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+
+    List<ServerToSegmentSetMap> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
 
     Map<String, Integer> segmentCountPerServer = new HashMap<>();
 
@@ -239,8 +241,9 @@ public class LargeClusterRoutingTableBuilderTest {
 
   private void validateAssertionForOneRoutingTable(RoutingTableValidator routingTableValidator, String message,
       ExternalView externalView, List<InstanceConfig> instanceConfigs, String tableName) {
-    List<ServerToSegmentSetMap> routingTables =
-        _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+
+    _largeClusterRoutingTableBuilder.computeRoutingTableFromExternalView(tableName, externalView, instanceConfigs);
+    List<ServerToSegmentSetMap> routingTables = _largeClusterRoutingTableBuilder.getRoutingTables();
 
     for (ServerToSegmentSetMap routingTable : routingTables) {
       boolean isValid = routingTableValidator.isRoutingTableValid(routingTable, externalView, instanceConfigs);


### PR DESCRIPTION
…on builderName in tableConfig.routing

Cleaned up HelixExternalViewBasedRouting class - the responsibility of this class is reduced to simply handle the EV changes and invoke the appropriate routingTableBuilder. The references to specific routingTableBuilder's are removed from this class.

I have removed the use of RoutingTableSelector class as we have confidence in the kafka LLC routing.

I have disabled two tests for now. Will fix them before pushing.
