### PR TITLE
[TE] Fix filter values are not shown completely for non-additive dataset

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -91,6 +91,7 @@ public class Utils {
         String dimensionValue = row.get(dimension);
         values.add(dimensionValue);
       }
+      Collections.sort(values);
       result.put(dimension, values);
     }
     return result;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -113,9 +113,11 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
           timeSpec = dataTimeSpec;
         }
 
-        // Decorate filter set for pre-computed (non-additive) dataset
         Multimap<String, String> decoratedFilterSet = request.getFilterSet();
-        if (!datasetConfig.isAdditive()) {
+        // Decorate filter set for pre-computed (non-additive) dataset
+        // NOTE: We do not decorate the filter if the metric name is '*', which is used by count(*) query, because
+        // the results are usually meta-data and should be shown regardless the filter setting.
+        if (!datasetConfig.isAdditive() && !"*".equals(metricFunction.getMetricName())) {
           decoratedFilterSet =
               generateFilterSetWithPreAggregatedDimensionValue(request.getFilterSet(), request.getGroupBy(),
                   datasetConfig.getDimensions(), datasetConfig.getDimensionsHaveNoPreAggregation(),


### PR DESCRIPTION
Problem:
Many filter values are not shown for non-additive dataset. The issue is that we add pre-aggregated keywords to the filter set (e.g., count=all) when we construct the query for non-additive dataset. However, the count(*) queries, which are used for retrieving meta-data such as filter values, should not have any setting regarding the filter set. Otherwise, the results may be incomplete.

Fix:
Before we append the decorated filterset, we check if the target of the query is '*'. If it is, then we don't add decorated filter set to the query and hence we get the complete meta-data (i.e., the filter values).

Test:
Local dashboard.