### PR TITLE
[TE]Unify BaseAlertFilter Thirdeye and Anomaly Library

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlphaBetaAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlphaBetaAlertFilter.java
@@ -17,17 +17,20 @@ public class AlphaBetaAlertFilter extends BaseAlertFilter {
   public static final String DEFAULT_ALPHA = "1";
   public static final String DEFAULT_BETA = "1";
   public static final String DEFAULT_THRESHOLD = "0.8";
+  public static final String DEFAULT_TYPE = "alpha_beta";
 
   public static final String ALPHA = "alpha";
   public static final String BETA = "beta";
   public static final String THRESHOLD = "threshold";
+  public static final String TYPE = "type";
 
   private double alpha = Double.parseDouble(DEFAULT_ALPHA);
   private double beta = Double.parseDouble(DEFAULT_BETA);
   private double threshold = Double.parseDouble(DEFAULT_THRESHOLD);
+  private String type = DEFAULT_TYPE;
 
   private static final List<String> propertyNames =
-      Collections.unmodifiableList(new ArrayList<>(Arrays.asList(ALPHA, BETA, THRESHOLD)));
+      Collections.unmodifiableList(new ArrayList<>(Arrays.asList(ALPHA, BETA, THRESHOLD, TYPE)));
 
   public List<String> getPropertyNames() {
     return propertyNames;
@@ -67,6 +70,10 @@ public class AlphaBetaAlertFilter extends BaseAlertFilter {
     this.threshold = threshold;
   }
 
+  public String getType() {
+    return this.type;
+  }
+
   @Override
   public boolean isQualified(MergedAnomalyResultDTO anomaly) {
     double lengthInHour =
@@ -79,6 +86,6 @@ public class AlphaBetaAlertFilter extends BaseAlertFilter {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add(ALPHA, alpha).add(BETA, beta).add(THRESHOLD, threshold).toString();
+    return MoreObjects.toStringHelper(this).add(ALPHA, alpha).add(BETA, beta).add(THRESHOLD, threshold).add(TYPE, type).toString();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
@@ -2,23 +2,25 @@ package com.linkedin.thirdeye.detector.email.filter;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.swing.StringUIClientPropertyKey;
 
 
 public abstract class BaseAlertFilter implements AlertFilter {
   private final static Logger LOG = LoggerFactory.getLogger(BaseAlertFilter.class);
 
-  // Check if the given string can be parsed as double value
-  public static boolean isNumeric(String str) {
-    try {
-      double d = Double.parseDouble(str);
-    }
-    catch(NumberFormatException nfe) {
-      return false;
-    }
-    return true;
-  }
+//  // Check if the given string can be parsed as double value
+//  public static boolean isNumeric(String str) {
+//    try {
+//      double d = Double.parseDouble(str);
+//    }
+//    catch(NumberFormatException nfe) {
+//      return false;
+//    }
+//    return true;
+//  }
 
 
   /**
@@ -37,14 +39,12 @@ public abstract class BaseAlertFilter implements AlertFilter {
     for (String fieldName : getPropertyNames()) {
       Double value = null;
       String strVal = null;
-      boolean isNumeric = true;
       // Get user's value for the specified field
       if (parameterSetting.containsKey(fieldName)) {
         String fieldVal = parameterSetting.get(fieldName);
-        if (isNumeric(fieldVal)) {
+        if (StringUtils.isNumeric(fieldVal)) {
           value = Double.parseDouble(parameterSetting.get(fieldName));
         } else {
-          isNumeric = false;
           strVal = fieldVal;
         }
       } else {
@@ -53,14 +53,19 @@ public abstract class BaseAlertFilter implements AlertFilter {
           Field field = c.getDeclaredField("DEFAULT_" + fieldName.toUpperCase());
           boolean accessible = field.isAccessible();
           field.setAccessible(true);
-          value = Double.parseDouble((String) field.get(this));
+          Object object = field.get(this);
+          if (object instanceof Double)  {
+            value = (Double) object;
+          } else {
+            strVal = object.toString();
+          }
           field.setAccessible(accessible);
         } catch (NoSuchFieldException | IllegalAccessException e) {
           LOG.error("Failed to get default value for field {} of class {}; exception: {}", "DEFAULT_" + fieldName,
               c.getSimpleName(), e.toString());
         }
         // If failed to get the default value from Class definition, then use value 0d
-        if (value == null) {
+        if (value == null && strVal == null) {
           value = 0d;
         }
         LOG.warn("Unable to read the setting for the field {} of class {}; the value {} is used.", fieldName,
@@ -69,10 +74,11 @@ public abstract class BaseAlertFilter implements AlertFilter {
       // Set the final value to the specified field
       try {
         Field field = c.getDeclaredField(fieldName);
+        Object object = field.get(this);
         boolean accessible = field.isAccessible();
         field.setAccessible(true);
-        if (isNumeric) {
-          field.set(this, Double.valueOf(value));
+        if (object instanceof Double) {
+          field.set(this, value);
         }
         else {
           field.set(this, strVal);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
@@ -3,24 +3,14 @@ package com.linkedin.thirdeye.detector.email.filter;
 import java.lang.reflect.Field;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.swing.StringUIClientPropertyKey;
 
 
 public abstract class BaseAlertFilter implements AlertFilter {
   private final static Logger LOG = LoggerFactory.getLogger(BaseAlertFilter.class);
 
-//  // Check if the given string can be parsed as double value
-//  public static boolean isNumeric(String str) {
-//    try {
-//      double d = Double.parseDouble(str);
-//    }
-//    catch(NumberFormatException nfe) {
-//      return false;
-//    }
-//    return true;
-//  }
 
 
   /**
@@ -42,7 +32,7 @@ public abstract class BaseAlertFilter implements AlertFilter {
       // Get user's value for the specified field
       if (parameterSetting.containsKey(fieldName)) {
         String fieldVal = parameterSetting.get(fieldName);
-        if (StringUtils.isNumeric(fieldVal)) {
+        if (NumberUtils.isNumber(fieldVal)) {
           value = Double.parseDouble(parameterSetting.get(fieldName));
         } else {
           strVal = fieldVal;
@@ -50,7 +40,7 @@ public abstract class BaseAlertFilter implements AlertFilter {
       } else {
         // If user's value does not exist, try to get the default value from Class definition
         try {
-          Field field = c.getDeclaredField("DEFAULT_" + fieldName.toUpperCase());
+          Field field = c.getDeclaredField(fieldName);
           boolean accessible = field.isAccessible();
           field.setAccessible(true);
           Object object = field.get(this);
@@ -74,9 +64,9 @@ public abstract class BaseAlertFilter implements AlertFilter {
       // Set the final value to the specified field
       try {
         Field field = c.getDeclaredField(fieldName);
-        Object object = field.get(this);
         boolean accessible = field.isAccessible();
         field.setAccessible(true);
+        Object object = field.get(this);
         if (object instanceof Double) {
           field.set(this, value);
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
@@ -67,8 +67,11 @@ public abstract class BaseAlertFilter implements AlertFilter {
         if (field.getType().equals(Double.class) || field.getType().equals(double.class)) {
           field.set(this, value);
         }
+        else if (field.getType().equals(String.class)) {
+            field.set(this, strVal);
+          }
         else {
-          field.set(this, strVal);
+         throw new IllegalAccessException ("Field type is neither Double or String, cannot set value!");
         }
         field.setAccessible(accessible);
       } catch (NoSuchFieldException | IllegalAccessException e) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
@@ -2,7 +2,6 @@ package com.linkedin.thirdeye.detector.email.filter;
 
 import java.lang.reflect.Field;
 import java.util.Map;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,11 +42,10 @@ public abstract class BaseAlertFilter implements AlertFilter {
           Field field = c.getDeclaredField(fieldName);
           boolean accessible = field.isAccessible();
           field.setAccessible(true);
-          Object object = field.get(this);
-          if (object instanceof Double)  {
-            value = (Double) object;
+          if (field.getType().equals(Double.class) || field.getType().equals(double.class)) {
+            value = (Double) field.get(this);
           } else {
-            strVal = object.toString();
+            strVal = field.get(this).toString();
           }
           field.setAccessible(accessible);
         } catch (NoSuchFieldException | IllegalAccessException e) {
@@ -66,8 +64,7 @@ public abstract class BaseAlertFilter implements AlertFilter {
         Field field = c.getDeclaredField(fieldName);
         boolean accessible = field.isAccessible();
         field.setAccessible(true);
-        Object object = field.get(this);
-        if (object instanceof Double) {
+        if (field.getType().equals(Double.class) || field.getType().equals(double.class)) {
           field.set(this, value);
         }
         else {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
@@ -144,9 +144,9 @@ public class PrecisionRecallEvaluator {
       AnomalyFeedback feedback = anomaly.getFeedback();
       boolean isLabeledTrueAnomaly = false;
       boolean isLabeledTrueAnomalyNotActionable = false;
-      if(feedback != null && feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY_NO_ACTION)) {
+      if(feedback != null && feedback.getFeedbackType() != null && feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY_NO_ACTION)) {
         isLabeledTrueAnomalyNotActionable = true;
-      } else if (feedback != null && feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY)) {
+      } else if (feedback != null && feedback.getFeedbackType() != null && feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY)) {
         isLabeledTrueAnomaly = true;
       }
 
@@ -154,7 +154,7 @@ public class PrecisionRecallEvaluator {
 
 
       if(isQualified) {
-        if(feedback == null) {
+        if(feedback == null || feedback.getFeedbackType() == null) {
           this.qualifiedNotLabeled++;
         } else if (isLabeledTrueAnomaly) {
           qualifiedTrueAnomaly++;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestBaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestBaseAlertFilter.java
@@ -11,6 +11,7 @@ import org.testng.Assert;
 public class TestBaseAlertFilter extends AbstractManagerTestBase {
   private static String collection = "my dataset";
   private static String metricName = "__counts";
+
   // test set up double, Double, string for alpha_beta
   // also test missing input parameter, will use default value defined in the specified class
   @Test
@@ -29,6 +30,12 @@ public class TestBaseAlertFilter extends AbstractManagerTestBase {
     alertfilter.put("threshold", String.valueOf(threshold));
     alphaBetaAlertFilter.setParameters(alertfilter);
     Assert.assertEquals(alphaBetaAlertFilter.getThreshold(), Double.valueOf(alertfilter.get("threshold")));
+
+    // test missing field
+    alertfilter.remove("threshold");
+    AlphaBetaAlertFilter alphaBetaAlertFilter1 = new AlphaBetaAlertFilter();
+    alphaBetaAlertFilter1.setParameters(alertfilter);
+    Assert.assertEquals(alphaBetaAlertFilter1.getThreshold(), Double.valueOf(AlphaBetaAlertFilter.DEFAULT_THRESHOLD));
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestBaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestBaseAlertFilter.java
@@ -1,0 +1,34 @@
+package com.linkedin.thirdeye.detector.email.filter;
+
+import com.linkedin.thirdeye.datalayer.bao.AbstractManagerTestBase;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import java.util.Map;
+import org.junit.Test;
+import org.testng.Assert;
+
+
+
+public class TestBaseAlertFilter extends AbstractManagerTestBase {
+  private static String collection = "my dataset";
+  private static String metricName = "__counts";
+  // test set up double, Double, string for alpha_beta
+  // also test missing input parameter, will use default value defined in the specified class
+  @Test
+  public void testSetAlphaBetaParamter(){
+    AnomalyFunctionDTO anomalyFunctionSpec = getTestFunctionAlphaBetaAlertFilterSpec(metricName, collection);
+    Map<String, String> alertfilter = anomalyFunctionSpec.getAlertFilter();
+    AlphaBetaAlertFilter alphaBetaAlertFilter = new AlphaBetaAlertFilter();
+    alphaBetaAlertFilter.setParameters(alertfilter);
+    Assert.assertEquals(alphaBetaAlertFilter.getAlpha(), Double.valueOf(alertfilter.get("alpha")));
+    Assert.assertEquals(alphaBetaAlertFilter.getBeta(), Double.valueOf(alertfilter.get("beta")));
+    Assert.assertEquals(alphaBetaAlertFilter.getType(), alertfilter.get("type"));
+    Assert.assertEquals(alphaBetaAlertFilter.getThreshold(), Double.valueOf(alertfilter.get("threshold")));
+
+    // test scientific decimal
+    double threshold = 1E-10;
+    alertfilter.put("threshold", String.valueOf(threshold));
+    alphaBetaAlertFilter.setParameters(alertfilter);
+    Assert.assertEquals(alphaBetaAlertFilter.getThreshold(), Double.valueOf(alertfilter.get("threshold")));
+  }
+
+}


### PR DESCRIPTION
There used to be two "BaseAlertFilter" classes in anomaly detection library and thirdeye. Refactoring this while deprecating wrapper classes for alert filter. Deprecate the based alert filter within AD library, let auto tuning to directly use "Performance Evaluation" in thirdeye to make it consistent. 