### PR TITLE
Optimize query parsing

### DIFF
--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest.java
@@ -86,8 +86,8 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizerTest {
   public void testEqualityAndInMerge() {
     // a = 1 OR a IN (2,3,4) -> a IN (1,2,3,4)
     checkForIdenticalFilterQueryTrees(
-        "select * from a where a = 1 OR a IN (2,3,4)",
-        "select * from a where a IN (1,2,3,4)"
+        "select * from a where a = 1 OR a IN (2,3,4,31)",
+        "select * from a where a IN (1,2,31,3,4)"
     );
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/FilterQueryTree.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/FilterQueryTree.java
@@ -15,7 +15,11 @@
  */
 package com.linkedin.pinot.common.utils.request;
 
+import com.google.common.collect.Lists;
 import com.linkedin.pinot.common.request.FilterOperator;
+import com.linkedin.pinot.common.utils.StringUtil;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -61,8 +65,21 @@ public class FilterQueryTree {
     if (operator == FilterOperator.OR || operator == FilterOperator.AND) {
       stringBuffer.append(operator);
     } else {
-      stringBuffer.append(column).append(" ").append(operator).append(" ").append(value);
+      List<String> sortedValues = new ArrayList<>(value);
+
+      // Old style double-tab separated list
+      if (sortedValues.size() == 1) {
+        String firstItem = sortedValues.get(0);
+        List<String> firstItemValues = Lists.newArrayList(firstItem.split("\t\t"));
+        Collections.sort(firstItemValues);
+        sortedValues.set(0, StringUtil.join("\t\t", firstItemValues.toArray(new String[firstItemValues.size()])));
+      }
+
+      Collections.sort(sortedValues);
+
+      stringBuffer.append(column).append(" ").append(operator).append(" ").append(sortedValues);
     }
+
     if (children != null) {
       for (FilterQueryTree child : children) {
         stringBuffer.append('\n');

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2AstListener.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2AstListener.java
@@ -306,10 +306,20 @@ public class Pql2AstListener extends PQL2BaseListener {
 
     // String literals can be either 'foo' or "bar". We support quoting by doubling the beginning character, so that
     // users can write 'Martha''s Vineyard' or """foo"""
+    String literalWithoutQuotes = text.substring(1, textLength - 1);
     if (text.charAt(0) == '\'') {
-      pushNode(new StringLiteralAstNode(text.substring(1, textLength - 1).replaceAll("''", "'")));
+      if (literalWithoutQuotes.contains("''")) {
+        System.out.println(literalWithoutQuotes);
+        literalWithoutQuotes = literalWithoutQuotes.replaceAll("''", "'");
+      }
+
+      pushNode(new StringLiteralAstNode(literalWithoutQuotes));
     } else if (text.charAt(0) == '"') {
-      pushNode(new StringLiteralAstNode(text.substring(1, textLength - 1).replaceAll("\"\"", "\"")));
+      if (literalWithoutQuotes.contains("\"\"")) {
+        literalWithoutQuotes = literalWithoutQuotes.replaceAll("\"\"", "\"");
+      }
+
+      pushNode(new StringLiteralAstNode(literalWithoutQuotes));
     } else {
       throw new Pql2CompilationException("String literal does not start with either '  or \"");
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/InPredicateAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/InPredicateAstNode.java
@@ -20,7 +20,8 @@ import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.pql.parsers.Pql2CompilationException;
 import java.util.Collections;
-import java.util.TreeSet;
+import java.util.HashSet;
+import java.util.Set;
 
 
 /**
@@ -63,7 +64,7 @@ public class InPredicateAstNode extends PredicateAstNode {
       throw new Pql2CompilationException("IN predicate has no identifier");
     }
 
-    TreeSet<String> values = new TreeSet<>();
+    Set<String> values = new HashSet<>();
 
     for (AstNode astNode : getChildren()) {
       if (astNode instanceof LiteralAstNode) {


### PR DESCRIPTION
Optimize some of the hot paths in query parsing:
- Avoid doing replaceAll if it would do nothing (eg. for string
  literals, we use replaceAll to replace double quoted quotes, for
  things such as 'O''Reilly')
- Use a HashSet instead of a TreeSet for items in an IN clause, avoids
  having to rebalance the tree many times if the items in the IN clause
  are in sorted order