### PR TITLE
Suppress unnecessary log for partition aware routing builder.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilder.java
@@ -155,8 +155,11 @@ public class PartitionAwareOfflineRoutingTableBuilder extends AbstractPartitionA
           }
         }
       }
-      // Update the final routing look up table
-      segmentIdToServersMapping.put(segmentId, serverInstanceMap);
+
+      // Update the final routing look up table.
+      if (!serverInstanceMap.isEmpty()) {
+        segmentIdToServersMapping.put(segmentId, serverInstanceMap);
+      }
     }
 
     // Delete segment metadata from cache if the segment no longer exists in the external view.

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -74,7 +74,7 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends AbstractPartition
     RoutingTableInstancePruner pruner = new RoutingTableInstancePruner(instanceConfigList);
 
     // Compute segment id to replica id to server instance
-    Map<SegmentId, Map<Integer, ServerInstance>> segmentId2ServersMapping = new HashMap<>();
+    Map<SegmentId, Map<Integer, ServerInstance>> segmentIdToServersMapping = new HashMap<>();
     for (String segmentName : externalView.getPartitionSet()) {
       SegmentId segmentId = new SegmentId(segmentName);
       int partitionId = getPartitionId(segmentName);
@@ -107,7 +107,11 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends AbstractPartition
         }
         replicaId++;
       }
-      segmentId2ServersMapping.put(segmentId, serverInstanceMap);
+
+      // Update the final routing look up table.
+      if (!serverInstanceMap.isEmpty()) {
+        segmentIdToServersMapping.put(segmentId, serverInstanceMap);
+      }
     }
 
     // Delete segment metadata from the cache if the segment no longer exists in the external view.
@@ -118,7 +122,7 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends AbstractPartition
       }
     }
 
-    _mappingReference.set(segmentId2ServersMapping);
+    _mappingReference.set(segmentIdToServersMapping);
   }
 
   /**


### PR DESCRIPTION
When the retention manager deletes the segment and all servers are marked as offline
for a specific segment, the partition aware routing builder emits unnecessary logs
indicating that no server is found for the segment. However, this log is for the case
when the segment is valid while all servers are not available. Adding check in the
external view change update fixes this problem.