### PR TITLE
[TE] Self-Serve Create Alert - adding user selected granularity

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -10,7 +10,12 @@ import Ember from 'ember';
  */
 export function checkStatus(response, mode = 'get', recoverBlank = false) {
   if (response.status >= 200 && response.status < 300) {
-    return (mode === 'get') ? response.json() : JSON.parse(JSON.stringify(response));
+    // Prevent parsing of null response
+    if (response.status === 204) {
+      return '';
+    } else {
+      return (mode === 'get') ? response.json() : JSON.parse(JSON.stringify(response));
+    }
   } else {
     const error = new Error(response.statusText);
     error.response = response;

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -209,7 +209,7 @@ export default Ember.Controller.extend({
       granularity,
       filters
     } = config;
-    const url = `/timeseries/compare/${id}/${currentStart}/${currentEnd}/${baselineStart}/${baselineEnd}?dimension=${dimension}&granularity=${granularity}&filters=${filters}`;
+    const url = `/timeseries/compare/${id}/${currentStart}/${currentEnd}/${baselineStart}/${baselineEnd}?dimension=${dimension}&granularity=${granularity}&filters=${encodeURIComponent(filters)}`;
     return fetch(url).then(checkStatus);
   },
 
@@ -311,6 +311,16 @@ export default Ember.Controller.extend({
           selectedMetric: metricData
         });
       }
+    })
+    .catch((error) => {
+      // The request failed. No graph to render.
+      this.clearAll();
+      this.setProperties({
+        isSelectMetricError: true,
+        isMetricDataInvalid: true,
+        isMetricDataLoading: false,
+        selectMetricErrMsg: error
+      });
     });
   },
 
@@ -507,6 +517,7 @@ export default Ember.Controller.extend({
     'selectedMetricOption',
     'selectedDimension',
     'selectedFilters',
+    'selectedGranularity',
     function() {
       let gkey = '';
       const granularity = this.get('graphConfig.granularity').toLowerCase();
@@ -517,6 +528,7 @@ export default Ember.Controller.extend({
           functionName: this.get('alertFunctionName') || this.get('alertFunctionName').trim(),
           metric: this.get('selectedMetricOption.name'),
           dataset: this.get('selectedMetricOption.dataset'),
+          dataGranularity: this.get('selectedGranularity'),
           metricFunction: 'SUM',
           isActive: true
         },
@@ -677,6 +689,7 @@ export default Ember.Controller.extend({
     onSelectMetric(selectedObj) {
       this.setProperties({
         isMetricDataLoading: true,
+        isSelectMetricError: false,
         selectedMetricOption: selectedObj,
         selectedFilters: JSON.stringify({}),
         selectedPattern: null,

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -28,7 +28,7 @@
 
     {{#if isSelectMetricError}}
       {{#bs-alert type="danger"}}
-        <strong>Error: {{selectMetricErrMsg}}</strong> Unable to fetch data for this metric.
+        <strong>{{selectMetricErrMsg}}</strong> Unable to fetch data for this metric.
       {{/bs-alert}}
     {{/if}}
 


### PR DESCRIPTION
Changes:
- More graceful handling of problematic metrics (same treatment as metrics with no graph-able data)
- Adding user-selected granularity to alert creation request (as per Kexin's request)
- URL encoding the filters param as per Neha's request