### PR TITLE
Added new priority based scheduler for multi-tenancy support

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
@@ -38,6 +38,9 @@ public class QueryException {
   public static final int SEGMENT_PLAN_EXECUTION_ERROR_CODE = 160;
   public static final int COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR_CODE = 170;
   public static final int QUERY_EXECUTION_ERROR_CODE = 200;
+  // TODO: Handle these errors in broker
+  public static final int SERVER_SHUTTING_DOWN_ERROR_CODE = 210;
+  public static final int SERVER_OUT_OF_CAPACITY_ERROR_CODE = 211;
   public static final int EXECUTION_TIMEOUT_ERROR_CODE = 250;
   public static final int BROKER_GATHER_ERROR_CODE = 300;
   public static final int DATA_TABLE_DESERIALIZATION_ERROR_CODE = 310;
@@ -60,6 +63,8 @@ public class QueryException {
   public static final ProcessingException COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR =
       new ProcessingException(COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR_CODE);
   public static final ProcessingException QUERY_EXECUTION_ERROR = new ProcessingException(QUERY_EXECUTION_ERROR_CODE);
+  public static final ProcessingException SERVER_SCHEDULER_DOWN_ERROR = new ProcessingException(SERVER_SHUTTING_DOWN_ERROR_CODE);
+  public static final ProcessingException SERVER_OUT_OF_CAPACITY_ERROR = new ProcessingException(SERVER_OUT_OF_CAPACITY_ERROR_CODE);
   public static final ProcessingException EXECUTION_TIMEOUT_ERROR =
       new ProcessingException(EXECUTION_TIMEOUT_ERROR_CODE);
   public static final ProcessingException BROKER_GATHER_ERROR = new ProcessingException(BROKER_GATHER_ERROR_CODE);
@@ -87,6 +92,8 @@ public class QueryException {
     SEGMENT_PLAN_EXECUTION_ERROR.setMessage("SegmentPlanExecutionError");
     COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR.setMessage("CombineSegmentPlanTimeoutError");
     QUERY_EXECUTION_ERROR.setMessage("QueryExecutionError");
+    SERVER_SCHEDULER_DOWN_ERROR.setMessage("ServerShuttingDown");
+    SERVER_OUT_OF_CAPACITY_ERROR.setMessage("ServerOutOfCapacity");
     EXECUTION_TIMEOUT_ERROR.setMessage("ExecutionTimeoutError");
     BROKER_GATHER_ERROR.setMessage("BrokerGatherError");
     DATA_TABLE_DESERIALIZATION_ERROR.setMessage("DataTableDeserializationError");

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/AbstractMetrics.java
@@ -15,20 +15,18 @@
  */
 package com.linkedin.pinot.common.metrics;
 
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
-import java.util.concurrent.atomic.AtomicLong;
-import org.antlr.v4.runtime.misc.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.antlr.v4.runtime.misc.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -135,6 +133,8 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    */
   private void addValueToTimer(String fullTimerName, final long duration, final TimeUnit timeUnit) {
     final MetricName metricName = new MetricName(_clazz, fullTimerName);
+    com.yammer.metrics.core.Timer timer =
+        MetricsHelper.newTimer(_metricsRegistry, metricName, TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
     MetricsHelper.newTimer(_metricsRegistry, metricName, TimeUnit.MILLISECONDS, TimeUnit.SECONDS).update(duration,
         timeUnit);
   }
@@ -243,6 +243,15 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     }
   }
 
+  public com.yammer.metrics.core.Meter getMeteredTableValue(final String tableName, final M meter) {
+    final String fullMeterName;
+    String meterName = meter.getMeterName();
+    fullMeterName = _metricPrefix + getTableName(tableName) + "." + meterName;
+    final MetricName metricName = new MetricName(_clazz, fullMeterName);
+
+    return MetricsHelper.newMeter(_metricsRegistry, metricName, meter.getUnit(), TimeUnit.SECONDS);
+  }
+
   /**
    * Logs a value to a meter for a specific query.
    *
@@ -259,7 +268,6 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
       fullMeterName = _metricPrefix + meterName;
     }
     final MetricName metricName = new MetricName(_clazz, fullMeterName);
-
     MetricsHelper.newMeter(_metricsRegistry, metricName, meter.getUnit(), TimeUnit.SECONDS).mark(unitCount);
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
@@ -46,7 +46,7 @@ public class ServerQueryRequest {
   private final TimerContext timerContext;
 
   private final ServerMetrics serverMetrics;
-  private int segmentCountAfterPruning;
+  private int segmentCountAfterPruning = -1;
 
   public ServerQueryRequest(InstanceRequest request, ServerMetrics serverMetrics) {
     this.instanceRequest = request;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/context/TimerContext.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/context/TimerContext.java
@@ -87,6 +87,10 @@ public class TimerContext {
     return queryArrivalTimeNs;
   }
 
+  public long getQueryArrivalTimeMs() {
+    return TimeUnit.MILLISECONDS.convert(queryArrivalTimeNs, TimeUnit.NANOSECONDS);
+  }
+
   /**
    * Creates and starts a new timer for query phase.
    * Calling this again for same phase will overwrite existing timing information

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineGroupByOperator.java
@@ -157,7 +157,6 @@ public class MCombineGroupByOperator extends BaseOperator {
 
     for (int i = 0; i < numOperators; i++) {
       final int index = i;
-
       _executorService.execute(new TraceRunnable() {
         @SuppressWarnings("unchecked")
         @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/AbstractSchedulerGroup.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/AbstractSchedulerGroup.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.base.Preconditions;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+
+
+/**
+ * Abstract {@link SchedulerGroup} class that provides common facilities like
+ * managing pending queries as a Linked queue of requests and provides basic accounting
+ * by tracking running queries, reserved threads and in-use threads
+ */
+public abstract class AbstractSchedulerGroup implements SchedulerGroup {
+  // Queue of pending queries for this group
+  protected final ConcurrentLinkedQueue<SchedulerQueryContext> pendingQueries = new ConcurrentLinkedQueue<>();
+  protected final String name;
+  // Tracks number of running queries for this group
+  protected AtomicInteger numRunning = new AtomicInteger(0);
+  // Total threads in use for this group
+  protected AtomicInteger threadsInUse = new AtomicInteger(0);
+  // Total reserved threads for currently running queries for this group
+  protected AtomicInteger reservedThreads = new AtomicInteger(0);
+
+  public AbstractSchedulerGroup(@Nonnull String name) {
+    Preconditions.checkNotNull(name);
+    this.name = name;
+  }
+
+  @Override
+  public String name() {
+    return this.name;
+  }
+
+  @Override
+  public void addLast(SchedulerQueryContext query) {
+    pendingQueries.add(query);
+  }
+
+  @Override
+  public SchedulerQueryContext peekFirst() {
+    return pendingQueries.peek();
+  }
+
+  @Override
+  public SchedulerQueryContext removeFirst() {
+    return pendingQueries.poll();
+  }
+
+  @Override
+  public void trimExpired(long deadlineMillis) {
+    Iterator<SchedulerQueryContext> iter = pendingQueries.iterator();
+    while (iter.hasNext()) {
+      SchedulerQueryContext next = iter.next();
+      if (next.getArrivalTimeMs() < deadlineMillis) {
+        iter.remove();
+      }
+    }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return pendingQueries.isEmpty();
+  }
+
+  @Override
+  public int numPending() {
+    return pendingQueries.size();
+  }
+
+  @Override
+  public int numRunning() {
+    return numRunning.get();
+  }
+
+  @Override
+  public void incrementThreads() {
+    threadsInUse.incrementAndGet();
+  }
+
+  @Override
+  public void decrementThreads() {
+    threadsInUse.decrementAndGet();
+  }
+
+  @Override
+  public int getThreadsInUse() {
+    return threadsInUse.get();
+  }
+
+  @Override
+  public void addReservedThreads(int threads) {
+    reservedThreads.addAndGet(threads);
+  }
+
+  @Override
+  public void releasedReservedThreads(int threads) {
+    reservedThreads.addAndGet(-1 * threads);
+  }
+
+  @Override
+  public int totalReservedThreads() {
+    return reservedThreads.get();
+  }
+
+  @Override
+  public void startQuery() {
+    incrementThreads();
+    numRunning.incrementAndGet();
+  }
+
+  @Override
+  public void endQuery() {
+    decrementThreads();
+    numRunning.decrementAndGet();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Priority queues of scheduler groups that determines query priority based on tokens
+ *
+ * This is a multi-level query scheduling queue with each sublevel maintaining a waitlist of
+ * queries for the group. The priority between groups is provided by specific SchedulerGroup
+ * implementation. If two groups have the same priority then the group with lower
+ * resource utilization is selected first. Oldest query from the winning SchedulerGroup
+ * is selected for execution.
+ */
+public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(MultiLevelPriorityQueue.class);
+  public static final String QUERY_DEADLINE_SECONDS_KEY = "query_deadline_seconds";
+  public static final String MAX_PENDING_PER_GROUP_KEY = "max_pending_per_group";
+  public static final String QUEUE_WAKEUP_MICROS = "queue_wakeup_micros";
+
+  private static final int DEFAULT_WAKEUP_MICROS = 1000;
+
+  private static int wakeUpTimeMicros = DEFAULT_WAKEUP_MICROS;
+  private final int maxPendingPerGroup;
+
+  private final Map<String, SchedulerGroup> schedulerGroups = new HashMap<>();
+  private final Lock queueLock = new ReentrantLock();
+  private final Condition queryReaderCondition = queueLock.newCondition();
+  private final ResourceManager resourceManager;
+  private final SchedulerGroupMapper groupSelector;
+  private final int queryDeadlineMillis;
+  private final SchedulerGroupFactory groupFactory;
+  private final Configuration config;
+
+
+  public MultiLevelPriorityQueue(@Nonnull Configuration config, @Nonnull ResourceManager resourceManager,
+      @Nonnull  SchedulerGroupFactory groupFactory,
+      @Nonnull SchedulerGroupMapper groupMapper) {
+    Preconditions.checkNotNull(config);
+    Preconditions.checkNotNull(resourceManager);
+    Preconditions.checkNotNull(groupFactory);
+    Preconditions.checkNotNull(groupMapper);
+
+    // max available tokens per millisecond equals number of threads (total execution capacity)
+    // we are over provisioning tokens here because its better to keep pipe full rather than empty
+    queryDeadlineMillis = config.getInt(QUERY_DEADLINE_SECONDS_KEY, 30) * 1000;
+    wakeUpTimeMicros = config.getInt(QUEUE_WAKEUP_MICROS, DEFAULT_WAKEUP_MICROS);
+    maxPendingPerGroup = config.getInt(MAX_PENDING_PER_GROUP_KEY, 10);
+    this.config = config;
+    this.resourceManager = resourceManager;
+    this.groupFactory = groupFactory;
+    this.groupSelector = groupMapper;
+  }
+
+  @Override
+  public void put(@Nonnull SchedulerQueryContext query) throws OutOfCapacityError {
+    Preconditions.checkNotNull(query);
+    queueLock.lock();
+    String groupName = groupSelector.getSchedulerGroupName(query);
+    try {
+      SchedulerGroup groupContext = getOrCreateGroupContext(groupName);
+      checkGroupHasCapacity(groupContext);
+      query.setSchedulerGroupContext(groupContext);
+      groupContext.addLast(query);
+      queryReaderCondition.signal();
+    } finally {
+      queueLock.unlock();
+    }
+  }
+
+  /**
+   * Blocking call to read the next query in order of priority
+   * @return
+   */
+  @Override
+  public @Nullable SchedulerQueryContext take() {
+    queueLock.lock();
+    try {
+      while (true) {
+        SchedulerQueryContext schedulerQueryContext;
+        while ( (schedulerQueryContext = takeNextInternal()) == null) {
+          try {
+            queryReaderCondition.await(wakeUpTimeMicros, TimeUnit.MICROSECONDS);
+          } catch (InterruptedException e) {
+            return null;
+          }
+        }
+        return schedulerQueryContext;
+      }
+    } finally {
+      queueLock.unlock();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public List<SchedulerQueryContext> drain() {
+    List<SchedulerQueryContext> pending = new ArrayList<>();
+    queueLock.lock();
+    try {
+      for (Map.Entry<String, SchedulerGroup> groupEntry : schedulerGroups.entrySet()) {
+        SchedulerGroup group = groupEntry.getValue();
+        while (!group.isEmpty()) {
+          pending.add(group.removeFirst());
+        }
+      }
+    } finally {
+      queueLock.unlock();
+    }
+    return pending;
+  }
+
+  private SchedulerQueryContext takeNextInternal() {
+    SchedulerGroup currentWinnerGroup = null;
+    long startTime = System.nanoTime();
+    StringBuilder sb = new StringBuilder("SchedulerInfo:");
+    long deadlineEpochMillis = currentTimeMillis() - queryDeadlineMillis;
+    for (Map.Entry<String, SchedulerGroup> groupInfoEntry : schedulerGroups.entrySet()) {
+      SchedulerGroup group = groupInfoEntry.getValue();
+      sb.append(group.toString());
+      group.trimExpired(deadlineEpochMillis);
+      if (group.isEmpty() || !resourceManager.canSchedule(group)) {
+        continue;
+      }
+
+      if (currentWinnerGroup == null) {
+        currentWinnerGroup = group;
+        continue;
+      }
+
+      // Preconditions:
+      // a. currentGroupResources <= hardLimit
+      // b. selectedGroupResources <= hardLimit
+      // We prefer group with higher priority but with resource limits.
+      // If current group priority are greater than currently winning priority then we choose current
+      // group over currentWinnerGroup if
+      // a. current group is using less than softLimit resources
+      // b. if softLimit < currentGroupResources <= hardLimit then
+      //     i. choose group if softLimit <= currentWinnerGroup <= hardLimit
+      //     ii. continue with currentWinnerGroup otherwise
+      int comparison = group.compareTo(currentWinnerGroup);
+      if (comparison < 0) {
+        continue;
+      }
+      if (comparison >= 0) {
+        if (group.totalReservedThreads() < resourceManager.getTableThreadsSoftLimit() ||
+            group.totalReservedThreads() < currentWinnerGroup.totalReservedThreads()) {
+          currentWinnerGroup = group;
+        }
+      }
+    }
+
+    SchedulerQueryContext query = null;
+    if (currentWinnerGroup != null) {
+      ServerQueryRequest queryRequest = currentWinnerGroup.peekFirst().getQueryRequest();
+      sb.append(String.format(" Winner: %s: [%d,%d,%d,%d]", currentWinnerGroup.name(),
+          queryRequest.getTimerContext().getQueryArrivalTimeMs(),
+          queryRequest.getInstanceRequest().getRequestId(),
+          queryRequest.getInstanceRequest().getSearchSegments().size(),
+          startTime));
+      query = currentWinnerGroup.removeFirst();
+    }
+    LOGGER.debug(sb.toString());
+    return query;
+  }
+
+  private void checkGroupHasCapacity(SchedulerGroup groupContext) throws OutOfCapacityError {
+    if (groupContext.numPending() >= maxPendingPerGroup &&
+        groupContext.totalReservedThreads() >= resourceManager.getTableThreadsHardLimit()) {
+      throw new OutOfCapacityError(
+          String.format("SchedulerGroup %s is out of capacity. numPending: %d, maxPending: %d, reservedThreads: %d threadsHardLimit: %d",
+              groupContext.name(),
+              groupContext.numPending(), maxPendingPerGroup,
+              groupContext.totalReservedThreads(), resourceManager.getTableThreadsHardLimit()));
+    }
+  }
+
+  private SchedulerGroup getOrCreateGroupContext(String groupName) {
+    SchedulerGroup groupContext = schedulerGroups.get(groupName);
+    if (groupContext == null) {
+      groupContext = groupFactory.create(config, groupName);
+      schedulerGroups.put(groupName, groupContext);
+    }
+    return groupContext;
+  }
+
+  // separate method to allow mocking for unit testing
+  private long currentTimeMillis() {
+    return System.currentTimeMillis();
+  }
+
+  @VisibleForTesting
+  long getWakeupTimeMicros() {
+    return wakeUpTimeMicros;
+  }
+}
+

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/OutOfCapacityError.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/OutOfCapacityError.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+/**
+ * Indicates that the scheduler queue is out of capacity
+ */
+public class OutOfCapacityError extends Exception {
+
+  public OutOfCapacityError(String msg) {
+    super(msg);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/PriorityScheduler.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.linkedin.pinot.common.exception.QueryException;
+import com.linkedin.pinot.common.metrics.ServerMeter;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.metrics.ServerQueryPhase;
+import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.core.query.scheduler.resources.QueryExecutorService;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Schedules queries from a {@link SchedulerGroup} with highest number of tokens on priority
+ */
+public abstract class PriorityScheduler extends QueryScheduler {
+  private static Logger LOGGER = LoggerFactory.getLogger(PriorityScheduler.class);
+
+  protected final SchedulerPriorityQueue queryQueue;
+
+  @VisibleForTesting
+  protected final Semaphore runningQueriesSemaphore;
+  private final int numRunners;
+  @VisibleForTesting
+  Thread scheduler;
+
+  public PriorityScheduler(@Nonnull ResourceManager resourceManager, @Nonnull QueryExecutor queryExecutor,
+      @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics) {
+    super(queryExecutor, resourceManager, metrics);
+    Preconditions.checkNotNull(queue);
+    this.queryQueue = queue;
+    this.numRunners = resourceManager.getNumQueryRunnerThreads();
+    runningQueriesSemaphore = new Semaphore(numRunners);
+  }
+
+  @Override
+  public ListenableFuture<byte[]> submit(@Nullable final ServerQueryRequest queryRequest) {
+    Preconditions.checkNotNull(queryRequest);
+    if (! isRunning) {
+      return immediateErrorResponse(queryRequest, QueryException.SERVER_SCHEDULER_DOWN_ERROR);
+    }
+    queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT);
+    final SchedulerQueryContext schedQueryContext = new SchedulerQueryContext(queryRequest);
+    try {
+      queryQueue.put(schedQueryContext);
+    } catch (OutOfCapacityError e) {
+      LOGGER.error("Out of capacity for table {}, message: {}", queryRequest.getTableName(), e.getMessage());
+      return immediateErrorResponse(queryRequest, QueryException.SERVER_OUT_OF_CAPACITY_ERROR);
+    }
+    serverMetrics.addMeteredTableValue(queryRequest.getTableName(), ServerMeter.QUERIES, 1);
+    return schedQueryContext.getResultFuture();
+  }
+
+
+  @Override
+  public void start() {
+    super.start();
+    scheduler = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        while (isRunning) {
+          try {
+            runningQueriesSemaphore.acquire();
+          } catch (InterruptedException e) {
+            if (! isRunning) {
+              LOGGER.info("Shutting down scheduler");
+            } else {
+              LOGGER.error("Interrupt while acquiring semaphore. Exiting.", e);
+            }
+            break;
+          }
+          try {
+            final SchedulerQueryContext request = queryQueue.take();
+            if (request == null) {
+              continue;
+            }
+            ServerQueryRequest queryRequest = request.getQueryRequest();
+            final QueryExecutorService executor = resourceManager.getExecutorService(queryRequest,
+                request.getSchedulerGroup());
+            final ListenableFutureTask<byte[]> queryFutureTask = createQueryFutureTask(queryRequest, executor);
+            queryFutureTask.addListener(new Runnable() {
+              @Override
+              public void run() {
+                executor.releaseWorkers();
+                request.getSchedulerGroup().endQuery();
+                runningQueriesSemaphore.release();
+                checkStopResourceManager();
+                if (!isRunning && runningQueriesSemaphore.availablePermits() == numRunners) {
+                  resourceManager.stop();
+                }
+              }
+            }, MoreExecutors.directExecutor());
+            request.setResultFuture(queryFutureTask);
+            request.getSchedulerGroup().startQuery();
+            queryRequest.getTimerContext().getPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT).stopAndRecord();
+            resourceManager.getQueryRunners().submit(queryFutureTask);
+          } catch (Throwable t){
+            LOGGER.error("Error in scheduler thread. This is indicative of a bug. Please report this. Server will continue with errors", t);
+          }
+        }
+        if (isRunning) {
+          throw new RuntimeException("FATAL: Scheduler thread is quitting.....something went horribly wrong.....!!!");
+        } else {
+          failAllPendingQueries();
+        }
+      }
+    });
+    scheduler.setName("scheduler");
+    scheduler.setPriority(Thread.MAX_PRIORITY);
+    scheduler.setDaemon(true);
+    scheduler.start();
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    // without this, scheduler will never stop if there are no pending queries
+    if (scheduler != null) {
+      scheduler.interrupt();
+    }
+  }
+
+  synchronized private void failAllPendingQueries() {
+    List<SchedulerQueryContext> pending = queryQueue.drain();
+    for (SchedulerQueryContext queryContext : pending) {
+      queryContext.setResultFuture(immediateErrorResponse(queryContext.getQueryRequest(),
+          QueryException.SERVER_SCHEDULER_DOWN_ERROR));
+    }
+  }
+
+  private void checkStopResourceManager() {
+    if (! isRunning && runningQueriesSemaphore.availablePermits() == numRunners) {
+      resourceManager.stop();
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -16,12 +16,11 @@
 
 package com.linkedin.pinot.core.query.scheduler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
@@ -30,17 +29,16 @@ import com.linkedin.pinot.common.query.QueryExecutor;
 import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.context.TimerContext;
 import com.linkedin.pinot.common.request.InstanceRequest;
+import com.linkedin.pinot.common.response.ProcessingException;
 import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.core.common.datatable.DataTableImplV2;
+import com.linkedin.pinot.core.query.scheduler.resources.QueryExecutorService;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,115 +51,87 @@ public abstract class QueryScheduler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryScheduler.class);
 
-  public static final String QUERY_RUNNER_CONFIG_KEY = "query_runner_threads";
-  public static final String QUERY_WORKER_CONFIG_KEY = "query_worker_threads";
-  // set the main query runner priority higher than NORM but lower than MAX
-  // because if a query is complete we want to deserialize and return response as soon
-  // as possible
-  private static final int QUERY_RUNNER_THREAD_PRIORITY = 7;
-  public static final int DEFAULT_QUERY_RUNNER_THREADS;
-  public static final int DEFAULT_QUERY_WORKER_THREADS;
   protected final ServerMetrics serverMetrics;
-
-  protected int numQueryRunnerThreads;
-  protected int numQueryWorkerThreads;
-
-  // This executor service will run the "main" operation of query processing
-  // including planning, distributing operators across threads, waiting and
-  // reducing the results from the parallel set of operators (MCombineOperator)
-  //
-  protected ListeningExecutorService queryRunners;
-
-  // TODO: in future, this should be driven by configured policy
-  // like poolPerTable or QoS based pools etc
-  // The policy should also determine how many threads we use per query
-
-  // These are worker threads to parallelize execution of query operators
-  // across groups of segments.
-  protected ListeningExecutorService queryWorkers;
-
   protected final QueryExecutor queryExecutor;
-
-  static {
-    int numCores = Runtime.getRuntime().availableProcessors();
-    // arbitrary...but not completely arbitrary
-    DEFAULT_QUERY_RUNNER_THREADS = numCores;
-    DEFAULT_QUERY_WORKER_THREADS = 2 * numCores;
-  }
+  protected final ResourceManager resourceManager;
+  protected volatile boolean isRunning = false;
 
   /**
-   * Constructor to initialize QueryScheduler based on scheduler configuration.
-   * The configuration variables can control the size of query executors per servers.
-   * 'pinot.query.scheduler.query_runner_threads' : controls the number 'main' threads for executing queries.
-   * These remain "blocked" for the duration of query execution and indicate the number of parallel queries
-   * a server can run. (default: equal to the number of cores on the server)
-   * 'pinot.query.scheduler.query_worker_threads' : controls the total number of workers for query execution.
-   * Actual work of parallel processing of a query on each segment is done by these threads.
-   * (Default: 2 * number of cores)
+   * Constructor to initialize QueryScheduler
+   * @param queryExecutor QueryExecutor engine to use
+   * @param resourceManager for managing server thread resources
+   * @param serverMetrics server metrics collector
    */
-  public QueryScheduler(@Nonnull Configuration schedulerConfig, QueryExecutor queryExecutor,
+  public QueryScheduler(@Nonnull QueryExecutor queryExecutor, @Nonnull ResourceManager resourceManager,
       @Nonnull ServerMetrics serverMetrics) {
-    Preconditions.checkNotNull(schedulerConfig);
     Preconditions.checkNotNull(queryExecutor);
+    Preconditions.checkNotNull(resourceManager);
     Preconditions.checkNotNull(serverMetrics);
 
     this.serverMetrics = serverMetrics;
-
-    numQueryRunnerThreads = schedulerConfig.getInt(QUERY_RUNNER_CONFIG_KEY, DEFAULT_QUERY_RUNNER_THREADS);
-    numQueryWorkerThreads = schedulerConfig.getInt(QUERY_WORKER_CONFIG_KEY, DEFAULT_QUERY_WORKER_THREADS);
-    LOGGER.info("Initializing with {} query runner threads and {} worker threads", numQueryRunnerThreads,
-        numQueryWorkerThreads);
-    // pqr -> pinot query runner (to give short names)
-    ThreadFactory queryRunnerFactory = new ThreadFactoryBuilder().setDaemon(false)
-        .setPriority(QUERY_RUNNER_THREAD_PRIORITY)
-        .setNameFormat("pqr-%d")
-        .build();
-    queryRunners = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numQueryRunnerThreads, queryRunnerFactory));
-
-    // pqw -> pinot query workers
-    ThreadFactory queryWorkersFactory = new ThreadFactoryBuilder().setDaemon(false)
-        .setPriority(Thread.NORM_PRIORITY)
-        .setNameFormat("pqw-%d")
-        .build();
-    queryWorkers = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(numQueryWorkerThreads, queryWorkersFactory));
+    this.resourceManager = resourceManager;
     this.queryExecutor = queryExecutor;
   }
 
-  public QueryScheduler(@Nullable QueryExecutor queryExecutor, @Nonnull ServerMetrics serverMetrics) {
-    this(new PropertiesConfiguration(), queryExecutor, serverMetrics);
-  }
-
+  /**
+   * Submit a query for execution. The query will be scheduled for execution as per the scheduling algorithm
+   * @param queryRequest query to schedule for execution
+   * @return Listenable future for query result representing serialized response. It is possible that the
+   *    future may return immediately or be scheduled for execution at a later time.
+   */
   public abstract @Nonnull ListenableFuture<byte[]> submit(@Nullable ServerQueryRequest queryRequest);
 
+  /**
+   * Query scheduler name for logging
+   */
   public abstract String name();
 
-  public abstract void start();
-
-  public @Nonnull QueryExecutor getQueryExecutor() {
-    return queryExecutor;
+  /**
+   * Start query scheduler thread
+   */
+  public void start() {
+    isRunning = true;
   }
 
-  public ExecutorService getWorkerExecutorService() { return queryWorkers; }
+  /**
+   * stop the scheduler and shutdown services
+   */
+  public void stop() {
+    // don't stop resourcemanager yet...we need to wait for all running queries to finish
+    isRunning = false;
+  }
 
-  protected Callable<byte[]> getQueryCallable(final ServerQueryRequest request, final ExecutorService e) {
-    return new Callable<byte[]>() {
+
+  @VisibleForTesting
+  public ExecutorService getQueryWorkers() {
+    return resourceManager.getQueryWorkers();
+  }
+
+  /**
+   * Create a future task for the query
+   * @param request incoming query request
+   * @param e executor service to use for parallelizing query. This is passed to the QueryExecutor
+   * @return Future task that can be scheduled for execution on an ExecutorService. Ideally, this future
+   * should be executed on a different executor service than {@code e} to avoid deadlock.
+   */
+  protected ListenableFutureTask<byte[]> createQueryFutureTask(@Nonnull final ServerQueryRequest request,
+      @Nonnull final QueryExecutorService e) {
+    return ListenableFutureTask.create(new Callable<byte[]>() {
       @Override
       public byte[] call()
           throws Exception {
         return processQueryAndSerialize(request, e);
       }
-    };
+    });
   }
 
-  protected ListenableFutureTask<byte[]> getQueryFutureTask(final ServerQueryRequest request) {
-    return ListenableFutureTask.create(getQueryCallable(request, getWorkerExecutorService()));
-  }
-
-  protected ListenableFutureTask<byte[]> getQueryFutureTask(final ServerQueryRequest request, ExecutorService e) {
-    return ListenableFutureTask.create(getQueryCallable(request, e));
-  }
-
-  protected byte[] processQueryAndSerialize(final ServerQueryRequest request, final ExecutorService e) {
+  /**
+   * Process query and serialize response
+   * @param request incoming query request
+   * @param e Executor service to use for parallelizing query processing
+   * @return serialized query response
+   */
+  protected byte[] processQueryAndSerialize(@Nonnull final ServerQueryRequest request, @Nonnull final ExecutorService e) {
     DataTable result;
     try {
       result = queryExecutor.processQuery(request, e);
@@ -194,7 +164,14 @@ public abstract class QueryScheduler {
     return (val == null) ? "" : val;
   }
 
-  public static byte[] serializeDataTable(ServerQueryRequest queryRequest, DataTable instanceResponse) {
+  /**
+   * Serialize the DataTable response for query request
+   * @param queryRequest Server query request for which response is serialized
+   * @param instanceResponse DataTable to serialize
+   * @return serialized response bytes
+   */
+  public static byte[] serializeDataTable(@Nonnull ServerQueryRequest queryRequest, @Nonnull DataTable instanceResponse) {
+
     byte[] responseByte;
 
     InstanceRequest instanceRequest = queryRequest.getInstanceRequest();
@@ -223,5 +200,18 @@ public abstract class QueryScheduler {
     timerContext.getPhaseTimer(ServerQueryPhase.TOTAL_QUERY_TIME).stopAndRecord();
 
     return responseByte;
+  }
+
+  /**
+   * Error response future in case of internal error where query response is not available. This can happen
+   * if the query can not be executed or
+   * @param queryRequest
+   * @param error error code to send
+   * @return
+   */
+  protected ListenableFuture<byte[]> immediateErrorResponse(ServerQueryRequest queryRequest, ProcessingException error) {
+    DataTable result = new DataTableImplV2();
+    result.addException(error);
+    return Futures.immediateFuture(QueryScheduler.serializeDataTable(queryRequest, result));
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroup.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroup.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+/**
+ * Scheduler group is a sub-queue in multi-level scheduling queues.
+ * This class maintains context information for each of the scheduling
+ * queues. Each SchedulerGroup is a queue of requests and related accounting.
+ * A query request is mapped to a scheduler group. This mapping can be based on
+ * tableName, tenantName or it can be completely configuration driven which allows
+ * mapping a group of tables to a specific group. For example, a set of tables
+ * with low QPS can be mapped to a single scheduler group.
+ */
+public interface SchedulerGroup extends SchedulerGroupAccountant {
+  /**
+   * Provides scheduler group name
+   */
+  String name();
+
+  /**
+   * Appends the query to the list of pending queries
+   */
+  void addLast(SchedulerQueryContext query);
+
+  /**
+   * Get the first pending query without removing it from the queue
+   * @return query at the head of the queue or null if the queue is empty
+   */
+  SchedulerQueryContext peekFirst();
+
+  /**
+   * Removes first query from the pending queue and returns it
+   * @return first query at the head of the pending queue or null if the queue is empty
+   */
+  SchedulerQueryContext removeFirst();
+
+  /**
+   * Remove all the pending queries with arrival time earlier than the deadline
+   */
+  void trimExpired(long deadlineMillis);
+
+  /**
+   * @return true if there are no pending queries for this group
+   */
+  boolean isEmpty();
+  /**
+   * Number of pending queries
+   * @return
+   */
+  int numPending();
+
+  /**
+   * Number of running queries
+   */
+  int numRunning();
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroupAccountant.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroupAccountant.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+/**
+ * Accounting interface to track resource utilization by a scheduler group.
+ * Scheduler group represents a subqueue if a typical multi-level scheduler.
+ * Sub-queues can selected using SchedulerGroupMapper.
+ *
+ * We mainly account for wall clock time of each thread for a query. This captures
+ * CPU and IO cost for each query but also penalizes for GC activity. We do not account
+ * for memory utilization yet. Nevertheless, wall clock time is a good approximation for
+ * resource utilization in an online system.
+ */
+public interface SchedulerGroupAccountant extends Comparable<SchedulerGroupAccountant> {
+  /**
+   * Mark that a new thread is being used for this group
+   */
+  void incrementThreads();
+
+  /**
+   * Decrement threads usage for this group
+   */
+  void decrementThreads();
+
+  /**
+   * Get total number of threads in active use
+   * @return number of threads in use
+   */
+  int getThreadsInUse();
+
+  /**
+   * Reserve additional threads for this scheduling group
+   * @param threads number of threads
+   */
+  void addReservedThreads(int threads);
+
+  /**
+   * Releases thread capacity reserved for this scheduler group
+   * @param threads
+   */
+  void releasedReservedThreads(int threads);
+
+  /**
+   * Total number of threads reserved for this group
+   * @return
+   */
+  int totalReservedThreads();
+
+  /**
+   * Mark start of a query if the implementor wants to perform additional accounting
+   */
+  void startQuery();
+
+  /**
+   * Mark end of query execution.
+   */
+  void endQuery();
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroupFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroupFactory.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+import org.apache.commons.configuration.Configuration;
+
+
+/**
+ * Factory class to create {@link SchedulerGroup}
+ */
+public interface SchedulerGroupFactory {
+
+  /**
+   * Factory method to create {@link SchedulerGroup} for given name
+   * @param config scheduler configuration
+   * @param groupName Scheduler group name
+   * @return instance of SchedulerGroup
+   */
+  SchedulerGroup create(Configuration config, String groupName);
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroupMapper.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerGroupMapper.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+/**
+ * Selector class to map incoming request to one of the
+ * multi-level scheduling groups. This decouples the logic
+ * of mapping query request to one of the scheduler group.
+ */
+public interface SchedulerGroupMapper {
+  /**
+   * Map query request to scheduler group
+   * @param query incoming query request
+   * @return Scheduler group name
+   */
+  String getSchedulerGroupName(SchedulerQueryContext query);
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerPriorityQueue.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerPriorityQueue.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+/**
+ * Interface for scheduler priority queue for priority based schedulers
+ */
+public interface SchedulerPriorityQueue {
+  /**
+   * Adds a query to the scheduler priority queue. This call always succeeds or
+   * throws exception if the queues are out of capacity. This will never block for
+   * resources to become available.
+   * @param query query to add to the list of waiters
+   * @throws OutOfCapacityError if the internal query queues are full
+   */
+  // TODO: throw OutOfCapacity or drop from the front of the queue ?
+  // It may be more beneficial to drop oldest queries to move forward
+  void put(@Nonnull SchedulerQueryContext query) throws OutOfCapacityError;
+
+  /**
+   * Blocking call to select the query with highest priority to schedule for execution next.
+   * The returned query will be removed from internal queues.
+   * @return query to schedule. Returns null only when interrupted
+   */
+  @Nullable SchedulerQueryContext take();
+
+  /**
+   * Get the list of all the pending queries in the queue
+   * @return Non-null list of all the pending queries in the queue
+   *         List is empty if there are no pending queries
+   */
+  @Nonnull List<SchedulerQueryContext> drain();
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerQueryContext.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/SchedulerQueryContext.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+/**
+ * Query specific scheduling context
+ */
+public class SchedulerQueryContext {
+
+  private final ServerQueryRequest queryRequest;
+  private final SettableFuture<byte[]> resultFuture;
+  private SchedulerGroup schedulerGroup;
+
+  public SchedulerQueryContext(@Nonnull ServerQueryRequest queryRequest) {
+    Preconditions.checkNotNull(queryRequest);
+
+    this.queryRequest = queryRequest;
+    this.resultFuture = SettableFuture.create();
+  }
+
+  public @Nonnull ServerQueryRequest getQueryRequest() {
+    return queryRequest;
+  }
+
+  public @Nonnull SettableFuture<byte[]> getResultFuture() {
+    return resultFuture;
+  }
+
+  public void setResultFuture(ListenableFuture<byte[]> f) {
+    resultFuture.setFuture(f);
+  }
+
+  public void setSchedulerGroupContext(SchedulerGroup schedulerGroup) {
+    this.schedulerGroup = schedulerGroup;
+  }
+
+  public @Nullable
+  SchedulerGroup getSchedulerGroup() {
+    return schedulerGroup;
+  }
+
+  /**
+   * Convenience method to get query arrival time
+   * @return
+   */
+  public long getArrivalTimeMs() {
+    return queryRequest.getTimerContext().getQueryArrivalTimeMs();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/TableBasedGroupMapper.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/TableBasedGroupMapper.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+/**
+ * Maps query request to scheduler group based on table name.
+ * This maintains per table query queues.
+ */
+public class TableBasedGroupMapper implements SchedulerGroupMapper {
+
+  /**
+   * Maps query to per-table {@link SchedulerGroup}
+   * @param query
+   * @return table name (per-table) SchedulerGroup
+   */
+  @Override
+  public String getSchedulerGroupName(SchedulerQueryContext query) {
+    return query.getQueryRequest().getTableName();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.fcfs;
+
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.core.query.scheduler.MultiLevelPriorityQueue;
+import com.linkedin.pinot.core.query.scheduler.PriorityScheduler;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroup;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupFactory;
+import com.linkedin.pinot.core.query.scheduler.SchedulerPriorityQueue;
+import com.linkedin.pinot.core.query.scheduler.TableBasedGroupMapper;
+import com.linkedin.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import javax.annotation.Nonnull;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Per group FCFS algorithm with bounded resource management per {@link SchedulerGroup}
+ * This class is a thin wrapper factory that configures {@link PriorityScheduler} with right
+ * concrete classes. All the scheduling logic resides in {@link PriorityScheduler}
+ */
+public class BoundedFCFSScheduler extends PriorityScheduler {
+  private static Logger LOGGER = LoggerFactory.getLogger(BoundedFCFSScheduler.class);
+
+  public static BoundedFCFSScheduler create(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
+      @Nonnull ServerMetrics serverMetrics) {
+    final ResourceManager rm = new PolicyBasedResourceManager(config);
+    final SchedulerGroupFactory groupFactory = new SchedulerGroupFactory() {
+      @Override
+      public SchedulerGroup create(Configuration config, String groupName) {
+        return new FCFSSchedulerGroup(groupName);
+      }
+    };
+    MultiLevelPriorityQueue queue = new MultiLevelPriorityQueue(config, rm, groupFactory, new TableBasedGroupMapper());
+    return new BoundedFCFSScheduler(rm , queryExecutor, queue, serverMetrics);
+  }
+
+  private BoundedFCFSScheduler(@Nonnull ResourceManager resourceManager, @Nonnull QueryExecutor queryExecutor,
+      @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics) {
+    super(resourceManager, queryExecutor, queue, metrics);
+  }
+
+  @Override
+  public String name() {
+    return "BoundedFCFSScheduler";
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroup.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroup.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.fcfs;
+
+import com.linkedin.pinot.core.query.scheduler.AbstractSchedulerGroup;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroup;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import com.linkedin.pinot.core.query.scheduler.SchedulerQueryContext;
+import javax.annotation.Nonnull;
+
+
+public class FCFSSchedulerGroup extends AbstractSchedulerGroup {
+
+  public FCFSSchedulerGroup(@Nonnull String group) {
+    super(group);
+  }
+
+  /**
+   * Group that has pending query with earlier arrival time has higher priority.
+   * @param rhs
+   * @return 1 if this has lower arrival time than rhs
+   *         -1 if this has higher arrival time than lhs
+   *         0 if arrival times are equal
+   */
+  @Override
+  public int compareTo(SchedulerGroupAccountant rhs) {
+    return compareTo(this, ((SchedulerGroup) rhs));
+  }
+
+  public static int compareTo(SchedulerGroup lhs, SchedulerGroup rhs) {
+    if (rhs == null) {
+      return 1;
+    }
+
+    if (lhs == rhs) {
+      return 0;
+    }
+
+    SchedulerQueryContext lhsFirst = lhs.peekFirst();
+    SchedulerQueryContext rhsFirst = rhs.peekFirst();
+    if (lhsFirst != null && rhsFirst != null) {
+      long lhsArrivalMs = lhsFirst.getArrivalTimeMs();
+      long rhsArrivalMs = rhsFirst.getArrivalTimeMs();
+      if (lhsArrivalMs < rhsArrivalMs) {
+        return 1;
+      } else if (lhsArrivalMs > rhsArrivalMs) {
+        return -1;
+      }
+      return 0;
+    } else if (lhsFirst != null && rhsFirst == null) {
+      return 1;
+    } else if (lhsFirst == null && rhsFirst != null) {
+      return -1;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/BoundedAccountingExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/BoundedAccountingExecutor.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Semaphore;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Bounded accounting executor service that puts an upper bound on the
+ * number of concurrent jobs that can be executed using this service. This service
+ * allows us to divide the resources (threads) of an existing executor service between
+ * different clients and limit the concurrent executions each client can run.
+ *
+ * This class also supports a resource accounting interface to accurately track resources
+ * utilization based on submission time and end time of a task. This does not require
+ * any changes to client code which continue to use ExecutorService interface.
+ */
+public class BoundedAccountingExecutor extends QueryExecutorService {
+  private static Logger LOGGER = LoggerFactory.getLogger(BoundedAccountingExecutor.class);
+
+  private final Executor delegateExecutor;
+  private final int bounds;
+  private Semaphore semaphore;
+  private final SchedulerGroupAccountant accountant;
+
+  public BoundedAccountingExecutor(@Nonnull Executor s, int bounds,
+      @Nonnull SchedulerGroupAccountant accountant) {
+    Preconditions.checkNotNull(s);
+    Preconditions.checkNotNull(accountant);
+    Preconditions.checkArgument(bounds > 0);
+    this.delegateExecutor = s;
+    this.bounds = bounds;
+    this.semaphore = new Semaphore(bounds);
+    this.accountant = accountant;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    delegateExecutor.execute(toAccountingRunnable(command));
+  }
+
+  @Override
+  public void releaseWorkers()  {
+    accountant.releasedReservedThreads(bounds);
+  }
+
+  private QueryAccountingRunnable toAccountingRunnable(Runnable runnable) {
+    acquirePermits(1);
+    return new QueryAccountingRunnable(runnable, semaphore, accountant);
+  }
+
+  private void acquirePermits(int permits) {
+    try {
+      semaphore.acquire(permits);
+    } catch (InterruptedException e) {
+      LOGGER.error("Thread interrupted while waiting for semaphore", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private class QueryAccountingRunnable implements Runnable {
+    private final Runnable runnable;
+    private final Semaphore semaphore;
+    private final SchedulerGroupAccountant accountant;
+
+    QueryAccountingRunnable(Runnable r, Semaphore semaphore, SchedulerGroupAccountant accountant) {
+      this.runnable = r;
+      this.semaphore = semaphore;
+      this.accountant = accountant;
+    }
+
+    @Override
+    public void run() {
+      try {
+        if (accountant != null) {
+          accountant.incrementThreads();
+        }
+        runnable.run();
+      } finally {
+        if (accountant != null) {
+          accountant.decrementThreads();
+        }
+        semaphore.release();
+      }
+    }
+  }
+}
+

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/PolicyBasedResourceManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/PolicyBasedResourceManager.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * ResourceManager class to manage threadpools as per the configured policy
+ */
+public class PolicyBasedResourceManager extends ResourceManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PolicyBasedResourceManager.class);
+
+  private final ResourceLimitPolicy resourcePolicy;
+
+  public PolicyBasedResourceManager(Configuration config) {
+    super(config);
+    this.resourcePolicy = new ResourceLimitPolicy(config, numQueryWorkerThreads);
+  }
+
+  /**
+   * Returns an executor service that query executor can use like a dedicated
+   * service for submitting jobs for parallel execution.
+   * @param query
+   * @param accountant Accountant for a scheduler group
+   * @return BoundedAccountingExecutor service that limits the number of threads available
+   * for query execution. Query execution can submit tasks for parallel execution without need
+   * for limiting their parallelism.
+   */
+  @Override
+  public QueryExecutorService getExecutorService(ServerQueryRequest query, SchedulerGroupAccountant accountant) {
+    int numSegments = query.getInstanceRequest().getSearchSegmentsSize();
+    int queryThreadLimit = Math.max(1, Math.min(resourcePolicy.getMaxThreadsPerQuery(), numSegments));
+    int spareThreads = resourcePolicy.getTableThreadsHardLimit() - accountant.totalReservedThreads();
+    if (spareThreads <= 0) {
+      LOGGER.warn("UNEXPECTED: Attempt to schedule query uses more than the configured hard limit on threads");
+      spareThreads = 1;
+    } else {
+      spareThreads = Math.min(spareThreads, queryThreadLimit);
+    }
+    Preconditions.checkState(spareThreads >= 1);
+    // We do not bound number of threads here by total available threads. We can potentially
+    // over-provision number of threads here. That is intentional and (potentially) good solution.
+    // Queries don't use their workers all the time. So, reserving workers leads to suboptimal resource
+    // utilization. We want to keep the pipe as full as possible for query workers. Overprovisioning is one
+    // way to achieve that (in fact, only way for us).  There is a couter-argument to be made that overprovisioning
+    // can impact cache-lines and memory in general.
+    // We use this thread reservation only to determine priority based on resource utilization and not as a way to
+    // improve system performance (because we don't have good insight on that yet)
+    accountant.addReservedThreads(spareThreads);
+    // TODO: For 1 thread we should have the query run in the same queryRunner thread
+    // by supplying an executor service that similar to Guava' directExecutor()
+    return new BoundedAccountingExecutor(queryWorkers, spareThreads, accountant);
+  }
+
+  @Override
+  public int getTableThreadsHardLimit() {
+    return resourcePolicy.getTableThreadsHardLimit();
+  }
+
+  @Override
+  public int getTableThreadsSoftLimit() {
+    return resourcePolicy.getTableThreadsSoftLimit();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/QueryExecutorService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/QueryExecutorService.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Executor service adaptor that supports limited interface for running queries.
+ * Derived implementations should provide implementation of {@code execute(Runnable r)} method
+ * from {@code Executor} interface.
+ */
+public abstract class QueryExecutorService implements ExecutorService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryExecutorService.class);
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    FutureTask futureTask = new FutureTask(task);
+    execute(futureTask);
+    return futureTask;
+  }
+
+  public void releaseWorkers() {
+
+  }
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    return submit(Executors.callable(task, result));
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return submit(Executors.callable(task));
+  }
+
+  @Override
+  public void shutdown() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/ResourceLimitPolicy.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/ResourceLimitPolicy.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Helper class to read configured resource limit policy
+ */
+public class ResourceLimitPolicy {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResourceLimitPolicy.class);
+
+  static final int MAX_THREAD_LIMIT = Math.max(1, Runtime.getRuntime().availableProcessors());
+  // The values for max threads count and pct below are educated guesses
+  public static final String THREADS_PER_QUERY_PCT = "threads_per_query_pct";
+  public static final int DEFAULT_THREADS_PER_QUERY_PCT = 20;
+  public static final String TABLE_THREADS_SOFT_LIMIT = "table_threads_soft_limit_pct";
+  public static final String TABLE_THREADS_HARD_LIMIT = "table_threads_hard_limit_pct";
+  public static final int DEFAULT_TABLE_THREADS_SOFT_LIMIT = 30;
+  public static final int DEFAULT_TABLE_THREADS_HARD_LIMIT = 45;
+
+  private final int maxThreadsPerQuery;
+  private final int tableThreadsSoftLimit;
+  private final int tableThreadsHardLimit;
+
+  ResourceLimitPolicy(Configuration config, int numWorkerThreads) {
+    int softLimit = checkGetOrDefaultPct(config, TABLE_THREADS_SOFT_LIMIT,
+        DEFAULT_TABLE_THREADS_SOFT_LIMIT);
+    tableThreadsSoftLimit = Math.min(numWorkerThreads,
+        Math.max(1, numWorkerThreads * softLimit / 100));
+    int hardLimit = checkGetOrDefaultPct(config, TABLE_THREADS_HARD_LIMIT,
+        DEFAULT_TABLE_THREADS_HARD_LIMIT);
+    // hardLimit <= tableThreadsHardLimit < numWorkerThreads
+    tableThreadsHardLimit = Math.min(numWorkerThreads,
+        Math.max(tableThreadsSoftLimit, numWorkerThreads * hardLimit / 100));
+
+    int tpqPct = checkGetOrDefaultPct(config, THREADS_PER_QUERY_PCT, DEFAULT_THREADS_PER_QUERY_PCT);
+    // 1 <= maxThreadsPerQuery <= tableThreadsHardLimit
+    maxThreadsPerQuery = Math.min(tableThreadsHardLimit,
+        Math.min(MAX_THREAD_LIMIT, Math.max(1, numWorkerThreads * tpqPct / 100)));
+
+    LOGGER.info("MaxThreadsPerQuery: {}, tableThreadsSoftLimit: {}, tableThreadsHardLimit: {}",
+        maxThreadsPerQuery, tableThreadsSoftLimit, tableThreadsHardLimit);
+  }
+
+  private int checkGetOrDefaultPct(Configuration schedulerConfig, String key, int defaultValue) {
+    int pct = schedulerConfig.getInt(key, defaultValue);
+    if (pct <= 0 || pct > 100) {
+      LOGGER.error("Incorrect value for {}, value: {}; using default: {}", key, pct, defaultValue);
+      pct = defaultValue;
+    }
+    return pct;
+  }
+
+  int getMaxThreadsPerQuery() {
+    return maxThreadsPerQuery;
+  }
+
+  int getTableThreadsSoftLimit() {
+    return tableThreadsSoftLimit;
+  }
+
+  int getTableThreadsHardLimit() {
+    return tableThreadsHardLimit;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/ResourceManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/ResourceManager.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Abstract class to manage all the server resources for query execution.
+ * Currently this manages the threadpool for query execution.
+ *
+ * This class supports soft and hard limits on the number of threads. A
+ * scheduler group will not get more than the hard_limit number of threads.
+ */
+// TODO: This class supports hard and soft thread limits. Potentially, we can make
+// these limits dynamic - SchedulerGroups with low latency can have higher hard limit
+// than the groups with high latency. That requires more experimentation and tuning
+public abstract class ResourceManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResourceManager.class);
+
+  public static final String QUERY_RUNNER_CONFIG_KEY = "query_runner_threads";
+  public static final String QUERY_WORKER_CONFIG_KEY = "query_worker_threads";
+  public static final int DEFAULT_QUERY_RUNNER_THREADS;
+  public static final int DEFAULT_QUERY_WORKER_THREADS;
+
+  static {
+    int numCores = Runtime.getRuntime().availableProcessors();
+    // arbitrary...but not completely arbitrary
+    DEFAULT_QUERY_RUNNER_THREADS = numCores;
+    DEFAULT_QUERY_WORKER_THREADS = 2 * numCores;
+  }
+
+  // set the main query runner priority higher than NORM but lower than MAX
+  // because if a query is complete we want to deserialize and return response as soon
+  // as possible
+  protected static final int QUERY_RUNNER_THREAD_PRIORITY = 7;
+  // This executor service will run the "main" operation of query processing
+  // including planning, distributing operators across threads, waiting and
+  // reducing the results from the parallel set of operators (MCombineOperator)
+  //
+  protected final ListeningExecutorService queryRunners;
+  protected final ListeningExecutorService queryWorkers;
+  protected final int numQueryRunnerThreads;
+  protected final int numQueryWorkerThreads;
+
+  /**
+   * @param config configuration for initializing resource manager
+   */
+  public ResourceManager(Configuration config) {
+    numQueryRunnerThreads = config.getInt(QUERY_RUNNER_CONFIG_KEY, DEFAULT_QUERY_RUNNER_THREADS);
+    numQueryWorkerThreads = config.getInt(QUERY_WORKER_CONFIG_KEY, DEFAULT_QUERY_WORKER_THREADS);
+
+    LOGGER.info("Initializing with {} query runner threads and {} worker threads", numQueryRunnerThreads,
+        numQueryWorkerThreads);
+    // pqr -> pinot query runner (to give short names)
+    ThreadFactory queryRunnerFactory = new ThreadFactoryBuilder().setDaemon(false)
+        .setPriority(QUERY_RUNNER_THREAD_PRIORITY)
+        .setNameFormat("pqr-%d")
+        .build();
+    queryRunners = MoreExecutors.listeningDecorator(
+        Executors.newFixedThreadPool(numQueryRunnerThreads, queryRunnerFactory));
+
+    // pqw -> pinot query workers
+    ThreadFactory queryWorkersFactory = new ThreadFactoryBuilder().setDaemon(false)
+        .setPriority(Thread.NORM_PRIORITY)
+        .setNameFormat("pqw-%d")
+        .build();
+    queryWorkers = MoreExecutors.listeningDecorator(
+        Executors.newFixedThreadPool(numQueryWorkerThreads, queryWorkersFactory));
+  }
+
+  public void stop() {
+    queryWorkers.shutdownNow();
+    queryRunners.shutdownNow();
+  }
+
+  /**
+   * Total number of query runner threads. Query runner threads are 'main'
+   * threads executing the query.
+   * @return
+   */
+  final public int getNumQueryRunnerThreads() {
+    return numQueryRunnerThreads;
+  }
+
+  /**
+   * Total number of query worker threads. Query worker threads are a pool of threads
+   * for parallel processing of a query.
+   * @return
+   */
+  final public int getNumQueryWorkerThreads() {
+    return numQueryWorkerThreads;
+  }
+
+  /**
+   * Returns executor service for running queries.
+   * @return
+   */
+  final public ListeningExecutorService getQueryRunners() {
+    return queryRunners;
+  }
+
+  @VisibleForTesting
+  final public ExecutorService getQueryWorkers() {
+    return queryWorkers;
+  }
+
+  /**
+   * Get the executor service for running the query. The provided executor
+   * service limits the number of resources available for executing query
+   * as per the configured policy
+   * @param query
+   * @param accountant Accountant for a scheduler group
+   * @return
+   */
+  public abstract QueryExecutorService getExecutorService(ServerQueryRequest query, SchedulerGroupAccountant accountant);
+
+  /**
+   * Hard limit on number of threads for a scheduler group.
+   * A group may not be allotted threads more than this for query execution.
+   * @return number of threads
+   */
+  public abstract int getTableThreadsHardLimit();
+
+  /**
+   * Soft limit on the number of threads for a scheduler group.
+   * Queries from a scheduler group will be de-prioritized if the group
+   * is using more than the soft limit.
+   * @return number of threads
+   */
+  public abstract int getTableThreadsSoftLimit();
+
+  /**
+   * Check if the query for a scheduler group can get required resources for scheduling
+   * @param accountant resource accounting information for a group
+   * @return
+   */
+  public boolean canSchedule(SchedulerGroupAccountant accountant) {
+    return accountant.totalReservedThreads() < getTableThreadsHardLimit();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/UnboundedResourceManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/resources/UnboundedResourceManager.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.commons.configuration.Configuration;
+
+
+/**
+ * Resource manager that does not limit resources for a query.
+ * This resource manager maintains the legacy approach of
+ * letting operators add parallel jobs to the same executor service.
+ */
+public class UnboundedResourceManager extends ResourceManager {
+
+  public UnboundedResourceManager(Configuration config) {
+    super(config);
+  }
+
+  @Override
+  public QueryExecutorService getExecutorService(ServerQueryRequest query, SchedulerGroupAccountant accountant) {
+    return new QueryExecutorService() {
+      @Override
+      public void execute(Runnable command) {
+        queryWorkers.submit(command);
+      }
+    };
+  }
+
+  @Override
+  public int getTableThreadsHardLimit() {
+    return numQueryRunnerThreads + numQueryWorkerThreads;
+  }
+
+  @Override
+  public int getTableThreadsSoftLimit() {
+    return numQueryRunnerThreads + numQueryWorkerThreads;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenPriorityScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenPriorityScheduler.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.tokenbucket;
+
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.core.query.scheduler.MultiLevelPriorityQueue;
+import com.linkedin.pinot.core.query.scheduler.PriorityScheduler;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroup;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupFactory;
+import com.linkedin.pinot.core.query.scheduler.TableBasedGroupMapper;
+import com.linkedin.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import javax.annotation.Nonnull;
+import org.apache.commons.configuration.Configuration;
+
+/**
+ * Schedules queries from a {@link SchedulerGroup} with highest number of tokens on priority.
+ * This is a thin wrapper factory class that configures {@link PriorityScheduler} with
+ * the right concrete classes. All the priority based scheduling logic is in {@link PriorityScheduler}
+ */
+public class TokenPriorityScheduler extends PriorityScheduler {
+  public static final String TOKENS_PER_MS_KEY = "tokens_per_ms";
+  public static final String TOKEN_LIFETIME_MS_KEY = "token_lifetime_ms";
+  private static final int DEFAULT_TOKEN_LIFETIME_MS = 100;
+
+  public static TokenPriorityScheduler create(@Nonnull Configuration config, @Nonnull QueryExecutor queryExecutor,
+      @Nonnull ServerMetrics metrics) {
+    final ResourceManager rm = new PolicyBasedResourceManager(config);
+    final SchedulerGroupFactory groupFactory =  new SchedulerGroupFactory() {
+      @Override
+      public SchedulerGroup create(Configuration config, String groupName) {
+        // max available tokens per millisecond equals number of threads (total execution capacity)
+        // we are over provisioning tokens here because its better to keep pipe full rather than empty
+        int maxTokensPerMs = rm.getNumQueryRunnerThreads() + rm.getNumQueryWorkerThreads();
+        int tokensPerMs = config.getInt(TOKENS_PER_MS_KEY, maxTokensPerMs);
+        int tokenLifetimeMs = config.getInt(TOKEN_LIFETIME_MS_KEY, DEFAULT_TOKEN_LIFETIME_MS);
+
+        return new TokenSchedulerGroup(groupName, tokensPerMs, tokenLifetimeMs);
+      }
+    };
+
+    MultiLevelPriorityQueue queue = new MultiLevelPriorityQueue(config, rm, groupFactory, new TableBasedGroupMapper());
+    return new TokenPriorityScheduler(rm, queryExecutor, queue, metrics);
+  }
+
+  private TokenPriorityScheduler(@Nonnull ResourceManager resourceManager, @Nonnull QueryExecutor queryExecutor,
+      @Nonnull MultiLevelPriorityQueue queue, @Nonnull ServerMetrics metrics) {
+    super(resourceManager, queryExecutor, queue, metrics);
+  }
+
+  @Override
+  public String name() {
+    return "TokenBucket";
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenSchedulerGroup.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenSchedulerGroup.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.query.scheduler.tokenbucket;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.core.query.scheduler.AbstractSchedulerGroup;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroup;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import com.linkedin.pinot.core.query.scheduler.fcfs.FCFSSchedulerGroup;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+/**
+ * Scheduler group that manages accounting based on the number of tokens.
+ *
+ * Each SchedulerGroup is allotted a set of token periodically. Token represents
+ * a unit of thread wall clock time. Tokens are deducted from group for each unit
+ * of time per thread that this group uses. New batch of tokens are allotted periodically
+ * by applying linear decay. Linear decay memorizes resource utilization in the previous
+ * time quantum penalizing heavy users. This is important to give fair chance to low qps
+ * workloads.
+ */
+public class TokenSchedulerGroup extends AbstractSchedulerGroup {
+
+  // Lifetime for which allotted token in valid. Effectively, new tokens are allotted at this frequency
+  private final int tokenLifetimeMs;
+
+  // number of tokens allotted per millisecond. 1 token corresponds to 1 millisecond of wall clock time of a thread
+  // numTokensPerMs will typically correspond to the total number of threads available for execution.
+  // We over-allocate total tokens by giving each group numTokensPerMs = total threads (instead of dividing
+  // between two groups). This is for easy work-stealing - since each group will always have some pending tokens
+  // those can be scheduled if there is no other work
+  private final int numTokensPerMs;
+
+  // currently available tokens for this group
+  private int availableTokens;
+  // last time token values were updated for this group
+  private long lastUpdateTimeMs;
+  // last time tokens were allotted for this group. Tokens are not allotted proactively after tokenLifetimeMs. Instead
+  // we allot tokens in response to events - need to scheduler queries, account for threads etc.
+  private long lastTokenTimeMs;
+  // Internal lock for synchronizing accounting
+  private final Lock tokenLock = new ReentrantLock();
+  // constant factor for applying linear decay when allotting tokens.
+  // We apply linear decay to temporarily lower the priority for the groups that heavily
+  // used resources in the previous token cycle. Without this, groups with steady requests will
+  // get a fresh start and continue to hog high resources impacting sparse users
+  private static final double ALPHA = 0.80;
+
+
+  TokenSchedulerGroup(String schedGroupName, int numTokensPerMs, int tokenLifetimeMs) {
+    super(schedGroupName);
+    Preconditions.checkArgument(numTokensPerMs > 0);
+    Preconditions.checkArgument(tokenLifetimeMs > 0);
+    this.numTokensPerMs = numTokensPerMs;
+    this.tokenLifetimeMs = tokenLifetimeMs;
+    lastUpdateTimeMs = currentTimeMillis();
+    availableTokens = numTokensPerMs * tokenLifetimeMs;
+    lastTokenTimeMs = lastUpdateTimeMs;
+  }
+
+  int getAvailableTokens() {
+    return consumeTokens();
+  }
+
+  @Override
+  public void incrementThreads() {
+    consumeTokens();
+    super.incrementThreads();
+  }
+
+  @Override
+  public void decrementThreads() {
+    consumeTokens();
+    super.decrementThreads();
+  }
+
+  @Override
+  public void startQuery() {
+    consumeTokens();
+    super.startQuery();
+  }
+
+  @Override
+  public void endQuery() {
+    consumeTokens();
+    super.endQuery();
+  }
+
+  /**
+   * Compares priority of this group with respect to another scheduler group.
+   * Priority is compared on the basis of available tokens. SchedulerGroup with
+   * higher number of tokens wins. If both groups have same tokens then the group
+   * with earliest waiting job has higher priority (FCFS if tokens are equal).
+   * If the arrival times of first waiting jobs are also equal then the group
+   * with least reserved resources is selected
+   * @param rhs SchedulerGroupAccount to compare with
+   * @return < 0 if lhs has lower priority than rhs
+   *     > 0 if lhs has higher priority than rhs
+   *     = 0 if lhs has same priority as rhs
+   */
+  @Override
+  public int compareTo(SchedulerGroupAccountant rhs) {
+    if (rhs == null) {
+      return 1;
+    }
+
+    if (this == rhs) {
+      return 0;
+    }
+
+    int leftTokens = getAvailableTokens();
+    int rightTokens = ((TokenSchedulerGroup) rhs).getAvailableTokens();
+    if (leftTokens > rightTokens) {
+      return 1;
+    }
+    if (leftTokens < rightTokens) {
+      return -1;
+    }
+    return FCFSSchedulerGroup.compareTo(this, (SchedulerGroup)rhs);
+  }
+
+  public String toString() {
+    return String.format(" {%s:[%d,%d,%d,%d,%d]},", name(),
+        getAvailableTokens(),
+        numPending(),
+        numRunning(),
+        getThreadsInUse(),
+        totalReservedThreads());
+  }
+
+  // callers must synchronize access to this method
+  private int consumeTokens() {
+    try (TokenLockManager lm = new TokenLockManager(tokenLock)) {
+      long currentTimeMs = currentTimeMillis();
+      // multiple time qantas may have elapsed..hence, the modulo operation
+      int diffMs = (int) (currentTimeMs - lastUpdateTimeMs);
+      if (diffMs <= 0) {
+        return availableTokens;
+      }
+      int threads = threadsInUse.get();
+      long nextTokenTime = lastTokenTimeMs + tokenLifetimeMs;
+      if (nextTokenTime > currentTimeMs) {
+        availableTokens -= diffMs * threads;
+      } else {
+        availableTokens -= (nextTokenTime - lastUpdateTimeMs) * threads;
+        // for each quantum allocate new set of tokens with linear decay of tokens.
+        // Linear decay lowers the tokens available to heavy users in the next period
+        // allowing light users to have better chance at scheduling. Without linear decay,
+        // groups with high request rate will win more often putting light users at disadvantage.
+        for (; nextTokenTime <= currentTimeMs; nextTokenTime += tokenLifetimeMs) {
+          availableTokens = (int) (ALPHA * tokenLifetimeMs * numTokensPerMs + (1 - ALPHA) * (availableTokens
+              - tokenLifetimeMs * threads));
+        }
+        lastTokenTimeMs = nextTokenTime - tokenLifetimeMs;
+        availableTokens -= (currentTimeMs - lastTokenTimeMs) * threads;
+      }
+      lastUpdateTimeMs = currentTimeMs;
+      return availableTokens;
+    }
+  }
+
+  protected long currentTimeMillis() {
+    return System.currentTimeMillis();
+  }
+
+  private class TokenLockManager implements AutoCloseable{
+    private final Lock lock;
+
+    TokenLockManager(Lock lock) {
+      this.lock = lock;
+      this.lock.lock();
+    }
+
+    @Override
+    public void close() {
+      lock.unlock();
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueueTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/MultiLevelPriorityQueueTest.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceLimitPolicy;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import com.linkedin.pinot.core.query.scheduler.resources.UnboundedResourceManager;
+import com.yammer.metrics.core.MetricsRegistry;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.linkedin.pinot.core.query.scheduler.TestHelper.*;
+import static org.testng.Assert.*;
+
+
+public class MultiLevelPriorityQueueTest {
+  SchedulerGroup group;
+  final ServerMetrics metrics = new ServerMetrics(new MetricsRegistry());
+
+  final SchedulerGroupMapper groupMapper = new TableBasedGroupMapper();
+  final TestSchedulerGroupFactory groupFactory = new TestSchedulerGroupFactory();
+  final String groupOne = "1";
+  final String groupTwo = "2";
+
+  @BeforeMethod
+  public void beforeMethod() {
+    groupFactory.reset();
+  }
+
+  @Test (expectedExceptions = NullPointerException.class)
+  public void testPutNull() throws OutOfCapacityError {
+    createQueue().put(null);
+  }
+
+  @Test
+  public void testSimplePutTake() throws OutOfCapacityError {
+    MultiLevelPriorityQueue queue = createQueue();
+    // NOTE: Timing matters here...running through debugger for
+    // over 30 seconds can cause the query to expire
+    queue.put(createQueryRequest(groupOne, metrics));
+    queue.put(createQueryRequest(groupTwo, metrics));
+    queue.put(createQueryRequest(groupOne, metrics));
+
+    assertEquals(groupFactory.numCalls.get(), 2);
+    SchedulerQueryContext r = queue.take();
+    assertEquals(r.getSchedulerGroup().name(), groupOne);
+    r = queue.take();
+    assertEquals(r.getSchedulerGroup().name(), groupOne);
+    r = queue.take();
+    assertEquals(r.getSchedulerGroup().name(), groupTwo);
+  }
+
+  @Test
+  public void testPutOutOfCapacity() throws OutOfCapacityError {
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.setProperty(MultiLevelPriorityQueue.MAX_PENDING_PER_GROUP_KEY, 2);
+    ResourceManager rm = new UnboundedResourceManager(conf);
+    MultiLevelPriorityQueue queue = createQueue(conf, rm);
+    queue.put(createQueryRequest(groupOne, metrics));
+    groupFactory.groupMap.get(groupOne).addReservedThreads(rm.getTableThreadsHardLimit());
+    // we should still be able to add one more waiting query
+    queue.put(createQueryRequest(groupOne, metrics));
+    // this assert is to test that above call to put() is not the one
+    // throwing exception
+    assertTrue(true);
+    // it should throw now
+    try {
+      queue.put(createQueryRequest(groupOne, metrics));
+    } catch (OutOfCapacityError e) {
+      assertTrue(true);
+      return;
+    }
+    assertTrue(false);
+  }
+
+  @Test
+  public void testPutForBlockedReader() throws Exception {
+    // test adding a query immediately makes blocked take() to return
+    final MultiLevelPriorityQueue queue = createQueue();
+    QueueReader reader = new QueueReader(queue);
+    // we know thread has started. Sleep for the wakeup duration and check again
+    reader.startAndWait();
+    assertTrue(reader.reader.isAlive());
+    assertEquals(reader.readQueries.size(), 0);
+    sleepForQueueWakeup(queue);
+    // add a request. We should get it back in atleast wakupTimeDuration (possibly sooner)
+    queue.put(createQueryRequest(groupOne, metrics));
+    sleepForQueueWakeup(queue);
+    assertEquals(reader.readQueries.size(), 1);
+  }
+
+  @Test
+  public void testTakeWithLimits() throws OutOfCapacityError, BrokenBarrierException, InterruptedException {
+    // Test that take() will not return query if that group is already using hardLimit resources
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.setProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, 40);
+    conf.setProperty(ResourceManager.QUERY_RUNNER_CONFIG_KEY, 10);
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_SOFT_LIMIT, 20);
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_HARD_LIMIT, 80);
+    PolicyBasedResourceManager rm = new PolicyBasedResourceManager(conf);
+    MultiLevelPriorityQueue queue = createQueue(conf, rm);
+    queue.put(createQueryRequest(groupOne, metrics));
+    queue.put(createQueryRequest(groupOne, metrics));
+    queue.put(createQueryRequest(groupTwo, metrics));
+    // group one has higher priority but it's above soft thread limit
+    TestSchedulerGroup testGroupOne = groupFactory.groupMap.get(groupOne);
+    TestSchedulerGroup testGroupTwo = groupFactory.groupMap.get(groupTwo);
+
+    testGroupOne.addReservedThreads(rm.getTableThreadsSoftLimit() + 1);
+    QueueReader reader = new QueueReader(queue);
+    reader.startAndWait();
+    assertEquals(reader.readQueries.size(), 1);
+    assertEquals(reader.readQueries.poll().getSchedulerGroup().name(), groupTwo);
+
+    // add one more group two
+    queue.put(createQueryRequest(groupTwo, metrics));
+    reader = new QueueReader(queue);
+    reader.startAndWait();
+    assertEquals(reader.readQueries.size(), 1);
+    assertEquals(reader.readQueries.poll().getSchedulerGroup().name(), groupTwo);
+
+    // add one more groupTwo and set groupTwo threads to higher than groupOne
+    queue.put(createQueryRequest(groupTwo, metrics));
+    testGroupTwo.addReservedThreads(testGroupOne.totalReservedThreads() + 1);
+    reader = new QueueReader(queue);
+    reader.startAndWait();
+    assertEquals(reader.readQueries.size(), 1);
+    assertEquals(reader.readQueries.poll().getSchedulerGroup().name(), groupOne);
+
+    // set groupOne above hard limit
+    testGroupOne.addReservedThreads(rm.getTableThreadsHardLimit());
+    reader = new QueueReader(queue);
+    reader.startAndWait();
+    assertEquals(reader.readQueries.size(), 1);
+    assertEquals(reader.readQueries.poll().getSchedulerGroup().name(), groupTwo);
+
+    // all groups above hard limit
+    queue.put(createQueryRequest(groupTwo, metrics));
+    queue.put(createQueryRequest(groupTwo, metrics));
+    queue.put(createQueryRequest(groupOne, metrics));
+    testGroupTwo.addReservedThreads(rm.getTableThreadsHardLimit());
+    reader = new QueueReader(queue);
+    reader.startAndWait();
+    assertEquals(reader.readQueries.size(), 0);
+    // try again
+    sleepForQueueWakeup(queue);
+    assertEquals(reader.readQueries.size(), 0);
+
+    // now set thread limit lower for a group (aka. query finished)
+    testGroupTwo.releasedReservedThreads(testGroupTwo.totalReservedThreads());
+    sleepForQueueWakeup(queue);
+    assertEquals(reader.readQueries.size(), 1);
+  }
+
+  private void sleepForQueueWakeup(MultiLevelPriorityQueue queue) throws InterruptedException {
+    // sleep is okay since we sleep for short time
+    // add 10 millis to avoid any race condition around time boundary
+    Thread.sleep(queue.getWakeupTimeMicros() / 1000 + 10);
+  }
+
+  @Test
+  public void testNoPendingAfterTrim() throws OutOfCapacityError, BrokenBarrierException, InterruptedException {
+    MultiLevelPriorityQueue queue = createQueue();
+    queue.put(createQueryRequest(groupOne, metrics));
+    queue.put(createQueryRequest(groupTwo, metrics));
+    // group one has higher priority but it's above soft thread limit
+    TestSchedulerGroup testGroupOne = groupFactory.groupMap.get(groupOne);
+    TestSchedulerGroup testGroupTwo = groupFactory.groupMap.get(groupTwo);
+    testGroupOne.peekFirst().getQueryRequest().getTimerContext().setQueryArrivalTimeNs(1000);
+    testGroupTwo.peekFirst().getQueryRequest().getTimerContext().setQueryArrivalTimeNs(1000);
+    QueueReader reader = new QueueReader(queue);
+    reader.startAndWait();
+    assertTrue(reader.readQueries.isEmpty());
+    assertTrue(testGroupOne.isEmpty());
+    assertTrue(testGroupTwo.isEmpty());
+    queue.put(createQueryRequest(groupOne, metrics));
+    sleepForQueueWakeup(queue);
+
+  }
+
+  private MultiLevelPriorityQueue createQueue() {
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.setProperty(MultiLevelPriorityQueue.QUERY_DEADLINE_SECONDS_KEY, 100000);
+    return createQueue(conf, new UnboundedResourceManager(conf));
+  }
+
+  private MultiLevelPriorityQueue createQueue(Configuration config, ResourceManager rm) {
+    return new MultiLevelPriorityQueue(config, rm, groupFactory, groupMapper);
+  }
+
+  // caller needs to start the thread
+  class QueueReader {
+    private final MultiLevelPriorityQueue queue;
+    CyclicBarrier startBarrier = new CyclicBarrier(2);
+    ConcurrentLinkedQueue<SchedulerQueryContext> readQueries = new ConcurrentLinkedQueue<>();
+    Thread reader;
+
+    QueueReader(final MultiLevelPriorityQueue queue) {
+      Preconditions.checkNotNull(queue);
+      this.queue = queue;
+      reader = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            startBarrier.await();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+          readQueries.add(queue.take());
+        }
+      });
+    }
+
+    // this is for main thread that creates reader. Pattern is odd
+    // it keeps calling code concise
+    void startAndWait() throws BrokenBarrierException, InterruptedException {
+      reader.start();
+      startBarrier.await();
+      sleepForQueueWakeup(queue);
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/PrioritySchedulerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/PrioritySchedulerTest.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.linkedin.pinot.common.data.DataManager;
+import com.linkedin.pinot.common.exception.QueryException;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.query.QueryExecutor;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.core.common.datatable.DataTableFactory;
+import com.linkedin.pinot.core.common.datatable.DataTableImplV2;
+import com.linkedin.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceLimitPolicy;
+import com.linkedin.pinot.core.query.scheduler.resources.ResourceManager;
+import com.yammer.metrics.core.MetricsRegistry;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static com.linkedin.pinot.core.query.scheduler.TestHelper.*;
+import static org.testng.Assert.*;
+
+
+public class PrioritySchedulerTest {
+  private static final ServerMetrics metrics = new ServerMetrics(new MetricsRegistry());
+  private static boolean useBarrier = false;
+  private static CyclicBarrier startupBarrier;
+  private static CyclicBarrier validationBarrier;
+  private static CountDownLatch numQueries = new CountDownLatch(1);
+
+  @AfterMethod
+  public void afterMethod() {
+    useBarrier = false;
+    startupBarrier = null;
+    validationBarrier = null;
+    numQueries = new CountDownLatch(1);
+  }
+
+  // Tests that there is no "hang" on stop
+  @Test
+  public void testStartStop() throws InterruptedException {
+    TestPriorityScheduler scheduler = TestPriorityScheduler.create();
+    scheduler.start();
+    // 100 is arbitrary.. we need to wait for scheduler thread to have completely started
+    Thread.sleep(100);
+    scheduler.stop();
+    long queueWakeTimeMicros = ((MultiLevelPriorityQueue) scheduler.getQueue()).getWakeupTimeMicros();
+    long sleepTimeMs = queueWakeTimeMicros >= 1000 ? queueWakeTimeMicros / 1000 + 10 : 10;
+    Thread.sleep(sleepTimeMs);
+    assertFalse(scheduler.scheduler.isAlive());
+  }
+
+  @Test
+  public void testStartStopQueries() throws ExecutionException, InterruptedException, IOException {
+    TestPriorityScheduler scheduler = TestPriorityScheduler.create();
+    scheduler.start();
+
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_HARD_LIMIT, 5);
+    conf.setProperty(MultiLevelPriorityQueue.MAX_PENDING_PER_GROUP_KEY, 5);
+    List<ListenableFuture<byte[]>> results = new ArrayList<>();
+    results.add(scheduler.submit(createServerQueryRequest("1", metrics)));
+    TestSchedulerGroup group = TestPriorityScheduler.groupFactory.groupMap.get("1");
+    group.addReservedThreads(10);
+    group.addLast(createQueryRequest("1", metrics));
+    results.add(scheduler.submit(createServerQueryRequest("1", metrics)));
+
+    scheduler.stop();
+     long queueWakeTimeMicros = ((MultiLevelPriorityQueue) scheduler.getQueue()).getWakeupTimeMicros();
+    long sleepTimeMs = queueWakeTimeMicros >= 1000 ? queueWakeTimeMicros / 1000 + 10 : 10;
+    Thread.sleep(sleepTimeMs);
+    int hasServerShuttingDownError = 0;
+    for (ListenableFuture<byte[]> result : results) {
+      DataTable table = DataTableFactory.getDataTable(result.get());
+      hasServerShuttingDownError += table.getMetadata().containsKey(
+          DataTable.EXCEPTION_METADATA_KEY + QueryException.SERVER_SCHEDULER_DOWN_ERROR.getErrorCode()) ? 1 : 0;
+    }
+    assertTrue(hasServerShuttingDownError > 0);
+  }
+
+  @Test
+  public void testOneQuery() throws InterruptedException, ExecutionException, IOException, BrokenBarrierException {
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.setProperty(ResourceLimitPolicy.THREADS_PER_QUERY_PCT, 50);
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_HARD_LIMIT, 40);
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_SOFT_LIMIT, 20);
+    useBarrier = true;
+    startupBarrier = new CyclicBarrier(2);
+    validationBarrier = new CyclicBarrier(2);
+
+    TestPriorityScheduler scheduler = TestPriorityScheduler.create(conf);
+    int totalPermits = scheduler.getRunningQueriesSemaphore().availablePermits();
+    scheduler.start();
+    ListenableFuture<byte[]> result = scheduler.submit(
+        createServerQueryRequest("1", metrics));
+    startupBarrier.await();
+    TestSchedulerGroup group = TestPriorityScheduler.groupFactory.groupMap.get("1");
+    assertEquals(group.numRunning(), 1);
+    assertEquals(group.getThreadsInUse(), 1);
+    assertEquals(group.totalReservedThreads(), 2 /* equals numSegments in request*/);
+    validationBarrier.await();
+    byte[] resultData = result.get();
+    DataTable table = DataTableFactory.getDataTable(resultData);
+    assertEquals(table.getMetadata().get("table"), "1");
+    // verify that accounting is handled right
+    assertEquals(group.numPending(), 0);
+    assertEquals(group.getThreadsInUse(), 0);
+    assertEquals(group.totalReservedThreads(), 0);
+    // -1 because we expect that 1 permit is blocked by the scheduler main thread
+    assertEquals(scheduler.getRunningQueriesSemaphore().availablePermits(), totalPermits - 1);
+    scheduler.stop();
+  }
+
+  @Test
+  public void testMultiThreaded() throws InterruptedException {
+    // add queries from multiple threads and verify that all those are executed
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.setProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, 60);
+    conf.setProperty(ResourceManager.QUERY_RUNNER_CONFIG_KEY, 20);
+    conf.setProperty(ResourceLimitPolicy.THREADS_PER_QUERY_PCT, 50);
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_HARD_LIMIT, 60);
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_SOFT_LIMIT, 40);
+    conf.setProperty(MultiLevelPriorityQueue.MAX_PENDING_PER_GROUP_KEY, 10);
+
+    final TestPriorityScheduler scheduler = TestPriorityScheduler.create(conf);
+    scheduler.start();
+    final Random random = new Random();
+    final ConcurrentLinkedQueue<ListenableFuture<byte[]>> results = new ConcurrentLinkedQueue<>();
+    final int numThreads = 3;
+    final int queriesPerThread = 10;
+    numQueries = new CountDownLatch(numThreads * queriesPerThread);
+
+    for (int i = 0; i < numThreads; i++) {
+      final int index = i;
+      new Thread(new Runnable() {
+        @Override
+        public void run() {
+          for (int j = 0; j < queriesPerThread; j++) {
+            results.add(scheduler.submit(createServerQueryRequest(Integer.toString(index), metrics)));
+            Uninterruptibles.sleepUninterruptibly(random.nextInt(100), TimeUnit.MILLISECONDS);
+          }
+        }
+      }).start();
+    }
+    numQueries.await();
+    scheduler.stop();
+  }
+
+  /*
+   * Disabled because of race condition
+   */
+  @Test (enabled = false)
+  public void testOutOfCapacityResponse()
+      throws Exception{
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.setProperty(ResourceLimitPolicy.TABLE_THREADS_HARD_LIMIT, 5);
+    conf.setProperty(MultiLevelPriorityQueue.MAX_PENDING_PER_GROUP_KEY, 1);
+    TestPriorityScheduler scheduler = TestPriorityScheduler.create(conf);
+    scheduler.start();
+    List<ListenableFuture<byte[]>> results = new ArrayList<>();
+    results.add(scheduler.submit(createServerQueryRequest("1", metrics)));
+    TestSchedulerGroup group = TestPriorityScheduler.groupFactory.groupMap.get("1");
+    group.addReservedThreads(10);
+    group.addLast(createQueryRequest("1", metrics));
+    results.add(scheduler.submit(createServerQueryRequest("1", metrics)));
+    DataTable dataTable = DataTableFactory.getDataTable(results.get(1).get());
+    assertTrue(dataTable.getMetadata().containsKey(
+        DataTable.EXCEPTION_METADATA_KEY + QueryException.SERVER_OUT_OF_CAPACITY_ERROR.getErrorCode()));
+    scheduler.stop();
+  }
+
+  @Test
+  public void testSubmitBeforeRunning() throws ExecutionException, InterruptedException, IOException {
+    TestPriorityScheduler scheduler = TestPriorityScheduler.create();
+    ListenableFuture<byte[]> result = scheduler.submit(
+        createServerQueryRequest("1", metrics));
+    // start is not called
+    DataTable response = DataTableFactory.getDataTable(result.get());
+    assertTrue(response.getMetadata().containsKey(
+        DataTable.EXCEPTION_METADATA_KEY + QueryException.SERVER_SCHEDULER_DOWN_ERROR.getErrorCode()));
+    assertFalse(response.getMetadata().containsKey("table"));
+    scheduler.stop();
+  }
+
+  static class TestPriorityScheduler extends PriorityScheduler {
+    static TestSchedulerGroupFactory groupFactory;
+
+    public static TestPriorityScheduler create(Configuration conf) {
+      ResourceManager rm = new PolicyBasedResourceManager(conf);
+      QueryExecutor qe = new TestQueryExecutor();
+      groupFactory = new TestSchedulerGroupFactory();
+      MultiLevelPriorityQueue queue = new MultiLevelPriorityQueue(conf, rm,
+          groupFactory, new TableBasedGroupMapper());
+      return new TestPriorityScheduler(rm, qe, queue, metrics);
+    }
+
+    public static TestPriorityScheduler create() {
+      PropertiesConfiguration conf = new PropertiesConfiguration();
+      return create(conf);
+    }
+
+    // store locally for easy access
+    public TestPriorityScheduler(@Nonnull ResourceManager resourceManager, @Nonnull QueryExecutor queryExecutor,
+        @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics) {
+      super(resourceManager, queryExecutor, queue, metrics);
+    }
+
+    ResourceManager getResourceManager() {
+      return this.resourceManager;
+    }
+
+    @Override
+    public String name() {
+      return "TestScheduler";
+    }
+
+    public Semaphore getRunningQueriesSemaphore() {
+      return runningQueriesSemaphore;
+    }
+
+    Thread getSchedulerThread() {
+      return scheduler;
+    }
+
+    SchedulerPriorityQueue getQueue() {
+      return queryQueue;
+    }
+  }
+
+  static class TestQueryExecutor implements QueryExecutor {
+
+    @Override
+    public void init(Configuration queryExecutorConfig, DataManager dataManager, ServerMetrics serverMetrics)
+        throws ConfigurationException {
+
+    }
+
+    @Override
+    public void start() {
+
+    }
+
+    @Override
+    public DataTable processQuery(ServerQueryRequest queryRequest,
+        ExecutorService executorService) {
+      if (useBarrier) {
+        try {
+          startupBarrier.await();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+      DataTableImplV2 result = new DataTableImplV2();
+      result.getMetadata().put("table", queryRequest.getTableName());
+      if (useBarrier) {
+        try {
+          validationBarrier.await();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+      numQueries.countDown();
+      return result;
+    }
+
+    @Override
+    public void shutDown() {
+
+    }
+
+    @Override
+    public boolean isStarted() {
+      return true;
+    }
+
+    @Override
+    public void updateResourceTimeOutInMs(String resource, long timeOutMs) {
+
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestHelper.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestHelper.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.request.InstanceRequest;
+import com.linkedin.pinot.common.request.QuerySource;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TestHelper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
+
+  public static ServerQueryRequest createServerQueryRequest(String table, ServerMetrics metrics) {
+    InstanceRequest request = new InstanceRequest();
+    request.setBrokerId("broker");
+    request.setEnableTrace(false);
+    request.setRequestId(1);
+    request.setSearchSegments(Arrays.asList("segment1", "segment2"));
+    BrokerRequest br = new BrokerRequest();
+    QuerySource qs = new QuerySource();
+    qs.setTableName(table);
+    br.setQuerySource(qs);
+    request.setQuery(br);
+    ServerQueryRequest qr = new ServerQueryRequest(request, metrics);
+    qr.getTimerContext().setQueryArrivalTimeNs(
+        TimeUnit.NANOSECONDS.convert(
+            System.currentTimeMillis(), TimeUnit.MILLISECONDS));
+    return qr;
+  }
+
+  public static SchedulerQueryContext createQueryRequest(String table, ServerMetrics metrics) {
+    return new SchedulerQueryContext(createServerQueryRequest(table, metrics));
+  }
+
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestSchedulerGroup.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestSchedulerGroup.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import javax.annotation.Nonnull;
+
+
+class TestSchedulerGroup extends AbstractSchedulerGroup {
+
+  TestSchedulerGroup(@Nonnull String name) {
+    super(name);
+  }
+
+  private ConcurrentLinkedQueue<SchedulerQueryContext> getQueue() {
+    return pendingQueries;
+  }
+
+  @Override
+  public int compareTo(SchedulerGroupAccountant o) {
+    int lhs = Integer.parseInt(name);
+    int rhs = Integer.parseInt(((TestSchedulerGroup) o).name);
+    if (lhs < rhs) {
+      return 1;
+    } else if (lhs > rhs) {
+      return -1;
+    }
+    return 0;
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestSchedulerGroupFactory.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/TestSchedulerGroupFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.configuration.Configuration;
+
+import static org.testng.Assert.*;
+
+
+class TestSchedulerGroupFactory implements SchedulerGroupFactory {
+  AtomicInteger numCalls = new AtomicInteger(0);
+  ConcurrentHashMap<String, TestSchedulerGroup> groupMap = new ConcurrentHashMap<>();
+  @Override
+  public SchedulerGroup create(Configuration config, String groupName) {
+    numCalls.incrementAndGet();
+    assertNull(groupMap.get(groupName));
+    TestSchedulerGroup group = new TestSchedulerGroup(groupName);
+    groupMap.put(groupName, group);
+    return group;
+  }
+
+  public void reset() {
+    numCalls.set(0);
+    groupMap.clear();
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroupTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroupTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.fcfs;
+
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.core.query.scheduler.SchedulerQueryContext;
+import com.yammer.metrics.core.MetricsRegistry;
+import org.testng.annotations.Test;
+
+import static com.linkedin.pinot.core.query.scheduler.TestHelper.*;
+import static org.testng.Assert.*;
+
+
+public class FCFSSchedulerGroupTest {
+  static final ServerMetrics metrics = new ServerMetrics(new MetricsRegistry());
+
+  @Test
+  public void testCompare() {
+    FCFSSchedulerGroup lhs = new FCFSSchedulerGroup("one");
+    FCFSSchedulerGroup rhs = new FCFSSchedulerGroup("two");
+
+    // both groups are empty
+    assertNull(lhs.peekFirst());
+    assertNull(rhs.peekFirst());
+    assertEquals(lhs.compareTo(lhs), 0);
+    assertEquals(lhs.compareTo(rhs), 0);
+    assertEquals(rhs.compareTo(lhs), 0);
+    SchedulerQueryContext firstRequest = createQueryRequest("groupOne", metrics);
+    firstRequest.getQueryRequest().getTimerContext().setQueryArrivalTimeNs(1000 * 1_000_000L);
+    lhs.addLast(firstRequest);
+
+    assertEquals(lhs.compareTo(rhs), 1);
+    assertEquals(rhs.compareTo(lhs), -1);
+    SchedulerQueryContext secondRequest = createQueryRequest("groupTwo", metrics);
+    secondRequest.getQueryRequest().getTimerContext().setQueryArrivalTimeNs(2000 * 1_000_000L);
+    rhs.addLast(secondRequest);
+    assertEquals(lhs.compareTo(rhs), 1);
+    assertEquals(rhs.compareTo(lhs), -1);
+    secondRequest.getQueryRequest().getTimerContext().setQueryArrivalTimeNs(1 * 1_000_000L);
+    assertEquals(lhs.compareTo(rhs), -1);
+    assertEquals(rhs.compareTo(lhs), 1);
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/resources/BoundedAccountingExecutorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/resources/BoundedAccountingExecutorTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class BoundedAccountingExecutorTest {
+  private AtomicInteger running = new AtomicInteger(0);
+
+  private class Syncer {
+    CyclicBarrier validationBarrier;
+    CyclicBarrier startupBarrier;
+  }
+
+  // Created bounded executor with limit 3 and add 5 jobs. Only 3 can be running at a time
+  @Test
+  public void testBoundsWithinThreadCount() throws BrokenBarrierException, InterruptedException {
+    SchedulerGroupAccountant accountant = mock(SchedulerGroupAccountant.class);
+    // Test below relies on jobs > limit
+    final int limit = 3;
+    final int jobs = 5;
+    // we want total threads > limit
+    Executor es = Executors.newFixedThreadPool(2 * limit);
+    final BoundedAccountingExecutor bes = new BoundedAccountingExecutor(es, limit, accountant);
+    final Syncer syncer = new Syncer();
+    // barrier parties: all the executables plus 1 for main testing thread
+    // startup barrier pauses main thread till all the threads have started
+    // validation barrier allows for validation to complete before proceeding further
+    syncer.startupBarrier = new CyclicBarrier(limit + 1);
+    syncer.validationBarrier = new CyclicBarrier(limit + 1);
+
+    // start adding jobs in new thread. We need to add jobs in new thread
+    // because the thread adding jobs is expected to block at limit
+    new Thread(new Runnable() {
+      @Override
+      public void run() {
+        for (int i = 0; i < jobs; i++) {
+          bes.execute(new Runnable() {
+            @Override
+            public void run() {
+              try {
+                running.incrementAndGet();
+                syncer.startupBarrier.await();
+                syncer.validationBarrier.await();
+                running.decrementAndGet();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+          });
+        }
+      }
+    }).start();
+
+    syncer.startupBarrier.await();
+    assertEquals(running.get(), limit);
+    verify(accountant, times(limit)).incrementThreads();
+    // reset will clear the counts on incrementThreads
+    reset(accountant);
+    int pendingJobs = jobs - limit;
+    syncer.startupBarrier = new CyclicBarrier(pendingJobs + 1);
+    syncer.validationBarrier.await();
+    // verify additional jobs are run as soon as current job finishes
+    syncer.validationBarrier = new CyclicBarrier(pendingJobs + 1);
+    syncer.startupBarrier.await();
+    assertEquals(running.get(), pendingJobs);
+    verify(accountant, times(pendingJobs)).incrementThreads();
+    syncer.validationBarrier.await();
+  }
+}
+

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/resources/ResourceManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/resources/ResourceManagerTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import com.linkedin.pinot.common.query.ServerQueryRequest;
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class ResourceManagerTest {
+
+  @Test
+  public void testCanSchedule() throws Exception {
+    ResourceManager rm = getResourceManager(2, 5, 1, 3);
+
+    SchedulerGroupAccountant accountant = mock(SchedulerGroupAccountant.class);
+    when(accountant.totalReservedThreads()).thenReturn(3);
+    assertFalse(rm.canSchedule(accountant));
+
+    when(accountant.totalReservedThreads()).thenReturn(2);
+    assertTrue(rm.canSchedule(accountant));
+  }
+
+  private ResourceManager getResourceManager(int runners, int workers, final int softLimit, final int hardLimit) {
+
+    return new ResourceManager(getConfig(runners, workers)) {
+
+      @Override
+      public QueryExecutorService getExecutorService(ServerQueryRequest query, SchedulerGroupAccountant accountant) {
+        return new QueryExecutorService() {
+          @Override
+          public void execute(Runnable command) {
+            getQueryWorkers().execute(command);
+          }
+        };
+      }
+
+      @Override
+      public int getTableThreadsHardLimit() {
+        return hardLimit;
+      }
+
+      @Override
+      public int getTableThreadsSoftLimit() {
+        return softLimit;
+      }
+    };
+  }
+  private Configuration getConfig(int runners, int workers) {
+    Configuration config = new PropertiesConfiguration();
+    config.setProperty(ResourceManager.QUERY_RUNNER_CONFIG_KEY, runners);
+    config.setProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, workers);
+    return config;
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/resources/UnboundedResourceManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/resources/UnboundedResourceManagerTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.resources;
+
+import com.linkedin.pinot.core.query.scheduler.SchedulerGroupAccountant;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+
+public class UnboundedResourceManagerTest {
+
+  @Test
+  public void testDefault() {
+    Configuration config = new PropertiesConfiguration();
+
+    UnboundedResourceManager rm = new UnboundedResourceManager(config);
+    assertTrue(rm.getNumQueryRunnerThreads() > 1);
+    assertTrue(rm.getNumQueryWorkerThreads() >= 1);
+    assertEquals(rm.getTableThreadsHardLimit(), rm.getNumQueryRunnerThreads() + rm.getNumQueryWorkerThreads());
+    assertEquals(rm.getTableThreadsSoftLimit(), rm.getNumQueryRunnerThreads() + rm.getNumQueryWorkerThreads());
+  }
+
+  @Test
+  public void testWithConfig() {
+    Configuration config = new PropertiesConfiguration();
+    final int workers = 5;
+    final int runners = 2;
+
+    config.setProperty(ResourceManager.QUERY_RUNNER_CONFIG_KEY, runners);
+    config.setProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, workers);
+
+    UnboundedResourceManager rm = new UnboundedResourceManager(config);
+    assertEquals(rm.getNumQueryWorkerThreads(), workers);
+    assertEquals(rm.getNumQueryRunnerThreads(), runners);
+    assertEquals(rm.getTableThreadsHardLimit(), runners + workers);
+    assertEquals(rm.getTableThreadsSoftLimit(), runners + workers);
+
+    SchedulerGroupAccountant accountant = mock(SchedulerGroupAccountant.class);
+    when(accountant.totalReservedThreads()).thenReturn(3);
+    assertTrue(rm.canSchedule(accountant));
+
+    when(accountant.totalReservedThreads()).thenReturn(workers + runners + 2);
+    assertFalse(rm.canSchedule(accountant));
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenSchedulerGroupTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/query/scheduler/tokenbucket/TokenSchedulerGroupTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.scheduler.tokenbucket;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class TokenSchedulerGroupTest {
+
+  int timeMillis = 100;
+  class TestTokenSchedulerGroup extends TokenSchedulerGroup {
+    static final int numTokensPerMs = 100;
+    static final int tokenLifetimeMs = 100;
+    TestTokenSchedulerGroup() {
+      super("testGroup", numTokensPerMs, tokenLifetimeMs);
+    }
+
+    @Override
+    public long currentTimeMillis() {
+      return timeMillis;
+    }
+  }
+  @Test
+  public void testIncrementThreads() throws Exception {
+    // set test time first
+    timeMillis = 100;
+    TestTokenSchedulerGroup group = new TestTokenSchedulerGroup();
+
+    int availableTokens = group.getAvailableTokens();
+    // verify token count is correctly set
+    assertEquals(availableTokens, TestTokenSchedulerGroup.numTokensPerMs * TestTokenSchedulerGroup.tokenLifetimeMs);
+
+    // no threads in use...incrementing time has no effect
+    timeMillis += 2 * TestTokenSchedulerGroup.tokenLifetimeMs;
+    availableTokens = group.getAvailableTokens();
+    int startTime = timeMillis;
+    assertEquals(availableTokens, TestTokenSchedulerGroup.numTokensPerMs * TestTokenSchedulerGroup.tokenLifetimeMs);
+
+    int nThreads = 1;
+    incrementThreads(group, nThreads);
+    assertEquals(group.getThreadsInUse(), nThreads);
+    assertEquals(group.getAvailableTokens(), availableTokens);
+
+    // advance time
+    int timeIncrement = 20;
+    timeMillis += timeIncrement;
+    group.decrementThreads();
+    assertEquals(group.getThreadsInUse(), 0);
+    assertEquals(group.getAvailableTokens(), availableTokens - timeIncrement * nThreads);
+
+
+    // more threads
+    availableTokens = group.getAvailableTokens();
+    nThreads = 5;
+    incrementThreads(group, nThreads);
+    assertEquals(group.getThreadsInUse(), nThreads);
+    // advance time now
+    timeMillis += timeIncrement;
+    assertEquals(group.getAvailableTokens(), availableTokens - timeIncrement * nThreads);
+
+    // simple getAvailableTokens() updates tokens and reservedThreads has no effect
+    group.addReservedThreads(2 * nThreads);
+    availableTokens = group.getAvailableTokens();
+    timeIncrement = 10;
+    timeMillis += timeIncrement;
+    assertEquals(group.getAvailableTokens(), availableTokens - timeIncrement * nThreads);
+    availableTokens = group.getAvailableTokens();
+
+    // decrement some threads
+    decrementThreads(group, 2);
+    nThreads -= 2;
+    timeMillis += timeIncrement;
+    assertEquals(group.getAvailableTokens(), availableTokens - timeIncrement * nThreads);
+
+    // 3 threads still in use. Advance time beyond time quantum
+    availableTokens = group.getAvailableTokens();
+    int pendingTimeInQuantum = startTime + TestTokenSchedulerGroup.tokenLifetimeMs - timeMillis;
+    timeMillis = startTime + TestTokenSchedulerGroup.tokenLifetimeMs + timeIncrement;
+    int timeAdvance = pendingTimeInQuantum + timeIncrement;
+    // these are "roughly" the tokens in use since we apply decay. So we don't test for exact value
+    int expectedTokens = TestTokenSchedulerGroup.numTokensPerMs * TestTokenSchedulerGroup.tokenLifetimeMs - timeAdvance * nThreads;
+    assertTrue(group.getAvailableTokens() < expectedTokens);
+    availableTokens = group.getAvailableTokens();
+
+    // increment by multiple quantums
+    timeMillis = startTime + 3 * TestTokenSchedulerGroup.tokenLifetimeMs + timeIncrement;
+    expectedTokens = TestTokenSchedulerGroup.numTokensPerMs * TestTokenSchedulerGroup.tokenLifetimeMs - timeIncrement * nThreads;
+    assertTrue(group.getAvailableTokens() < expectedTokens );
+  }
+
+  @Test
+  public void testStartStopQuery() {
+    timeMillis = 100;
+    TestTokenSchedulerGroup group = new TestTokenSchedulerGroup();
+    assertEquals(group.numRunning(), 0);
+    assertEquals(group.numPending(), 0);
+    assertEquals(group.getThreadsInUse(), 0);
+    group.startQuery();
+    assertEquals(group.numRunning(), 1);
+    assertEquals(group.getThreadsInUse(), 1);
+
+    group.endQuery();
+    assertEquals(group.numRunning(), 0);
+    assertEquals(group.getThreadsInUse(), 0);
+  }
+
+  private void incrementThreads(TokenSchedulerGroup group, int nThreads) {
+    for (int i = 0; i < nThreads; i++) {
+      group.incrementThreads();
+    }
+  }
+
+  private void decrementThreads(TokenSchedulerGroup group, int nThreads) {
+    for (int i = 0; i < nThreads; i++) {
+      group.decrementThreads();
+    }
+  }
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/SchedulerResource.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/api/resources/SchedulerResource.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.server.api.resources;
+
+import com.linkedin.pinot.server.starter.ServerInstance;
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * REST API to change server query scheduler. This is intended for testing ONLY.
+ * The goal is easily change server query scheduler without the need to redploy configs or
+ * restart server for comparison of different scheduling strategies.
+ */
+@Path("/")
+public class SchedulerResource {
+  private static Logger LOGGER = LoggerFactory.getLogger(SchedulerResource.class);
+
+  @Inject
+  ServerInstance server;
+
+  // Missing swagger doc is intentional
+  @POST
+  @Path("scheduler")
+  public void setQueryScheduler(String schedulerName) {
+    server.resetQueryScheduler(schedulerName);
+  }
+
+}
+

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/ServerBuilder.java
@@ -26,7 +26,6 @@ import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.linkedin.pinot.core.query.scheduler.QuerySchedulerFactory;
 import com.linkedin.pinot.server.conf.NettyServerConfig;
 import com.linkedin.pinot.server.conf.ServerConf;
-import com.linkedin.pinot.server.request.ScheduledRequestHandler;
 import com.linkedin.pinot.transport.netty.NettyServer;
 import com.linkedin.pinot.transport.netty.NettyServer.RequestHandlerFactory;
 import com.linkedin.pinot.transport.netty.NettyTCPServer;
@@ -43,8 +42,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Initialize a ServerBuilder with serverConf file.
- *
- *
  */
 public class ServerBuilder {
 
@@ -151,15 +148,6 @@ public class ServerBuilder {
     return QuerySchedulerFactory.create(schedulerConfig, queryExecutor, _serverMetrics);
   }
 
-  public RequestHandlerFactory buildRequestHandlerFactory(final QueryScheduler queryScheduler) {
-    RequestHandlerFactory requestHandlerFactory = new RequestHandlerFactory() {
-      @Override
-      public NettyServer.RequestHandler createNewRequestHandler() {
-        return new ScheduledRequestHandler(queryScheduler, _serverMetrics);
-      }
-    };
-    return requestHandlerFactory;
-  }
 
   /**
    * This method initializes the transform factory containing built-in functions

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/integration/InstanceServerStarter.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/integration/InstanceServerStarter.java
@@ -15,20 +15,9 @@
  */
 package com.linkedin.pinot.server.integration;
 
+import com.linkedin.pinot.common.data.DataManager;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.ServerQueryRequest;
-import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
-import com.yammer.metrics.core.MetricsRegistry;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.common.data.DataManager;
 import com.linkedin.pinot.common.query.QueryExecutor;
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
@@ -36,8 +25,16 @@ import com.linkedin.pinot.common.request.FilterQuery;
 import com.linkedin.pinot.common.request.InstanceRequest;
 import com.linkedin.pinot.common.request.QuerySource;
 import com.linkedin.pinot.common.utils.DataTable;
+import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.linkedin.pinot.server.starter.ServerBuilder;
-import com.linkedin.pinot.transport.netty.NettyServer.RequestHandlerFactory;
+import com.yammer.metrics.core.MetricsRegistry;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class InstanceServerStarter {
@@ -60,7 +57,6 @@ public class InstanceServerStarter {
     LOGGER.info("Trying to build QueryExecutor");
     final QueryExecutor queryExecutor = serverBuilder.buildQueryExecutor(instanceDataManager);
     QueryScheduler queryScheduler = serverBuilder.buildQueryScheduler(queryExecutor);
-    RequestHandlerFactory simpleRequestHandlerFactory = serverBuilder.buildRequestHandlerFactory(queryScheduler);
     LOGGER.info("Trying to build NettyServer");
 
     System.out.println(getMaxQuery());
@@ -84,7 +80,7 @@ public class InstanceServerStarter {
     InstanceRequest instanceRequest = new InstanceRequest(0, brokerRequest);
     try {
       ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, metrics);
-      DataTable instanceResponse = queryExecutor.processQuery(queryRequest, queryScheduler.getWorkerExecutorService());
+      DataTable instanceResponse = queryExecutor.processQuery(queryRequest, queryScheduler.getQueryWorkers());
       System.out.println(instanceResponse.toString());
       System.out.println("Query Time Used : " + instanceResponse.getMetadata().get(DataTable.TIME_USED_MS_METADATA_KEY));
     } catch (Exception e) {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/QueryRunner.java
@@ -332,6 +332,7 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
       if (executorService.isTerminated()) {
         LOGGER.error("All threads got exception and already dead.");
         return;
+
       }
 
       for (String query : queries) {

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
@@ -400,7 +400,6 @@ public class NettyTCPClientConnection extends NettyClientConnection  {
       setSelfClose(true);
     }
   }
-
   /**
    * Timer task responsible for closing the connection on timeout
    *

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPServer.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPServer.java
@@ -89,7 +89,7 @@ public class NettyTCPServer extends NettyServer {
 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
-      LOGGER.info("Setting up Server channel !!");
+      LOGGER.info("Setting up Server channel, scheduler");
       ch.pipeline().addLast("decoder", new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
       ch.pipeline().addLast("encoder", new LengthFieldPrepender(4));
       //ch.pipeline().addLast("logger", new LoggingHandler());


### PR DESCRIPTION
Added resource management policy, bounded executor service and
priority based schedulers to provide better scheduling and
isolation between different tenants.
* Default behavior is the legacy FCFS approach with no resource limitations
* Supports configurable resource allocation policy per query
* Bounded executor service limits the threads used for a query to the limit
set of resource manager without changes to query processing logic.
* Priority Token Bucket scheduler implements a multi-level query scheduler
that prioritizes queries from a scheduler group with highest tokens. For groups
with same tokens, the group with least committed resources is selected for scheduling.
A group is not allowed to exceed the configured hard limit on the number of threads.