### PR TITLE
Optimizing routing table builder tests

### DIFF
--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilderTest.java
@@ -46,7 +46,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilderTest {
 
   @Test
   public void testAllOnlineRoutingTable() {
-    final int ITERATIONS = 1000;
+    final int ITERATIONS = 50;
     Random random = new Random();
 
     KafkaLowLevelConsumerRoutingTableBuilder routingTableBuilder = new KafkaLowLevelConsumerRoutingTableBuilder();

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
@@ -62,7 +62,7 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
 
   @Test
   public void testBrokerSideServerAndSegmentPruning() throws Exception {
-    int numIterations = 100;
+    int numIterations = 50;
 
     for (int iter = 0; iter < numIterations; iter++) {
       NUM_PARTITION = random.nextInt(8) + 3;

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
@@ -66,7 +66,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
   @Test
   public void testBrokerSideSegmentPruning() throws Exception {
-    int numIterations = 100;
+    int numIterations = 50;
 
     for (int iter = 0; iter < numIterations; iter++) {
       NUM_PARTITION = random.nextInt(8) + 3;


### PR DESCRIPTION
Kafka low level consumer test takes long time because it repeats the check for
1000 times. One time testing with a high number of iteration makes sense to
check for correctness; however, we don't need to check 1000 times for every test.