### PR TITLE
Avoid creation of byte[] during DataTable deserialization.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
@@ -424,10 +424,10 @@ public class DataTableImplV2 implements DataTable {
   public <T> T getObject(int rowId, int colId) {
     int size = positionCursorInVariableBuffer(rowId, colId);
     ObjectType objectType = ObjectType.getObjectType(_variableSizeData.getInt());
-    byte[] bytes = new byte[size];
-    _variableSizeData.get(bytes);
+    ByteBuffer byteBuffer = _variableSizeData.slice();
+    byteBuffer.limit(size);
     try {
-      return ObjectCustomSerDe.deserialize(bytes, objectType);
+      return ObjectCustomSerDe.deserialize(byteBuffer, objectType);
     } catch (IOException e) {
       throw new RuntimeException("Caught exception while de-serializing object.", e);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/customobject/AvgPair.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/customobject/AvgPair.java
@@ -57,7 +57,11 @@ public class AvgPair implements Comparable<AvgPair> {
 
   @Nonnull
   public static AvgPair fromBytes(byte[] bytes) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    return fromByteBuffer(ByteBuffer.wrap(bytes));
+  }
+
+  @Nonnull
+  public static AvgPair fromByteBuffer(ByteBuffer byteBuffer) {
     return new AvgPair(byteBuffer.getDouble(), byteBuffer.getLong());
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/customobject/MinMaxRangePair.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/customobject/MinMaxRangePair.java
@@ -65,7 +65,11 @@ public class MinMaxRangePair implements Comparable<MinMaxRangePair> {
 
   @Nonnull
   public static MinMaxRangePair fromBytes(byte[] bytes) {
-    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    return fromByteBuffer(ByteBuffer.wrap(bytes));
+  }
+
+  @Nonnull
+  public static MinMaxRangePair fromByteBuffer(ByteBuffer byteBuffer) {
     return new MinMaxRangePair(byteBuffer.getDouble(), byteBuffer.getDouble());
   }
 


### PR DESCRIPTION
During deserialization of DataTable, we create new byte[] and copy out
bytes from a ByteBuffer, and then wrap byte[] into a ByteBuffer for
deserialization. This change eliminates the creation of temporary byte[]
and its wrapping into ByteBuffer by directly slicing out a new
ByteBuffer from the original ByteBuffer.

While the total number of objects created does not reduce, creation of
byte[] and data copy is replaced by creation of shallow ByteBuffer
slices.