### PR TITLE
[TE] multi-keyword metric search/autocomplete

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -218,7 +218,8 @@ public class DataResource {
   public List<MetricConfigDTO> getMetricsWhereNameLike(@QueryParam("name") String name) {
     List<MetricConfigDTO> metricConfigs = Collections.emptyList();
     if (StringUtils.isNotBlank(name)) {
-      metricConfigs = metricConfigDAO.findWhereNameOrAliasLikeAndActive("%" + name + "%");
+      Set<String> aliasParts = new HashSet<>(Arrays.asList(name.split("\\s+")));
+      metricConfigs = metricConfigDAO.findWhereAliasLikeAndActive(aliasParts);
     }
     return metricConfigs;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MetricConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MetricConfigManager.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.datalayer.bao;
 import java.util.List;
 
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import java.util.Set;
 
 
 public interface MetricConfigManager extends AbstractManager<MetricConfigDTO> {
@@ -12,6 +13,7 @@ public interface MetricConfigManager extends AbstractManager<MetricConfigDTO> {
   MetricConfigDTO findByAliasAndDataset(String alias, String dataset);
   List<MetricConfigDTO> findActiveByDataset(String dataset);
   List<MetricConfigDTO> findWhereNameOrAliasLikeAndActive(String name);
+  List<MetricConfigDTO> findWhereAliasLikeAndActive(Set<String> aliasParts);
   List<MetricConfigDTO> findByMetricName(String metricName);
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/SqlQueryBuilder.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/SqlQueryBuilder.java
@@ -413,7 +413,10 @@ public class SqlQueryBuilder {
     LinkedHashMap<String, ColumnInfo> columnInfo =
         entityMappingHolder.columnInfoPerTable.get(tableName);
     for (String entityFieldName : paramNames) {
-      String dbFieldName = dbNameToEntityNameMapping.inverse().get(entityFieldName);
+      String[] entityFieldNameParts = entityFieldName.split("__", 2);
+      if (entityFieldNameParts.length > 1)
+        LOG.info("Using field name decomposition: '{}' to '{}'", entityFieldName, entityFieldNameParts[0]);
+      String dbFieldName = dbNameToEntityNameMapping.inverse().get(entityFieldNameParts[0]);
 
       Object val = parameterMap.get(entityFieldName);
       if (Enum.class.isAssignableFrom(val.getClass())) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMetricConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestMetricConfigManager.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.testng.Assert;
@@ -78,7 +80,7 @@ public class TestMetricConfigManager extends AbstractManagerTestBase {
     Assert.assertEquals(metricConfigs.size(), 0);
   }
 
-  @Test(dependsOnMethods = { "testFindLike" })
+  @Test(dependsOnMethods = { "testFindLike", "testFindByAlias" })
   public void testUpdate() {
     MetricConfigDTO metricConfig = metricConfigDAO.findById(metricConfigId1);
     Assert.assertNotNull(metricConfig);
@@ -95,5 +97,16 @@ public class TestMetricConfigManager extends AbstractManagerTestBase {
     metricConfigDAO.deleteById(metricConfigId2);
     MetricConfigDTO metricConfig = metricConfigDAO.findById(metricConfigId2);
     Assert.assertNull(metricConfig);
+  }
+
+  @Test(dependsOnMethods = {"testFind"})
+  public void testFindByAlias() {
+    List<MetricConfigDTO> metricConfigs = metricConfigDAO.findWhereAliasLikeAndActive(
+        new HashSet<>(Arrays.asList("1", "3")));
+    Assert.assertEquals(metricConfigs.size(), 1);
+
+    metricConfigs = metricConfigDAO.findWhereAliasLikeAndActive(
+        new HashSet<>(Arrays.asList("etric", "m")));
+    Assert.assertEquals(metricConfigs.size(), 2);
   }
 }


### PR DESCRIPTION
Currently, autocomplete only supports a single, continuous keyword (including spaces). This change enables ThirdEye to search for metric names via multiple keywords - e.g. "metric my" now matches "my_dataset::metric_a"