### PR TITLE
Replica group aware segment assignment strategy

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/ReplicaGroupStrategyConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/ReplicaGroupStrategyConfig.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.config;
+
+import javax.annotation.Nullable;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+/**
+ * Class representing configurations related to segment assignment strategy.
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReplicaGroupStrategyConfig {
+
+  private String _partitionColumn;
+  private int _numInstancesPerPartition;
+  private boolean _mirrorAssignmentAcrossReplicaGroups;
+
+  /**
+   * Returns the number of instances that segments for a partition span.
+   *
+   * @return Number of instances used for a partition.
+   */
+  public int getNumInstancesPerPartition() {
+    return _numInstancesPerPartition;
+  }
+
+  public void setNumInstancesPerPartition(int numInstancesPerPartition) {
+    _numInstancesPerPartition = numInstancesPerPartition;
+  }
+
+  /**
+   * Returns the configuration for mirror assignment across replica groups. If this is set to true, each server in
+   * a replica group will be mirrored in other replica groups.
+   *
+   * @return Configuration for mirror assignment across replica groups.
+   */
+  public boolean getMirrorAssignmentAcrossReplicaGroups() {
+    return _mirrorAssignmentAcrossReplicaGroups;
+  }
+
+  public void setMirrorAssignmentAcrossReplicaGroups(boolean mirrorAssignmentAcrossReplicaGroups) {
+    _mirrorAssignmentAcrossReplicaGroups = mirrorAssignmentAcrossReplicaGroups;
+  }
+
+  /**
+   * Returns the name of column used for partitioning. If this is set to null, we use the table level replica groups.
+   * Otherwise, we use the partition level replica groups.
+   *
+   * @return Name of partitioning column.
+   */
+  @Nullable
+  public String getPartitionColumn() {
+    return _partitionColumn;
+  }
+
+  public void setPartitionColumn(String partitionColumn) {
+    _partitionColumn = partitionColumn;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ReplicaGroupStrategyConfig that = (ReplicaGroupStrategyConfig) o;
+
+    if (_numInstancesPerPartition != that._numInstancesPerPartition) {
+      return false;
+    }
+    if (_mirrorAssignmentAcrossReplicaGroups != that._mirrorAssignmentAcrossReplicaGroups) {
+      return false;
+    }
+    return _partitionColumn != null ? _partitionColumn.equals(that._partitionColumn) : that._partitionColumn == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = _partitionColumn != null ? _partitionColumn.hashCode() : 0;
+    result = 31 * result + _numInstancesPerPartition;
+    result = 31 * result + (_mirrorAssignmentAcrossReplicaGroups ? 1 : 0);
+    return result;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
@@ -33,7 +33,9 @@ public class SegmentsValidationAndRetentionConfig {
   private String schemaName;
   private String timeColumnName;
   private String timeType;
+
   private String segmentAssignmentStrategy;
+  private ReplicaGroupStrategyConfig replicaGroupStrategyConfig;
 
   // Number of replicas per partition of low-level kafka consumers. This config is used for realtime tables only.
   private String replicasPerPartition;
@@ -108,6 +110,14 @@ public class SegmentsValidationAndRetentionConfig {
 
   public void setReplicasPerPartition(String replicasPerPartition) {
     this.replicasPerPartition = replicasPerPartition;
+  }
+
+  public ReplicaGroupStrategyConfig getReplicaGroupStrategyConfig() {
+    return replicaGroupStrategyConfig;
+  }
+
+  public void setReplicaGroupStrategyConfig(ReplicaGroupStrategyConfig replicaGroupStrategyConfig) {
+    this.replicaGroupStrategyConfig = replicaGroupStrategyConfig;
   }
 
   @JsonIgnore

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -21,6 +21,7 @@ import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.PartitionToReplicaGroupMappingZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.SchemaUtils;
 import com.linkedin.pinot.common.utils.SegmentName;
@@ -45,6 +46,7 @@ public class ZKMetadataProvider {
   private static final String PROPERTYSTORE_SEGMENTS_PREFIX = "/SEGMENTS";
   private static final String PROPERTYSTORE_SCHEMAS_PREFIX = "/SCHEMAS";
   private static final String PROPERTYSTORE_KAFKA_PARTITIONS_PREFIX = "/KAFKA_PARTITIONS";
+  private static final String PROPERTYSTORE_INSTANCE_PARTITIONS_PREFIX = "/INSTANCE_PARTITIONS";
   private static final String PROPERTYSTORE_TABLE_CONFIGS_PREFIX = "/CONFIGS/TABLE";
   private static final String PROPERTYSTORE_INSTANCE_CONFIGS_PREFIX = "/CONFIGS/INSTANCE";
   private static final String PROPERTYSTORE_CLUSTER_CONFIGS_PREFIX = "/CONFIGS/CLUSTER";
@@ -83,6 +85,10 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_KAFKA_PARTITIONS_PREFIX, realtimeTableName);
   }
 
+  public static String constructPropertyStorePathForInstancePartitions(String offlineTableName) {
+    return StringUtil.join("/", PROPERTYSTORE_INSTANCE_PARTITIONS_PREFIX, offlineTableName);
+  }
+
   public static String constructPropertyStorePathForResource(String resourceName) {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENTS_PREFIX, resourceName);
   }
@@ -119,6 +125,20 @@ public class ZKMetadataProvider {
     if (propertyStore.exists(propertyStorePath, AccessOption.PERSISTENT)) {
       propertyStore.remove(propertyStorePath, AccessOption.PERSISTENT);
     }
+  }
+
+  public static void removeInstancePartitionAssignmentFromPropertyStore(ZkHelixPropertyStore<ZNRecord> propertyStore, String offlineTableName) {
+    String propertyStorePath = constructPropertyStorePathForInstancePartitions(offlineTableName);
+    if (propertyStore.exists(propertyStorePath, AccessOption.PERSISTENT)) {
+      propertyStore.remove(propertyStorePath, AccessOption.PERSISTENT);
+    }
+  }
+
+  public static void setInstancePartitionAssignmentFromPropertyStore(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      PartitionToReplicaGroupMappingZKMetadata partitionMappingZKMetadata) {
+    propertyStore.set(constructPropertyStorePathForInstancePartitions(
+        TableNameBuilder.OFFLINE.tableNameWithType(partitionMappingZKMetadata.getTableName())),
+        partitionMappingZKMetadata.toZNRecord(), AccessOption.PERSISTENT);
   }
 
   public static void setOfflineSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore,
@@ -162,6 +182,19 @@ public class ZKMetadataProvider {
     } else {
       return new LLCRealtimeSegmentZKMetadata(znRecord);
     }
+  }
+
+  @Nullable
+  public static PartitionToReplicaGroupMappingZKMetadata getPartitionToReplicaGroupMappingZKMedata(
+      @Nonnull ZkHelixPropertyStore<ZNRecord> propertyStore, @Nonnull String tableName) {
+    // Segment Assignment Strategy is triggered only for offline table.
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+    ZNRecord znRecord = propertyStore.get(constructPropertyStorePathForInstancePartitions(offlineTableName), null,
+        AccessOption.PERSISTENT);
+    if (znRecord == null) {
+      return null;
+    }
+    return new PartitionToReplicaGroupMappingZKMetadata(znRecord);
   }
 
   @Nullable

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/PartitionToReplicaGroupMappingZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/PartitionToReplicaGroupMappingZKMetadata.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.metadata.segment;
+
+import com.linkedin.pinot.common.metadata.ZKMetadata;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.apache.helix.ZNRecord;
+
+/**
+ * Class for the partition mapping table. The table maps a tuple of (partition number, replica group number) to
+ * a list of instances.
+ *
+ */
+public class PartitionToReplicaGroupMappingZKMetadata implements ZKMetadata {
+
+  private Map<String, List<String>> _partitionToReplicaGroupMapping;
+  private String _tableName;
+
+  public PartitionToReplicaGroupMappingZKMetadata(ZNRecord znRecord) {
+    _partitionToReplicaGroupMapping = znRecord.getListFields();
+    _tableName = znRecord.getId();
+  }
+
+  public PartitionToReplicaGroupMappingZKMetadata() {
+    _partitionToReplicaGroupMapping = new HashMap<>();
+  }
+
+  public String getTableName() {
+    return _tableName;
+  }
+
+  public void setTableName(String tableName) {
+    _tableName = tableName;
+  }
+
+  /**
+   * Add an instance to a replica group for a partition.
+   *
+   * @param partition Partition number
+   * @param replicaGroup Replica group number
+   * @param instanceName Name of an instance
+   */
+  public void addInstanceToReplicaGroup(int partition, int replicaGroup, String instanceName) {
+    String key = createMappingKey(partition, replicaGroup);
+    if (!_partitionToReplicaGroupMapping.containsKey(key)) {
+      _partitionToReplicaGroupMapping.put(key, new ArrayList<String>());
+    }
+    _partitionToReplicaGroupMapping.get(key).add(instanceName);
+  }
+
+  /**
+   * Get instances of a replica group for a partition.
+   *
+   * @param partition Partition number
+   * @param replicaGroup Replica group number
+   * @return List of instances belongs to the given partition and replica group.
+   */
+  public List<String> getInstancesfromReplicaGroup(int partition, int replicaGroup) {
+    String key = createMappingKey(partition, replicaGroup);
+    if (!_partitionToReplicaGroupMapping.containsKey(key)) {
+      throw new NoSuchElementException();
+    }
+    return _partitionToReplicaGroupMapping.get(key);
+  }
+
+  /**
+   * Convert the partition mapping table to ZNRecord.
+   *
+   * @return ZNRecord of the partition to replica group mapping table.
+   */
+  @Override
+  public ZNRecord toZNRecord() {
+    ZNRecord znRecord = new ZNRecord(_tableName);
+    znRecord.setListFields(_partitionToReplicaGroupMapping);
+    return znRecord;
+  }
+
+  /**
+   * Helper method to create a key for the partition mapping table.
+   *
+   * @param partition Partition number
+   * @param replicaGroup Replica group number
+   * @return Key for the partition mapping table
+   */
+  private String createMappingKey(int partition, int replicaGroup) {
+    return partition + "_" + replicaGroup;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    PartitionToReplicaGroupMappingZKMetadata that = (PartitionToReplicaGroupMappingZKMetadata) o;
+    return _partitionToReplicaGroupMapping.equals(that._partitionToReplicaGroupMapping);
+  }
+
+  @Override
+  public int hashCode() {
+    return _partitionToReplicaGroupMapping != null ? _partitionToReplicaGroupMapping.hashCode() : 0;
+  }
+}

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/metadata/SegmentZKMetadataTest.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.common.metadata;
 
 import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.PartitionToReplicaGroupMappingZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
@@ -24,8 +25,10 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Segment.Realtime.Status;
 import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.math.IntRange;
@@ -102,6 +105,19 @@ public class SegmentZKMetadataTest {
     actualPartitionMetadata = expectedSegmentMetadata.getPartitionMetadata();
     Assert.assertEquals(actualPartitionMetadata, expectedPartitionMetadata);
     Assert.assertEquals(expectedSegmentMetadata, new RealtimeSegmentZKMetadata(expectedSegmentMetadata.toZNRecord()));
+  }
+
+  @Test
+  public void partitionToReplicaGroupMappingZKMetadataTest() {
+    // Test the partition mapping table.
+    ZNRecord partitionMappingZNRecord = getTestPartitionToReplicaGroupMappingZNRecord();
+    PartitionToReplicaGroupMappingZKMetadata partitionMappingMetadata = getTestPartitionToReplicaGroupMappingZKMetadata();
+
+    Assert.assertTrue(MetadataUtils.comparisonZNRecords(partitionMappingZNRecord, partitionMappingMetadata.toZNRecord()));
+    Assert.assertTrue(partitionMappingMetadata.equals(new PartitionToReplicaGroupMappingZKMetadata(partitionMappingZNRecord)));
+    Assert.assertTrue(MetadataUtils.comparisonZNRecords(partitionMappingZNRecord,
+        new PartitionToReplicaGroupMappingZKMetadata(partitionMappingZNRecord).toZNRecord()));
+    Assert.assertTrue(partitionMappingMetadata.equals(new PartitionToReplicaGroupMappingZKMetadata(partitionMappingMetadata.toZNRecord())));
   }
 
   private ZNRecord getTestDoneRealtimeSegmentZNRecord() {
@@ -209,5 +225,45 @@ public class SegmentZKMetadataTest {
     offlineSegmentMetadata.setPushTime(4000);
     offlineSegmentMetadata.setRefreshTime(8000);
     return offlineSegmentMetadata;
+  }
+
+  private PartitionToReplicaGroupMappingZKMetadata getTestPartitionToReplicaGroupMappingZKMetadata() {
+    String tableName = "testTable";
+    PartitionToReplicaGroupMappingZKMetadata partitionToReplicaGroupMapping = new PartitionToReplicaGroupMappingZKMetadata();
+    partitionToReplicaGroupMapping.setTableName(tableName);
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(0, 0, "instance1");
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(0, 0, "instance2");
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(0, 1, "instance3");
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(0, 1, "instance4");
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(1, 0, "instance1");
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(1, 0, "instance2");
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(1, 1, "instance3");
+    partitionToReplicaGroupMapping.addInstanceToReplicaGroup(1, 1, "instance4");
+
+    return partitionToReplicaGroupMapping;
+  }
+
+  private ZNRecord getTestPartitionToReplicaGroupMappingZNRecord() {
+    String tableName = "testTable";
+    ZNRecord record = new ZNRecord(tableName);
+
+    List<String> replicaGroupOne = new ArrayList<>();
+    replicaGroupOne.add("instance1");
+    replicaGroupOne.add("instance2");
+
+    List<String> replicaGroupTwo = new ArrayList<>();
+    replicaGroupTwo.add("instance3");
+    replicaGroupTwo.add("instance4");
+
+    record.setListField(generateKeyForPartitionMappingTable(0, 0), replicaGroupOne);
+    record.setListField(generateKeyForPartitionMappingTable(0, 1), replicaGroupTwo);
+    record.setListField(generateKeyForPartitionMappingTable(1, 0), replicaGroupOne);
+    record.setListField(generateKeyForPartitionMappingTable(1, 1), replicaGroupTwo);
+
+    return record;
+  }
+
+  private String generateKeyForPartitionMappingTable(int partition, int replicaGroup) {
+    return partition + "_" + replicaGroup;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -21,6 +21,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.IndexingConfig;
+import com.linkedin.pinot.common.config.ReplicaGroupStrategyConfig;
 import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableCustomConfig;
@@ -33,6 +34,7 @@ import com.linkedin.pinot.common.messages.SegmentReloadMessage;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.PartitionToReplicaGroupMappingZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.stream.KafkaStreamMetadata;
@@ -54,6 +56,7 @@ import com.linkedin.pinot.controller.api.pojos.Instance;
 import com.linkedin.pinot.controller.helix.core.PinotResourceManagerResponse.ResponseStatus;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategy;
+import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategyEnum;
 import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategyFactory;
 import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
 import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
@@ -1094,6 +1097,18 @@ public class PinotHelixResourceManager {
 
         _propertyStore.create(ZKMetadataProvider.constructPropertyStorePathForResource(offlineTableName), new ZNRecord(
             offlineTableName), AccessOption.PERSISTENT);
+
+        // If the segment assignment strategy is using replica groups, build the mapping table and
+        // store to property store.
+        String assignmentStrategy = segmentsConfig.getSegmentAssignmentStrategy();
+        if (assignmentStrategy != null && SegmentAssignmentStrategyEnum.valueOf(assignmentStrategy)
+            == SegmentAssignmentStrategyEnum.ReplicaGroupSegmentAssignmentStrategy) {
+          PartitionToReplicaGroupMappingZKMetadata partitionMappingMetadata =
+              buildPartitionToReplicaGroupMapping(offlineTableName, config);
+          _propertyStore.set(ZKMetadataProvider.constructPropertyStorePathForInstancePartitions(offlineTableName),
+              partitionMappingMetadata.toZNRecord(), AccessOption.PERSISTENT);
+        }
+
         break;
       case REALTIME:
         final String realtimeTableName = config.getTableName();
@@ -1332,6 +1347,64 @@ public class PinotHelixResourceManager {
 
     // dropping table
     _helixAdmin.dropResource(_helixClusterName, realtimeTableName);
+  }
+
+  /**
+   * Build the partition mapping table that maps a tuple of (partition number, replica group number) to a list of
+   * servers. Two important configurations are explained below.
+   *
+   * - 'numInstancesPerPartition': this number decides the number of servers within a replica group.
+   *
+   * - 'partitionColumn': this configuration decides whether to use the table or partition level replica groups.
+   *
+   * @param tableName: Name of table
+   * @param tableConfig: Configuration for table
+   * @return Partition mapping table from the given configuration
+   */
+  private PartitionToReplicaGroupMappingZKMetadata buildPartitionToReplicaGroupMapping(String tableName,
+      TableConfig tableConfig) {
+
+    // Fetch the server instances for the table.
+    List<String> servers = getServerInstancesForTable(tableName, TableType.OFFLINE);
+
+    // Fetch information required to build the mapping table from the table configuration.
+    ReplicaGroupStrategyConfig replicaGroupStrategyConfig = tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
+    String partitionColumn = replicaGroupStrategyConfig.getPartitionColumn();
+    int numInstancesPerPartition = replicaGroupStrategyConfig.getNumInstancesPerPartition();
+
+    // If we do not have the partition column configuration, we assume to use the table level replica groups,
+    // which is equivalent to have the same partition number for all segments (i.e. 1 partition).
+    int numPartitions = 1;
+    if (partitionColumn != null) {
+      numPartitions = tableConfig.getIndexingConfig().getSegmentPartitionConfig().getNumPartitions(partitionColumn);
+    }
+    int numReplicas = tableConfig.getValidationConfig().getReplicationNumber();
+    int numServers = servers.size();
+
+    // Enforcing disjoint server sets for each replica group.
+    if (numInstancesPerPartition * numReplicas > numServers) {
+      throw new UnsupportedOperationException("Replica group aware segment assignment assumes that servers in "
+          + "each replica group are disjoint. Check the configurations to see if the following inequality holds. "
+          + "'numInstancePerPartition' * 'numReplicas' <= 'totalServerNumbers'" );
+    }
+
+    // Creating a mapping table
+    PartitionToReplicaGroupMappingZKMetadata
+        partitionToReplicaGroupMapping = new PartitionToReplicaGroupMappingZKMetadata();
+    partitionToReplicaGroupMapping.setTableName(tableName);
+
+    Collections.sort(servers);
+    for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
+      // If the configuration contains partition column information, we use the segment level replica groups.
+      if (numPartitions != 1) {
+        Collections.shuffle(servers);
+      }
+      for (int i = 0; i < numInstancesPerPartition * numReplicas; i++) {
+        int groupId = i / numInstancesPerPartition;
+        partitionToReplicaGroupMapping.addInstanceToReplicaGroup(partitionId, groupId, servers.get(i));
+      }
+    }
+    return partitionToReplicaGroupMapping;
   }
 
   /**
@@ -1606,7 +1679,7 @@ public class PinotHelixResourceManager {
               ControllerTenantNameBuilder.getOfflineTenantNameForTenant(offlineTableConfig.getTenantConfig()
                   .getServer());
           final int replicas = Integer.parseInt(offlineTableConfig.getValidationConfig().getReplication());
-          return segmentAssignmentStrategy.getAssignedInstances(_helixAdmin, _helixClusterName, segmentMetadata,
+          return segmentAssignmentStrategy.getAssignedInstances(_helixAdmin, _propertyStore, _helixClusterName, segmentMetadata,
               replicas, serverTenant);
         } else {
           return new ArrayList<String>(currentIdealState.getInstanceSet(segmentName));

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
@@ -28,7 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +42,8 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
   private static final Logger LOGGER = LoggerFactory.getLogger(BalanceNumSegmentAssignmentStrategy.class);
 
   @Override
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, String helixClusterName,
-      SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
+  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String serverTenantName;
     String tableName;
     if ("realtime".equalsIgnoreCase(segmentMetadata.getIndexType())) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +39,8 @@ public class BucketizedSegmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(BucketizedSegmentStrategy.class);
 
   @Override
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, String helixClusterName,
-      SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
+  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String serverTenantName = null;
     if ("realtime".equalsIgnoreCase(segmentMetadata.getIndexType())) {
       serverTenantName = ControllerTenantNameBuilder.getRealtimeTenantNameForTenant(tenantName);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Random;
 
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,8 +41,8 @@ public class RandomAssignmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(RandomAssignmentStrategy.class);
 
   @Override
-  public List<String> getAssignedInstances(HelixAdmin helixAdmin, String helixClusterName,
-      SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
+  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String serverTenantName = null;
     if ("realtime".equalsIgnoreCase(segmentMetadata.getIndexType())) {
       serverTenantName = ControllerTenantNameBuilder.getRealtimeTenantNameForTenant(tenantName);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/ReplicaGroupSegmentAssignmentStrategy.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.helix.core.sharding;
+
+import com.linkedin.pinot.common.config.ReplicaGroupStrategyConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.metadata.segment.PartitionToReplicaGroupMappingZKMetadata;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class to represent the segment assignment strategy based on the concept of a replica group.
+ *
+ * A replica group is a pool of servers that is guaranteed to have all segments for a partition or a table
+ * (depend on the configuration). If the broker is aware of the replica group, the broker can prune servers
+ * when scattering and gathering requests because queries can be answered with a subset of servers.
+ *
+ */
+public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupSegmentAssignmentStrategy.class);
+  private static final Random random = new Random(System.currentTimeMillis());
+
+  @Override
+  public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
+
+    // Parse information from the input metadata.
+    SegmentMetadataImpl metadata = (SegmentMetadataImpl) segmentMetadata;
+    String tableName = segmentMetadata.getTableName();
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+
+    // Fetch the partition mapping table from the property store.
+    PartitionToReplicaGroupMappingZKMetadata partitionToReplicaGroupMapping =
+        ZKMetadataProvider.getPartitionToReplicaGroupMappingZKMedata(propertyStore, tableName);
+
+    // Fetch the segment assignment related configurations.
+    TableConfig tableConfig = ZKMetadataProvider.getTableConfig(propertyStore, offlineTableName);
+    int numReplica = tableConfig.getValidationConfig().getReplicationNumber();
+    ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
+        tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
+    boolean mirrorAssignmentAcrossReplicaGroups = replicaGroupStrategyConfig.getMirrorAssignmentAcrossReplicaGroups();
+
+    String partitionColumn = replicaGroupStrategyConfig.getPartitionColumn();
+
+    int partitionNumber = 0;
+    if (partitionColumn != null) {
+      // TODO: Need to address when we have multiple partition numbers.
+      partitionNumber = metadata.getColumnMetadataFor(replicaGroupStrategyConfig.getPartitionColumn())
+          .getPartitionRanges()
+          .get(0)
+          .getMaximumInteger();
+    }
+
+    // Perform the segment assignment.
+    // If mirror assignment is on, we randomly pick the index and use the same index for all replica groups.
+    // Else, we randomly pick server from each replica group.
+    List<String> selectedInstanceList = new ArrayList<>();
+    int index = 0;
+    for (int groupId = 0; groupId < numReplicas; groupId++) {
+      List<String> instancesInReplicaGroup =
+          partitionToReplicaGroupMapping.getInstancesfromReplicaGroup(partitionNumber, groupId);
+
+      if (mirrorAssignmentAcrossReplicaGroups) {
+        // Randomly pick the index and use the same index for all replica groups.
+        if (groupId == 0) {
+          index = random.nextInt(numReplica);
+        }
+      } else {
+        // Randomly pick the index for all replica groups.
+        index = random.nextInt(numReplica);
+      }
+      selectedInstanceList.add(instancesInReplicaGroup.get(index));
+    }
+
+    LOGGER.info("Segment assignment result for : " + segmentMetadata.getName() + ", in resource : "
+        + segmentMetadata.getTableName() + ", selected instances: " + Arrays.toString(selectedInstanceList.toArray()));
+
+    return selectedInstanceList;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategy.java
@@ -18,6 +18,8 @@ package com.linkedin.pinot.controller.helix.core.sharding;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import java.util.List;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 
 /**
@@ -27,8 +29,9 @@ import org.apache.helix.HelixAdmin;
  */
 public interface SegmentAssignmentStrategy {
 
-  List<String> getAssignedInstances(HelixAdmin helixAdmin, String helixClusterName,
-      SegmentMetadata segmentMetadata, int numReplicas, String tenantName);
-
+  List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName);
 
 }
+
+

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyEnum.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyEnum.java
@@ -23,6 +23,6 @@ package com.linkedin.pinot.controller.helix.core.sharding;
 public enum SegmentAssignmentStrategyEnum {
   RandomAssignmentStrategy,
   BalanceNumSegmentAssignmentStrategy,
-  BucketizedSegmentAssignmentStrategy;
-
+  BucketizedSegmentAssignmentStrategy,
+  ReplicaGroupSegmentAssignmentStrategy;
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/SegmentAssignmentStrategyFactory.java
@@ -34,6 +34,8 @@ public class SegmentAssignmentStrategyFactory {
         return new RandomAssignmentStrategy();
       case BucketizedSegmentAssignmentStrategy:
         return new BucketizedSegmentStrategy();
+      case ReplicaGroupSegmentAssignmentStrategy:
+        return new ReplicaGroupSegmentAssignmentStrategy();
       default:
         return new BalanceNumSegmentAssignmentStrategy();
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/sharding/SegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/sharding/SegmentAssignmentStrategyTest.java
@@ -15,8 +15,14 @@
  */
 package com.linkedin.pinot.controller.helix.sharding;
 
+import com.linkedin.pinot.common.config.ColumnPartitionConfig;
+import com.linkedin.pinot.common.config.IndexingConfig;
+import com.linkedin.pinot.common.config.ReplicaGroupStrategyConfig;
+import com.linkedin.pinot.common.config.SegmentPartitionConfig;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.metadata.segment.PartitionToReplicaGroupMappingZKMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.ZkStarter;
@@ -25,19 +31,29 @@ import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
 import com.linkedin.pinot.controller.helix.starter.HelixConfig;
 import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.I0Itec.zkclient.ZkClient;
+import org.apache.commons.lang.math.IntRange;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
 
 
 public class SegmentAssignmentStrategyTest {
@@ -47,11 +63,16 @@ public class SegmentAssignmentStrategyTest {
   private final static String HELIX_CLUSTER_NAME = "TestSegmentAssignmentStrategyHelix";
   private final static String TABLE_NAME_BALANCED = "testResourceBalanced";
   private final static String TABLE_NAME_RANDOM = "testResourceRandom";
+  private final static String TABLE_NAME_TABLE_LEVEL_REPLICA_GROUP= "testTableLevelReplicaGroup";
+  private final static String TABLE_NAME_PARTITION_LEVEL_REPLICA_GROUP = "testPartitionLevelReplicaGroup";
+
+  private final static String PARTITION_COLUMN = "memberId";
+  private final static int NUM_REPLICA = 2;
   private PinotHelixResourceManager _pinotHelixResourceManager;
   private ZkClient _zkClient;
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
-  private final int _numServerInstance = 5;
+  private final int _numServerInstance = 6;
   private final int _numBrokerInstance = 1;
   private ZkStarter.ZookeeperInstance _zookeeperInstance;
 
@@ -76,7 +97,7 @@ public class SegmentAssignmentStrategyTest {
         _numServerInstance, true);
     ControllerRequestBuilderUtil.addFakeBrokerInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME, ZK_SERVER,
         _numBrokerInstance, true);
-    Thread.sleep(3000);
+    Thread.sleep(100);
     Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, "DefaultTenant_OFFLINE").size(),
         _numServerInstance);
     Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, "DefaultTenant_REALTIME").size(),
@@ -95,33 +116,38 @@ public class SegmentAssignmentStrategyTest {
 
   @Test
   public void testRandomSegmentAssignmentStrategy() throws Exception {
-    final int numReplicas = 2;
-
     // Adding table
     TableConfig tableConfig =
         new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(TABLE_NAME_RANDOM)
             .setSegmentAssignmentStrategy("RandomAssignmentStrategy")
-            .setNumReplicas(numReplicas)
+            .setNumReplicas(NUM_REPLICA)
             .build();
     _pinotHelixResourceManager.addTable(tableConfig);
 
-    Thread.sleep(3000);
+    // Wait for the table addition
+    while (!_pinotHelixResourceManager.hasOfflineTable(TABLE_NAME_RANDOM)) {
+      Thread.sleep(100);
+    }
+
     for (int i = 0; i < 10; ++i) {
       addOneSegment(TABLE_NAME_RANDOM);
-      Thread.sleep(3000);
+
+      // Wait for all segments appear in the external view
+      while (!allSegmentsPushedToExternalView(TABLE_NAME_RANDOM, i + 1)) {
+        Thread.sleep(100);
+      }
       final Set<String> taggedInstances =
           _pinotHelixResourceManager.getAllInstancesForServerTenant("DefaultTenant_OFFLINE");
       final Map<String, Integer> instance2NumSegmentsMap = new HashMap<String, Integer>();
       for (final String instance : taggedInstances) {
         instance2NumSegmentsMap.put(instance, 0);
       }
-      final ExternalView externalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME,
+      ExternalView externalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME,
           TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME_RANDOM));
       Assert.assertEquals(externalView.getPartitionSet().size(), i + 1);
       for (final String segmentId : externalView.getPartitionSet()) {
-        Assert.assertEquals(externalView.getStateMap(segmentId).size(), numReplicas);
+        Assert.assertEquals(externalView.getStateMap(segmentId).size(), NUM_REPLICA);
       }
-
     }
   }
 
@@ -137,12 +163,16 @@ public class SegmentAssignmentStrategyTest {
             .build();
     _pinotHelixResourceManager.addTable(tableConfig);
 
-    Thread.sleep(3000);
     int numSegments = 20;
     for (int i = 0; i < numSegments; ++i) {
       addOneSegment(TABLE_NAME_BALANCED);
-      Thread.sleep(2000);
     }
+
+    // Wait for all segments appear in the external view
+    while (!allSegmentsPushedToExternalView(TABLE_NAME_BALANCED, numSegments)) {
+      Thread.sleep(100);
+    }
+
     final Set<String> taggedInstances =
         _pinotHelixResourceManager.getAllInstancesForServerTenant("DefaultTenant_OFFLINE");
     final Map<String, Integer> instance2NumSegmentsMap = new HashMap<String, Integer>();
@@ -171,10 +201,204 @@ public class SegmentAssignmentStrategyTest {
     _helixAdmin.dropResource(HELIX_CLUSTER_NAME, TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME_BALANCED));
   }
 
+  @Test
+  public void testTableLevelAndMirroringReplicaGroupSegmentAssignmentStrategy() throws Exception {
+    // Create the configuration for segment assignment strategy.
+    int numInstancesPerPartition = 3;
+    ReplicaGroupStrategyConfig replicaGroupStrategyConfig = new ReplicaGroupStrategyConfig();
+    replicaGroupStrategyConfig.setNumInstancesPerPartition(numInstancesPerPartition);
+    replicaGroupStrategyConfig.setMirrorAssignmentAcrossReplicaGroups(true);
+
+    // Create table config
+    TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE)
+        .setTableName(TABLE_NAME_TABLE_LEVEL_REPLICA_GROUP)
+        .setNumReplicas(NUM_REPLICA)
+        .setSegmentAssignmentStrategy("ReplicaGroupSegmentAssignmentStrategy")
+        .build();
+
+    tableConfig.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
+
+    // Create the table and upload segments
+    _pinotHelixResourceManager.addTable(tableConfig);
+
+    // Wait for table addition
+    while (!_pinotHelixResourceManager.hasOfflineTable(TABLE_NAME_TABLE_LEVEL_REPLICA_GROUP)) {
+      Thread.sleep(100);
+    }
+
+    int numSegments = 20;
+    Set<String> segments = new HashSet<>();
+    for (int i = 0; i < numSegments; ++i) {
+      String segmentName = "segment" + i;
+      addOneSegmentWithPartitionInfo(TABLE_NAME_TABLE_LEVEL_REPLICA_GROUP, segmentName, null, 0);
+      segments.add(segmentName);
+    }
+
+    // Wait for all segments appear in the external view
+    while (!allSegmentsPushedToExternalView(TABLE_NAME_TABLE_LEVEL_REPLICA_GROUP, numSegments)) {
+      Thread.sleep(100);
+    }
+
+    // Create a table of a list of segments that are assigned to a server.
+    Map<String, Set<String>> serverToSegments = getServersToSegmentsMapping(TABLE_NAME_TABLE_LEVEL_REPLICA_GROUP);
+
+    // Fetch the replica group mapping table
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _helixZkManager.getHelixPropertyStore();
+    PartitionToReplicaGroupMappingZKMetadata partitionToReplicaGroupMaping =
+        ZKMetadataProvider.getPartitionToReplicaGroupMappingZKMedata(propertyStore,
+            TABLE_NAME_TABLE_LEVEL_REPLICA_GROUP);
+
+    // Check that each replica group for contains all segments of the table.
+    for (int group = 0; group < NUM_REPLICA; group++) {
+      List<String> serversInReplicaGroup = partitionToReplicaGroupMaping.getInstancesfromReplicaGroup(0, group);
+      Set<String> segmentsInReplicaGroup = new HashSet<>();
+      for (String server : serversInReplicaGroup) {
+        segmentsInReplicaGroup.addAll(serverToSegments.get(server));
+      }
+      Assert.assertTrue(segmentsInReplicaGroup.containsAll(segments));
+    }
+
+    // Create the expected mirroring servers.
+    for (int instanceIndex = 0; instanceIndex < numInstancesPerPartition; instanceIndex++) {
+      Set<Set<String>> mirroringServerSegments = new HashSet<>();
+      for (int group = 0; group < NUM_REPLICA; group++) {
+        List<String> serversInReplicaGroup = partitionToReplicaGroupMaping.getInstancesfromReplicaGroup(0, group);
+        String server = serversInReplicaGroup.get(instanceIndex);
+        mirroringServerSegments.add(serverToSegments.get(server));
+      }
+      Assert.assertEquals(mirroringServerSegments.size(), 1);
+    }
+  }
+
+  @Test
+  public void testPartitionLevelReplicaGroupSegmentAssignmentStrategy() throws Exception {
+    int totalPartitionNumber = 2;
+    int numInstancesPerPartition = 3;
+
+    // Create the configuration for segment assignment strategy.
+    ReplicaGroupStrategyConfig replicaGroupStrategyConfig = new ReplicaGroupStrategyConfig();
+    replicaGroupStrategyConfig.setNumInstancesPerPartition(numInstancesPerPartition);
+    replicaGroupStrategyConfig.setMirrorAssignmentAcrossReplicaGroups(false);
+    // Now, set the partitioning column to trigger the partition level replica group assignment.
+    replicaGroupStrategyConfig.setPartitionColumn(PARTITION_COLUMN);
+
+    // Create the indexing config
+    IndexingConfig indexingConfig = new IndexingConfig();
+    Map<String, ColumnPartitionConfig> partitionConfigMap = new HashMap<>();
+    partitionConfigMap.put(PARTITION_COLUMN, new ColumnPartitionConfig("modulo", totalPartitionNumber));
+    indexingConfig.setSegmentPartitionConfig(new SegmentPartitionConfig(partitionConfigMap));
+
+    // Create table config
+    TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE)
+        .setTableName(TABLE_NAME_PARTITION_LEVEL_REPLICA_GROUP)
+        .setNumReplicas(NUM_REPLICA)
+        .setSegmentAssignmentStrategy("ReplicaGroupSegmentAssignmentStrategy")
+        .build();
+
+    tableConfig.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
+    tableConfig.setIndexingConfig(indexingConfig);
+
+    // This will trigger to build the partition to replica group mapping table.
+    _pinotHelixResourceManager.addTable(tableConfig);
+
+    // Wait for table addition
+    while (!_pinotHelixResourceManager.hasOfflineTable(TABLE_NAME_PARTITION_LEVEL_REPLICA_GROUP)) {
+      Thread.sleep(100);
+    }
+
+    // Tracking segments that belong to a partition number.
+    Map<Integer, Set<String>> partitionToSegment = new HashMap<>();
+
+    // Upload segments
+    int numSegments = 20;
+    for (int i = 0; i < numSegments; ++i) {
+      int partitionNumber = i % totalPartitionNumber;
+      String segmentName = "segment" + i;
+      addOneSegmentWithPartitionInfo(TABLE_NAME_PARTITION_LEVEL_REPLICA_GROUP, segmentName, PARTITION_COLUMN,
+          partitionNumber);
+      if (!partitionToSegment.containsKey(partitionNumber)) {
+        partitionToSegment.put(partitionNumber, new HashSet<String>());
+      }
+      partitionToSegment.get(partitionNumber).add(segmentName);
+    }
+
+    // Wait for all segments appear in the external view
+    while (!allSegmentsPushedToExternalView(TABLE_NAME_PARTITION_LEVEL_REPLICA_GROUP, numSegments)) {
+      Thread.sleep(100);
+    }
+
+    // Create a table of a list of segments that are assigned to a server.
+    Map<String, Set<String>> serverToSegments = getServersToSegmentsMapping(TABLE_NAME_PARTITION_LEVEL_REPLICA_GROUP);
+
+    // Fetch the replica group mapping table.
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _helixZkManager.getHelixPropertyStore();
+    PartitionToReplicaGroupMappingZKMetadata partitionToReplicaGroupMaping =
+        ZKMetadataProvider.getPartitionToReplicaGroupMappingZKMedata(propertyStore,
+            TABLE_NAME_PARTITION_LEVEL_REPLICA_GROUP);
+
+    // Check that each replica group for a partition contains all segments that belong to the partition.
+    for (int partition = 0; partition < totalPartitionNumber; partition++) {
+      for (int group = 0; group < NUM_REPLICA; group++) {
+        List<String> serversInReplicaGroup =
+            partitionToReplicaGroupMaping.getInstancesfromReplicaGroup(partition, group);
+        Set<String> segmentsInReplicaGroup = new HashSet<>();
+        for (String server : serversInReplicaGroup) {
+          segmentsInReplicaGroup.addAll(serverToSegments.get(server));
+        }
+        Assert.assertTrue(segmentsInReplicaGroup.containsAll(partitionToSegment.get(partition)));
+      }
+    }
+  }
+
+  private boolean allSegmentsPushedToExternalView(String tableName, int segmentNum) {
+    ExternalView externalView =
+        _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, TableNameBuilder.OFFLINE.tableNameWithType(tableName));
+    if (externalView != null && externalView.getPartitionSet() != null
+        && externalView.getPartitionSet().size() == segmentNum) {
+      return true;
+    }
+    return false;
+  }
+
+  private Map<String, Set<String>> getServersToSegmentsMapping(String tableName) {
+    ExternalView externalView =
+        _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, TableNameBuilder.OFFLINE.tableNameWithType(tableName));
+
+    List<String> servers = _pinotHelixResourceManager.getServerInstancesForTable(tableName, CommonConstants.Helix.TableType.OFFLINE);
+    Map<String, Set<String>> serverToSegments = new HashMap<>();
+
+    for (String server : servers) {
+      serverToSegments.put(server, new HashSet<String>());
+    }
+
+    for (String segment : externalView.getPartitionSet()) {
+      for (String server : externalView.getStateMap(segment).keySet()) {
+        serverToSegments.get(server).add(segment);
+      }
+    }
+    return serverToSegments;
+  }
+
   private void addOneSegment(String tableName) {
     final SegmentMetadata segmentMetadata = new SimpleSegmentMetadata(tableName);
     LOGGER.info("Trying to add IndexSegment : " + segmentMetadata.getName());
     _pinotHelixResourceManager.addSegment(segmentMetadata, "downloadUrl");
   }
 
+  private void addOneSegmentWithPartitionInfo(String tableName, String segmentName, String columnName,
+      int partitionNumber) {
+    ColumnMetadata columnMetadata = mock(ColumnMetadata.class);
+    List<IntRange> partitionRanges = new ArrayList<>();
+    partitionRanges.add(new IntRange(partitionNumber));
+    when(columnMetadata.getPartitionRanges()).thenReturn(partitionRanges);
+
+    SegmentMetadataImpl meta = mock(SegmentMetadataImpl.class);
+    if (columnName != null) {
+      when(meta.getColumnMetadataFor(columnName)).thenReturn(columnMetadata);
+    }
+    when(meta.getTableName()).thenReturn(tableName);
+    when(meta.getName()).thenReturn(segmentName);
+    when(meta.getCrc()).thenReturn("0");
+    _pinotHelixResourceManager.addSegment(meta, "downloadUrl");
+  }
 }


### PR DESCRIPTION
A replica group is a pool of servers that is guaranteed to
have all segments for a partition or a table (depending on the
configuration). If the broker is aware of the replica group, the broker
can prune servers when scattering and gathering requests because queries
can be answered with a subset of servers.

1. Configurations for the segment assignment strategy are uploaded
   along with a table config.

2. When adding a table, if segment assignment strategy is set to
   'ReplicaGroupSegmentAssignmentStrategy', the partition mapping table
   is created and stored in the property store.

3. When segments are uploaded, servers will be assigned based on
   the configurations and the partition mapping table.