### PR TITLE
Fix the LLC_PARTITION_CONSUMING metric

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -288,7 +288,7 @@ public class LLRealtimeSegmentDataManager extends SegmentDataManager {
   protected boolean consumeLoop() throws Exception {
     _fieldExtractor.resetCounters();
     final long idlePipeSleepTimeMillis = 100;
-    final long maxIdleCountBeforeStatUpdate = (3 * 60 * 1000)/idlePipeSleepTimeMillis;  // 3 minute count
+    final long maxIdleCountBeforeStatUpdate = (3 * 60 * 1000)/(idlePipeSleepTimeMillis + _kafkaStreamMetadata.getKafkaFetchTimeoutMillis());  // 3 minute count
     long lastUpdatedOffset = _currentOffset;  // so that we always update the metric when we enter this method.
     long idleCount = 0;
     // At this point, we know that we can potentially move the offset, so the old saved segment file is not valid


### PR DESCRIPTION
The idea was to update this metric every 3 minutes if there is no event from Kafka.
Since we also have a timeout set when we poll kafka, the total idle time is the timeout
plus the amount of time we wait if we receive no event from kafka.

Without accounting for the kafka fetch timeout, the metric was getting updated much less
frequently, causing alerts in cases where kafka event rate is very small.