### PR TITLE
Enhance AggregationGroupByTrimmingService to support trimming on non-comparable intermediate result

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -99,6 +99,11 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
       @Nonnull IntermediateResult intermediateResult2);
 
   /**
+   * Return whether the intermediate result is comparable.
+   */
+  boolean isIntermediateResultComparable();
+
+  /**
    * Get the {@link FieldSpec.DataType} of the intermediate result.
    * <p>This data type is used for transferring data in data table.
    */

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -139,6 +139,11 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
     return intermediateResult1;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return true;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -100,6 +100,11 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
     return intermediateResult1 + intermediateResult2;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return true;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -238,6 +238,11 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
     return intermediateResult1;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return false;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -241,6 +241,11 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
     return intermediateResult1;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return false;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -157,6 +157,11 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
     return intermediateResult1;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return false;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -120,6 +120,11 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
     }
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return true;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -120,6 +120,11 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
     }
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return true;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -147,6 +147,11 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
     return intermediateResult1;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return true;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -158,6 +158,11 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
     return intermediateResult1;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return false;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -157,6 +157,11 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
     return intermediateResult1;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return false;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -108,6 +108,11 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
     return intermediateResult1 + intermediateResult2;
   }
 
+  @Override
+  public boolean isIntermediateResultComparable() {
+    return true;
+  }
+
   @Nonnull
   @Override
   public FieldSpec.DataType getIntermediateResultDataType() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/AggregationGroupByTrimmingService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/AggregationGroupByTrimmingService.java
@@ -15,66 +15,47 @@
  */
 package com.linkedin.pinot.core.query.aggregation.groupby;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.response.broker.GroupByResult;
-import com.linkedin.pinot.core.query.aggregation.AggregationFunctionContext;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
-import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import com.linkedin.pinot.core.query.aggregation.function.MinAggregationFunction;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.TreeMap;
 import javax.annotation.Nonnull;
+import org.apache.commons.collections.comparators.ComparableComparator;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 
 /**
- * The <code>AggregationGroupByTrimmingService</code> class provides trimming service for aggregation group-by query.
+ * The <code>AggregationGroupByTrimmingService</code> class provides trimming service for aggregation group-by queries.
  */
-// TODO: revisit the trim algorithm, implement trim on all Object but not only for Comparable.
 public class AggregationGroupByTrimmingService {
   public static final String GROUP_KEY_DELIMITER = "\t";
 
-  private final int _numAggregationFunctions;
-  private final boolean[] _minOrders;
-
+  private final AggregationFunction[] _aggregationFunctions;
   private final int _groupByTopN;
-  // To keep the precision, _trimSize is the larger of (_groupByTopN * 5) or 5000.
   private final int _trimSize;
-  // To trigger the trimming, number of groups should be larger than _trimThreshold which is (_trimSize * 4).
   private final int _trimThreshold;
 
-  public AggregationGroupByTrimmingService(@Nonnull AggregationFunctionContext[] aggregationFunctionContexts,
-      int groupByTopN) {
-    _numAggregationFunctions = aggregationFunctionContexts.length;
-    _minOrders = new boolean[_numAggregationFunctions];
-    for (int i = 0; i < _numAggregationFunctions; i++) {
-      String aggregationFunctionName = aggregationFunctionContexts[i].getAggregationFunction().getName();
-      if (aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MIN.getName())
-          || aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MINMV.getName())) {
-        _minOrders[i] = true;
-      }
-    }
-    _groupByTopN = groupByTopN;
-    _trimSize = Math.max(_groupByTopN * 5, 5000);
-    _trimThreshold = _trimSize * 4;
-  }
-
   public AggregationGroupByTrimmingService(@Nonnull AggregationFunction[] aggregationFunctions, int groupByTopN) {
-    _numAggregationFunctions = aggregationFunctions.length;
-    _minOrders = new boolean[_numAggregationFunctions];
-    for (int i = 0; i < _numAggregationFunctions; i++) {
-      String aggregationFunctionName = aggregationFunctions[i].getName();
-      if (aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MIN.getName())
-          || aggregationFunctionName.equals(AggregationFunctionFactory.AggregationFunctionType.MINMV.getName())) {
-        _minOrders[i] = true;
-      }
-    }
+    Preconditions.checkArgument(groupByTopN > 0);
+
+    _aggregationFunctions = aggregationFunctions;
     _groupByTopN = groupByTopN;
+
+    // To keep the precision, _trimSize is the larger of (_groupByTopN * 5) or 5000
     _trimSize = Math.max(_groupByTopN * 5, 5000);
+
+    // To trigger the trimming, number of groups should be larger than _trimThreshold which is (_trimSize * 4)
     _trimThreshold = _trimSize * 4;
   }
 
@@ -82,67 +63,53 @@ public class AggregationGroupByTrimmingService {
    * Given a map from group key to the intermediate results for multiple aggregation functions, trim the results to
    * desired size and put them into a list of maps from group key to intermediate result for each aggregation function.
    */
+  @SuppressWarnings("unchecked")
   @Nonnull
   public List<Map<String, Object>> trimIntermediateResultsMap(@Nonnull Map<String, Object[]> intermediateResultsMap) {
-    List<Map<String, Object>> trimmedResults = new ArrayList<>(_numAggregationFunctions);
-    for (int i = 0; i < _numAggregationFunctions; i++) {
-      trimmedResults.add(new HashMap<String, Object>());
-    }
+    int numAggregationFunctions = _aggregationFunctions.length;
+    Map<String, Object>[] trimmedResultMaps = new Map[numAggregationFunctions];
 
-    if (intermediateResultsMap.isEmpty()) {
-      return trimmedResults;
-    }
+    int numGroups = intermediateResultsMap.size();
+    if (numGroups > _trimThreshold) {
+      // Trim the result only if number of groups is larger than the threshold
 
-    if (intermediateResultsMap.size() > _trimThreshold) {
-      // Need to trim.
-
-      // Construct the priority queues.
-      @SuppressWarnings("unchecked")
-      PriorityQueue<GroupKeyResultPair>[] priorityQueues = new PriorityQueue[_numAggregationFunctions];
-      Object[] sampleResults = intermediateResultsMap.values().iterator().next();
-      for (int i = 0; i < _numAggregationFunctions; i++) {
-        if (sampleResults[i] instanceof Comparable) {
-          priorityQueues[i] = new PriorityQueue<>(_trimSize + 1, getGroupKeyResultPairComparator(_minOrders[i]));
-        }
+      Sorter[] sorters = new Sorter[numAggregationFunctions];
+      for (int i = 0; i < numAggregationFunctions; i++) {
+        AggregationFunction aggregationFunction = _aggregationFunctions[i];
+        sorters[i] = getSorter(_trimSize, aggregationFunction, aggregationFunction.isIntermediateResultComparable());
       }
 
-      // Fill results into the priority queues.
+      // Add results into sorters
       for (Map.Entry<String, Object[]> entry : intermediateResultsMap.entrySet()) {
         String groupKey = entry.getKey();
         Object[] intermediateResults = entry.getValue();
-        for (int i = 0; i < _numAggregationFunctions; i++) {
-          PriorityQueue<GroupKeyResultPair> priorityQueue = priorityQueues[i];
-          if (priorityQueue == null) {
-            trimmedResults.get(i).put(groupKey, intermediateResults[i]);
-          } else {
-            GroupKeyResultPair newValue = new GroupKeyResultPair(groupKey, (Comparable) intermediateResults[i]);
-            addToPriorityQueue(priorityQueue, newValue, _trimSize);
-          }
+        for (int i = 0; i < numAggregationFunctions; i++) {
+          sorters[i].add(groupKey, intermediateResults[i]);
         }
       }
 
-      // Fill trimmed results into the maps.
-      for (int i = 0; i < _numAggregationFunctions; i++) {
-        PriorityQueue<GroupKeyResultPair> priorityQueue = priorityQueues[i];
-        if (priorityQueue != null) {
-          while (!priorityQueue.isEmpty()) {
-            GroupKeyResultPair groupKeyResultPair = priorityQueue.poll();
-            trimmedResults.get(i).put(groupKeyResultPair._groupKey, groupKeyResultPair._result);
-          }
-        }
+      // Dump trimmed results into maps
+      for (int i = 0; i < numAggregationFunctions; i++) {
+        Map<String, Object> trimmedResultMap = new HashMap<>(_trimSize);
+        sorters[i].dumpToMap(trimmedResultMap);
+        trimmedResultMaps[i] = trimmedResultMap;
       }
     } else {
-      // No need to trim.
+      // Simply put results from intermediateResultsMap into trimmedResults
+
+      for (int i = 0; i < numAggregationFunctions; i++) {
+        trimmedResultMaps[i] = new HashMap<>(numGroups);
+      }
       for (Map.Entry<String, Object[]> entry : intermediateResultsMap.entrySet()) {
         String groupKey = entry.getKey();
         Object[] intermediateResults = entry.getValue();
-        for (int i = 0; i < _numAggregationFunctions; i++) {
-          trimmedResults.get(i).put(groupKey, intermediateResults[i]);
+        for (int i = 0; i < numAggregationFunctions; i++) {
+          trimmedResultMaps[i].put(groupKey, intermediateResults[i]);
         }
       }
     }
 
-    return trimmedResults;
+    return Arrays.asList(trimmedResultMaps);
   }
 
   /**
@@ -151,102 +118,232 @@ public class AggregationGroupByTrimmingService {
   @SuppressWarnings("unchecked")
   @Nonnull
   public List<GroupByResult>[] trimFinalResults(@Nonnull Map<String, Comparable>[] finalResultMaps) {
-    List<GroupByResult>[] trimmedResults = new List[_numAggregationFunctions];
+    int numAggregationFunctions = _aggregationFunctions.length;
+    List<GroupByResult>[] trimmedResults = new List[numAggregationFunctions];
 
-    for (int i = 0; i < _numAggregationFunctions; i++) {
+    for (int i = 0; i < numAggregationFunctions; i++) {
       LinkedList<GroupByResult> groupByResults = new LinkedList<>();
       trimmedResults[i] = groupByResults;
+
       Map<String, Comparable> finalResultMap = finalResultMaps[i];
       if (finalResultMap.isEmpty()) {
         continue;
       }
 
-      // Construct the priority queues.
-      PriorityQueue<GroupKeyResultPair> priorityQueue =
-          new PriorityQueue<>(_groupByTopN + 1, getGroupKeyResultPairComparator(_minOrders[i]));
+      // Final result is always comparable
+      Sorter sorter = getSorter(_groupByTopN, _aggregationFunctions[i], true);
 
-      // Fill results into the priority queues.
+      // Add results into sorter
       for (Map.Entry<String, Comparable> entry : finalResultMap.entrySet()) {
-        String groupKey = entry.getKey();
-        Comparable finalResult = entry.getValue();
-
-        GroupKeyResultPair newValue = new GroupKeyResultPair(groupKey, finalResult);
-        addToPriorityQueue(priorityQueue, newValue, _groupByTopN);
+        sorter.add(entry.getKey(), entry.getValue());
       }
 
-      // Fill trimmed results into the list.
-      while (!priorityQueue.isEmpty()) {
-        GroupKeyResultPair groupKeyResultPair = priorityQueue.poll();
-        GroupByResult groupByResult = new GroupByResult();
-        // Do not remove trailing empty strings.
-        String[] groupKeys = groupKeyResultPair._groupKey.split(GROUP_KEY_DELIMITER, -1);
-        groupByResult.setGroup(Arrays.asList(groupKeys));
-        groupByResult.setValue(AggregationFunctionUtils.formatValue(groupKeyResultPair._result));
-        groupByResults.addFirst(groupByResult);
-      }
+      // Dump trimmed results into list
+      sorter.dumpToGroupByResults(groupByResults);
     }
 
     return trimmedResults;
   }
 
-  /**
-   * Helper method to add a value into priority queue:
-   * <ul>
-   *   <li> If the queue size is less than maxQueueSize, then the element is simply added into the priority queue. </li>
-   *   <li> If the queue size is >= maxQueueSize, then the given value is compared against the top of priority queue.
-   *        If value is 'better' than the top, then it is inserted into the queue, and the top element is removed,
-   *        to keep the size of the queue bounded. </li>
-   *   <li> If max queue size is <= 0, then simply returns. Caller is responsible for ensuring a valid value of
-   *        max queue size is provided. </li>
-   * </ul>
-   * @param priorityQueue Priority queue into which the element needs to be inserted.
-   * @param value Value to be inserted.
-   * @param maxQueueSize Max allowed queue size.
-   */
-  private void addToPriorityQueue(PriorityQueue<GroupKeyResultPair> priorityQueue, GroupKeyResultPair value, int maxQueueSize) {
-    // If maxQueueSize is zero, then simply return. Caller should check the validity of maxQueueSize.
-    if (maxQueueSize <= 0) {
-      return;
-    }
+  private interface Sorter {
+    void add(String groupKey, Object result);
 
-    if (priorityQueue.size() >= maxQueueSize) {
-      GroupKeyResultPair topValue = priorityQueue.peek();
-      if (priorityQueue.comparator().compare(topValue, value) < 0) {
-        priorityQueue.poll();
-        priorityQueue.add(value);
+    void dumpToMap(Map<String, Object> dest);
+
+    void dumpToGroupByResults(LinkedList<GroupByResult> dest);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Sorter getSorter(int trimSize, AggregationFunction aggregationFunction, boolean isComparable) {
+    // This will cover both MIN and MINMV
+    boolean minOrder = aggregationFunction instanceof MinAggregationFunction;
+
+    if (isComparable) {
+      if (minOrder) {
+        return new ComparableSorter(trimSize, Collections.reverseOrder());
+      } else {
+        return new ComparableSorter(trimSize, new ComparableComparator());
       }
     } else {
-      priorityQueue.add(value);
+      // Reverse the comparator so that keys are ordered in descending order
+      if (minOrder) {
+        return new NonComparableSorter(trimSize, new ComparableComparator(), aggregationFunction);
+      } else {
+        return new NonComparableSorter(trimSize, Collections.reverseOrder(), aggregationFunction);
+      }
     }
   }
 
-  private static class GroupKeyResultPair {
-    public String _groupKey;
-    public Comparable _result;
+  /**
+   * Helper class based on {@link PriorityQueue} to sort on comparable values:
+   * <ul>
+   *   <li>
+   *     If the heap size is less than the trim size, simply add the groupKey-result pair into the heap
+   *   </li>
+   *   <li>
+   *     If the heap size is equal to the trim size, compare the given groupKey-result pair against the min
+   *     groupKey-result pair from the heap. If the given groupKey-result pair is bigger, remove the min groupKey-result
+   *     pair and insert the new one to keep the heap size bounded
+   *   </li>
+   * </ul>
+   */
+  private static class ComparableSorter implements Sorter {
+    private final int _trimSize;
+    private final Comparator<? super Comparable> _comparator;
+    private final PriorityQueue<GroupKeyResultPair> _heap;
 
-    public GroupKeyResultPair(@Nonnull String groupKey, @Nonnull Comparable result) {
-      _groupKey = groupKey;
-      _result = result;
+    public ComparableSorter(int trimSize, Comparator<? super Comparable> comparator) {
+      _trimSize = trimSize;
+      _comparator = comparator;
+      _heap = new PriorityQueue<>(_trimSize, comparator);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void add(String groupKey, Object result) {
+      GroupKeyResultPair newGroupKeyResultPair = new GroupKeyResultPair(groupKey, (Comparable) result);
+      if (_heap.size() == _trimSize) {
+        GroupKeyResultPair minGroupKeyResultPair = _heap.peek();
+        if (_comparator.compare(newGroupKeyResultPair, minGroupKeyResultPair) > 0) {
+          _heap.poll();
+          _heap.add(newGroupKeyResultPair);
+        }
+      } else {
+        _heap.add(newGroupKeyResultPair);
+      }
+    }
+
+    @Override
+    public void dumpToMap(Map<String, Object> dest) {
+      GroupKeyResultPair groupKeyResultPair;
+      while ((groupKeyResultPair = _heap.poll()) != null) {
+        dest.put(groupKeyResultPair._groupKey, groupKeyResultPair._result);
+      }
+    }
+
+    @Override
+    public void dumpToGroupByResults(LinkedList<GroupByResult> dest) {
+      GroupKeyResultPair groupKeyResultPair;
+      while ((groupKeyResultPair = _heap.poll()) != null) {
+        // Set limit to -1 to prevent removing trailing empty strings
+        String[] groupKeys = groupKeyResultPair._groupKey.split(GROUP_KEY_DELIMITER, -1);
+
+        GroupByResult groupByResult = new GroupByResult();
+        groupByResult.setGroup(Arrays.asList(groupKeys));
+        groupByResult.setValue(AggregationFunctionUtils.formatValue(groupKeyResultPair._result));
+
+        // Add to head to reverse the order
+        dest.addFirst(groupByResult);
+      }
+    }
+
+    private static class GroupKeyResultPair implements Comparable<GroupKeyResultPair> {
+      private String _groupKey;
+      private Comparable<? super Comparable> _result;
+
+      public GroupKeyResultPair(@Nonnull String groupKey, @Nonnull Comparable<? super Comparable> result) {
+        _groupKey = groupKey;
+        _result = result;
+      }
+
+      @Override
+      public int compareTo(@Nonnull GroupKeyResultPair o) {
+        return _result.compareTo(o._result);
+      }
     }
   }
 
-  private static Comparator<GroupKeyResultPair> getGroupKeyResultPairComparator(boolean minOrder) {
-    if (minOrder) {
-      return new Comparator<GroupKeyResultPair>() {
-        @SuppressWarnings("unchecked")
-        @Override
-        public int compare(GroupKeyResultPair o1, GroupKeyResultPair o2) {
-          return o2._result.compareTo(o1._result);
+  /**
+   * Helper class based on {@link TreeMap} to sort on non-comparable values:
+   * <ul>
+   *   <li>
+   *     The key of the map is the final result derived from the intermediate result passed in
+   *   </li>
+   *   <li>
+   *     The value of the map is a list of groupKey-result pairs that inserted with the same key
+   *   </li>
+   *   <li>
+   *     If the number of values added is less than the trim size, simply add the groupKey-result pair into the map
+   *   </li>
+   *   <li>
+   *     If the number of values added is greater or equal to the trim size, compare the given key against the max key
+   *     from the map. If the given key is smaller, insert the new groupKey-result pair into the map
+   *   </li>
+   *   <li>
+   *     When possible, remove the max key from the map when enough values inserted
+   *   </li>
+   * </ul>
+   */
+  private static class NonComparableSorter implements Sorter {
+    private final int _trimSize;
+    private final Comparator<? super Comparable> _comparator;
+    private final AggregationFunction _aggregationFunction;
+    private final TreeMap<Comparable, List<ImmutablePair<String, Object>>> _treeMap;
+    private int _numValuesAdded = 0;
+
+    public NonComparableSorter(int trimSize, Comparator<? super Comparable> comparator,
+        AggregationFunction aggregationFunction) {
+      _trimSize = trimSize;
+      _comparator = comparator;
+      _aggregationFunction = aggregationFunction;
+      _treeMap = new TreeMap<>(comparator);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void add(String groupKey, Object result) {
+      Comparable newKey = _aggregationFunction.extractFinalResult(result);
+      ImmutablePair<String, Object> groupKeyResultPair = new ImmutablePair<>(groupKey, result);
+
+      List<ImmutablePair<String, Object>> groupKeyResultPairs = _treeMap.get(newKey);
+      if (_numValuesAdded >= _trimSize) {
+        // Check whether the pair should be added
+        Map.Entry<Comparable, List<ImmutablePair<String, Object>>> maxEntry = _treeMap.lastEntry();
+        Comparable maxKey = maxEntry.getKey();
+        if (_comparator.compare(newKey, maxKey) < 0) {
+          // Add the pair into list of pairs
+          if (groupKeyResultPairs == null) {
+            groupKeyResultPairs = new ArrayList<>();
+            _treeMap.put(newKey, groupKeyResultPairs);
+          }
+          groupKeyResultPairs.add(groupKeyResultPair);
+          _numValuesAdded++;
+
+          // Check if the max key can be removed
+          if (maxEntry.getValue().size() + _trimSize == _numValuesAdded) {
+            _treeMap.remove(maxKey);
+          }
         }
-      };
-    } else {
-      return new Comparator<GroupKeyResultPair>() {
-        @SuppressWarnings("unchecked")
-        @Override
-        public int compare(GroupKeyResultPair o1, GroupKeyResultPair o2) {
-          return o1._result.compareTo(o2._result);
+      } else {
+        // Pair should be added
+        if (groupKeyResultPairs == null) {
+          groupKeyResultPairs = new ArrayList<>();
+          _treeMap.put(newKey, groupKeyResultPairs);
         }
-      };
+        groupKeyResultPairs.add(groupKeyResultPair);
+        _numValuesAdded++;
+      }
+    }
+
+    @Override
+    public void dumpToMap(Map<String, Object> dest) {
+      // Track the number of results added because there could be more than trim size values inside the map
+      int numResultsAdded = 0;
+      for (List<ImmutablePair<String, Object>> groupKeyResultPairs : _treeMap.values()) {
+        for (ImmutablePair<String, Object> groupResultPair : groupKeyResultPairs) {
+          if (numResultsAdded != _trimSize) {
+            dest.put(groupResultPair.left, groupResultPair.right);
+            numResultsAdded++;
+          } else {
+            return;
+          }
+        }
+      }
+    }
+
+    @Override
+    public void dumpToGroupByResults(LinkedList<GroupByResult> dest) {
+      throw new UnsupportedOperationException();
     }
   }
 }


### PR DESCRIPTION
Currently the following aggregation functions have non-comparable intermediate result:
DistinctCount, DistinctCountHLL, FastHLL, Percentile, PercentileEst
Current trimming service does not work on them, which might cause huge amount of data serialized and transfered to brokers

Implemented a TreeMap based class to support trimming on non-comparable intermediate result
Added a helper Sorter interface and two implementations: ComparableSorter and NonComparableSorter
Also enhanced the test to cover the new code