### PR TITLE
Fix NPE when accessing broker's routing table debug endpoint.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/servlet/PinotBrokerRoutingTableDebugServlet.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/servlet/PinotBrokerRoutingTableDebugServlet.java
@@ -49,7 +49,7 @@ public class PinotBrokerRoutingTableDebugServlet extends HttpServlet {
       String tableName;
       String pathInfo = req.getPathInfo();
 
-      if (pathInfo.startsWith("/") && pathInfo.lastIndexOf('/') == 0) {
+      if (pathInfo != null && !pathInfo.isEmpty() && pathInfo.startsWith("/") && pathInfo.lastIndexOf('/') == 0) {
         // Drop leading slash
         tableName = pathInfo.substring(1);
       } else {


### PR DESCRIPTION
The broker endpoint at /debug/routingTable throws NPE if table name is
not specified. Fixed it to return all routing tables in that case.