### PR TITLE
Add a REST API to fetch crc information

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -195,6 +195,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName, "segments");
   }
 
+  public String forListAllCrcInformationForTable(String tableName) throws Exception {
+    return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName, "segments", "crc");
+  }
+
   public String forDeleteTableWithType(String tableName, String tableType) throws Exception {
     return StringUtil.join("/", StringUtils.chomp(_baseUrl, "/"), "tables", tableName + "?type=" + tableType);
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentRestletResourceTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.api.restlet.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
+import com.linkedin.pinot.controller.helix.ControllerRequestURLBuilder;
+import com.linkedin.pinot.controller.helix.ControllerTest;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
+
+
+public class PinotSegmentRestletResourceTest extends ControllerTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentRestletResourceTest.class);
+  ControllerRequestURLBuilder urlBuilder = ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL);
+
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+  private final static String ZK_SERVER = ZkStarter.DEFAULT_ZK_STR;
+  private final static String TABLE_NAME = "testTable";
+  private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    startZk();
+    startController();
+    _pinotHelixResourceManager = _controllerStarter.getHelixResourceManager();
+
+    ControllerRequestBuilderUtil.addFakeDataInstancesToAutoJoinHelixCluster(
+        getHelixClusterName(), ZK_SERVER, 1, true);
+    ControllerRequestBuilderUtil.addFakeBrokerInstancesToAutoJoinHelixCluster(
+        getHelixClusterName(), ZK_SERVER, 1, true);
+
+    while (_helixAdmin.getInstancesInClusterWithTag(getHelixClusterName(), "DefaultTenant_OFFLINE").size() == 0) {
+      Thread.sleep(100);
+    }
+
+    Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(
+        getHelixClusterName(), "DefaultTenant_OFFLINE").size(), 1);
+    Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(
+        getHelixClusterName(), "DefaultTenant_BROKER").size(), 1);
+  }
+
+  @AfterClass
+  public void tearDown() throws Exception {
+    stopController();
+    stopZk();
+  }
+
+  @Test
+  public void testSegmentCrcApi() throws Exception {
+    // Adding table
+    TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNumReplicas(1)
+        .build();
+    _pinotHelixResourceManager.addTable(tableConfig);
+
+    // Wait for the table addition
+    while (!_pinotHelixResourceManager.hasOfflineTable(TABLE_NAME)) {
+      Thread.sleep(100);
+    }
+
+    // Check when there is no segment.
+    Map<String, SegmentMetadata> segmentMetadataTable = new HashMap<>();
+    checkCrcRequest(segmentMetadataTable, 0);
+
+    // Upload Segments
+    for (int i = 0; i < 5; ++i) {
+      SegmentMetadata metadata = addOneSegment(TABLE_NAME);
+      segmentMetadataTable.put(metadata.getName(), metadata);
+    }
+
+    // Get crc info from API and check that they are correct.
+    checkCrcRequest(segmentMetadataTable, 5);
+
+    // Add more segments
+    for (int i = 0; i < 5; ++i) {
+      SegmentMetadata metadata = addOneSegment(TABLE_NAME);
+      segmentMetadataTable.put(metadata.getName(), metadata);
+    }
+
+    // Get crc info from API and check that they are correct.
+    checkCrcRequest(segmentMetadataTable, 10);
+
+    // Delete segments
+    _pinotHelixResourceManager.deleteSegment(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME),
+        segmentMetadataTable.values().iterator().next().getName());
+
+    // Check crc api
+    checkCrcRequest(segmentMetadataTable, 9);
+  }
+
+  private void checkCrcRequest(Map<String, SegmentMetadata> metadataTable, int expectedSize) throws Exception {
+    String crcMapStr = sendGetRequest(urlBuilder.forListAllCrcInformationForTable(TABLE_NAME));
+    Map<String, String> crcMap = OBJECT_MAPPER.readValue(crcMapStr, new TypeReference<Map<String, Object>>() {
+    });
+    for (String segmentName : crcMap.keySet()) {
+      SegmentMetadata metadata = metadataTable.get(segmentName);
+      Assert.assertTrue(metadata != null);
+      Assert.assertEquals(crcMap.get(segmentName), metadata.getCrc());
+    }
+    Assert.assertEquals(crcMap.size(), expectedSize);
+  }
+
+  private SegmentMetadata addOneSegment(String resourceName) {
+    final SegmentMetadata segmentMetadata = new SimpleSegmentMetadata(resourceName);
+    LOGGER.info("Trying to add IndexSegment : " + segmentMetadata.getName());
+    _pinotHelixResourceManager.addSegment(segmentMetadata, "downloadUrl");
+    return segmentMetadata;
+  }
+}

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/api/resources/ResourceTestHelper.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/api/resources/ResourceTestHelper.java
@@ -36,6 +36,8 @@ import com.yammer.metrics.core.MetricsRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -105,6 +107,14 @@ public class ResourceTestHelper {
     if (indexSegment != null) {
       indexSegment.destroy();
     }
+  }
+
+  public List<IndexSegment> setUpSegments(int numSegments) throws Exception {
+    List<IndexSegment> segments = new ArrayList<>();
+    for (int i = 0; i < numSegments; i++) {
+      segments.add(setupSegment(DEFAULT_TABLE_NAME, DEFAULT_AVRO_DATA_FILE, "1_" + i));
+    }
+    return segments;
   }
 
   public IndexSegment setupSegment()


### PR DESCRIPTION
In pinot-custom-metrics, crc checker is very slow and puts a lot of load to ZK because it needs
to fetch segment metadata one by one. To fix that, the rest api for fetching crc information
of a table is added. This api caches the segment crc information and its metadata version.
It only updates the cache when the segment is new or its metadata is updated to newer version.