### PR TITLE
[TE] Fix on the missing filters on anomaly result in DataResource

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -973,7 +973,7 @@ public class AnomaliesResource {
    *
    * @return the filter set for querying the time series that produce the anomaly.
    */
-  private static Multimap<String, String> generateFilterSetForTimeSeriesQuery(MergedAnomalyResultDTO mergedAnomaly) {
+  public static Multimap<String, String> generateFilterSetForTimeSeriesQuery(MergedAnomalyResultDTO mergedAnomaly) {
     AnomalyFunctionDTO anomalyFunctionDTO = mergedAnomaly.getFunction();
     Multimap<String, String> filterSet = anomalyFunctionDTO.getFilterSet();
     Multimap<String, String> newFilterSet = generateFilterSetWithDimensionMap(mergedAnomaly.getDimensions(), filterSet);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -786,13 +786,13 @@ public class DataResource {
    * @return {@code true} if anomaly passed the filters, {@code false} otherwise
    */
   static boolean applyAnomalyFilters(MergedAnomalyResultDTO anomaly, Multimap<String, String> filters) {
-    DimensionMap dim = anomaly.getDimensions();
+    Multimap<String, String> anomalyFilter = AnomaliesResource.generateFilterSetForTimeSeriesQuery(anomaly);
     for (String filterKey : filters.keySet()) {
-      if (!dim.containsKey(filterKey))
+      if (!anomalyFilter.containsKey(filterKey))
         return false;
 
       Collection<String> filterValues = filters.get(filterKey);
-      if (!filterValues.contains(dim.get(filterKey)))
+      if (!filterValues.containsAll(anomalyFilter.get(filterKey)))
         return false;
     }
     return true;


### PR DESCRIPTION
The anomaly result itself only contains it dimension information, without the filter information in its anomaly function. It leads to a bug on UI display. The fixture is on the DataResource, which extends the filter of the anomaly results.