### PR TITLE
[TE] Rootcause frontend tweaks and fixes

### DIFF
--- a/thirdeye/thirdeye-frontend/app/actions/constants.js
+++ b/thirdeye/thirdeye-frontend/app/actions/constants.js
@@ -27,11 +27,11 @@ const eventColorMapping = {
 };
 
 const eventWeightMapping = {
-  lix: 0.05,
-  gcn: 0.1,
-  anomaly: 0.15,
-  holiday: 0.2,
-  informed: 0
+  informed: 0.025,
+  lix: 0.075,
+  anomaly: 0.125,
+  gcn: 0.175,
+  holiday: 0.175
 };
 
 export {

--- a/thirdeye/thirdeye-frontend/app/actions/events.js
+++ b/thirdeye/thirdeye-frontend/app/actions/events.js
@@ -113,7 +113,11 @@ const assignHumanTimeInfo = (event) => {
 
   var humanDuration = event.duration;
   if (!Number.isNaN(event.duration)) {
-    humanDuration = humanizeShort(moment.duration(event.duration));
+    if (event.duration < moment.duration(1, 'minute')) {
+      humanDuration = '';
+    } else {
+      humanDuration = humanizeShort(moment.duration(event.duration));
+    }
   }
 
   return Object.assign(event, { humanRelStart, humanDuration });

--- a/thirdeye/thirdeye-frontend/app/actions/events.js
+++ b/thirdeye/thirdeye-frontend/app/actions/events.js
@@ -69,9 +69,9 @@ const assignEventColor = (event) => {
  */
 const setWeight = (event) => {
   const { eventType } = event;
-  const weight = eventWeightMapping[eventType] || 0;
+  const displayScore = eventWeightMapping[eventType] || 0;
 
-  return Object.assign(event, {score: weight});
+  return Object.assign(event, { displayScore });
 };
 
 /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
@@ -314,14 +314,14 @@ export default Ember.Component.extend({
         const {
           // start,
           // end,
-          score,
+          displayScore,
           label
         } = event;
 
         // const scores = (!end || start === end)
         //   ? [score, score]
         //   : [score];
-        return [label, score];
+        return [label, displayScore];
       });
     }
   ),

--- a/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
@@ -20,7 +20,8 @@ export default Ember.Component.extend({
       if (selectedTab === 'all') { return events; }
       return events
         .filter(event => (event.eventType === selectedTab))
-        .sortBy('score');
+        .sortBy('score')
+        .reverse();
     }
   ),
 


### PR DESCRIPTION
* show holidays and major alert dots on same line

* separate display score from entity score

* omit durations < 1 minute

* sort table entities in descending order even when filtered