### PR TITLE
Refactoring to query scheduler to support priority based scheduling

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/FCFSQueryScheduler.java
@@ -18,43 +18,48 @@ package com.linkedin.pinot.core.query.scheduler;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.metrics.ServerQueryPhase;
 import com.linkedin.pinot.common.query.QueryExecutor;
 import com.linkedin.pinot.common.query.ServerQueryRequest;
-import com.linkedin.pinot.common.utils.DataTable;
-import java.util.concurrent.Callable;
 import javax.annotation.Nonnull;
 import org.apache.commons.configuration.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * First Come First Served(FCFS) query scheduler.
- * The FCFS policy applies across all tables.
+ * First Come First Served(FCFS) query scheduler. The FCFS policy applies across all tables.
+ * This implementation does not throttle resource utilization. That makes it unsafe in
+ * the multi-tenant clusters.
+ *
  * This is similar to the existing query scheduling logic.
  */
 public class FCFSQueryScheduler extends QueryScheduler {
 
   private static Logger LOGGER = LoggerFactory.getLogger(FCFSQueryScheduler.class);
 
-  public FCFSQueryScheduler(@Nonnull Configuration schedulerConfig, @Nonnull QueryExecutor queryExecutor) {
-    super(schedulerConfig, queryExecutor);
-    Preconditions.checkNotNull(queryExecutor);
+  public FCFSQueryScheduler(@Nonnull Configuration schedulerConfig, @Nonnull QueryExecutor queryExecutor, @Nonnull
+      ServerMetrics serverMetrics) {
+    super(schedulerConfig, queryExecutor, serverMetrics);
   }
 
   @Override
-  public ListenableFuture<DataTable> submit(final ServerQueryRequest queryRequest) {
+  public ListenableFuture<byte[]> submit(final ServerQueryRequest queryRequest) {
     Preconditions.checkNotNull(queryRequest);
-
     queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT);
-    ListenableFuture<DataTable> queryResultFuture = queryRunners.submit(new Callable<DataTable>() {
-      @Override
-      public DataTable call() {
-        return queryExecutor.processQuery(queryRequest, queryWorkers);
-      }
-    });
-
-    return queryResultFuture;
+    ListenableFutureTask<byte[]> queryTask = getQueryFutureTask(queryRequest);
+    queryRunners.submit(queryTask);
+    return queryTask;
   }
 
+  @Override
+  public void start() {
+    // no-op
+  }
+
+  @Override
+  public String name() {
+    return "fcfs";
+  }
 }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.server.request;
 
-import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.linkedin.pinot.common.exception.QueryException;
@@ -33,7 +33,6 @@ import com.linkedin.pinot.transport.netty.NettyServer;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import java.net.InetSocketAddress;
-import javax.annotation.Nullable;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,9 +42,11 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledRequestHandler.class);
 
   private final ServerMetrics serverMetrics;
-  private final QueryScheduler queryScheduler;
+  private QueryScheduler queryScheduler;
 
   public ScheduledRequestHandler(QueryScheduler queryScheduler, ServerMetrics serverMetrics) {
+    Preconditions.checkNotNull(queryScheduler);
+    Preconditions.checkNotNull(serverMetrics);
     this.queryScheduler = queryScheduler;
     this.serverMetrics = serverMetrics;
   }
@@ -53,6 +54,7 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
   @Override
   public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext,
       ByteBuf request) {
+
     final long queryStartTimeNs = System.nanoTime();
     serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
 
@@ -71,7 +73,7 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
       serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_DESERIALIZATION_EXCEPTIONS, 1);
       ServerQueryRequest queryRequest = new ServerQueryRequest(null, serverMetrics);
       queryRequest.getTimerContext().setQueryArrivalTimeNs(queryStartTimeNs);
-      return Futures.immediateFuture(serializeDataTable(queryRequest, result));
+      return Futures.immediateFuture(QueryScheduler.serializeDataTable(queryRequest, result));
     }
     final ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
     final TimerContext timerContext = queryRequest.getTimerContext();
@@ -81,76 +83,13 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
     deserializationTimer.stopAndRecord();
 
     LOGGER.debug("Processing requestId:{},request={}", instanceRequest.getRequestId(), instanceRequest);
-
-    ListenableFuture<DataTable> queryTask = queryScheduler.submit(queryRequest);
-
-    // following future will provide default response in case of uncaught
-    // exceptions from query processing
-    ListenableFuture<DataTable> queryResponse =
-        Futures.catching(queryTask, Throwable.class, new Function<Throwable, DataTable>() {
-          @Nullable
-          @Override
-          public DataTable apply(@Nullable Throwable input) {
-            // this is called iff queryTask fails with unhandled exception
-            serverMetrics.addMeteredGlobalValue(ServerMeter.UNCAUGHT_EXCEPTIONS, 1);
-            DataTable result = new DataTableImplV2();
-            result.addException(QueryException.INTERNAL_ERROR);
-            return result;
-          }
-        });
-
-    // transform the DataTable to serialized byte[] to send back to broker
-    ListenableFuture<byte[]> serializedQueryResponse = Futures.transform(queryResponse, new Function<DataTable, byte[]>() {
-      @Nullable
-      @Override
-      public byte[] apply(@Nullable DataTable instanceResponse) {
-        byte[] responseData = serializeDataTable(queryRequest, instanceResponse);
-        LOGGER.info("Processed requestId {},reqSegments={},prunedToSegmentCount={},deserTimeMs={},planTimeMs={},planExecTimeMs={},totalExecMs={},serTimeMs={}TotalTimeMs={},broker={}",
-            queryRequest.getInstanceRequest().getRequestId(),
-            queryRequest.getInstanceRequest().getSearchSegments().size(),
-            queryRequest.getSegmentCountAfterPruning(),
-            timerContext.getPhaseDurationMs(ServerQueryPhase.REQUEST_DESERIALIZATION),
-            timerContext.getPhaseDurationMs(ServerQueryPhase.BUILD_QUERY_PLAN),
-            timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PLAN_EXECUTION),
-            timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
-            timerContext.getPhaseDurationMs(ServerQueryPhase.RESPONSE_SERIALIZATION),
-            timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME),
-            queryRequest.getBrokerId());
-        return responseData;
-      }
-    });
-
-    return serializedQueryResponse;
+    ListenableFuture<byte[]> queryResponse = queryScheduler.submit(queryRequest);
+    return queryResponse;
   }
 
-  static byte[] serializeDataTable(ServerQueryRequest queryRequest, DataTable instanceResponse) {
-    byte[] responseByte;
-
-    InstanceRequest instanceRequest = queryRequest.getInstanceRequest();
-    ServerMetrics metrics = queryRequest.getServerMetrics();
-    TimerContext timerContext = queryRequest.getTimerContext();
-    timerContext.startNewPhaseTimer(ServerQueryPhase.RESPONSE_SERIALIZATION);
-    long requestId = instanceRequest != null ? instanceRequest.getRequestId() : -1;
-    String brokerId = instanceRequest != null ? instanceRequest.getBrokerId() : "null";
-
-    try {
-      if (instanceResponse == null) {
-        LOGGER.warn("Instance response is null for requestId: {}, brokerId: {}", requestId, brokerId);
-        responseByte = new byte[0];
-      } else {
-        responseByte = instanceResponse.toBytes();
-      }
-    } catch (Exception e) {
-      metrics.addMeteredGlobalValue(ServerMeter.RESPONSE_SERIALIZATION_EXCEPTIONS, 1);
-      LOGGER.error("Got exception while serializing response for requestId: {}, brokerId: {}",
-          requestId, brokerId, e);
-      responseByte = null;
-    }
-
-    timerContext.getPhaseTimer(ServerQueryPhase.RESPONSE_SERIALIZATION).stopAndRecord();
-    timerContext.startNewPhaseTimerAtNs(ServerQueryPhase.TOTAL_QUERY_TIME, timerContext.getQueryArrivalTimeNs());
-    timerContext.getPhaseTimer(ServerQueryPhase.TOTAL_QUERY_TIME).stopAndRecord();
-
-    return responseByte;
+  public void setScheduler(QueryScheduler scheduler) {
+    Preconditions.checkNotNull(scheduler);
+    LOGGER.info("Setting scheduler to {}", scheduler.name());
+    queryScheduler = scheduler;
   }
 }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
@@ -148,7 +148,7 @@ public class ServerBuilder {
       throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException,
              InstantiationException {
     Configuration schedulerConfig = _serverConf.getSchedulerConfig();
-    return QuerySchedulerFactory.create(schedulerConfig, queryExecutor);
+    return QuerySchedulerFactory.create(schedulerConfig, queryExecutor, _serverMetrics);
   }
 
   public RequestHandlerFactory buildRequestHandlerFactory(final QueryScheduler queryScheduler) {


### PR DESCRIPTION
Moved code to create query result future and to serialize responses from
ScheduledRequestHandler to QueryScheduler. This is preparation for supporting
priority based scheduling that will put queries on internal queues before scheduling
requests.