### PR TITLE
Adding partition aware routing table builder

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/PartitionZKMetadataPruner.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/pruner/PartitionZKMetadataPruner.java
@@ -60,6 +60,10 @@ public class PartitionZKMetadataPruner implements SegmentZKMetadataPruner {
    */
   private boolean pruneSegment(FilterQueryTree filterQueryTree,
       Map<String, ColumnPartitionMetadata> columnMetadataMap) {
+    if (filterQueryTree == null) {
+      return false;
+    }
+
     List<FilterQueryTree> children = filterQueryTree.getChildren();
 
     // Non-leaf node

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -560,7 +560,7 @@ public class BrokerRequestHandler {
     phaseTimes.addToRoutingTime(System.nanoTime() - routingStartTime);
     if (segmentServices == null || segmentServices.isEmpty()) {
       String tableNameWithType = brokerRequest.getQuerySource().getTableName();
-      LOGGER.info("No server found for table: {}", tableNameWithType);
+      LOGGER.info("No server found or all segments are pruned for table: {}", tableNameWithType);
       _brokerMetrics.addMeteredTableValue(tableNameWithType, BrokerMeter.NO_SERVER_FOUND_EXCEPTIONS, 1L);
       return null;
     }
@@ -594,7 +594,8 @@ public class BrokerRequestHandler {
       routingOptions =
           Splitter.on(",").omitEmptyStrings().trimResults().splitToList(debugOptions.get("routingOptions"));
     }
-    RoutingTableLookupRequest routingTableLookupRequest = new RoutingTableLookupRequest(tableName, routingOptions, brokerRequest);
+    RoutingTableLookupRequest routingTableLookupRequest = new RoutingTableLookupRequest(tableName, routingOptions,
+        brokerRequest);
     return _routingTable.findServers(routingTableLookupRequest);
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -594,7 +594,7 @@ public class BrokerRequestHandler {
       routingOptions =
           Splitter.on(",").omitEmptyStrings().trimResults().splitToList(debugOptions.get("routingOptions"));
     }
-    RoutingTableLookupRequest routingTableLookupRequest = new RoutingTableLookupRequest(tableName, routingOptions);
+    RoutingTableLookupRequest routingTableLookupRequest = new RoutingTableLookupRequest(tableName, routingOptions, brokerRequest);
     return _routingTable.findServers(routingTableLookupRequest);
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/CfgBasedRouting.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/CfgBasedRouting.java
@@ -52,7 +52,7 @@ public class CfgBasedRouting implements RoutingTable {
 
   @Override
   public boolean routingTableExists(String tableName) {
-    Map<ServerInstance, SegmentIdSet> routingTableEntry = findServers(new RoutingTableLookupRequest(tableName, null));
+    Map<ServerInstance, SegmentIdSet> routingTableEntry = findServers(new RoutingTableLookupRequest(tableName, null, null));
     return routingTableEntry != null && !routingTableEntry.isEmpty();
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -127,7 +127,7 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
 
     RoutingTableBuilder routingTableBuilder = _routingTableBuilderFactory.createRoutingTableBuilder(tableConfig);
     routingTableBuilder.init(_configuration, tableConfig, _propertyStore);
-    LOGGER.info("Initialized routingTableBuilder:%s for table:%", routingTableBuilder.getClass().getName(), tableName);
+    LOGGER.info("Initialized routingTableBuilder: {} for table {}", routingTableBuilder.getClass().getName(), tableName);
     _routingTableBuilderMap.put(tableName, routingTableBuilder);
 
     // Build the routing table

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/HelixExternalViewBasedRouting.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/HelixExternalViewBasedRouting.java
@@ -91,13 +91,12 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
     _timeBoundaryService = new HelixExternalViewBasedTimeBoundaryService(propertyStore);
     _routingTableBuilderMap = new HashMap<>();
     _helixManager = helixManager;
-    _routingTableBuilderFactory = new RoutingTableBuilderFactory(_configuration);
+    _routingTableBuilderFactory = new RoutingTableBuilderFactory(_configuration, propertyStore);
   }
 
   @Override
   public Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request) {
     String tableName = request.getTableName();
-
     RoutingTableBuilder routingTableBuilder = _routingTableBuilderMap.get(tableName);
     return routingTableBuilder.findServers(request);
   }
@@ -127,9 +126,10 @@ public class HelixExternalViewBasedRouting implements RoutingTable {
     String tableName = tableConfig.getTableName();
 
     RoutingTableBuilder routingTableBuilder = _routingTableBuilderFactory.createRoutingTableBuilder(tableConfig);
-    routingTableBuilder.init(_configuration);
+    routingTableBuilder.init(_configuration, tableConfig, _propertyStore);
     LOGGER.info("Initialized routingTableBuilder:%s for table:%", routingTableBuilder.getClass().getName(), tableName);
     _routingTableBuilderMap.put(tableName, routingTableBuilder);
+
     // Build the routing table
     if (externalView == null) {
       // It is possible for us to get a request to serve a table for which there is no external view. In this case, just

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -18,6 +18,8 @@ package com.linkedin.pinot.broker.routing;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,12 +38,15 @@ public class RoutingTableBuilderFactory {
   private static final Set<Class<? extends RoutingTableBuilder>> _routingTableBuilders = new HashSet<>();
   private Configuration _configuration;
 
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
   enum RoutingTableBuilderName {
     DefaultOffline, DefaultRealtime, BalancedRandom, KafkaLowLevel, KafkaHighLevel
   }
 
-  public RoutingTableBuilderFactory(Configuration configuration) {
+  public RoutingTableBuilderFactory(Configuration configuration, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _configuration = configuration;
+    _propertyStore = propertyStore;
   }
 
   public RoutingTableBuilder createRoutingTableBuilder(TableConfig tableConfig) {
@@ -87,7 +92,7 @@ public class RoutingTableBuilderFactory {
       builder = new KafkaLowLevelConsumerRoutingTableBuilder();
       break;
     }
-    builder.init(_configuration);
+    builder.init(_configuration, tableConfig, _propertyStore);
     return builder;
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableLookupRequest.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableLookupRequest.java
@@ -17,6 +17,8 @@ package com.linkedin.pinot.broker.routing;
 
 import java.util.List;
 
+import com.linkedin.pinot.common.request.BrokerRequest;
+
 
 /**
  * Routing table lookup request. Future filtering parameters for lookup needs to be added here.
@@ -29,6 +31,8 @@ public class RoutingTableLookupRequest {
 
   private final List<String> routingOptions;
 
+  private BrokerRequest brokerRequest;
+  
   public String getTableName() {
     return tableName;
   }
@@ -36,10 +40,15 @@ public class RoutingTableLookupRequest {
   public List<String> getRoutingOptions() {
     return routingOptions;
   }
+  
+  public BrokerRequest getBrokerRequest() {
+    return brokerRequest;
+  }
 
-  public RoutingTableLookupRequest(String tableName, List<String> routingOptions) {
+  public RoutingTableLookupRequest(String tableName, List<String> routingOptions, BrokerRequest brokerRequest) {
     super();
     this.tableName = tableName;
     this.routingOptions = routingOptions;
+    this.brokerRequest = brokerRequest;
   }
 }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/ServerToSegmentSetMap.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/ServerToSegmentSetMap.java
@@ -54,16 +54,8 @@ public class ServerToSegmentSetMap {
     _serverToSegmentSetMap = serverToSegmentSetMap;
     _routingTable = new HashMap<ServerInstance, SegmentIdSet>();
     for (Entry<String, Set<String>> entry : _serverToSegmentSetMap.entrySet()) {
-      String namePortStr = entry.getKey().split(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)[1];
-      String hostName = namePortStr.split(NAME_PORT_DELIMITER)[0];
-      int port;
-      try {
-        port = Integer.parseInt(namePortStr.split(NAME_PORT_DELIMITER)[1]);
-      } catch (Exception e) {
-        port = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
-      }
-
-      ServerInstance serverInstance = ServerInstance.forHostPort(hostName, port);
+      String instanceName = entry.getKey();
+      ServerInstance serverInstance = ServerInstance.forInstanceName(instanceName);
       SegmentIdSet segmentIdSet = new SegmentIdSet();
       for (String segmentId : entry.getValue()) {
         segmentIdSet.addSegment(new SegmentId(segmentId));

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/ServerToSegmentSetMap.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/ServerToSegmentSetMap.java
@@ -48,8 +48,6 @@ public class ServerToSegmentSetMap {
   private Map<String, Set<String>> _serverToSegmentSetMap;
   private Map<ServerInstance, SegmentIdSet> _routingTable;
 
-  public static final String NAME_PORT_DELIMITER = "_";
-
   public ServerToSegmentSetMap(Map<String, Set<String>> serverToSegmentSetMap) {
     _serverToSegmentSetMap = serverToSegmentSetMap;
     _routingTable = new HashMap<ServerInstance, SegmentIdSet>();

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/AbstractRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/AbstractRoutingTableBuilder.java
@@ -126,5 +126,8 @@ public abstract class AbstractRoutingTableBuilder implements RoutingTableBuilder
     _isEmpty = isEmpty;
   }
   
-   
+   @Override
+  public boolean isPartitionAware() {
+    return false;
+  }
 }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
@@ -25,11 +25,14 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.SegmentIdSet;
 
@@ -54,7 +57,7 @@ public class BalancedRandomRoutingTableBuilder extends AbstractRoutingTableBuild
   }
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _numberOfRoutingTables = configuration.getInt("numOfRoutingTables", 10);
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultOfflineRoutingTableBuilder.java
@@ -21,13 +21,16 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.SegmentIdSet;
 
@@ -45,7 +48,7 @@ public class DefaultOfflineRoutingTableBuilder extends AbstractRoutingTableBuild
   RoutingTableBuilder _routingTableBuilder;
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _largeClusterRoutingTableBuilder = new LargeClusterRoutingTableBuilder();
     _smallClusterRoutingTableBuilder = new BalancedRandomRoutingTableBuilder();
     if (configuration.containsKey("minServerCountForLargeCluster")) {
@@ -74,8 +77,8 @@ public class DefaultOfflineRoutingTableBuilder extends AbstractRoutingTableBuild
       LOGGER.info("Using default value for large cluster min replica count of {}", MIN_REPLICA_COUNT_FOR_LARGE_CLUSTER);
     }
 
-    _largeClusterRoutingTableBuilder.init(configuration);
-    _smallClusterRoutingTableBuilder.init(configuration);
+    _largeClusterRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
+    _smallClusterRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
   }
 
   @Override

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/DefaultRealtimeRoutingTableBuilder.java
@@ -23,13 +23,16 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.common.utils.SegmentName;
 import com.linkedin.pinot.transport.common.SegmentIdSet;
@@ -45,11 +48,11 @@ public class DefaultRealtimeRoutingTableBuilder extends AbstractRoutingTableBuil
   boolean _hasHLC;
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _realtimeHLCRoutingTableBuilder = new KafkaHighLevelConsumerBasedRoutingTableBuilder();
     _realtimeLLCRoutingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
-    _realtimeHLCRoutingTableBuilder.init(configuration);
-    _realtimeLLCRoutingTableBuilder.init(configuration);
+    _realtimeHLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
+    _realtimeLLCRoutingTableBuilder.init(configuration, tableConfig, propertyStore);
   }
 
   @Override

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaHighLevelConsumerBasedRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaHighLevelConsumerBasedRoutingTableBuilder.java
@@ -22,11 +22,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
@@ -38,7 +41,7 @@ public class KafkaHighLevelConsumerBasedRoutingTableBuilder extends AbstractRout
 
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
   }
 
   @Override

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
@@ -30,13 +30,16 @@ import java.util.TreeSet;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
@@ -53,7 +56,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRout
   private int TARGET_SERVER_COUNT_PER_QUERY = 8;
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     // TODO jfim This is a broker-level configuration for now, until we refactor the configuration of the routing table to allow per-table routing settings
     if (configuration.containsKey("realtimeTargetServerCountPerQuery")) {
       final String targetServerCountPerQuery = configuration.getString("realtimeTargetServerCountPerQuery");

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LargeClusterRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/LargeClusterRoutingTableBuilder.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.transport.common.SegmentIdSet;
@@ -33,8 +34,10 @@ import java.util.Random;
 import java.util.Set;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +156,7 @@ public class LargeClusterRoutingTableBuilder extends GeneratorBasedRoutingTableB
   }
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     // TODO jfim This is a broker-level configuration for now, until we refactor the configuration of the routing table to allow per-table routing settings
     if (configuration.containsKey("offlineTargetServerCountPerQuery")) {
       final String targetServerCountPerQuery = configuration.getString("offlineTargetServerCountPerQuery");

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.routing.builder;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+
+import com.linkedin.pinot.broker.pruner.PartitionZKMetadataPruner;
+import com.linkedin.pinot.broker.pruner.SegmentPrunerContext;
+import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.PartitionToReplicaGroupMappingZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.transport.common.SegmentId;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
+public class PartitionAwareOfflineRoutingTableBuilder extends AbstractRoutingTableBuilder {
+  Map<SegmentId, Map<Integer, ServerInstance>> _segmentId2ServersMapping = new HashMap<>();
+  AtomicReference<Map<SegmentId, Map<Integer, ServerInstance>>> _mappingRef = new AtomicReference<>(_segmentId2ServersMapping);
+  Map<SegmentId, SegmentZKMetadata> _zkSegment2ColumnMetadataMap = new ConcurrentHashMap<>();
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private PartitionZKMetadataPruner _pruner;
+  private PartitionToReplicaGroupMappingZKMetadata _partitionToReplicaGroupMappingZKMedata;
+  private Random _random = new Random();
+  private TableConfig _tableConfig;
+  private int _numReplicas;
+
+  @Override
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _tableConfig = tableConfig;
+    _propertyStore = propertyStore;
+    _pruner = new PartitionZKMetadataPruner();
+  }
+
+  @Override
+  public void computeRoutingTableFromExternalView(String tableName, ExternalView externalView, List<InstanceConfig> instanceConfigList) {
+    Map<SegmentId, Map<Integer, ServerInstance>> segmentId2ServersMapping = new HashMap<>();
+    RoutingTableInstancePruner pruner = new RoutingTableInstancePruner(instanceConfigList);
+    String[] segmentSet = externalView.getPartitionSet().toArray(new String[0]);
+    _numReplicas = _tableConfig.getValidationConfig().getReplicationNumber();
+    _partitionToReplicaGroupMappingZKMedata = ZKMetadataProvider.getPartitionToReplicaGroupMappingZKMedata(_propertyStore, tableName);
+
+    Set<Integer> partitionIds = new HashSet<>();
+    for (String segment : segmentSet) {
+      SegmentId segmentId = new SegmentId(segment);
+      // retrieve the metadata for the segment and compute the partitionIds set
+      SegmentZKMetadata segmentZKMetadata = _zkSegment2ColumnMetadataMap.get(segmentId);
+      if (segmentZKMetadata == null) {
+        segmentZKMetadata = ZKMetadataProvider.getOfflineSegmentZKMetadata(_propertyStore, tableName, segment);
+        _zkSegment2ColumnMetadataMap.put(segmentId, segmentZKMetadata);
+      }
+      int partitionId = getPartitionId(segmentZKMetadata);
+      partitionIds.add(partitionId);
+
+    }
+    // compute server to replica id mapping for each partition
+    Map<Integer, Map<ServerInstance, Integer>> perPartitionServer2ReplicaIdMapping = new HashMap<>();
+    for (Integer partitionId : partitionIds) {
+      for (int replicaId = 0; replicaId < _numReplicas; replicaId++) {
+        List<String> instancesfromReplicaGroup = _partitionToReplicaGroupMappingZKMedata.getInstancesfromReplicaGroup(partitionId, replicaId);
+        for (String instanceName : instancesfromReplicaGroup) {
+          perPartitionServer2ReplicaIdMapping.get(partitionId).put(ServerInstance.forInstanceName(instanceName), replicaId);
+        }
+      }
+
+    }
+
+    for (String segment : segmentSet) {
+      SegmentId segmentId = new SegmentId(segment);
+      SegmentZKMetadata segmentZKMetadata = _zkSegment2ColumnMetadataMap.get(segmentId);
+      int partitionId = getPartitionId(segmentZKMetadata);
+      Map<String, String> instanceToStateMap = new HashMap<>(externalView.getStateMap(segment));
+      Map<Integer, ServerInstance> serverInstanceMap = new HashMap<>();
+
+      for (String instance : instanceToStateMap.keySet()) {
+        if (pruner.isInactive(instance)) {
+          continue;
+        }
+        if (instanceToStateMap.get(instance).equals("ONLINE")) {
+          ServerInstance serverInstance = ServerInstance.forInstanceName(instance);
+          int replicaId = perPartitionServer2ReplicaIdMapping.get(partitionId).get(serverInstance);
+          serverInstanceMap.put(replicaId, serverInstance);
+        }
+      }
+      segmentId2ServersMapping.put(segmentId, serverInstanceMap);
+    }
+    _mappingRef.set(segmentId2ServersMapping);
+
+  }
+
+  @Override
+  public Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request) {
+
+    Map<ServerInstance, SegmentIdSet> result = new HashMap<>();
+    Map<SegmentId, Map<Integer, ServerInstance>> map = _mappingRef.get();
+    SegmentPrunerContext prunerContext = new SegmentPrunerContext(request.getBrokerRequest());
+    int replicaGroupId = _random.nextInt(_numReplicas);
+    for (SegmentId segmentId : map.keySet()) {
+      SegmentZKMetadata segmentZKMetadata = _zkSegment2ColumnMetadataMap.get(segmentId);
+      boolean pruned = _pruner.prune(segmentZKMetadata, prunerContext);
+      if (!pruned) {
+        Map<Integer, ServerInstance> replicaId2ServerMapping = map.get(segmentId);
+        ServerInstance serverInstance = replicaId2ServerMapping.get(replicaGroupId);
+        // pick any other available server instance when the node is down/disabled
+        if (serverInstance == null && !replicaId2ServerMapping.isEmpty()) {
+          serverInstance = replicaId2ServerMapping.values().iterator().next();
+        }
+        SegmentIdSet segmentIdSet = result.get(serverInstance);
+        if (segmentIdSet == null) {
+          segmentIdSet = new SegmentIdSet();
+          result.put(serverInstance, segmentIdSet);
+        }
+        segmentIdSet.addSegment(segmentId);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Assumes there is only one column
+   * 
+   * @param segmentZKMetadata
+   * @return
+   */
+  private int getPartitionId(SegmentZKMetadata segmentZKMetadata) {
+    SegmentPartitionMetadata partitionMetadata = segmentZKMetadata.getPartitionMetadata();
+    Map<String, ColumnPartitionMetadata> columnPartitionMap = partitionMetadata.getColumnPartitionMap();
+    ColumnPartitionMetadata columnPartitionMetadata;
+    if (columnPartitionMap.size() == 1) {
+      columnPartitionMetadata = columnPartitionMap.values().iterator().next();
+      int partitionIdStart = columnPartitionMetadata.getPartitionRanges().get(0).getMaximumInteger();
+      // int partitionIdEnd = columnPartitionMetadata.getPartitionRanges().get(0).getMaximumInteger();
+      return partitionIdStart;
+    }
+    return 0;
+  }
+
+  @Override
+  public boolean isPartitionAware() {
+    return true;
+  }
+
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/RandomRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/RandomRoutingTableBuilder.java
@@ -24,10 +24,13 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 
 
 /**
@@ -46,7 +49,7 @@ public class RandomRoutingTableBuilder extends AbstractRoutingTableBuilder {
   }
 
   @Override
-  public void init(Configuration configuration) {
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
     _numberOfRoutingTables = configuration.getInt("numOfRoutingTables", 10);
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/RoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/RoutingTableBuilder.java
@@ -19,12 +19,15 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 
 import com.linkedin.pinot.broker.routing.RoutingTable;
 import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
 import com.linkedin.pinot.broker.routing.ServerToSegmentSetMap;
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.SegmentIdSet;
 
@@ -39,7 +42,7 @@ public interface RoutingTableBuilder {
    *
    * @param configuration The configuration to use
    */
-  void init(Configuration configuration);
+  void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore);
 
   /**
    * Builds one or more routing tables (maps of servers to segment lists) that are used for query routing. The union of
@@ -66,6 +69,8 @@ public interface RoutingTableBuilder {
    * @return List of routing tables used to route queries
    */
   List<ServerToSegmentSetMap> getRoutingTables();
+  
+  boolean isPartitionAware();
 
 
 }

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RandomRoutingTableTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RandomRoutingTableTest.java
@@ -74,7 +74,7 @@ public class RandomRoutingTableTest {
     double[] globalArrays = new double[9];
 
     for (int numRun = 0; numRun < totalRuns; ++numRun) {
-      RoutingTableLookupRequest request = new RoutingTableLookupRequest(tableName, Collections.<String>emptyList());
+      RoutingTableLookupRequest request = new RoutingTableLookupRequest(tableName, Collections.<String>emptyList(), null);
       Map<ServerInstance, SegmentIdSet> serversMap = routingTable.findServers(request);
       TreeSet<ServerInstance> serverInstances = new TreeSet<ServerInstance>(serversMap.keySet());
 

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
@@ -167,7 +167,7 @@ public class RoutingTableTest {
 
   private void assertResourceRequest(HelixExternalViewBasedRouting routingTable, String resource,
       String expectedSegmentList, int expectedNumSegment) {
-    RoutingTableLookupRequest request = new RoutingTableLookupRequest(resource, Collections.<String>emptyList());
+    RoutingTableLookupRequest request = new RoutingTableLookupRequest(resource, Collections.<String>emptyList(), null);
     Map<ServerInstance, SegmentIdSet> serversMap = routingTable.findServers(request);
     List<String> selectedSegments = new ArrayList<String>();
     for (ServerInstance serverInstance : serversMap.keySet()) {
@@ -281,7 +281,7 @@ public class RoutingTableTest {
 
   private void assertResourceRequest(HelixExternalViewBasedRouting routingTable, String resource,
       String[] expectedSegmentLists, int expectedNumSegment) {
-    RoutingTableLookupRequest request = new RoutingTableLookupRequest(resource, Collections.<String>emptyList());
+    RoutingTableLookupRequest request = new RoutingTableLookupRequest(resource, Collections.<String>emptyList(), null);
     Map<ServerInstance, SegmentIdSet> serversMap = routingTable.findServers(request);
     List<String> selectedSegments = new ArrayList<String>();
     for (ServerInstance serverInstance : serversMap.keySet()) {
@@ -344,7 +344,7 @@ public class RoutingTableTest {
     ev.setState(llcSegment2.getSegmentName(), helixInstance2, consuming);
     routingTable.markDataResourceOnline(generateTableConfig(resourceName), ev, instanceConfigs);
 
-    RoutingTableLookupRequest request = new RoutingTableLookupRequest(resourceName, Collections.<String>emptyList());
+    RoutingTableLookupRequest request = new RoutingTableLookupRequest(resourceName, Collections.<String>emptyList(), null);
     for (int i = 0; i < 100; i++) {
       Map<ServerInstance, SegmentIdSet> routingMap = routingTable.findServers(request);
       Assert.assertEquals(routingMap.size(), 1);
@@ -407,7 +407,7 @@ public class RoutingTableTest {
     Assert.assertTrue(llc >= 10, "Got low values hlc=" + hlc + ",llc="  + llc);
 
     // Check that force HLC works
-    request = new RoutingTableLookupRequest(resourceName, Collections.singletonList("FORCE_HLC"));
+    request = new RoutingTableLookupRequest(resourceName, Collections.singletonList("FORCE_HLC"), null);
     hlc = 0;
     llc = 0;
     for (int i = 0; i < 100; i++) {
@@ -432,7 +432,7 @@ public class RoutingTableTest {
     Assert.assertEquals(llc, 0);
 
     // Check that force LLC works
-    request = new RoutingTableLookupRequest(resourceName, Collections.singletonList("FORCE_LLC"));
+    request = new RoutingTableLookupRequest(resourceName, Collections.singletonList("FORCE_LLC"), null);
     hlc = 0;
     llc = 0;
     for (int i = 0; i < 100; i++) {

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
@@ -50,7 +50,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
     Random random = new Random();
 
     KafkaLowLevelConsumerRoutingTableBuilder routingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
-    routingTableBuilder.init(new BaseConfiguration());
+    routingTableBuilder.init(new BaseConfiguration(), null, null);
 
     long totalNanos = 0L;
 
@@ -158,7 +158,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
     final int CONSUMING_SEGMENT_COUNT = SEGMENT_COUNT - ONLINE_SEGMENT_COUNT;
 
     KafkaLowLevelConsumerRoutingTableBuilder routingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();
-    routingTableBuilder.init(new BaseConfiguration());
+    routingTableBuilder.init(new BaseConfiguration(), null, null);
 
     List<SegmentName> segmentNames = new ArrayList<SegmentName>();
     for(int i = 0; i < SEGMENT_COUNT; ++i) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/PartitionToReplicaGroupMappingZKMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/segment/PartitionToReplicaGroupMappingZKMetadata.java
@@ -32,7 +32,7 @@ public class PartitionToReplicaGroupMappingZKMetadata implements ZKMetadata {
 
   private Map<String, List<String>> _partitionToReplicaGroupMapping;
   private String _tableName;
-
+  
   public PartitionToReplicaGroupMappingZKMetadata(ZNRecord znRecord) {
     _partitionToReplicaGroupMapping = znRecord.getListFields();
     _tableName = znRecord.getId();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/ServerInstance.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/ServerInstance.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.common.net.InternetDomainName;
+import com.linkedin.pinot.common.utils.CommonConstants;
 
 
 /**
@@ -203,5 +204,17 @@ public class ServerInstance implements Comparable<ServerInstance> {
 
       return newInstance;
     }
+  }
+
+  public static ServerInstance forInstanceName(String instanceName) {
+    String namePortStr = instanceName.split(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)[1];
+    String hostName = namePortStr.split(NAME_PORT_DELIMITER)[0];
+    int port;
+    try {
+      port = Integer.parseInt(namePortStr.split(NAME_PORT_DELIMITER)[1]);
+    } catch (Exception e) {
+      port = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
+    }
+    return forHostPort(hostName, port);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/response/ServerInstance.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/response/ServerInstance.java
@@ -41,6 +41,7 @@ public class ServerInstance implements Comparable<ServerInstance> {
   protected static final Logger LOGGER = LoggerFactory.getLogger(ServerInstance.class);
 
   public static final String NAME_PORT_DELIMITER = ":";
+  public static final String NAME_PORT_DELIMITER_FOR_INSTANCE_NAME = "_";
 
   /** Host-name where the service is running **/
   private final String _hostname;
@@ -208,10 +209,10 @@ public class ServerInstance implements Comparable<ServerInstance> {
 
   public static ServerInstance forInstanceName(String instanceName) {
     String namePortStr = instanceName.split(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)[1];
-    String hostName = namePortStr.split(NAME_PORT_DELIMITER)[0];
+    String hostName = namePortStr.split(NAME_PORT_DELIMITER_FOR_INSTANCE_NAME)[0];
     int port;
     try {
-      port = Integer.parseInt(namePortStr.split(NAME_PORT_DELIMITER)[1]);
+      port = Integer.parseInt(namePortStr.split(NAME_PORT_DELIMITER_FOR_INSTANCE_NAME)[1]);
     } catch (Exception e) {
       port = CommonConstants.Helix.DEFAULT_SERVER_NETTY_PORT;
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -66,7 +66,8 @@ public class CommonConstants {
       public static enum SegmentAssignmentStrategyType {
         RandomAssignmentStrategy,
         BalanceNumSegmentAssignmentStrategy,
-        BucketizedSegmentAssignmentStrategy;
+        BucketizedSegmentAssignmentStrategy,
+        ReplicaGroupSegmentAssignmentStrategy;
       }
 
       public static class Schema {


### PR DESCRIPTION
Partition aware routing table builder prunes the segment based on zkmetadata and picks the servers based on the partition assignment info in property store. This is done only for the offline tables for now. Will extend it to realtime in the another PR.