### PR TITLE
[TE] Refine the function to find merged anomalies in time range

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -101,7 +101,7 @@ public class ClassificationTaskRunner implements TaskRunner {
       AlertFilter alertFilter = alertFilterMap.get(mainFunctionId);
       // Get the anomalies from the main anomaly function
       List<MergedAnomalyResultDTO> mainAnomalies =
-          mergedAnomalyDAO.findAllOverlapByFunctionId(mainFunctionId, windowStart, windowEnd, false);
+          mergedAnomalyDAO.findOverlappingByFunctionId(mainFunctionId, windowStart, windowEnd, false);
       filteredMainAnomalies.addAll(filterAnomalies(alertFilter, mainAnomalies));
     }
     // Run classification on each main anomaly that passes through alert filter
@@ -182,7 +182,7 @@ public class ClassificationTaskRunner implements TaskRunner {
         List<MergedAnomalyResultDTO> anomalies;
         if (anomalyFunctionDTO.getIsActive()) {
           // Get existing anomalies from DB
-          anomalies = mergedAnomalyDAO.findAllOverlapByFunctionIdDimensions(auxFunctionId, startTimeForCorrelatedAnomalies,
+          anomalies = mergedAnomalyDAO.findOverlappingByFunctionIdDimensions(auxFunctionId, startTimeForCorrelatedAnomalies,
               endTimeForCorrelatedAnomalies, dimensionMap.toString(), false);
         } else {
           LOG.info("Invoking ad-hoc anomaly detection for anomaly function {} at window ({}--{}).", auxFunctionId,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContextBuilder.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContextBuilder.java
@@ -389,7 +389,7 @@ public class AnomalyDetectionInputContextBuilder {
     for (Pair<Long, Long> startEndTimeRange : startEndTimeRanges) {
       try {
         results.addAll(
-            DAO_REGISTRY.getMergedAnomalyResultDAO().findAllOverlapByFunctionId(functionId, startEndTimeRange.getFirst(),
+            DAO_REGISTRY.getMergedAnomalyResultDAO().findOverlappingByFunctionId(functionId, startEndTimeRange.getFirst(),
                 startEndTimeRange.getSecond(), loadRawAnomalies));
       } catch (Exception e) {
         LOG.error("Exception in getting merged anomalies", e);
@@ -415,7 +415,7 @@ public class AnomalyDetectionInputContextBuilder {
     for (Pair<Long, Long> startEndTimeRange : startEndTimeRanges) {
       try {
         results.addAll(
-            DAO_REGISTRY.getMergedAnomalyResultDAO().findAllOverlapByFunctionIdDimensions(functionId,
+            DAO_REGISTRY.getMergedAnomalyResultDAO().findOverlappingByFunctionIdDimensions(functionId,
                 startEndTimeRange.getFirst(), startEndTimeRange.getSecond(), dimensions.toString(), true));
       } catch (Exception e) {
         LOG.error("Exception in getting merged anomalies", e);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/performanceEvaluation/PerformanceEvaluateHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/performanceEvaluation/PerformanceEvaluateHelper.java
@@ -27,9 +27,9 @@ public class PerformanceEvaluateHelper {
       long functionId, long clonedFunctionId, Interval windowInterval,
       MergedAnomalyResultManager mergedAnomalyResultDAO) {
     PerformanceEvaluate performanceEvaluator = null;
-    List<MergedAnomalyResultDTO> knownAnomalies = mergedAnomalyResultDAO.findAllOverlapByFunctionId(functionId,
+    List<MergedAnomalyResultDTO> knownAnomalies = mergedAnomalyResultDAO.findOverlappingByFunctionId(functionId,
         windowInterval.getStartMillis(), windowInterval.getEndMillis(), true);
-    List<MergedAnomalyResultDTO> detectedMergedAnomalies = mergedAnomalyResultDAO.findAllOverlapByFunctionId(
+    List<MergedAnomalyResultDTO> detectedMergedAnomalies = mergedAnomalyResultDAO.findOverlappingByFunctionId(
         clonedFunctionId, windowInterval.getStartMillis(), windowInterval.getEndMillis(), true);
     switch (performanceEvaluationMethod){
       case F1_SCORE:

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -18,9 +18,9 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
   List<MergedAnomalyResultDTO> getAllByTimeEmailIdAndNotifiedFalse(long startTime, long endTime,
       long emailId, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findAllOverlapByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies);
+  List<MergedAnomalyResultDTO> findOverlappingByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies);
 
-  List<MergedAnomalyResultDTO> findAllOverlapByFunctionIdDimensions(long functionId, long conflictWindowStart, long conflictWindowEnd, String dimensions, boolean loadRawAnomalies);
+  List<MergedAnomalyResultDTO> findOverlappingByFunctionIdDimensions(long functionId, long conflictWindowStart, long conflictWindowEnd, String dimensions, boolean loadRawAnomalies);
 
   List<MergedAnomalyResultDTO> findByCollectionMetricDimensionsTime(String collection,
       String metric, String dimensions, long startTime, long endTime, boolean loadRawAnomalies);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -158,19 +158,22 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findAllOverlapByFunctionId(long functionId, long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies) {
-    Predicate predicate =
-        Predicate.AND(Predicate.LT("startTime", conflictWindowEnd), Predicate.GE("endTime", conflictWindowStart),
+  public List<MergedAnomalyResultDTO> findOverlappingByFunctionId(long functionId, long searchWindowStart,
+      long searchWindowEnd, boolean loadRawAnomalies) {
+    // LT and GT are used instead of LE and GE because ThirdEye uses end time exclusive.
+    Predicate predicate = Predicate
+        .AND(Predicate.LT("startTime", searchWindowEnd), Predicate.GT("endTime", searchWindowStart),
             Predicate.EQ("functionId", functionId));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
     return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);
   }
 
   @Override
-  public List<MergedAnomalyResultDTO> findAllOverlapByFunctionIdDimensions(long functionId, long conflictWindowStart,
-      long conflictWindowEnd, String dimensions, boolean loadRawAnomalies) {
-    Predicate predicate =
-        Predicate.AND(Predicate.LE("startTime", conflictWindowEnd), Predicate.GE("endTime", conflictWindowStart),
+  public List<MergedAnomalyResultDTO> findOverlappingByFunctionIdDimensions(long functionId, long searchWindowStart,
+      long searchWindowEnd, String dimensions, boolean loadRawAnomalies) {
+    // LT and GT are used instead of LE and GE because ThirdEye uses end time exclusive.
+    Predicate predicate = Predicate
+        .AND(Predicate.LT("startTime", searchWindowEnd), Predicate.GT("endTime", searchWindowStart),
             Predicate.EQ("functionId", functionId), Predicate.EQ("dimensions", dimensions));
     List<MergedAnomalyResultBean> list = genericPojoDao.get(predicate, MergedAnomalyResultBean.class);
     return convertMergedAnomalyBean2DTO(list, loadRawAnomalies);


### PR DESCRIPTION
1. Rename the method findAllOverlapByFunctionId() to findOverlappingByFunctionId().
2. Make sure the method uses end time exclusive convention.

Tested on local workers.