### PR TITLE
Added support for dimension columns to be no-dictinary columns while consuming realtime segments

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -56,7 +56,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   private static final String DEFAULT_SORTED_COLUMN = "Carrier";
   private static final List<String> DEFAULT_INVERTED_INDEX_COLUMNS = Arrays.asList("FlightNum", "Origin", "Quarter");
   private static final List<String> DEFAULT_RAW_INDEX_COLUMNS =
-      Arrays.asList("ActualElapsedTime", "ArrDelay", "DepDelay");
+      Arrays.asList("ActualElapsedTime", "ArrDelay", "DepDelay", "CRSDepTime");
 
   protected final File _tempDir = new File(FileUtils.getTempDirectory(), getClass().getSimpleName());
   protected final File _segmentDir = new File(_tempDir, "segmentDir");


### PR DESCRIPTION
All the plumbing has already been done for no-dictionary columns, we were just supporting the
feature only for metric columns.

Added logic to support no-dictionary for dimension columns as well, and added a dimension column
in the test case for coverage