### PR TITLE
[TE] Fix runtime problem of Node.class from org.w3c is not found

### DIFF
--- a/thirdeye/thirdeye-hadoop/pom.xml
+++ b/thirdeye/thirdeye-hadoop/pom.xml
@@ -155,6 +155,8 @@
                                     <excludes>
                                         <exclude>org.apache.hadoop.**</exclude>
                                         <exclude>org.apache.httpcomponents.**</exclude>
+                                        <!-- excluding w3c package, which is not pulled into this fat jar but is used by databind during runtime -->
+                                        <!-- if we don't exclude this package, databind code would try to find thirdeye.org.w3c, which does not exist -->
                                         <exclude>org.w3c.**</exclude>
                                     </excludes>
                                 </relocation>

--- a/thirdeye/thirdeye-hadoop/pom.xml
+++ b/thirdeye/thirdeye-hadoop/pom.xml
@@ -135,12 +135,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <transformers>
+                            <!--<transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.linkedin.thirdeye.hadoop.ThirdEyeJob</mainClass>
                                 </transformer>
-                            </transformers>
+                            </transformers>-->
                             <relocations>
                                 <relocation>
                                     <pattern>com.</pattern>
@@ -155,6 +155,7 @@
                                     <excludes>
                                         <exclude>org.apache.hadoop.**</exclude>
                                         <exclude>org.apache.httpcomponents.**</exclude>
+                                        <exclude>org.w3c.**</exclude>
                                     </excludes>
                                 </relocation>
                                 <relocation>

--- a/thirdeye/thirdeye-hadoop/pom.xml
+++ b/thirdeye/thirdeye-hadoop/pom.xml
@@ -135,12 +135,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <!--<transformers>
+                            <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>com.linkedin.thirdeye.hadoop.ThirdEyeJob</mainClass>
                                 </transformer>
-                            </transformers>-->
+                            </transformers>
                             <relocations>
                                 <relocation>
                                     <pattern>com.</pattern>


### PR DESCRIPTION
Problem:
An exception is thrown during runtime: 
    Caused by: java.lang.NoClassDefFoundError: thirdeye/org/w3c/dom/Node

The problem is probably caused by the shaded jar, fasterjackson.databind, that is trying to use org.w3c.dom.Node, which is not shaded because it is provided in rt.jar by JVM.

Fix:
Exclude org.w3c package from being shaded explicitly.

Test:
Will be performed by other teams who use this jar.