### PR TITLE
Fix the flakiness of OfflineClusterIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -40,6 +40,7 @@ import org.testng.Assert;
  * Shared set of common tests for cluster integration tests.
  * <p>To enable the test, override it and add @Test annotation.
  */
+@SuppressWarnings("unused")
 public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrationTest {
   private static final Random RANDOM = new Random();
 
@@ -95,8 +96,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
    *
    * @throws Exception
    */
-  public void testHardcodedQueries()
-      throws Exception {
+  public void testHardcodedQueries() throws Exception {
     // Here are some sample queries.
     String query;
     query = "SELECT COUNT(*) FROM mytable WHERE DaysSinceEpoch = 16312 AND Carrier = 'DL'";
@@ -121,8 +121,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
    *
    * @throws Exception
    */
-  public void testQueriesFromQueryFile()
-      throws Exception {
+  public void testQueriesFromQueryFile() throws Exception {
     URL resourceUrl = BaseClusterIntegrationTestSet.class.getClassLoader().getResource(getQueryFileName());
     Assert.assertNotNull(resourceUrl);
     File queriesFile = new File(resourceUrl.getFile());
@@ -159,8 +158,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
    *
    * @throws Exception
    */
-  public void testGeneratedQueriesWithoutMultiValues()
-      throws Exception {
+  public void testGeneratedQueriesWithoutMultiValues() throws Exception {
     testGeneratedQueries(false);
   }
 
@@ -169,13 +167,11 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
    *
    * @throws Exception
    */
-  public void testGeneratedQueriesWithMultiValues()
-      throws Exception {
+  public void testGeneratedQueriesWithMultiValues() throws Exception {
     testGeneratedQueries(true);
   }
 
-  private void testGeneratedQueries(boolean withMultiValues)
-      throws Exception {
+  private void testGeneratedQueries(boolean withMultiValues) throws Exception {
     QueryGenerator queryGenerator = getQueryGenerator();
     queryGenerator.setSkipMultiValuePredicates(!withMultiValues);
     int numQueriesToGenerate = getNumQueriesToGenerate();
@@ -186,12 +182,28 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
   }
 
   /**
+   * Test invalid queries which should cause query exceptions.
+   *
+   * @throws Exception
+   */
+  public void testQueryExceptions() throws Exception {
+    testQueryException("POTATO");
+    testQueryException("SELECT COUNT(*) FROM potato");
+    testQueryException("SELECT POTATO(ArrTime) FROM mytable");
+    testQueryException("SELECT COUNT(*) FROM mytable where ArrTime = 'potato'");
+  }
+
+  private void testQueryException(String query) throws Exception {
+    JSONObject jsonObject = postQuery(query);
+    Assert.assertTrue(jsonObject.getJSONArray("exceptions").length() > 0);
+  }
+
+  /**
    * Test if routing table get updated when instance is shutting down.
    *
    * @throws Exception
    */
-  public void testInstanceShutdown()
-      throws Exception {
+  public void testInstanceShutdown() throws Exception {
     List<String> instances = _helixAdmin.getInstancesInCluster(_clusterName);
     Assert.assertFalse(instances.isEmpty(), "List of instances should not be empty");
 
@@ -281,8 +293,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     }, 60_000L, errorMessage);
   }
 
-  private void checkForEmptyRoutingTable(final boolean shouldBeEmpty)
-      throws Exception {
+  private void checkForEmptyRoutingTable(final boolean shouldBeEmpty) throws Exception {
     String errorMessage;
     if (shouldBeEmpty) {
       errorMessage = "Routing table is not empty";

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -131,8 +131,8 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     String timeType = outgoingTimeUnit.toString();
 
     addHybridTable(getTableName(), useLlc(), KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
-        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName,
-        TENANT_NAME, TENANT_NAME, getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(),
+        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName, TENANT_NAME,
+        TENANT_NAME, getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(),
         getTaskConfig());
   }
 
@@ -190,6 +190,12 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   @Override
   public void testGeneratedQueriesWithMultiValues() throws Exception {
     super.testGeneratedQueriesWithMultiValues();
+  }
+
+  @Test
+  @Override
+  public void testQueryExceptions() throws Exception {
+    super.testQueryExceptions();
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.integration.tests;
+
+import org.testng.annotations.Test;
+
+
+/**
+ * Integration test that extends OfflineClusterIntegrationTest but start multiple brokers and servers.
+ */
+public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterIntegrationTest {
+  private static final int NUM_BROKERS = 2;
+  private static final int NUM_SERVERS = 3;
+
+  @Override
+  protected int getNumBrokers() {
+    return NUM_BROKERS;
+  }
+
+  @Override
+  protected int getNumServers() {
+    return NUM_SERVERS;
+  }
+
+  @Test
+  @Override
+  public void testQueriesFromQueryFile() throws Exception {
+    super.testQueriesFromQueryFile();
+  }
+
+  @Test
+  @Override
+  public void testGeneratedQueriesWithMultiValues() throws Exception {
+    super.testGeneratedQueriesWithMultiValues();
+  }
+
+  @Test
+  @Override
+  public void testQueryExceptions() throws Exception {
+    super.testQueryExceptions();
+  }
+
+  @Test
+  @Override
+  public void testInstanceShutdown() throws Exception {
+    super.testInstanceShutdown();
+  }
+
+  // Disabled because with multiple servers, there is no way to check and guarantee that all servers get all segments
+  // reloaded, which cause the flakiness of the tests.
+  @Test(enabled = false)
+  @Override
+  public void testInvertedIndexTriggering() throws Exception {
+    // Ignored
+  }
+
+  // Disabled because with multiple servers, there is no way to check and guarantee that all servers get all segments
+  // reloaded, which cause the flakiness of the tests.
+  @Test(enabled = false)
+  @Override
+  public void testDefaultColumns() throws Exception {
+    // Ignored
+  }
+}

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -93,8 +93,8 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
     String timeType = outgoingTimeUnit.toString();
 
     addRealtimeTable(getTableName(), useLlc(), KafkaStarterUtils.DEFAULT_KAFKA_BROKER, KafkaStarterUtils.DEFAULT_ZK_STR,
-        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName, null,
-        null, getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(), getTaskConfig());
+        getKafkaTopic(), getRealtimeSegmentFlushSize(), avroFile, timeColumnName, timeType, schemaName, null, null,
+        getLoadMode(), getSortedColumn(), getInvertedIndexColumns(), getRawIndexColumns(), getTaskConfig());
   }
 
   @Test
@@ -107,6 +107,12 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
   @Override
   public void testGeneratedQueriesWithMultiValues() throws Exception {
     super.testGeneratedQueriesWithMultiValues();
+  }
+
+  @Test
+  @Override
+  public void testQueryExceptions() throws Exception {
+    super.testQueryExceptions();
   }
 
   @Test


### PR DESCRIPTION
With multiple servers, there is no way to check and guarantee that all servers get all segments reloaded, which cause the flakiness of the tests.
To fix that, in OfflineClusterIntegrationTest, only start one server.
Added a MultiNodesOfflineClusterIntegrationTest to keep the same coverage for multiple brokers and multiple servers.