### PR TITLE
[TE] Shade Apache hadoop jar to solve runtime error

### DIFF
--- a/thirdeye/thirdeye-hadoop/pom.xml
+++ b/thirdeye/thirdeye-hadoop/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Problem:
thirdeye.org.apache.hadoop.mapreduce.Job could not be found during runtime. The reason is that we assume org.apache.hadoop is given and hence it is not shaded in thirdeye-hadoop.jar.

Fix:
Add org.apache.hadoop to thirdeye-hadoop.jar and rename it to thirdeye.org.apache.hadoop.

Test:
Local.