### PR TITLE
[TE] Fix delay when users trigger replay

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -341,6 +341,9 @@ public class DetectionJobResource {
       detectionJobIdMap.put(functionId, detectionJobId);
     }
 
+    /**
+     * Check the job status in thread and recover the function
+     */
     new Thread(new Runnable() {
       @Override
       public void run() {
@@ -350,7 +353,7 @@ public class DetectionJobResource {
         // Revert window setup
         revertFunctionWindow(functionIdList, originalWindowSize, originalWindowUnit, originalCron);
       }
-    }).run();
+    }).start();
 
     return Response.ok(detectionJobIdMap).build();
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
@@ -31,6 +31,7 @@ public class TestBackwardAnoamlyFunctionUtils {
     List<Interval> intervalList = new ArrayList<>();
     intervalList.add(new Interval(TimeUnit.DAYS.toMillis(140), TimeUnit.DAYS.toMillis(168)));
     intervalList.add(new Interval(0, TimeUnit.DAYS.toMillis(140)));
+
     List<TimeSeries> timeSeriesList =
         BackwardAnomalyFunctionUtils.splitSetsOfTimeSeries(metricTimeSeries, TEST_METRIC, intervalList);
     assert(timeSeriesList.size() == 2);


### PR DESCRIPTION
When users trigger replay, the system should respond the job id right away. However, the system wait for long until the detection jobs finish. This is cause by the bug when using Thread. Originally, it uses run(), which triggers the run() in the Runnable instead of triggering in a thread. The correct one should be start(), which generates a thread and triggers the run() in the Runnable. 