### PR TITLE
Plumbing for realtime consuming segment statistics

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -173,6 +173,7 @@ public class MutableOffHeapByteArrayStore implements Closeable {
   private volatile Buffer _currentBuffer;
   private final RealtimeIndexOffHeapMemoryManager _memoryManager;
   private final String _columnName;
+  private long _totalStringSize = 0;
 
   public MutableOffHeapByteArrayStore(RealtimeIndexOffHeapMemoryManager memoryManager, String columnName) {
     _memoryManager = memoryManager;
@@ -220,6 +221,7 @@ public class MutableOffHeapByteArrayStore implements Closeable {
 
   // Adds a byte array and returns the index. No verification is made as to whether the byte array already exists or not
   public int add(byte[] value) {
+    _totalStringSize += value.length;
     Buffer buffer = _currentBuffer;
     int index = buffer.add(value);
     if (index < 0) {
@@ -248,5 +250,20 @@ public class MutableOffHeapByteArrayStore implements Closeable {
       buffer.close();
     }
     _buffers.clear();
+  }
+
+  public long getTotalOffHeapMemUsed() {
+    long ret = 0;
+    for (Buffer buffer : _buffers) {
+      ret += buffer.getSize();
+    }
+    return ret;
+  }
+
+  public long getAvgValueSize() {
+    if (_numElements > 0) {
+      return _totalStringSize / _numElements;
+    }
+    return 0;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+
+/*
+ * Keeps history of statistics for segments consumed from kafka for a single table.
+ */
+public class RealtimeSegmentStatsHistory implements Serializable {
+  private static final long serialVersionUID = 1L;  // Change this if a new field is added to this class
+  private static int MAX_NUM_ENTRIES = 16;  // Max number of past segments for which stats are kept
+  // Fields to be serialzied.
+  private int _cursor = 0;
+  private SegmentStats[] _entries;
+  private boolean _isFull;
+
+  // We return these values when we don't have any prior statistics.
+  private final int DEFAULT_EST_AVG_STRING_LEN = 32;
+  private final int DEFAULT_EST_CARDINALITY = 5000;
+
+  // Not to be serialized
+  transient int _arraySize;
+
+  @VisibleForTesting
+  public static int getMaxNumEntries() {
+    return MAX_NUM_ENTRIES;
+  }
+
+  @VisibleForTesting
+  public static void setMaxNumEntries(int maxNumEntries) {
+    MAX_NUM_ENTRIES = maxNumEntries;
+  }
+
+  public static class SegmentStats implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private int _numRowsConsumed;   // Number of rows consumed
+    private int _numMinutes;        // Number of minutes taken to consume them
+    private long _memUsed;          // Memory used for consumption (bytes)
+    private Map<String, ColumnStats> _colNameToStats = new HashMap();
+
+    public int getNumRowsConsumed() {
+      return _numRowsConsumed;
+    }
+
+    public void setNumRowsConsumed(int numRowsConsumed) {
+      _numRowsConsumed = numRowsConsumed;
+    }
+
+    public int getNumMinutes() {
+      return _numMinutes;
+    }
+
+    public void setNumMinutes(int numMinutes) {
+      _numMinutes = numMinutes;
+    }
+
+    public long getMemUsed() {
+      return _memUsed;
+    }
+
+    public void setMemUsed(long memUsed) {
+      _memUsed = memUsed;
+    }
+
+    public void setColumnStats(@Nonnull String columnName, @Nonnull ColumnStats columnStats) {
+      _colNameToStats.put(columnName, columnStats);
+    }
+
+    public @Nullable ColumnStats getColumnStats(String columnName) {
+      return _colNameToStats.get(columnName);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("nRows=" + getNumRowsConsumed())
+          .append(",nMinutes=" + getNumMinutes())
+          .append(",memUsed=" + getMemUsed());
+
+      for (Map.Entry<String, ColumnStats> entry : _colNameToStats.entrySet()) {
+        sb.append(",")
+            .append(entry.getKey())
+            .append(":")
+            .append(entry.getValue().toString());
+      }
+      return sb.toString();
+    }
+  }
+
+  public static class ColumnStats implements Serializable {
+    private static final long serialVersionUID = 1L;  // Change this if a new field is added to this class
+    private int _avgStringSize;     // Only for string columns, if they have a dictionary
+    private int _cardinality;       // Only if a column has a dictionary
+
+    public int getCardinality() {
+      return _cardinality;
+    }
+
+    public void setCardinality(int cardinality) {
+      _cardinality = cardinality;
+    }
+
+    public int getAvgStringSize() {
+      return _avgStringSize;
+    }
+
+    public void setAvgStringSize(int avgStringSize) {
+      _avgStringSize = avgStringSize;
+    }
+
+    @Override
+    public String toString() {
+      return "cardinality=" + getCardinality() + ",avgSize=" + getAvgStringSize();
+    }
+  }
+
+  public RealtimeSegmentStatsHistory() {
+    _entries = new SegmentStats[MAX_NUM_ENTRIES];
+    normalize();
+  }
+
+  // We may choose to change the number of segments we keep in history. So, if MAX_NUM_ENTRIES is changed,
+  // then after deserialization we need to copy old array entries to an array of new size. Depending on
+  // whether the new size is higher or lower, the values of _cursor and _isFull will change.
+  private void normalize() {
+    if (_entries.length == MAX_NUM_ENTRIES) {
+      _arraySize = MAX_NUM_ENTRIES;
+      _cursor = 0;
+      _isFull = false;
+      return;
+    }
+    int toCopy;
+    if (isFull()) {
+      toCopy = Math.min(_entries.length, MAX_NUM_ENTRIES);
+      if (_entries.length > MAX_NUM_ENTRIES) {
+        _cursor = 0;
+      } else {
+        _isFull = false;
+        _cursor = _entries.length;
+      }
+    } else {
+      toCopy = Math.min(_cursor, MAX_NUM_ENTRIES);
+      if (_cursor > MAX_NUM_ENTRIES) {
+        _cursor = 0;
+        _isFull = true;
+      }
+    }
+
+    SegmentStats[] tmp = _entries;
+    _entries = new SegmentStats[MAX_NUM_ENTRIES];
+
+    for (int i = 0; i < toCopy; i++) {
+      _entries[i] = tmp[i];
+    }
+    _arraySize = _entries.length;
+  }
+
+  public int getCursor() {
+    return _cursor;
+  }
+
+  public int getArraySize() {
+    return _arraySize;
+  }
+
+  public boolean isFull() {
+    return _isFull;
+  }
+
+  public synchronized void addSegmentStats(SegmentStats segmentStats) {
+    _entries[_cursor] = segmentStats;
+    if (_cursor >= _arraySize -1) {
+      _isFull = true;
+    }
+    _cursor = (_cursor + 1) % _arraySize;
+  }
+
+  /**
+   * Estimate the cardinality of a column based on past segments of a table
+   * For now, we return the average value.
+   *
+   * @param columnName
+   * @return estimated
+   */
+  public synchronized int getEstimatedCardinality(@Nonnull String columnName) {
+    int numEntriesToScan = getNumntriesToScan();
+    if (numEntriesToScan == 0) {
+      return DEFAULT_EST_CARDINALITY;
+    }
+    int estCardinality = 0;
+    for (int i = 0; i < numEntriesToScan; i++) {
+      SegmentStats segmentStats = getSegmentStatsAt(i);
+      estCardinality += segmentStats.getColumnStats(columnName).getCardinality();
+    }
+    return estCardinality/numEntriesToScan;
+  }
+
+  /**
+   * Estimate the average size of a string column based on the past segments of the table.
+   * For now, we return the average value.
+   *
+   * @param columnName
+   * @return estimated average string size
+   */
+  public synchronized int getEstimatedAvgColSize(@Nonnull String columnName) {
+    int numEntriesToScan = getNumntriesToScan();
+    if (numEntriesToScan == 0) {
+      return DEFAULT_EST_AVG_STRING_LEN;
+    }
+    int estCardinality = 0;
+    for (int i = 0; i < numEntriesToScan; i++) {
+      SegmentStats segmentStats = getSegmentStatsAt(i);
+      estCardinality += segmentStats.getColumnStats(columnName).getAvgStringSize();
+    }
+    return estCardinality/numEntriesToScan;
+  }
+
+  public SegmentStats getSegmentStatsAt(int index) {
+    return _entries[index];
+  }
+
+  @Override
+  public String toString() {
+    return "cursor=" + getCursor() + ",numEntries=" + getArraySize() + ",isFull=" + isFull();
+  }
+
+  public synchronized void serializeInto(File outFile) throws IOException {
+    OutputStream os = new FileOutputStream(outFile);
+    ObjectOutputStream obos = new ObjectOutputStream(os);
+    obos.writeObject(this);
+    obos.flush();
+    os.close();
+  }
+
+  public static RealtimeSegmentStatsHistory deserialzeFrom(File inFile) throws IOException, ClassNotFoundException {
+    InputStream is = new FileInputStream(inFile);
+    ObjectInputStream obis = new ObjectInputStream(is);
+    RealtimeSegmentStatsHistory history = (RealtimeSegmentStatsHistory)(obis.readObject());
+    is.close();
+    history.normalize();
+    return history;
+  }
+
+  private int getNumntriesToScan() {
+    if (isFull()) {
+      return getArraySize();
+    }
+    return getCursor();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -132,7 +132,9 @@ import javax.annotation.Nonnull;
  */
 public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
   // List of primes from http://compoasso.free.fr/primelistweb/page/prime/liste_online_en.php
-  private static int[] PRIME_NUMBERS = new int[] {20011, 40009, 60013, 80021, 100003, 125113, 150011, 175003, 200003,
+  private static int[] PRIME_NUMBERS = new int[] {
+      13, 127, 547, 1009, 2003, 3001, 4003, 5003, 7001, 9001, 10007, 12007, 14009, 16001, 18013,
+      20011, 40009, 60013, 80021, 100003, 125113, 150011, 175003, 200003,
       225023, 250007, 275003, 300007,350003, 400009, 450001, 500009, 600011,700001, 800011, 900001, 1000003};
 
   // expansionMultiple setting as we add new buffers. A setting of 1 sets the new buffer to be

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -162,4 +162,9 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
       _max = value;
     }
   }
+
+  @Override
+  public long getTotalOffHeapMemUsed() {
+    return super.getTotalOffHeapMemUsed() + V1Constants.Numbers.DOUBLE_SIZE * length();
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -162,4 +162,9 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
       _max = value;
     }
   }
+
+  @Override
+  public long getTotalOffHeapMemUsed() {
+    return super.getTotalOffHeapMemUsed() + V1Constants.Numbers.FLOAT_SIZE * length();
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -162,4 +162,9 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
       _max = value;
     }
   }
+
+  @Override
+  public long getTotalOffHeapMemUsed() {
+    return super.getTotalOffHeapMemUsed() + V1Constants.Numbers.INTEGER_SIZE * length();
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -162,4 +162,9 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
       _max = value;
     }
   }
+
+  @Override
+  public long getTotalOffHeapMemUsed() {
+    return super.getTotalOffHeapMemUsed() + V1Constants.Numbers.LONG_SIZE * length();
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -151,4 +151,13 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
       }
     }
   }
+
+  @Override
+  public long getTotalOffHeapMemUsed() {
+    return super.getTotalOffHeapMemUsed() + _byteStore.getTotalOffHeapMemUsed();
+  }
+
+  public int getAvgStringSize() {
+    return (int)_byteStore.getAvgValueSize();
+  }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.realtime.impl;
+
+import java.io.File;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class RealtimeSegmentStatsHistoryTest {
+  private static final String STATS_FILE_NAME = RealtimeSegmentStatsHistoryTest.class.getSimpleName() + ".ser";
+
+  private void addSegmentStats(int segmentId, RealtimeSegmentStatsHistory history) {
+    RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
+    segmentStats.setMemUsed(segmentId);
+    segmentStats.setNumMinutes(segmentId);
+    segmentStats.setNumRowsConsumed(segmentId);
+    for (int i = 0; i < 2; i++) {
+      RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
+      columnStats.setAvgStringSize(segmentId*100 + i);
+      columnStats.setCardinality(segmentId*100 + i);
+      segmentStats.setColumnStats(String.valueOf(i), columnStats);
+    }
+    history.addSegmentStats(segmentStats);
+  }
+
+  @Test
+  public void serdeTest() throws Exception {
+    final String tmpDir = System.getProperty("java.io.tmpdir");
+    File serializedFile = new File(tmpDir, STATS_FILE_NAME);
+    serializedFile.deleteOnExit();
+
+    int maxNumEntries = RealtimeSegmentStatsHistory.getMaxNumEntries();
+    int segmentId = 0;
+    {
+      RealtimeSegmentStatsHistory history = new RealtimeSegmentStatsHistory();
+
+      history.getEstimatedAvgColSize("1");
+      history.getEstimatedCardinality("1");
+
+      // Add one less segment than max.
+      for (; segmentId < maxNumEntries - 1; segmentId++) {
+        addSegmentStats(segmentId, history);
+        Assert.assertEquals(history.getCursor(), segmentId + 1);
+        Assert.assertEquals(history.isFull(), false);
+      }
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      history.serializeInto(serializedFile);
+      history.getEstimatedAvgColSize("0");
+      history.getEstimatedCardinality("0");
+    }
+
+    {
+      // Set the max to be 2 higher.
+      int prevMax = maxNumEntries;
+      maxNumEntries += 2;
+      RealtimeSegmentStatsHistory.setMaxNumEntries(maxNumEntries);
+      // Deserialize
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      Assert.assertEquals(history.isFull(), false);
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      Assert.assertEquals(history.getCursor(), prevMax-1);
+      // Add one segment
+      addSegmentStats(segmentId++, history);
+      Assert.assertEquals(history.isFull(), false);
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      Assert.assertEquals(history.getCursor(), prevMax);
+      Assert.assertEquals(history.getCursor(), segmentId);
+      history.getEstimatedAvgColSize("0");
+      history.getEstimatedCardinality("0");
+    // Now add 2 more segments for it to go over.
+      addSegmentStats(segmentId++, history);
+      Assert.assertEquals(history.isFull(), false);
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      Assert.assertEquals(history.getCursor(), prevMax+1);
+      Assert.assertEquals(history.getCursor(), segmentId);
+      history.getEstimatedAvgColSize("0");
+      history.getEstimatedCardinality("0");
+
+      addSegmentStats(segmentId++, history);
+      Assert.assertEquals(history.isFull(), true);
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      Assert.assertEquals(history.getCursor(), 0);
+      history.getEstimatedAvgColSize("0");
+      history.getEstimatedCardinality("0");
+
+      // And then one more to bump the cursor.
+
+      addSegmentStats(segmentId++, history);
+      Assert.assertEquals(history.isFull(), true);
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      Assert.assertEquals(history.getCursor(), 1);
+      // Rewrite the history file
+      history.serializeInto(serializedFile);
+      history.getEstimatedAvgColSize("0");
+      history.getEstimatedCardinality("0");
+    }
+
+    // Now there should be "maxNumEntries" entries in the file, and the cursor is at 1.
+    {
+      maxNumEntries -=2;
+      RealtimeSegmentStatsHistory.setMaxNumEntries(maxNumEntries);
+
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      Assert.assertEquals(history.isFull(), true);
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      Assert.assertEquals(history.getCursor(), 0);
+
+      history.serializeInto(serializedFile);
+      history.getEstimatedAvgColSize("0");
+      history.getEstimatedCardinality("0");
+    }
+
+    // Now increase it, the cursor should go to the prev max.
+    {
+      int prevMax = maxNumEntries;
+      maxNumEntries += 2;
+      RealtimeSegmentStatsHistory.setMaxNumEntries(maxNumEntries);
+
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      Assert.assertEquals(history.isFull(), false);
+      Assert.assertEquals(history.getArraySize(), maxNumEntries);
+      Assert.assertEquals(history.getCursor(), prevMax);
+      history.getEstimatedAvgColSize("0");
+      history.getEstimatedCardinality("0");
+    }
+  }
+}


### PR DESCRIPTION
In order to allocate memory efficiently for dictionary for a column, we can attempt to use
the statistics gathered from previously completed segments.

Added a class to keep track of statistics for N previously completed segments for a table on local disk
of each server. For now, we have code to store average size (in case of a string column) and cardinality
(for all columns). These can be used when initializing a dictionary for the next segment.

Some methods are synchronized since we expect that segments may be completing at the same time for all
partitions hosted in a machine.

Added a test class.

Added methods in off-heap dictionary classes to get the statistics we want