### PR TITLE
Implement an endpoint that surfaces the baseline calculated by anomaly functions

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -367,7 +367,7 @@ public class ClassificationTaskRunner implements TaskRunner {
     }
     AnomalyDetectionInputContext adInputContext = anomalyDetectionInputContextBuilder.build();
 
-    MetricTimeSeries metricTimeSeries = adInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
+    MetricTimeSeries metricTimeSeries = adInputContext.getDimensionMapMetricTimeSeriesMap().get(dimensions);
     if (metricTimeSeries != null) {
       List<MergedAnomalyResultDTO> knownAnomalies = adInputContext.getKnownMergedAnomalies().get(dimensions);
       // Transform time series with scaling factor

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContext.java
@@ -13,19 +13,19 @@ import java.util.Map;
 
 
 public class AnomalyDetectionInputContext {
-  Map<DimensionMap, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap = Collections.emptyMap();
+  Map<DimensionMap, MetricTimeSeries> dimensionMapMetricTimeSeriesMap = Collections.emptyMap();
   MetricTimeSeries globalMetric;
   ListMultimap<DimensionMap, RawAnomalyResultDTO> existingRawAnomalies = ArrayListMultimap.create();;
   ListMultimap<DimensionMap, MergedAnomalyResultDTO> knownMergedAnomalies = ArrayListMultimap.create();;
   List<ScalingFactor> scalingFactors = Collections.emptyList();
 
-  public Map<DimensionMap, MetricTimeSeries> getDimensionKeyMetricTimeSeriesMap() {
-    return dimensionKeyMetricTimeSeriesMap;
+  public Map<DimensionMap, MetricTimeSeries> getDimensionMapMetricTimeSeriesMap() {
+    return dimensionMapMetricTimeSeriesMap;
   }
 
-  public void setDimensionKeyMetricTimeSeriesMap(
-      Map<DimensionMap, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap) {
-    this.dimensionKeyMetricTimeSeriesMap = dimensionKeyMetricTimeSeriesMap;
+  public void setDimensionMapMetricTimeSeriesMap(
+      Map<DimensionMap, MetricTimeSeries> dimensionMapMetricTimeSeriesMap) {
+    this.dimensionMapMetricTimeSeriesMap = dimensionMapMetricTimeSeriesMap;
   }
 
   public ListMultimap<DimensionMap, RawAnomalyResultDTO> getExistingRawAnomalies() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContextBuilder.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContextBuilder.java
@@ -131,7 +131,7 @@ public class AnomalyDetectionInputContextBuilder {
         LOG.warn("Insufficient data for {} to run anomaly detection function", dimensionMap);
       }
     }
-    this.anomalyDetectionInputContext.setDimensionKeyMetricTimeSeriesMap(dimensionMapMetricTimeSeriesMap);
+    this.anomalyDetectionInputContext.setDimensionMapMetricTimeSeriesMap(dimensionMapMetricTimeSeriesMap);
 
     return this;
   }
@@ -224,7 +224,7 @@ public class AnomalyDetectionInputContextBuilder {
         getTimeSeriesByDimension(anomalyFunctionSpec, startEndTimeRanges, dimensions, timeGranularity, endTimeInclusive);
     Map<DimensionMap, MetricTimeSeries> metricTimeSeriesMap = new HashMap<>();
     metricTimeSeriesMap.put(dimensions, metricTimeSeries);
-    this.anomalyDetectionInputContext.setDimensionKeyMetricTimeSeriesMap(metricTimeSeriesMap);
+    this.anomalyDetectionInputContext.setDimensionMapMetricTimeSeriesMap(metricTimeSeriesMap);
 
     return this;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -164,11 +164,11 @@ public class DetectionTaskRunner implements TaskRunner {
     ListMultimap<DimensionMap, RawAnomalyResultDTO> resultRawAnomalies = ArrayListMultimap.create();
 
     DataFilter dataFilter = DataFilterFactory.fromSpec(anomalyFunctionSpec.getDataFilter());
-    for (DimensionMap dimensionMap : anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().keySet()) {
+    for (DimensionMap dimensionMap : anomalyDetectionInputContext.getDimensionMapMetricTimeSeriesMap().keySet()) {
       // Skip anomaly detection if the current time series does not pass data filter, which may check if the traffic
       // or total count of the data has enough volume for produce sufficient confidence anomaly results
       MetricTimeSeries metricTimeSeries =
-          anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensionMap);
+          anomalyDetectionInputContext.getDimensionMapMetricTimeSeriesMap().get(dimensionMap);
       if (!dataFilter.isQualified(metricTimeSeries, dimensionMap, windowStart.getMillis(), windowEnd.getMillis())) {
         continue;
       }
@@ -194,7 +194,7 @@ public class DetectionTaskRunner implements TaskRunner {
     List<RawAnomalyResultDTO> resultsOfAnEntry = Collections.emptyList();
 
     String metricName = anomalyFunction.getSpec().getTopicMetric();
-    MetricTimeSeries metricTimeSeries = anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensionMap);
+    MetricTimeSeries metricTimeSeries = anomalyDetectionInputContext.getDimensionMapMetricTimeSeriesMap().get(dimensionMap);
 
     /*
     Check if current task is running offline analysis

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -260,7 +260,7 @@ public class AnomalyMergeExecutor implements Runnable {
         .fetchExistingMergedAnomaliesByDimension(anomalyResultStart, anomalyResultEnd, dimensions)
         .fetchScalingFactors(anomalyResultStart, anomalyResultEnd);
     AnomalyDetectionInputContext anomalyDetectionInputContext = anomalyDetectionInputContextBuilder.build();
-    MetricTimeSeries metricTimeSeries = anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
+    MetricTimeSeries metricTimeSeries = anomalyDetectionInputContext.getDimensionMapMetricTimeSeriesMap().get(dimensions);
 
     if (metricTimeSeries != null) {
       DateTime windowStart = new DateTime(anomalyMergedResult.getStartTime());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -257,7 +257,7 @@ public class TimeBasedAnomalyMerger {
     }
     AnomalyDetectionInputContext adInputContext = anomalyDetectionInputContextBuilder.build();
 
-    MetricTimeSeries metricTimeSeries = adInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
+    MetricTimeSeries metricTimeSeries = adInputContext.getDimensionMapMetricTimeSeriesMap().get(dimensions);
 
     if (metricTimeSeries != null) {
       List<MergedAnomalyResultDTO> knownAnomalies = adInputContext.getKnownMergedAnomalies().get(dimensions);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyFunctionResource.java
@@ -125,7 +125,7 @@ public class AnomalyFunctionResource {
     AnomalyDetectionInputContext anomalyDetectionInputContext = anomalyDetectionInputContextBuilder.build();
 
     Map<DimensionMap, MetricTimeSeries> dimensionKeyMetricTimeSeriesMap =
-        anomalyDetectionInputContext.getDimensionKeyMetricTimeSeriesMap();
+        anomalyDetectionInputContext.getDimensionMapMetricTimeSeriesMap();
 
     List<RawAnomalyResultDTO> anomalyResults = new ArrayList<>();
     List<RawAnomalyResultDTO> results = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -848,7 +848,7 @@ public class AnomalyResource {
 
       AnomalyDetectionInputContext adInputContext = anomalyDetectionInputContextBuilder.build();
 
-      MetricTimeSeries metricTimeSeries = adInputContext.getDimensionKeyMetricTimeSeriesMap().get(dimensions);
+      MetricTimeSeries metricTimeSeries = adInputContext.getDimensionMapMetricTimeSeriesMap().get(dimensions);
 
       if (metricTimeSeries == null) {
         // If this case happened, there was something wrong with anomaly detection because we are not able to retrieve


### PR DESCRIPTION
1. Add an end-point that can surface the baseline from anomaly functions to the user interface, even though no anomalies are detected. Normally, the baseline from anomaly functions can be surfaced when there is an anomaly. But if user wants to know the baseline information, there is no way to surface that yet. This endpoint can help thirdeye surface the baseline from anomaly functions to users.

2. Unify the baseline calculation in the AnomaliesResource, so that both AnomalyDetail and the new end-point use the same function to calculate the baseline values.