### PR TITLE
Follow up to PR 1606 to avoid int overflow during star tree creation.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeDataSorter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/StarTreeDataSorter.java
@@ -58,7 +58,7 @@ public class StarTreeDataSorter {
 
   /**
    * Sort from to given start (inclusive) to end (exclusive) as per the provided sort order.
-   * 
+   *
    * @param startRecordId inclusive
    * @param endRecordId exclusive
    * @param sortOrder
@@ -148,7 +148,7 @@ public class StarTreeDataSorter {
 
   /**
    * Perform group-by based on the 'count' for the given column.
-   * 
+   *
    * @param startDocId inclusive
    * @param endDocId exclusive
    * @param colIndex
@@ -206,9 +206,10 @@ public class StarTreeDataSorter {
         byte[] dimBuff = new byte[dimensionSizeInBytes];
         byte[] metBuff = new byte[metricSizeInBytes];
 
-        copyTo(startOffset + (pointer * totalSizeInBytes), dimBuff, 0, dimensionSizeInBytes);
+        long pointerOffset = (long) pointer * totalSizeInBytes;
+        copyTo(startOffset + pointerOffset, dimBuff, 0, dimensionSizeInBytes);
         if (metricSizeInBytes > 0) {
-          copyTo(startOffset + (pointer * totalSizeInBytes) + dimensionSizeInBytes, metBuff, 0, metricSizeInBytes);
+          copyTo(startOffset + pointerOffset + dimensionSizeInBytes, metBuff, 0, metricSizeInBytes);
         }
 
         pointer = pointer + 1;


### PR DESCRIPTION
When computing offsets that are larger than Integer.MAX_VALUE (as a
result of multiplication), we need to ensure that the result of
multiplication does not cause integer overflow, and is properly upcasted
to long.