### PR TITLE
Optimize sorted index

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/SortedInvertedIndexReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/SortedInvertedIndexReader.java
@@ -53,9 +53,7 @@ public class SortedInvertedIndexReader implements InvertedIndexReader {
     MutableRoaringBitmap rr = new MutableRoaringBitmap();
     int min = indexReader.getInt(idx, 0);
     int max = indexReader.getInt(idx, 1);
-    for (int i = min; i <= max; i++) {
-      rr.add(i);
-    }
+    rr.add(min, max + 1);
     return rr;
   }
 


### PR DESCRIPTION
Optimize the roaring bitmap generation for sorted indexes by adding
ranges directly instead of adding docIds one by one.

Performance impact of adding 1000 values is about 133x faster and is likely to have a large impact :
```
Benchmark                                             Mode      Cnt         Score    Error  Units
BenchmarkRoaringBitmap.addFixed                     sample  3956823       128.876 ±  9.871  ns/op
BenchmarkRoaringBitmap.addInLoop                    sample  3520867     17109.083 ± 33.184  ns/op
```

For one million values, it's over 100000x faster (900 nanoseconds vs 12.5 milliseconds):
```
Benchmark                                             Mode      Cnt         Score       Error  Units
BenchmarkRoaringBitmap.addFixed                     sample  4475444       972.145 ±    16.770  ns/op
BenchmarkRoaringBitmap.addInLoop                    sample     9463  12688404.668 ± 55250.599  ns/op
```

For single value columns (eg. days since epoch), they count as a single value sorted column, so this should have a large impact for queries that have those.