### PR TITLE
[TE] Self-Serve Create Alert Pre-Launch Modifications (table layout)

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -57,6 +57,24 @@ export default Ember.Controller.extend({
   ],
 
   /**
+   * Array to define alerts table columns for selected config group
+   */
+  alertsTableColumns: [
+    {
+      propertyName: 'name',
+      title: 'Alert Name'
+    },
+    {
+      propertyName: 'metric',
+      title: 'Alert Metric'
+    },
+    {
+      propertyName: 'type',
+      title: 'Alert Type'
+    }
+  ],
+
+  /**
    * Options for patterns of interest field. These may eventually load from the backend.
    */
   patternsOfInterest: ['Up and Down', 'Up only', 'Down only'],
@@ -301,17 +319,28 @@ export default Ember.Controller.extend({
     const startTime = moment().subtract(1, 'month').endOf('day').utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
     const endTime = moment().subtract(1, 'day').endOf('day').utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
 
+    // Set banner to 'pending' state
+    this.setProperties({
+      isReplaySuccess: true,
+      isReplayStatusPending: true
+    });
+
+    // Begin replay sequence. Simulate trigger response time since we don't yet need
+    // to wait for the actual response, which takes 30+ seconds
     this.callCloneAlert(newFuncId)
       .then((clonedId) => {
+        const that = this;
+        Ember.run.later((function() {
+          that.setProperties({
+            isReplaySuccess: true,
+            isReplayStatusPending: false,
+            replayStatusClass: 'te-form__banner--success'
+          });
+        }), 3000);
         return this.callReplayStart(clonedId, startTime, endTime);
       })
-      .then((jobId) => {
-        this.setProperties({
-          isReplaySuccess: true,
-          isReplayStatusPending: false,
-          replayStatusClass: 'te-form__banner--success'
-        });
-      })
+      // NOTE: Once we decide how to "listen" for replay end in the UI, we will do something here.
+      // .then((jobId) => {})
       .catch((error) => {
         this.setProperties({
           isReplayError: true,
@@ -545,6 +574,18 @@ export default Ember.Controller.extend({
       const body = `TE Team, please look into a possible inconsistency issue with [ ${fullMetricName} ]`;
       const mailtoString = `mailto:${recipient}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
       return mailtoString;
+    }
+  ),
+
+  /**
+   * Returns the appropriate subtitle for selected config group monitored alerts
+   * @method selectedConfigGroupSubtitle
+   * @return {String} title of expandable section for selected config group
+   */
+  selectedConfigGroupSubtitle: Ember.computed(
+    'selectedConfigGroup',
+    function () {
+      return `Alerts Monitored by: ${this.get('selectedConfigGroup.name')}`;
     }
   ),
 
@@ -825,7 +866,7 @@ export default Ember.Controller.extend({
 
             if (alertResult.ok) {
               this.setProperties({
-                selectedGroupRecipients: finalConfigObj.recipients,
+                selectedGroupRecipients: finalConfigObj.recipients.replace(/,+/g, ', '),
                 isCreateAlertSuccess: true,
                 finalFunctionId: newFunctionId
               });

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -1,5 +1,5 @@
 <h1 class="te-title">Create An Alert</h1>
-<main class="alert-create paper-container paper-container--padded">
+<main class="alert-create paper-container paper-container--padded te-form">
 
   <fieldset class="te-form__section te-form__section--first">
     <legend class="te-form__section-title">Metric</legend>
@@ -9,7 +9,7 @@
       {{/link-to}}
     </div>
     <div class="form-group">
-      <label for="select-metric" class="control-label required">Searh for a Metric</label>
+      <label for="select-metric" class="control-label required">Search for a Metric</label>
       {{#power-select
         search=(perform searchMetricsList)
         selected=selectedMetricOption
@@ -18,6 +18,7 @@
         placeholder="Search by Metric Name"
         searchPlaceholder="Type to filter..."
         triggerId="select-metric"
+        triggerClass="te-form__select"
         disabled=false
         as |metric|
       }}
@@ -51,6 +52,7 @@
         placeholder="Select a Granularity"
         searchPlaceholder="Type to filter..."
         triggerId="select-granularity"
+        triggerClass="te-form__select"
         disabled=isGranularitySelectDisabled
         as |granularity|
       }}
@@ -68,6 +70,7 @@
         placeholder="Break Dimensions By..."
         searchPlaceholder="Type to filter..."
         triggerId="select-dimension"
+        triggerClass="te-form__select"
         disabled=(not isMetricSelected)
         as |dimension|
       }}
@@ -115,6 +118,7 @@
       {{#power-select
         loadingMessage="Waiting for the server...."
         triggerId="select-pattern"
+        triggerClass="te-form__select"
         placeholder="Select a Pattern"
         loadingMessage="Please select a metric first"
         options=patternsOfInterest
@@ -140,6 +144,7 @@
           placeholder="Select an existing product/team name"
           searchPlaceholder="Type to filter..."
           triggerId="anomaly-form-app-name"
+          triggerClass="te-form__select"
           disabled=(not isMetricSelected)
           as |app|
         }}
@@ -181,6 +186,7 @@
         placeholder="Select an existing alert subscription group"
         searchPlaceholder="Type to filter..."
         triggerId="config-group"
+        triggerClass="te-form__select"
         as |group|
       }}
         {{group.name}}
@@ -199,6 +205,26 @@
         disabled=(not isMetricSelected)
       }}
     </div>
+    {{!-- Alert Group Metadata --}}
+    {{#if selectedConfigGroup}}
+      <div class="form-group te-form__group">
+        {{#if selectedGroupFunctions.length}}
+          {{#bs-accordion as |acc|}}
+            {{#acc.item class="te-form__custom-label" title=selectedConfigGroupSubtitle}}
+              {{models-table
+                data=selectedGroupFunctions
+                columns=alertsTableColumns
+                showGlobalFilter=false
+                showColumnsDropdown=false
+                filteringIgnoreCase=true
+              }}
+            {{/acc.item}}
+          {{/bs-accordion}}
+        {{else}}
+          <span class="alert-group-functions__item--id">NONE</span>
+        {{/if}}
+      </div>
+    {{/if}}
     {{!-- Field: new alert group recipient emails --}}
     <div class="form-group">
       <label for="config-group" class="control-label">Add Alert Notification Recipients *</label>
@@ -219,25 +245,6 @@
         required=true
       }}
     </div>
-    {{#if selectedConfigGroup}}
-      {{!-- Alert Group Metadata --}}
-      <div class="form-group">
-        <label for="config-group-functions" class="control-label">Alerts Monitored by This Group</label>
-        <ul class="alert-group-functions">
-          {{#each selectedGroupFunctions as |function|}}
-            <li class="alert-group-functions__item {{if function.isNewId 'alert-group-functions__item--new'}}">
-              <span class="alert-group-functions__item--value">{{function.name}} </span>
-              <span class="alert-group-functions__item--key">metric/collection: </span>
-              <span class="alert-group-functions__item--value">{{function.metric}} </span>
-              <span class="alert-group-functions__item--key">type: </span>
-              <span class="alert-group-functions__item--value">{{function.type}} </span>
-            </li>
-          {{else}}
-            <span class="alert-group-functions__item--id">NONE</span>
-          {{/each}}
-        </ul>
-      </div>
-    {{/if}}
   </fieldset>
 
   {{#if isCreateAlertSuccess}}
@@ -266,7 +273,7 @@
       {{#if isReplayStatusPending}}
         ...triggering replay. Please wait.
       {{else}}
-        <strong>Replay Success!</strong> The replay of anomaly alert <strong>{{alertFunctionName}}</strong> has started processing. We will notify <strong>{{alertGroupNewRecipient}}</strong> when the replay is complete.
+        <strong>Replay Success!</strong> The replay of anomaly alert <strong>{{alertFunctionName}}</strong> has started processing.
       {{/if}}
     {{/bs-alert}}
   {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -44,23 +44,6 @@
     </div>
 
     <div class="form-group te-form__group--horizontal te-form__group--small">
-      <label for="select-granularity" class="control-label">Desired Granularity</label>
-      {{#power-select
-        options=metricGranularityOptions
-        selected=selectedGranularity
-        onchange=(action "onSelectGranularity")
-        placeholder="Select a Granularity"
-        searchPlaceholder="Type to filter..."
-        triggerId="select-granularity"
-        triggerClass="te-form__select"
-        disabled=isGranularitySelectDisabled
-        as |granularity|
-      }}
-        {{granularity}}
-      {{/power-select}}
-    </div>
-
-    <div class="form-group te-form__group--horizontal te-form__group--small te-form__group--last">
       <label for="select-dimension" class="control-label">Dimension</label>
       {{#power-select
         options=dimensions
@@ -75,6 +58,23 @@
         as |dimension|
       }}
         {{dimension}}
+      {{/power-select}}
+    </div>
+
+    <div class="form-group te-form__group--horizontal te-form__group--small te-form__group--last">
+      <label for="select-granularity" class="control-label">Desired Granularity</label>
+      {{#power-select
+        options=metricGranularityOptions
+        selected=selectedGranularity
+        onchange=(action "onSelectGranularity")
+        placeholder="Select a Granularity"
+        searchPlaceholder="Type to filter..."
+        triggerId="select-granularity"
+        triggerClass="te-form__select"
+        disabled=isGranularitySelectDisabled
+        as |granularity|
+      }}
+        {{granularity}}
       {{/power-select}}
     </div>
 
@@ -268,19 +268,17 @@
     {{/bs-alert}}
   {{/if}}
 
-  {{#if isReplaySuccess}}
-    {{#bs-alert type="success" class="te-form__banner" classNameBindings="replayStatusClass"}}
+  {{#if isReplayStarted}}
+    {{#bs-alert type=bsAlertBannerType class="te-form__banner" classNameBindings="replayStatusClass"}}
       {{#if isReplayStatusPending}}
         ...triggering replay. Please wait.
-      {{else}}
+      {{/if}}
+      {{#if isReplayStatusSuccess}}
         <strong>Replay Success!</strong> The replay of anomaly alert <strong>{{alertFunctionName}}</strong> has started processing.
       {{/if}}
-    {{/bs-alert}}
-  {{/if}}
-
-  {{#if isReplayError}}
-    {{#bs-alert type="danger" class="te-form__banner te-form__banner--failure"}}
-      <strong>Replay Error:</strong> {{failureMessage}}
+      {{#if isReplayStatusError}}
+        <strong>Replay Warning:</strong> {{failureMessage}}
+      {{/if}}
     {{/bs-alert}}
   {{/if}}
 

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -28,9 +28,12 @@ body {
   margin-top: $te-default-element-spacing;
 
   &__group {
+    clear: left;
+
     &--horizontal {
       float: left;
       margin-right: 21px;
+      clear: right;
     }
 
     &--last {

--- a/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
@@ -191,6 +191,11 @@ body {
     font-size: 14px;
   }
 
+  &__table-index {
+    text-align: right;
+    width: 100px;
+  }
+
   // overriding bootstrap for create alert form
   .panel-title {
     font-size: 15px;

--- a/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
@@ -104,8 +104,6 @@ body {
 
 .te-form {
   &__section {
-    margin-top: 10px;
-
     &--first {
       margin-top: 0;
     }
@@ -156,7 +154,7 @@ body {
     font-size: 16px;
     margin-top: 10px;
     padding-top: 10px;
-    border-left: 35px solid;
+    border-left: 30px solid;
 
     &--success {
       color: #1f5a8c;
@@ -187,6 +185,24 @@ body {
 
   &__note {
     padding: 5px;
+  }
+
+  &__custom-label {
+    font-size: 14px;
+  }
+
+  // overriding bootstrap for create alert form
+  .panel-title {
+    font-size: 15px;
+    color: #369ece;
+    font-weight: 600;
+    letter-spacing: .1px;
+  }
+
+  // overriding power-select basic field style
+  .ember-power-select-trigger {
+    padding-top: 2px;
+    min-height: 2.4em !important;
   }
 }
 


### PR DESCRIPTION
Changes made to Crete Alert view:

- Changing up replay triggering sequence… not waiting for jobId since we’re not using it yet
- Enhancing readability of “Alerts Monitored by This Group” with a table layout
- Styles - overriding bootstrap and power-select for one class (making power-select fields match “fatness” of bootstrap inputs)

Changes in commit 5dd360a...
- Removed "clone" call and not waiting for response from "replay" call, since the flow currently ends there.
- Changed handling of error messages on replay call (using the same banner with different states)
- Handled a small bug that was introducing trailing `,` chars to recipients list.
- Added ID column to alerts table, and made sure newly created alerts float to the top of the list for visual confirmation.