### PR TITLE
Fix the bug where dropping a HLC table will throw NPE

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -115,6 +115,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
   @AfterClass
   public void tearDown()
       throws Exception {
+    dropRealtimeTable(getTableName());
     stopServer();
     stopBroker();
     stopController();


### PR DESCRIPTION
The reason for the NPE is that:
1. We first drop the table config, then remove the Helix resource. When we rebuild IdealState, it accesses the table config, which will be null at that time.
2. In the handleChildChange callback, when parentPath get removed, currentChildren will be null.

Updated RealtimeClusterIntegrationTest to test dropRealtimeTable() (also tested in HybridClusterIntegrationTest)