### PR TITLE
Reduce the table level broker metrics emitted

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
@@ -32,10 +32,11 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   // These metrics track the exceptions caught during query execution in broker side.
   // PQL compile phase.
   REQUEST_COMPILATION_EXCEPTIONS("exceptions", true),
+  // Get resource phase.
+  RESOURCE_MISSING_EXCEPTIONS("exceptions", true),
   // Query validation phase.
   QUERY_VALIDATION_EXCEPTIONS("exceptions", false),
   // Scatter phase.
-  RESOURCE_MISSING_EXCEPTIONS("exceptions", false),
   NO_SERVER_FOUND_EXCEPTIONS("exceptions", false),
   // Gather phase.
   RESPONSE_FETCH_EXCEPTIONS("exceptions", false),

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -15,14 +15,7 @@
  */
 package com.linkedin.pinot.core.query.reduce;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.BrokerMeter;
@@ -44,9 +37,17 @@ import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionUti
 import com.linkedin.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import com.linkedin.pinot.core.query.selection.SelectionOperatorService;
 import com.linkedin.pinot.core.query.selection.SelectionOperatorUtils;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -147,10 +148,12 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
 
     // Update broker metrics.
     String tableName = brokerRequest.getQuerySource().getTableName();
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
     if (brokerMetrics != null) {
-      brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.DOCUMENTS_SCANNED, numDocsScanned);
-      brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.ENTRIES_SCANNED_IN_FILTER, numEntriesScannedInFilter);
-      brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.ENTRIES_SCANNED_POST_FILTER,
+      brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.DOCUMENTS_SCANNED, numDocsScanned);
+      brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_IN_FILTER,
+          numEntriesScannedInFilter);
+      brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.ENTRIES_SCANNED_POST_FILTER,
           numEntriesScannedPostFilter);
     }
 
@@ -182,7 +185,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
                     + " from servers: " + droppedServers + " got dropped due to data schema inconsistency.";
             LOGGER.info(errorMessage);
             if (brokerMetrics != null) {
-              brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.RESPONSE_MERGE_EXCEPTIONS, 1);
+              brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.RESPONSE_MERGE_EXCEPTIONS, 1L);
             }
             brokerResponseNative.addToExceptions(
                 new QueryProcessingException(QueryException.MERGE_RESPONSE_ERROR_CODE, errorMessage));


### PR DESCRIPTION
1. Change RESOURCE_MISSING_EXCEPTIONS to a global meter so that random table name does not create a new metric
2. First check if any resource gets hit, so that random table name does not create a new metric
3. If multiple tables might be hit (hybrid case), use raw table name for the metrics
4. If only one table can be hit, use table name with type for the metrics

By doing this, metrics for a single table/resource will not split into multiple set of metrics
e.g. For offline use case, metircs for tableName and tableName_OFFLINE should be the same set of metrics