### PR TITLE
[TE] filter-select component

### DIFF
--- a/thirdeye/thirdeye-frontend/.eslintrc.js
+++ b/thirdeye/thirdeye-frontend/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
   rules: {
     "eol-last": ["error", "always"],
     "indent": ["error", 2, { "SwitchCase": 1 }],
-    "space-in-parens": ["error", "never"]
+    "space-in-parens": ["error", "never"],
+    "no-trailing-spaces": ["error"],
   }
 };

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-select/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-select/component.js
@@ -1,0 +1,181 @@
+import Ember from 'ember';
+import { task, timeout } from 'ember-concurrency';
+
+/**
+ * Parse the filter Object and return a Object of groupName
+ * containing Arrays of filter options
+ * @param {Object} filters
+ */
+const buildFilterOptions = (filters) => {
+  return Object.keys(filters).map((filterName) => {
+
+    const options = filters[filterName]
+      .filter(value => !!value)
+      .map((value) => {
+        return {
+          name: value,
+          id: `${filterName}::${value}`
+        }
+      })
+
+    return {
+      groupName: `${filterName}`,
+      options
+    }
+  })
+};
+
+/**
+ * Converts the query Params JSON into
+ * powerselect compatible groups
+ * @param {Object} filters
+ */
+const convertHashToFilters = (filters) => {
+  const filterArray = [];
+
+  Object.keys(filters).forEach((filterGroup) => {
+    const options = filters[filterGroup].map((option) => {
+      return {
+        name: option,
+        id: `${filterGroup}::${option}`
+      }
+    })
+    filterArray.push(...options);
+  })
+
+  return filterArray;
+};
+
+/**
+ * Converts the powerselect grouped filters into
+ * JSON for query Params
+ * @param {Object} selectedFilters
+ */
+const convertFiltersToHash = (selectedFilters) => {
+  const filters = selectedFilters.reduce((filterHash, filter) => {
+    const [ filterGroup, filterName ] = filter.id.split('::');
+
+    filterHash[filterGroup] = filterHash[filterGroup] || [];
+    filterHash[filterGroup].push(filterName);
+
+    return filterHash;
+  }, {})
+
+  return JSON.stringify(filters);
+};
+
+/**
+ * Helper function performing the typeahead search
+ * @param   {Object} filterOptions  All Filters
+ * @param   {String} filterToMatch  Filter name to match
+ * @param   {Number} maxNum         Maximum Number of filters to display
+ * @returns {Array}                 Array that contains the ouput of the search
+ */
+const getSearchResults = (filterOptions, filterToMatch, maxNum) => {
+  let count = 0;
+  const filters = filterOptions.reduce((foundFilters, filterOption) => {
+    if (count > maxNum) {
+      return [];
+    }
+    let options = filterOption.options.filter((el) => {
+      return el.id.toLowerCase().includes(filterToMatch.toLowerCase());
+    })
+
+    if (options.length) {
+      count += options.length;
+      foundFilters.push({
+        groupName: `${filterOption.groupName} (${options.length})`,
+        options: options
+      });
+    }
+    return foundFilters;
+  }, []);
+
+  const NoMatchMessage = count
+    ? `Too Many results found (${count})`
+    : 'No results found.'
+
+  return [filters, NoMatchMessage];
+};
+
+
+export default Ember.Component.extend({
+  // Maximum filters by filter group
+  maxNumFilters: 25,
+
+  // Maximum total filter to display
+  maxTotalFilters: 100,
+
+  noMatchesMessage: '',
+
+  // selected Filters JSON
+  selected: {},
+
+  // all Filters Object
+  options: {},
+
+  /**
+   * Takes the filters and massage them for the power-select grouping api
+   * Currently not showing the whole list because of performance issues
+   */
+  filterOptions: Ember.computed('options', function() {
+    const filters = this.get('options') || {};
+
+    return buildFilterOptions(filters);
+  }),
+
+  // Selected Filters Serializer
+  selectedFilters: Ember.computed('selected', {
+    get() {
+      const filters = JSON.parse(this.get('selected'));
+
+      return convertHashToFilters(filters);
+    },
+    set(key, value) {
+      const filters = convertFiltersToHash(value);
+      this.set('selected', filters);
+
+      return value;
+    }
+  }),
+
+  // Initial filter View (subset of FilterOptions)
+  viewFilterOptions: Ember.computed(
+    'filterOptions.@each',
+    'maxNumFilters',
+    function() {
+      const maxNumFilters = this.get('maxNumFilters');
+      return [...this.get('filterOptions')].map((filter) => {
+        const viewFilter = Object.assign({}, filter);
+        viewFilter.groupName += ` (${viewFilter.options.length})`
+
+        if (viewFilter.options.length > maxNumFilters) {
+          viewFilter.options = viewFilter.options[0];
+        }
+        return viewFilter;
+      });
+    }
+  ),
+
+  /**
+   * Ember concurrency generator helper tasks
+   * that performs the typeahead search
+   */
+  searchByFilterName: task(function* (filter) {
+    yield timeout(600);
+
+    const filterOptions = [...this.get('filterOptions')];
+    const maxNum = this.get('maxTotalFilters');
+    const [ filters, message ] = getSearchResults(filterOptions, filter, maxNum);
+    this.set('noMatchesMessage', message);
+
+    return filters;
+  }),
+
+  actions: {
+    // Action handler for filter Selection/Deselection
+    onFilterChange(filters) {
+      this.set('selectedFilters', filters);
+    },
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-select/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-select/template.hbs
@@ -1,0 +1,11 @@
+{{#power-select-multiple 
+  selected=selectedFilters
+  options=viewFilterOptions
+  search=(perform searchByFilterName)
+  onchange=(action "onFilterChange")
+  placeholder="Add a filter (Type to search)"
+  noMatchesMessage=noMatchesMessage
+  as |filter|
+}}
+  {{filter.name}}
+{{/power-select-multiple}}

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/filter-select/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/filter-select/component-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('filter-select', 'Integration | Component | filter select', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{filter-select}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#filter-select}}
+      template block text
+    {{/filter-select}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
### What's new: 
Added a `filter-select` component that wraps around `power-select-multiple`. 
The default `power-select-multiple` component currently doesn't support lazy loading rendering; In thirdeye, the filter search can potentially return more than 1000 items, and this can take more than 15 sec to render. 

The `filter-select` component uses ember-concurrency's task to debounce searches and display result by group if a group has less than 25 items or the total search has less than 100 items (customizable) 

### Usage: 

```
{{filter-select
    options=metricFilters  // (required)  
    selected=filters  // (required) JSON filters (from endpoint)
    maxNumFilters=25  // (optional {default: 25}) max number of filters per group
    maxTotalFilters=100  // (optional {default:100}) max number of filters for the search
}}
```