### PR TITLE
add frequency as query parameter for endpoint that update anomaly detection function, make time series retrieve endpoints do not roll-up

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContextBuilder.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/AnomalyDetectionInputContextBuilder.java
@@ -480,12 +480,8 @@ public class AnomalyDetectionInputContextBuilder {
 
     TimeGranularity timeGranularity = new TimeGranularity(anomalyFunctionSpec.getBucketSize(),
         anomalyFunctionSpec.getBucketUnit());
-
-    DatasetConfigDTO dataset = DAORegistry.getInstance().getDatasetConfigDAO().findByDataset(anomalyFunctionSpec.getCollection());
-    boolean doRollUp = true;
-    if (!dataset.isAdditive()) {
-      doRollUp = false;
-    }
+    // if doRollUp, small categories (<1% to total) will be aggregated to "OTHER"
+    boolean doRollUp = false;  // do anomaly detection on every categories for the dimension to explore, no rollup
 
     TimeSeriesResponse timeSeriesResponse =
         getTimeSeriesResponseImpl(anomalyFunctionSpec, startEndTimeRanges,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -415,7 +415,8 @@ public class AnomalyResource {
       @QueryParam("exploreDimension") String exploreDimensions,
       @QueryParam("filters") String filters,
       @QueryParam("properties") String properties,
-      @QueryParam("isActive") Boolean isActive) throws Exception {
+      @QueryParam("isActive") Boolean isActive,
+      @QueryParam("frequency") String frequency) throws Exception {
 
     AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(id);
     if (anomalyFunctionSpec == null) {
@@ -485,6 +486,11 @@ public class AnomalyResource {
         throw new IllegalArgumentException("Invalid cron expression for cron : " + cron);
       }
       anomalyFunctionSpec.setCron(cron);
+    }
+
+    if (StringUtils.isNotEmpty(frequency)) {
+      // frequency string should be in the format of "5_MINUTES", "1_HOURS"
+      anomalyFunctionSpec.setFrequency(TimeGranularity.fromString(frequency));
     }
 
     anomalyFunctionDAO.update(anomalyFunctionSpec);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DashboardResource.java
@@ -450,7 +450,7 @@ public class DashboardResource {
       request.setEndDateInclusive(true);
     }
 
-    TimeSeriesHandler handler = new TimeSeriesHandler(queryCache);
+    TimeSeriesHandler handler = new TimeSeriesHandler(queryCache, false);
     String jsonResponse = "";
     try {
       TimeSeriesResponse response = handler.handle(request);


### PR DESCRIPTION
add frequency as query parameter for endpoint that update anomaly detection function, make time series retrieve endpoints do not roll-up

Anomaly detection can work on 'dimension exploration' - for a given dimension, run parallel anomaly detection for all categories in this dimension.
for example if we set anomaly detection for 'page views' and explore on 'country' dimension, and there are ten distinct countries, we are going to do
10 parallel detection, treat each country as a independent metric.

If the rollup flag is 'true', we will group those low contribution coutries (<1%) to a single category 'OTHER'. For example assume most of pageviews come from
US, CA and CN, all 7 rest have only contribute 2% together, 0.7% each. Then all the rest will be group to 'OTHER' and effectively we are doing anomaly detection for
'US', 'CA', 'CN' and 'OTHER'

Here we set the default behavior to rollup = flase, to do all possible categories in a perticular dimension.

For API calls we make it a query variable.