### PR TITLE
[TE] events in table matches events in view

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
@@ -40,8 +40,12 @@ export default Ember.Component.extend({
       if (!(start && end)) { return events; }
 
       return events.filter((event) => {
-        return (!event.displayEnd || (event.displayEnd > start))
-          && (!event.displayStart || (event.displayStart < end));
+        const {
+          displayStart,
+          displayEnd } = event;
+
+        const date = displayStart || displayEnd;
+        return (date >= start) && (date <= end);
       });
     }
   ),


### PR DESCRIPTION
Fixing a bug where the events shown in the `events-table` didn't match the events shown on the graph.