### PR TITLE
[TE] support object de-serialization over string only

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventsPipeline.java
@@ -52,7 +52,7 @@ public class AnomalyEventsPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param ignore configuration properties (none)
    */
-  public AnomalyEventsPipeline(String outputName, Set<String> inputNames, Map<String, String> ignore) {
+  public AnomalyEventsPipeline(String outputName, Set<String> inputNames, Map<String, Object> ignore) {
     super(outputName, inputNames);
     this.manager = EventDataProviderManager.getInstance();
     this.metricDAO = DAORegistry.getInstance().getMetricConfigDAO();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
@@ -95,7 +95,7 @@ public class DimensionAnalysisPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param properties configuration properties ({@code PROP_PARALLELISM=1})
    */
-  public DimensionAnalysisPipeline(String outputName, Set<String> inputNames, Map<String, String> properties) {
+  public DimensionAnalysisPipeline(String outputName, Set<String> inputNames, Map<String, Object> properties) {
     super(outputName, inputNames);
 
     this.metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
@@ -104,7 +104,7 @@ public class DimensionAnalysisPipeline extends Pipeline {
 
     String parallelismProp = PROP_PARALLELISM_DEFAULT;
     if(properties.containsKey(PROP_PARALLELISM))
-      parallelismProp = properties.get(PROP_PARALLELISM);
+      parallelismProp = properties.get(PROP_PARALLELISM).toString();
     this.executor = Executors.newFixedThreadPool(Integer.parseInt(parallelismProp));
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityMappingPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityMappingPipeline.java
@@ -68,20 +68,20 @@ public class EntityMappingPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param properties configuration properties ({@code PROP_MAPPING_TYPE}, {@code PROP_IS_REWRITER=false}, {@code PROP_MATCH_PREFIX=false})
    */
-  public EntityMappingPipeline(String outputName, Set<String> inputNames, Map<String, String> properties) throws IOException {
+  public EntityMappingPipeline(String outputName, Set<String> inputNames, Map<String, Object> properties) throws IOException {
     super(outputName, inputNames);
 
     if(!properties.containsKey(PROP_MAPPING_TYPE))
       throw new IllegalArgumentException(String.format("Property '%s' required, but not found", PROP_MAPPING_TYPE));
-    String mappingTypeProp = properties.get(PROP_MAPPING_TYPE);
+    String mappingTypeProp = properties.get(PROP_MAPPING_TYPE).toString();
 
     String isRewriterProp = String.valueOf(PROP_IS_REWRITER_DEFAULT);
     if(properties.containsKey(PROP_IS_REWRITER))
-      isRewriterProp = properties.get(PROP_IS_REWRITER);
+      isRewriterProp = properties.get(PROP_IS_REWRITER).toString();
 
     String matchPrefixProp = String.valueOf(PROP_MATCH_PREFIX_DEFAULT);
     if(properties.containsKey(PROP_MATCH_PREFIX))
-      matchPrefixProp = properties.get(PROP_MATCH_PREFIX);
+      matchPrefixProp = properties.get(PROP_MATCH_PREFIX).toString();
 
     this.entityDAO = DAORegistry.getInstance().getEntityToEntityMappingDAO();
     this.mappingType = mappingTypeProp;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
@@ -53,7 +53,7 @@ public class HolidayEventsPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param ignore configuration properties (none)
    */
-  public HolidayEventsPipeline(String outputName, Set<String> inputNames, Map<String, String> ignore) {
+  public HolidayEventsPipeline(String outputName, Set<String> inputNames, Map<String, Object> ignore) {
     super(outputName, inputNames);
     this.eventDataProvider = EventDataProviderManager.getInstance();
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/LinearAggregationPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/LinearAggregationPipeline.java
@@ -51,12 +51,12 @@ public class LinearAggregationPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param properties configuration properties ({@code PROP_K})
    */
-  public LinearAggregationPipeline(String outputName, Set<String> inputNames, Map<String, String> properties) {
+  public LinearAggregationPipeline(String outputName, Set<String> inputNames, Map<String, Object> properties) {
     super(outputName, inputNames);
 
     String kProp = PROP_K_DEFAULT;
     if(properties.containsKey(PROP_K))
-      kProp = properties.get(PROP_K);
+      kProp = properties.get(PROP_K).toString();
     this.k = Integer.parseInt(kProp);
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricCorrelationRankingPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricCorrelationRankingPipeline.java
@@ -94,7 +94,7 @@ public class MetricCorrelationRankingPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param properties configuration properties ({@code PROP_TARGET_INPUT})
    */
-  public MetricCorrelationRankingPipeline(String outputName, Set<String> inputNames, Map<String, String> properties) {
+  public MetricCorrelationRankingPipeline(String outputName, Set<String> inputNames, Map<String, Object> properties) {
     super(outputName, inputNames);
     this.metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
     this.datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();
@@ -102,11 +102,11 @@ public class MetricCorrelationRankingPipeline extends Pipeline {
 
     if(!properties.containsKey(PROP_TARGET_INPUT))
       throw new IllegalArgumentException(String.format("Property '%s' required, but not found.", PROP_TARGET_INPUT));
-    this.targetInput = properties.get(PROP_TARGET_INPUT);
+    this.targetInput = properties.get(PROP_TARGET_INPUT).toString();
 
     String propStrategy = STRATEGY_CORRELATION;
     if(properties.containsKey(PROP_STRATEGY))
-      propStrategy = properties.get(PROP_STRATEGY);
+      propStrategy = properties.get(PROP_STRATEGY).toString();
     this.strategy = parseStrategy(propStrategy);
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricDatasetPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricDatasetPipeline.java
@@ -55,7 +55,7 @@ public class MetricDatasetPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param ignore configuration properties (none)
    */
-  public MetricDatasetPipeline(String outputName, Set<String> inputNames, Map<String, String> ignore) {
+  public MetricDatasetPipeline(String outputName, Set<String> inputNames, Map<String, Object> ignore) {
     super(outputName, inputNames);
     this.metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
     this.datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/NormalizationPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/NormalizationPipeline.java
@@ -34,7 +34,7 @@ public class NormalizationPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param ignore configuration properties (none)
    */
-  public NormalizationPipeline(String outputName, Set<String> inputNames, Map<String, String> ignore) {
+  public NormalizationPipeline(String outputName, Set<String> inputNames, Map<String, Object> ignore) {
     super(outputName, inputNames);
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/NullPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/NullPipeline.java
@@ -32,7 +32,7 @@ public class NullPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param ignore configuration properties (none)
    */
-  public NullPipeline(String outputName, Set<String> inputNames, Map<String, String> ignore) {
+  public NullPipeline(String outputName, Set<String> inputNames, Map<String, Object> ignore) {
     super(outputName, inputNames);
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/PipelineConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/PipelineConfiguration.java
@@ -14,7 +14,7 @@ public class PipelineConfiguration {
   private String outputName;
   private String className;
   private List<String> inputNames;
-  private Map<String, String> properties = null;
+  private Map<String, Object> properties;
 
   public String getOutputName() {
     return outputName;
@@ -28,10 +28,10 @@ public class PipelineConfiguration {
   public void setClassName(String className) {
     this.className = className;
   }
-  public Map<String, String> getProperties() {
+  public Map<String, Object> getProperties() {
     return properties;
   }
-  public void setProperties(Map<String, String> properties) {
+  public void setProperties(Map<String, Object> properties) {
     this.properties = properties;
   }
   public List<String> getInputNames() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/RCAFrameworkLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/RCAFrameworkLoader.java
@@ -44,7 +44,7 @@ public class RCAFrameworkLoader {
         String outputName = pipelineConfig.getOutputName();
         Set<String> inputNames = new HashSet<>(pipelineConfig.getInputNames());
         String className = pipelineConfig.getClassName();
-        Map<String, String> properties = pipelineConfig.getProperties();
+        Map<String, Object> properties = pipelineConfig.getProperties();
         if(properties == null)
           properties = new HashMap<>();
 
@@ -61,11 +61,12 @@ public class RCAFrameworkLoader {
     return pipelines;
   }
 
-  static Map<String, String> augmentPathProperty(Map<String, String> properties, File rcaConfig) {
-    for(Map.Entry<String, String> entry : properties.entrySet()) {
-      if (entry.getKey().equals(PROP_PATH) ||
-          entry.getKey().endsWith(PROP_PATH_POSTFIX)) {
-        File path = new File(entry.getValue());
+  static Map<String, Object> augmentPathProperty(Map<String, Object> properties, File rcaConfig) {
+    for(Map.Entry<String, Object> entry : properties.entrySet()) {
+      if ((entry.getKey().equals(PROP_PATH) ||
+          entry.getKey().endsWith(PROP_PATH_POSTFIX)) &&
+          entry.getValue() instanceof String) {
+        File path = new File(entry.getValue().toString());
         if (!path.isAbsolute()) {
           properties.put(entry.getKey(), rcaConfig.getParent() + File.separator + path);
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/TopKPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/TopKPipeline.java
@@ -48,17 +48,18 @@ public class TopKPipeline extends Pipeline {
    * @param inputNames input pipeline names
    * @param properties configuration properties ({@code PROP_K}, {@code PROP_CLASS})
    */
-  public TopKPipeline(String outputName, Set<String> inputNames, Map<String, String> properties) throws Exception {
+  @SuppressWarnings("unchecked")
+  public TopKPipeline(String outputName, Set<String> inputNames, Map<String, Object> properties) throws Exception {
     super(outputName, inputNames);
 
     if(!properties.containsKey(PROP_K))
       throw new IllegalArgumentException(String.format("Property '%s' required, but not found", PROP_K));
-    this.k = Integer.parseInt(properties.get(PROP_K));
+    this.k = Integer.parseInt(properties.get(PROP_K).toString());
 
     String classProp = PROP_CLASS_DEFAULT;
     if(properties.containsKey(PROP_CLASS))
-      classProp = properties.get(PROP_CLASS);
-    this.clazz = (Class<? extends Entity>)Class.forName(classProp);
+      classProp = properties.get(PROP_CLASS).toString();
+    this.clazz = (Class<? extends Entity>) Class.forName(classProp);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/RCAFrameworkLoaderTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/RCAFrameworkLoaderTest.java
@@ -12,13 +12,13 @@ public class RCAFrameworkLoaderTest {
   public void testAugmentPathProperty() {
     File rcaConfig = new File("/my/path/config.yml");
 
-    Map<String, String> prop = new HashMap<>();
+    Map<String, Object> prop = new HashMap<>();
     prop.put("key", "value");
     prop.put("absolutePath", "/absolute/path.txt");
     prop.put("relativePath", "relative_path.txt");
     prop.put("path", "another_relative_path.txt");
 
-    Map<String, String> aug = RCAFrameworkLoader.augmentPathProperty(prop, rcaConfig);
+    Map<String, Object> aug = RCAFrameworkLoader.augmentPathProperty(prop, rcaConfig);
 
     Assert.assertEquals(aug.get("key"), "value");
     Assert.assertEquals(aug.get("absolutePath"), "/absolute/path.txt");


### PR DESCRIPTION
* support pipeline configuration properties that de-serialize object trees rather than String values only

Currently, "properties" of RCA pipelines can only hold String-String tuples. This is an artificial limitation to the object de-serialization (YAML object mapper) we use anyways. It leads to unnecessary ad-hoc representations for lists and maps of values (e.g. multiple related metric urns in one string separated by commas). This PR streamlines the process and allows "properties" to hold String-Object tuples.