### PR TITLE
Remove metrics from non-leader controller

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/MetricsHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/MetricsHelper.java
@@ -242,6 +242,17 @@ public class MetricsHelper {
   }
 
   /**
+   * Removes an existing metric
+   */
+  public static void removeMetric(MetricsRegistry registry, MetricName name) {
+    if (registry != null) {
+      registry.removeMetric(name);
+    } else {
+      Metrics.defaultRegistry().removeMetric(name);
+    }
+  }
+
+  /**
    *
    * Return an existing aggregated long gauge if registry is not null and a aggregated long gauge already exist
    * with the same metric name. Otherwise, creates a new aggregated long gauge and registers (if registry not null)

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -128,6 +128,7 @@ public class ValidationManager {
    */
   public void runValidation() {
     if (!_pinotHelixResourceManager.isLeader()) {
+      _validationMetrics.unregisterAllMetrics();
       LOGGER.info("Skipping validation, not leader!");
       return;
     }


### PR DESCRIPTION
Remove all validation metrics from controllers which are not currently
the cluster leader. This avoids issues where a non-leader controller
emits a metric which would trigger an alert.