### PR TITLE
Endpoints for triggering onboard service for data sources

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboard.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboard.java
@@ -20,4 +20,9 @@ public abstract class AutoOnboard {
    * Method which contains implementation of what needs to be done as part of onboarding for this data source
    */
   public abstract void run();
+
+  /**
+   * Method for triggering adhoc run of the onboard logic
+   */
+  public abstract void runAdhoc();
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
@@ -69,8 +69,6 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
     }
   }
 
-
-
   /**
    * Adds a dataset to the thirdeye database
    * @param dataset
@@ -311,6 +309,12 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
       LOG.info("Creating dashboard config for {}", dashboardName);
       DAO_REGISTRY.getDashboardConfigDAO().update(dashboardConfig);
     }
+  }
+
+  @Override
+  public void runAdhoc() {
+    LOG.info("Triggering adhoc run for AutoOnboard Pinot data source");
+    run();
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -5,6 +5,7 @@ import com.linkedin.thirdeye.common.BaseThirdEyeApplication;
 import com.linkedin.thirdeye.dashboard.resources.AdminResource;
 import com.linkedin.thirdeye.dashboard.resources.AnomalyFunctionResource;
 import com.linkedin.thirdeye.dashboard.resources.AnomalyResource;
+import com.linkedin.thirdeye.dashboard.resources.AutoOnboardResource;
 import com.linkedin.thirdeye.dashboard.resources.CacheResource;
 import com.linkedin.thirdeye.dashboard.resources.DashboardConfigResource;
 import com.linkedin.thirdeye.dashboard.resources.DashboardResource;
@@ -35,17 +36,21 @@ import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.rootcause.Pipeline;
 import com.linkedin.thirdeye.rootcause.RCAFramework;
 import com.linkedin.thirdeye.rootcause.impl.RCAFrameworkLoader;
+
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.Executors;
+
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
+
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,6 +124,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new DataCompletenessResource(DAO_REGISTRY.getDataCompletenessConfigDAO()));
     env.jersey().register(new EntityMappingResource());
     env.jersey().register(new OnboardDatasetMetricResource());
+    env.jersey().register(new AutoOnboardResource(config));
     env.jersey().register(new ConfigResource(DAO_REGISTRY.getConfigDAO()));
 
     env.getObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AutoOnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AutoOnboardResource.java
@@ -1,0 +1,69 @@
+package com.linkedin.thirdeye.dashboard.resources;
+
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.thirdeye.auto.onboard.AutoOnboard;
+import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
+import com.linkedin.thirdeye.datasource.DataSourceConfig;
+import com.linkedin.thirdeye.datasource.DataSources;
+import com.linkedin.thirdeye.datasource.DataSourcesLoader;
+
+
+/**
+ * Endpoints for triggering adhoc onboard on auto onboard services
+ */
+@Path(value = "/autoOnboard")
+@Produces(MediaType.APPLICATION_JSON)
+public class AutoOnboardResource {
+  private Map<String, AutoOnboard> dataSourceToOnboardMap = new HashMap<>();
+
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardResource.class);
+
+  public AutoOnboardResource(ThirdEyeConfiguration thirdeyeConfig) {
+    String dataSourcesPath = thirdeyeConfig.getDataSourcesPath();
+    DataSources dataSources = DataSourcesLoader.fromDataSourcesPath(dataSourcesPath);
+    if (dataSources == null) {
+      throw new IllegalStateException("Could not create data sources config from path " + dataSourcesPath);
+    }
+    for (DataSourceConfig dataSourceConfig : dataSources.getDataSourceConfigs()) {
+      String autoLoadClassName = dataSourceConfig.getAutoLoadClassName();
+      if (StringUtils.isNotBlank(autoLoadClassName)) {
+        try {
+          Constructor<?> constructor = Class.forName(autoLoadClassName).getConstructor(DataSourceConfig.class);
+          AutoOnboard autoOnboardConstructor = (AutoOnboard) constructor.newInstance(dataSourceConfig);
+          String datasourceClassName = dataSourceConfig.getClassName();
+          String dataSource = datasourceClassName.substring(datasourceClassName.lastIndexOf(".") + 1, datasourceClassName.length());
+          dataSourceToOnboardMap.put(dataSource, autoOnboardConstructor);
+        } catch (Exception e) {
+          LOG.error("Exception in creating autoload constructor {}", autoLoadClassName);
+        }
+      }
+    }
+  }
+
+  @POST
+  @Path("/runAdhoc/{datasource}")
+  public Response runAdhocOnboard(@PathParam("datasource") String datasource) {
+    if (!dataSourceToOnboardMap.containsKey(datasource)) {
+      return Response.status(Status.INTERNAL_SERVER_ERROR)
+          .entity(String.format("Data source %s does not exist in config", datasource)).build();
+    }
+    dataSourceToOnboardMap.get(datasource).runAdhoc();
+    return Response.ok().build();
+  }
+
+}


### PR DESCRIPTION
This PR contains endpoints, which will enable us to trigger onboard service for all data sources adhoc. This will ensure that we don't have delays between making an onboard request to the onbaord service and the metrics being ready.