### PR TITLE
[TE] Self Serve Import and Create - refinement

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -4,15 +4,21 @@ import Ember from 'ember';
  * The Promise returned from fetch() won't reject on HTTP error status even if the response is an HTTP 404 or 500.
  * This helps us define a custom response handler.
  * @param {Object} response - the response object from a fetch call
+ * @param {String} mode - the request type: 'post', 'get'
+ * @param {Boolean} recoverBlank - whether silent failure is allowed
  * @return {Object} either json-formatted payload or error object
  */
-export function checkStatus(response) {
+export function checkStatus(response, mode = 'get', recoverBlank = false) {
   if (response.status >= 200 && response.status < 300) {
-    return JSON.parse(JSON.stringify(response));
+    return (mode === 'get') ? response.json() : JSON.parse(JSON.stringify(response));
   } else {
     const error = new Error(response.statusText);
     error.response = response;
-    throw error;
+    if (recoverBlank) {
+      return '';
+    } else {
+      throw error;
+    }
   }
 }
 

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -18,25 +18,54 @@
         placeholder="Search by Metric Name"
         searchPlaceholder="Type to filter..."
         triggerId="select-metric"
-        disabled=isFormDisabled
+        disabled=false
         as |metric|
       }}
         {{metric.alias}}
       {{/power-select}}
     </div>
 
-    <label for="select-filters" class="control-label required">Filters</label>
-    <div class="form-group">
+    {{#if isSelectMetricError}}
+      {{#bs-alert type="danger"}}
+        <strong>Error: {{selectMetricErrMsg}}</strong> Unable to fetch data for this metric.
+      {{/bs-alert}}
+    {{/if}}
+
+    <div class="form-group te-form__group--horizontal te-form__group--large">
+      <label for="select-filters" class="control-label required">Filters</label>
       {{filter-select
         options=filters
         selected=filterPropNames
         triggerId="select-filters"
         onChange=(action "onSelectFilter")
-        disabled=(not isMetricSelected)
+        disabled=isFilterSelectDisabled
       }}
-
     </div>
-    <div class="te-graph-alert {{unless isMetricSelected 'te-graph-alert--pending'}}">
+
+    <div class="form-group te-form__group--horizontal te-form__group--last te-form__group--medium">
+      <label for="select-granularity" class="control-label">Desired Granularity</label>
+      {{#power-select
+        options=metricGranularityOptions
+        selected=selectedGranularity
+        onchange=(action "onSelectGranularity")
+        placeholder="Select a Granularity"
+        searchPlaceholder="Type to filter..."
+        triggerId="select-granularity"
+        disabled=isGranularitySelectDisabled
+        as |granularity|
+      }}
+        {{granularity}}
+      {{/power-select}}
+    </div>
+
+    <div class="te-graph-alert {{if (not isMetricSelected) 'te-graph-alert--pending'}}">
+      {{#if isMetricDataLoading}}
+        <section>
+          <div class="spinner-wrapper--self-serve">
+            {{ember-spinner}}
+          </div>
+        </section>
+      {{/if}}
       {{#if isMetricSelected}}
         {{anomaly-graph
           primaryMetric=selectedMetric
@@ -47,8 +76,8 @@
         }}
       {{else}}
         <div class="te-graph-alert__content">
-          <div class="glyphicon glyphicon-equalizer te-graph-alert__icon"></div>
-          <p class="te-graph-alert__pre-text">Once a metric is selected, the graph replay will show here</p>
+          <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
+          <p class="te-graph-alert__pre-text">{{graphMessageText}}</p>
         </div>
       {{/if}}
     </div>
@@ -56,8 +85,8 @@
 
   <fieldset class="te-form__section">
     <legend class="te-form__section-title">Detection:</legend>
-    <div class="form-group te-form__group--horizontal">
-      <label for="select-pattern" class="control-label required">Pattern of Interest</label>
+    <div class="form-group te-form__group--horizontal te-form__group--two-share">
+      <label for="select-pattern" class="control-label required">Pattern of Interest *</label>
       {{#power-select
         loadingMessage="Waiting for the server...."
         triggerId="select-pattern"
@@ -68,12 +97,13 @@
         selected=selectedPattern
         onchange=(action (mut selectedPattern))
         disabled=(not isMetricSelected)
+        required=true
         as |name|
       }}
         {{name}}
       {{/power-select}}
     </div>
-    <div class="form-group te-form__group--horizontal">
+    <div class="form-group te-form__group--horizontal te-form__group--two-share te-form__group--last">
       <label for="select-dimension" class="control-label">Dimension Exploration</label>
       {{#power-select
         options=selectedMetricDimensions
@@ -89,21 +119,6 @@
         {{dimension}}
       {{/power-select}}
     </div>
-    <div class="form-group te-form__group--horizontal te-form__group--last">
-      <label for="select-granularity" class="control-label">Desired Granularity</label>
-      {{#power-select
-        options=metricGranularityOptions
-        selected=selectedGranularity
-        onchange=(action "onSelectGranularity")
-        placeholder="Select a Granularity"
-        searchPlaceholder="Type to filter..."
-        triggerId="select-granularity"
-        disabled=(not isMetricSelected)
-        as |granularity|
-      }}
-        {{granularity}}
-      {{/power-select}}
-    </div>
     <div class="form-group te-hide">
       <label for="tune-sensitivity" class="control-label">Tune Sensitivity</label>
       <div class="form-slider"></div>
@@ -114,7 +129,7 @@
     <legend class="te-form__section-title">Alert and Notification:</legend>
     {{!-- Field: New Alert Name --}}
     <div class="form-group">
-      <label for="anomaly-form-function-name" class="control-label required">Alert Name</label>
+      <label for="anomaly-form-function-name" class="control-label required">Alert Name *</label>
       <div class="te-form__sub-label">Please follow this naming convention: <span class="te-form__sub-label--strong">productName_metricName_dimensionName_other</span></div>
       {{#if isAlertNameDuplicate}}
         <div class="alert alert-warning">Warning: <strong>{{alertFunctionName}}</strong> already exists. Please try another name.</div>
@@ -132,7 +147,7 @@
     </div>
     {{!-- Field: App Name --}}
     <div class="form-group">
-      <label for="anomaly-form-app-name" class="control-label required">Related Product or Team</label>
+      <label for="anomaly-form-app-name" class="control-label required">Related Product or Team *</label>
        {{#power-select
           options=allApplicationNames
           selected=selectedAppName
@@ -179,7 +194,7 @@
     </div>
     {{!-- Field: new alert group recipient emails --}}
     <div class="form-group">
-      <label for="config-group" class="control-label">Add Alert Notification Recipients</label>
+      <label for="config-group" class="control-label">Add Alert Notification Recipients *</label>
       <div class="te-form__sub-label">Current recipients: <span class="te-form__sub-label--strong">{{if selectedGroupRecipients selectedGroupRecipients "None"}}</span></div>
       {{#if isDuplicateEmail}}
         <div class="alert alert-warning">Warning: <strong>{{duplicateEmails}}</strong> is already included in this group.</div>
@@ -220,7 +235,10 @@
 
   {{#if isCreateAlertSuccess}}
     {{#bs-alert type="success"}}
-      <strong>Success!</strong> You have created anomaly alert Id <strong>{{finalFunctionId}}</strong>.
+      <strong>Success!</strong> You have created anomaly alert Id <strong>{{finalFunctionId}}</strong>
+      {{#if selectedConfigGroup}}
+        ... and assigned it to existing notification group <strong>{{selectedConfigGroup.name}}</strong>.
+      {{/if}}
     {{/bs-alert}}
   {{/if}}
 

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/template.hbs
@@ -12,16 +12,19 @@
   <fieldset class="te-form__section">
     <legend class="te-form__section-title">Existing Dashboard</legend>
     <div class="form-group">
-      {{form.element
-        controlType="text"
-        label="Onboard Existing InGraph Dashboard"
+      <label for="existing-dashboard-name" class="control-label">Alert Name</label>
+      {{#if isDashboardExistError}}
+        <div class="te-form__alert--warning alert-warning"><strong>Warning...</strong> This dashboard name cannot be found in inGraphs. Please verify.</div>
+      {{/if}}
+      {{input
+        type="text"
+        id="existing-dashboard-name"
+        class="form-control required"
         placeholder="Type inGraph dashboard name..."
-        property="importExistingDashboardName"
+        value=importExistingDashboardName
+        key-up="clearExistingDashboardNameError"
         disabled=isExistingDashFieldDisabled
       }}
-      {{#if isDashboardExistError}}
-        <div class="alert alert-warning">Warning: This dashboard name does not exist in inGraphs. Please verify.</div>
-      {{/if}}
     </div>
   </fieldset>
 
@@ -30,25 +33,50 @@
   <fieldset class="te-form__section">
     <legend class="te-form__section-title">New Custom Dashboard</legend>
     <div class="form-group">
-      {{form.element
-        controlType="text"
-        label="New Dataset Name"
+      <label for="import-custom-dataset" class="control-label">New Dataset Name *</label>
+      {{input
+        type="text"
+        id="import-custom-dataset"
+        class="form-control"
         placeholder="Type new dataset name..."
-        property="importCustomNewDataset"
+        value=importCustomNewDataset
         disabled=isCustomDashFieldDisabled
       }}
-      {{form.element
-        controlType="text"
-        label="New Metric Name"
+    </div>
+    <div class="form-group">
+      <label for="import-custom-metric" class="control-label">New Metric Name *</label>
+      {{input
+        type="text"
+        id="import-custom-metric"
+        class="form-control"
         placeholder="Type new metric name..."
-        property="importCustomNewMetric"
+        value=importCustomNewMetric
         disabled=isCustomDashFieldDisabled
       }}
-      {{form.element
-        controlType="text"
-        label="Provide RRD"
-        placeholder="RRD here"
-        property="importCustomNewRrd"
+      </div>
+      <div class="form-group">
+      <label for="select-dimension" class="control-label">Consolidate</label>
+      {{#power-select
+        options=consolidateOptions
+        selected=selectedConsolidateOption
+        onchange=(action (mut selectedConsolidateOption))
+        placeholder="Select a Consolidation"
+        triggerId="select-consolidate"
+        triggerClass="te-form__spacer"
+        disabled=isCustomDashFieldDisabled
+        as |consolidateOption|
+      }}
+        {{consolidateOption}}
+      {{/power-select}}
+      </div>
+      <div class="form-group">
+      <label for="import-custom-rrd" class="control-label">Provide RRD *</label>
+      {{input
+        type="text"
+        id="import-custom-rrd"
+        class="form-control"
+        placeholder="RRD here..."
+        value=importCustomNewRrd
         disabled=isCustomDashFieldDisabled
       }}
     </div>
@@ -68,7 +96,7 @@
 
     {{#if isImportError}}
       {{#bs-alert type="danger"}}
-        <strong>Error:</strong> Metrics not onboarded. Please check your dashboard, datased, and metric names.
+        <strong>Error:</strong> {{failureMessage}}
       {{/bs-alert}}
     {{/if}}
 
@@ -84,9 +112,9 @@
         {{bs-button
           defaultText="Onboard Another Dashboard"
           type="primary"
-          onClick=(action "clearAll")
           buttonType="submit"
           class="te-submit-button"
+          onClick=(action "clearAll")
         }}
       {{else}}
         {{bs-button

--- a/thirdeye/thirdeye-frontend/app/styles/pods/self-serve/create-alert.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/pods/self-serve/create-alert.scss
@@ -4,18 +4,27 @@
 
 .te-graph-alert {
   width: 100%;
+  clear: both;
+  border-radius: 5px;
+  margin: 93px 0 20px 0;
 
   &--pending {
     background-color: $te-light-grey;
     height: 420px;
     text-align: center;
     font-weight: bold;
-    color: app-shade(black, 1);
+    color: app-shade(black, 2);
     font-size: 20px;
   }
 
   &__icon {
     font-size: 100px;
+    color: app-shade(black, 1);
+
+    &--warning {
+      color: app-shade(black, 3);
+      font-size: 82px;
+    }
   }
 
   &__content {

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -29,13 +29,25 @@ body {
 
   &__group {
     &--horizontal {
-      width: 350px;
       float: left;
-      margin-right: 20px;
+      margin-right: 21px;
     }
 
     &--last {
       margin-right: 0;
+      float: right;
+    }
+
+    &--large {
+      width: 65%;
+    }
+
+    &--medium {
+      width: 33%;
+    }
+
+    &--two-share {
+      width: 49%;
     }
   }
 }

--- a/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
@@ -53,6 +53,12 @@ body {
   margin: $te-default-element-spacing;
   height: 250px;
   position: relative;
+
+  &--self-serve {
+    position: absolute;
+    margin-top: 190px;
+    left: 50%;
+  }
 }
 
 .anomaly-title-bar {
@@ -109,6 +115,29 @@ body {
 
     &--strong {
       font-weight: 600;
+    }
+  }
+
+  &__input {
+    &--required {
+      box-shadow: 0 0 5px rgba(238, 81, 81, 0.69);
+      padding: 3px 0px 3px 3px;
+      margin: 5px 1px 3px 0px;
+      border: 1px solid rgba(238, 81, 81, 0.52);
+    }
+  }
+
+  &__spacer {
+    margin-bottom: 15px;
+  }
+
+  &__alert {
+    &--warning {
+      display: inline-block;
+      margin-left: 5px;
+      padding: 1px 7px;
+      border-radius: 3px;
+      border: 1px solid #faebcc;
     }
   }
 }


### PR DESCRIPTION
In this iteration...
- Catching API call errors and properly handling fetch promises
- Adding an optional "Consolidation" field to the Import Metrics view
- Indicating required fields in the most basic way
- Showing a "no data" placeholder in the event that a metric is not "graphable"
- Adding a validation call to inGraph dashboard name field