### PR TITLE
Cleanup: Remove unnecessary ByteBuffer.duplicate in VarByteChunkSingleValueReader.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
@@ -75,11 +75,10 @@ public class VarByteChunkSingleValueReader extends BaseChunkSingleValueReader {
     }
 
     int length = nextRowOffset - rowOffset;
-    ByteBuffer byteBuffer = chunkBuffer.duplicate();
-    byteBuffer.position(rowOffset);
+    chunkBuffer.position(rowOffset);
 
     byte[] bytes = _reusableBytes.get();
-    byteBuffer.get(bytes, 0, length);
+    chunkBuffer.get(bytes, 0, length);
     return new String(bytes, 0, length, UTF_8);
   }
 


### PR DESCRIPTION
Since chunk buffers are allocated by individual threads in the reader
context, they don't need to be protected for concurrency. We can
directly modify the 'position' of chunk buffer and read from it.