### PR TITLE
[PINOT-4889] Implemented off-heap dictionary work for strings

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.io.writer.impl;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+/**
+ * @class OffHeapMutableByteArrayStore
+ *
+ * An off-heap byte array store that provides APIs to add byte array (value), retrieve a value, and compare value at
+ * an index. No verification is made as to whether the value added already exists or not.
+ * Empty byte arrays are supported.
+ *
+ * @note The class is thread-safe for single writer and multiple readers.
+ *
+ * This class has a list of OffHeapMutableByteArrayStore.Buffer objects. As Buffer objects get filled, new Buffer objects
+ * are added to the list. New Buffers objects have twice the capacity of the previous Buffer
+ *
+ * Within a Buffer object byte arrays (values) are stored as below:
+ *
+ *                  __________________________________
+ *                  |  start offset of array  1      |
+ *                  |  start offset of array  2      |
+ *                  |        .....                   |
+ *                  |  start offset of array  N      |
+ *                  |                                |
+ *                  |         UNUSED                 |
+ *                  |                                |
+ *                  |  Array N .....                 |
+ *                  |          .....                 |
+ *                  |          .....                 |
+ *                  |  Array N-1                     |
+ *                  |          .....                 |
+ *                  |          .....                 |
+ *                  |  Array 0 .....                 |
+ *                  |          .....                 |
+ *                  |          .....                 |
+ *                  |________________________________|
+ *
+ *
+ * We fill the buffer as follows:
+ * - The values are added from the bottom, each new value appearing nearer to the top of the buffer, leaving no
+ *   room between them. Each value is stored as a sequence of bytes.
+ *
+ * - The start offsets of the byte arrays are added from the top. Each start offset is stored as an integer, taking 4 bytes.
+ *
+ * Each time we want to add a new value, we check if we have space to add the length of the value, and the value
+ * itself. If we do, then we compute the start offset of the new value as:
+ *
+ *    new-start-offset = (start offset of prev value added) - (length of this value)
+ *
+ * The new start offset value is stored in the offset
+ *
+ *    buffer[numValuesSoFar * 4]
+ *
+ * and the value itself is stored starting at new-start-offset
+ *
+ */
+public class MutableOffHeapByteArrayStore implements Closeable {
+  private static final int START_SIZE = 32 * 1024;
+
+  private static class Buffer implements Closeable {
+    private static final int INT_SIZE = V1Constants.Numbers.INTEGER_SIZE;
+
+    private final PinotDataBuffer _pinotDataBuffer;
+    private final ByteBuffer _byteBuffer;
+    private final int _startIndex;
+    private final long _size;
+
+    private int _numValues = 0;
+    private int _availEndOffset;  // Exclusive
+
+    private Buffer(long size, int startIndex) {
+      if (size >= Integer.MAX_VALUE) {
+        size = Integer.MAX_VALUE - 1;
+      }
+      _pinotDataBuffer = PinotDataBuffer.allocateDirect(size);
+      _pinotDataBuffer.order(ByteOrder.nativeOrder());
+      _byteBuffer = _pinotDataBuffer.toDirectByteBuffer(0, (int) size);
+      _startIndex = startIndex;
+      _availEndOffset = _byteBuffer.capacity();
+      _size = size;
+    }
+
+    private int add(byte[] value) {
+      int startOffset = _availEndOffset - value.length;
+      if (startOffset <= (_numValues + 1) * INT_SIZE) {
+        // full
+        return -1;
+      }
+      for (int i = 0, j = startOffset; i < value.length; i++, j++) {
+        _byteBuffer.put(j, value[i]);
+      }
+      _byteBuffer.putInt(_numValues * INT_SIZE, startOffset);
+      _availEndOffset = startOffset;
+      return _numValues++;
+    }
+
+    private boolean equalsValueAt(byte[] value, int index) {
+      int startOffset = _byteBuffer.getInt(index * INT_SIZE);
+      int endOffset = _byteBuffer.capacity();
+      if (index > 0) {
+        endOffset = _byteBuffer.getInt((index - 1) * INT_SIZE);
+      }
+      if ((endOffset - startOffset) != value.length) {
+        return false;
+      }
+      for (int i = 0, j = startOffset; i < value.length; i++, j++) {
+        if (value[i] != _byteBuffer.get(j)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private byte[] get(final int index) {
+      int startOffset = _byteBuffer.getInt(index * INT_SIZE);
+      int endOffset = _byteBuffer.capacity();
+      if (index > 0) {
+        endOffset = _byteBuffer.getInt((index - 1) * INT_SIZE);
+      }
+      byte[] value = new byte[endOffset - startOffset];
+      for (int i = 0, j = startOffset; i < value.length; i++, j++) {
+        value[i] = _byteBuffer.get(j);
+      }
+      return value;
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      _pinotDataBuffer.close();
+    }
+
+    private long getSize() {
+      return _size;
+    }
+
+    private int getStartIndex() {
+      return _startIndex;
+    }
+  }
+
+  private volatile List<Buffer> _buffers = new ArrayList<Buffer>();
+  private int _numElements = 0;
+  private volatile Buffer _currentBuffer;
+
+  public MutableOffHeapByteArrayStore() {
+    expand(START_SIZE);
+  }
+
+  // Expand the buffer size, allocating a min of 32k
+  private Buffer expand(long size) {
+    Buffer buffer = new Buffer(size, _numElements);
+    List<Buffer> newList = new LinkedList<>();
+    for (Buffer b : _buffers) {
+      newList.add(b);
+    }
+    newList.add(buffer);
+    _buffers = newList;
+    _currentBuffer = buffer;
+    return buffer;
+  }
+
+  private Buffer expand() {
+    Buffer newBuffer = expand(_currentBuffer.getSize() * 2);
+    return newBuffer;
+  }
+
+  // Returns a byte array, given an index
+  public byte[] get(int index) {
+    List<Buffer> bufList = _buffers;
+    for (int x = bufList.size()-1; x >= 0; x--) {
+      Buffer buffer = bufList.get(x);
+      if (index >= buffer.getStartIndex()) {
+        return buffer.get(index - buffer.getStartIndex());
+      }
+    }
+    // Assumed that we will never ask for an index that does not exist.
+    throw new RuntimeException("dictionary ID '" + index + "' too low");
+  }
+
+  // Adds a byte array and returns the index. No verification is made as to whether the byte array already exists or not
+  public int add(byte[] value) {
+    Buffer buffer = _currentBuffer;
+    int index = buffer.add(value);
+    while (index < 0) {
+      buffer = expand();
+      index = buffer.add(value);
+    }
+    _numElements++;
+    return index + buffer.getStartIndex();
+  }
+
+  public boolean equalsValueAt(byte[] value, int index) {
+    List<Buffer> bufList = _buffers;
+    for (int x = bufList.size()-1; x >= 0; x--) {
+      Buffer buffer = bufList.get(x);
+      // Assumed that we will never ask for a
+      if (index >= buffer.getStartIndex()) {
+        return buffer.equalsValueAt(value, index - buffer.getStartIndex());
+      }
+    }
+    throw new RuntimeException("dictionary ID '" + index + "' too low");
+  }
+
+  @Override
+  public void close() throws IOException {
+    _numElements = 0;
+    for (Buffer buffer : _buffers) {
+      buffer.close();
+    }
+    _buffers.clear();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -20,7 +20,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -164,7 +163,7 @@ public class MutableOffHeapByteArrayStore implements Closeable {
     }
   }
 
-  private volatile List<Buffer> _buffers = new ArrayList<Buffer>();
+  private volatile List<Buffer> _buffers = new LinkedList<>();
   private int _numElements = 0;
   private volatile Buffer _currentBuffer;
 
@@ -219,7 +218,6 @@ public class MutableOffHeapByteArrayStore implements Closeable {
     List<Buffer> bufList = _buffers;
     for (int x = bufList.size()-1; x >= 0; x--) {
       Buffer buffer = bufList.get(x);
-      // Assumed that we will never ask for a
       if (index >= buffer.getStartIndex()) {
         return buffer.equalsValueAt(value, index - buffer.getStartIndex());
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -217,7 +217,7 @@ public class MutableOffHeapByteArrayStore implements Closeable {
   public int add(byte[] value) {
     Buffer buffer = _currentBuffer;
     int index = buffer.add(value);
-    while (index < 0) {
+    if (index < 0) {
       buffer = expand(value.length);
       index = buffer.add(value);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -213,7 +213,7 @@ public class OffHeapStringStore implements Closeable {
   public int add(String string) {
     Buffer buffer = _currentBuffer;
     int index = buffer.add(string);
-    while (index < 0) {
+    if (index < 0) {
       buffer = expand(string.length());
       index = buffer.add(string);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -20,7 +20,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -167,7 +166,7 @@ public class OffHeapStringStore implements Closeable {
     }
   }
 
-  private volatile List<Buffer> _buffers = new ArrayList<Buffer>();
+  private volatile List<Buffer> _buffers = new LinkedList<>();
   private int _numElements = 0;
   private volatile Buffer _currentBuffer;
 
@@ -222,7 +221,6 @@ public class OffHeapStringStore implements Closeable {
     List<Buffer> bufList = _buffers;
     for (int x = bufList.size()-1; x >= 0; x--) {
       Buffer buffer = bufList.get(x);
-      // Assumed that we will never ask for a
       if (index >= buffer.getStartIndex()) {
         return buffer.equalsStringAt(string, index- buffer.getStartIndex());
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
@@ -177,7 +178,7 @@ public class OffHeapStringStore implements Closeable {
   // Expand the buffer size, allocating a min of 32k for strings.
   private Buffer expand(long size) {
     Buffer buffer = new Buffer(size, _numElements);
-    List<Buffer> newList = new ArrayList<>(_buffers.size() + 1);
+    List<Buffer> newList = new LinkedList<>();
     for (Buffer b : _buffers) {
       newList.add(b);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -214,7 +214,7 @@ public class OffHeapStringStore implements Closeable {
     Buffer buffer = _currentBuffer;
     int index = buffer.add(string);
     while (index < 0) {
-      buffer = expand(0L);
+      buffer = expand(string.length());
       index = buffer.add(string);
     }
     _numElements++;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -189,8 +189,7 @@ public class OffHeapStringStore implements Closeable {
   }
 
   private Buffer expand() {
-    Buffer lastBuffer = _buffers.get(_buffers.size()-1);
-    Buffer newBuffer = expand(lastBuffer.getSize());
+    Buffer newBuffer = expand(_currentBuffer.getSize() * 2);
     return newBuffer;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -180,7 +180,7 @@ public class OffHeapStringStore implements Closeable {
 
   // Expand the buffer size, allocating a min of 32k for strings.
   private Buffer expand(long suggestedSize, long minSize) {
-    Buffer buffer = new Buffer(suggestedSize, _numElements);
+    Buffer buffer = new Buffer(Math.max(suggestedSize, minSize), _numElements);
     List<Buffer> newList = new LinkedList<>();
     for (Buffer b : _buffers) {
       newList.add(b);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.io.writer.impl;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+/**
+ * @class OffHeaStringStore
+ *
+ * An off-heap string store that provides APIs to add a string, retrieve a string, and compare string at an index
+ * No verification is made as to whether the string added already exists or not. Strings are stored by
+ * copying one 'char' at a time into a CharBuffer, and keeping the offsets in the CharBuffer in another IntBuffer.
+ * Empty strings are supported.
+ *
+ * @note The class is thread-unsafe.
+ *
+ * This class has a list of OffHeapStringStore.Buffer objects. As Buffer objects get filled, new Buffer objects
+ * are added to the list. New Buffers objects have twice the capacity of the previous Buffer
+ *
+ * Within a Buffer object strings are stored as below:
+ *
+ *                  __________________________________
+ *                  |  start offset of string 1      |
+ *                  |  start offset of string 2      |
+ *                  |        .....                   |
+ *                  |  start offset of string N      |
+ *                  |                                |
+ *                  |         UNUSED                 |
+ *                  |                                |
+ *                  | STRING N .....                 |
+ *                  |          .....                 |
+ *                  |          .....                 |
+ *                  | STRING N-1                     |
+ *                  |          .....                 |
+ *                  |          .....                 |
+ *                  | STRING 0 .....                 |
+ *                  |          .....                 |
+ *                  |          .....                 |
+ *                  |________________________________|
+ *
+ *
+ * We fill the buffer as follows:
+ * - The strings are added from the bottom, each new string appearing nearer to the top of the buffer, leaving no
+ *   room between them. Each string is stored as a sequence of 'char' elements. (In Java, each char element takes 2
+ *   bytes. A string has string.length() char elements in it).
+ *
+ * - The start offsets of the strings are added from the top. Each start offset is stored as an integer, taking 4 bytes.
+ *
+ * Each time we want to add a new string, we check if we have space to add the length of the string, and the string
+ * string itself. If we do, then we compute the start offset of the new string as:
+ *
+ *    new-start-offset = (start offset of prev string added) - (length of this string)
+ *
+ * The new start offset value is stored in the offset
+ *
+ *    buffer[numStringsSoFar * 4]
+ *
+ * and the string itself is stored starting at new-start-offset
+ *
+ */
+public class OffHeapStringStore implements Closeable {
+  private static class Buffer implements Closeable {
+    private static final int INT_SIZE = V1Constants.Numbers.INTEGER_SIZE;
+    private static final int CHAR_SIZE = Character.SIZE / 8;
+
+    final PinotDataBuffer _pinotDataBuffer;
+    final ByteBuffer _byteBuffer;
+    final int _startIndex;
+    final long _size;
+
+    int _numStrings = 0;
+    int _availEndOffset;  // Exclusive
+
+    private Buffer(long size, int startIndex) {
+      if (size > Integer.MAX_VALUE) {
+        size = Integer.MAX_VALUE;
+      }
+      _pinotDataBuffer = PinotDataBuffer.allocateDirect(size);
+      _pinotDataBuffer.order(ByteOrder.nativeOrder());
+      _byteBuffer = _pinotDataBuffer.toDirectByteBuffer(0, (int) size);
+      _startIndex = startIndex;
+      _availEndOffset = _byteBuffer.capacity();
+      _size = size;
+    }
+
+    private int add(String string) {
+      int startOffset = _availEndOffset - string.length() * CHAR_SIZE;
+      if (startOffset <= (_numStrings + 1) * INT_SIZE) {
+        // full
+        return -1;
+      }
+      for (int i = 0, j = startOffset; i < string.length(); i++, j = j + CHAR_SIZE) {
+        _byteBuffer.putChar(j, string.charAt(i));
+      }
+      _byteBuffer.putInt(_numStrings * INT_SIZE, startOffset);
+      _availEndOffset = startOffset;
+      return _numStrings++;
+    }
+
+    private boolean equalsStringAt(String string, int index) {
+      int startOffset = _byteBuffer.getInt(index * INT_SIZE);
+      int endOffset = _byteBuffer.capacity();
+      if (index > 0) {
+        endOffset = _byteBuffer.getInt((index - 1) * INT_SIZE);
+      }
+      if ((endOffset - startOffset)/CHAR_SIZE != string.length()) {
+        return false;
+      }
+      for (int i = 0, j = startOffset; i < string.length(); i++, j = j + CHAR_SIZE) {
+        if (string.charAt(i) != _byteBuffer.getChar(j)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private String get(final int index) {
+      int startOffset = _byteBuffer.getInt(index * INT_SIZE);
+      int endOffset = _byteBuffer.capacity();
+      if (index > 0) {
+        endOffset = _byteBuffer.getInt((index - 1) * INT_SIZE);
+      }
+      char[] chars = new char[(endOffset - startOffset)/CHAR_SIZE];
+      for (int i = 0, j = startOffset; i < chars.length; i++, j = j + CHAR_SIZE) {
+        chars[i] = _byteBuffer.getChar(j);
+      }
+      return new String(chars);
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      _pinotDataBuffer.close();
+    }
+
+    private long getSize() {
+      return _size;
+    }
+
+    private int getStartIndex() {
+      return _startIndex;
+    }
+  }
+
+  volatile List<Buffer> _buffers = new ArrayList<Buffer>();
+  int _numElements = 0;
+
+  public OffHeapStringStore() {
+    expand(32 * 1024);
+  }
+
+  // Expand the buffer size, allocating a min of 32k for strings.
+  private Buffer expand(long size) {
+    Buffer buffer = new Buffer(size, _numElements);
+    List<Buffer> newList = new ArrayList<>(_buffers.size() + 1);
+    for (Buffer b : _buffers) {
+      newList.add(b);
+    }
+    newList.add(buffer);
+    _buffers = newList;
+    return buffer;
+  }
+
+  private Buffer expand() {
+    Buffer lastBuffer = _buffers.get(_buffers.size()-1);
+    Buffer newBuffer = expand(lastBuffer.getSize());
+    return newBuffer;
+  }
+
+  // Returns a string, given an index
+  public String get(int index) {
+    for (int x = _buffers.size()-1; x >= 0; x--) {
+      Buffer buffer = _buffers.get(x);
+      // Assumed that we will never ask for a
+      if (index >= buffer.getStartIndex()) {
+        return buffer.get(index - buffer.getStartIndex());
+      }
+    }
+    throw new RuntimeException("dictionary ID '" + index + "' too low");
+  }
+
+  // Adds a string and returns the index. No verification is made as to whether the string already exists or not
+  public int add(String string) {
+    Buffer buffer = _buffers.get(_buffers.size() - 1);
+    int index = buffer.add(string);
+    while (index < 0) {
+      buffer = expand();
+      index = buffer.add(string);
+    }
+    _numElements++;
+    return index + buffer.getStartIndex();
+  }
+
+  public boolean equalsStringAt(String string, int index) {
+    for (int x = _buffers.size()-1; x >= 0; x--) {
+      Buffer buffer = _buffers.get(x);
+      // Assumed that we will never ask for a
+      if (index >= buffer.getStartIndex()) {
+        return buffer.equalsStringAt(string, index- buffer.getStartIndex());
+      }
+    }
+    throw new RuntimeException("dictionary ID '" + index + "' too low");
+  }
+
+  @Override
+  public void close() throws IOException {
+    _numElements = 0;
+    for (Buffer buffer : _buffers) {
+      buffer.close();
+    }
+    _buffers.clear();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -356,7 +356,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
       for (int i = offsetInBuf; i < offsetInBuf + NUM_COLUMNS; i++) {
         int dictId = iBuf.get(i);
         if (dictId != NULL_VALUE_INDEX) {
-          if (rawValue.equals(get(dictId))) {
+          if (equalsValueAt(dictId, rawValue)) {
             return dictId;
           }
         }
@@ -387,7 +387,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
           iBuf.put(i, _numEntries++);
           return;
         }
-        if (value.equals(get(dictId))) {
+        if (equalsValueAt(dictId, value)) {
           return;
         }
       }
@@ -474,6 +474,12 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
     return rowsWith1Col;
   }
 
+  protected boolean equalsValueAt(int dictId, Object value) {
+    if (value.equals(get(dictId))) {
+      return true;
+    }
+    return false;
+  }
 
   public abstract void doClose() throws IOException;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -346,7 +346,18 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
     return 1 << power;
   }
 
-  protected int getDictId(@Nonnull Object rawValue) {
+  /**
+   * Given a raw value, get the dictionary ID from the reverse map.
+   *
+   * Since the dictionary IDs are stored in a hash map, multiple dictionary
+   * IDs may match to the same raw value. Use the methods provided by sub-class
+   * to compare the raw values with those in the forward map.
+   *
+   * @param rawValue value of object for which we need to get dictionary ID
+   * @param serializedValue serialized form of the
+   * @return dictionary ID if found, NULL_VALUE_INDEX otherwise.
+   */
+  protected int getDictId(@Nonnull Object rawValue, byte[] serializedValue) {
     final long hashVal = Math.abs(rawValue.hashCode());
     final ValueToDictId valueToDictId = _valueToDict;
     final List<IntBuffer> iBufList = valueToDictId.getIBufList();
@@ -356,7 +367,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
       for (int i = offsetInBuf; i < offsetInBuf + NUM_COLUMNS; i++) {
         int dictId = iBuf.get(i);
         if (dictId != NULL_VALUE_INDEX) {
-          if (equalsValueAt(dictId, rawValue)) {
+          if (equalsValueAt(dictId, rawValue, serializedValue)) {
             return dictId;
           }
         }
@@ -372,7 +383,16 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
     return dictId;
   }
 
-  protected void indexValue(@Nonnull Object value) {
+  /**
+   * Index a value into the forward map (dictionary ID to value) and the reverse map
+   * (value to dictionary). Take care to set the reverse map last so as to make it
+   * work correctly for single writer multiple reader threads. Insertion and comparison
+   * methods for the forward map are provided by sub-classes.
+   *
+   * @param value value to be inserted into the dictionary
+   * @param serializedValue serialized representation of the value, may be null.
+   */
+  protected void indexValue(@Nonnull Object value, byte[] serializedValue) {
     final long hashVal = Math.abs(value.hashCode());
     ValueToDictId valueToDictId = _valueToDict;
     final List<IntBuffer> iBufList = valueToDictId.getIBufList();
@@ -383,11 +403,11 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
       for (int i = offsetInBuf; i < offsetInBuf + NUM_COLUMNS; i++) {
         final int dictId = iBuf.get(i);
         if (dictId == NULL_VALUE_INDEX) {
-          setRawValueAt(_numEntries, value);
+          setRawValueAt(_numEntries, value, serializedValue);
           iBuf.put(i, _numEntries++);
           return;
         }
-        if (equalsValueAt(dictId, value)) {
+        if (equalsValueAt(dictId, value, serializedValue)) {
           return;
         }
       }
@@ -401,7 +421,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
       }
     }
 
-    setRawValueAt(_numEntries, value);
+    setRawValueAt(_numEntries, value, serializedValue);
 
     if (_maxItemsInOverflowHash > 0) {
       if (overflowMap.size() < _maxItemsInOverflowHash) {
@@ -474,12 +494,12 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
     return rowsWith1Col;
   }
 
-  protected boolean equalsValueAt(int dictId, Object value) {
+  protected boolean equalsValueAt(int dictId, Object value, byte[] serializedValue) {
     return value.equals(get(dictId));
   }
 
   public abstract void doClose() throws IOException;
 
-  protected abstract void setRawValueAt(int dictId, Object rawValue);
+  protected abstract void setRawValueAt(int dictId, Object rawValue, byte[] serializedValue);
 
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -475,10 +475,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
   }
 
   protected boolean equalsValueAt(int dictId, Object value) {
-    if (value.equals(get(dictId))) {
-      return true;
-    }
-    return false;
+    return value.equals(get(dictId));
   }
 
   public abstract void doClose() throws IOException;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -42,9 +42,9 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getDictId(Double.valueOf((String) rawValue));
+      return getDictId(Double.valueOf((String) rawValue), null);
     } else {
-      return getDictId(rawValue);
+      return getDictId(rawValue, null);
     }
   }
 
@@ -52,13 +52,13 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   public void index(@Nonnull Object rawValue) {
     if (rawValue instanceof Double) {
       // Single value
-      indexValue(rawValue);
+      indexValue(rawValue, null);
       updateMinMax((Double) rawValue);
     } else {
       // Multi value
       Object[] values = (Object[]) rawValue;
       for (Object value : values) {
-        indexValue(value);
+        indexValue(value, null);
         updateMinMax((Double) value);
       }
     }
@@ -122,7 +122,7 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   @Override
-  protected void setRawValueAt(int dictId, Object value) {
+  protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setDouble(dictId, (Double) value);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -42,9 +42,9 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getDictId(Float.valueOf((String) rawValue));
+      return getDictId(Float.valueOf((String) rawValue), null);
     } else {
-      return getDictId(rawValue);
+      return getDictId(rawValue, null);
     }
   }
 
@@ -52,13 +52,13 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   public void index(@Nonnull Object rawValue) {
     if (rawValue instanceof Float) {
       // Single value
-      indexValue(rawValue);
+      indexValue(rawValue, null);
       updateMinMax((Float) rawValue);
     } else {
       // Multi value
       Object[] values = (Object[]) rawValue;
       for (Object value : values) {
-        indexValue(value);
+        indexValue(value, null);
         updateMinMax((Float) value);
       }
     }
@@ -122,7 +122,7 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
-  protected void setRawValueAt(int dictId, Object value) {
+  protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setFloat(dictId, (Float) value);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -42,9 +42,9 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getDictId(Integer.valueOf((String) rawValue));
+      return getDictId(Integer.valueOf((String) rawValue), null);
     } else {
-      return getDictId(rawValue);
+      return getDictId(rawValue, null);
     }
   }
 
@@ -52,13 +52,13 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   public void index(@Nonnull Object rawValue) {
     if (rawValue instanceof Integer) {
       // Single value
-      indexValue(rawValue);
+      indexValue(rawValue, null);
       updateMinMax((Integer) rawValue);
     } else {
       // Multi value
       Object[] values = (Object[]) rawValue;
       for (Object value : values) {
-        indexValue(value);
+        indexValue(value, null);
         updateMinMax((Integer) value);
       }
     }
@@ -122,7 +122,7 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
-  protected void setRawValueAt(int dictId, Object value) {
+  protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setInt(dictId, (Integer) value);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -42,9 +42,9 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   @Override
   public int indexOf(Object rawValue) {
     if (rawValue instanceof String) {
-      return getDictId(Long.valueOf((String) rawValue));
+      return getDictId(Long.valueOf((String) rawValue), null);
     } else {
-      return getDictId(rawValue);
+      return getDictId(rawValue, null);
     }
   }
 
@@ -52,13 +52,13 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   public void index(@Nonnull Object rawValue) {
     if (rawValue instanceof Long) {
       // Single value
-      indexValue(rawValue);
+      indexValue(rawValue, null);
       updateMinMax((Long) rawValue);
     } else {
       // Multi value
       Object[] values = (Object[]) rawValue;
       for (Object value : values) {
-        indexValue(value);
+        indexValue(value, null);
         updateMinMax((Long) value);
       }
     }
@@ -122,7 +122,7 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
-  protected void setRawValueAt(int dictId, Object value) {
+  protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setLong(dictId, (Long) value);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.impl.dictionary;
+
+import java.io.IOException;
+import java.util.Arrays;
+import com.linkedin.pinot.core.io.writer.impl.OffHeapStringStore;
+import javax.annotation.Nonnull;
+
+
+public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
+
+  private final OffHeapStringStore _stringStore;
+  private String _min = null;
+  private String _max = null;
+
+  public StringOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize) {
+    super(estimatedCardinality, maxOverflowHashSize);
+    _stringStore = new OffHeapStringStore();
+  }
+
+  @Override
+  public void doClose() throws IOException {
+    _stringStore.close();
+  }
+
+  @Override
+  protected void setRawValueAt(int dictId, Object rawValue) {
+    _stringStore.add(rawValue.toString());
+  }
+
+  @Override
+  public Object get(int dictionaryId) {
+    return _stringStore.get(dictionaryId);
+  }
+
+  @Override
+  public void index(@Nonnull Object rawValue) {
+    if (rawValue instanceof String) {
+      // Single value
+      indexValue(rawValue);
+      updateMinMax((String) rawValue);
+    } else {
+      // Multi value
+      Object[] values = (Object[]) rawValue;
+      for (Object value : values) {
+        indexValue(value);
+        updateMinMax((String) value);
+      }
+    }
+  }
+
+  @Override
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+      boolean includeUpper) {
+    String valueToCompare = (String) get(dictIdToCompare);
+
+    if (includeLower) {
+      if (valueToCompare.compareTo(lower) < 0) {
+        return false;
+      }
+    } else {
+      if (valueToCompare.compareTo(lower) <= 0) {
+        return false;
+      }
+    }
+
+    if (includeUpper) {
+      if (valueToCompare.compareTo(upper) > 0) {
+        return false;
+      }
+    } else {
+      if (valueToCompare.compareTo(upper) >= 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public int indexOf(Object rawValue) {
+    return getDictId(rawValue);
+  }
+
+  @Nonnull
+  @Override
+  public Object getMinVal() {
+    return _min;
+  }
+
+  @Nonnull
+  @Override
+  public Object getMaxVal() {
+    return _max;
+  }
+
+  @Nonnull
+  @Override
+  public Object getSortedValues() {
+    int numValues = length();
+    String[] sortedValues = new String[numValues];
+
+    for (int i = 0; i < numValues; i++) {
+      sortedValues[i] = (String) get(i);
+    }
+
+    Arrays.sort(sortedValues);
+    return sortedValues;
+  }
+
+  protected boolean equalsValueAt(int dictId, Object value) {
+    if (_stringStore.equalsStringAt(value.toString(), dictId)) {
+      return true;
+    }
+    return false;
+  }
+
+  private void updateMinMax(String value) {
+    if (_min == null) {
+      _min = value;
+      _max = value;
+    } else {
+      if (value.compareTo(_min) < 0) {
+        _min = value;
+      }
+      if (value.compareTo(_max) > 0) {
+        _max = value;
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -64,10 +64,14 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
     }
   }
 
+  private String getInternal(int dictId) {
+    return _stringStore.get(dictId);
+  }
+
   @Override
   public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
       boolean includeUpper) {
-    String valueToCompare = (String) get(dictIdToCompare);
+    String valueToCompare = getInternal(dictIdToCompare);
 
     if (includeLower) {
       if (valueToCompare.compareTo(lower) < 0) {
@@ -124,10 +128,7 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   protected boolean equalsValueAt(int dictId, Object value) {
-    if (_stringStore.equalsStringAt(value.toString(), dictId)) {
-      return true;
-    }
-    return false;
+    return _stringStore.equalsStringAt(value.toString(), dictId);
   }
 
   private void updateMinMax(String value) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotByteBuffer.java
@@ -117,7 +117,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
   }
 
   public static PinotByteBuffer allocateDirect(long size, String context) {
-    Preconditions.checkArgument(size >= 0 && size < Integer.MAX_VALUE);
+    Preconditions.checkArgument(size >= 0 && size < Integer.MAX_VALUE, "bad value for size " + size);
     Preconditions.checkNotNull(context);
 
     ByteBuffer bb = MmapUtils.allocateDirectByteBuffer( (int)size, null, context);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.indexsegment.utils;
+
+import java.util.Arrays;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
+import junit.framework.Assert;
+
+
+public class MutableOffHeapByteArrayStoreTest {
+
+  @Test
+  public void maxValueTest() throws Exception {
+    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore();
+    final int arrSize = MutableOffHeapByteArrayStore.getStartSize();
+    byte[] dataIn = new byte[arrSize-4];
+    for (int i = 0; i < dataIn.length; i++) {
+      dataIn[i] = (byte)(i % Byte.MAX_VALUE);
+    }
+    int index = store.add(dataIn);
+    byte[] dataOut = store.get(index);
+    Assert.assertTrue(Arrays.equals(dataIn, dataOut));
+    store.close();
+  }
+
+  @Test
+  public void overflowTest() throws Exception {
+    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore();
+    final int maxSize = MutableOffHeapByteArrayStore.getStartSize() - 4;
+
+    byte[] b1 = new byte[3];
+    for (int i = 0; i < b1.length; i++) {
+      b1[i] = (byte)i;
+    }
+
+    byte[] b2 = new byte[maxSize];
+    for (int i = 0; i < b2.length; i++) {
+      b2[i] = (byte)(i % Byte.MAX_VALUE);
+    }
+
+    // Add small array
+    final int i1 = store.add(b1);
+    Assert.assertTrue(Arrays.equals(store.get(i1), b1));
+
+    // And now the larger one, should result in a new buffer
+    final int i2 = store.add(b2);
+    Assert.assertTrue(Arrays.equals(store.get(i2), b2));
+
+    // And now one more, should result in a new buffer but exact fit.
+    final int i3 = store.add(b2);
+    Assert.assertTrue(Arrays.equals(store.get(i3), b2));
+
+    // One more buffer when we add the small one again.
+    final int i4 = store.add(b1);
+    Assert.assertTrue(Arrays.equals(store.get(i4), b1));
+
+    // Test with one more 'get' to ensure that things have not changed.
+    Assert.assertTrue(Arrays.equals(store.get(i1), b1));
+    Assert.assertTrue(Arrays.equals(store.get(i2), b2));
+    Assert.assertTrue(Arrays.equals(store.get(i3), b2));
+    Assert.assertTrue(Arrays.equals(store.get(i4), b1));
+
+    byte[] b3 = new byte[5];
+    for (int i = 0; i < b3.length; i++) {
+      b3[i] = (byte)(i+1);
+    }
+
+    int ix = -1;
+    final int iters = 1_000_000;
+
+    // Now add the small one multiple times causing many additions.
+    for (int i = 0; i < iters; i++) {
+      if (ix == -1) {
+        ix = store.add(b3);
+      }
+      store.add(b3);
+    }
+    for (int i = 0; i < iters; i++) {
+      Assert.assertTrue(Arrays.equals(store.get(ix++), b3));
+    }
+
+    // Original values should still be good.
+    Assert.assertTrue(Arrays.equals(store.get(i1), b1));
+    Assert.assertTrue(Arrays.equals(store.get(i2), b2));
+    Assert.assertTrue(Arrays.equals(store.get(i3), b2));
+    Assert.assertTrue(Arrays.equals(store.get(i4), b1));
+    store.close();
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/OffHeapStringStoreTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/OffHeapStringStoreTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.indexsegment.utils;
+
+import java.util.Random;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.core.io.writer.impl.OffHeapStringStore;
+
+
+public class OffHeapStringStoreTest {
+  private static Random RANDOM = new Random();
+  @Test
+  public void maxValueTest() throws Exception {
+    OffHeapStringStore store = new OffHeapStringStore();
+    final int arrSize = OffHeapStringStore.getStartSize() - 4;
+    String dataIn = generateRandomString(arrSize);
+    int index = store.add(dataIn);
+    String dataOut = store.get(index);
+    Assert.assertEquals(dataIn, dataOut);
+    store.close();
+  }
+
+  @Test
+  public void overflowTest() throws Exception {
+    OffHeapStringStore store = new OffHeapStringStore();
+    final int maxSize = OffHeapStringStore.getStartSize() - 4;
+
+    String b1 = generateRandomString(3);
+    String b2 = generateRandomString(maxSize);
+
+    // Add small array
+    final int i1 = store.add(b1);
+    Assert.assertEquals(store.get(i1), b1);
+
+    // And now the larger one, should result in a new buffer
+    final int i2 = store.add(b2);
+    Assert.assertEquals(store.get(i2), b2);
+
+    // And now one more, should result in a new buffer but exact fit.
+    final int i3 = store.add(b2);
+    Assert.assertEquals(store.get(i3), b2);
+
+    // One more buffer when we add the small one again.
+    final int i4 = store.add(b1);
+    Assert.assertEquals(store.get(i4), b1);
+
+    // Test with one more 'get' to ensure that things have not changed.
+    Assert.assertEquals(store.get(i1), b1);
+    Assert.assertEquals(store.get(i2), b2);
+    Assert.assertEquals(store.get(i3), b2);
+    Assert.assertEquals(store.get(i4), b1);
+
+    String b3 = generateRandomString(5);
+
+    int ix = -1;
+    final int iters = 1_000_000;
+
+    // Now add the small one multiple times causing many additions.
+    for (int i = 0; i < iters; i++) {
+      if (ix == -1) {
+        ix = store.add(b3);
+      }
+      store.add(b3);
+    }
+    for (int i = 0; i < iters; i++) {
+      Assert.assertEquals(store.get(ix++), b3);
+    }
+
+    // Original values should still be good.
+    Assert.assertEquals(store.get(i1), b1);
+    Assert.assertEquals(store.get(i2), b2);
+    Assert.assertEquals(store.get(i3), b2);
+    Assert.assertEquals(store.get(i4), b1);
+    store.close();
+  }
+
+  // Generates a ascii displayable string of given length
+  private String generateRandomString(final int len) {
+    byte[] bytes = new byte[len];
+    for (int i = 0; i < len; i++) {
+      bytes[i] = (byte)(RANDOM.nextInt(92) + 32);
+    }
+    return new String(bytes);
+  }
+}

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
@@ -71,7 +71,7 @@ public class BenchmarkStringDictionary {
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public StringOffHeapMutableDictionary benchmarkOffStringDictionary() {
+  public StringOffHeapMutableDictionary benchmarkOffHeapStringDictionary() {
     StringOffHeapMutableDictionary dictionary = new StringOffHeapMutableDictionary(10, 10);
 
     for (int i = 0; i < stringValues.length; i++) {
@@ -96,7 +96,7 @@ public class BenchmarkStringDictionary {
 
   public static void main(String[] args) throws Exception {
     ChainedOptionsBuilder opt = new OptionsBuilder()
-        .include(BenchmarkDictionary.class.getSimpleName())
+        .include(BenchmarkStringDictionary.class.getSimpleName())
         .addProfiler(GCProfiler.class)
         .addProfiler(HotspotMemoryProfiler.class)
         .warmupTime(TimeValue.seconds(60))

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.perf;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.profile.HotspotMemoryProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import com.linkedin.pinot.core.realtime.impl.dictionary.StringOffHeapMutableDictionary;
+import com.linkedin.pinot.core.realtime.impl.dictionary.StringOnHeapMutableDictionary;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkStringDictionary {
+  private final int ROW_COUNT = 2_500_000;
+  private String[] stringValues;
+  private String[] uniqueStrings;
+  private final int CARDINALITY = 1_000_000;
+  private final int MAX_STRING_LEN = 32;
+
+  @Setup
+  public void setUp() {
+    // Create a list of values to insert into the hash map
+    uniqueStrings = new String[CARDINALITY];
+    Random r = new Random();
+    for (int i = 0; i < uniqueStrings.length; i++) {
+      uniqueStrings[i] = generateRandomString(r, r.nextInt(MAX_STRING_LEN+1));
+    }
+    stringValues = new String[ROW_COUNT];
+    for (int i = 0; i < stringValues.length; i++) {
+      int u = r.nextInt(CARDINALITY);
+      stringValues[i] = uniqueStrings[u];
+    }
+  }
+
+  // Generates a ascii displayable string of given length
+  private String generateRandomString(Random r, final int len) {
+    byte[] bytes = new byte[len];
+    for (int i = 0; i < len; i++) {
+      bytes[i] = (byte)(r.nextInt(92) + 32);
+    }
+    return new String(bytes);
+  }
+
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public StringOffHeapMutableDictionary benchmarkOffStringDictionary() {
+    StringOffHeapMutableDictionary dictionary = new StringOffHeapMutableDictionary(10, 10);
+
+    for (int i = 0; i < stringValues.length; i++) {
+      dictionary.index(stringValues[i]);
+    }
+
+    return dictionary;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public StringOnHeapMutableDictionary benchmarkOnHeapStringDictionary() {
+    StringOnHeapMutableDictionary dictionary = new StringOnHeapMutableDictionary();
+
+    for (int i = 0; i < stringValues.length; i++) {
+      dictionary.index(stringValues[i]);
+    }
+
+    return dictionary;
+  }
+
+  public static void main(String[] args) throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder()
+        .include(BenchmarkDictionary.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .addProfiler(HotspotMemoryProfiler.class)
+        .warmupTime(TimeValue.seconds(60))
+        .warmupIterations(8)
+        .measurementTime(TimeValue.seconds(60))
+        .measurementIterations(8)
+        .forks(5)
+        ;
+
+    new Runner(opt.build()).run();
+  }
+}


### PR DESCRIPTION
Off-heap dictionary for strings has been implemented using an MutableOffHeapByteStore class,
that supports three basic operations: add(byte[]), compareBytesAtIndex(byte[], index), and get(index)

The StringOffHeapDictionary class makes use of this store and the reverse mapping already implemented
in BaseOffHeapDictionary class.

Added tests.