### PR TITLE
Optimize ControllerTenantTest and ControllerInstanceToggleTest

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
@@ -65,7 +65,6 @@ public class ControllerRequestBuilderUtil {
       } else {
         helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, brokerId, UNTAGGED_BROKER_INSTANCE);
       }
-      Thread.sleep(1000);
     }
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -16,17 +16,15 @@
 package com.linkedin.pinot.controller.helix;
 
 import com.linkedin.pinot.common.config.TableConfig;
-import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.core.query.utils.SimpleSegmentMetadata;
 import java.util.Set;
-import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.ExternalView;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -34,146 +32,107 @@ import org.testng.annotations.Test;
 
 
 public class ControllerInstanceToggleTest extends ControllerTest {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerInstanceToggleTest.class);
   private static final String HELIX_CLUSTER_NAME = "ControllerInstanceToggleTest";
-  static ZkClient _zkClient = null;
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
+  private static final String SERVER_TENANT_NAME = ControllerTenantNameBuilder.getOfflineTenantNameForTenant(null);
+  private static final String BROKER_TENANT_NAME = ControllerTenantNameBuilder.getBrokerTenantNameForTenant(null);
+  private static final int NUM_INSTANCES = 3;
 
-  private PinotHelixResourceManager _pinotResourceManager;
-
-  @BeforeClass
-  public void setup() throws Exception {
-    startZk();
-    _zkClient = new ZkClient(ZkStarter.DEFAULT_ZK_STR);
-    startController();
-    _pinotResourceManager = _controllerStarter.getHelixResourceManager();
-    ControllerRequestBuilderUtil.addFakeBrokerInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME,
-        ZkStarter.DEFAULT_ZK_STR, 20, true);
-    ControllerRequestBuilderUtil.addFakeDataInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME,
-        ZkStarter.DEFAULT_ZK_STR, 20, true);
-  }
-
-  @AfterClass
-  public void tearDown() {
-    stopController();
-    try {
-      if (_zkClient.exists("/" + HELIX_CLUSTER_NAME)) {
-        _zkClient.deleteRecursive("/" + HELIX_CLUSTER_NAME);
-      }
-    } catch (Exception e) {
-    }
-    _zkClient.close();
-    stopZk();
-  }
-
-  @Test
-  public void testInstanceToggle()
-      throws Exception {
-    // Create offline table creation request
-    String tableName = "testTable";
-    String tableJSONConfigString =
-        new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(tableName)
-            .setNumReplicas(20)
-            .build()
-            .toJSONConfigString();
-    sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableCreate(),
-        tableJSONConfigString);
-    Assert.assertEquals(
-        _helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
-            .getPartitionSet().size(), 1);
-    Assert.assertEquals(
-        _helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
-            .getInstanceSet(tableName + "_OFFLINE").size(), 20);
-
-    // Adding segments
-    for (int i = 0; i < 10; ++i) {
-      Assert.assertEquals(_helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, tableName + "_OFFLINE")
-          .getNumPartitions(), i);
-      addOneOfflineSegment(tableName);
-      Thread.sleep(2000);
-      Assert.assertEquals(_helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, tableName + "_OFFLINE")
-          .getNumPartitions(), i + 1);
-    }
-
-    Thread.sleep(2000);
-    // Disable Instance
-    int i = 20;
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, "DefaultTenant_OFFLINE")) {
-      ExternalView resourceExternalView =
-          _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
-      Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i--);
-      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "disable");
-      Thread.sleep(2000);
-      resourceExternalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
-      instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i);
-      LOGGER.trace("Current running server instance: " + instanceSet.size());
-    }
-
-    // Enable Instance
-    i = 0;
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, "DefaultTenant_OFFLINE")) {
-      ExternalView resourceExternalView =
-          _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
-      Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i++);
-      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "ENABLE");
-      Thread.sleep(2000);
-      resourceExternalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, tableName + "_OFFLINE");
-      instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i);
-      LOGGER.trace("Current running server instance: " + instanceSet.size());
-    }
-
-    // Disable BrokerInstance
-    i = 20;
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, "DefaultTenant_BROKER")) {
-      ExternalView resourceExternalView =
-          _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
-      Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i--);
-      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "Disable");
-      Thread.sleep(2000);
-      resourceExternalView =
-          _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
-      instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i);
-      LOGGER.trace("Current running broker instance: " + instanceSet.size());
-    }
-
-    // Enable BrokerInstance
-    i = 0;
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, "DefaultTenant_BROKER")) {
-      ExternalView resourceExternalView =
-          _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
-      Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i++);
-      sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forInstanceState(instanceName), "Enable");
-      Thread.sleep(2000);
-      resourceExternalView =
-          _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
-      instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
-      Assert.assertEquals(instanceSet.size(), i);
-      LOGGER.trace("Current running broker instance: " + instanceSet.size());
-    }
-    // Delete table
-    sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTableDelete(tableName));
-    Thread.sleep(2000);
-    Assert.assertEquals(
-        _helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
-            .getPartitionSet().size(), 0);
-
-  }
-
-  private void addOneOfflineSegment(String resourceName) {
-    final SegmentMetadata segmentMetadata = new SimpleSegmentMetadata(resourceName);
-    _pinotResourceManager.addSegment(segmentMetadata, "downloadUrl");
-  }
+  private final ControllerRequestURLBuilder _requestBuilder =
+      ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL);
 
   @Override
   protected String getHelixClusterName() {
     return HELIX_CLUSTER_NAME;
   }
 
+  @BeforeClass
+  public void setup() throws Exception {
+    startZk();
+    startController();
+    ControllerRequestBuilderUtil.addFakeBrokerInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME,
+        ZkStarter.DEFAULT_ZK_STR, NUM_INSTANCES, true);
+    ControllerRequestBuilderUtil.addFakeDataInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME,
+        ZkStarter.DEFAULT_ZK_STR, NUM_INSTANCES, true);
+  }
+
+  @Test
+  public void testInstanceToggle() throws Exception {
+    // Create an offline table
+    String tableJSONConfigString =
+        new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+            .setNumReplicas(NUM_INSTANCES)
+            .build()
+            .toJSONConfigString();
+    sendPostRequest(_requestBuilder.forTableCreate(), tableJSONConfigString);
+    Assert.assertEquals(
+        _helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
+            .getPartitionSet()
+            .size(), 1);
+    Assert.assertEquals(
+        _helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
+            .getInstanceSet(OFFLINE_TABLE_NAME)
+            .size(), NUM_INSTANCES);
+
+    // Add segments
+    PinotHelixResourceManager helixResourceManager = _controllerStarter.getHelixResourceManager();
+    for (int i = 0; i < NUM_INSTANCES; i++) {
+      helixResourceManager.addSegment(new SimpleSegmentMetadata(RAW_TABLE_NAME), "downloadUrl");
+      Assert.assertEquals(_helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, OFFLINE_TABLE_NAME).getNumPartitions(),
+          i + 1);
+    }
+
+    // Disable server instances
+    int numEnabledInstances = NUM_INSTANCES;
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, SERVER_TENANT_NAME)) {
+      sendPostRequest(_requestBuilder.forInstanceState(instanceName), "disable");
+      checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, --numEnabledInstances);
+    }
+
+    // Enable server instances
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, SERVER_TENANT_NAME)) {
+      sendPostRequest(_requestBuilder.forInstanceState(instanceName), "ENABLE");
+      checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, ++numEnabledInstances);
+    }
+
+    // Disable broker instances
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, BROKER_TENANT_NAME)) {
+      sendPostRequest(_requestBuilder.forInstanceState(instanceName), "Disable");
+      checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, --numEnabledInstances);
+    }
+
+    // Enable broker instances
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, BROKER_TENANT_NAME)) {
+      sendPostRequest(_requestBuilder.forInstanceState(instanceName), "Enable");
+      checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, ++numEnabledInstances);
+    }
+
+    // Delete table
+    sendDeleteRequest(_requestBuilder.forTableDelete(RAW_TABLE_NAME));
+    Assert.assertEquals(
+        _helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
+            .getPartitionSet()
+            .size(), 0);
+  }
+
+  private void checkNumOnlineInstancesFromExternalView(String resourceName, int expectedNumOnlineInstances)
+      throws InterruptedException {
+    long endTime = System.currentTimeMillis() + 10_000L;
+    while (System.currentTimeMillis() < endTime) {
+      ExternalView resourceExternalView = _helixAdmin.getResourceExternalView(HELIX_CLUSTER_NAME, resourceName);
+      Set<String> instanceSet = HelixHelper.getOnlineInstanceFromExternalView(resourceExternalView);
+      if (instanceSet.size() == expectedNumOnlineInstances) {
+        return;
+      }
+      Thread.sleep(100L);
+    }
+    Assert.fail("Failed to reach " + expectedNumOnlineInstances + " online instances for resource: " + resourceName);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopController();
+    stopZk();
+  }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTenantTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTenantTest.java
@@ -15,297 +15,171 @@
  */
 package com.linkedin.pinot.controller.helix;
 
+import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
+import com.linkedin.pinot.common.utils.ZkStarter;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-
-import org.apache.helix.manager.zk.ZkClient;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.ZkStarter;
-
 
 public class ControllerTenantTest extends ControllerTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ControllerTenantTest.class);
-
   private static final String HELIX_CLUSTER_NAME = "ControllerTenantTest";
-  static ZkClient _zkClient = null;
+  private static final String BROKER_TAG_PREFIX = "brokerTag_";
+  private static final String SERVER_TAG_PREFIX = "serverTag_";
+  private static final int NUM_INSTANCES = 10;
+  private static final int NUM_BROKER_TAGS = 3;
+  private static final int NUM_BROKERS_PER_TAG = 3;
+  private static final int NUM_SERVER_TAGS = 2;
+  private static final int NUM_OFFLINE_SERVERS_PER_TAG = 2;
+  private static final int NUM_REALTIME_SERVERS_PER_TAG = 1;
+  private static final int NUM_SERVERS_PER_TAG = NUM_OFFLINE_SERVERS_PER_TAG + NUM_REALTIME_SERVERS_PER_TAG;
+
+  private final ControllerRequestURLBuilder _requestBuilder =
+      ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL);
+
+  @Override
+  protected String getHelixClusterName() {
+    return HELIX_CLUSTER_NAME;
+  }
 
   @BeforeClass
-  public void setup() throws Exception {
+  public void setUp() throws Exception {
     startZk();
-    _zkClient = new ZkClient(ZkStarter.DEFAULT_ZK_STR);
     startController();
     ZKMetadataProvider.setClusterTenantIsolationEnabled(_propertyStore, false);
     ControllerRequestBuilderUtil.addFakeBrokerInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME,
-        ZkStarter.DEFAULT_ZK_STR, 20);
+        ZkStarter.DEFAULT_ZK_STR, NUM_INSTANCES);
     ControllerRequestBuilderUtil.addFakeDataInstancesToAutoJoinHelixCluster(HELIX_CLUSTER_NAME,
-        ZkStarter.DEFAULT_ZK_STR, 20);
+        ZkStarter.DEFAULT_ZK_STR, NUM_INSTANCES);
+  }
 
+  @Test
+  public void testBrokerTenant() throws IOException, JSONException {
+    // Create broker tenants
+    for (int i = 1; i <= NUM_BROKER_TAGS; i++) {
+      String brokerTag = BROKER_TAG_PREFIX + i;
+      JSONObject payload =
+          ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, NUM_BROKERS_PER_TAG);
+      sendPostRequest(_requestBuilder.forTenantCreate(), payload.toString());
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getBrokerTenantNameForTenant(brokerTag)).size(), NUM_BROKERS_PER_TAG);
+      Assert.assertEquals(
+          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
+              .size(), NUM_INSTANCES - i * NUM_BROKERS_PER_TAG);
+    }
+
+    // Get broker tenants
+    JSONObject response = new JSONObject(sendGetRequest(_requestBuilder.forTenantGet()));
+    Assert.assertEquals(response.getJSONArray("BROKER_TENANTS").length(), NUM_BROKER_TAGS);
+    for (int i = 1; i <= NUM_BROKER_TAGS; i++) {
+      String brokerTag = BROKER_TAG_PREFIX + i;
+      response = new JSONObject(sendGetRequest(_requestBuilder.forBrokerTenantGet(brokerTag)));
+      Assert.assertEquals(response.getJSONArray("BrokerInstances").length(), NUM_BROKERS_PER_TAG);
+      Assert.assertEquals(response.getString("tenantName"), brokerTag);
+      response = new JSONObject(sendGetRequest(_requestBuilder.forTenantGet(brokerTag)));
+      Assert.assertEquals(response.getJSONArray("BrokerInstances").length(), NUM_BROKERS_PER_TAG);
+      Assert.assertEquals(response.getJSONArray("ServerInstances").length(), 0);
+      Assert.assertEquals(response.getString("tenantName"), brokerTag);
+    }
+
+    // Update broker tenants
+    for (int i = 0; i <= NUM_INSTANCES - (NUM_BROKER_TAGS - 1) * NUM_BROKERS_PER_TAG; i++) {
+      String brokerTag = BROKER_TAG_PREFIX + 1;
+      JSONObject payload = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, i);
+      sendPutRequest(_requestBuilder.forTenantCreate(), payload.toString());
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getBrokerTenantNameForTenant(brokerTag)).size(), i);
+      Assert.assertEquals(
+          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
+              .size(), NUM_INSTANCES - (NUM_BROKER_TAGS - 1) * NUM_BROKERS_PER_TAG - i);
+    }
+
+    // Delete broker tenants
+    for (int i = 1; i <= NUM_BROKER_TAGS; i++) {
+      String brokerTag = BROKER_TAG_PREFIX + i;
+      sendDeleteRequest(_requestBuilder.forBrokerTenantDelete(brokerTag));
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getBrokerTenantNameForTenant(brokerTag)).size(), 0);
+      Assert.assertEquals(
+          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
+              .size(), NUM_INSTANCES - (NUM_BROKER_TAGS - i) * NUM_BROKERS_PER_TAG);
+    }
+  }
+
+  @Test
+  public void testServerTenant() throws IOException, JSONException {
+    // Create server tenants
+    for (int i = 1; i <= NUM_SERVER_TAGS; i++) {
+      String serverTag = SERVER_TAG_PREFIX + i;
+      JSONObject payload =
+          ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, NUM_SERVERS_PER_TAG,
+              NUM_OFFLINE_SERVERS_PER_TAG, NUM_REALTIME_SERVERS_PER_TAG);
+      sendPostRequest(_requestBuilder.forTenantCreate(), payload.toString());
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getOfflineTenantNameForTenant(serverTag)).size(), NUM_OFFLINE_SERVERS_PER_TAG);
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getRealtimeTenantNameForTenant(serverTag)).size(), NUM_REALTIME_SERVERS_PER_TAG);
+      Assert.assertEquals(
+          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
+              .size(), NUM_INSTANCES - i * NUM_SERVERS_PER_TAG);
+    }
+
+    // Get server tenants
+    JSONObject response = new JSONObject(sendGetRequest(_requestBuilder.forTenantGet()));
+    Assert.assertEquals(response.getJSONArray("SERVER_TENANTS").length(), NUM_SERVER_TAGS);
+    for (int i = 1; i <= NUM_SERVER_TAGS; i++) {
+      String serverTag = SERVER_TAG_PREFIX + i;
+      response = new JSONObject(sendGetRequest(_requestBuilder.forServerTenantGet(serverTag)));
+      Assert.assertEquals(response.getJSONArray("ServerInstances").length(), NUM_SERVERS_PER_TAG);
+      Assert.assertEquals(response.getString("tenantName"), serverTag);
+      response = new JSONObject(sendGetRequest(_requestBuilder.forTenantGet(serverTag)));
+      Assert.assertEquals(response.getJSONArray("BrokerInstances").length(), 0);
+      Assert.assertEquals(response.getJSONArray("ServerInstances").length(), NUM_SERVERS_PER_TAG);
+      Assert.assertEquals(response.getString("tenantName"), serverTag);
+    }
+
+    // Update server tenants
+    // Note: server tenants cannot scale down
+    for (int i = 0; i <= (NUM_INSTANCES - NUM_SERVER_TAGS * NUM_SERVERS_PER_TAG) / 2; i++) {
+      String serverTag = SERVER_TAG_PREFIX + 1;
+      JSONObject payload =
+          ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, NUM_SERVERS_PER_TAG + i * 2,
+              NUM_OFFLINE_SERVERS_PER_TAG + i, NUM_REALTIME_SERVERS_PER_TAG + i);
+      sendPutRequest(_requestBuilder.forTenantCreate(), payload.toString());
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getOfflineTenantNameForTenant(serverTag)).size(),
+          NUM_OFFLINE_SERVERS_PER_TAG + i);
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getRealtimeTenantNameForTenant(serverTag)).size(),
+          NUM_REALTIME_SERVERS_PER_TAG + i);
+      Assert.assertEquals(
+          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
+              .size(), NUM_INSTANCES - NUM_SERVER_TAGS * NUM_SERVERS_PER_TAG - i * 2);
+    }
+
+    // Delete server tenants
+    for (int i = 1; i < NUM_SERVER_TAGS; i++) {
+      String serverTag = SERVER_TAG_PREFIX + i;
+      sendDeleteRequest(_requestBuilder.forServerTenantDelete(serverTag));
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getOfflineTenantNameForTenant(serverTag)).size(), 0);
+      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME,
+          ControllerTenantNameBuilder.getRealtimeTenantNameForTenant(serverTag)).size(), 0);
+      Assert.assertEquals(
+          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
+              .size(), NUM_INSTANCES - (NUM_SERVER_TAGS - i) * NUM_SERVERS_PER_TAG);
+    }
   }
 
   @AfterClass
   public void tearDown() {
     stopController();
-    try {
-      if (_zkClient.exists("/" + HELIX_CLUSTER_NAME)) {
-        _zkClient.deleteRecursive("/" + HELIX_CLUSTER_NAME);
-      }
-    } catch (Exception e) {
-    }
-    _zkClient.close();
     stopZk();
-  }
-
-  @Test
-  public void testBrokerTenantCreation() throws JSONException, UnsupportedEncodingException, IOException {
-    for (int i = 0; i < 4; i++) {
-      String brokerTag = "colocated_" + i;
-      final JSONObject payload = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, 5);
-      final String res =
-          sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-              payload.toString());
-      LOGGER.trace(res);
-      Assert
-          .assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, brokerTag + "_BROKER").size(), 5);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
-              .size(), 15 - i * 5);
-    }
-    for (int i = 0; i < 4; i++) {
-      String brokerTag = "colocated_" + i;
-      final String res =
-          sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forBrokerTenantDelete(
-              brokerTag));
-      LOGGER.trace(res);
-      Assert
-          .assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, brokerTag + "_BROKER").size(), 0);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
-              .size(), i * 5 + 5);
-    }
-  }
-
-  @Test
-  public void testBrokerTenantUpdate() throws JSONException, UnsupportedEncodingException, IOException {
-    String brokerTag = "colocated_0";
-    JSONObject payload = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, 5);
-    String res =
-        sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-            payload.toString());
-    LOGGER.trace(res);
-    Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, brokerTag + "_BROKER").size(), 5);
-    Assert.assertEquals(
-        _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
-            .size(), 15);
-
-    for (int i = 6; i < 15; ++i) {
-      payload = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, i);
-      res =
-          sendPutRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-              payload.toString());
-      Assert
-          .assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, brokerTag + "_BROKER").size(), i);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
-              .size(), 20 - i);
-    }
-    res =
-        sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forBrokerTenantDelete(brokerTag));
-    LOGGER.trace(res);
-    Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, brokerTag + "_BROKER").size(), 0);
-    Assert.assertEquals(
-        _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
-            .size(), 20);
-  }
-
-  @Test
-  public void testServerTenantCreation() throws JSONException, UnsupportedEncodingException, IOException {
-    for (int i = 0; i < 4; i++) {
-      String serverTag = "serverTag_" + i;
-      final JSONObject payload = ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, 5, 2, 3);
-      final String res =
-          sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-              payload.toString());
-      LOGGER.trace(res);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_OFFLINE").size(),
-          2);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_REALTIME").size(),
-          3);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
-              .size(), 20 - 5 * (i + 1));
-    }
-
-    for (int i = 0; i < 4; i++) {
-      String serverTag = "serverTag_" + i;
-      final String res =
-          sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forServerTenantDelete(
-              serverTag));
-      LOGGER.trace(res);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_OFFLINE").size(),
-          0);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_REALTIME").size(),
-          0);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
-              .size(), i * 5 + 5);
-    }
-  }
-
-  @Test
-  public void testServerTenantUpdate() throws JSONException, UnsupportedEncodingException, IOException {
-    String serverTag = "serverTag_0";
-    JSONObject payload = ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, 5, 2, 3);
-    String res =
-        sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-            payload.toString());
-    LOGGER.trace(res);
-    Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_OFFLINE").size(), 2);
-    Assert
-        .assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_REALTIME").size(), 3);
-    Assert.assertEquals(
-        _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
-            .size(), 15);
-
-    for (int i = 6; i < 18; i += 2) {
-      payload = ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, i, i / 2, i / 2);
-      res =
-          sendPutRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-              payload.toString());
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_OFFLINE").size(),
-          i / 2);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_REALTIME").size(),
-          i / 2);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
-              .size(), 20 - i);
-    }
-    res =
-        sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forServerTenantDelete(serverTag));
-    LOGGER.trace(res);
-    Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_OFFLINE").size(), 0);
-    Assert
-        .assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_REALTIME").size(), 0);
-    Assert.assertEquals(
-        _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
-            .size(), 20);
-  }
-
-  @Test
-  public void testGetBrokerCall() throws JSONException, UnsupportedEncodingException, IOException {
-    for (int i = 0; i < 4; i++) {
-      String brokerTag = "colocated_" + i;
-      JSONObject payload = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, 5);
-      String res =
-          sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-              payload.toString());
-      LOGGER.trace(res);
-      Assert
-          .assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, brokerTag + "_BROKER").size(), 5);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
-              .size(), 15 - i * 5);
-    }
-    String res = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantGet());
-    LOGGER.trace("**************");
-    LOGGER.trace(res);
-    JSONObject resJsonObject = new JSONObject(res);
-    Assert.assertEquals(resJsonObject.getJSONArray("BROKER_TENANTS").length(), 4);
-    for (int i = 0; i < 4; i++) {
-      String brokerTag = "colocated_" + i;
-      res = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forBrokerTenantGet(brokerTag));
-      LOGGER.trace("**************");
-      LOGGER.trace(res);
-      resJsonObject = new JSONObject(res);
-      Assert.assertEquals(resJsonObject.getJSONArray("BrokerInstances").length(), 5);
-      Assert.assertEquals(resJsonObject.getString("tenantName"), brokerTag);
-      res = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantGet(brokerTag));
-      LOGGER.trace("**************");
-      LOGGER.trace(res);
-      resJsonObject = new JSONObject(res);
-      Assert.assertEquals(resJsonObject.getJSONArray("BrokerInstances").length(), 5);
-      Assert.assertEquals(resJsonObject.getJSONArray("ServerInstances").length(), 0);
-      Assert.assertEquals(resJsonObject.getString("tenantName"), brokerTag);
-    }
-    for (int i = 0; i < 4; i++) {
-      String brokerTag = "colocated_" + i;
-      res =
-          sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forBrokerTenantDelete(
-              brokerTag));
-      LOGGER.trace(res);
-      Assert
-          .assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, brokerTag + "_BROKER").size(), 0);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
-              .size(), i * 5 + 5);
-    }
-  }
-
-  @Test
-  public void testGetServerCall() throws JSONException, UnsupportedEncodingException, IOException {
-    for (int i = 0; i < 4; i++) {
-      String serverTag = "serverTag_" + i;
-      final JSONObject payload = ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, 5, 2, 3);
-      final String res =
-          sendPostRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantCreate(),
-              payload.toString());
-      LOGGER.trace(res);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_OFFLINE").size(),
-          2);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_REALTIME").size(),
-          3);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
-              .size(), 20 - 5 * (i + 1));
-    }
-    String res = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantGet());
-    LOGGER.trace("**************");
-    LOGGER.trace(res);
-    JSONObject resJsonObject = new JSONObject(res);
-    Assert.assertEquals(resJsonObject.getJSONArray("SERVER_TENANTS").length(), 4);
-    for (int i = 0; i < 4; i++) {
-      String serverTag = "serverTag_" + i;
-      res = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forServerTenantGet(serverTag));
-      LOGGER.trace("**************");
-      LOGGER.trace(res);
-      resJsonObject = new JSONObject(res);
-      Assert.assertEquals(resJsonObject.getJSONArray("ServerInstances").length(), 5);
-      Assert.assertEquals(resJsonObject.getString("tenantName"), serverTag);
-      res = sendGetRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forTenantGet(serverTag));
-      LOGGER.trace("**************");
-      LOGGER.trace(res);
-      resJsonObject = new JSONObject(res);
-      Assert.assertEquals(resJsonObject.getJSONArray("BrokerInstances").length(), 0);
-      Assert.assertEquals(resJsonObject.getJSONArray("ServerInstances").length(), 5);
-      Assert.assertEquals(resJsonObject.getString("tenantName"), serverTag);
-    }
-    for (int i = 0; i < 4; i++) {
-      String serverTag = "serverTag_" + i;
-      res =
-          sendDeleteRequest(ControllerRequestURLBuilder.baseUrl(CONTROLLER_BASE_API_URL).forServerTenantDelete(
-              serverTag));
-      LOGGER.trace(res);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_OFFLINE").size(),
-          0);
-      Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, serverTag + "_REALTIME").size(),
-          0);
-      Assert.assertEquals(
-          _helixAdmin.getInstancesInClusterWithTag(HELIX_CLUSTER_NAME, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
-              .size(), i * 5 + 5);
-    }
-  }
-
-  @Override
-  protected String getHelixClusterName() {
-    return HELIX_CLUSTER_NAME;
   }
 }


### PR DESCRIPTION
Remove the sleep time for adding fake broker instances
Merge tests to reduce redundant set up
Reduce number of fake instances
Use small interval to check for state instead of long sleep