### PR TITLE
[PINOT-4926] Introduce a memory manager so that we can switch between Mmap and direct allocation

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/OffHeapMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/OffHeapMemoryManager.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.io.readerwriter;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+/**
+ * @class OffHeapMemoryManager is an abstract class that implements base functionality to allocate and release
+ * memory that is acquired during realtime segment consumption.
+ *
+ * Realtime consuming segments use memory for dictionary, forward index, and inverted indices. For off-heap
+ * allocation of memory, we instantiate one OffHeapMemoryManager for each segment in the server,
+ *
+ * Closing the OffHeapMemoryManager also releases all the resources allocated by the OffHeapMemoryManager.
+ */
+public abstract class OffHeapMemoryManager implements Closeable {
+  protected final List<PinotDataBuffer> _buffers = new LinkedList<>();
+  protected final String _segmentName;
+
+  protected OffHeapMemoryManager(String segmentName) {
+    _segmentName = segmentName;
+  }
+
+  /**
+   * @return A string representing a context for all allocations using this policy
+   */
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  /**
+   * Allocate memory
+   * @param size size of memory
+   * @param columnName Name of the column for which memory is being allocated
+   * @return PinotDataBuffer
+   */
+  public abstract  PinotDataBuffer allocate(long size, String columnName);
+
+  public abstract void doClose();
+
+  /**
+   * Close out this memory manager and release all memory and resources
+   * @throws IOException
+   */
+  public void close() throws IOException {
+    for (PinotDataBuffer buffer : _buffers) {
+      buffer.close();
+    }
+    doClose();
+    _buffers.clear();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/DirectMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/DirectMemoryManager.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.io.writer.impl;
+
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+// Allocates memory using direct allocation
+public class DirectMemoryManager extends OffHeapMemoryManager {
+
+  public DirectMemoryManager(final String segmentName) {
+    super(segmentName);
+  }
+
+  @Override
+  public PinotDataBuffer allocate(long size, String columnName) {
+    return PinotDataBuffer.allocateDirect(size, getSegmentName() + "." + columnName);
+  }
+
+  @Override
+  public void doClose() {
+    // Nothing to do.
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MmapMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MmapMemoryManager.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.io.writer.impl;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.util.LinkedList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+/**
+ * @class MmapMemoryManager is an OffHeapMemoryManager that manages memory by
+ * allocating it via mmap.
+ *
+ * This class attempts to minimize the overall number of file handles used for mapping the files.
+ * We create files of length 0.25g (or the requested buffer length, whichever is higher),
+ * and map areas of the file for each allocation request within a segment.
+ *
+ * @note Thread-unsafe. We expect to use this class only in a single writer case.
+ */
+public class MmapMemoryManager extends OffHeapMemoryManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MmapMemoryManager.class);
+
+  private static final long FILE_LENGTH = 512 * 1024 * 1024L; // 0.5G per segment
+
+  private final String _dirPathName;
+  // It is possible that one thread stops consumption, and another thread takes over consumption, in LLC.
+  // So we should make numFiles as a volatile, in case buffer expansion happens in a different thread.
+  private volatile int _numFiles = 0;
+  private long _availableOffset = FILE_LENGTH; // Available offset in this file.
+  private long _curFileLen = -1;
+  private final List<String> _paths = new LinkedList<>();
+  PinotDataBuffer _currentBuffer;
+
+  /**
+   * @param dirPathName directory under which all mmap files are created.
+   * @param segmentName Name of the segment for which this memory manager allocates memory
+   */
+  public MmapMemoryManager(String dirPathName, String segmentName) {
+    super(segmentName);
+    _dirPathName = dirPathName;
+  }
+
+  private void addFileIfNecessary(long len) {
+    if (len + _availableOffset < _curFileLen) {
+      return;
+    }
+    String thisContext = getSegmentName() + "." + _numFiles++;
+    String filePath;
+    filePath = _dirPathName + "/" + thisContext;
+    final File file = new File(filePath);
+    if (file.exists()) {
+      throw new RuntimeException("File " + filePath + " already exists");
+    }
+    file.deleteOnExit();
+    RandomAccessFile raf;
+    try {
+      raf = new RandomAccessFile(filePath, "rw");
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    long fileLen = Math.max(FILE_LENGTH, len);
+    try {
+      raf.setLength(fileLen);
+      raf.close();
+      _currentBuffer = PinotDataBuffer.fromFile(file, ReadMode.mmap, FileChannel.MapMode.READ_WRITE, thisContext);
+    }  catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    _paths.add(filePath);
+    _buffers.add(_currentBuffer);
+    _availableOffset = 0;
+    _curFileLen = fileLen;
+  }
+
+  /**
+   * @param size size of memory to be mmaped
+   * @param columnName Name of the column for which memory is being allocated
+   * @return
+   */
+  @Override
+  public PinotDataBuffer allocate(long size, String columnName) {
+    addFileIfNecessary(size);
+    PinotDataBuffer buffer = _currentBuffer.view(_availableOffset, _availableOffset+size);
+    _availableOffset += size;
+    return buffer;
+  }
+
+  public void doClose() {
+    for (String path: _paths) {
+      try {
+        File file = new File(path);
+        file.delete();
+      } catch (Exception e) {
+        LOGGER.warn("Exception closing entry {}", path, e);
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.LinkedList;
 import java.util.List;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
@@ -96,11 +97,11 @@ public class MutableOffHeapByteArrayStore implements Closeable {
     private int _numValues = 0;
     private int _availEndOffset;  // Exclusive
 
-    private Buffer(long size, int startIndex) {
+    private Buffer(long size, int startIndex, OffHeapMemoryManager memoryManager, String columnName) {
       if (size >= Integer.MAX_VALUE) {
         size = Integer.MAX_VALUE - 1;
       }
-      _pinotDataBuffer = PinotDataBuffer.allocateDirect(size);
+      _pinotDataBuffer = memoryManager.allocate(size, columnName);
       _pinotDataBuffer.order(ByteOrder.nativeOrder());
       _byteBuffer = _pinotDataBuffer.toDirectByteBuffer(0, (int) size);
       _startIndex = startIndex;
@@ -170,8 +171,12 @@ public class MutableOffHeapByteArrayStore implements Closeable {
   private volatile List<Buffer> _buffers = new LinkedList<>();
   private int _numElements = 0;
   private volatile Buffer _currentBuffer;
+  private final OffHeapMemoryManager _memoryManager;
+  private final String _columnName;
 
-  public MutableOffHeapByteArrayStore() {
+  public MutableOffHeapByteArrayStore(OffHeapMemoryManager memoryManager, String columnName) {
+    _memoryManager = memoryManager;
+    _columnName = columnName;
     expand(START_SIZE, 0L);
   }
 
@@ -184,7 +189,7 @@ public class MutableOffHeapByteArrayStore implements Closeable {
    * @return
    */
   private Buffer expand(long suggestedSize, long minSize) {
-    Buffer buffer = new Buffer(Math.max(suggestedSize, minSize), _numElements);
+    Buffer buffer = new Buffer(Math.max(suggestedSize, minSize), _numElements, _memoryManager, _columnName);
     List<Buffer> newList = new LinkedList<>();
     for (Buffer b : _buffers) {
       newList.add(b);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -46,8 +46,10 @@ import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.readers.RecordReader;
 import com.linkedin.pinot.core.indexsegment.IndexType;
 import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.realtime.RealtimeSegment;
 import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
 import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
@@ -98,6 +100,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   private StarTreeIndexSpec starTreeIndexSpec = null;
   private SegmentPartitionConfig segmentPartitionConfig = null;
   private final List<String> consumingNoDictionaryColumns = new ArrayList<>();
+  private final OffHeapMemoryManager memoryManager;
 
   // TODO Dynamcally adjust these variables, maybe on a per column basis
 
@@ -117,6 +120,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     dictionaryMap = new HashMap<String, MutableDictionary>();
     maxNumberOfMultivaluesMap = new HashMap<String, Integer>();
     outgoingTimeColumnName = dataSchema.getTimeFieldSpec().getOutgoingTimeColumnName();
+    this.memoryManager = new DirectMemoryManager(segmentName);
 
     for (final String column : noDictionaryColumns) {
       // Not all no-dictionary columns can be so while the segment is being consumed.
@@ -165,12 +169,12 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       }
       if (schema.getFieldSpecFor(dimension).isSingleValueField()) {
         columnIndexReaderWriterMap.put(dimension,
-            new FixedByteSingleColumnSingleValueReaderWriter(capacity, V1Constants.Numbers.INTEGER_SIZE, segmentName + "." + dimension + ".fwd"));
+            new FixedByteSingleColumnSingleValueReaderWriter(capacity, V1Constants.Numbers.INTEGER_SIZE, memoryManager, dimension));
       } else {
         // TODO Start with a smaller capacity on FixedByteSingleColumnMultiValueReaderWriter and let it expand
         columnIndexReaderWriterMap.put(dimension,
             new FixedByteSingleColumnMultiValueReaderWriter(MAX_MULTI_VALUES_PER_ROW, avgMultiValueCount,
-                capacity, V1Constants.Numbers.INTEGER_SIZE, segmentName + "." + dimension + ".fwd"));
+                capacity, V1Constants.Numbers.INTEGER_SIZE, memoryManager, dimension));
       }
     }
 
@@ -183,14 +187,15 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
         colSize = getColWidth(schema.getFieldSpecFor(metric).getDataType());
       }
       columnIndexReaderWriterMap.put(metric,
-          new FixedByteSingleColumnSingleValueReaderWriter(capacity, colSize, segmentName + "." + metric + ".fwd"));
+          new FixedByteSingleColumnSingleValueReaderWriter(capacity, colSize, memoryManager, metric));
     }
 
     if (invertedIndexColumns.contains(outgoingTimeColumnName)) {
       invertedIndexMap.put(outgoingTimeColumnName, new TimeInvertedIndex(outgoingTimeColumnName));
     }
     columnIndexReaderWriterMap.put(outgoingTimeColumnName,
-        new FixedByteSingleColumnSingleValueReaderWriter(capacity, V1Constants.Numbers.INTEGER_SIZE, segmentName + outgoingTimeColumnName + ".fwd"));
+        new FixedByteSingleColumnSingleValueReaderWriter(capacity, V1Constants.Numbers.INTEGER_SIZE, memoryManager,
+            outgoingTimeColumnName));
 
     tableAndStreamName = tableName + "-" + streamName;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import javax.annotation.Nonnull;
@@ -157,6 +158,8 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
   // that we can call close() on these.
   private List<PinotDataBuffer> _pinotDataBuffers = new ArrayList<>();
   private final int _initialRowCount;
+  protected final OffHeapMemoryManager _memoryManager;
+  protected final String _columnName;
 
   /**
    * A class to hold all the objects needed for the reverse mapping.
@@ -182,7 +185,10 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
 
   private volatile ValueToDictId _valueToDict;
 
-  protected BaseOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize) {
+  protected BaseOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize, OffHeapMemoryManager memoryManager,
+      String columnName) {
+    _memoryManager = memoryManager;
+    _columnName = columnName;
     int initialRowCount = nearestPrime(estimatedCardinality);
     _numEntries = 0;
     _maxItemsInOverflowHash = maxOverflowHashSize;
@@ -288,7 +294,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
     for (IntBuffer iBuf : oldList) {
       newList.add(iBuf);
     }
-    PinotDataBuffer buffer = PinotDataBuffer.allocateDirect(bbSize);
+    PinotDataBuffer buffer = _memoryManager.allocate(bbSize, _columnName);
     _pinotDataBuffers.add(buffer);
     buffer.order(ByteOrder.nativeOrder());
     IntBuffer iBuf = buffer.toDirectByteBuffer(0L, bbSize).asIntBuffer();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import java.io.IOException;
 import java.util.Arrays;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import javax.annotation.Nonnull;
@@ -29,11 +30,12 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public DoubleOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize) {
-    super(estimatedCardinality, maxOverflowSize);
+  public DoubleOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, OffHeapMemoryManager memoryManager,
+      String columnName) {
+    super(estimatedCardinality, maxOverflowSize, memoryManager, columnName);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.DOUBLE_SIZE,
-        null);
+        memoryManager, columnName);
   }
 
   public Object get(int dictionaryId) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import java.io.IOException;
 import java.util.Arrays;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import javax.annotation.Nonnull;
@@ -29,11 +30,12 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public FloatOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize) {
-    super(estimatedCardinality, maxOverflowSize);
+  public FloatOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, OffHeapMemoryManager memoryManager,
+      String columnName) {
+    super(estimatedCardinality, maxOverflowSize, memoryManager, columnName);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.FLOAT_SIZE,
-        null);
+        memoryManager, columnName);
   }
 
   public Object get(int dictionaryId) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import java.io.IOException;
 import java.util.Arrays;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import javax.annotation.Nonnull;
@@ -29,11 +30,12 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public IntOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize) {
-    super(estimatedCardinality, maxOverflowSize);
+  public IntOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, OffHeapMemoryManager memoryManager,
+      String columnName) {
+    super(estimatedCardinality, maxOverflowSize, memoryManager, columnName);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.INTEGER_SIZE,
-        null);
+        memoryManager, columnName);
   }
 
   public Object get(int dictionaryId) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import java.io.IOException;
 import java.util.Arrays;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import javax.annotation.Nonnull;
@@ -29,11 +30,12 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public LongOffHeapMutableDictionary(int estimatedCardinality, int overflowSize) {
-    super(estimatedCardinality, overflowSize);
+  public LongOffHeapMutableDictionary(int estimatedCardinality, int overflowSize, OffHeapMemoryManager memoryManager,
+      String columnName) {
+    super(estimatedCardinality, overflowSize, memoryManager, columnName);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.LONG_SIZE,
-        null);
+        memoryManager, columnName);
   }
 
   public Object get(int dictionaryId) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -19,6 +19,7 @@ package com.linkedin.pinot.core.realtime.impl.dictionary;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
 import javax.annotation.Nonnull;
 
@@ -30,9 +31,10 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   private String _min = null;
   private String _max = null;
 
-  public StringOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize) {
-    super(estimatedCardinality, maxOverflowHashSize);
-    _byteStore = new MutableOffHeapByteArrayStore();
+  public StringOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize, OffHeapMemoryManager memoryManager,
+      String columnName) {
+    super(estimatedCardinality, maxOverflowHashSize, memoryManager, columnName);
+    _byteStore = new MutableOffHeapByteArrayStore(memoryManager, columnName);
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/RealtimeNoDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/RealtimeNoDictionaryTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
 
@@ -48,13 +49,13 @@ public class RealtimeNoDictionaryTest {
     _random = new Random(seed);
 
     FixedByteSingleColumnSingleValueReaderWriter intRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        _random.nextInt(NUM_ROWS)+1, Integer.SIZE/8, "int");
+        _random.nextInt(NUM_ROWS)+1, Integer.SIZE/8, new DirectMemoryManager("test"), "int");
     FixedByteSingleColumnSingleValueReaderWriter longRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        _random.nextInt(NUM_ROWS)+1, Long.SIZE/8, "long");
+        _random.nextInt(NUM_ROWS)+1, Long.SIZE/8, new DirectMemoryManager("test"), "long");
     FixedByteSingleColumnSingleValueReaderWriter floatRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        _random.nextInt(NUM_ROWS)+1, Float.SIZE/8, "float");
+        _random.nextInt(NUM_ROWS)+1, Float.SIZE/8, new DirectMemoryManager("test"), "float");
     FixedByteSingleColumnSingleValueReaderWriter doubleRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        _random.nextInt(NUM_ROWS)+1, Double.SIZE/8, "double");
+        _random.nextInt(NUM_ROWS)+1, Double.SIZE/8, new DirectMemoryManager("test"), "double");
 
     for (int i = 0; i < NUM_ROWS; i++) {
       _intVals[i] = _random.nextInt();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.indexsegment.utils;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import com.linkedin.pinot.core.io.readerwriter.OffHeapMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+public class MmapMemoryManagerTest {
+
+  private String _tmpDir;
+
+  @BeforeSuite
+  public void setUp() {
+    _tmpDir = System.getProperty("java.io.tmpdir") + "/" + MmapMemoryManagerTest.class.getSimpleName();
+    File dir = new File(_tmpDir);
+    FileUtils.deleteQuietly(dir);
+    dir.mkdir();
+    dir.deleteOnExit();
+  }
+
+  @AfterSuite
+  public void tearDown() {
+    new File(_tmpDir).delete();
+  }
+
+  @Test
+  public void testLargeBlocks() throws Exception {
+    final String segmentName = "someSegment";
+    OffHeapMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    final long s1 = 1024*1024*1024;
+    final long s2 = 1000;
+    final String col1 = "col1";
+    final String col2 = "col2";
+    final byte value = 34;
+    PinotDataBuffer buf1 = memoryManager.allocate(s1, col1);
+
+    // Verify that we can write to and read from the buffer
+    ByteBuffer b1 = buf1.toDirectByteBuffer(0, (int) s1);
+    b1.putLong(0, s1);
+    Assert.assertEquals(b1.getLong(0), s1);
+    b1.put((int)s1-1, value);
+    Assert.assertEquals(b1.get((int)s1-1), value);
+
+    PinotDataBuffer buf2 = memoryManager.allocate(s2, col2);
+    ByteBuffer b2 = buf2.toDirectByteBuffer(0, (int) s2);
+    b2.putLong(0, s2);
+    Assert.assertEquals(b2.getLong(0), s2);
+
+    File dir = new File(_tmpDir);
+    File[] files = dir.listFiles();
+    Assert.assertEquals(files.length, 2);
+
+    Arrays.sort(files, new Comparator<File>() {
+      @Override
+      public int compare(File o1, File o2) {
+        return o1.getName().compareTo(o2.getName());
+      }
+    });
+
+    String fileName = files[0].getName();
+    Assert.assertTrue(fileName.contains(segmentName));
+
+    fileName = files[1].getName();
+    Assert.assertTrue(fileName.contains(segmentName));
+
+    buf1.close();
+    buf2.close();
+
+    memoryManager.close();
+
+    Assert.assertEquals(new File(_tmpDir).listFiles().length, 0);
+  }
+
+  @Test
+  public void testSmallBlocksForSameColumn() throws Exception {
+    final String segmentName = "someSegment";
+    OffHeapMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    final long s1 = 500;
+    final long s2 = 1000;
+    final String col1 = "col1";
+    PinotDataBuffer buf1 = memoryManager.allocate(s1, col1);
+
+    PinotDataBuffer buf2 = memoryManager.allocate(s2, col1);
+
+    ByteBuffer b1 = buf1.toDirectByteBuffer(0, (int) s1);
+    b1.putLong(0, s1);
+
+    ByteBuffer b2 = buf2.toDirectByteBuffer(0, (int) s2);
+    b2.putLong(0, s2);
+
+    Assert.assertEquals(b1.getLong(0), s1);
+    Assert.assertEquals(b2.getLong(0), s2);
+
+    File dir = new File(_tmpDir);
+    Assert.assertEquals(dir.listFiles().length, 1);
+
+    buf1.close();
+    buf2.close();
+
+    memoryManager.close();
+
+    Assert.assertEquals(dir.listFiles().length, 0);
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.indexsegment.utils;
 
 import java.util.Arrays;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
 import junit.framework.Assert;
 
@@ -26,7 +27,8 @@ public class MutableOffHeapByteArrayStoreTest {
 
   @Test
   public void maxValueTest() throws Exception {
-    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore();
+    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore(new DirectMemoryManager("test"),
+        "stringColumn");
     final int arrSize = MutableOffHeapByteArrayStore.getStartSize();
     byte[] dataIn = new byte[arrSize-4];
     for (int i = 0; i < dataIn.length; i++) {
@@ -40,7 +42,8 @@ public class MutableOffHeapByteArrayStoreTest {
 
   @Test
   public void overflowTest() throws Exception {
-    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore();
+    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore(new DirectMemoryManager("test"),
+        "stringColumn");
     final int maxSize = MutableOffHeapByteArrayStore.getStartSize() - 4;
 
     byte[] b1 = new byte[3];

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/OffHeapStringStoreTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/OffHeapStringStoreTest.java
@@ -19,6 +19,7 @@ package com.linkedin.pinot.core.indexsegment.utils;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.OffHeapStringStore;
 
 
@@ -26,7 +27,7 @@ public class OffHeapStringStoreTest {
   private static Random RANDOM = new Random();
   @Test
   public void maxValueTest() throws Exception {
-    OffHeapStringStore store = new OffHeapStringStore();
+    OffHeapStringStore store = new OffHeapStringStore(new DirectMemoryManager("test"), "stringColumn");
     final int arrSize = OffHeapStringStore.getStartSize() - 4;
     String dataIn = generateRandomString(arrSize);
     int index = store.add(dataIn);
@@ -37,7 +38,7 @@ public class OffHeapStringStoreTest {
 
   @Test
   public void overflowTest() throws Exception {
-    OffHeapStringStore store = new OffHeapStringStore();
+    OffHeapStringStore store = new OffHeapStringStore(new DirectMemoryManager("test"), "stringColumn");
     final int maxSize = OffHeapStringStore.getStartSize() - 4;
 
     String b1 = generateRandomString(3);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.Constants;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 
 
@@ -44,13 +45,13 @@ public class RealtimeSingleValueIteratorTest {
     final long _seed = new Random().nextLong();
     _random = new Random(_seed);
     _intReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.INTEGER_SIZE,
-        "intReader");
+        new DirectMemoryManager("test"), "intReader");
     _longReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.LONG_SIZE,
-        "longReader");
+        new DirectMemoryManager("test"), "longReader");
     _floatReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.FLOAT_SIZE,
-        "floatReader");
+        new DirectMemoryManager("test"), "floatReader");
     _doubleReader = new FixedByteSingleColumnSingleValueReaderWriter(_random.nextInt(NUM_ROWS)+1, V1Constants.Numbers.DOUBLE_SIZE,
-        "doubleReader");
+        new DirectMemoryManager("test"), "doubleReader");
 
     for (int i = 0; i < NUM_ROWS; i++) {
       _intVals[i] = _random.nextInt();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeNoDictionaryColStatsTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeNoDictionaryColStatsTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
 
 
@@ -53,13 +54,13 @@ public class RealtimeNoDictionaryColStatsTest {
     random = new Random(seed);
 
     FixedByteSingleColumnSingleValueReaderWriter intRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        random.nextInt(NUM_ROWS)+1, Integer.SIZE/8, "int");
+        random.nextInt(NUM_ROWS)+1, Integer.SIZE/8, new DirectMemoryManager("test"), "int");
     FixedByteSingleColumnSingleValueReaderWriter longRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        random.nextInt(NUM_ROWS)+1, Long.SIZE/8, "long");
+        random.nextInt(NUM_ROWS)+1, Long.SIZE/8, new DirectMemoryManager("test"), "long");
     FixedByteSingleColumnSingleValueReaderWriter floatRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        random.nextInt(NUM_ROWS)+1, Float.SIZE/8, "float");
+        random.nextInt(NUM_ROWS)+1, Float.SIZE/8, new DirectMemoryManager("test"), "float");
     FixedByteSingleColumnSingleValueReaderWriter doubleRawIndex = new FixedByteSingleColumnSingleValueReaderWriter(
-        random.nextInt(NUM_ROWS)+1, Double.SIZE/8, "double");
+        random.nextInt(NUM_ROWS)+1, Double.SIZE/8, new DirectMemoryManager("test"), "double");
 
     _intMinVal = Integer.MAX_VALUE; _intMaxVal = Integer.MIN_VALUE;
     _longMinVal = Long.MAX_VALUE; _longMaxVal = Long.MIN_VALUE;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/ConcurrentReadWriteDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/ConcurrentReadWriteDictionaryTest.java
@@ -26,6 +26,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 
 
 /**
@@ -49,12 +50,14 @@ public class ConcurrentReadWriteDictionaryTest {
         dictionary.close();
       }
       {
-        MutableDictionary dictionary = new IntOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000);
+        MutableDictionary dictionary = new IntOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000,
+            new DirectMemoryManager("test"), "intColumn");
         testSingleReaderSingleWriter(dictionary, FieldSpec.DataType.INT);
         dictionary.close();
       }
       {
-        MutableDictionary dictionary = new StringOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000);
+        MutableDictionary dictionary = new StringOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000,
+            new DirectMemoryManager("test"), "stringColumn");
         testSingleReaderSingleWriter(dictionary, FieldSpec.DataType.STRING);
         dictionary.close();
       }
@@ -80,11 +83,13 @@ public class ConcurrentReadWriteDictionaryTest {
         testMultiReadersSingleWriter(dictionary, FieldSpec.DataType.INT);
       }
       {
-        MutableDictionary dictionary = new IntOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000);
+        MutableDictionary dictionary = new IntOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000,
+            new DirectMemoryManager("test"), "intColumn");
         testMultiReadersSingleWriter(dictionary, FieldSpec.DataType.INT);
       }
       {
-        MutableDictionary dictionary = new StringOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000);
+        MutableDictionary dictionary = new StringOffHeapMutableDictionary(NUM_ENTRIES / RANDOM.nextInt(NUM_ENTRIES/3), 2000,
+            new DirectMemoryManager("test"), "stringColumn");
         testMultiReadersSingleWriter(dictionary, FieldSpec.DataType.STRING);
       }
     } catch (Throwable t) {
@@ -141,27 +146,32 @@ public class ConcurrentReadWriteDictionaryTest {
         if (onHeap) {
           return new IntOnHeapMutableDictionary();
         }
-        return new IntOffHeapMutableDictionary(estCaridinality, maxOverflowSize);
+        return new IntOffHeapMutableDictionary(estCaridinality, maxOverflowSize, new DirectMemoryManager("test"),
+            "intColumn");
       case LONG:
         if (onHeap) {
           return new LongOnHeapMutableDictionary();
         }
-        return new LongOffHeapMutableDictionary(estCaridinality, maxOverflowSize);
+        return new LongOffHeapMutableDictionary(estCaridinality, maxOverflowSize, new DirectMemoryManager("test"),
+            "longColumn");
       case FLOAT:
         if (onHeap) {
           return new FloatOnHeapMutableDictionary();
         }
-        return new FloatOffHeapMutableDictionary(estCaridinality, maxOverflowSize);
+        return new FloatOffHeapMutableDictionary(estCaridinality, maxOverflowSize,
+            new DirectMemoryManager("floatColumn"), "floatColumn");
       case DOUBLE:
         if (onHeap) {
           return new DoubleOnHeapMutableDictionary();
         }
-        return new DoubleOffHeapMutableDictionary(estCaridinality, maxOverflowSize);
+        return new DoubleOffHeapMutableDictionary(estCaridinality, maxOverflowSize, new DirectMemoryManager("test"),
+            "doubleColumn");
       case STRING:
         if (onHeap) {
           return new StringOnHeapMutableDictionary();
         }
-        return new StringOffHeapMutableDictionary(estCaridinality, maxOverflowSize);
+        return new StringOffHeapMutableDictionary(estCaridinality, maxOverflowSize, new DirectMemoryManager("test"),
+            "stringColumn");
     }
     throw new UnsupportedOperationException("Unsupported type " + dataType.toString());
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
@@ -19,6 +19,7 @@ import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 
 
 public class MultiValueDictionaryTest {
@@ -39,7 +40,7 @@ public class MultiValueDictionaryTest {
       throws Exception {
     final LongOnHeapMutableDictionary dict = new LongOnHeapMutableDictionary();
     final FixedByteSingleColumnMultiValueReaderWriter indexer =
-        new FixedByteSingleColumnMultiValueReaderWriter(MAX_N_VALUES, MAX_N_VALUES/2, NROWS/3, Integer.SIZE/8, "indexer");
+        new FixedByteSingleColumnMultiValueReaderWriter(MAX_N_VALUES, MAX_N_VALUES/2, NROWS/3, Integer.SIZE/8, new DirectMemoryManager("test"), "indexer");
 
     // Insert rows into the indexer and dictionary
     Random random = new Random(seed);

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
@@ -22,6 +22,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 
 
 public class FixedByteSingleColumnMultiValueReaderWriterTest {
@@ -54,8 +55,7 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     int columnSizeInBytes = Integer.SIZE / 8;
     int maxNumberOfMultiValuesPerRow = 2000;
     readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 2, rows/2, columnSizeInBytes,
-            "testIntArray");
+        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 2, rows/2, columnSizeInBytes, new DirectMemoryManager("test"), "IntArray");
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -84,7 +84,7 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     // transition to new ones
     readerWriter =
         new FixedByteSingleColumnMultiValueReaderWriter(multiValuesPerRow, multiValuesPerRow, multiValuesPerRow * 2, columnSizeInBytes,
-            "testIntArrayFixedSize");
+            new DirectMemoryManager("test"), "IntArrayFixedSize");
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -112,7 +112,7 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     Random r = new Random(seed);
     readerWriter =
         new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 3, r.nextInt(rows) + 1, columnSizeInBytes,
-            "testWithZeroSize");
+            new DirectMemoryManager("test"), "ZeroSize");
 
     int[][] data = new int[rows][];
     for (int i = 0; i < rows; i++) {
@@ -144,7 +144,7 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
 
     FixedByteSingleColumnMultiValueReaderWriter readerWriter =
         new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, avgMultiValueCount,
-            rowCountPerChunk, columnSize, "readerWriter");
+            rowCountPerChunk, columnSize, new DirectMemoryManager("test"), "ReaderWriter");
 
     return readerWriter;
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnSingleValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnSingleValueReaderWriterTest.java
@@ -21,6 +21,7 @@ import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 
 
 public class FixedByteSingleColumnSingleValueReaderWriterTest {
@@ -43,7 +44,8 @@ public class FixedByteSingleColumnSingleValueReaderWriterTest {
   private void testInt(final Random r, final int rows, final int div) throws IOException {
     FixedByteSingleColumnSingleValueReaderWriter readerWriter;
     final int columnSizesInBytes = Integer.SIZE / 8;
-    readerWriter = new FixedByteSingleColumnSingleValueReaderWriter(rows/div, columnSizesInBytes, "testInt");
+    readerWriter = new FixedByteSingleColumnSingleValueReaderWriter(rows/div, columnSizesInBytes, new DirectMemoryManager("test"),
+        "Int");
     int[] data = new int[rows];
     for (int i = 0; i < rows; i++) {
       data[i] = r.nextInt();
@@ -87,7 +89,8 @@ public class FixedByteSingleColumnSingleValueReaderWriterTest {
   private void testLong(final Random r, final int rows, final int div) throws IOException {
     FixedByteSingleColumnSingleValueReaderWriter readerWriter;
     final int columnSizesInBytes = Long.SIZE / 8;
-    readerWriter = new FixedByteSingleColumnSingleValueReaderWriter(rows/div, columnSizesInBytes, "testLong");
+    readerWriter = new FixedByteSingleColumnSingleValueReaderWriter(rows/div, columnSizesInBytes, new DirectMemoryManager("test"),
+        "Long");
     long[] data = new long[rows];
     for (int i = 0; i < rows; i++) {
       data[i] = r.nextLong();

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkDictionary.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkDictionary.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.realtime.impl.dictionary.LongOffHeapMutableDictionary;
 import com.linkedin.pinot.core.realtime.impl.dictionary.LongOnHeapMutableDictionary;
 
@@ -70,7 +71,8 @@ public class BenchmarkDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public LongOffHeapMutableDictionary benchmarkOffHeapMidSizeWithOverflow() {
-    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY/3, 1000);
+    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY/3, 1000,
+        new DirectMemoryManager("test"), "longColumn");
 
     for (int i = 0; i < colValues.length; i++) {
       dictionary.index(colValues[i]);
@@ -84,7 +86,8 @@ public class BenchmarkDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public LongOffHeapMutableDictionary benchmarkOffHeapMidSizeWithoutOverflow() {
-    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY/3, 0);
+    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY/3, 0,
+        new DirectMemoryManager("test"), "longColumn");
 
     for (int i = 0; i < colValues.length; i++) {
       dictionary.index(colValues[i]);
@@ -99,7 +102,8 @@ public class BenchmarkDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public LongOffHeapMutableDictionary benchmarkOffHeapPreSizeWithOverflow() {
-    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY, 1000);
+    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY, 1000,
+        new DirectMemoryManager("test"), "longColumn");
 
     for (int i = 0; i < colValues.length; i++) {
       dictionary.index(colValues[i]);
@@ -113,7 +117,8 @@ public class BenchmarkDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public LongOffHeapMutableDictionary benchmarkOffHeapPreSizeWithoutOverflow() {
-    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY, 0);
+    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(CARDINALITY, 0,
+        new DirectMemoryManager("test"), "longColumn");
 
     for (int i = 0; i < colValues.length; i++) {
       dictionary.index(colValues[i]);
@@ -127,7 +132,8 @@ public class BenchmarkDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public LongOffHeapMutableDictionary benchmarkOffHeapMinSizeWithoutOverflow() {
-    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(10000, 0);
+    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(10000, 0, new DirectMemoryManager("test"),
+        "longColumn");
 
     for (int i = 0; i < colValues.length; i++) {
       dictionary.index(colValues[i]);
@@ -141,7 +147,8 @@ public class BenchmarkDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public LongOffHeapMutableDictionary benchmarkOffHeapMinSizeWithOverflow() {
-    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(10000, 1000);
+    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(10000, 1000,
+        new DirectMemoryManager("test"), "longColumn");
 
     for (int i = 0; i < colValues.length; i++) {
       dictionary.index(colValues[i]);

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOffHeapDictionaryMemory.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOffHeapDictionaryMemory.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.perf;
 
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOffHeapMutableDictionary;
 import com.linkedin.pinot.core.realtime.impl.dictionary.LongOffHeapMutableDictionary;
 
@@ -45,7 +46,8 @@ public class BenchmarkOffHeapDictionaryMemory {
   }
 
   private BaseOffHeapMutableDictionary testMem(final int actualCardinality, final int initialCardinality, final int maxOverflowSize) throws Exception {
-    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(initialCardinality, maxOverflowSize);
+    LongOffHeapMutableDictionary dictionary = new LongOffHeapMutableDictionary(initialCardinality, maxOverflowSize,
+        new DirectMemoryManager("test"), "longColumn");
 
     for (int i = 0; i < colValues.length; i++) {
       dictionary.index(colValues[i]);

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
@@ -31,6 +31,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.realtime.impl.dictionary.StringOffHeapMutableDictionary;
 import com.linkedin.pinot.core.realtime.impl.dictionary.StringOnHeapMutableDictionary;
 
@@ -72,7 +73,8 @@ public class BenchmarkStringDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public StringOffHeapMutableDictionary benchmarkOffHeapStringDictionary() {
-    StringOffHeapMutableDictionary dictionary = new StringOffHeapMutableDictionary(10, 10);
+    StringOffHeapMutableDictionary dictionary = new StringOffHeapMutableDictionary(10, 10,
+        new DirectMemoryManager("test"), "stringColumn");
 
     for (int i = 0; i < stringValues.length; i++) {
       dictionary.index(stringValues[i]);


### PR DESCRIPTION
Introduced the abstract class OffHeapMemoryManager, and the two concrete sub-classes DirectMemoryManager
and MmapMemoryManager.

Re-factored all the classes allocating memory for real-time segments to use the OffHeapMemoryManager abstract
class to allocate memory.