### PR TITLE
Fix the bug in timeseries comparison

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
@@ -118,7 +118,7 @@ public class BackwardAnomalyFunctionUtils {
     @Override public int compare(TimeSeries ts1, TimeSeries ts2) {
       long startTime1 = ts1.getTimeSeriesInterval().getStartMillis();
       long startTime2 = ts2.getTimeSeriesInterval().getStartMillis();
-      return (int) (startTime1 - startTime2);
+      return Long.compare(startTime1, startTime2);
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
@@ -7,6 +7,7 @@ import com.linkedin.thirdeye.api.MetricType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.joda.time.Interval;
 import org.junit.Test;
 
@@ -21,15 +22,15 @@ public class TestBackwardAnoamlyFunctionUtils {
         new MetricSchema(metricNames, Collections.nCopies(metricNames.size(), MetricType.DOUBLE));
     MetricTimeSeries metricTimeSeries = new MetricTimeSeries(metricSchema);
     metricTimeSeries.set(0, TEST_METRIC, 0);
-    metricTimeSeries.set(1, TEST_METRIC, 1);
-    metricTimeSeries.set(2, TEST_METRIC, 2);
-    metricTimeSeries.set(3, TEST_METRIC, 3);
-    metricTimeSeries.set(4, TEST_METRIC, 4);
-    metricTimeSeries.set(5, TEST_METRIC, 5);
+    metricTimeSeries.set(TimeUnit.DAYS.toMillis(28), TEST_METRIC, 1);
+    metricTimeSeries.set(TimeUnit.DAYS.toMillis(56), TEST_METRIC, 2);
+    metricTimeSeries.set(TimeUnit.DAYS.toMillis(84), TEST_METRIC, 3);
+    metricTimeSeries.set(TimeUnit.DAYS.toMillis(112), TEST_METRIC, 4);
+    metricTimeSeries.set(TimeUnit.DAYS.toMillis(140), TEST_METRIC, 5);
 
     List<Interval> intervalList = new ArrayList<>();
-    intervalList.add(new Interval(5, 6));
-    intervalList.add(new Interval(0, 5));
+    intervalList.add(new Interval(TimeUnit.DAYS.toMillis(140), TimeUnit.DAYS.toMillis(168)));
+    intervalList.add(new Interval(0, TimeUnit.DAYS.toMillis(140)));
     List<TimeSeries> timeSeriesList =
         BackwardAnomalyFunctionUtils.splitSetsOfTimeSeries(metricTimeSeries, TEST_METRIC, intervalList);
     assert(timeSeriesList.size() == 2);
@@ -37,10 +38,10 @@ public class TestBackwardAnoamlyFunctionUtils {
     assert(timeSeriesList.get(1).size() == 5);
 
     // assert current time series
-    assert(timeSeriesList.get(0).get(5).equals(5.0));
+    assert(timeSeriesList.get(0).get(TimeUnit.DAYS.toMillis(140)).equals(5.0));
 
     for (int i = 0; i < 5; i++) {
-      assert (timeSeriesList.get(1).get(i).equals(Double.valueOf(i)));
+      assert (timeSeriesList.get(1).get(TimeUnit.DAYS.toMillis(28 * i)).equals(Double.valueOf(i)));
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
@@ -35,5 +35,12 @@ public class TestBackwardAnoamlyFunctionUtils {
     assert(timeSeriesList.size() == 2);
     assert(timeSeriesList.get(0).size() == 1);
     assert(timeSeriesList.get(1).size() == 5);
+
+    // assert current time series
+    assert(timeSeriesList.get(0).get(5).equals(5.0));
+
+    for (int i = 0; i < 5; i++) {
+      assert (timeSeriesList.get(1).get(i).equals(Double.valueOf(i)));
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
@@ -1,0 +1,39 @@
+package com.linkedin.thirdeye.anomalydetection.function;
+
+import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
+import com.linkedin.thirdeye.api.MetricSchema;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.api.MetricType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.joda.time.Interval;
+import org.junit.Test;
+
+
+public class TestBackwardAnoamlyFunctionUtils {
+  private static final String TEST_METRIC = "test";
+  @Test
+  public void testSplitSetsOfTimeSeries() {
+    List<String> metricNames = new ArrayList<>();
+    metricNames.add(TEST_METRIC);
+    MetricSchema metricSchema =
+        new MetricSchema(metricNames, Collections.nCopies(metricNames.size(), MetricType.DOUBLE));
+    MetricTimeSeries metricTimeSeries = new MetricTimeSeries(metricSchema);
+    metricTimeSeries.set(0, TEST_METRIC, 0);
+    metricTimeSeries.set(1, TEST_METRIC, 1);
+    metricTimeSeries.set(2, TEST_METRIC, 2);
+    metricTimeSeries.set(3, TEST_METRIC, 3);
+    metricTimeSeries.set(4, TEST_METRIC, 4);
+    metricTimeSeries.set(5, TEST_METRIC, 5);
+
+    List<Interval> intervalList = new ArrayList<>();
+    intervalList.add(new Interval(5, 6));
+    intervalList.add(new Interval(0, 5));
+    List<TimeSeries> timeSeriesList =
+        BackwardAnomalyFunctionUtils.splitSetsOfTimeSeries(metricTimeSeries, TEST_METRIC, intervalList);
+    assert(timeSeriesList.size() == 2);
+    assert(timeSeriesList.get(0).size() == 1);
+    assert(timeSeriesList.get(1).size() == 5);
+  }
+}


### PR DESCRIPTION
When building AnomalyInputContext, ThirdEye splits the time series into current and baseline. The split and assignment requires a TimeSeriesStartTimeComparator to sort the time series. However, there is a bug detected in the long value comparison. This pull request is to fix the bug on the value comparison function. 