### PR TITLE
Compatibility patch for older http clients, a bug fix in segment state toggle, logging

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/ControllerAdminApiApplication.java
@@ -51,6 +51,8 @@ public class ControllerAdminApiApplication extends ResourceConfig {
       CONSOLE_WEB_PATH += "/";
     }
     packages(RESOURCE_PACKAGE);
+    // TODO See ControllerResponseFilter
+//    register(new LoggingFeature());
     register(JacksonFeature.class);
     register(MultiPartFeature.class);
     registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerResponseFilter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerResponseFilter.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.api.resources;
+
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+
+// TODO Remove this class and find out how to use LoggingFeature as described in
+// https://jersey.github.io/documentation/latest/logging_chapter.html#d0e15719
+@Provider
+public class ControllerResponseFilter implements ContainerResponseFilter {
+  public static final Logger LOGGER = LoggerFactory.getLogger(ControllerResponseFilter.class);
+  @Override
+  public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+      throws IOException {
+    final String method = requestContext.getMethod();
+    final String uri = requestContext.getUriInfo().getRequestUri().toString();
+    final int respStatus = responseContext.getStatus();
+    final String reasonPhrase = responseContext.getStatusInfo().getReasonPhrase();
+    LOGGER.info("Handled request {} {} status code {} {}", method, uri, respStatus, reasonPhrase);
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerResponseFilter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerResponseFilter.java
@@ -19,9 +19,11 @@ package com.linkedin.pinot.controller.api.resources;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.ext.Provider;
 
 
@@ -29,6 +31,10 @@ import javax.ws.rs.ext.Provider;
 // https://jersey.github.io/documentation/latest/logging_chapter.html#d0e15719
 @Provider
 public class ControllerResponseFilter implements ContainerResponseFilter {
+
+  @Inject
+  private javax.inject.Provider<org.glassfish.grizzly.http.server.Request> request;
+
   public static final Logger LOGGER = LoggerFactory.getLogger(ControllerResponseFilter.class);
   @Override
   public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
@@ -37,6 +43,8 @@ public class ControllerResponseFilter implements ContainerResponseFilter {
     final String uri = requestContext.getUriInfo().getRequestUri().toString();
     final int respStatus = responseContext.getStatus();
     final String reasonPhrase = responseContext.getStatusInfo().getReasonPhrase();
-    LOGGER.info("Handled request {} {} status code {} {}", method, uri, respStatus, reasonPhrase);
+    final String srcIpAddr = request.get().getRemoteAddr();
+    final String contentType = requestContext.getHeaderString(HttpHeaders.CONTENT_TYPE);
+    LOGGER.info("Handled request from {} {} {}, content-type {} status code {} {}", srcIpAddr, method, uri, contentType, respStatus, reasonPhrase);
   }
 }


### PR DESCRIPTION
Some http clients do not send a leading slash in the URI in their http request.
As in "GET tables HTTP/1.1" instead of "GET /tables HTTP/1.1". Jersey framework does not
parse this correctly, so added logic to rewrite the request in such cases. Previous version
of third-eye library will now work correctly with the jersey server.

The log message, when such an API comes in, shows up as follows:
2017/08/09 10:42:14.643 WARN [HeaderAdder] [grizzly-http-server-15] [pinot-controller] [] Rewriting new Request URI http://localhost:8862/tables (incomingBaseUri = http://localhost:8862/, incomingReqUri = http://localhost:8862tables)

Also, fixed a but in the API that changes state of a segment. restlet API (and therefore
the derived jersey implementation) threw exception when changing state of all segments of
a table. Fixed in the jersey part.

Fixed a bug in the jersey implementation where toggling the state of one segment would end up
toggling the state of all segments

Also added a log of each request and response code.