### PR TITLE
Fixing invalid enum constant in segment get API

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -195,7 +195,11 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
       ret.put(formatSegments(tableName, CommonConstants.Helix.TableType.valueOf(offline)));
       ret.put(formatSegments(tableName, CommonConstants.Helix.TableType.valueOf(realtime)));
     } else {
-      ret.put(formatSegments(tableName, CommonConstants.Helix.TableType.valueOf(type)));
+      if (!isValidTableType(type)) {
+        setStatus(Status.CLIENT_ERROR_BAD_REQUEST);
+        return new StringRepresentation("Table type " + type + " is not valid! Please use offline or realtime.");
+      }
+      ret.put(formatSegments(tableName, CommonConstants.Helix.TableType.valueOf(type.toUpperCase())));
     }
 
     presentation = new StringRepresentation(ret.toString());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -183,7 +183,7 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   private Representation getSegmentsForTable(
       @Parameter(name = "tableName", in = "path", description = "The name of the table for which to list segments", required = true)
       String tableName,
-      @Parameter(name = "tableType", in = "query", description = "Type of table {offline|realtime}", required = false)
+      @Parameter(name = "type", in = "query", description = "Type of table {offline|realtime}", required = false)
       String type
       ) throws Exception {
     Representation presentation;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/restlet/resources/PinotSegmentUploadRestletResource.java
@@ -178,7 +178,8 @@ public class PinotSegmentUploadRestletResource extends BasePinotControllerRestle
   })
   @Responses({
       @Response(statusCode = "200", description = "A list of all segments for the specified table"),
-      @Response(statusCode = "404", description = "The segment file or table does not exist")
+      @Response(statusCode = "404", description = "The segment file or table does not exist"),
+      @Response(statusCode = "400", description = "Bad client tableType parameter")
   })
   private Representation getSegmentsForTable(
       @Parameter(name = "tableName", in = "path", description = "The name of the table for which to list segments", required = true)


### PR DESCRIPTION
* Also throws an illegal parameter if client puts an invalid type
* Verified that the error is thrown before code change and after by manually testing with HybridClusterIntegrationTest and calling the API