### PR TITLE
Adding default aggregation function as a metric field, so that we don't always default to SUM

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/MetricAggFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/MetricAggFunction.java
@@ -1,5 +1,5 @@
 package com.linkedin.thirdeye.constant;
 
 public enum MetricAggFunction {
-  SUM, AVG, COUNT
+  SUM, AVG, COUNT, MAX
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -382,7 +382,8 @@ public class DataResource {
 
     HeatMapViewRequest request = new HeatMapViewRequest();
     request.setCollection(collection);
-    List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metric, MetricAggFunction.SUM, collection);
+    List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metric,
+        metricConfigDTO.getDefaultAggFunction(), collection);
 
     request.setMetricExpressions(metricExpressions);
     long maxDataTime = collectionMaxDataTimeCache.get(collection);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.thirdeye.api.MetricType;
+import com.linkedin.thirdeye.constant.MetricAggFunction;
 
 import java.util.Map;
 import java.util.Objects;
@@ -14,6 +15,7 @@ public class MetricConfigBean extends AbstractBean {
   public static final String ALIAS_JOINER = "::";
   public static final String URL_TEMPLATE_START_TIME = "startTime";
   public static final String URL_TEMPLATE_END_TIME = "endTime";
+  public static final MetricAggFunction DEFAULT_AGG_FUNCTION = MetricAggFunction.SUM;
 
   private String name;
 
@@ -26,6 +28,8 @@ public class MetricConfigBean extends AbstractBean {
   private boolean derived = false;
 
   private String derivedMetricExpression;
+
+  private MetricAggFunction defaultAggFunction = DEFAULT_AGG_FUNCTION;
 
   private Double rollupThreshold = DEFAULT_THRESHOLD;
 
@@ -88,6 +92,14 @@ public class MetricConfigBean extends AbstractBean {
 
   public void setDerivedMetricExpression(String derivedMetricExpression) {
     this.derivedMetricExpression = derivedMetricExpression;
+  }
+
+  public MetricAggFunction getDefaultAggFunction() {
+    return defaultAggFunction;
+  }
+
+  public void setDefaultAggFunction(MetricAggFunction defaultAggFunction) {
+    this.defaultAggFunction = defaultAggFunction;
   }
 
   public Double getRollupThreshold() {
@@ -158,6 +170,7 @@ public class MetricConfigBean extends AbstractBean {
         && Objects.equals(alias, mc.getAlias())
         && Objects.equals(derived, mc.isDerived())
         && Objects.equals(derivedMetricExpression, mc.getDerivedMetricExpression())
+        && Objects.equals(defaultAggFunction, mc.getDefaultAggFunction())
         && Objects.equals(rollupThreshold, mc.getRollupThreshold())
         && Objects.equals(inverseMetric, mc.isInverseMetric())
         && Objects.equals(cellSizeExpression, mc.getCellSizeExpression())
@@ -168,7 +181,7 @@ public class MetricConfigBean extends AbstractBean {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getId(), dataset, alias, derived, derivedMetricExpression, rollupThreshold,
+    return Objects.hash(getId(), dataset, alias, derived, derivedMetricExpression, defaultAggFunction, rollupThreshold,
         inverseMetric, cellSizeExpression, active, extSourceLinkInfo, metricProperties);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
@@ -240,7 +240,8 @@ public class DimensionAnalysisPipeline extends Pipeline {
 
   private OLAPDataBaseClient getOlapDataBaseClient(TimeRangeEntity current, TimeRangeEntity baseline, MetricConfigDTO metric, DatasetConfigDTO dataset) throws Exception {
     final String timezone = "UTC";
-    List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metric.getName(), MetricAggFunction.SUM, dataset.getDataset());
+    List<MetricExpression> metricExpressions = Utils.convertToMetricExpressions(metric.getName(),
+        metric.getDefaultAggFunction(), dataset.getDataset());
 
     OLAPDataBaseClient olapClient = new PinotThirdEyeSummaryClient(cache);
     olapClient.setCollection(dataset.getDataset());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricCorrelationRankingPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricCorrelationRankingPipeline.java
@@ -1,6 +1,18 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
-import com.linkedin.thirdeye.constant.MetricAggFunction;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import com.linkedin.thirdeye.dataframe.DataFrameUtils;
@@ -21,17 +33,6 @@ import com.linkedin.thirdeye.rootcause.Entity;
 import com.linkedin.thirdeye.rootcause.Pipeline;
 import com.linkedin.thirdeye.rootcause.PipelineContext;
 import com.linkedin.thirdeye.rootcause.PipelineResult;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -303,7 +304,8 @@ public class MetricCorrelationRankingPipeline extends Pipeline {
       throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for metric id '%d'", metric.getDataset(), metric.getId()));
 
     List<MetricFunction> functions = new ArrayList<>();
-    List<MetricExpression> expressions = Utils.convertToMetricExpressions(metric.getName(), MetricAggFunction.SUM, metric.getDataset());
+    List<MetricExpression> expressions = Utils.convertToMetricExpressions(metric.getName(),
+        metric.getDefaultAggFunction(), metric.getDataset());
     for(MetricExpression exp : expressions) {
       functions.addAll(exp.computeMetricFunctions());
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -249,7 +249,8 @@ public abstract class ThirdEyeUtils {
     } else {
       expression = MetricConfigBean.DERIVED_METRIC_ID_PREFIX + metricConfig.getId();
     }
-    MetricExpression metricExpression = new MetricExpression(metricConfig.getName(), expression, metricConfig.getDataset());
+    MetricExpression metricExpression = new MetricExpression(metricConfig.getName(), expression,
+        metricConfig.getDefaultAggFunction(), metricConfig.getDataset());
     return metricExpression;
   }
 


### PR DESCRIPTION
In thirdeye we've defaulted to using sum everywhere in metric functions. We want to be able to support max, count etc in data fetches. This PR will enable us to set a default agg function for a metric
After this PR, we should extend this feature to be able to get in the agg function as input from the front end interfaces. While it is okay to have a default agg function for metrics, the agg function should be independent of the metric, and we should be able to apply any agg function on any metric at runtime.