### PR TITLE
[TE] Rootcause - frontend event and metrics patches

### DIFF
--- a/thirdeye/thirdeye-frontend/app/actions/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/actions/metrics.js
@@ -122,9 +122,6 @@ function fetchRelatedMetricIds() {
       compareMode,
     } = primaryMetric;
 
-    // const analysisEnd = currentEnd || moment().subtract(1, 'day').endOf('day').valueOf();
-    // const analysisStart = currentStart || moment(analysisEnd).subtract(1, 'week').valueOf();
-
     const offset = COMPARE_MODE_MAPPING[compareMode] || 1;
     const baselineStart = moment(anomalyStart).subtract(offset, 'week').valueOf();
     const baselineEnd = moment(anomalyEnd).subtract(offset, 'week').valueOf();

--- a/thirdeye/thirdeye-frontend/app/actions/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/actions/metrics.js
@@ -112,25 +112,22 @@ function fetchRelatedMetricIds() {
 
     let {
       primaryMetricId: metricId,
-      currentStart: startDate,
-      currentEnd: endDate
+      currentStart: analysisStart,
+      currentEnd: analysisEnd,
+      regionStart: anomalyStart,
+      regionEnd: anomalyEnd
     } = metrics;
 
     const {
-      compareMode
+      compareMode,
     } = primaryMetric;
 
-    // TODO use actual anomaly period only
-    const anomalyEnd = endDate || moment().subtract(1, 'day').endOf('day').valueOf();
-    const anomalyStart = startDate || moment(endDate).subtract(1, 'week').valueOf();
+    // const analysisEnd = currentEnd || moment().subtract(1, 'day').endOf('day').valueOf();
+    // const analysisStart = currentStart || moment(analysisEnd).subtract(1, 'week').valueOf();
 
     const offset = COMPARE_MODE_MAPPING[compareMode] || 1;
     const baselineStart = moment(anomalyStart).subtract(offset, 'week').valueOf();
     const baselineEnd = moment(anomalyEnd).subtract(offset, 'week').valueOf();
-
-    // TODO use currentStart/currentEnd when anomaly period separated
-    const analysisStart = anomalyStart;
-    const analysisEnd = anomalyEnd;
 
     if (!metricId) {
       return Promise.reject(new Error("Must provide a metricId"));

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
@@ -333,7 +333,10 @@ export default Ember.Component.extend({
       const holidays = this.get('holidayEvents');
 
       return holidays.map((holiday) => {
-        const { start, end } = holiday;
+        const { displayStart, displayEnd } = holiday;
+
+        const start = displayStart;
+        const end = displayEnd;
 
         const date = !end ? [end] : [start];
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
@@ -40,8 +40,8 @@ export default Ember.Component.extend({
       if (!(start && end)) { return events; }
 
       return events.filter((event) => {
-        return (event.end && ((event.end > start) && (event.end < end)))
-          || ((event.start < end) && (event.start > start));
+        return (!event.displayEnd || (event.displayEnd > start))
+          && (!event.displayStart || (event.displayStart < end));
       });
     }
   ),

--- a/thirdeye/thirdeye-frontend/app/reducers/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/reducers/metrics.js
@@ -84,7 +84,7 @@ export default function reducer(state = INITIAL_STATE, action = {}) {
     case ActionTypes.LOAD_IDS: {
       const relatedMetrics = action.payload;
       const relatedMetricIds = relatedMetrics
-        .sort((prev, next) => next.score > prev.score)
+        .sortBy('score').reverse()
         .map((metric) => Number(metric.urn.split('thirdeye:metric:').pop()));
 
       return Object.assign({}, state,  {


### PR DESCRIPTION
* baseline events are displayed within the current the anomaly region

* holiday (utc midnight) timestamps are adjusted to the local timezone

* related metrics use only the anomaly region for scoring