### PR TITLE
Refactor AvroRecordToPinotRowGenerator for bug-fix and cleaner logic

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/AvroRecordToPinotRowGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/AvroRecordToPinotRowGenerator.java
@@ -15,82 +15,75 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
-import com.linkedin.pinot.common.data.TimeFieldSpec;
-
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericData.Array;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.util.Utf8;
-
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.readers.AvroRecordReader;
+import javax.annotation.Nonnull;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Array;
 
 
 public class AvroRecordToPinotRowGenerator {
-  private final Schema indexingSchema;
-  private final String incomingTimeColumnName;
-  private final FieldSpec incomingTimeFieldSpec;
+  private final Schema _schema;
+  private final FieldSpec _incomingTimeFieldSpec;
 
-  public AvroRecordToPinotRowGenerator(Schema indexingSchema) {
-    this.indexingSchema = indexingSchema;
-    incomingTimeColumnName = indexingSchema.getTimeFieldSpec().getIncomingTimeColumnName();
-    if (indexingSchema.getTimeColumnName().equals(incomingTimeColumnName)) {
-      incomingTimeFieldSpec = new TimeFieldSpec(indexingSchema.getTimeFieldSpec().getIncomingGranularitySpec());
-    } else {
-      incomingTimeFieldSpec = indexingSchema.getTimeFieldSpec();
-    }
+  public AvroRecordToPinotRowGenerator(@Nonnull Schema schema) {
+    _schema = schema;
+
+    // For time field, we use the incoming time field spec
+    TimeFieldSpec timeFieldSpec = schema.getTimeFieldSpec();
+    Preconditions.checkNotNull(timeFieldSpec);
+    _incomingTimeFieldSpec = new TimeFieldSpec(timeFieldSpec.getIncomingGranularitySpec());
   }
 
-  public GenericRow transform(GenericData.Record record, org.apache.avro.Schema schema, GenericRow destination) {
-    FieldSpec fieldSpec;
-    for (String column : indexingSchema.getColumnNames()) {
-      if (column.equals(indexingSchema.getTimeFieldSpec().getOutgoingTimeColumnName())) {
-        column = incomingTimeColumnName;
-        fieldSpec = incomingTimeFieldSpec;
-      } else {
-        fieldSpec = indexingSchema.getFieldSpecFor(column);
+  @Nonnull
+  public GenericRow transform(@Nonnull GenericData.Record avroRecord, @Nonnull GenericRow destination) {
+    FieldSpec incomingFieldSpec;
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      switch (fieldSpec.getFieldType()) {
+        case TIME:
+          incomingFieldSpec = _incomingTimeFieldSpec;
+          break;
+        default:
+          incomingFieldSpec = fieldSpec;
+          break;
       }
-      Object entry = record.get(column);
+      String columnName = incomingFieldSpec.getName();
 
+      Object entry = avroRecord.get(columnName);
       if (entry != null) {
+        // Entry is not null
         if (entry instanceof Array) {
-          entry = AvroRecordReader.transformAvroArrayToObjectArray((Array) entry, fieldSpec);
-          if (fieldSpec.getDataType() == DataType.STRING || fieldSpec.getDataType() == DataType.STRING_ARRAY) {
-            for (int i = 0; i < ((Object[]) entry).length; ++i) {
-              if (((Object[]) entry)[i] != null) {
-                ((Object[]) entry)[i] = ((Object[]) entry)[i].toString();
+          Object[] entryArray = AvroRecordReader.transformAvroArrayToObjectArray((Array) entry, incomingFieldSpec);
+          if (incomingFieldSpec.getDataType() == DataType.STRING) {
+            int length = entryArray.length;
+            for (int i = 0; i < length; i++) {
+              if (entryArray[i] != null) {
+                entryArray[i] = entryArray[i].toString();
               }
             }
           }
+          entry = entryArray;
         } else {
-          if (entry instanceof Utf8) {
-            entry = ((Utf8) entry).toString();
-          }
-          if (fieldSpec.getDataType() == DataType.STRING) {
+          if (incomingFieldSpec.getDataType() == DataType.STRING) {
             entry = entry.toString();
           }
         }
       } else {
-        // entry was null.
-        if (fieldSpec.isSingleValueField()) {
-          entry = AvroRecordReader.getDefaultNullValue(fieldSpec);
+        // Entry is null
+        if (incomingFieldSpec.isSingleValueField()) {
+          // Single-value field
+          entry = AvroRecordReader.getDefaultNullValue(incomingFieldSpec);
         } else {
-          // A multi-value field, and null. Any of the instanceof checks above will not match, so we need to repeat some
-          // of the logic above here.
-          entry = AvroRecordReader.transformAvroArrayToObjectArray((Array) entry, fieldSpec);
-          if (fieldSpec.getDataType() == DataType.STRING || fieldSpec.getDataType() == DataType.STRING_ARRAY) {
-            for (int i = 0; i < ((Object[]) entry).length; ++i) {
-              if (((Object[]) entry)[i] != null) {
-                ((Object[]) entry)[i] = ((Object[]) entry)[i].toString();
-              }
-            }
-          }
+          // Multi-value field
+          entry = new Object[]{AvroRecordReader.getDefaultNullValue(incomingFieldSpec)};
         }
       }
-      destination.putField(column, entry);
+      destination.putField(columnName, entry);
     }
 
     return destination;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
@@ -109,10 +109,9 @@ public class KafkaAvroMessageDecoder implements KafkaMessageDecoder {
     }
     DatumReader<Record> reader = new GenericDatumReader<Record>(schema);
     try {
-      GenericData.Record avroRecord =
-          reader.read(null, decoderFactory.createBinaryDecoder(payload, HEADER_LENGTH + offset,
-              length - HEADER_LENGTH, null));
-      return avroRecordConvetrer.transform(avroRecord, schema, destination);
+      GenericData.Record avroRecord = reader.read(null,
+          decoderFactory.createBinaryDecoder(payload, HEADER_LENGTH + offset, length - HEADER_LENGTH, null));
+      return avroRecordConvetrer.transform(avroRecord, destination);
     } catch (IOException e) {
       LOGGER.error("Caught exception while reading message using schema {}{}", (schema==null ? "null" : schema.getName()),
           (schemaUpdateFailed? "(possibly due to schema update failure)" : ""), e);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/AvroRecordToPinotRowGeneratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/AvroRecordToPinotRowGeneratorTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl.kafka;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.data.GenericRow;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AvroRecordToPinotRowGeneratorTest {
+
+  @Test
+  public void testIncomingTimeColumn() throws Exception {
+    List<Schema.Field> avroFields =
+        Collections.singletonList(new Schema.Field("incomingTime", Schema.create(Schema.Type.LONG), null, null));
+    Schema avroSchema = Schema.createRecord(avroFields);
+    GenericData.Record avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("incomingTime", 12345L);
+
+    com.linkedin.pinot.common.data.Schema pinotSchema =
+        new com.linkedin.pinot.common.data.Schema.SchemaBuilder().setSchemaName("testSchema")
+            .addTime("incomingTime", TimeUnit.MILLISECONDS, FieldSpec.DataType.LONG, "outgoingTime", TimeUnit.DAYS,
+                FieldSpec.DataType.INT)
+            .build();
+
+    AvroRecordToPinotRowGenerator avroRecordToPinotRowGenerator = new AvroRecordToPinotRowGenerator(pinotSchema);
+    GenericRow genericRow = new GenericRow();
+    avroRecordToPinotRowGenerator.transform(avroRecord, genericRow);
+
+    Assert.assertEquals(genericRow.getFieldNames(), new String[]{"incomingTime"});
+    Assert.assertEquals(genericRow.getValue("incomingTime"), 12345L);
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -288,7 +288,7 @@ public abstract class ClusterTest extends ControllerTest {
       try {
         GenericData.Record avroRecord =
             _reader.read(null, _decoderFactory.binaryDecoder(payload, offset, length, null));
-        return _rowGenerator.transform(avroRecord, _avroSchema, destination);
+        return _rowGenerator.transform(avroRecord, destination);
       } catch (Exception e) {
         LOGGER.error("Caught exception", e);
         throw new RuntimeException(e);


### PR DESCRIPTION
1. Fix the issue where incomingTimeFieldSpec is not correctly created
2. Do not rely on time column name because incoming and outgoing could have the same column name
3. Simplify the logic of transform