### PR TITLE
[Minion] Add Minion use case ConvertToRawIndexTask

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableTaskConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableTaskConfig.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.common.config;
 
-import java.util.Set;
+import java.util.Map;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.json.JSONException;
@@ -25,29 +25,34 @@ import org.json.JSONObject;
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TableTaskConfig {
-  private static final String ENABLED_TASK_TYPES_KEY = "enabledTaskTypes";
+  private static final String TASK_TYPE_CONFIGS_MAP_KEY = "taskTypeConfigsMap";
 
-  private Set<String> _enabledTaskTypes;
+  private Map<String, Map<String, String>> _taskTypeConfigsMap;
 
-  public void setEnabledTaskTypes(Set<String> enabledTaskTypes) {
-    _enabledTaskTypes = enabledTaskTypes;
+  public void setTaskTypeConfigsMap(Map<String, Map<String, String>> taskTypeConfigsMap) {
+    _taskTypeConfigsMap = taskTypeConfigsMap;
   }
 
-  public Set<String> getEnabledTaskTypes() {
-    return _enabledTaskTypes;
+  public Map<String, Map<String, String>> getTaskTypeConfigsMap() {
+    return _taskTypeConfigsMap;
   }
 
   @JsonIgnore
   public boolean isTaskTypeEnabled(String taskType) {
-    return _enabledTaskTypes.contains(taskType);
+    return _taskTypeConfigsMap.containsKey(taskType);
+  }
+
+  @JsonIgnore
+  public Map<String, String> getConfigsForTaskType(String taskType) {
+    return _taskTypeConfigsMap.get(taskType);
   }
 
   @Override
   public String toString() {
-    JSONObject jsonConfig = new JSONObject();
+    JSONObject jsonTaskConfigsMap = new JSONObject();
     try {
-      jsonConfig.put(ENABLED_TASK_TYPES_KEY, _enabledTaskTypes);
-      return jsonConfig.toString(2);
+      jsonTaskConfigsMap.put(TASK_TYPE_CONFIGS_MAP_KEY, _taskTypeConfigsMap);
+      return jsonTaskConfigsMap.toString(2);
     } catch (JSONException e) {
       return e.toString();
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
@@ -48,7 +48,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_STATE_MACHINE_ABORTS("aborts", false),
   LLC_AUTO_CREATED_PARTITIONS("creates", false),
   LLC_ZOOKEPER_UPDATE_FAILURES("failures", false),
-  LLC_KAFKA_DATA_LOSS("dataLoss", false);
+  LLC_KAFKA_DATA_LOSS("dataLoss", false),
+  NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
+  NUMBER_TASKS_SUBMITTED("tasks", false);
 
 
   private final String brokerMeterName;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/SegmentMetadata.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.common.segment;
 
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -124,6 +125,14 @@ public interface SegmentMetadata {
    */
   @Nullable
   String getDerivedColumn(String column, MetricFieldSpec.DerivedMetricType derivedMetricType);
+
+  /**
+   * Get the enabled optimizations for the segment.
+   *
+   * @return List of enabled optimizations
+   */
+  @Nullable
+  List<String> getOptimizations();
 
   Map<String, String> toMap();
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -284,6 +284,7 @@ public class CommonConstants {
     public static final String CREATION_TIME = "segment.creation.time";
     public static final String FLUSH_THRESHOLD_SIZE = "segment.flush.threshold.size";
     public static final String PARTITION_METADATA = "segment.partition.metadata";
+    public static final String OPTIMIZATIONS = "segment.optimizations";
 
     public static final String SEGMENT_BACKUP_DIR_SUFFIX = ".segment.bak";
     public static final String SEGMENT_TEMP_DIR_SUFFIX = ".segment.tmp";

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
@@ -14,6 +14,7 @@
  ******************************************************************************/
 package com.linkedin.pinot.common.utils;
 
+import com.linkedin.pinot.common.Utils;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -21,8 +22,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import java.nio.file.Path;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpVersion;
@@ -43,8 +42,6 @@ import org.apache.http.entity.ContentType;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.common.Utils;
 
 public class FileUploadUtils {
 
@@ -80,27 +77,30 @@ public class FileUploadUtils {
 
   public static int sendFile(final String host, final String port, final String path, final String fileName,
       final InputStream inputStream, final long lengthInBytes, SendFileMethod httpMethod) {
+    return sendFile("http://" + host + ":" + port + "/" + path, fileName, inputStream, lengthInBytes, httpMethod);
+  }
+
+  public static int sendFile(String uri, final String fileName, final InputStream inputStream, final long lengthInBytes,
+      SendFileMethod httpMethod) {
     EntityEnclosingMethod method = null;
     try {
-      method = httpMethod.forUri("http://" + host + ":" + port + "/" + path);
-      Part[] parts = {
-          new FilePart(fileName, new PartSource() {
-            @Override
-            public long getLength() {
-              return lengthInBytes;
-            }
+      method = httpMethod.forUri(uri);
+      Part[] parts = {new FilePart(fileName, new PartSource() {
+        @Override
+        public long getLength() {
+          return lengthInBytes;
+        }
 
-            @Override
-            public String getFileName() {
-              return fileName;
-            }
+        @Override
+        public String getFileName() {
+          return fileName;
+        }
 
-            @Override
-            public InputStream createInputStream() throws IOException {
-              return new BufferedInputStream(inputStream);
-            }
-          })
-      };
+        @Override
+        public InputStream createInputStream() throws IOException {
+          return new BufferedInputStream(inputStream);
+        }
+      })};
       method.setRequestEntity(new MultipartRequestEntity(parts, new HttpMethodParams()));
       FILE_UPLOAD_HTTP_CLIENT.executeMethod(method);
       if (method.getStatusCode() >= 400) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ServiceStatus.java
@@ -16,12 +16,12 @@
 
 package com.linkedin.pinot.common.utils;
 
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
 import java.util.Set;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixDataAccessor;
@@ -34,8 +34,6 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.model.LiveInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
 
 /**
  * Utility class to obtain the status of the Pinot instance running in this JVM.
@@ -125,6 +123,11 @@ public class ServiceStatus {
       _resourcesToMonitor = new ArrayList<>();
 
       for (String resource : _helixAdmin.getResourcesInCluster(_clusterName)) {
+        // Only monitor table resources and broker resource
+        if (!TableNameBuilder.isTableResource(resource) && !resource.equals(
+            CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)) {
+          continue;
+        }
         final IdealState idealState = getResourceIdealState(resource);
         for (String partitionInResource : idealState.getPartitionSet()) {
           if (idealState.getInstanceSet(partitionInResource).contains(_instanceName)) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -126,7 +126,8 @@ public class ControllerStarter {
       _helixTaskResourceManager = new PinotHelixTaskResourceManager(taskDriver);
 
       LOGGER.info("Starting task manager");
-      _taskManager = new PinotTaskManager(taskDriver, helixResourceManager, _helixTaskResourceManager);
+      _taskManager =
+          new PinotTaskManager(taskDriver, helixResourceManager, _helixTaskResourceManager, config, controllerMetrics);
       _taskManager.ensureTaskQueuesExist();
       int taskManagerFrequencyInSeconds = config.getTaskManagerFrequencyInSeconds();
       if (taskManagerFrequencyInSeconds > 0) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.helix.core.minion.generator;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.config.PinotTaskConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableTaskConfig;
+import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.controller.helix.core.minion.ClusterInfoProvider;
+import com.linkedin.pinot.core.common.MinionConstants;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.helix.task.TaskState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ConvertToRawIndexTaskGenerator implements PinotTaskGenerator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToRawIndexTaskGenerator.class);
+
+  private final ClusterInfoProvider _clusterInfoProvider;
+
+  public ConvertToRawIndexTaskGenerator(ClusterInfoProvider clusterInfoProvider) {
+    _clusterInfoProvider = clusterInfoProvider;
+  }
+
+  @Nonnull
+  @Override
+  public String getTaskType() {
+    return MinionConstants.ConvertToRawIndexTask.TASK_TYPE;
+  }
+
+  @Nonnull
+  @Override
+  public List<PinotTaskConfig> generateTasks(@Nonnull List<TableConfig> tableConfigs) {
+    List<PinotTaskConfig> pinotTaskConfigs = new ArrayList<>();
+
+    // Get the segments that are already submitted so that we don't submit them again
+    Set<String> runningSegments = new HashSet<>();
+    Map<String, TaskState> taskStates =
+        _clusterInfoProvider.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE);
+    for (Map.Entry<String, TaskState> entry : taskStates.entrySet()) {
+      TaskState taskState = entry.getValue();
+      if (taskState == TaskState.NOT_STARTED || taskState == TaskState.IN_PROGRESS || taskState == TaskState.STOPPED
+          || taskState == TaskState.COMPLETED) {
+        Map<String, String> configs = _clusterInfoProvider.getTaskConfig(entry.getKey()).getConfigs();
+        runningSegments.add(
+            configs.get(MinionConstants.TABLE_NAME_KEY) + "__" + configs.get(MinionConstants.SEGMENT_NAME_KEY));
+      }
+    }
+
+    for (TableConfig tableConfig : tableConfigs) {
+      // Only generate tasks for OFFLINE tables
+      String offlineTableName = tableConfig.getTableName();
+      if (tableConfig.getTableType() != CommonConstants.Helix.TableType.OFFLINE) {
+        LOGGER.warn("Skip generating ConvertToRawIndexTask for non-OFFLINE table: {}", offlineTableName);
+        continue;
+      }
+
+      TableTaskConfig tableTaskConfig = tableConfig.getTaskConfig();
+      Preconditions.checkNotNull(tableTaskConfig);
+      Map<String, String> taskConfigs =
+          tableTaskConfig.getConfigsForTaskType(MinionConstants.ConvertToRawIndexTask.TASK_TYPE);
+      Preconditions.checkNotNull(tableConfigs);
+
+      // Get max number of tasks for this table
+      int tableMaxNumTasks;
+      String tableMaxNumTasksConfig = taskConfigs.get(MinionConstants.TABLE_MAX_NUM_TASKS_KEY);
+      if (tableMaxNumTasksConfig != null) {
+        try {
+          tableMaxNumTasks = Integer.valueOf(tableMaxNumTasksConfig);
+        } catch (Exception e) {
+          tableMaxNumTasks = Integer.MAX_VALUE;
+        }
+      } else {
+        tableMaxNumTasks = Integer.MAX_VALUE;
+      }
+
+      // Get the config for columns to convert
+      String columnsToConvertConfig = taskConfigs.get(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY);
+
+      // Generate tasks
+      int tableNumTasks = 0;
+      for (OfflineSegmentZKMetadata offlineSegmentZKMetadata : _clusterInfoProvider.getOfflineSegmentsMetadata(
+          offlineTableName)) {
+        // Generate up to tableMaxNumTasks tasks each time for each table
+        if (tableNumTasks == tableMaxNumTasks) {
+          break;
+        }
+
+        // Skip segments that are already submitted
+        String segmentName = offlineSegmentZKMetadata.getSegmentName();
+        if (runningSegments.contains(offlineTableName + "__" + segmentName)) {
+          continue;
+        }
+
+        // Only submit segments that have not been optimized
+        List<String> optimizations = offlineSegmentZKMetadata.getOptimizations();
+        if (optimizations == null || !optimizations.contains(V1Constants.MetadataKeys.Optimization.RAW_INDEX)) {
+          Map<String, String> configs = new HashMap<>();
+          configs.put(MinionConstants.TABLE_NAME_KEY, offlineTableName);
+          configs.put(MinionConstants.SEGMENT_NAME_KEY, segmentName);
+          configs.put(MinionConstants.DOWNLOAD_URL_KEY, offlineSegmentZKMetadata.getDownloadUrl());
+          configs.put(MinionConstants.UPLOAD_URL_KEY, _clusterInfoProvider.getVipUrl() + "/segments");
+          if (columnsToConvertConfig != null) {
+            configs.put(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY, columnsToConvertConfig);
+          }
+          pinotTaskConfigs.add(new PinotTaskConfig(MinionConstants.ConvertToRawIndexTask.TASK_TYPE, configs));
+          tableNumTasks++;
+        }
+      }
+    }
+
+    return pinotTaskConfigs;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/TaskGeneratorRegistry.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/TaskGeneratorRegistry.java
@@ -32,8 +32,7 @@ public class TaskGeneratorRegistry {
   private final Map<String, PinotTaskGenerator> _taskGeneratorRegistry = new HashMap<>();
 
   public TaskGeneratorRegistry(@Nonnull ClusterInfoProvider clusterInfoProvider) {
-    // TODO: register all task generators here
-    // E.g. registerTaskGenerator(new DummyTaskGenerator(clusterInfoProvider));
+    registerTaskGenerator(new ConvertToRawIndexTaskGenerator(clusterInfoProvider));
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/util/ZKMetadataUtils.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/util/ZKMetadataUtils.java
@@ -30,6 +30,8 @@ import org.joda.time.Duration;
 
 
 public class ZKMetadataUtils {
+  private ZKMetadataUtils() {
+  }
 
   public static OfflineSegmentZKMetadata updateSegmentMetadata(OfflineSegmentZKMetadata offlineSegmentZKMetadata, SegmentMetadata segmentMetadata) {
     offlineSegmentZKMetadata.setSegmentName(segmentMetadata.getName());
@@ -72,6 +74,9 @@ public class ZKMetadataUtils {
     if (!columnPartitionMap.isEmpty()) {
       offlineSegmentZKMetadata.setPartitionMetadata(new SegmentPartitionMetadata(columnPartitionMap));
     }
+
+    offlineSegmentZKMetadata.setOptimizations(segmentMetadata.getOptimizations());
+
     return offlineSegmentZKMetadata;
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableRetentionValidator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/util/TableRetentionValidator.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.controller.util;
 
 import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.time.TimeUtils;
@@ -87,7 +88,7 @@ public class TableRetentionValidator {
 
     for (String tableName : resourcesInCluster) {
       // Skip non-table resources
-      if (!tableName.endsWith("_OFFLINE") && !tableName.endsWith("_REALTIME")) {
+      if (!TableNameBuilder.isTableResource(tableName)) {
         continue;
       }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
@@ -15,23 +15,6 @@
  */
 package com.linkedin.pinot.controller.helix.retention;
 
-import java.io.IOException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.model.IdealState;
-import org.joda.time.Duration;
-import org.joda.time.Interval;
-import org.json.JSONException;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
@@ -52,7 +35,25 @@ import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.IdealState;
+import org.joda.time.Duration;
+import org.joda.time.Interval;
+import org.json.JSONException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
@@ -481,6 +482,12 @@ public class RetentionManagerTest {
       @Nullable
       @Override
       public String getDerivedColumn(String column, MetricFieldSpec.DerivedMetricType derivedMetricType) {
+        return null;
+      }
+
+      @Nullable
+      @Override
+      public List<String> getOptimizations() {
         return null;
       }
     };

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -66,8 +66,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -674,6 +673,12 @@ public class ValidationManagerTest {
     @Nullable
     @Override
     public String getDerivedColumn(String column, MetricFieldSpec.DerivedMetricType derivedMetricType) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public List<String> getOptimizations() {
       return null;
     }
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/MinionConstants.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.common;
+
+public class MinionConstants {
+  private MinionConstants() {
+  }
+
+  public static final String TABLE_NAME_KEY = "tableName";
+  public static final String SEGMENT_NAME_KEY = "segmentName";
+  public static final String DOWNLOAD_URL_KEY = "downloadURL";
+  public static final String UPLOAD_URL_KEY = "uploadURL";
+
+  public static final String TABLE_MAX_NUM_TASKS_KEY = "tableMaxNumTasks";
+
+  public static class ConvertToRawIndexTask {
+    public static final String TASK_TYPE = "ConvertToRawIndexTask";
+    public static final String COLUMNS_TO_CONVERT_KEY = "columnsToConvert";
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/minion/RawIndexConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/minion/RawIndexConverter.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.minion;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.common.BlockSingleValIterator;
+import com.linkedin.pinot.core.common.DataSource;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.segment.creator.SingleValueRawIndexCreator;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentColumnarIndexCreator;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The <code>RawIndexConverter</code> class takes a segment and converts the dictionary-based indexes inside the segment
+ * into raw indexes.
+ * <ul>
+ *   <li>
+ *     If columns to convert are specified, check whether their dictionary-based indexes exist and convert them.
+ *   </li>
+ *   <li>
+ *     If not specified, for each metric column, calculate the size of dictionary-based index and uncompressed raw
+ *     index. If the size of raw index is smaller or equal to (size of dictionary-based index * CONVERSION_THRESHOLD),
+ *     convert it.
+ *   </li>
+ * </ul>
+ * <p>After the conversion, add "rawIndex" into the segment metadata "optimizations" field.
+ */
+public class RawIndexConverter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RawIndexConverter.class);
+
+  // Threshold for the ratio of uncompressed raw index size and dictionary-based index size to trigger conversion
+  private static final int CONVERSION_THRESHOLD = 4;
+
+  // BITS_PER_ELEMENT is not applicable for raw index
+  private static final int BITS_PER_ELEMENT_FOR_RAW_INDEX = -1;
+
+  private final IndexSegment _originalIndexSegment;
+  private final SegmentMetadataImpl _originalSegmentMetadata;
+  private final File _convertedIndexDir;
+  private final PropertiesConfiguration _convertedProperties;
+  private final String _columnsToConvert;
+
+  /**
+   * NOTE: original segment should be in V1 format.
+   * TODO: support V3 format
+   */
+  public RawIndexConverter(@Nonnull File originalIndexDir, @Nonnull File convertedIndexDir,
+      @Nullable String columnsToConvert) throws Exception {
+    FileUtils.copyDirectory(originalIndexDir, convertedIndexDir);
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    indexLoadingConfig.setSegmentVersion(SegmentVersion.v1);
+    indexLoadingConfig.setReadMode(ReadMode.mmap);
+    _originalIndexSegment = ColumnarSegmentLoader.load(originalIndexDir, indexLoadingConfig);
+    _originalSegmentMetadata = (SegmentMetadataImpl) _originalIndexSegment.getSegmentMetadata();
+    _convertedIndexDir = convertedIndexDir;
+    _convertedProperties =
+        new PropertiesConfiguration(new File(_convertedIndexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME));
+    _columnsToConvert = columnsToConvert;
+  }
+
+  @SuppressWarnings("unchecked")
+  public void convert() throws Exception {
+    String segmentName = _originalSegmentMetadata.getName();
+    String tableName = _originalSegmentMetadata.getTableName();
+    LOGGER.info("Start converting segment: {} in table: {}", segmentName, tableName);
+
+    Schema schema = _originalSegmentMetadata.getSchema();
+    if (_columnsToConvert == null) {
+      LOGGER.info("Columns to convert are not specified, check each metric column");
+      for (MetricFieldSpec metricFieldSpec : schema.getMetricFieldSpecs()) {
+        if (_originalSegmentMetadata.hasDictionary(metricFieldSpec.getName()) && shouldConvertColumn(metricFieldSpec)) {
+          convertColumn(metricFieldSpec);
+        }
+      }
+    } else {
+      LOGGER.info("Columns to convert: {}", _columnsToConvert);
+      for (String columnToConvert : StringUtils.split(_columnsToConvert, ',')) {
+        FieldSpec fieldSpec = schema.getFieldSpecFor(columnToConvert);
+        if (fieldSpec == null) {
+          LOGGER.warn("Skip converting column: {} because is does not exist in the schema");
+          continue;
+        }
+        if (!fieldSpec.isSingleValueField()) {
+          LOGGER.warn("Skip converting column: {} because it's a multi-value column");
+          continue;
+        }
+        if (!_originalSegmentMetadata.hasDictionary(columnToConvert)) {
+          LOGGER.warn("Skip converting column: {} because its index is not dictionary-based");
+          continue;
+        }
+        convertColumn(fieldSpec);
+      }
+    }
+
+    // Update optimizations field
+    List optimizations =
+        _convertedProperties.getList(V1Constants.MetadataKeys.Segment.SEGMENT_OPTIMIZATIONS, new ArrayList());
+    Preconditions.checkState(!optimizations.contains(V1Constants.MetadataKeys.Optimization.RAW_INDEX));
+    optimizations.add(V1Constants.MetadataKeys.Optimization.RAW_INDEX);
+    _convertedProperties.setProperty(V1Constants.MetadataKeys.Segment.SEGMENT_OPTIMIZATIONS, optimizations);
+    _convertedProperties.save();
+
+    LOGGER.info("Finish converting segment: {} in table: {}", segmentName, tableName);
+  }
+
+  private boolean shouldConvertColumn(FieldSpec fieldSpec) {
+    String columnName = fieldSpec.getName();
+    FieldSpec.DataType dataType = fieldSpec.getDataType();
+    int numTotalDocs = _originalSegmentMetadata.getTotalDocs();
+    ColumnMetadata columnMetadata = _originalSegmentMetadata.getColumnMetadataFor(columnName);
+
+    int cardinality = columnMetadata.getCardinality();
+
+    // In bits
+    int lengthOfEachEntry;
+    if (dataType.equals(FieldSpec.DataType.STRING)) {
+      lengthOfEachEntry = columnMetadata.getStringColumnMaxLength() * Byte.SIZE;
+    } else {
+      lengthOfEachEntry = dataType.size() * Byte.SIZE;
+    }
+    long dictionaryBasedIndexSize =
+        (long) numTotalDocs * columnMetadata.getBitsPerElement() + (long) cardinality * lengthOfEachEntry;
+    long rawIndexSize = (long) numTotalDocs * lengthOfEachEntry;
+    LOGGER.info("For column: {}, size of dictionary based index: {} bits, size of raw index: {} bits", columnName,
+        dictionaryBasedIndexSize, rawIndexSize);
+
+    return rawIndexSize <= dictionaryBasedIndexSize * CONVERSION_THRESHOLD;
+  }
+
+  private void convertColumn(FieldSpec fieldSpec) throws Exception {
+    String columnName = fieldSpec.getName();
+    LOGGER.info("Converting column: {}", columnName);
+
+    // Delete dictionary and existing indexes
+    FileUtils.deleteQuietly(new File(_convertedIndexDir, columnName + V1Constants.Dict.FILE_EXTENTION));
+    FileUtils.deleteQuietly(
+        new File(_convertedIndexDir, columnName + V1Constants.Indexes.UN_SORTED_SV_FWD_IDX_FILE_EXTENTION));
+    FileUtils.deleteQuietly(
+        new File(_convertedIndexDir, columnName + V1Constants.Indexes.SORTED_FWD_IDX_FILE_EXTENTION));
+    FileUtils.deleteQuietly(
+        new File(_convertedIndexDir, columnName + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION));
+
+    // Create the raw index
+    DataSource dataSource = _originalIndexSegment.getDataSource(columnName);
+    Dictionary dictionary = dataSource.getDictionary();
+    FieldSpec.DataType dataType = fieldSpec.getDataType();
+    int lengthOfLongestEntry = _originalSegmentMetadata.getColumnMetadataFor(columnName).getStringColumnMaxLength();
+    try (SingleValueRawIndexCreator rawIndexCreator = SegmentColumnarIndexCreator.getRawIndexCreatorForColumn(
+        _convertedIndexDir, columnName, dataType, _originalSegmentMetadata.getTotalDocs(), lengthOfLongestEntry)) {
+      BlockSingleValIterator iterator =
+          (BlockSingleValIterator) dataSource.getNextBlock().getBlockValueSet().iterator();
+      int docId = 0;
+      while (iterator.hasNext()) {
+        int dictId = iterator.nextIntVal();
+        rawIndexCreator.index(docId++, dictionary.get(dictId));
+      }
+    }
+
+    // Update the segment metadata
+    _convertedProperties.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(columnName, V1Constants.MetadataKeys.Column.HAS_DICTIONARY), false);
+    _convertedProperties.setProperty(
+        V1Constants.MetadataKeys.Column.getKeyFor(columnName, V1Constants.MetadataKeys.Column.BITS_PER_ELEMENT),
+        BITS_PER_ELEMENT_FOR_RAW_INDEX);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/utils/SimpleSegmentMetadata.java
@@ -16,20 +16,19 @@
 package com.linkedin.pinot.core.query.utils;
 
 import com.linkedin.pinot.common.data.MetricFieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.segment.StarTreeMetadata;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.startree.hll.HllConstants;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.segment.SegmentMetadata;
 
 
 public class SimpleSegmentMetadata implements SegmentMetadata {
@@ -237,6 +236,12 @@ public class SimpleSegmentMetadata implements SegmentMetadata {
   @Nullable
   @Override
   public String getDerivedColumn(String column, MetricFieldSpec.DerivedMetricType derivedMetricType) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public List<String> getOptimizations() {
     return null;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
@@ -131,6 +131,7 @@ public class V1Constants {
       public static final String SEGMENT_TOTAL_CONVERSIONS = "segment.total.conversions";
       public static final String SEGMENT_TOTAL_NULL_COLS = "segment.total.null.cols";
       public static final String SEGMENT_HLL_LOG2M = "segment.hll.log2m";
+      public static final String SEGMENT_OPTIMIZATIONS = "segment.optimizations";
 
       // not using currently
       public static final String SEGMENT_INDEX_TYPE = "segment.index.type";
@@ -170,6 +171,10 @@ public class V1Constants {
       public static String getKeyFor(String column, String key) {
         return COLUMN_PROPS_KEY_PREFIX + column + "." + key;
       }
+    }
+
+    public static class Optimization {
+      public static final String RAW_INDEX = "rawIndex";
     }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/SegmentMetadataImpl.java
@@ -59,9 +59,9 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys;
-import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment;
-import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.TIME_UNIT;
+import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.*;
+import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.*;
+import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataKeys.Segment.*;
 
 
 public class SegmentMetadataImpl implements SegmentMetadata {
@@ -93,6 +93,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   private int _totalRawDocs;
   private long _segmentStartTime;
   private long _segmentEndTime;
+  private List<String> _optimizations;
 
   /**
    * Load segment metadata based on the segment version passed in.
@@ -355,6 +356,9 @@ public class SegmentMetadataImpl implements SegmentMetadata {
 
     // Set hll log2m.
     _hllLog2m = _segmentMetadataPropertiesConfiguration.getInt(Segment.SEGMENT_HLL_LOG2M, HllConstants.DEFAULT_LOG2M);
+
+    // Set enabled optimizations
+    _optimizations = _segmentMetadataPropertiesConfiguration.getList(Segment.SEGMENT_OPTIMIZATIONS, null);
 
     // Build column metadata map, schema and hll derived column map.
     for (String column : _allColumns) {
@@ -663,6 +667,12 @@ public class SegmentMetadataImpl implements SegmentMetadata {
       default:
         throw new IllegalArgumentException();
     }
+  }
+
+  @Nullable
+  @Override
+  public List<String> getOptimizations() {
+    return _optimizations;
   }
 
   /**

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -80,7 +80,7 @@
               <excludes>
                 <!-- Covered by FlakyConsumerRealtimeClusterIntegrationTest -->
                 <exclude>**/RealtimeClusterIntegrationTest.java</exclude>
-                <!-- Covered by MinionClusterIntegrationTest -->
+                <!-- Covered by ConvertToRawIndexMinionClusterIntegrationTest -->
                 <exclude>**/HybridClusterIntegrationTest.java</exclude>
               </excludes>
             </configuration>

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
@@ -1,0 +1,217 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.integration.tests;
+
+import com.google.common.base.Function;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TableTaskConfig;
+import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import com.linkedin.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import com.linkedin.pinot.controller.helix.core.minion.PinotTaskManager;
+import com.linkedin.pinot.core.common.MinionConstants;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.util.TestUtils;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
+import org.apache.helix.task.TaskState;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Integration test that extends HybridClusterIntegrationTest and add Minions into the cluster to convert 3 metric
+ * columns' index into raw index for OFFLINE segments.
+ */
+public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridClusterIntegrationTest {
+  private static final int NUM_MINIONS = 3;
+  private static final String COLUMNS_TO_CONVERT = "ActualElapsedTime,ArrDelay,DepDelay";
+
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+  private PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
+  private PinotTaskManager _pinotTaskManager;
+
+  @Nullable
+  @Override
+  protected List<String> getRawIndexColumns() {
+    return null;
+  }
+
+  @Override
+  protected TableTaskConfig getTaskConfig() {
+    TableTaskConfig taskConfig = new TableTaskConfig();
+    Map<String, String> convertToRawIndexTaskConfigs = new HashMap<>();
+    convertToRawIndexTaskConfigs.put(MinionConstants.TABLE_MAX_NUM_TASKS_KEY, "5");
+    convertToRawIndexTaskConfigs.put(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY, COLUMNS_TO_CONVERT);
+    taskConfig.setTaskTypeConfigsMap(
+        Collections.singletonMap(MinionConstants.ConvertToRawIndexTask.TASK_TYPE, convertToRawIndexTaskConfigs));
+    return taskConfig;
+  }
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    // The parent setUp() sets up Zookeeper, Kafka, controller, broker and servers
+    super.setUp();
+
+    startMinions(NUM_MINIONS, null);
+
+    _pinotHelixResourceManager = _controllerStarter.getHelixResourceManager();
+    _pinotHelixTaskResourceManager = _controllerStarter.getHelixTaskResourceManager();
+    _pinotTaskManager = _controllerStarter.getTaskManager();
+  }
+
+  @Test
+  public void testConvertToRawIndexTask() throws Exception {
+    final String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(getTableName());
+    final File tableDataDir = new File(CommonConstants.Server.DEFAULT_INSTANCE_DATA_DIR + "-0", offlineTableName);
+
+    // Check that all columns have dictionary
+    File[] indexDirs = tableDataDir.listFiles();
+    Assert.assertNotNull(indexDirs);
+    for (File indexDir : indexDirs) {
+      SegmentMetadata segmentMetadata = new SegmentMetadataImpl(indexDir);
+      for (String columnName : segmentMetadata.getSchema().getColumnNames()) {
+        Assert.assertTrue(segmentMetadata.hasDictionary(columnName));
+      }
+    }
+
+    // Should generate 5 ConvertToRawIndexTask tasks
+    _pinotTaskManager.scheduleTasks();
+    // Wait at most 60 seconds for all 5 tasks showing up in the cluster
+    TestUtils.waitForCondition(new Function<Void, Boolean>() {
+      @Override
+      public Boolean apply(@Nullable Void aVoid) {
+        return _pinotHelixTaskResourceManager.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size()
+            == 5;
+      }
+    }, 60_000L, "Failed to get all tasks showing up in the cluster");
+
+    // Should generate 3 more ConvertToRawIndexTask tasks
+    _pinotTaskManager.scheduleTasks();
+    // Wait at most 60 seconds for all 8 tasks showing up in the cluster
+    TestUtils.waitForCondition(new Function<Void, Boolean>() {
+      @Override
+      public Boolean apply(@Nullable Void aVoid) {
+        return _pinotHelixTaskResourceManager.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size()
+            == 8;
+      }
+    }, 60_000L, "Failed to get all tasks showing up in the cluster");
+
+    // Should not generate more tasks
+    _pinotTaskManager.scheduleTasks();
+    Assert.assertEquals(
+        _pinotHelixTaskResourceManager.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 8);
+
+    // Wait at most 600 seconds for all tasks COMPLETED and new segments refreshed
+    TestUtils.waitForCondition(new Function<Void, Boolean>() {
+      @Override
+      public Boolean apply(@Nullable Void aVoid) {
+        try {
+          // Check task state
+          for (TaskState taskState : _pinotHelixTaskResourceManager.getTaskStates(
+              MinionConstants.ConvertToRawIndexTask.TASK_TYPE).values()) {
+            if (taskState != TaskState.COMPLETED) {
+              return false;
+            }
+          }
+
+          // Check segment ZK metadata
+          for (OfflineSegmentZKMetadata offlineSegmentZKMetadata : _pinotHelixResourceManager.getOfflineSegmentMetadata(
+              offlineTableName)) {
+            List<String> optimizations = offlineSegmentZKMetadata.getOptimizations();
+            if (optimizations == null || optimizations.size() != 1 || !optimizations.get(0)
+                .equals(V1Constants.MetadataKeys.Optimization.RAW_INDEX)) {
+              return false;
+            }
+          }
+
+          // Check segment metadata
+          File[] indexDirs = tableDataDir.listFiles();
+          Assert.assertNotNull(indexDirs);
+          for (File indexDir : indexDirs) {
+            SegmentMetadata segmentMetadata = new SegmentMetadataImpl(indexDir);
+            List<String> optimizations = segmentMetadata.getOptimizations();
+            if (optimizations == null || optimizations.size() != 1 || !optimizations.get(0)
+                .equals(V1Constants.MetadataKeys.Optimization.RAW_INDEX)) {
+              return false;
+            }
+
+            // The columns in COLUMNS_TO_CONVERT should have raw index
+            List<String> rawIndexColumns = Arrays.asList(StringUtils.split(COLUMNS_TO_CONVERT, ','));
+            for (String columnName : segmentMetadata.getSchema().getColumnNames()) {
+              if (rawIndexColumns.contains(columnName)) {
+                if (segmentMetadata.hasDictionary(columnName)) {
+                  return false;
+                }
+              } else {
+                if (!segmentMetadata.hasDictionary(columnName)) {
+                  return false;
+                }
+              }
+            }
+          }
+
+          return true;
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }, 600_000L, "Failed to get all tasks COMPLETED and new segments refreshed");
+  }
+
+  @Test
+  public void testPinotHelixResourceManagerAPIs() {
+    // Instance APIs
+    Assert.assertEquals(_pinotHelixResourceManager.getAllInstances().size(), 6);
+    Assert.assertEquals(_pinotHelixResourceManager.getOnlineInstanceList().size(), 6);
+    Assert.assertEquals(_pinotHelixResourceManager.getOnlineUnTaggedBrokerInstanceList().size(), 0);
+    Assert.assertEquals(_pinotHelixResourceManager.getOnlineUnTaggedServerInstanceList().size(), 0);
+
+    // Table APIs
+    String rawTableName = getTableName();
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+    List<String> tableNames = _pinotHelixResourceManager.getAllTables();
+    Assert.assertEquals(tableNames.size(), 2);
+    Assert.assertTrue(tableNames.contains(offlineTableName));
+    Assert.assertTrue(tableNames.contains(realtimeTableName));
+    Assert.assertEquals(_pinotHelixResourceManager.getAllRawTables(), Collections.singletonList(rawTableName));
+    Assert.assertEquals(_pinotHelixResourceManager.getAllRealtimeTables(),
+        Collections.singletonList(realtimeTableName));
+
+    // Tenant APIs
+    Assert.assertEquals(_pinotHelixResourceManager.getAllBrokerTenantNames(), Collections.singleton("TestTenant"));
+    Assert.assertEquals(_pinotHelixResourceManager.getAllServerTenantNames(), Collections.singleton("TestTenant"));
+  }
+
+  @AfterClass
+  public void tearDown() throws Exception {
+    stopMinion();
+
+    super.tearDown();
+  }
+}

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.minion.executor;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.config.PinotTaskConfig;
+import com.linkedin.pinot.common.segment.fetcher.SegmentFetcherFactory;
+import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
+import com.linkedin.pinot.core.common.MinionConstants;
+import com.linkedin.pinot.core.minion.RawIndexConverter;
+import com.linkedin.pinot.minion.exception.TaskCancelledException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ConvertToRawIndexTaskExecutor extends BaseTaskExecutor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToRawIndexTaskExecutor.class);
+
+  @Override
+  public void executeTask(@Nonnull PinotTaskConfig pinotTaskConfig) {
+    Map<String, String> configs = pinotTaskConfig.getConfigs();
+    String tableName = configs.get(MinionConstants.TABLE_NAME_KEY);
+    String segmentName = configs.get(MinionConstants.SEGMENT_NAME_KEY);
+    String downloadURL = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
+    String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
+
+    LOGGER.info("Start executing ConvertToRawIndexTask on table: {}, segment: {} with downloadURL: {}, uploadURL: {}",
+        tableName, segmentName, downloadURL, uploadURL);
+
+    File tempDataDir = new File(new File(_minionContext.getDataDir(), MinionConstants.ConvertToRawIndexTask.TASK_TYPE),
+        "tmp-" + System.nanoTime());
+    Preconditions.checkState(tempDataDir.mkdirs());
+    try {
+      // Download the tarred segment file
+      File tempTarredSegmentFile = new File(tempDataDir, "tarredSegmentFile");
+      SegmentFetcherFactory.getSegmentFetcherBasedOnURI(downloadURL)
+          .fetchSegmentToLocal(downloadURL, tempTarredSegmentFile);
+
+      // Un-tar the segment file
+      File tempSegmentDir = new File(tempDataDir, "segmentDir");
+      TarGzCompressionUtils.unTar(tempTarredSegmentFile, tempSegmentDir);
+      File[] files = tempSegmentDir.listFiles();
+      Preconditions.checkState(files != null && files.length == 1);
+      File indexDir = files[0];
+
+      // Convert the segment
+      File convertedIndexDir = new File(tempDataDir, "convertedIndexDir");
+      new RawIndexConverter(indexDir, convertedIndexDir,
+          configs.get(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY)).convert();
+
+      // Tar the converted segment
+      File convertedTarredSegmentFile = new File(
+          TarGzCompressionUtils.createTarGzOfDirectory(convertedIndexDir.getPath(),
+              new File(tempDataDir, "convertedTarredSegmentFile").getPath()));
+
+      // Check whether the task get cancelled before uploading the segment
+      if (_cancelled) {
+        throw new TaskCancelledException(
+            MinionConstants.ConvertToRawIndexTask.TASK_TYPE + " task on table: " + tableName + ", segment: "
+                + segmentName + " has been cancelled");
+      }
+
+      // Upload the converted tarred segment file
+      FileUploadUtils.sendFile(uploadURL, "convertedTarredSegmentFile", new FileInputStream(convertedTarredSegmentFile),
+          convertedTarredSegmentFile.length(), FileUploadUtils.SendFileMethod.POST);
+
+      LOGGER.info("Done executing ConvertToRawIndexTask on table: {}, segment: {}", tableName, segmentName);
+    } catch (TaskCancelledException e) {
+      LOGGER.info("ConvertToRawIndexTask on table: {}, segment: {} gets cancelled", tableName, segmentName);
+      throw e;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while executing ConvertToRawIndexTask on table: {}, segment: {}", tableName,
+          segmentName, e);
+      throw new RuntimeException(e);
+    } finally {
+      FileUtils.deleteQuietly(tempDataDir);
+    }
+  }
+}

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/TaskExecutorRegistry.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/TaskExecutorRegistry.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.minion.executor;
 
+import com.linkedin.pinot.core.common.MinionConstants;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -29,8 +30,7 @@ public class TaskExecutorRegistry {
   private final Map<String, Class<? extends PinotTaskExecutor>> _taskExecutorRegistry = new HashMap<>();
 
   public TaskExecutorRegistry() {
-    // TODO: register all task executors here
-    // E.g. registerTaskExecutor(DummyTaskExecutor.TASK_TYPE, DummyTaskExecutor.class);
+    registerTaskExecutorClass(MinionConstants.ConvertToRawIndexTask.TASK_TYPE, ConvertToRawIndexTaskExecutor.class);
   }
 
   /**

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ShowClusterInfoCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/ShowClusterInfoCommand.java
@@ -15,10 +15,23 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.tools.Command;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.ZNRecord;
-import org.apache.helix.manager.zk.*;
+import org.apache.helix.manager.zk.ZKHelixAdmin;
+import org.apache.helix.manager.zk.ZKHelixDataAccessor;
+import org.apache.helix.manager.zk.ZNRecordStreamingSerializer;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.manager.zk.ZkClient;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
@@ -27,9 +40,6 @@ import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
-
-import java.io.StringWriter;
-import java.util.*;
 
 public class ShowClusterInfoCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(ShowClusterInfoCommand.class.getName());
@@ -114,7 +124,8 @@ public class ShowClusterInfoCommand extends AbstractBaseAdminCommand implements 
       }
     }
     for (String table : tables) {
-      if ("brokerResource".equalsIgnoreCase(table)) {
+      // Skip non-table resources
+      if (!TableNameBuilder.isTableResource(table)) {
         continue;
       }
 

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/VerifySegmentState.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/VerifySegmentState.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.tools.admin.command;
 
 import com.google.common.collect.Sets;
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.tools.AbstractBaseCommand;
 import com.linkedin.pinot.tools.Command;
 import java.util.List;
@@ -58,6 +59,11 @@ public class VerifySegmentState extends AbstractBaseCommand implements Command {
     List<String> resourcesInCluster = helixAdmin.getResourcesInCluster(clusterName);
 
     for (String resourceName : resourcesInCluster) {
+      // Skip non-table resources
+      if (!TableNameBuilder.isTableResource(resourceName)) {
+        continue;
+      }
+
       if (resourceName.startsWith(tablePrefix)) {
         IdealState resourceIdealState = helixAdmin.getResourceIdealState(clusterName, resourceName);
         ExternalView resourceExternalView = helixAdmin.getResourceExternalView(clusterName, resourceName);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -15,6 +15,20 @@
  */
 package com.linkedin.pinot.tools.perf;
 
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.Tenant;
+import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.TenantRole;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.ControllerStarter;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import com.linkedin.pinot.server.starter.helix.HelixServerStarter;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -28,6 +42,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
@@ -39,20 +54,6 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
-import com.google.common.base.Preconditions;
-import com.linkedin.pinot.broker.broker.helix.HelixBrokerStarter;
-import com.linkedin.pinot.common.config.TableConfig;
-import com.linkedin.pinot.common.config.Tenant;
-import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
-import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.FileUploadUtils;
-import com.linkedin.pinot.common.utils.TenantRole;
-import com.linkedin.pinot.controller.ControllerConf;
-import com.linkedin.pinot.controller.ControllerStarter;
-import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.linkedin.pinot.server.starter.helix.HelixServerStarter;
-import javax.annotation.Nullable;
 
 
 @SuppressWarnings("FieldCanBeLocal")
@@ -310,6 +311,12 @@ public class PerfBenchmarkDriver {
         LOGGER.info("Waiting for the cluster to be set up and indexes to be loaded on the servers" + new Timestamp(
             System.currentTimeMillis()));
         for (String resourceName : resourcesInCluster) {
+          // Only check table resources and broker resource
+          if (!TableNameBuilder.isTableResource(resourceName) && !resourceName.equals(
+              CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)) {
+            continue;
+          }
+
           IdealState idealState = helixAdmin.getResourceIdealState(clusterName, resourceName);
           ExternalView externalView = helixAdmin.getResourceExternalView(clusterName, resourceName);
           if (idealState == null || externalView == null) {


### PR DESCRIPTION
1. This task converts indexes for configured columns / (by default) metric columns that meet the condition (uncompressed raw index size <= CONVERSION_THRESHOLD * dictionary-based index size) into raw indexes (no dictionary indexes)
2. Add a list field 'optimizations' into segmentMetadata and segmentZKMetadata to mark the optimizations done (can be set by Minion or segment creation job)
3. Allow custom configs for each task type in TableTaskConfig
4. Add a new ConvertToRawIndexMinionClusterIntegrationTest to test the new use case

NOTE: In Helix Task framework, TaskQueue resource will only show up in IS but not in EV