### PR TITLE
[Minion] In ConvertToRawIndexTaskGenerator, do not count COMPLETED segment as running segment

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
@@ -56,14 +56,13 @@ public class ConvertToRawIndexTaskGenerator implements PinotTaskGenerator {
   public List<PinotTaskConfig> generateTasks(@Nonnull List<TableConfig> tableConfigs) {
     List<PinotTaskConfig> pinotTaskConfigs = new ArrayList<>();
 
-    // Get the segments that are already submitted so that we don't submit them again
+    // Get the segments that are being converted so that we don't submit them again
     Set<String> runningSegments = new HashSet<>();
     Map<String, TaskState> taskStates =
         _clusterInfoProvider.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE);
     for (Map.Entry<String, TaskState> entry : taskStates.entrySet()) {
       TaskState taskState = entry.getValue();
-      if (taskState == TaskState.NOT_STARTED || taskState == TaskState.IN_PROGRESS || taskState == TaskState.STOPPED
-          || taskState == TaskState.COMPLETED) {
+      if (taskState == TaskState.NOT_STARTED || taskState == TaskState.IN_PROGRESS || taskState == TaskState.STOPPED) {
         Map<String, String> configs = _clusterInfoProvider.getTaskConfig(entry.getKey()).getConfigs();
         runningSegments.add(
             configs.get(MinionConstants.TABLE_NAME_KEY) + "__" + configs.get(MinionConstants.SEGMENT_NAME_KEY));


### PR DESCRIPTION
If we count COMPLETED segment as running segment, then we cannot optimize the same segment before the task expired.
We might want to optimize the same segment because it might have been refreshed.