### PR TITLE
[TE] Add filter set to summary algorithm

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/Cube.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/Cube.java
@@ -1,8 +1,10 @@
 package com.linkedin.thirdeye.client.diffsummary;
 
+import com.google.common.collect.Multimap;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import java.util.TreeSet;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.lang3.tuple.MutablePair;
@@ -76,68 +79,91 @@ public class Cube { // the cube (Ca|Cb)
 
   public void buildWithAutoDimensionOrder(OLAPDataBaseClient olapClient, Dimensions dimensions)
       throws Exception {
-    buildWithAutoDimensionOrder(olapClient, dimensions, DEFAULT_TOP_DIMENSION, Collections.<List<String>>emptyList());
+    buildWithAutoDimensionOrder(olapClient, dimensions, DEFAULT_TOP_DIMENSION, Collections.<List<String>>emptyList(),
+        null);
   }
 
   public void buildWithAutoDimensionOrder(OLAPDataBaseClient olapClient, Dimensions dimensions, int topDimensions)
       throws Exception {
-    buildWithAutoDimensionOrder(olapClient, dimensions, topDimensions, Collections.<List<String>>emptyList());
+    buildWithAutoDimensionOrder(olapClient, dimensions, topDimensions, Collections.<List<String>>emptyList(), null);
   }
 
   public void buildWithAutoDimensionOrder(OLAPDataBaseClient olapClient, Dimensions dimensions, int topDimension,
-      List<List<String>> hierarchy)
+      List<List<String>> hierarchy, Multimap<String, String> filterSets)
       throws Exception {
-    Dimensions sanitizedDimensions = sanitizeDimensions(dimensions);
-    initializeBasicInfo(olapClient);
     if (dimensions == null || dimensions.size() == 0) {
       throw new IllegalArgumentException("Dimensions cannot be empty.");
     }
     if (hierarchy == null) {
       hierarchy = Collections.emptyList();
     }
-    this.costSet = computeOneDimensionCost(olapClient, topRatio, sanitizedDimensions);
-    this.dimensions = sortDimensionOrder(costSet, sanitizedDimensions, topDimension, hierarchy);
+
+    initializeBasicInfo(olapClient, filterSets);
+    Dimensions sanitizedDimensions = sanitizeDimensions(dimensions);
+    Dimensions shrankDimensions = shrinkDimensionsByFilterSets(sanitizedDimensions, filterSets);
+    this.costSet = computeOneDimensionCost(olapClient, topRatio, shrankDimensions);
+    this.dimensions = sortDimensionOrder(costSet, shrankDimensions, topDimension, hierarchy);
 
     LOG.info("Auto decided dimensions: " + this.dimensions);
 
-    buildWithManualDimensionOrder(olapClient, this.dimensions);
+    buildWithManualDimensionOrder(olapClient, this.dimensions, filterSets);
   }
 
-  public void buildDimensionCostSet(OLAPDataBaseClient olapClient, Dimensions dimensions)
+  public void buildDimensionCostSet(OLAPDataBaseClient olapClient, Dimensions dimensions,
+      Multimap<String, String> filterSets)
       throws Exception {
     Dimensions sanitizedDimensions = sanitizeDimensions(dimensions);
-    initializeBasicInfo(olapClient);
+    initializeBasicInfo(olapClient, filterSets);
     this.costSet = computeOneDimensionCost(olapClient, topRatio, sanitizedDimensions);
   }
 
-  private Dimensions sanitizeDimensions(Dimensions dimensions) {
-    List<String> allDimensions = dimensions.allDimensions();
-    List<String> dimensionsToRemove = new ArrayList<>();
+  private static Dimensions sanitizeDimensions(Dimensions dimensions) {
+    List<String> allDimensionNames = dimensions.allDimensions();
+    Set<String> dimensionsToRemove = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
     dimensionsToRemove.add("environment");
     dimensionsToRemove.add("colo");
     dimensionsToRemove.add("fabric");
-    List<String> validDimensionNames = new ArrayList<>();
-    for(String dim:allDimensions){
-      if(dim.indexOf("_topk") > -1) {
-        String rawDimensionName = dim.replaceAll("_topk", "");
+    for (String dimensionName : allDimensionNames) {
+      if(dimensionName.contains("_topk")) {
+        String rawDimensionName = dimensionName.replaceAll("_topk", "");
         dimensionsToRemove.add(rawDimensionName.toLowerCase());
       }
     }
-    for(String dim:allDimensions){
-      if(!dimensionsToRemove.contains(dim.toLowerCase())){
-        validDimensionNames.add(dim);
-      }
-    }
-    return new Dimensions(validDimensionNames);
+    return removeDimensions(dimensions, dimensionsToRemove);
   }
 
-  public void buildWithManualDimensionOrder(OLAPDataBaseClient olapClient, Dimensions dimensions)
+  private static Dimensions shrinkDimensionsByFilterSets(Dimensions dimensions, Multimap<String, String> filterSets) {
+    // Only dimensions with one value is removed from the given dimensions. Because setting a filter one dimension names
+    // with one dimension value (e.g., "country=US") implies that the final data cube does not contain other dimension
+    // values. Thus, the summary algorithm could simply ignore that dimension (because the cube does not have any other
+    // values to compare with in that dimension).
+    Set<String> dimensionsToRemove = new HashSet<>();
+    for (Map.Entry<String, Collection<String>> filterSetEntry : filterSets.asMap().entrySet()) {
+      if (filterSetEntry.getValue().size() == 1) {
+        dimensionsToRemove.add(filterSetEntry.getKey());
+      }
+    }
+    return removeDimensions(dimensions, dimensionsToRemove);
+  }
+
+  private static Dimensions removeDimensions(Dimensions dimensions, Collection<String> dimensionsToRemove) {
+    List<String> dimensionsToRetain = new ArrayList<>();
+    for (String dimensionName : dimensions.allDimensions()) {
+      if(!dimensionsToRemove.contains(dimensionName)){
+        dimensionsToRetain.add(dimensionName);
+      }
+    }
+    return new Dimensions(dimensionsToRetain);
+  }
+
+  public void buildWithManualDimensionOrder(OLAPDataBaseClient olapClient, Dimensions dimensions,
+      Multimap<String, String> filterSets)
       throws Exception {
     if (dimensions == null || dimensions.size() == 0) {
       throw new IllegalArgumentException("Dimensions cannot be empty.");
     }
     if (this.dimensions == null) { // which means buildWithAutoDimensionOrder is not triggered
-      initializeBasicInfo(olapClient);
+      initializeBasicInfo(olapClient, filterSets);
       this.dimensions = dimensions;
       this.costSet = computeOneDimensionCost(olapClient, topRatio, dimensions);
     }
@@ -152,7 +178,7 @@ public class Cube { // the cube (Ca|Cb)
     //                       / \   \
     //     Level 2          d   e   f
     // The Comparator for generating the order is implemented in the class DimensionValues.
-    List<List<Row>> rowOfLevels = olapClient.getAggregatedValuesOfLevels(dimensions);
+    List<List<Row>> rowOfLevels = olapClient.getAggregatedValuesOfLevels(dimensions, null);
     for (int i = 0; i <= dimensions.size(); ++i) {
       List<Row> rowAtLevelI = rowOfLevels.get(i);
       Collections.sort(rowAtLevelI, new RowDimensionValuesComparator());
@@ -168,9 +194,9 @@ public class Cube { // the cube (Ca|Cb)
    * Calculate the change ratio of the top aggregated values.
    * @throws Exception An exception is thrown if OLAP database cannot be connected.
    */
-  private void initializeBasicInfo(OLAPDataBaseClient olapClient)
+  private void initializeBasicInfo(OLAPDataBaseClient olapClient, Multimap<String, String> filterSets)
       throws Exception {
-    Row topAggValues = olapClient.getTopAggregatedValues();
+    Row topAggValues = olapClient.getTopAggregatedValues(filterSets);
     topBaselineValue = topAggValues.baselineValue; // aggregated baseline values
     topCurrentValue = topAggValues.currentValue; // aggregated current values
     topRatio = topCurrentValue / topBaselineValue; // change ratio
@@ -236,7 +262,7 @@ public class Cube { // the cube (Ca|Cb)
       Dimensions dimensions) throws Exception {
     List<DimNameValueCostEntry> costSet = new ArrayList<>();
 
-    List<List<Row>> wowValuesOfDimensions = olapClient.getAggregatedValuesOfDimension(dimensions);
+    List<List<Row>> wowValuesOfDimensions = olapClient.getAggregatedValuesOfDimension(dimensions, null);
     double baselineTotal = 0;
     double currentTotal = 0;
     //use one dimension to compute baseline/current total

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/OLAPDataBaseClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/OLAPDataBaseClient.java
@@ -1,29 +1,29 @@
 package com.linkedin.thirdeye.client.diffsummary;
 
+import com.google.common.collect.Multimap;
 import java.util.List;
 
 import org.joda.time.DateTime;
 
-import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.datasource.MetricExpression;
 
 public interface OLAPDataBaseClient {
 
-  public void setCollection(String collection);
+  void setCollection(String collection);
 
-  public void setMetricExpression(MetricExpression metricExpressions);
+  void setMetricExpression(MetricExpression metricExpressions);
 
-  public void setBaselineStartInclusive(DateTime dateTime);
+  void setBaselineStartInclusive(DateTime dateTime);
 
-  public void setBaselineEndExclusive(DateTime dateTime);
+  void setBaselineEndExclusive(DateTime dateTime);
 
-  public void setCurrentStartInclusive(DateTime dateTime);
+  void setCurrentStartInclusive(DateTime dateTime);
 
-  public void setCurrentEndExclusive(DateTime dateTime);
+  void setCurrentEndExclusive(DateTime dateTime);
 
-  public Row getTopAggregatedValues() throws Exception;
+  Row getTopAggregatedValues(Multimap<String, String> filterSets) throws Exception;
 
-  public List<List<Row>> getAggregatedValuesOfDimension(Dimensions dimensions) throws Exception;
+  List<List<Row>> getAggregatedValuesOfDimension(Dimensions dimensions, Multimap<String, String> filterSets) throws Exception;
 
-  public List<List<Row>> getAggregatedValuesOfLevels(Dimensions dimensions) throws Exception;
+  List<List<Row>> getAggregatedValuesOfLevels(Dimensions dimensions, Multimap<String, String> filterSets) throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/OLAPDataBaseClient.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/client/diffsummary/OLAPDataBaseClient.java
@@ -23,7 +23,9 @@ public interface OLAPDataBaseClient {
 
   Row getTopAggregatedValues(Multimap<String, String> filterSets) throws Exception;
 
-  List<List<Row>> getAggregatedValuesOfDimension(Dimensions dimensions, Multimap<String, String> filterSets) throws Exception;
+  List<List<Row>> getAggregatedValuesOfDimension(Dimensions dimensions, Multimap<String, String> filterSets)
+      throws Exception;
 
-  List<List<Row>> getAggregatedValuesOfLevels(Dimensions dimensions, Multimap<String, String> filterSets) throws Exception;
+  List<List<Row>> getAggregatedValuesOfLevels(Dimensions dimensions, Multimap<String, String> filterSets)
+      throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/SummaryResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/SummaryResource.java
@@ -37,14 +37,17 @@ import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
 
 @Path(value = "/dashboard")
 public class SummaryResource {
+  private static final Logger LOG = LoggerFactory.getLogger(SummaryResource.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
 
-  private static final Logger LOG = LoggerFactory.getLogger(SummaryResource.class);
   private static final String DEFAULT_TIMEZONE_ID = "UTC";
   private static final String DEFAULT_TOP_DIMENSIONS = "3";
   private static final String DEFAULT_HIERARCHIES = "[]";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String DEFAULT_ONE_SIDE_ERROR = "false";
+  private static final String JAVASCRIPT_NULL_STRING = "undefined";
+  private static final String HTML_STRING_ENCODING = "UTF-8";
+
 
   @GET
   @Path(value = "/summary/autoDimensionOrder")
@@ -77,18 +80,18 @@ public class SummaryResource {
       olapClient.setBaselineEndExclusive(new DateTime(baselineEndExclusive, DateTimeZone.forID(timeZone)));
 
       Dimensions dimensions;
-      if (groupByDimensions == null || groupByDimensions.length() == 0 || groupByDimensions.equals("undefined")) {
+      if (StringUtils.isBlank(groupByDimensions) || JAVASCRIPT_NULL_STRING.equals(groupByDimensions)) {
         dimensions = new Dimensions(Utils.getSchemaDimensionNames(collection));
       } else {
         dimensions = new Dimensions(Arrays.asList(groupByDimensions.trim().split(",")));
       }
 
       Multimap<String, String> filterSetMap;
-      if (StringUtils.isNotBlank(filterJsonPayload)) {
-        filterJsonPayload = URLDecoder.decode(filterJsonPayload, "UTF-8");
-        filterSetMap = ThirdEyeUtils.convertToMultiMap(filterJsonPayload);
-      } else {
+      if (StringUtils.isBlank(filterJsonPayload) || JAVASCRIPT_NULL_STRING.equals(filterJsonPayload)) {
         filterSetMap = ArrayListMultimap.create();
+      } else {
+        filterJsonPayload = URLDecoder.decode(filterJsonPayload, HTML_STRING_ENCODING);
+        filterSetMap = ThirdEyeUtils.convertToMultiMap(filterJsonPayload);
       }
 
       List<List<String>> hierarchies =
@@ -138,7 +141,7 @@ public class SummaryResource {
       olapClient.setBaselineEndExclusive(new DateTime(baselineEndExclusive, DateTimeZone.forID(timeZone)));
 
       List<String> allDimensions;
-      if (groupByDimensions == null || groupByDimensions.length() == 0 || groupByDimensions.equals("undefined")) {
+      if (StringUtils.isBlank(groupByDimensions) || JAVASCRIPT_NULL_STRING.equals(groupByDimensions)) {
         allDimensions = Utils.getSchemaDimensionNames(collection);
       } else {
         allDimensions = Arrays.asList(groupByDimensions.trim().split(","));
@@ -149,11 +152,11 @@ public class SummaryResource {
       Dimensions dimensions = new Dimensions(allDimensions);
 
       Multimap<String, String> filterSets;
-      if (StringUtils.isNotBlank(filterJsonPayload)) {
-        filterJsonPayload = URLDecoder.decode(filterJsonPayload, "UTF-8");
-        filterSets = ThirdEyeUtils.convertToMultiMap(filterJsonPayload);
-      } else {
+      if (StringUtils.isBlank(filterJsonPayload) || JAVASCRIPT_NULL_STRING.equals(filterJsonPayload)) {
         filterSets = ArrayListMultimap.create();
+      } else {
+        filterJsonPayload = URLDecoder.decode(filterJsonPayload, HTML_STRING_ENCODING);
+        filterSets = ThirdEyeUtils.convertToMultiMap(filterJsonPayload);
       }
 
       Cube cube = new Cube();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
@@ -24,7 +24,6 @@ import com.linkedin.thirdeye.rootcause.PipelineContext;
 import com.linkedin.thirdeye.rootcause.PipelineResult;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -233,7 +232,7 @@ public class DimensionAnalysisPipeline extends Pipeline {
     Dimensions dimensions = new Dimensions(dataset.getDimensions());
 
     Cube cube = new Cube();
-    cube.buildDimensionCostSet(olapClient, dimensions);
+    cube.buildDimensionCostSet(olapClient, dimensions, null);
 
     return toNormalizedDataFrame(cube.getCostSet());
   }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/heatmap.js
@@ -24,6 +24,7 @@ function getHeatmap(tab) {
             "&currentStart=" + hash.currentStart +
             "&currentEnd=" + hash.currentEnd +
             "&dimensions=" + hash.dimensions +
+            "&filters=" + hash.filters +
             "&topDimensions=3" +
             "&oneSideError=false" +
             "&summarySize=10" +


### PR DESCRIPTION
Problem:
Current summary algorithm could not take filter set (e.g. {country=US, device=iOS}). Consequently, the generated summary always show the results for top level of the data cube even though users have drilled down to a certain dimension (e.g., country=US) on the dashboard.

Solution:
Added filter set as a parameter of the summary algorithm to ensure that the input cube for the algorithm consistent with users' drilling path.

Tested on local dashboard.