### PR TITLE
Adding partition aware realtime routing table builder

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/AbstractPartitionAwareRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/AbstractPartitionAwareRoutingTableBuilder.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.routing.builder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.pinot.broker.pruner.SegmentPrunerContext;
+import com.linkedin.pinot.broker.pruner.SegmentZKMetadataPrunerService;
+import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.transport.common.SegmentId;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
+
+/**
+ * Abstract partition aware routing table builder.
+ *
+ * For an external view change, a subclass is in change of updating the look up table that is used
+ * for routing. The look up table is in the format of < segment_name -> (replica_id -> server_instance) >.
+ *
+ * When the query comes in, the routing algorithm is as follows:
+ *   1. Randomly pick a replica id (or replica group id)
+ *   2. For each segment of the given table,
+ *      a. Check if the segment can be pruned. If pruned, go to the next segment.
+ *      b. If not pruned, assign the segment to a server with the replica id that is picked above.
+ *
+ */
+public abstract class AbstractPartitionAwareRoutingTableBuilder extends AbstractRoutingTableBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPartitionAwareRoutingTableBuilder.class);
+
+  protected static final String PARTITION_METADATA_PRUNER = "PartitionZKMetadataPruner";
+  protected static final int NO_PARTITION_NUMBER = -1;
+
+  // Reference mapping table (segment id, (replica group id, server)) that is used for routing.
+  Map<SegmentId, Map<Integer, ServerInstance>> _segmentNameToServersMapping = new HashMap<>();
+  AtomicReference<Map<SegmentId, Map<Integer, ServerInstance>>> _mappingReference =
+      new AtomicReference<>(_segmentNameToServersMapping);
+
+  // Cache for segment zk metadata to reduce the lookup to ZK store.
+  Map<SegmentId, SegmentZKMetadata> _segmentToZkMetadataMapping = new ConcurrentHashMap<>();
+
+  protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  protected SegmentZKMetadataPrunerService _pruner;
+  protected TableConfig _tableConfig;
+  protected Random _random = new Random();
+  protected int _numReplicas;
+
+  @Override
+  public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _tableConfig = tableConfig;
+    _propertyStore = propertyStore;
+
+    // TODO: We need to specify the type of pruners via config instead of hardcoding.
+    _pruner = new SegmentZKMetadataPrunerService(new String[]{PARTITION_METADATA_PRUNER});
+  }
+
+  @Override
+  public Map<ServerInstance, SegmentIdSet> findServers(RoutingTableLookupRequest request) {
+    Map<ServerInstance, SegmentIdSet> result = new HashMap<>();
+    Map<SegmentId, Map<Integer, ServerInstance>> mappingReference = _mappingReference.get();
+    SegmentPrunerContext prunerContext = new SegmentPrunerContext(request.getBrokerRequest());
+
+    // 1. Randomly pick a replica id
+    int replicaGroupId = _random.nextInt(_numReplicas);
+    for (SegmentId segmentId : mappingReference.keySet()) {
+      SegmentZKMetadata segmentZKMetadata = _segmentToZkMetadataMapping.get(segmentId);
+
+      // 2a. Check if the segment can be pruned
+      boolean segmentPruned = (segmentZKMetadata != null) && _pruner.prune(segmentZKMetadata, prunerContext);
+
+      if (!segmentPruned) {
+        // 2b. Segment cannot be pruned. Assign the segment to a server with the replica id picked above.
+        Map<Integer, ServerInstance> replicaId2ServerMapping = mappingReference.get(segmentId);
+        ServerInstance serverInstance = replicaId2ServerMapping.get(replicaGroupId);
+
+        // When the server is not available with this replica id, we need to pick another available server.
+        if (serverInstance == null) {
+          if (!replicaId2ServerMapping.isEmpty()) {
+            serverInstance = replicaId2ServerMapping.values().iterator().next();
+          } else {
+            // No server is found for this segment.
+            LOGGER.warn("No server is found for the segment {}.", segmentId.getSegmentId());
+            continue;
+          }
+        }
+        SegmentIdSet segmentIdSet = result.get(serverInstance);
+        if (segmentIdSet == null) {
+          segmentIdSet = new SegmentIdSet();
+          result.put(serverInstance, segmentIdSet);
+        }
+        segmentIdSet.addSegment(segmentId);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public boolean isPartitionAware() {
+    return true;
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelRoutingTableBuilderUtil.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelRoutingTableBuilderUtil.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.broker.routing.builder;
+
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.common.utils.SegmentName;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.helix.model.ExternalView;
+
+
+/**
+ * Util class for Kafka low level routing table builder.
+ */
+public class KafkaLowLevelRoutingTableBuilderUtil {
+
+  /**
+   * Compute the table of a sorted list of segments grouped by Kafka partition.
+   *
+   * @param externalView helix external view.
+   * @return map of Kafka partition to sorted set of segment names.
+   */
+  public static Map<String, SortedSet<SegmentName>> getSortedSegmentsByKafkaPartition(ExternalView externalView) {
+    Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition = new HashMap<>();
+    for (String helixPartitionName : externalView.getPartitionSet()) {
+      // Ignore segments that are not low level consumer segments
+      if (!SegmentName.isLowLevelConsumerSegmentName(helixPartitionName)) {
+        continue;
+      }
+
+      final LLCSegmentName segmentName = new LLCSegmentName(helixPartitionName);
+      String kafkaPartitionName = segmentName.getPartitionRange();
+      SortedSet<SegmentName> segmentsForPartition = sortedSegmentsByKafkaPartition.get(kafkaPartitionName);
+
+      // Create sorted set if necessary
+      if (segmentsForPartition == null) {
+        segmentsForPartition = new TreeSet<>();
+
+        sortedSegmentsByKafkaPartition.put(kafkaPartitionName, segmentsForPartition);
+      }
+
+      segmentsForPartition.add(segmentName);
+    }
+    return sortedSegmentsByKafkaPartition;
+  }
+
+  /**
+   * Compute the map of allowed 'consuming' segments for each partition.
+   *
+   * @param externalView helix external view
+   * @param sortedSegmentsByKafkaPartition map of Kafka partition to sorted set of segment names.
+   * @return map of allowed consuming segment for each partition for routing.
+   */
+  public static Map<String, SegmentName> getAllowedConsumingStateSegments(ExternalView externalView,
+      Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition) {
+    Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition = new HashMap<>();
+    for (String kafkaPartition : sortedSegmentsByKafkaPartition.keySet()) {
+      SortedSet<SegmentName> sortedSegmentsForKafkaPartition = sortedSegmentsByKafkaPartition.get(kafkaPartition);
+      SegmentName lastAllowedSegmentInConsumingState = null;
+
+      for (SegmentName segmentName : sortedSegmentsForKafkaPartition) {
+        Map<String, String> helixPartitionState = externalView.getStateMap(segmentName.getSegmentName());
+        boolean allInConsumingState = true;
+        int replicasInConsumingState = 0;
+
+        // Only keep the segment if all replicas have it in CONSUMING state
+        for (String externalViewState : helixPartitionState.values()) {
+          // Ignore ERROR state
+          if (externalViewState.equalsIgnoreCase(
+              CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ERROR)) {
+            continue;
+          }
+
+          // Not all segments are in CONSUMING state, therefore don't consider the last segment assignable to CONSUMING
+          // replicas
+          if (externalViewState.equalsIgnoreCase(
+              CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+            allInConsumingState = false;
+            break;
+          }
+
+          // Otherwise count the replica as being in CONSUMING state
+          if (externalViewState.equalsIgnoreCase(
+              CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+            replicasInConsumingState++;
+          }
+        }
+
+        // If all replicas have this segment in consuming state (and not all of them are in ERROR state), then pick this
+        // segment to be the last allowed segment to be in CONSUMING state
+        if (allInConsumingState && 0 < replicasInConsumingState) {
+          lastAllowedSegmentInConsumingState = segmentName;
+          break;
+        }
+      }
+
+      if (lastAllowedSegmentInConsumingState != null) {
+        allowedSegmentInConsumingStateByKafkaPartition.put(kafkaPartition, lastAllowedSegmentInConsumingState);
+      }
+    }
+    return allowedSegmentInConsumingStateByKafkaPartition;
+  }
+}

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.broker.routing.builder;
+
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.common.utils.SegmentName;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.transport.common.SegmentId;
+
+/**
+ * Partition aware routing table builder for the Kafka low level consumer.
+ *
+ * In contrast to the offline partition aware routing builder where the replica group aware segment assignment can be
+ * assumed, we do not use the concept of replica group for a realtime table. The routing look up table is simply built
+ * from the external view.
+ *
+ */
+public class PartitionAwareRealtimeRoutingTableBuilder extends AbstractPartitionAwareRoutingTableBuilder {
+
+  @Override
+  public void computeRoutingTableFromExternalView(String tableName, ExternalView externalView,
+      List<InstanceConfig> instanceConfigList) {
+
+    _numReplicas = Integer.valueOf(_tableConfig.getValidationConfig().getReplicasPerPartition());
+
+    // Update the cache for the segment ZK metadata
+    for (String segment : externalView.getPartitionSet()) {
+      SegmentId segmentId = new SegmentId(segment);
+      SegmentZKMetadata segmentZKMetadata = _segmentToZkMetadataMapping.get(segmentId);
+      if (segmentZKMetadata == null || segmentZKMetadata.getPartitionMetadata() == null ||
+          segmentZKMetadata.getPartitionMetadata().getColumnPartitionMap().size() == 0) {
+        segmentZKMetadata = ZKMetadataProvider.getRealtimeSegmentZKMetadata(_propertyStore, tableName, segment);
+        if (segmentZKMetadata != null) {
+          _segmentToZkMetadataMapping.put(segmentId, segmentZKMetadata);
+        }
+      }
+    }
+
+    // Gather all segments and group them by Kafka partition, sorted by sequence number
+    Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition =
+        KafkaLowLevelRoutingTableBuilderUtil.getSortedSegmentsByKafkaPartition(externalView);
+
+    // Ensure that for each Kafka partition, we have at most one Helix partition (Pinot segment) in consuming state
+    Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition =
+        KafkaLowLevelRoutingTableBuilderUtil.getAllowedConsumingStateSegments(externalView,
+            sortedSegmentsByKafkaPartition);
+
+    RoutingTableInstancePruner pruner = new RoutingTableInstancePruner(instanceConfigList);
+
+    // Compute segment id to replica id to server instance
+    Map<SegmentId, Map<Integer, ServerInstance>> segmentId2ServersMapping = new HashMap<>();
+    for (String segmentName : externalView.getPartitionSet()) {
+      SegmentId segmentId = new SegmentId(segmentName);
+      int partitionId = getPartitionId(segmentName);
+      Map<String, String> instanceToStateMap = new HashMap<>(externalView.getStateMap(segmentName));
+      Map<Integer, ServerInstance> serverInstanceMap = new HashMap<>();
+
+      String partitionStr = Integer.toString(partitionId);
+      SegmentName validConsumingSegment = allowedSegmentInConsumingStateByKafkaPartition.get(partitionStr);
+
+      int replicaId = 0;
+      for (String instanceName : instanceToStateMap.keySet()) {
+        // Do not add the server if it is inactive
+        if (pruner.isInactive(instanceName)) {
+          continue;
+        }
+
+        String state = instanceToStateMap.get(instanceName);
+        ServerInstance serverInstance = ServerInstance.forInstanceName(instanceName);
+
+        // If the server is in ONLINE status, it's always to safe to add
+        if (state.equalsIgnoreCase(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.ONLINE)) {
+          serverInstanceMap.put(replicaId, serverInstance);
+        }
+
+        // If the server is in CONSUMING status, the segment has to be match with the valid consuming segment
+        if (state.equalsIgnoreCase(CommonConstants.Helix.StateModel.RealtimeSegmentOnlineOfflineStateModel.CONSUMING)) {
+          if (validConsumingSegment != null && segmentName.equals(validConsumingSegment.getSegmentName())) {
+            serverInstanceMap.put(replicaId, serverInstance);
+          }
+        }
+        replicaId++;
+      }
+      segmentId2ServersMapping.put(segmentId, serverInstanceMap);
+    }
+
+    // Delete segment metadata from the cache if the segment no longer exists in the external view.
+    Set<String> segmentsFromExternalView = externalView.getPartitionSet();
+    for (SegmentId segmentId : _segmentToZkMetadataMapping.keySet()) {
+      if (!segmentsFromExternalView.contains(segmentId.getSegmentId())) {
+        _segmentToZkMetadataMapping.remove(segmentId);
+      }
+    }
+
+    _mappingReference.set(segmentId2ServersMapping);
+  }
+
+  /**
+   * Retrieve the partition Id from the segment name of the realtime segment
+   *
+   * @param segmentName the name of the realtime segment
+   * @return partition id of the segment
+   */
+  private int getPartitionId(String segmentName) {
+    final LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+    return llcSegmentName.getPartitionId();
+  }
+}

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/FakePropertyStore.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/FakePropertyStore.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.broker.routing;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.I0Itec.zkclient.IZkDataListener;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.zookeeper.data.Stat;
+
+public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
+  private Map<String, ZNRecord> _contents = new HashMap<>();
+  private IZkDataListener _listener = null;
+
+  public FakePropertyStore() {
+    super((ZkBaseDataAccessor<ZNRecord>) null, null, null);
+  }
+
+  @Override
+  public ZNRecord get(String path, Stat stat, int options) {
+    return _contents.get(path);
+  }
+
+  @Override
+  public void subscribeDataChanges(String path, IZkDataListener listener) {
+    _listener = listener;
+  }
+
+  @Override
+  public boolean set(String path, ZNRecord stat, int options) {
+    try {
+      setContents(path, stat);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public void setContents(String path, ZNRecord contents) throws Exception {
+    _contents.put(path, contents);
+    if (_listener != null) {
+      _listener.handleDataChange(path, contents);
+    }
+  }
+
+  @Override
+  public void start() {
+    // Don't try to connect to zk
+  }
+}

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/RoutingTableTest.java
@@ -15,12 +15,6 @@
  */
 package com.linkedin.pinot.broker.routing;
 
-import com.linkedin.pinot.broker.routing.HelixExternalViewBasedRouting;
-import com.linkedin.pinot.broker.routing.PercentageBasedRoutingTableSelector;
-import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
-import com.linkedin.pinot.broker.routing.RoutingTableSelector;
-import com.linkedin.pinot.broker.routing.RoutingTableSelectorFactory;
-import com.linkedin.pinot.broker.routing.TableConfigRoutingTableSelector;
 import com.linkedin.pinot.broker.routing.builder.KafkaHighLevelConsumerBasedRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.RandomRoutingTableBuilder;
 import com.linkedin.pinot.broker.routing.builder.RoutingTableBuilder;
@@ -94,7 +88,7 @@ public class RoutingTableTest {
 
     TableConfig testResource1Config = generateTableConfig("testResource1_OFFLINE");
     routingTable.markDataResourceOnline(testResource1Config, externalView1, instanceConfigs);
-    
+
     ExternalView externalView2 = new ExternalView("testResource2_OFFLINE");
     externalView2.setState("segment20", "dataServer_instance_0", "ONLINE");
     externalView2.setState("segment21", "dataServer_instance_0", "ONLINE");
@@ -475,44 +469,12 @@ public class RoutingTableTest {
     }
     return configs;
   }
-  
+
   private TableConfig generateTableConfig(String tableName) throws IOException, JSONException {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
     Builder builder = new TableConfig.Builder(tableType);
     builder.setTableName(tableName);
     return builder.build();
-  }
-
-
-  class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
-    private Map<String, ZNRecord> _contents = new HashMap<>();
-    private IZkDataListener _listener = null;
-
-    public FakePropertyStore() {
-      super((ZkBaseDataAccessor<ZNRecord>) null, null, null);
-    }
-
-    @Override
-    public ZNRecord get(String path, Stat stat, int options) {
-      return _contents.get(path);
-    }
-
-    @Override
-    public void subscribeDataChanges(String path, IZkDataListener listener) {
-      _listener = listener;
-    }
-
-    public void setContents(String path, ZNRecord contents) throws Exception {
-      _contents.put(path, contents);
-      if (_listener != null) {
-        _listener.handleDataChange(path, contents);
-      }
-    }
-
-    @Override
-    public void start() {
-      // Don't try to connect to zk
-    }
   }
 
   @Test

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.broker.routing.builder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import java.util.Set;
+import org.apache.commons.lang.math.IntRange;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.pinot.broker.routing.FakePropertyStore;
+import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.common.config.ReplicaGroupStrategyConfig;
+import com.linkedin.pinot.common.config.RoutingConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.PartitionToReplicaGroupMappingZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import com.linkedin.pinot.transport.common.SegmentId;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
+public class PartitionAwareOfflineRoutingTableBuilderTest {
+  private static final String OFFLINE_TABLE_NAME = "myTable_OFFLINE";
+  private static final String PARTITION_FUNCTION_NAME = "modulo";
+  private static final String PARTITION_COLUMN = "memberId";
+  private static final Random random = new Random();
+
+  private int NUM_REPLICA;
+  private int NUM_PARTITION;
+  private int NUM_SERVERS;
+  private int NUM_SEGMENTS;
+
+  @Test
+  public void testBrokerSideServerAndSegmentPruning() throws Exception {
+    int numIterations = 100;
+
+    for (int iter = 0; iter < numIterations; iter++) {
+      NUM_PARTITION = random.nextInt(8) + 3;
+      NUM_REPLICA = random.nextInt(3) + 3;
+      NUM_SERVERS = NUM_REPLICA * (random.nextInt(10) + 3);
+      NUM_SEGMENTS = random.nextInt(100) + 3;
+
+      // Create the fake property store
+      FakePropertyStore fakePropertyStore = new FakePropertyStore();
+
+      // Create the table config, partition mapping,
+      TableConfig tableConfig = buildOfflineTableConfig();
+
+      // Create the replica group id to server mapping
+      Map<Integer, List<String>> replicaToServerMapping = buildReplicaGroupMapping();
+
+      // Update segment zk metadata.
+      Map<Integer, Integer> partitionSegmentCount = new HashMap<>();
+      for (int i = 0; i < NUM_PARTITION; i++) {
+        partitionSegmentCount.put(i, 0);
+      }
+
+      for (int i = 0; i < NUM_SEGMENTS; i++) {
+        String segmentName = "segment" + i;
+        int partition = i % NUM_PARTITION;
+        partitionSegmentCount.put(partition, partitionSegmentCount.get(partition) + 1);
+
+        SegmentZKMetadata metadata = buildOfflineSegmentZKMetadata(segmentName, partition);
+        fakePropertyStore.setContents(ZKMetadataProvider.constructPropertyStorePathForSegment(OFFLINE_TABLE_NAME, segmentName),
+            metadata.toZNRecord());
+      }
+
+      // Update replica group mapping zk metadata
+      updatePartitionMappingZkMetadata(OFFLINE_TABLE_NAME, fakePropertyStore);
+
+      // Create the fake external view
+      ExternalView externalView = buildExternalView(OFFLINE_TABLE_NAME, fakePropertyStore, replicaToServerMapping);
+
+      // Create instance Configs
+      List<InstanceConfig> instanceConfigs = new ArrayList<>();
+      for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+        String serverName = "Server_localhost_" + serverId;
+        instanceConfigs.add(new InstanceConfig(serverName));
+      }
+
+      // Create the partition aware offline routing table builder.
+      RoutingTableBuilder routingTableBuilder = buildPartitionAwareOfflineRoutingTableBuilder(fakePropertyStore,
+          tableConfig, externalView, instanceConfigs);
+
+      // Check the query that requires to scan all segment.
+      String countStarQuery = "select count(*) from myTable";
+      Map<ServerInstance, SegmentIdSet> routingResult =
+          routingTableBuilder.findServers(buildRoutingTableLookupRequest(countStarQuery));
+
+      // Check that the number of servers picked are always equal or less than the number of servers
+      // from a single replica group.
+      Assert.assertTrue(routingResult.keySet().size() <= (NUM_SERVERS / NUM_REPLICA));
+
+      // Check that all segments are covered exactly for once.
+      Set<String> assignedSegments = new HashSet<>();
+      for (SegmentIdSet segmentIdSet : routingResult.values()) {
+        for (SegmentId segment: segmentIdSet.getSegments()) {
+          Assert.assertFalse(assignedSegments.contains(segment.getSegmentId()));
+          assignedSegments.add(segment.getSegmentId());
+        }
+      }
+      Assert.assertEquals(assignedSegments.size(), NUM_SEGMENTS);
+
+      // Check the broker side server and segment pruning.
+      for (int queryPartition = 0; queryPartition < 100; queryPartition++) {
+        String filterQuery = "select count(*) from myTable where " + PARTITION_COLUMN + " = " + queryPartition;
+        routingResult = routingTableBuilder.findServers(buildRoutingTableLookupRequest(filterQuery));
+
+        // Check that the number of servers picked are always equal or less than the number of servers
+        // in a single replica group.
+        Assert.assertTrue(routingResult.keySet().size() <= (NUM_SERVERS / NUM_REPLICA));
+
+        int partition = queryPartition % NUM_PARTITION;
+        assignedSegments = new HashSet<>();
+        for (SegmentIdSet segmentIdSet : routingResult.values()) {
+          for (SegmentId segment: segmentIdSet.getSegments()) {
+            Assert.assertFalse(assignedSegments.contains(segment.getSegmentId()));
+            assignedSegments.add(segment.getSegmentId());
+          }
+        }
+        Assert.assertEquals(assignedSegments.size(), partitionSegmentCount.get(partition).intValue());
+      }
+    }
+  }
+
+  private void updatePartitionMappingZkMetadata(String tableName, FakePropertyStore propertyStore) {
+    // Create partition assignment mapping table.
+    PartitionToReplicaGroupMappingZKMetadata replicaGroupMappingZKMetadata = new PartitionToReplicaGroupMappingZKMetadata();
+    replicaGroupMappingZKMetadata.setTableName(tableName);
+
+    int partitionId = 0;
+    for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+      String serverName = "Server_localhost_" + serverId;
+      int replicaGroupId = serverId / (NUM_SERVERS / NUM_REPLICA);
+      replicaGroupMappingZKMetadata.addInstanceToReplicaGroup(partitionId, replicaGroupId, serverName);
+    }
+
+    ZKMetadataProvider.setInstancePartitionAssignmentFromPropertyStore(propertyStore, replicaGroupMappingZKMetadata);
+  }
+
+  private RoutingTableBuilder buildPartitionAwareOfflineRoutingTableBuilder(FakePropertyStore propertyStore,
+      TableConfig tableConfig, ExternalView externalView, List<InstanceConfig> instanceConfigs) throws Exception{
+    PartitionAwareOfflineRoutingTableBuilder routingTableBuilder = new PartitionAwareOfflineRoutingTableBuilder();
+    routingTableBuilder.init(null, tableConfig, propertyStore);
+    routingTableBuilder.computeRoutingTableFromExternalView(OFFLINE_TABLE_NAME, externalView, instanceConfigs);
+
+    return routingTableBuilder;
+  }
+
+  private ExternalView buildExternalView(String tableName, FakePropertyStore propertyStore,
+      Map<Integer, List<String>> replicaGroupServers) throws Exception {
+
+    // Create External View
+    ExternalView externalView = new ExternalView(tableName);
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      String segmentName = "segment" + i;
+      int serverIndex = i % (NUM_SERVERS / NUM_REPLICA);
+      for (List<String> serversInReplicaGroup: replicaGroupServers.values()) {
+        externalView.setState(segmentName, serversInReplicaGroup.get(serverIndex), "ONLINE");
+      }
+    }
+    return externalView;
+  }
+
+  private  Map<Integer, List<String>> buildReplicaGroupMapping() {
+    Map<Integer, List<String>> replicaGroupServers = new HashMap<>();
+    int numServersPerReplica = NUM_SERVERS / NUM_REPLICA;
+    for (int serverId = 0; serverId < NUM_SERVERS; serverId ++ ) {
+      int groupId = serverId / numServersPerReplica;
+      if (!replicaGroupServers.containsKey(groupId)) {
+        replicaGroupServers.put(groupId, new ArrayList<String>());
+      }
+      String serverName = "Server_localhost_" + serverId;
+      replicaGroupServers.get(groupId).add(serverName);
+    }
+    return replicaGroupServers;
+  }
+
+  private RoutingTableLookupRequest buildRoutingTableLookupRequest(String query) {
+    Pql2Compiler compiler = new Pql2Compiler();
+    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+    RoutingTableLookupRequest request = new RoutingTableLookupRequest(OFFLINE_TABLE_NAME,
+        Collections.<String>emptyList(), brokerRequest);
+    return request;
+  }
+
+  private TableConfig buildOfflineTableConfig() throws Exception {
+    // Create the replica group aware assignment strategy config
+    ReplicaGroupStrategyConfig replicaGroupStrategyConfig = new ReplicaGroupStrategyConfig();
+    replicaGroupStrategyConfig.setNumInstancesPerPartition(NUM_PARTITION);
+    replicaGroupStrategyConfig.setMirrorAssignmentAcrossReplicaGroups(true);
+
+    // Create the routing config
+    RoutingConfig routingConfig = new RoutingConfig();
+    routingConfig.setRoutingTableBuilderName("PartitionAwareOffline");
+
+    // Create table config
+    TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE)
+        .setTableName(OFFLINE_TABLE_NAME)
+        .setNumReplicas(NUM_REPLICA)
+        .setSegmentAssignmentStrategy("ReplicaGroupSegmentAssignmentStrategy")
+        .build();
+
+    tableConfig.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
+    tableConfig.setRoutingConfig(routingConfig);
+    return tableConfig;
+  }
+
+  private SegmentZKMetadata buildOfflineSegmentZKMetadata(String segmentName, int partition) {
+    OfflineSegmentZKMetadata metadata = new OfflineSegmentZKMetadata();
+    Map<String, ColumnPartitionMetadata> columnPartitionMap = new HashMap<>();
+    columnPartitionMap.put(PARTITION_COLUMN, new ColumnPartitionMetadata(PARTITION_FUNCTION_NAME, NUM_PARTITION,
+        Collections.singletonList(new IntRange(partition))));
+    SegmentPartitionMetadata segmentPartitionMetadata = new SegmentPartitionMetadata(columnPartitionMap);
+
+    metadata.setSegmentName(segmentName);
+    metadata.setPartitionMetadata(segmentPartitionMetadata);
+
+    return metadata;
+  }
+}

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
@@ -1,0 +1,325 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.broker.routing.builder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import org.apache.commons.lang.math.IntRange;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.pinot.broker.routing.FakePropertyStore;
+import com.linkedin.pinot.broker.routing.RoutingTableLookupRequest;
+import com.linkedin.pinot.common.config.ColumnPartitionConfig;
+import com.linkedin.pinot.common.config.RoutingConfig;
+import com.linkedin.pinot.common.config.SegmentPartitionConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.response.ServerInstance;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import com.linkedin.pinot.transport.common.SegmentId;
+import com.linkedin.pinot.transport.common.SegmentIdSet;
+
+
+public class PartitionAwareRealtimeRoutingTableBuilderTest {
+  private static final String REALTIME_TABLE_NAME = "myTable_REALTIME";
+  private static final String PARTITION_FUNCTION_NAME = "Modulo";
+  private static final String PARTITION_COLUMN = "memberId";
+  private static final Random random = new Random();
+
+  private int NUM_REPLICA;
+  private int NUM_PARTITION;
+  private int NUM_SERVERS;
+  private int NUM_SEGMENTS;
+
+  @Test
+  public void testBrokerSideSegmentPruning() throws Exception {
+    int numIterations = 100;
+
+    for (int iter = 0; iter < numIterations; iter++) {
+      NUM_PARTITION = random.nextInt(8) + 3;
+      NUM_REPLICA = random.nextInt(3) + 3;
+      NUM_SERVERS = random.nextInt(10) + 3;
+      NUM_SEGMENTS = random.nextInt(100) + 3;
+
+      // Create the fake property store
+      FakePropertyStore fakePropertyStore = new FakePropertyStore();
+
+      // Create the table config, partition mapping,
+      TableConfig tableConfig = buildRealtimeTableConfig();
+
+      Map<Integer, Integer> partitionSegmentCount = new HashMap<>();
+      for (int i = 0; i < NUM_PARTITION; i++) {
+        partitionSegmentCount.put(i, 0);
+      }
+
+      // Update segment zk metadata.
+      List<String> segmentList = updateZkMetadataAndBuildSegmentList(partitionSegmentCount, fakePropertyStore);
+
+      // Create instance Configs
+      List<InstanceConfig> instanceConfigs = new ArrayList<>();
+      for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+        String serverName = "Server_localhost_" + serverId;
+        instanceConfigs.add(new InstanceConfig(serverName));
+      }
+
+      // Update replica group mapping zk metadata
+      Map<Integer, List<String>> partitionToServerMapping =
+          buildKafkaPartitionMapping(REALTIME_TABLE_NAME, fakePropertyStore, instanceConfigs);
+
+      // Create the fake external view
+      ExternalView externalView =
+          buildExternalView(REALTIME_TABLE_NAME, fakePropertyStore, partitionToServerMapping, segmentList);
+
+
+      // Create the partition aware realtime routing table builder.
+      RoutingTableBuilder routingTableBuilder =
+          buildPartitionAwareRealtimeRoutingTableBuilder(fakePropertyStore, tableConfig, externalView, instanceConfigs);
+
+      // Check the query that requires to scan all segment.
+      String countStarQuery = "select count(*) from myTable";
+      Map<ServerInstance, SegmentIdSet> routingResult =
+          routingTableBuilder.findServers(buildRoutingTableLookupRequest(countStarQuery));
+
+      // Check that all segments are covered exactly for once.
+      Set<String> assignedSegments = new HashSet<>();
+      for (SegmentIdSet segmentIdSet : routingResult.values()) {
+        for (SegmentId segment : segmentIdSet.getSegments()) {
+          Assert.assertFalse(assignedSegments.contains(segment.getSegmentId()));
+          assignedSegments.add(segment.getSegmentId());
+        }
+      }
+      Assert.assertEquals(assignedSegments.size(), NUM_SEGMENTS);
+
+      // Check the broker side server and segment pruning.
+      for (int queryPartition = 0; queryPartition < 100; queryPartition++) {
+        String filterQuery = "select count(*) from myTable where " + PARTITION_COLUMN + " = " + queryPartition;
+        routingResult = routingTableBuilder.findServers(buildRoutingTableLookupRequest(filterQuery));
+
+        int partition = queryPartition % NUM_PARTITION;
+        assignedSegments = new HashSet<>();
+        for (SegmentIdSet segmentIdSet : routingResult.values()) {
+          for (SegmentId segment : segmentIdSet.getSegments()) {
+            Assert.assertFalse(assignedSegments.contains(segment.getSegmentId()));
+            assignedSegments.add(segment.getSegmentId());
+          }
+        }
+        Assert.assertEquals(assignedSegments.size(), partitionSegmentCount.get(partition).intValue());
+      }
+    }
+  }
+
+  @Test
+  public void testMultipleConsumingSegments() throws Exception {
+    NUM_PARTITION = 1;
+    NUM_REPLICA = 1;
+    NUM_SERVERS = 1;
+    NUM_SEGMENTS = 10;
+    int ONLINE_SEGMENTS = 8;
+
+    // Create the fake property store
+    FakePropertyStore fakePropertyStore = new FakePropertyStore();
+
+    // Create the table config, partition mapping,
+    TableConfig tableConfig = buildRealtimeTableConfig();
+
+    Map<Integer, Integer> partitionSegmentCount = new HashMap<>();
+    for (int i = 0; i < NUM_PARTITION; i++) {
+      partitionSegmentCount.put(i, 0);
+    }
+
+    List<String> segmentList = updateZkMetadataAndBuildSegmentList(partitionSegmentCount, fakePropertyStore);
+
+    // Create instance Configs
+    List<InstanceConfig> instanceConfigs = new ArrayList<>();
+    for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+      String serverName = "Server_localhost_" + serverId;
+      instanceConfigs.add(new InstanceConfig(serverName));
+    }
+
+    // Update replica group mapping zk metadata
+    Map<Integer, List<String>> partitionToServerMapping =
+        buildKafkaPartitionMapping(REALTIME_TABLE_NAME, fakePropertyStore, instanceConfigs);
+
+    ExternalView externalView =
+        buildExternalView(REALTIME_TABLE_NAME, fakePropertyStore, partitionToServerMapping, segmentList);
+
+    LLCSegmentName consumingSegment = new LLCSegmentName(REALTIME_TABLE_NAME, 0, 9, 0);
+    externalView.setState(consumingSegment.getSegmentName(), "Server_localhost_0", "CONSUMING");
+    consumingSegment = new LLCSegmentName(REALTIME_TABLE_NAME, 0, 8, 0);
+    externalView.setState(consumingSegment.getSegmentName(), "Server_localhost_0", "CONSUMING");
+
+    // Create the partition aware realtime routing table builder.
+    RoutingTableBuilder routingTableBuilder =
+        buildPartitionAwareRealtimeRoutingTableBuilder(fakePropertyStore, tableConfig, externalView, instanceConfigs);
+
+    // Check the query that requires to scan all segment.
+    String countStarQuery = "select count(*) from myTable";
+    Map<ServerInstance, SegmentIdSet> routingResult =
+        routingTableBuilder.findServers(buildRoutingTableLookupRequest(countStarQuery));
+
+    // Check that all segments are covered exactly for once.
+    Set<String> assignedSegments = new HashSet<>();
+    for (SegmentIdSet segmentIdSet : routingResult.values()) {
+      for (SegmentId segment : segmentIdSet.getSegments()) {
+        Assert.assertFalse(assignedSegments.contains(segment.getSegmentId()));
+        assignedSegments.add(segment.getSegmentId());
+      }
+    }
+    Assert.assertEquals(assignedSegments.size(), ONLINE_SEGMENTS + 1);
+
+    // Check that only one consuming segment is assigned
+    Assert.assertTrue(assignedSegments.contains(segmentList.get(ONLINE_SEGMENTS)));
+    for (int i = ONLINE_SEGMENTS + 1; i < NUM_SEGMENTS; i++) {
+      Assert.assertFalse(assignedSegments.contains(segmentList.get(i)));
+    }
+  }
+
+  private List<String> updateZkMetadataAndBuildSegmentList(Map<Integer, Integer> partitionSegmentCount,
+      FakePropertyStore propertyStore) throws Exception {
+    // Update segment zk metadata.
+    List<String> segmentList = new ArrayList<>();
+    int seqId = 0;
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
+      int partitionId = i % NUM_PARTITION;
+      partitionSegmentCount.put(partitionId, partitionSegmentCount.get(partitionId) + 1);
+
+      LLCSegmentName segment = new LLCSegmentName(REALTIME_TABLE_NAME, partitionId, seqId, 0);
+      String segmentName = segment.getSegmentName();
+
+      SegmentZKMetadata metadata = buildSegmentZKMetadata(segmentName, partitionId);
+      propertyStore.setContents(
+          ZKMetadataProvider.constructPropertyStorePathForSegment(REALTIME_TABLE_NAME, segmentName),
+          metadata.toZNRecord());
+      segmentList.add(segmentName);
+      if (partitionId % NUM_PARTITION == 0) {
+        seqId++;
+      }
+    }
+    return segmentList;
+  }
+
+  private Map<Integer, List<String>> buildKafkaPartitionMapping(String tableName, FakePropertyStore propertyStore,
+      List<InstanceConfig> instanceConfigs) {
+    // Create partition assignment mapping table.
+    Map<Integer, List<String>> partitionToServers = new HashMap<>();
+    ZNRecord kafkaPartitionMapping = new ZNRecord(REALTIME_TABLE_NAME);
+
+    int serverIndex = 0;
+    for (int partitionId = 0; partitionId < NUM_PARTITION; partitionId++) {
+      List<String> assignedServers = new ArrayList<>();
+      for (int replicaId = 0; replicaId < NUM_REPLICA; replicaId++) {
+        assignedServers.add(instanceConfigs.get(serverIndex % NUM_SERVERS).getInstanceName());
+        serverIndex++;
+      }
+      partitionToServers.put(partitionId, assignedServers);
+      kafkaPartitionMapping.setListField(Integer.toString(partitionId), assignedServers);
+    }
+
+    String path = ZKMetadataProvider.constructPropertyStorePathForKafkaPartitions(tableName);
+    propertyStore.set(path, kafkaPartitionMapping, AccessOption.PERSISTENT);
+
+    return partitionToServers;
+  }
+
+  private RoutingTableBuilder buildPartitionAwareRealtimeRoutingTableBuilder(FakePropertyStore propertyStore,
+      TableConfig tableConfig, ExternalView externalView, List<InstanceConfig> instanceConfigs) throws Exception{
+
+    PartitionAwareRealtimeRoutingTableBuilder routingTableBuilder = new PartitionAwareRealtimeRoutingTableBuilder();
+    routingTableBuilder.init(null, tableConfig, propertyStore);
+    routingTableBuilder.computeRoutingTableFromExternalView(REALTIME_TABLE_NAME, externalView, instanceConfigs);
+
+    return routingTableBuilder;
+  }
+
+  private ExternalView buildExternalView(String tableName, FakePropertyStore propertyStore,
+      Map<Integer, List<String>> partitionToServerMapping, List<String> segmentList) throws Exception {
+
+    // Create External View
+    ExternalView externalView = new ExternalView(tableName);
+    for (String segmentName: segmentList) {
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+      int partitionId = llcSegmentName.getPartitionId();
+      for (String server: partitionToServerMapping.get(partitionId)) {
+        externalView.setState(segmentName, server, "ONLINE");
+      }
+    }
+    return externalView;
+  }
+
+  private RoutingTableLookupRequest buildRoutingTableLookupRequest(String query) {
+    Pql2Compiler compiler = new Pql2Compiler();
+    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
+    RoutingTableLookupRequest request = new RoutingTableLookupRequest(REALTIME_TABLE_NAME,
+        Collections.<String>emptyList(), brokerRequest);
+    return request;
+  }
+
+  private TableConfig buildRealtimeTableConfig() throws Exception {
+    // Create partition config
+    Map<String, ColumnPartitionConfig> metadataMap = new HashMap<>();
+    metadataMap.put(PARTITION_COLUMN, new ColumnPartitionConfig(PARTITION_FUNCTION_NAME, NUM_PARTITION));
+    SegmentPartitionConfig partitionConfig = new SegmentPartitionConfig(metadataMap);
+
+    // Create the routing config
+    RoutingConfig routingConfig = new RoutingConfig();
+    routingConfig.setRoutingTableBuilderName("PartitionAwareOffline");
+
+    // Create table config
+    TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME)
+        .setTableName(REALTIME_TABLE_NAME)
+        .setNumReplicas(NUM_REPLICA)
+        .build();
+
+    tableConfig.getValidationConfig().setReplicasPerPartition(Integer.toString(NUM_REPLICA));
+    tableConfig.getIndexingConfig().setSegmentPartitionConfig(partitionConfig);
+    tableConfig.setRoutingConfig(routingConfig);
+    return tableConfig;
+  }
+
+  private SegmentZKMetadata buildSegmentZKMetadata(String segmentName, int partition) {
+    LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+    Map<String, ColumnPartitionMetadata> columnPartitionMap = new HashMap<>();
+    columnPartitionMap.put(PARTITION_COLUMN, new ColumnPartitionMetadata(PARTITION_FUNCTION_NAME, NUM_PARTITION,
+        Collections.singletonList(new IntRange(partition))));
+    SegmentPartitionMetadata segmentPartitionMetadata = new SegmentPartitionMetadata(columnPartitionMap);
+
+    metadata.setSegmentName(segmentName);
+    metadata.setPartitionMetadata(segmentPartitionMetadata);
+    metadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+    return metadata;
+  }
+
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -63,11 +63,21 @@ public class CommonConstants {
       public static final String SCHEMA = "schema";
       public static final String KAFKA = "kafka";
       public static final String STREAM_PREFIX = "stream";
-      public static enum SegmentAssignmentStrategyType {
+      public enum SegmentAssignmentStrategyType {
         RandomAssignmentStrategy,
         BalanceNumSegmentAssignmentStrategy,
         BucketizedSegmentAssignmentStrategy,
-        ReplicaGroupSegmentAssignmentStrategy;
+        ReplicaGroupSegmentAssignmentStrategy
+      }
+
+      public enum RoutingTableBuilderName {
+        DefaultOffline,
+        DefaultRealtime,
+        BalancedRandom,
+        KafkaLowLevel,
+        KafkaHighLevel,
+        PartitionAwareOffline,
+        PartitionAwareRealtime
       }
 
       public static class Schema {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/TableConfigCache.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/TableConfigCache.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.helix.core.realtime;
+
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+
+
+/**
+ * Cache for table config.
+ */
+public class TableConfigCache {
+  private static final long DEFAULT_CACHE_SIZE = 50;
+  private static final long DEFAULT_CACHE_TIMEOUT_IN_MINUTE = 5;
+
+  private final LoadingCache<String, TableConfig> _tableConfigCache;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  public TableConfigCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _tableConfigCache = CacheBuilder.newBuilder()
+        .maximumSize(DEFAULT_CACHE_SIZE)
+        .expireAfterWrite(DEFAULT_CACHE_TIMEOUT_IN_MINUTE, TimeUnit.MINUTES)
+        .build(new CacheLoader<String, TableConfig>() {
+          @Override
+          public TableConfig load(String tableNameWithType) throws Exception {
+            return ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+          }
+        });
+    _propertyStore = propertyStore;
+  }
+
+  public TableConfig getTableConfig(String tableNameWithType) throws ExecutionException {
+    return _tableConfigCache.get(tableNameWithType);
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -792,7 +792,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       _nCallsToUpdateHelix++;
     }
 
-    protected void writeKafkaPartitionAssignemnt(final String realtimeTableName, ZNRecord znRecord) {
+    protected void writeKafkaPartitionAssignment(final String realtimeTableName, ZNRecord znRecord) {
       _partitionAssignment = znRecord;
     }
 

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SegmentId.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/SegmentId.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.transport.common;
 /**
  * Represent one segment in the system identified by a "string" type identifier
  *
+ * TODO: need to evaluate if we really need this class
  */
 public class SegmentId {
 


### PR DESCRIPTION
- Added the partition aware realtime routing table builder that can prune segments.
- Refactored the offline routing table builder to share the duplicate code with the
  realtime version.
- Added unit tests for both offline and realtime partition aware routing table builders.