### PR TITLE
Fix commons-math dependency

### DIFF
--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -143,5 +143,10 @@
       <version>1.8.4</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math</artifactId>
+    </dependency>
    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -649,6 +649,11 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-math</artifactId>
+        <version>2.1</version>
+      </dependency>
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
Fix missing commons-math dependency pulled in transitively via Helix.
This fixes classpath issues when building against Helix versions that do
not expose the commons-math dependency.