### PR TITLE
[TE] Self-serve Create Alert Bug Fix

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -885,8 +885,6 @@ export default Ember.Controller.extend({
 
       // A reference to whichever 'alert config' object will be sent. Let's default to the new one
       let finalConfigObj = newConfigObj;
-      let functionArray = [];
-      let that = this;
 
       // URL encode filters to avoid API issues
       newFunctionObj.filters = encodeURIComponent(newFunctionObj.filters);


### PR DESCRIPTION
Bug fix for Create Alert call sequence : for new alert groups, the name property was not properly set. Also: 
- Now deleting the new alert function created if any error occurs with config group creation (tested by sending unexpected data format to create endpoint)
- Now catching errors more efficiently
- URL encoding part of the function creation payload