### PR TITLE
Preparation for OffHeap config: Re-organizing parameters to RealtimeSegmentImpl

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/RealtimeSegmentDataManager.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.data.manager.offline;
+
+import com.linkedin.pinot.common.data.Schema;
+import java.io.File;
+import java.util.List;
+
+
+public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
+  public abstract String getTableName();
+
+  public abstract Schema getSchema();
+
+  public abstract List<String> getNoDictionaryColumns();
+
+  public abstract List<String> getInvertedIndexColumns();
+
+  public abstract File getTableDataDir();
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -15,17 +15,6 @@
  */
 package com.linkedin.pinot.core.data.manager.realtime;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimerTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.data.Schema;
@@ -39,7 +28,7 @@ import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.extractors.FieldExtractorFactory;
 import com.linkedin.pinot.core.data.extractors.PlainFieldExtractor;
-import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
+import com.linkedin.pinot.core.data.manager.offline.RealtimeSegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
@@ -50,9 +39,20 @@ import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
-public class HLRealtimeSegmentDataManager extends SegmentDataManager {
+public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(HLRealtimeSegmentDataManager.class);
   private final static long ONE_MINUTE_IN_MILLSEC = 1000 * 60;
 
@@ -167,9 +167,8 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
     // lets create a new realtime segment
     segmentLogger.info("Started kafka stream provider");
     realtimeSegment =
-        new RealtimeSegmentImpl(schema, kafkaStreamProviderConfig.getSizeThresholdToFlushSegment(), tableName,
-            segmentMetadata.getSegmentName(), kafkaStreamProviderConfig.getStreamName(), serverMetrics,
-            this.invertedIndexColumns, indexLoadingConfig.getRealtimeAvgMultiValueCount(), noDictionaryColumns);
+        new RealtimeSegmentImpl(serverMetrics, this, indexLoadingConfig, kafkaStreamProviderConfig.getSizeThresholdToFlushSegment(),
+            kafkaStreamProviderConfig.getStreamName());
     realtimeSegment.setSegmentMetadata(segmentMetadata, this.schema);
     notifier = realtimeTableDataManager;
 
@@ -431,5 +430,30 @@ public class HLRealtimeSegmentDataManager extends SegmentDataManager {
     keepIndexing = false;
     segmentStatusTask.cancel();
     realtimeSegment.destroy();
+  }
+
+  @Override
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public List<String> getNoDictionaryColumns() {
+    return noDictionaryColumns;
+  }
+
+  @Override
+  public List<String> getInvertedIndexColumns() {
+    return invertedIndexColumns;
+  }
+
+  @Override
+  public File getTableDataDir() {
+    return resourceDir;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -28,7 +28,6 @@ import com.linkedin.pinot.common.utils.CommonConstants.Segment.SegmentType;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.extractors.FieldExtractorFactory;
 import com.linkedin.pinot.core.data.extractors.PlainFieldExtractor;
-import com.linkedin.pinot.core.data.manager.offline.RealtimeSegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -38,7 +38,6 @@ import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.extractors.FieldExtractorFactory;
 import com.linkedin.pinot.core.data.extractors.PlainFieldExtractor;
-import com.linkedin.pinot.core.data.manager.offline.RealtimeSegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.linkedin.pinot.core.data.manager.offline;
+package com.linkedin.pinot.core.data.manager.realtime;
 
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
 import java.io.File;
 import java.util.List;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime.impl;
 
-import com.linkedin.pinot.core.data.manager.offline.RealtimeSegmentDataManager;
+import com.linkedin.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -43,78 +43,82 @@ public class IndexLoadingConfig {
   private Set<String> _onHeapDictionaryColumns = new HashSet<>();
   private SegmentVersion _segmentVersion;
   private StarTreeFormatVersion _starTreeVersion = StarTreeFormatVersion.DEFAULT_VERSION;
-  private boolean _enableDefaultColumns = true;
+  private boolean _enableDefaultColumns;
   private ColumnMinMaxValueGeneratorMode _columnMinMaxValueGeneratorMode = ColumnMinMaxValueGeneratorMode.DEFAULT_MODE;
   private int _realtimeAvgMultiValueCount = DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT;
-  private boolean _enableSplitCommit = false;
+  private boolean _enableSplitCommit;
 
-  public IndexLoadingConfig(@Nullable InstanceDataManagerConfig instanceDataManagerConfig,
+  public IndexLoadingConfig(@Nonnull InstanceDataManagerConfig instanceDataManagerConfig,
       @Nullable TableConfig tableConfig) {
-    // Extract config from instance config
-    if (instanceDataManagerConfig != null) {
-      ReadMode instanceReadMode = instanceDataManagerConfig.getReadMode();
-      if (instanceReadMode != null) {
-        _readMode = instanceReadMode;
-      }
+    extractFromInstanceConfig(instanceDataManagerConfig);
 
-      String instanceSegmentVersion = instanceDataManagerConfig.getSegmentFormatVersion();
-      if (instanceSegmentVersion != null) {
-        _segmentVersion = SegmentVersion.valueOf(instanceSegmentVersion.toLowerCase());
-      }
+    if (tableConfig != null) {
+      extractFromTableConfig(tableConfig);
+    }
+  }
 
-      _enableDefaultColumns = instanceDataManagerConfig.isEnableDefaultColumns();
-
-      _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
-
-      String avgMultiValueCount = instanceDataManagerConfig.getAvgMultiValueCount();
-      if (avgMultiValueCount != null) {
-        _realtimeAvgMultiValueCount = Integer.valueOf(avgMultiValueCount);
-      }
+  private void extractFromTableConfig(@Nullable TableConfig tableConfig) {
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    String tableReadMode = indexingConfig.getLoadMode();
+    if (tableReadMode != null) {
+      _readMode = ReadMode.getEnum(tableReadMode);
     }
 
-    // Extract config from table indexing config
-    if (tableConfig != null) {
-      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-      String tableReadMode = indexingConfig.getLoadMode();
-      if (tableReadMode != null) {
-        _readMode = ReadMode.getEnum(tableReadMode);
-      }
+    List<String> sortedColumns = indexingConfig.getSortedColumn();
+    if (sortedColumns != null) {
+      _sortedColumns = sortedColumns;
+    }
 
-      List<String> sortedColumns = indexingConfig.getSortedColumn();
-      if (sortedColumns != null) {
-        _sortedColumns = sortedColumns;
-      }
+    List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    if (invertedIndexColumns != null) {
+      _invertedIndexColumns.addAll(invertedIndexColumns);
+    }
 
-      List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
-      if (invertedIndexColumns != null) {
-        _invertedIndexColumns.addAll(invertedIndexColumns);
-      }
+    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    if (noDictionaryColumns != null) {
+      _noDictionaryColumns.addAll(noDictionaryColumns);
+    }
 
-      List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
-      if (noDictionaryColumns != null) {
-        _noDictionaryColumns.addAll(noDictionaryColumns);
-      }
+    List<String> onHeapDictionaryColumns = indexingConfig.getOnHeapDictionaryColumns();
+    if (onHeapDictionaryColumns != null) {
+      _onHeapDictionaryColumns.addAll(onHeapDictionaryColumns);
+    }
 
-      List<String> onHeapDictionaryColumns = indexingConfig.getOnHeapDictionaryColumns();
-      if (onHeapDictionaryColumns != null) {
-        _onHeapDictionaryColumns.addAll(onHeapDictionaryColumns);
-      }
+    String tableSegmentVersion = indexingConfig.getSegmentFormatVersion();
+    if (tableSegmentVersion != null) {
+      _segmentVersion = SegmentVersion.valueOf(tableSegmentVersion.toLowerCase());
+    }
 
-      String tableSegmentVersion = indexingConfig.getSegmentFormatVersion();
-      if (tableSegmentVersion != null) {
-        _segmentVersion = SegmentVersion.valueOf(tableSegmentVersion.toLowerCase());
-      }
+    String starTreeFormat = indexingConfig.getStarTreeFormat();
+    if (starTreeFormat != null) {
+      _starTreeVersion = StarTreeFormatVersion.valueOf(starTreeFormat.toUpperCase());
+    }
 
-      String starTreeFormat = indexingConfig.getStarTreeFormat();
-      if (starTreeFormat != null) {
-        _starTreeVersion = StarTreeFormatVersion.valueOf(starTreeFormat.toUpperCase());
-      }
+    String columnMinMaxValueGeneratorMode = indexingConfig.getColumnMinMaxValueGeneratorMode();
+    if (columnMinMaxValueGeneratorMode != null) {
+      _columnMinMaxValueGeneratorMode =
+          ColumnMinMaxValueGeneratorMode.valueOf(columnMinMaxValueGeneratorMode.toUpperCase());
+    }
+  }
 
-      String columnMinMaxValueGeneratorMode = indexingConfig.getColumnMinMaxValueGeneratorMode();
-      if (columnMinMaxValueGeneratorMode != null) {
-        _columnMinMaxValueGeneratorMode =
-            ColumnMinMaxValueGeneratorMode.valueOf(columnMinMaxValueGeneratorMode.toUpperCase());
-      }
+  private void extractFromInstanceConfig(@Nonnull InstanceDataManagerConfig instanceDataManagerConfig) {
+    ReadMode instanceReadMode = instanceDataManagerConfig.getReadMode();
+    if (instanceReadMode != null) {
+      _readMode = instanceReadMode;
+    }
+
+    String instanceSegmentVersion = instanceDataManagerConfig.getSegmentFormatVersion();
+    if (instanceSegmentVersion != null) {
+      _segmentVersion = SegmentVersion.valueOf(instanceSegmentVersion.toLowerCase());
+    }
+
+    _enableDefaultColumns = instanceDataManagerConfig.isEnableDefaultColumns();
+
+    _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
+
+    String avgMultiValueCount = instanceDataManagerConfig.getAvgMultiValueCount();
+    if (avgMultiValueCount != null) {
+      _realtimeAvgMultiValueCount = Integer.valueOf(avgMultiValueCount);
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -43,7 +43,8 @@ public class IndexLoadingConfig {
   private Set<String> _onHeapDictionaryColumns = new HashSet<>();
   private SegmentVersion _segmentVersion;
   private StarTreeFormatVersion _starTreeVersion = StarTreeFormatVersion.DEFAULT_VERSION;
-  private boolean _enableDefaultColumns;
+  // This value will remain true only when the empty constructor is invoked.
+  private boolean _enableDefaultColumns = true;
   private ColumnMinMaxValueGeneratorMode _columnMinMaxValueGeneratorMode = ColumnMinMaxValueGeneratorMode.DEFAULT_MODE;
   private int _realtimeAvgMultiValueCount = DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT;
   private boolean _enableSplitCommit;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -24,6 +24,7 @@ import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
@@ -627,12 +628,22 @@ public class LLRealtimeSegmentDataManagerTest {
     public boolean _throwExceptionFromConsume = false;
     public boolean _postConsumeStoppedCalled = false;
 
+    private static InstanceDataManagerConfig makeInstanceDataManagerConfig() {
+      InstanceDataManagerConfig dataManagerConfig = mock(InstanceDataManagerConfig.class);
+      when(dataManagerConfig.getReadMode()).thenReturn(null);
+      when(dataManagerConfig.getAvgMultiValueCount()).thenReturn(null);
+      when(dataManagerConfig.getSegmentFormatVersion()).thenReturn(null);
+      when(dataManagerConfig.isEnableDefaultColumns()).thenReturn(false);
+      when(dataManagerConfig.isEnableSplitCommit()).thenReturn(false);
+      return dataManagerConfig;
+    }
+
     public FakeLLRealtimeSegmentDataManager(RealtimeSegmentZKMetadata segmentZKMetadata, TableConfig tableConfig,
         InstanceZKMetadata instanceZKMetadata, RealtimeTableDataManager realtimeTableDataManager,
         String resourceDataDir, Schema schema, ServerMetrics serverMetrics)
         throws Exception {
       super(segmentZKMetadata, tableConfig, instanceZKMetadata, realtimeTableDataManager, resourceDataDir,
-          new IndexLoadingConfig(null, tableConfig), schema, serverMetrics);
+          new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, serverMetrics);
       _state = LLRealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);
       _shouldStop = LLRealtimeSegmentDataManager.class.getDeclaredField("_shouldStop");

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.realtime;
 
-import com.linkedin.pinot.core.data.manager.offline.RealtimeSegmentDataManager;
+import com.linkedin.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import java.io.File;
 import java.util.ArrayList;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
@@ -15,6 +15,14 @@
  */
 package com.linkedin.pinot.core.realtime.impl.kafka;
 
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.manager.offline.RealtimeSegmentDataManager;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
+import com.yammer.metrics.core.MetricsRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,12 +30,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.common.data.Schema;
-import com.linkedin.pinot.common.metrics.ServerMetrics;
-import com.linkedin.pinot.core.data.GenericRow;
-import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
-import com.yammer.metrics.core.MetricsRegistry;
+
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -36,8 +40,17 @@ import com.yammer.metrics.core.MetricsRegistry;
 public class RealtimeSegmentImplTest {
   public static RealtimeSegmentImpl createRealtimeSegmentImpl(Schema schema, int sizeThresholdToFlushSegment, String tableName, String segmentName, String streamName,
       ServerMetrics serverMetrics) throws IOException {
-    return new RealtimeSegmentImpl(schema, sizeThresholdToFlushSegment, tableName, segmentName, streamName, serverMetrics, new ArrayList<String>(),
-        2, new ArrayList<String>());
+    RealtimeSegmentDataManager segmentDataManager = mock(RealtimeSegmentDataManager.class);
+    when(segmentDataManager.getSchema()).thenReturn(schema);
+    when(segmentDataManager.getTableName()).thenReturn(tableName);
+    when(segmentDataManager.getNoDictionaryColumns()).thenReturn(new ArrayList<String>());
+    when(segmentDataManager.getSegmentName()).thenReturn(segmentName);
+    when(segmentDataManager.getInvertedIndexColumns()).thenReturn(new ArrayList<String>());
+
+    IndexLoadingConfig indexLoadingConfig = mock(IndexLoadingConfig.class);
+    when(indexLoadingConfig.getRealtimeAvgMultiValueCount()).thenReturn(2);
+    return new RealtimeSegmentImpl(serverMetrics, segmentDataManager, indexLoadingConfig, sizeThresholdToFlushSegment,
+        streamName);
   }
   @Test
   public void testDropInvalidRows() throws Exception {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
@@ -19,7 +19,7 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.data.GenericRow;
-import com.linkedin.pinot.core.data.manager.offline.RealtimeSegmentDataManager;
+import com.linkedin.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.yammer.metrics.core.MetricsRegistry;

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -67,12 +67,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private boolean _isStarted = false;
   private SegmentMetadataLoader _segmentMetadataLoader;
 
-  public synchronized void init(HelixInstanceDataManagerConfig instanceDataManagerConfig)
-      throws ConfigurationException, InstantiationException, IllegalAccessException, ClassNotFoundException {
-    _instanceDataManagerConfig = instanceDataManagerConfig;
-    _segmentMetadataLoader = getSegmentMetadataLoader(_instanceDataManagerConfig.getSegmentMetadataLoaderClass());
-  }
-
   @Override
   public synchronized void init(Configuration dataManagerConfig) {
     try {

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/integration/realtime/RealtimeTableDataManagerTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/integration/realtime/RealtimeTableDataManagerTest.java
@@ -32,6 +32,7 @@ import com.linkedin.pinot.core.common.BlockMultiValIterator;
 import com.linkedin.pinot.core.common.BlockSingleValIterator;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.common.Constants;
+import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import com.linkedin.pinot.core.data.manager.config.TableDataManagerConfig;
 import com.linkedin.pinot.core.data.manager.realtime.HLRealtimeSegmentDataManager;
 import com.linkedin.pinot.core.data.manager.realtime.TimerService;
@@ -55,6 +56,8 @@ import org.apache.helix.ZNRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
+
+import static org.mockito.Mockito.*;
 
 
 public class RealtimeTableDataManagerTest {
@@ -115,10 +118,21 @@ public class RealtimeTableDataManagerTest {
     return tableDataManagerConfig;
   }
 
+  private InstanceDataManagerConfig makeInstanceDataManagerConfig() {
+    InstanceDataManagerConfig dataManagerConfig = mock(InstanceDataManagerConfig.class);
+    when(dataManagerConfig.getReadMode()).thenReturn(null);
+    when(dataManagerConfig.getAvgMultiValueCount()).thenReturn(null);
+    when(dataManagerConfig.getSegmentFormatVersion()).thenReturn(null);
+    when(dataManagerConfig.isEnableDefaultColumns()).thenReturn(false);
+    when(dataManagerConfig.isEnableSplitCommit()).thenReturn(false);
+    return dataManagerConfig;
+  }
+
   public void testSetup() throws Exception {
+    InstanceDataManagerConfig dataManagerConfig = makeInstanceDataManagerConfig();
     final HLRealtimeSegmentDataManager manager =
         new HLRealtimeSegmentDataManager(realtimeSegmentZKMetadata, tableConfig, instanceZKMetadata, null,
-            tableDataManagerConfig.getDataDir(), new IndexLoadingConfig(null, tableConfig), getTestSchema(),
+            tableDataManagerConfig.getDataDir(), new IndexLoadingConfig(dataManagerConfig, tableConfig), getTestSchema(),
             new ServerMetrics(new MetricsRegistry()));
 
     final long start = System.currentTimeMillis();


### PR DESCRIPTION
No new functionality added.

The class RealtimeSegmentImpl needs to have access to the configuration so it can determine
whether to allocate memory on-heap or off-heap. Until we turn the default to be off-heap
allocation, this will be useful to configur on a per server or per use case basis.

Re-factored the constructor for RealtimeSegmentImpl so that it has fewer arguments,
preferring to pass in entire config objects as opposed to individual elements from the
config.

Turned out that InstanceDataManagerConfig can be null only for tests, so changed the tests to include a
mock, so that this paramter can always be non-null when constructing IndexLoadingConfig.

The only behavior change in this check-in is that if IndexLoadingConfig is constructed with InstanceDataManagerConfig as null
(never happens in non-test use cases), then we will now turn _enableDefaultColumns to false because the mock for these
tests sets it to the default value.

In live situations, InstanceDataManagerConfig is never null, so the member variable _enableDefaultColumns is always taken
from whatever is configured in InstanceDataManagerConfig