### PR TITLE
[TE] Allow job status checking for detection jobs

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -225,7 +225,7 @@ public class DetectionJobResource {
    * @param speedup
    *      whether this backfill should speedup with 7-day window. The assumption is that the functions are using
    *      WoW-based algorithm, or Seasonal Data Model.
-   * @return HTTP response of this request with a map from function id to its job execution id
+   * @return HTTP response of this request with a job execution id
    * @throws Exception
    */
   @POST
@@ -235,8 +235,11 @@ public class DetectionJobResource {
       @QueryParam("end") @NotNull String endTimeIso,
       @QueryParam("force") @DefaultValue("false") String isForceBackfill,
       @QueryParam("speedup") @DefaultValue("false") final Boolean speedup) throws Exception {
-
-    return generateAnomaliesInRangeForFunctions(Long.toString(id), startTimeIso, endTimeIso, isForceBackfill, speedup);
+    Response response = generateAnomaliesInRangeForFunctions(Long.toString(id), startTimeIso, endTimeIso,
+        isForceBackfill, speedup);
+    // As there is only one function id, simplify the response message to a single job execution id
+    Map<Long, Long> entity = (Map<Long, Long>) response.getEntity();
+    return Response.status(response.getStatus()).entity(entity.values()).build();
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -225,7 +225,7 @@ public class DetectionJobResource {
    * @param speedup
    *      whether this backfill should speedup with 7-day window. The assumption is that the functions are using
    *      WoW-based algorithm, or Seasonal Data Model.
-   * @return HTTP response of this request
+   * @return HTTP response of this request with a job execution id
    * @throws Exception
    */
   @POST
@@ -254,7 +254,7 @@ public class DetectionJobResource {
    * @param speedup
    *      whether this backfill should speedup with 7-day window. The assumption is that the functions are using
    *      WoW-based algorithm, or Seasonal Data Model.
-   * @return HTTP response of this request
+   * @return HTTP response of this request with the list of job execution id
    * @throws Exception
    */
   @POST

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/JobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/JobResource.java
@@ -96,6 +96,11 @@ public class JobResource {
     JobDTO jobDTO = jobDao.findById(id);
     List<TaskDTO> taskDTOs = taskDao.findByJobIdStatusNotIn(id, TaskStatus.COMPLETED);
     JobStatus jobStatus = jobDTO.getStatus();
+    if (jobStatus.equals(JobStatus.FAILED) || jobStatus.equals(JobStatus.COMPLETED)) {
+      // The final job status is reached. No change is made.
+      return jobStatus;
+    }
+    JobStatus previousStatus = jobStatus;
     if (taskDTOs.size() > 0) {
       boolean containFails = false;
       for (TaskDTO task : taskDTOs) {
@@ -111,8 +116,11 @@ public class JobResource {
     } else {
       jobStatus = JobStatus.COMPLETED;
     }
-    jobDTO.setStatus(jobStatus);
-    jobDao.update(jobDTO);
+    // If there is no change, no update is made.
+    if (!previousStatus.equals(jobStatus)) {
+      jobDTO.setStatus(jobStatus);
+      jobDao.update(jobDTO);
+    }
     return jobStatus;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/JobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/JobResource.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -82,18 +83,18 @@ public class JobResource {
 
   /**
    * Get the execution status of the given job id
-   * @param jobId
+   * @param id
    * @return the status of the job
    * COMPLETE if all tasks of the job are done without errors
    * FAILED if at least one of the tasks underneath is failed
    * SCHEDULED if at least one task underneath is still running or waiting
    */
   @GET
-  @Path("/job/status")
+  @Path("/job/{id}/status")
   @Produces(MediaType.APPLICATION_JSON)
-  public JobStatus getJobStatus(@NotNull @QueryParam("jobId") long jobId) {
-    JobDTO jobDTO = jobDao.findById(jobId);
-    List<TaskDTO> taskDTOs = taskDao.findByJobIdStatusNotIn(jobId, TaskStatus.COMPLETED);
+  public JobStatus getJobStatus(@NotNull @PathParam("id") long id) {
+    JobDTO jobDTO = jobDao.findById(id);
+    List<TaskDTO> taskDTOs = taskDao.findByJobIdStatusNotIn(id, TaskStatus.COMPLETED);
     JobStatus jobStatus = jobDTO.getStatus();
     if (taskDTOs.size() > 0) {
       boolean containFails = false;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/JobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/JobResource.java
@@ -80,6 +80,14 @@ public class JobResource {
     return rootNode.toString();
   }
 
+  /**
+   * Get the execution status of the given job id
+   * @param jobId
+   * @return the status of the job
+   * COMPLETE if all tasks of the job are done without errors
+   * FAILED if at least one of the tasks underneath is failed
+   * SCHEDULED if at least one task underneath is still running or waiting
+   */
   @GET
   @Path("/job/status")
   @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
During the onboard process, one missing component is the ability to check the replay execution status. After function set-up, the replay is triggered. A detection job is triggered, and tasks are generated to perform analyses. The front-end then can check the status through this end-point to get the status of the job. Once the job is COMPLETED, the alerts or the auto-tune can be triggered afterward. 

- Enable detection jobs to return job ids

- Implement an endpoint to check the job status