### PR TITLE
[TE] Self-serve Logic Enhancement for Import Metrics

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/controller.js
@@ -147,28 +147,28 @@ export default Ember.Controller.extend({
   processNewImportSequence(isRrdImport, importObj) {
     // Make request to create new dataset name in TE Database
     this.onboardNewDataset(importObj)
-    // Make request to trigger instant onboard
-    .then((importResult) => {
-      return this.triggerInstantOnboard();
-    })
-    // Check for metrics in TE that belong to the new dataset name
-    .then((onboardResult) => {
-      return this.fetchMetricsList(importObj.datasetName);
-    })
-    // If this is a custom dashboard import, and no metrics returned, assume something went wrong.
-    .then((metricsList) => {
-      if (isRrdImport && !metricsList.Records.length) {
-        return new Promise.reject();
-      } else {
-        this.setProperties({
-          isImportSuccess: true,
-          importedMetrics: metricsList.Records
-        });
-      }
-    })
-    .catch((error) => {
-      this.set('isImportError', true);
-    });
+      // Make request to trigger instant onboard
+      .then((importResult) => {
+        return this.triggerInstantOnboard();
+      })
+      // Check for metrics in TE that belong to the new dataset name
+      .then((onboardResult) => {
+        return this.fetchMetricsList(importObj.datasetName);
+      })
+      // If this is a custom dashboard import, and no metrics returned, assume something went wrong.
+      .then((metricsList) => {
+        if (isRrdImport && !metricsList.Records.length) {
+          return new Promise.reject();
+        } else {
+          this.setProperties({
+            isImportSuccess: true,
+            importedMetrics: metricsList.Records
+          });
+        }
+      })
+      .catch((error) => {
+        this.set('isImportError', true);
+      });
   },
 
   /**
@@ -217,24 +217,24 @@ export default Ember.Controller.extend({
 
       // Check whether provided dashboard name exists before sending onboard requests.
       this.validateDashboardName(isRrdImport, datasetName)
-      .then((isValid) => {
-        if (isValid) {
-          // Begin onboard sequence
-          this.processNewImportSequence(isRrdImport, importObj);
-          // Disable the form and show options to user
-          this.setProperties({
-            datasetName,
-            isSubmitDone: true,
-            isCustomDashFieldDisabled: true
-          });
-        } else {
-          this.set('isCustomDashFieldDisabled', true);
-          this.set('isDashboardExistError', true);
-        }
-      })
-      .catch((error) => {
-        this.set('isImportError', true);
-      });
+        .then((isValid) => {
+          if (isValid) {
+            // Begin onboard sequence
+            this.processNewImportSequence(isRrdImport, importObj);
+            // Disable the form and show options to user
+            this.setProperties({
+              datasetName,
+              isSubmitDone: true,
+              isCustomDashFieldDisabled: true
+            });
+          } else {
+            this.set('isCustomDashFieldDisabled', true);
+            this.set('isDashboardExistError', true);
+          }
+        })
+        .catch((error) => {
+          this.set('isImportError', true);
+        });
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/template.hbs
@@ -17,6 +17,9 @@
         property="importExistingDashboardName"
         disabled=isExistingDashFieldDisabled
       }}
+      {{#if isDashboardExistError}}
+        <div class="alert alert-warning">Warning: This dashboard name does not exist in inGraphs. Please verify.</div>
+      {{/if}}
     </div>
   </fieldset>
 
@@ -51,24 +54,19 @@
 
     {{#if isImportSuccess}}
       {{#bs-alert type="success"}}
-        <strong>Success!</strong> You have successfully imported <strong>{{datasetName}}</strong> dataset, including the following metrics:
+        <strong>Success!</strong> You have successfully onboarded the <strong>{{datasetName}}</strong> dataset
+        {{#if importedMetrics.length}}, including the following metrics:{{/if}}
         {{#each importedMetrics as |metric|}}
           <br>{{metric}}
         {{else}}
-          <br>No metrics imported.
+          <br>But no metrics were imported.
         {{/each}}
-      {{/bs-alert}}
-    {{/if}}
-
-    {{#if isMetricOnboarded}}
-      {{#bs-alert type="success"}}
-        <strong>Success!</strong> The metrics have been onboarded for <strong>{{datasetName}}</strong>
       {{/bs-alert}}
     {{/if}}
 
     {{#if isImportError}}
       {{#bs-alert type="danger"}}
-        <strong>Error:</strong> Metrics not imported. Please check your dashboard, datased, and metric names.
+        <strong>Error:</strong> Metrics not onboarded. Please check your dashboard, datased, and metric names.
       {{/bs-alert}}
     {{/if}}
 


### PR DESCRIPTION
I've refactored and ...

- added some validation for non-existent inGraph dashboard names ... still waiting for the endpoint to be created, but placeholder is there.
- made sure that the "list metrics for this new dataset name" is called AFTER the "trigger onboard" call. Otherwise, it will return empty if called before the metrics actually onboard.