### PR TITLE
Minor cleanups for validation metrics

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ValidationMetrics.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ValidationMetrics.java
@@ -27,12 +27,11 @@ import com.yammer.metrics.core.MetricsRegistry;
 
 /**
  * Validation metrics utility class, which contains the glue code to publish metrics.
- *
  */
 public class ValidationMetrics {
   private final MetricsRegistry _metricsRegistry;
 
-  private final Map<String, Long> _gaugeValues = new HashMap<String, Long>();
+  private final Map<String, Long> _gaugeValues = new HashMap<>();
   private final Set<MetricName> _metricNames = new HashSet<>();
 
   /**
@@ -136,18 +135,18 @@ public class ValidationMetrics {
   }
 
   /**
-   * Updates the gauge for the number of missing segments.
+   * Updates the missing segment count gauge.
    *
    * @param resource The resource for which the gauge is updated
    * @param missingSegmentCount The number of missing segments
    */
-  public void updateMissingSegmentsGauge(final String resource, final int missingSegmentCount) {
+  public void updateMissingSegmentCountGauge(final String resource, final int missingSegmentCount) {
     final String fullGaugeName = makeGaugeName(resource, "missingSegmentCount");
     makeGauge(fullGaugeName, makeMetricName(fullGaugeName), _storedValueGaugeFactory, missingSegmentCount);
   }
 
   /**
-   * Updates the gauge for the offline segment delay.
+   * Updates the offline segment delay gauge.
    *
    * @param resource The resource for which the gauge is updated
    * @param lastOfflineSegmentTime The last offline segment end time, in milliseconds since the epoch, or Long.MIN_VALUE
@@ -161,7 +160,7 @@ public class ValidationMetrics {
   }
 
   /**
-   * Updates the gauge for the last push time.
+   * Updates the last push time gauge.
    *
    * @param resource The resource for which the gauge is updated
    * @param lastPushTimeMillis The last push time, in milliseconds since the epoch, or Long.MIN_VALUE if there is no
@@ -175,33 +174,33 @@ public class ValidationMetrics {
   }
 
   /**
-   * Updates the gauge for the Total Document Count
+   * Updates the total document count gauge.
    *
    * @param resource The resource for which the gauge is updated
-   * @param documentCount Total document count for the give resource name / tablename
+   * @param documentCount Total document count for the given resource name or table name
    */
-  public void updateTotalDocumentsGauge(final String resource, final long documentCount)
+  public void updateTotalDocumentCountGauge(final String resource, final long documentCount)
   {
     final String fullGaugeName = makeGaugeName(resource, "TotalDocumentCount");
     makeGauge(fullGaugeName, makeMetricName(fullGaugeName), _storedValueGaugeFactory, documentCount);
   }
 
   /**
+   * Updates the non consuming partition count metric.
    *
-   * @param resource The resource for which the guage is updated
-   * @param partitionCount Number of kafka partitions that do not have any segment in CONSUMING state.
+   * @param resource The resource for which the gauge is updated
+   * @param partitionCount Number of Kafka partitions that do not have any segment in CONSUMING state.
    */
-  public void updateNumNonConsumingPartitionsMetric(final String resource, final int partitionCount) {
+  public void updateNonConsumingPartitionCountMetric(final String resource, final int partitionCount) {
     final String fullGaugeName = makeGaugeName(resource, "NonConsumingPartitionCount");
     makeGauge(fullGaugeName, makeMetricName(fullGaugeName), _storedValueGaugeFactory, partitionCount);
-
   }
 
   /**
-   * Updates the gauge for the Total segment count
+   * Updates the segment count gauge.
    *
    * @param resource The resource for which the gauge is updated
-   * @param segmentCount Total segment count for the give resource name / tablename
+   * @param segmentCount Total segment count for the given resource name or table name
    */
   public void updateSegmentCountGauge(final String resource, final long segmentCount)
   {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -58,8 +58,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Manages the segment validation metrics, to ensure that all offline segments are contiguous (no missing segments) and
  * that the offline push delay isn't too high.
- *
- * Dec 10, 2014
 */
 
 public class ValidationManager {
@@ -163,7 +161,7 @@ public class ValidationManager {
             segmentMetadataList.add(segmentMetadata);
           }
           // Update the gauge to contain the total document count in the segments
-          _validationMetrics.updateTotalDocumentsGauge(tableName, computeRealtimeTotalDocumentInSegments(segmentMetadataList,
+          _validationMetrics.updateTotalDocumentCountGauge(tableName, computeRealtimeTotalDocumentInSegments(segmentMetadataList,
               countHLCSegments));
           if (streamMetadata.hasSimpleKafkaConsumerType()) {
             validateLLCSegments(tableName, tableConfig);
@@ -238,7 +236,7 @@ public class ValidationManager {
     // Kafka partition set now has all the partitions that do not have any segments in CONSUMING state.
     if (!llcSegments.isEmpty()) {
       // Raise the metric only if there is at least one llc segment in the idealstate.
-      _validationMetrics.updateNumNonConsumingPartitionsMetric(realtimeTableName, nonConsumingKafkaPartitions.size());
+      _validationMetrics.updateNonConsumingPartitionCountMetric(realtimeTableName, nonConsumingKafkaPartitions.size());
       // Recreate a segment for the partitions that are missing one.
       for (Integer kafkaPartition : nonConsumingKafkaPartitions) {
         LOGGER.warn("Table {}, kafka partition {} has no segments in CONSUMING state (out of {} llc segments)",
@@ -288,7 +286,7 @@ public class ValidationManager {
     }
 
     // Update the gauge that contains the number of missing segments
-    _validationMetrics.updateMissingSegmentsGauge(tableName, missingSegmentCount);
+    _validationMetrics.updateMissingSegmentCountGauge(tableName, missingSegmentCount);
 
     // Compute the max segment end time and max segment push time
     long maxSegmentEndTime = Long.MIN_VALUE;
@@ -314,7 +312,7 @@ public class ValidationManager {
     _validationMetrics.updateOfflineSegmentDelayGauge(tableName, maxSegmentEndTime);
     _validationMetrics.updateLastPushTimeGauge(tableName, maxSegmentPushTime);
     // Update the gauge to contain the total document count in the segments
-    _validationMetrics.updateTotalDocumentsGauge(tableName, computeOfflineTotalDocumentInSegments(segmentMetadataList));
+    _validationMetrics.updateTotalDocumentCountGauge(tableName, computeOfflineTotalDocumentInSegments(segmentMetadataList));
     // Update the gauge to contain the total number of segments for this table
     _validationMetrics.updateSegmentCountGauge(tableName, segmentMetadataList.size());
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -72,7 +72,6 @@ import static org.mockito.Mockito.when;
 
 /**
  * Tests for the ValidationManager.
- *
  */
 public class ValidationManagerTest {
   private String HELIX_CLUSTER_NAME = "TestValidationManager";
@@ -471,7 +470,7 @@ public class ValidationManagerTest {
       super(null);
     }
     @Override
-    public void updateNumNonConsumingPartitionsMetric(final String tableName, final int count) {
+    public void updateNonConsumingPartitionCountMetric(final String tableName, final int count) {
       partitionCount = count;
     }
   }


### PR DESCRIPTION
Minor cleanups for validation metrics:
 - Fix grammar and spelling of various comments
 - Normalize public methods that update gauges to match up with the
   actual gauge name that is being updated
 - Remove some empty lines