### PR TITLE
On-Heap implementation of immutable StringDictionary.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
@@ -39,6 +39,7 @@ public class IndexingConfig {
   private String _starTreeFormat;
   private String _columnMinMaxValueGeneratorMode;
   private List<String> _noDictionaryColumns;
+  private List<String> _onHeapDictionaryColumns;
   private StarTreeIndexSpec _starTreeIndexSpec;
   private SegmentPartitionConfig _segmentPartitionConfig;
 
@@ -110,8 +111,16 @@ public class IndexingConfig {
     return _noDictionaryColumns;
   }
 
+  public List<String> getOnHeapDictionaryColumns() {
+    return _onHeapDictionaryColumns;
+  }
+
   public void setNoDictionaryColumns(List<String> noDictionaryColumns) {
     _noDictionaryColumns = noDictionaryColumns;
+  }
+
+  public void setOnHeapDictionaryColumns(List<String> onHeapDictionaryColumns) {
+    _onHeapDictionaryColumns = onHeapDictionaryColumns;
   }
 
   public void setStarTreeIndexSpec(StarTreeIndexSpec starTreeIndexSpec) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
@@ -319,6 +319,7 @@ public class TableConfig {
     private String _sortedColumn;
     private List<String> _invertedIndexColumns;
     private List<String> _noDictionaryColumns;
+    private List<String> _onHeapDictionaryColumns;
     private Map<String, String> _streamConfigs;
 
     private TableCustomConfig _customConfig;
@@ -430,6 +431,11 @@ public class TableConfig {
       return this;
     }
 
+    public Builder setOnHeapDictionaryColumns(List<String> onHeapDictionaryColumns) {
+      _onHeapDictionaryColumns = onHeapDictionaryColumns;
+      return this;
+    }
+
     public Builder setStreamConfigs(Map<String, String> streamConfigs) {
       Preconditions.checkState(_tableType == TableType.REALTIME);
       _streamConfigs = streamConfigs;
@@ -487,6 +493,7 @@ public class TableConfig {
       }
       indexingConfig.setInvertedIndexColumns(_invertedIndexColumns);
       indexingConfig.setNoDictionaryColumns(_noDictionaryColumns);
+      indexingConfig.setOnHeapDictionaryColumns(_onHeapDictionaryColumns);
       indexingConfig.setStreamConfigs(_streamConfigs);
       // TODO: set SegmentPartitionConfig here
 

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
@@ -35,11 +35,14 @@ import org.testng.annotations.Test;
 public class IndexingConfigTest {
 
   @Test
-  public void testIgnoreUnknown()
+  public void testSerDe()
       throws JSONException, IOException {
     JSONObject json = new JSONObject();
     json.put("invertedIndexColumns", Arrays.asList("a", "b", "c"));
     json.put("sortedColumn", Arrays.asList("d", "e", "f"));
+
+    String[] expectedOnHeapDictionaryColumns = new String[] {"x", "y", "z"};
+    json.put("onHeapDictionaryColumns", Arrays.asList(expectedOnHeapDictionaryColumns));
     json.put("loadMode", "MMAP");
     json.put("keyThatIsUnknown", "randomValue");
 
@@ -59,6 +62,12 @@ public class IndexingConfigTest {
     Assert.assertEquals("d", sortedIndexColumns.get(0));
     Assert.assertEquals("e", sortedIndexColumns.get(1));
     Assert.assertEquals("f", sortedIndexColumns.get(2));
+
+    List<String> actualOnHeapDictionaryColumns = indexingConfig.getOnHeapDictionaryColumns();
+    Assert.assertEquals(actualOnHeapDictionaryColumns.size(), expectedOnHeapDictionaryColumns.length);
+    for (int i = 0; i < expectedOnHeapDictionaryColumns.length; i++) {
+      Assert.assertEquals(actualOnHeapDictionaryColumns.get(i), expectedOnHeapDictionaryColumns[i]);
+    }
   }
 
   @Test

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -160,7 +160,6 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     LOGGER.debug("starTreeTempDir:{}", starTreeTempDir);
   }
 
-  @Deprecated
   public void init(SegmentGeneratorConfig config, RecordReader reader) throws Exception {
     init(config, new RecordReaderSegmentCreationDataSource(reader));
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -40,6 +40,7 @@ public class IndexLoadingConfig {
   private List<String> _sortedColumns = Collections.emptyList();
   private Set<String> _invertedIndexColumns = new HashSet<>();
   private Set<String> _noDictionaryColumns = new HashSet<>();
+  private Set<String> _onHeapDictionaryColumns = new HashSet<>();
   private SegmentVersion _segmentVersion = SegmentVersion.DEFAULT_VERSION;
   private StarTreeFormatVersion _starTreeVersion = StarTreeFormatVersion.DEFAULT_VERSION;
   private boolean _enableDefaultColumns = true;
@@ -92,6 +93,11 @@ public class IndexLoadingConfig {
       List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
       if (noDictionaryColumns != null) {
         _noDictionaryColumns.addAll(noDictionaryColumns);
+      }
+
+      List<String> onHeapDictionaryColumns = indexingConfig.getOnHeapDictionaryColumns();
+      if (onHeapDictionaryColumns != null) {
+        _onHeapDictionaryColumns.addAll(onHeapDictionaryColumns);
       }
 
       String tableSegmentVersion = indexingConfig.getSegmentFormatVersion();
@@ -150,6 +156,11 @@ public class IndexLoadingConfig {
   @Nonnull
   public Set<String> getNoDictionaryColumns() {
     return _noDictionaryColumns;
+  }
+
+  @Nonnull
+  public Set<String> getOnHeapDictionaryColumns() {
+    return _onHeapDictionaryColumns;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapStringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapStringDictionary.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.readers;
+
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import joptsimple.internal.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Implementation of String immutable dictionary based using on-heap String array and HashMap.
+ * This is useful for:
+ * <ul>
+ *   <li> Low cardinality string dictionaries where memory footprint on-heap is acceptably small. </li>
+ *   <li> Heavily queried columns: This helps avoid creation of String from byte[], which is expensive
+ *        as well as creates garbage. </li>
+ * </ul>
+ * This is useful for low cardinality dictionaries that can be stored in-heap with small memory footprint.
+ * For
+ */
+public class OnHeapStringDictionary extends ImmutableDictionaryReader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OnHeapStringDictionary.class);
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  private final int _lengthOfMaxEntry;
+  private final char _paddingChar;
+
+  private String[] _idToStringMap;
+  private String[] _idToRawStringMap;
+  private Map<String, Integer> _stringToIdMap;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param dataBuffer Pinot Data buffer for the dictionary
+   * @param metadata Column metadata
+   */
+  public OnHeapStringDictionary(PinotDataBuffer dataBuffer, ColumnMetadata metadata) {
+    super(dataBuffer, metadata.getCardinality(), metadata.getStringColumnMaxLength());
+    _lengthOfMaxEntry = metadata.getStringColumnMaxLength();
+    _paddingChar = metadata.getPaddingCharacter();
+
+    int cardinality = metadata.getCardinality();
+    _idToStringMap = new String[cardinality];
+    _idToRawStringMap = new String[cardinality];
+    _stringToIdMap = new HashMap<>(cardinality);
+
+    for (int id = 0; id < cardinality; id++) {
+      byte[] bytes = dataFileReader.getBytes(id, 0);
+      String value = getStringFromBytes(bytes, true);
+      _idToStringMap[id] = value;
+      _idToRawStringMap[id] = getStringFromBytes(bytes, false);
+      _stringToIdMap.put(value, id);
+    }
+
+    // Close the data-buffer since on-heap dictionary has already been built.
+    try {
+      close();
+    } catch (IOException e) {
+      LOGGER.error("Error closing data-buffer for on-heap dictionary for column: " + metadata.getColumnName());
+      Utils.rethrowException(e);
+    }
+    dataBuffer.close();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public int indexOf(Object rawValue) {
+    final String lookup = (String) rawValue; // This will always be a string
+    Integer index = _stringToIdMap.get(lookup);
+    return (index != null) ? index : -1;
+  }
+
+  @Override
+  public String get(int dictionaryId) {
+    if ((dictionaryId == -1) || (dictionaryId >= length())) {
+      return "null";
+    }
+    return _idToStringMap[dictionaryId];
+  }
+
+  @Override
+  public long getLongValue(int dictionaryId) {
+    throw new RuntimeException("cannot converted string to long");
+  }
+
+  @Override
+  public double getDoubleValue(int dictionaryId) {
+    throw new RuntimeException("cannot converted string to double");
+  }
+
+  @Override
+  public int getIntValue(int dictionaryId) {
+    throw new RuntimeException("cannot converted string to int");
+  }
+
+  @Override
+  public float getFloatValue(int dictionaryId) {
+    throw new RuntimeException("cannot converted string to float");
+  }
+
+  @Override
+  public String getStringValue(int dictionaryId) {
+    if ((dictionaryId == -1) || (dictionaryId >= length())) {
+      return "null";
+    }
+    return _idToRawStringMap[dictionaryId];
+  }
+
+  @Override
+  public void readIntValues(int[] dictionaryIds, int startPos, int limit, int[] outValues, int outStartPos) {
+    throw new RuntimeException("Can not convert string to int");
+  }
+
+  @Override
+  public void readLongValues(int[] dictionaryIds, int startPos, int limit, long[] outValues, int outStartPos) {
+    throw new RuntimeException("Can not convert string to long");
+  }
+
+  @Override
+  public void readFloatValues(int[] dictionaryIds, int startPos, int limit, float[] outValues, int outStartPos) {
+    throw new RuntimeException("Can not convert string to float");
+  }
+
+  @Override
+  public void readDoubleValues(int[] dictionaryIds, int startPos, int limit, double[] outValues, int outStartPos) {
+    throw new RuntimeException("Can not convert string to double");
+  }
+
+  @Override
+  public void readStringValues(int[] dictionaryIds, int startPos, int limit, String[] outValues, int outStartPos) {
+    for (int i = 0; i < limit; i++) {
+      outValues[i + outStartPos] = get(dictionaryIds[i + startPos]);
+    }
+  }
+
+  /**
+   * Helper method to read string value from the data file.
+   *
+   * @param bytes Raw bytes from which to build String.
+   * @param stripPadding Strip padding character if true.
+   * @return String value corresponding to the raw bytes
+   */
+  private String getStringFromBytes(byte[] bytes, boolean stripPadding) {
+    if (!stripPadding) {
+      return new String(bytes, UTF_8);
+    } else {
+      for (int i = _lengthOfMaxEntry - 1; i >= 0; i--) {
+        if (bytes[i] != _paddingChar) {
+          return new String(bytes, 0, i + 1, UTF_8);
+        }
+      }
+      return "";
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/OnHeapStringDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/OnHeapStringDictionaryTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.segments.v1.creator;
+
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.readers.FileFormat;
+import com.linkedin.pinot.core.data.readers.RecordReader;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.index.column.ColumnIndexContainer;
+import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
+import com.linkedin.pinot.core.segment.store.SegmentDirectory;
+import com.linkedin.pinot.util.TestUtils;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link com.linkedin.pinot.core.segment.index.readers.OnHeapStringDictionary} class.
+ */
+public class OnHeapStringDictionaryTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OnHeapStringDictionaryTest.class);
+  private static final int NUM_ROWS = 1001;
+
+  private static final String SEGMENT_DIR_NAME = System.getProperty("java.io.tmpdir") + File.separator + "onHeapDict";
+  private static final String SEGMENT_NAME = "onHeapDictSeg";
+  private static final int MAX_STRING_LENGTH = 101;
+  private static final String COLUMN_NAME = "column";
+
+  /**
+   * Builds a segment with one string column, and loads two version of its dictionaries, one with default
+   * off-heap {@link com.linkedin.pinot.core.segment.index.readers.StringDictionary} and another with
+   * {@link com.linkedin.pinot.core.segment.index.readers.OnHeapStringDictionary}.
+   *
+   * Tests all interfaces return the same result for the two dictionary implementations.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void test()
+      throws Exception {
+
+    buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME);
+    File indexDir = new File(SEGMENT_DIR_NAME, SEGMENT_NAME);
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
+    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(COLUMN_NAME);
+    SegmentDirectory segmentDirectory = SegmentDirectory.createFromLocalFS(indexDir, segmentMetadata, ReadMode.mmap);
+    SegmentDirectory.Reader segmentReader = segmentDirectory.createReader();
+
+    ImmutableDictionaryReader offHeapDictionary =
+        ColumnIndexContainer.loadDictionary(columnMetadata, segmentReader, false);
+    ImmutableDictionaryReader onHeapDictionary =
+        ColumnIndexContainer.loadDictionary(columnMetadata, segmentReader, true);
+
+    int numElements = offHeapDictionary.length();
+    Assert.assertEquals(onHeapDictionary.length(), numElements, "Dictionary length mis-match");
+    for (int id = 0; id < numElements; id++) {
+      String expected = (String) offHeapDictionary.get(id);
+      Assert.assertEquals(onHeapDictionary.get(id), expected);
+      Assert.assertEquals(onHeapDictionary.getStringValue(id), offHeapDictionary.getStringValue(id));
+      Assert.assertEquals(onHeapDictionary.indexOf(expected), id);
+    }
+
+    Random random = new Random(System.nanoTime());
+    int batchSize = random.nextInt(onHeapDictionary.length());
+    int dictIds[] = new int[batchSize];
+
+    String[] actualValues = new String[batchSize];
+    String[] expectedValues = new String[batchSize];
+
+    for (int i = 0; i < 100; i++) {
+      for (int j = 0; j < batchSize; j++) {
+        dictIds[j] = random.nextInt(numElements);
+      }
+      onHeapDictionary.readStringValues(dictIds, 0, batchSize, actualValues, 0);
+      offHeapDictionary.readStringValues(dictIds, 0, batchSize, expectedValues, 0);
+      Assert.assertEquals(actualValues, expectedValues);
+    }
+
+    segmentReader.close();
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(new File(SEGMENT_DIR_NAME));
+  }
+
+  /**
+   * Helper method to build a segment with one String column.
+   *
+   * @param segmentDirName Name of segment directory
+   * @param segmentName Name of segment
+   * @throws Exception
+   */
+  private void buildSegment(String segmentDirName, String segmentName)
+      throws Exception {
+    // Build schema with two string columns:
+    Schema schema = new Schema();
+    schema.addField(new DimensionFieldSpec(COLUMN_NAME, FieldSpec.DataType.STRING, true));
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setOutDir(segmentDirName);
+    config.setFormat(FileFormat.AVRO);
+    config.setSegmentName(segmentName);
+
+    Random random = new Random(System.nanoTime());
+    List<GenericRow> data = new ArrayList<>();
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      String value = RandomStringUtils.random(random.nextInt(MAX_STRING_LENGTH));
+
+      Map<String, Object> map = new HashMap<>();
+      for (String column : schema.getColumnNames()) {
+        map.put(column, value);
+      }
+      GenericRow row = new GenericRow();
+      row.init(map);
+      data.add(row);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    RecordReader reader = new TestUtils.GenericRowRecordReader(schema, data);
+    driver.init(config, reader);
+    driver.build();
+
+    LOGGER.info("Built segment {} at {}", segmentName, segmentDirName);
+  }
+}


### PR DESCRIPTION
The call to StringDictionary.get()/indexOf() is expensive because it has
to pad/unpad the string, create new String from byte[], perform binary
search etc. This is done in the order of numDocsScanned, per query.
It can take > 30% of server side latency if numDocsScanned is of the
order of several tens of thousands or more (99th percentile).

For String columns with very low cardinality, we can simply build an
on-heap dictionary using array + map at the time of loading segment.
This gets rid of the padding/unpadding, binary search, as well as
eliminates all temporary String creation.

Added field in IndexingConfig to specify (String) columns for which
on-heap dictionary should be loaded.

Added unit tests for the new code.