### PR TITLE
[TE] fix spacing in filter name bug

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyResultModel.js
@@ -195,6 +195,7 @@ AnomalyResultModel.prototype = {
     params.anomaliesSearchMode = constants.MODE_ID;
     params.updateModelAndNotifyView = this.updateModelAndNotifyView;
     params.anomalyIds = anomalyIds;
+    params.spinner = this.spinner;
     this.ajaxCall = dataService.fetchAnomalies(params);
   },
   /**

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomaly-filters.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/anomaly-filters.ftl
@@ -17,8 +17,8 @@
               {{#each this}}
                 {{#if this.length}}
                    <li class="filter-item">
-                    <input class="filter-item__checkbox" type="checkbox" id="{{@key}}" data-filter={{@key}} {{#if this.selected}} checked=true {{/if}}>
-                    <label for="{{@key}}" class="filter-item__label" title={{@key}}>{{@key}}</label>
+                    <input class="filter-item__checkbox" type="checkbox" id="{{@key}}" data-filter="{{@key}}" {{#if this.selected}} checked=true {{/if}}>
+                    <label for="{{@key}}" class="filter-item__label" title="{{@key}}">{{@key}}</label>
                     <span class="filter-item__count">{{this.length}}</span>
                   </li>
                 {{/if}}
@@ -28,8 +28,8 @@
         {{else}}
           {{#if this.length}}
             <li class="filter-item">
-              <input class="filter-item__checkbox" type="checkbox" id="{{@key}}" data-filter={{@key}} {{#if this.selected}} checked=true {{/if}}>
-              <label for="{{@key}}" class="filter-item__label" title={{@key}}>{{@key}}</label>
+              <input class="filter-item__checkbox" type="checkbox" id="{{@key}}" data-filter="{{@key}}" {{#if this.selected}} checked=true {{/if}}>
+              <label for="{{@key}}" class="filter-item__label" title="{{@key}}">{{@key}}</label>
               <span class="filter-item__count">{{this.length}}</span>
             </li>
           {{/if}}


### PR DESCRIPTION
Minor bug fix. The space wasn't properly escaped in the element's data attribute. 