### PR TITLE
Filter query tree serialization bugfix

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/FilterQueryTree.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/FilterQueryTree.java
@@ -20,31 +20,16 @@ import java.util.List;
 
 
 public class FilterQueryTree {
-  private final int id;
   private final String column;
   private final List<String> value;
   private final FilterOperator operator;
   private final List<FilterQueryTree> children;
 
   public FilterQueryTree(String column, List<String> value, FilterOperator operator, List<FilterQueryTree> children) {
-    this.id = System.identityHashCode(this);
     this.column = column;
     this.value = value;
     this.operator = operator;
     this.children = children;
-  }
-
-  public FilterQueryTree(int id, String column, List<String> value, FilterOperator operator,
-      List<FilterQueryTree> children) {
-    this.id = id;
-    this.column = column;
-    this.value = value;
-    this.operator = operator;
-    this.children = children;
-  }
-
-  public int getId() {
-    return id;
   }
 
   public String getColumn() {
@@ -74,9 +59,9 @@ public class FilterQueryTree {
       stringBuffer.append(' ');
     }
     if (operator == FilterOperator.OR || operator == FilterOperator.AND) {
-      stringBuffer.append(operator).append(" (").append(id).append(")");
+      stringBuffer.append(operator);
     } else {
-      stringBuffer.append(column).append(" ").append(operator).append(" ").append(value).append(" (").append(id).append(")");
+      stringBuffer.append(column).append(" ").append(operator).append(" ").append(value);
     }
     if (children != null) {
       for (FilterQueryTree child : children) {


### PR DESCRIPTION
Fix the serialization of the filter query tree. During filter query tree
serialization, we convert the tree into a map of ids to individual query
predicates. Since the id is generated automatically, if there is a
collision on the id on the leaf nodes, individual query predicates can
be overwritten, causing incorrect query processing.

This patch fixes this issue by removing the individually generated node
ids and generates them sequentially at serialization time, ensuring that
there is no possible collisions, assuming that there are fewer than
$2^31-1$ query filter predicates.