### PR TITLE
[TE] rootcause - related entities tracking

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/RootCauseEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/RootCauseEntity.java
@@ -1,11 +1,16 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.pojo;
 
+import java.util.ArrayList;
+import java.util.List;
+
+
 public class RootCauseEntity {
   String urn;
   double score;
   String label;
   String type;
   String link;
+  List<RootCauseEntity> relatedEntities = new ArrayList<>();
 
   public RootCauseEntity() {
     // left blank
@@ -57,5 +62,17 @@ public class RootCauseEntity {
 
   public void setLink(String link) {
     this.link = link;
+  }
+
+  public List<RootCauseEntity> getRelatedEntities() {
+    return relatedEntities;
+  }
+
+  public void setRelatedEntities(List<RootCauseEntity> relatedEntities) {
+    this.relatedEntities = relatedEntities;
+  }
+
+  public void addRelatedEntity(RootCauseEntity e) {
+    this.relatedEntities.add(e);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/RootCauseEventEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/RootCauseEventEntity.java
@@ -1,17 +1,13 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.pojo;
 
-import java.util.ArrayList;
-import java.util.List;
-
-
 public class RootCauseEventEntity extends RootCauseEntity {
   long start;
   long end;
   String eventType;
   String details;
-  List<RootCauseEntity> relatedEntities = new ArrayList<>();
 
   public RootCauseEventEntity() {
+    // left blank
   }
 
   public long getStart() {
@@ -44,18 +40,6 @@ public class RootCauseEventEntity extends RootCauseEntity {
 
   public void setDetails(String details) {
     this.details = details;
-  }
-
-  public List<RootCauseEntity> getRelatedEntities() {
-    return relatedEntities;
-  }
-
-  public void setRelatedEntities(List<RootCauseEntity> relatedEntities) {
-    this.relatedEntities = relatedEntities;
-  }
-
-  public void addRelatedEntity(RootCauseEntity e) {
-    this.relatedEntities.add(e);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/AnomalyEventFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/AnomalyEventFormatter.java
@@ -2,19 +2,11 @@ package com.linkedin.thirdeye.dashboard.resources.v2.rootcause;
 
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseEventEntityFormatter;
 import com.linkedin.thirdeye.dashboard.resources.v2.pojo.RootCauseEventEntity;
-import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
-import com.linkedin.thirdeye.datalayer.dto.EventDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
-import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.rootcause.impl.AnomalyEventEntity;
-import com.linkedin.thirdeye.rootcause.impl.DimensionEntity;
 import com.linkedin.thirdeye.rootcause.impl.EventEntity;
-import com.linkedin.thirdeye.rootcause.impl.HolidayEventEntity;
-import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
-import java.util.List;
-import java.util.Map;
 
 
 public class AnomalyEventFormatter extends RootCauseEventEntityFormatter {
@@ -42,18 +34,8 @@ public class AnomalyEventFormatter extends RootCauseEventEntityFormatter {
     MergedAnomalyResultDTO dto = e.getDto();
     String label = String.format("Anomaly %d (%s)", dto.getId(), dto.getFunction().getFunctionName());
 
-    RootCauseEventEntity out = makeRootCauseEventEntity(entity, label, null, dto.getStartTime(), dto.getEndTime(), null);
-
-    // TODO use metric id when available
-    String metric = dto.getMetric();
-    String dataset = dto.getCollection();
-    MetricConfigDTO metricDTO = this.metricDAO.findByMetricAndDataset(metric, dataset);
-
-    MetricEntity me = MetricEntity.fromMetric(1.0, metricDTO.getId());
-    out.addRelatedEntity(METRIC_FORMATTER.format(me));
-
     // TODO add filters/dimensions as related entities
 
-    return out;
+    return makeRootCauseEventEntity(entity, label, null, dto.getStartTime(), dto.getEndTime(), null);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/Entity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/Entity.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.rootcause;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 
 /**
@@ -21,6 +24,7 @@ import java.util.Comparator;
 public class Entity {
   private final String urn;
   private final double score;
+  private final List<Entity> related;
 
   public static final Comparator<Entity> HIGHEST_SCORE_FIRST = new Comparator<Entity>() {
     @Override
@@ -29,9 +33,10 @@ public class Entity {
     }
   };
 
-  public Entity(String urn, double score) {
+  public Entity(String urn, double score, List<? extends Entity> related) {
     this.urn = urn;
     this.score = score;
+    this.related = Collections.unmodifiableList(new ArrayList<>(related));
   }
 
   public String getUrn() {
@@ -42,8 +47,16 @@ public class Entity {
     return score;
   }
 
+  public List<Entity> getRelated() {
+    return related;
+  }
+
   public Entity withScore(double score) {
-    return new Entity(this.urn, score);
+    return new Entity(this.urn, score, this.related);
+  }
+
+  public Entity withRelated(List<? extends Entity> related) {
+    return new Entity(this.urn, this.score, related);
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventEntity.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class AnomalyEventEntity extends EventEntity {
@@ -10,8 +13,8 @@ public class AnomalyEventEntity extends EventEntity {
 
   private final MergedAnomalyResultDTO dto;
 
-  public AnomalyEventEntity(String urn, double score, long id, MergedAnomalyResultDTO dto) {
-    super(urn, score, EVENT_TYPE_ANOMALY, id);
+  protected AnomalyEventEntity(String urn, double score, List<? extends Entity> related, long id, MergedAnomalyResultDTO dto) {
+    super(urn, score, related, EVENT_TYPE_ANOMALY, id);
     this.dto = dto;
   }
 
@@ -21,11 +24,16 @@ public class AnomalyEventEntity extends EventEntity {
 
   @Override
   public AnomalyEventEntity withScore(double score) {
-    return new AnomalyEventEntity(super.getUrn(), score, super.getId(), this.dto);
+    return new AnomalyEventEntity(this.getUrn(), score, this.getRelated(), this.getId(), this.dto);
+  }
+
+  @Override
+  public AnomalyEventEntity withRelated(List<? extends Entity> related) {
+    return new AnomalyEventEntity(this.getUrn(), this.getScore(), related, this.getId(), this.dto);
   }
 
   public static AnomalyEventEntity fromDTO(double score, MergedAnomalyResultDTO dto) {
     String urn = TYPE.formatURN(dto.getId());
-    return new AnomalyEventEntity(urn, score, dto.getId(), dto);
+    return new AnomalyEventEntity(urn, score, new ArrayList<Entity>(), dto.getId(), dto);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntity.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 
 /**
@@ -14,8 +17,8 @@ public class DimensionEntity extends Entity {
   private final String name;
   private final String value;
 
-  protected DimensionEntity(String urn, double score, String name, String value) {
-    super(urn, score);
+  protected DimensionEntity(String urn, double score, List<? extends Entity> related, String name, String value) {
+    super(urn, score, related);
     this.name = name;
     this.value = value;
   }
@@ -30,11 +33,20 @@ public class DimensionEntity extends Entity {
 
   @Override
   public DimensionEntity withScore(double score) {
-    return new DimensionEntity(this.getUrn(), score, this.name, this.value);
+    return new DimensionEntity(this.getUrn(), score, this.getRelated(), this.name, this.value);
+  }
+
+  public static DimensionEntity fromDimension(double score, Collection<? extends Entity> related, String name, String value) {
+    return new DimensionEntity(TYPE.formatURN(name, value), score, new ArrayList<>(related), name, value);
   }
 
   public static DimensionEntity fromDimension(double score, String name, String value) {
-    return new DimensionEntity(TYPE.formatURN(name, value), score, name, value);
+    return fromDimension(score, new ArrayList<Entity>(), name, value);
+  }
+
+  @Override
+  public DimensionEntity withRelated(List<? extends Entity> related) {
+    return new DimensionEntity(this.getUrn(), this.getScore(), related, this.getName(), this.getValue());
   }
 
   public static DimensionEntity fromURN(String urn, double score) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityMappingPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityMappingPipeline.java
@@ -7,7 +7,6 @@ import com.linkedin.thirdeye.rootcause.Entity;
 import com.linkedin.thirdeye.rootcause.Pipeline;
 import com.linkedin.thirdeye.rootcause.PipelineContext;
 import com.linkedin.thirdeye.rootcause.PipelineResult;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,7 +15,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,7 +128,7 @@ public class EntityMappingPipeline extends Pipeline {
     for(EntityToEntityMappingDTO match : matches) {
       String postfix = entity.getUrn().substring(match.getFromURN().length());
       String toURN = match.getToURN() + postfix;
-      entities.add(EntityUtils.parseURN(toURN, entity.getScore() * match.getScore()));
+      entities.add(EntityUtils.parseURN(toURN, entity.getScore() * match.getScore()).withRelated(Collections.singletonList(entity)));
     }
 
     return entities;
@@ -143,7 +141,7 @@ public class EntityMappingPipeline extends Pipeline {
 
     Set<Entity> entities = new HashSet<>();
     for(EntityToEntityMappingDTO match : matches) {
-      entities.add(EntityUtils.parseURN(match.getToURN(), entity.getScore() * match.getScore()));
+      entities.add(EntityUtils.parseURN(match.getToURN(), entity.getScore() * match.getScore()).withRelated(Collections.singletonList(entity)));
     }
 
     return entities;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
@@ -1,11 +1,9 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.rootcause.Entity;
-import com.linkedin.thirdeye.rootcause.PipelineContext;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -186,8 +184,73 @@ public class EntityUtils {
     try {
       return parseURN(urn, score);
     } catch (IllegalArgumentException e) {
-      return new Entity(urn, score);
+      return new Entity(urn, score, new ArrayList<Entity>());
     }
   }
 
+  /**
+   * Sets a list of entities as the related entities set.
+   * <br/><b>NOTE:</b> co-variant. Requires {@code Entity.withRelated(Entity)}
+   * to return an instance of the respective {@code Entity} subclass.
+   *
+   * @param entities base entities to set related entities on
+   * @param related related entities
+   * @return List of base entities with related entities
+   */
+  public static <T extends Entity> List<T> withRelated(Iterable<T> entities, List<? extends Entity> related) {
+    List<T> tagged = new ArrayList<>();
+    for(T e : entities) {
+      tagged.add((T)e.withRelated(related));
+    }
+    return tagged;
+  }
+
+  /**
+   * Sets a single entity as the related entities set.
+   * <br/><b>NOTE:</b> co-variant. Requires {@code Entity.withRelated(Entity)}
+   * to return an instance of the respective {@code Entity} subclass.
+   *
+   * @see EntityUtils#addRelated(Iterable, List)
+   *
+   * @param entities base entities to set related entity on
+   * @param related related entity
+   * @return List of base entities with added related entity
+   */
+  public static <T extends Entity> List<T> withRelated(Iterable<T> entities, Entity related) {
+    return withRelated(entities, Collections.singletonList(related));
+  }
+
+  /**
+   * Adds a list of entities to the related entities set.
+   * <br/><b>NOTE:</b> co-variant. Requires {@code Entity.withRelated(Entity)}
+   * to return an instance of the respective {@code Entity} subclass.
+   *
+   * @param entities base entities to add related entities to
+   * @param related related entities
+   * @return List of base entities with related entities
+   */
+  public static <T extends Entity> List<T> addRelated(Iterable<T> entities, List<? extends Entity> related) {
+    List<T> tagged = new ArrayList<>();
+    for(T e : entities) {
+      List<Entity> newRelated = new ArrayList<>(e.getRelated());
+      newRelated.addAll(related);
+      tagged.add((T)e.withRelated(newRelated));
+    }
+    return tagged;
+  }
+
+  /**
+   * Adds a list of entities to the related entities set.
+   * <br/><b>NOTE:</b> co-variant. Requires {@code Entity.withRelated(Entity)}
+   * to return an instance of the respective {@code Entity} subclass.
+   *
+   * @see EntityUtils#addRelated(Iterable, List)
+   *
+   * @param entities base entities to add related entities to
+   * @param related related entities
+   * @return List of base entities with related entities
+   */
+  public static <T extends Entity> List<T> addRelated(Iterable<T> entities, Entity related) {
+    return addRelated(entities, Collections.singletonList(related));
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EventEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EventEntity.java
@@ -1,6 +1,8 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -13,8 +15,8 @@ public class EventEntity extends Entity {
   private final String eventType;
   private final long id;
 
-  protected EventEntity(String urn, double score, String eventType, long id) {
-    super(urn, score);
+  protected EventEntity(String urn, double score, List<? extends Entity> related, String eventType, long id) {
+    super(urn, score, related);
     this.id = id;
     this.eventType = eventType;
   }
@@ -29,7 +31,12 @@ public class EventEntity extends Entity {
 
   @Override
   public EventEntity withScore(double score) {
-    return new EventEntity(this.getUrn(), score, this.eventType, this.id);
+    return new EventEntity(this.getUrn(), score, this.getRelated(), this.eventType, this.id);
+  }
+
+  @Override
+  public EventEntity withRelated(List<? extends Entity> related) {
+    return new EventEntity(this.getUrn(), this.getScore(), related, this.eventType, this.id);
   }
 
   public static EventEntity fromURN(String urn, double score) {
@@ -38,6 +45,6 @@ public class EventEntity extends Entity {
     String[] parts = urn.split(":", 4);
     if(parts.length != 4)
       throw new IllegalArgumentException(String.format("URN must have 3 parts but has '%d'", parts.length));
-    return new EventEntity(urn, score, parts[2], Long.parseLong(parts[3]));
+    return new EventEntity(urn, score, new ArrayList<Entity>(), parts[2], Long.parseLong(parts[3]));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventEntity.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.datalayer.dto.EventDTO;
+import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class HolidayEventEntity extends EventEntity {
@@ -10,8 +13,8 @@ public class HolidayEventEntity extends EventEntity {
 
   private final EventDTO dto;
 
-  private HolidayEventEntity(String urn, double score, long id, EventDTO dto) {
-    super(urn, score, EVENT_TYPE_HOLIDAY, id);
+  private HolidayEventEntity(String urn, double score, List<? extends Entity> related, long id, EventDTO dto) {
+    super(urn, score, related, EVENT_TYPE_HOLIDAY, id);
     this.dto = dto;
   }
 
@@ -21,11 +24,16 @@ public class HolidayEventEntity extends EventEntity {
 
   @Override
   public HolidayEventEntity withScore(double score) {
-    return new HolidayEventEntity(super.getUrn(), score, super.getId(), this.dto);
+    return new HolidayEventEntity(this.getUrn(), score, this.getRelated(), this.getId(), this.dto);
+  }
+
+  @Override
+  public HolidayEventEntity withRelated(List<? extends Entity> related) {
+    return new HolidayEventEntity(this.getUrn(), this.getScore(), related, this.getId(), this.dto);
   }
 
   public static HolidayEventEntity fromDTO(double score, EventDTO dto) {
     String urn = TYPE.formatURN(dto.getId());
-    return new HolidayEventEntity(urn, score, dto.getId(), dto);
+    return new HolidayEventEntity(urn, score, new ArrayList<Entity>(), dto.getId(), dto);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
@@ -80,15 +80,15 @@ public class HolidayEventsPipeline extends Pipeline {
     TimeRangeEntity baseline = TimeRangeEntity.getTimeRangeBaseline(context);
     TimeRangeEntity analysis = TimeRangeEntity.getTimeRangeAnalysis(context);
 
-    ScoringStrategy strategyCurrent = makeStrategy(analysis.getStart(), anomaly.getStart(), anomaly.getEnd());
+    ScoringStrategy strategyAnomaly = makeStrategy(analysis.getStart(), anomaly.getStart(), anomaly.getEnd());
     ScoringStrategy strategyBaseline = makeStrategy(baseline.getStart(), baseline.getStart(), baseline.getEnd());
 
     Set<DimensionEntity> dimensionEntities = context.filter(DimensionEntity.class);
     Map<String, DimensionEntity> urn2entity = EntityUtils.mapEntityURNs(dimensionEntities);
 
     Set<HolidayEventEntity> entities = new HashSet<>();
-    entities.addAll(score(strategyCurrent, this.getHolidayEvents(analysis.getStart(), anomaly.getEnd(), dimensionEntities), urn2entity, 1.0));
-    entities.addAll(score(strategyBaseline, this.getHolidayEvents(baseline.getStart(), baseline.getEnd(), dimensionEntities), urn2entity, baseline.getScore()));
+    entities.addAll(EntityUtils.addRelated(score(strategyAnomaly, this.getHolidayEvents(analysis.getStart(), anomaly.getEnd(), dimensionEntities), urn2entity, anomaly.getScore()), anomaly));
+    entities.addAll(EntityUtils.addRelated(score(strategyBaseline, this.getHolidayEvents(baseline.getStart(), baseline.getEnd(), dimensionEntities), urn2entity, baseline.getScore()), baseline));
 
     return new PipelineResult(context, EntityUtils.topk(entities, this.k));
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HyperlinkEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HyperlinkEntity.java
@@ -1,22 +1,34 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.List;
 
 
 public class HyperlinkEntity extends Entity {
   public static final EntityType TYPE = new EntityType("http:");
 
-  public static HyperlinkEntity fromURL(String url, double score) {
-    if(!TYPE.isType(url))
-      throw new IllegalArgumentException(String.format("Requires prefix '%s' but got '%s'", TYPE.getPrefix(), url));
-    return new HyperlinkEntity(url, score);
-  }
-
-  private HyperlinkEntity(String urn, double score) {
-    super(urn, score);
+  private HyperlinkEntity(String urn, double score, List<? extends Entity> related) {
+    super(urn, score, related);
   }
 
   public String getUrl() {
     return this.getUrn();
+  }
+
+  @Override
+  public HyperlinkEntity withScore(double score) {
+    return new HyperlinkEntity(this.getUrn(), score, this.getRelated());
+  }
+
+  @Override
+  public HyperlinkEntity withRelated(List<? extends Entity> related) {
+    return new HyperlinkEntity(this.getUrn(), this.getScore(), related);
+  }
+
+  public static HyperlinkEntity fromURL(String url, double score) {
+    if(!TYPE.isType(url))
+      throw new IllegalArgumentException(String.format("Requires prefix '%s' but got '%s'", TYPE.getPrefix(), url));
+    return new HyperlinkEntity(url, score, new ArrayList<Entity>());
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricDatasetPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricDatasetPipeline.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
@@ -67,6 +69,7 @@ public class MetricDatasetPipeline extends Pipeline {
 
     Set<String> datasets = new HashSet<>();
     Map<String, Double> datasetScores = new HashMap<>();
+    Multimap<String, MetricEntity> related = ArrayListMultimap.create();
     for(MetricEntity me : metrics) {
       MetricConfigDTO metricDTO = this.metricDAO.findById(me.getId());
 
@@ -77,6 +80,8 @@ public class MetricDatasetPipeline extends Pipeline {
       if(!datasetScores.containsKey(d))
         datasetScores.put(d, 0.0d);
       datasetScores.put(d, datasetScores.get(d) + metricScore);
+
+      related.put(d, me);
     }
 
     Set<Entity> entities = new HashSet<>();
@@ -93,8 +98,7 @@ public class MetricDatasetPipeline extends Pipeline {
       dtos = removeExisting(dtos, metrics);
 
       for(MetricConfigDTO dto : dtos) {
-        double score = datasetScore / dtos.size();
-        entities.add(MetricEntity.fromMetric(score, dto.getId()));
+        entities.add(MetricEntity.fromMetric(datasetScore, related.get(d), dto.getId()));
       }
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricEntity.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 
 /**
@@ -12,8 +15,8 @@ public class MetricEntity extends Entity {
 
   private final long id;
 
-  protected MetricEntity(String urn, double score, long id) {
-    super(urn, score);
+  protected MetricEntity(String urn, double score, List<? extends Entity> related, long id) {
+    super(urn, score, related);
     this.id = id;
   }
 
@@ -23,11 +26,20 @@ public class MetricEntity extends Entity {
 
   @Override
   public MetricEntity withScore(double score) {
-    return new MetricEntity(this.getUrn(), score, this.id);
+    return new MetricEntity(this.getUrn(), score, this.getRelated(), this.id);
+  }
+
+  @Override
+  public MetricEntity withRelated(List<? extends Entity> related) {
+    return new MetricEntity(this.getUrn(), this.getScore(), related, this.id);
+  }
+
+  public static MetricEntity fromMetric(double score, Collection<? extends Entity> related, long id) {
+    return new MetricEntity(TYPE.formatURN(id), score, new ArrayList<>(related), id);
   }
 
   public static MetricEntity fromMetric(double score, long id) {
-    return new MetricEntity(TYPE.formatURN(id), score, id);
+    return fromMetric(score, new ArrayList<Entity>(), id);
   }
 
   public static MetricEntity fromURN(String urn, double score) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/ServiceEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/ServiceEntity.java
@@ -1,6 +1,8 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -14,8 +16,8 @@ public class ServiceEntity extends Entity {
 
   private final String name;
 
-  protected ServiceEntity(String urn, double score, String name) {
-    super(urn, score);
+  protected ServiceEntity(String urn, double score, List<? extends Entity> related, String name) {
+    super(urn, score, related);
     this.name = name;
   }
 
@@ -25,12 +27,17 @@ public class ServiceEntity extends Entity {
 
   @Override
   public ServiceEntity withScore(double score) {
-    return new ServiceEntity(this.getUrn(), score, this.name);
+    return new ServiceEntity(this.getUrn(), score, this.getRelated(), this.name);
+  }
+
+  @Override
+  public ServiceEntity withRelated(List<? extends Entity> related) {
+    return new ServiceEntity(this.getUrn(), this.getScore(), related, this.name);
   }
 
   public static ServiceEntity fromName(double score, String name) {
     String urn = TYPE.formatURN(name);
-    return new ServiceEntity(urn, score, name);
+    return new ServiceEntity(urn, score, new ArrayList<Entity>(), name);
   }
 
   public static ServiceEntity fromURN(String urn, double score) {
@@ -39,6 +46,6 @@ public class ServiceEntity extends Entity {
     String[] parts = urn.split(":", 3);
     if(parts.length != 3)
       throw new IllegalArgumentException(String.format("URN must have 3 parts but has '%d'", parts.length));
-    return new ServiceEntity(urn, score, parts[2]);
+    return new ServiceEntity(urn, score, new ArrayList<Entity>(), parts[2]);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/TimeRangeEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/TimeRangeEntity.java
@@ -2,7 +2,9 @@ package com.linkedin.thirdeye.rootcause.impl;
 
 import com.linkedin.thirdeye.rootcause.Entity;
 import com.linkedin.thirdeye.rootcause.PipelineContext;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 
@@ -21,8 +23,8 @@ public class TimeRangeEntity extends Entity {
   private final long start;
   private final long end;
 
-  protected TimeRangeEntity(String urn, double score, String type, long start, long end) {
-    super(urn, score);
+  protected TimeRangeEntity(String urn, double score, List<? extends Entity> related, String type, long start, long end) {
+    super(urn, score, related);
     this.type = type;
     this.start = start;
     this.end = end;
@@ -40,6 +42,16 @@ public class TimeRangeEntity extends Entity {
     return type;
   }
 
+  @Override
+  public TimeRangeEntity withScore(double score) {
+    return new TimeRangeEntity(this.getUrn(), score, this.getRelated(), this.type, this.start, this.end);
+  }
+
+  @Override
+  public TimeRangeEntity withRelated(List<? extends Entity> related) {
+    return new TimeRangeEntity(this.getUrn(), this.getScore(), related, this.type, this.start, this.end);
+  }
+
   public static TimeRangeEntity fromURN(String urn, double score) {
     if(!TYPE.isType(urn))
       throw new IllegalArgumentException(String.format("URN '%s' is not type '%s'", urn, TYPE.getPrefix()));
@@ -51,7 +63,7 @@ public class TimeRangeEntity extends Entity {
 
   public static TimeRangeEntity fromRange(double score, String type, long start, long end) {
     String urn = TYPE.formatURN(type, start, end);
-    return new TimeRangeEntity(urn, score, type, start, end);
+    return new TimeRangeEntity(urn, score, new ArrayList<Entity>(), type, start, end);
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/RCAFrameworkTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/RCAFrameworkTest.java
@@ -34,10 +34,10 @@ public class RCAFrameworkTest {
   public void testLinearAggregationPipeline() {
     LinearAggregationPipeline agg = new LinearAggregationPipeline("", Collections.<String>emptySet(), -1);
 
-    Entity e1 = new Entity("e:one", 1.0);
-    Entity e2 = new Entity("e:two", 2.1);
-    Entity e3 = new Entity("e:three", 3.2);
-    Entity e4 = new Entity("e:four", 4.0);
+    Entity e1 = new Entity("e:one", 1.0, new ArrayList<Entity>());
+    Entity e2 = new Entity("e:two", 2.1, new ArrayList<Entity>());
+    Entity e3 = new Entity("e:three", 3.2, new ArrayList<Entity>());
+    Entity e4 = new Entity("e:four", 4.0, new ArrayList<Entity>());
 
     Set<Entity> scores1 = new HashSet<>();
     scores1.add(e1);


### PR DESCRIPTION
* track an entity's related entities throughout the RCA framework

Whenever a pipeline emits an entity it may tag the entity with related entities it was derived from. For example, the AnomalyPipeline can now tag every AnomalyEntity with the time range, metric, and metric dimension it was found in. This solves a whole list of issues, including (a) distinction of baseline and anomaly-period events, (b) intelligent merging of multiple pipeline scores for the same entity, (c) providing the user with country information for holiday events, (d) redundant querying of data sources for context-dependent formatting, and (e) debugging of unexpected RCA results via a complete derivation tree per entity.