### PR TITLE
[TE] expanding daterangepicker max time range

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnalysisView.js
@@ -248,7 +248,7 @@ AnalysisView.prototype = {
       endDate: initialEnd,
       maxDate: maxTime,
       dateLimit: {
-        days: 60
+      months: 6
       },
       showDropdowns: true,
       showWeekNumbers: true,

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/AnomalyResultView.js
@@ -92,8 +92,8 @@ function AnomalyResultView(anomalyResultModel) {
   this.timeRangeConfig = {
     startDate : this.anomalyResultModel.startDate,
     endDate : this.anomalyResultModel.endDate,
-    dateLimit : {
-      days : 60
+    dateLimit: {
+      months: 6
     },
     showDropdowns : true,
     showWeekNumbers : true,


### PR DESCRIPTION
Per @bl44's request, increasing the max time limit (from 60 days to 6 months). 
This shouldn't be an issue since users can now filter down the results. 

### Test: 
Tested locally.