### PR TITLE
[TE] Enhance interface of group recipient provider for advanced usage

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/AlertGroupRecipientProvider.java
@@ -1,6 +1,8 @@
 package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
 
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -19,9 +21,11 @@ public interface AlertGroupRecipientProvider {
   /**
    * Returns a list of email recipients (separated by commas) for the given dimension.
    *
-   * @param dimensions the dimension to look for the recipients.
+   * @param dimensions the dimension of the group, which is used to look for the recipients.
+   * @param anomalyResultList the list of anomalies of this group, whose information could be used to determine the
+   *                          recipients.
    *
    * @return a list of email recipients (separated by commas).
    */
-  String getAlertGroupRecipients(DimensionMap dimensions);
+  String getAlertGroupRecipients(DimensionMap dimensions, List<MergedAnomalyResultDTO> anomalyResultList);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProvider.java
@@ -2,8 +2,10 @@ package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
@@ -44,7 +46,7 @@ public class DimensionalAlertGroupRecipientProvider extends BaseAlertGroupRecipi
   }
 
   @Override
-  public String getAlertGroupRecipients(DimensionMap dimensions) {
+  public String getAlertGroupRecipients(DimensionMap dimensions, List<MergedAnomalyResultDTO> anomalyResultList) {
     if (dimensions == null || !auxiliaryEmailRecipients.containsKey(dimensions)) {
       return EMPTY_RECIPIENTS;
     } else {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DummyAlertGroupRecipientProvider.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DummyAlertGroupRecipientProvider.java
@@ -1,10 +1,12 @@
 package com.linkedin.thirdeye.anomaly.alert.grouping.recipientprovider;
 
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import java.util.List;
 
 public class DummyAlertGroupRecipientProvider extends BaseAlertGroupRecipientProvider {
   @Override
-  public String getAlertGroupRecipients(DimensionMap dimensions) {
+  public String getAlertGroupRecipients(DimensionMap dimensions, List<MergedAnomalyResultDTO> anomalyResultList) {
     return EMPTY_RECIPIENTS;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertTaskRunnerV2.java
@@ -181,7 +181,7 @@ public class AlertTaskRunnerV2 implements TaskRunner {
           //   Get auxiliary email recipient from provider
           AlertGroupRecipientProvider recipientProvider =
               alertGroupRecipientProviderFactory.fromSpec(alertGroupConfig.getGroupAuxiliaryEmailProvider());
-          String auxiliaryRecipients = recipientProvider.getAlertGroupRecipients(dimensions);
+          String auxiliaryRecipients = recipientProvider.getAlertGroupRecipients(dimensions, anomalyResultListOfGroup);
           if (StringUtils.isNotBlank(auxiliaryRecipients)) {
             recipientsForThisGroup = recipientsForThisGroup + EmailHelper.EMAIL_ADDRESS_SEPARATOR + auxiliaryRecipients;
           }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProviderTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/alert/grouping/recipientprovider/DimensionalAlertGroupRecipientProviderTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.thirdeye.anomaly.alert.grouping.BaseAlertGrouper;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -59,17 +61,27 @@ public class DimensionalAlertGroupRecipientProviderTest {
     // Test AlertGroupKey to auxiliary recipients
     DimensionMap alertGroupKey1 = new DimensionMap();
     alertGroupKey1.put(GROUP_BY_DIMENSION_NAME, "V1");
-    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(alertGroupKey1), EMAIL1);
+    Assert.assertEquals(
+        recipientProvider.getAlertGroupRecipients(alertGroupKey1, Collections.<MergedAnomalyResultDTO>emptyList()),
+        EMAIL1);
 
     DimensionMap alertGroupKey2 = new DimensionMap();
     alertGroupKey2.put(GROUP_BY_DIMENSION_NAME, "V1");
-    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(alertGroupKey2), EMAIL1);
+    Assert.assertEquals(
+        recipientProvider.getAlertGroupRecipients(alertGroupKey2, Collections.<MergedAnomalyResultDTO>emptyList()),
+        EMAIL1);
 
     // Test empty recipients
-    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(new DimensionMap()), BaseAlertGrouper.EMPTY_RECIPIENTS);
-    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(null), BaseAlertGrouper.EMPTY_RECIPIENTS);
+    Assert.assertEquals(
+        recipientProvider.getAlertGroupRecipients(new DimensionMap(), Collections.<MergedAnomalyResultDTO>emptyList()),
+        BaseAlertGrouper.EMPTY_RECIPIENTS);
+    Assert
+        .assertEquals(recipientProvider.getAlertGroupRecipients(null, Collections.<MergedAnomalyResultDTO>emptyList()),
+            BaseAlertGrouper.EMPTY_RECIPIENTS);
     DimensionMap dimensionMapNonExist = new DimensionMap();
     dimensionMapNonExist.put("K2", "V1");
-    Assert.assertEquals(recipientProvider.getAlertGroupRecipients(dimensionMapNonExist), BaseAlertGrouper.EMPTY_RECIPIENTS);
+    Assert.assertEquals(recipientProvider
+            .getAlertGroupRecipients(dimensionMapNonExist, Collections.<MergedAnomalyResultDTO>emptyList()),
+        BaseAlertGrouper.EMPTY_RECIPIENTS);
   }
 }


### PR DESCRIPTION
Pass the list of anomalies of the grouped anomaly to GroupRecipientProvider as an argument for advanced recipients calculation.

Tested on local.