### PR TITLE
Refactor StarTreeClusterIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -124,10 +124,10 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
   public void testQueriesFromQueryFile() throws Exception {
     URL resourceUrl = BaseClusterIntegrationTestSet.class.getClassLoader().getResource(getQueryFileName());
     Assert.assertNotNull(resourceUrl);
-    File queriesFile = new File(resourceUrl.getFile());
+    File queryFile = new File(resourceUrl.getFile());
 
     int maxNumQueriesToSkipInQueryFile = getMaxNumQueriesToSkipInQueryFile();
-    try (BufferedReader reader = new BufferedReader(new FileReader(queriesFile))) {
+    try (BufferedReader reader = new BufferedReader(new FileReader(queryFile))) {
       while (true) {
         int numQueriesSkipped = RANDOM.nextInt(maxNumQueriesToSkipInQueryFile);
         for (int i = 0; i < numQueriesSkipped; i++) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package com.linkedin.pinot.integration.tests;
 
-import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.tools.query.comparison.QueryComparison;
 import com.linkedin.pinot.tools.query.comparison.SegmentInfoProvider;
 import com.linkedin.pinot.tools.query.comparison.StarTreeQueryGenerator;
@@ -25,354 +23,179 @@ import com.linkedin.pinot.util.TestUtils;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
-import java.io.IOException;
 import java.net.URL;
-import java.sql.Timestamp;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.compress.archivers.ArchiveException;
-import org.apache.commons.compress.utils.IOUtils;
+import javax.annotation.Nonnull;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.helix.manager.zk.ZKHelixAdmin;
-import org.apache.helix.model.ExternalView;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.tools.ClusterStateVerifier;
 import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+
 /**
- * Integration test for Star Tree based indexes: - Sets up the Pinot cluster and creates two tables,
- * one with default indexes, and another with star tree indexes. - Sends queries to both the tables
- * and asserts that results match. - Query to reference table is sent with TOP 10000, and the
- * comparator ensures that response from star tree is contained within the reference response. This
- * is to avoid false failures when groups with same value are truncated due to LIMIT or TOP N.
+ * Integration test for Star-Tree based indexes.
+ * <ul>
+ *   <li>
+ *     Set up the Pinot cluster and create two tables, one with default indexes, one with star tree indexes
+ *   </li>
+ *   <li>
+ *     Send queries to both the tables and assert that results match
+ *   </li>
+ *   <li>
+ *     Query to reference table is sent with TOP 10000, and the comparator ensures that response from star tree is
+ *     contained within the reference response. This is to avoid false failures when groups with same value are
+ *     truncated due to TOP N
+ *   </li>
+ * </ul>
  */
-// TODO: clean up this test
 public class StarTreeClusterIntegrationTest extends BaseClusterIntegrationTest {
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(StarTreeClusterIntegrationTest.class);
-
-  private static final int NUM_GENERATED_QUERIES = 100;
-
-  private static final int TOTAL_EXPECTED_DOCS = 115545;
-
   private static final String DEFAULT_TABLE_NAME = "myTable";
   private static final String STAR_TREE_TABLE_NAME = "myStarTable";
+  private static final String SCHEMA_FILE_NAME =
+      "On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema";
+  private static final String QUERY_FILE_NAME = "OnTimeStarTreeQueries.txt";
+  private static final int NUM_QUERIES_TO_GENERATE = 100;
 
-  private static final long TIMEOUT_IN_MILLISECONDS = 30 * 1000;
-  private static final long TIMEOUT_IN_SECONDS = 3600;
-
-  private static final File _tmpDir = new File("/tmp/StarTreeClusterIntegrationTest");
-  private static final File _segmentsDir = new File("/tmp/StarTreeClusterIntegrationTest/segmentDir");
-  private static final File _tarredSegmentsDir = new File("/tmp/StarTreeClusterIntegrationTest/tarDir");
-
+  private String _currentTable;
   private StarTreeQueryGenerator _queryGenerator;
-  private File _queryFile;
 
-  /**
-   * Start the Pinot Cluster: - Zookeeper - One Controller - One Broker - Two Servers
-   * @throws Exception
-   */
-  private void startCluster() throws Exception {
-
-    startZk();
-    startController();
-    startBroker();
-    startServers(2);
+  @Nonnull
+  @Override
+  protected String getTableName() {
+    return _currentTable;
   }
 
-  /**
-   * Add the reference and star tree tables to the cluster.
-   * @throws Exception
-   */
-  private void addOfflineTables() throws Exception {
-    addOfflineTable(DEFAULT_TABLE_NAME);
-    addOfflineTable(STAR_TREE_TABLE_NAME);
-  }
-
-  /**
-   * Get schema with all single-value columns.
-   *
-   * @return Schema with all single-value columns.
-   * @throws IOException
-   */
-  private Schema getSingleValueColumnsSchema()
-      throws IOException {
-    URL resourceUrl = OfflineClusterIntegrationTest.class.getClassLoader()
-        .getResource("On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema");
-    Preconditions.checkNotNull(resourceUrl);
-    File schemaFile = new File(resourceUrl.getFile());
-    return Schema.fromFile(schemaFile);
-  }
-
-  /**
-   * Generate the reference and star tree indexes and upload to corresponding tables.
-   * @param avroFiles
-   * @param tableName
-   * @param starTree
-   * @throws IOException
-   * @throws ArchiveException
-   * @throws InterruptedException
-   */
-  private void generateAndUploadSegments(List<File> avroFiles, String tableName, boolean starTree)
-      throws IOException, ArchiveException, InterruptedException {
-    TestUtils.ensureDirectoriesExistAndEmpty(_segmentsDir, _tarredSegmentsDir);
-
-    ExecutorService executor = Executors.newCachedThreadPool();
-    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, 0, _segmentsDir, _tarredSegmentsDir,
-        tableName, starTree, null, getSingleValueColumnsSchema(), executor);
-
-    executor.shutdown();
-    executor.awaitTermination(TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
-
-    uploadSegments(_tarredSegmentsDir);
-  }
-
-  /**
-   * Waits for total docs to match the expected value in the given table. There may be delay between
-   * @param expectedRecordCount
-   * @param deadline
-   * @throws Exception
-   */
-  private void waitForTotalDocsToMatch(String tableName, int expectedRecordCount, long deadline)
-      throws Exception {
-    int actualRecordCount;
-
-    do {
-      String query = "select count(*) from " + tableName;
-      JSONObject response = postQuery(query);
-      actualRecordCount = response.getInt("totalDocs");
-
-      String msg =
-          "Actual record count: " + actualRecordCount + "\tExpected count: " + expectedRecordCount;
-      LOGGER.info(msg);
-      Assert.assertTrue(System.currentTimeMillis() < deadline,
-          "Failed to read all records within the deadline.  " + msg);
-      Thread.sleep(2000L);
-    } while (expectedRecordCount != actualRecordCount);
-  }
-
-  /**
-   * Wait for External View to be in sync with Ideal State.
-   * @return
-   */
-  private boolean waitForExternalViewUpdate() {
-    final ZKHelixAdmin helixAdmin = new ZKHelixAdmin(ZkStarter.DEFAULT_ZK_STR);
-    ClusterStateVerifier.Verifier customVerifier = new ClusterStateVerifier.Verifier() {
-
-      @Override
-      public boolean verify() {
-        List<String> resourcesInCluster = helixAdmin.getResourcesInCluster(_clusterName);
-        LOGGER.info("Waiting for external view to update for resources: {} startTime: {}",
-            resourcesInCluster, new Timestamp(System.currentTimeMillis()));
-
-        for (String resourceName : resourcesInCluster) {
-          IdealState idealState = helixAdmin.getResourceIdealState(_clusterName, resourceName);
-          ExternalView externalView = helixAdmin.getResourceExternalView(_clusterName, resourceName);
-          LOGGER.info("HERE for {},\n IS:{} \n EV:{}", resourceName, idealState, externalView);
-
-          if (idealState == null || externalView == null) {
-            return false;
-          }
-
-          Set<String> partitionSet = idealState.getPartitionSet();
-          for (String partition : partitionSet) {
-            Map<String, String> instanceStateMapIS = idealState.getInstanceStateMap(partition);
-            Map<String, String> instanceStateMapEV = externalView.getStateMap(partition);
-
-            if (instanceStateMapIS == null || instanceStateMapEV == null) {
-              return false;
-            }
-            if (!instanceStateMapIS.equals(instanceStateMapEV)) {
-              return false;
-            }
-          }
-          LOGGER.info("External View updated successfully for {},\n IS:{} \n EV:{}", resourceName,
-              idealState, externalView);
-        }
-
-        LOGGER.info("External View updated successfully for {}", resourcesInCluster);
-        return true;
-      }
-    };
-
-    return ClusterStateVerifier.verifyByPolling(customVerifier, TIMEOUT_IN_MILLISECONDS);
-  }
-
-  /**
-   * Replace the star tree table name with reference table name, and add TOP 10000. The TOP 10000 is
-   * added to make the reference result a super-set of star tree result. This will ensure any groups
-   * with equal values that are truncated still appear in the reference result.
-   * @param starQuery
-   */
-  private String convertToRefQuery(String starQuery) {
-    String refQuery = StringUtils.replace(starQuery, STAR_TREE_TABLE_NAME, DEFAULT_TABLE_NAME);
-    return (refQuery + " TOP 10000");
+  @Nonnull
+  @Override
+  protected String getSchemaFileName() {
+    return SCHEMA_FILE_NAME;
   }
 
   @BeforeClass
   public void setUp() throws Exception {
-    startCluster();
-    addOfflineTables();
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
 
-    TestUtils.ensureDirectoriesExistAndEmpty(_tmpDir);
-    List<File> avroFiles = unpackAvroData(_tmpDir);
-    _queryFile = new File(TestUtils.getFileFromResourceUrl(BaseClusterIntegrationTest.class
-        .getClassLoader().getResource("OnTimeStarTreeQueries.txt")));
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServers(2);
 
-    generateAndUploadSegments(avroFiles, DEFAULT_TABLE_NAME, false);
-    generateAndUploadSegments(avroFiles, STAR_TREE_TABLE_NAME, true);
+    // Create the tables
+    addOfflineTable(DEFAULT_TABLE_NAME);
+    addOfflineTable(STAR_TREE_TABLE_NAME);
 
-    Thread.sleep(15000);
-    // Ensure that External View is in sync with Ideal State.
-    if (!waitForExternalViewUpdate()) {
-      Assert.fail("Cluster did not reach stable state");
-    }
+    // Unpack the Avro files
+    List<File> avroFiles = unpackAvroData(_tempDir);
 
-    // Wait until all docs are available, this is required because the broker routing tables may not
-    // be updated yet.
-    waitForTotalDocsToMatch(DEFAULT_TABLE_NAME, TOTAL_EXPECTED_DOCS,
-        System.currentTimeMillis() + 1500000L);
-    waitForTotalDocsToMatch(STAR_TREE_TABLE_NAME, TOTAL_EXPECTED_DOCS,
-        System.currentTimeMillis() + 1500000L);
+    // Create and upload segments without star tree indexes from Avro data
+    createAndUploadSegments(avroFiles, DEFAULT_TABLE_NAME, false);
 
-    // Initialize the query generator
-    SegmentInfoProvider dictionaryReader =
-        new SegmentInfoProvider(_tarredSegmentsDir.getAbsolutePath());
+    // Initialize the query generator using segments without star tree indexes
+    SegmentInfoProvider segmentInfoProvider = new SegmentInfoProvider(_tarDir.getAbsolutePath());
+    _queryGenerator =
+        new StarTreeQueryGenerator(STAR_TREE_TABLE_NAME, segmentInfoProvider.getSingleValueDimensionColumns(),
+            segmentInfoProvider.getMetricColumns(), segmentInfoProvider.getSingleValueDimensionValuesMap());
 
-    List<String> metricColumns = dictionaryReader.getMetricColumns();
-    List<String> singleValueDimensionColumns = dictionaryReader.getSingleValueDimensionColumns();
-    Map<String, List<Object>> singleValueDimensionValuesMap = dictionaryReader.getSingleValueDimensionValuesMap();
+    // Create and upload segments with star tree indexes from Avro data
+    createAndUploadSegments(avroFiles, STAR_TREE_TABLE_NAME, true);
 
-    _queryGenerator = new StarTreeQueryGenerator(STAR_TREE_TABLE_NAME, singleValueDimensionColumns, metricColumns,
-        singleValueDimensionValuesMap);
+    // Wait for all documents loaded
+    _currentTable = DEFAULT_TABLE_NAME;
+    waitForAllDocsLoaded(600_000L);
+    _currentTable = STAR_TREE_TABLE_NAME;
+    waitForAllDocsLoaded(600_000L);
   }
 
-  /**
-   * Given a query string for star tree: - Get the result from star tree cluster - Convert the query
-   * to reference query (change table name, add TOP 10000) - Get the result from reference cluster -
-   * Compare the results and assert that result of star tree is contained in reference result. NOTE:
-   * This method of testing is limited in that it cannot detect cases where a valid entry is missing
-   * from star tree result (to be addressed in future).
-   * @param starQuery
-   * @param expectNonZeroDocsScanned
-   */
-  public void testOneQuery(String starQuery, boolean expectNonZeroDocsScanned) {
-    try {
-      JSONObject starResponse = postQuery(starQuery);
-      if (expectNonZeroDocsScanned) {
-        int numDocsScanned = starResponse.getInt("numDocsScanned");
-        String message = "Zero Docs Scanned for query: " + starQuery;
-        Assert.assertTrue((numDocsScanned > 0), message);
+  private void createAndUploadSegments(List<File> avroFiles, String tableName, boolean createStarTreeIndex)
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_segmentDir, _tarDir);
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, 0, _segmentDir, _tarDir, tableName,
+        createStarTreeIndex, null, Schema.fromFile(getSchemaFile()), executor);
+    executor.shutdown();
+    executor.awaitTermination(10, TimeUnit.MINUTES);
+
+    uploadSegments(_tarDir);
+  }
+
+  @Test
+  public void testQueriesFromQueryFile() throws Exception {
+    URL resourceUrl = BaseClusterIntegrationTestSet.class.getClassLoader().getResource(QUERY_FILE_NAME);
+    Assert.assertNotNull(resourceUrl);
+    File queryFile = new File(resourceUrl.getFile());
+
+    try (BufferedReader reader = new BufferedReader(new FileReader(queryFile))) {
+      String starQuery;
+      while ((starQuery = reader.readLine()) != null) {
+        testStarQuery(starQuery);
       }
-
-      String refQuery = convertToRefQuery(starQuery);
-      JSONObject refResponse = postQuery(refQuery);
-
-      // Skip comparison if not all results returned for reference response.
-      if (refResponse.getInt("numDocsScanned") > 0) {
-        JSONObject aggregationResults = refResponse.getJSONArray("aggregationResults").getJSONObject(0);
-        if (aggregationResults.has("groupByResult")
-            && aggregationResults.getJSONArray("groupByResult").length() == 10000) {
-          return;
-        }
-      }
-
-      boolean result = QueryComparison.compare(starResponse, refResponse, false);
-      String message = "Result mis-match for Query: " + starQuery + "\nStar: "
-          + starResponse.toString() + "\nRef: " + refResponse.toString();
-      Assert.assertTrue(result, message);
-    } catch (Exception e) {
-      LOGGER.error("Exception caught when executing query {}", starQuery, e);
     }
+  }
+
+  @Test
+  public void testGeneratedQueries() throws Exception {
+    for (int i = 0; i < NUM_QUERIES_TO_GENERATE; i++) {
+      String starQuery = _queryGenerator.nextQuery();
+      testStarQuery(starQuery);
+    }
+  }
+
+  @Test
+  public void testPredicateOnMetrics() throws Exception {
+    String starQuery;
+
+    // Query containing predicate on one metric only
+    starQuery = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay > 0";
+    testStarQuery(starQuery);
+    starQuery = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay BETWEEN 0 and 10000";
+    testStarQuery(starQuery);
+
+    // Query containing predicate on multiple metrics
+    starQuery = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay > 0 AND ArrDelay > 0";
+    testStarQuery(starQuery);
+
+    // Query containing predicate on multiple metrics and dimensions
+    starQuery =
+        "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay > 0 AND ArrDelay > 0 AND OriginStateName = 'Massachusetts'";
+    testStarQuery(starQuery);
+  }
+
+  private void testStarQuery(String starQuery) throws Exception {
+    String referenceQuery = starQuery.replace(STAR_TREE_TABLE_NAME, DEFAULT_TABLE_NAME) + " TOP 10000";
+    JSONObject starResponse = postQuery(starQuery);
+    JSONObject referenceResponse = postQuery(referenceQuery);
+
+    // Skip comparison if not all results returned in reference response
+    if (referenceResponse.has("aggregationResults")) {
+      JSONObject aggregationResults = referenceResponse.getJSONArray("aggregationResults").getJSONObject(0);
+      if (aggregationResults.has("groupByResult")
+          && aggregationResults.getJSONArray("groupByResult").length() == 10000) {
+        return;
+      }
+    }
+
+    Assert.assertTrue(QueryComparison.compare(starResponse, referenceResponse, false),
+        "Query comparison failed for: \nStar Query: " + starQuery + "\nStar Response: " + starResponse
+            + "\nReference Query: " + referenceQuery + "\nReference Response: " + referenceResponse);
   }
 
   @AfterClass
   public void tearDown() throws Exception {
+    dropOfflineTable(DEFAULT_TABLE_NAME);
+    dropOfflineTable(STAR_TREE_TABLE_NAME);
+
+    stopServer();
     stopBroker();
     stopController();
-    stopServer();
     stopZk();
 
-    FileUtils.deleteDirectory(_tmpDir);
-  }
-
-  @Test
-  public void testGeneratedQueries() {
-    for (int i = 0; i < NUM_GENERATED_QUERIES; i++) {
-      String starQuery = _queryGenerator.nextQuery();
-      testOneQuery(starQuery, false);
-    }
-  }
-
-  @Test
-  public void testHardCodedQueries() {
-    BufferedReader queryReader = null;
-    try {
-      queryReader = new BufferedReader(new FileReader(_queryFile));
-      String starQuery;
-      while ((starQuery = queryReader.readLine()) != null) {
-        testOneQuery(starQuery, true);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e.getMessage());
-    } finally {
-      IOUtils.closeQuietly(queryReader);
-    }
-  }
-
-  /**
-   * Test that when metrics have predicates on them, we still get
-   * correct results, ie correctly fall back on non-StarTree based execution.
-   */
-  @Test
-  public void testPredicateOnMetrics() {
-    String query;
-
-    // Query containing predicate on one metric only
-    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay > 0\n";
-    testOneQuery(query, false);
-
-    // Query containing predicate on multiple metrics
-    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay > 0 AND ArrDelay > 0\n";
-    testOneQuery(query, false);
-
-    // Query containing predicate on multiple metrics and dimensions
-    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay > 0 AND ArrDelay > 0 AND OriginStateName = 'Massachusetts'\n";
-    testOneQuery(query, false);
-  }
-
-  /**
-   * Tests queries with non-equality predicates
-   */
-  @Test
-  public void testNonEqualityPredicates() {
-    String query;
-
-    // 'Range' query
-    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE DepDelay between 0 and 10000\n";
-    testOneQuery(query, false);
-
-    // 'IN' query
-    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin IN ('JFK', 'LAX', 'DCW')\n";
-    testOneQuery(query, false);
-
-    // 'NOT IN' Query
-    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin NOT IN ('JFK', 'LAX', 'DCW')\n";
-    testOneQuery(query, false);
-
-    // 'NOT EQ' Query
-    query = "SELECT SUM(DepDelayMinutes) FROM myStarTable WHERE Origin <> 'JFK'\n";
-    testOneQuery(query, false);
+    FileUtils.deleteDirectory(_tempDir);
   }
 }


### PR DESCRIPTION
Refactor StarTreeClusterIntegrationTest using the new test utils
Fix the problem where the old testOneQuery() swallowed the exception which cause the query comparison always pass