### PR TITLE
Fix rebalancer adding extra replicas

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotSegmentRebalancer.java
@@ -186,6 +186,8 @@ public class PinotSegmentRebalancer extends PinotZKChanger {
               public IdealState apply(@Nullable IdealState idealState) {
                 for (String segmentId : newMapping.keySet()) {
                   Map<String, String> instanceStateMap = newMapping.get(segmentId);
+
+                  idealState.getInstanceStateMap(segmentId).clear();
                   for (String instanceId : instanceStateMap.keySet()) {
                     idealState.setPartitionState(segmentId, instanceId, instanceStateMap.get(instanceId));
                   }


### PR DESCRIPTION
Fix the rebalancer adding extra replicas when downsizing clusters due to
not clearing the instance state map before writing in the new segment
assignment.