### PR TITLE
[TE] rca_bug_fix_and_improvements

### DIFF
--- a/thirdeye/thirdeye-frontend/app/actions/dimensions.js
+++ b/thirdeye/thirdeye-frontend/app/actions/dimensions.js
@@ -9,6 +9,7 @@ import moment from 'moment';
 export const ActionTypes = {
   LOAD: type('[Dimensions] Load'),
   LOADING: type('[Dimensions] Loading'),
+  LOADED: type('[Dimensions] Loaded'),
   LOAD_TIMESERIES: type('[Dimensions] Load TimeSeries'),
   LOAD_HEATMAP: type('[Dimensions] Load HeatMap'),
   SET: type('[Dimension] Set Dimension'),
@@ -20,6 +21,15 @@ export const ActionTypes = {
 function resetData() {
   return {
     type: ActionTypes.RESET
+  };
+}
+
+/**
+ * Set Dimension Status to loaded
+ */
+function loaded() {
+  return {
+    type: ActionTypes.LOADED
   };
 }
 
@@ -157,7 +167,7 @@ function fetchHeatMapData(start, end) {
  * @param {Number} end The end time in unix ms
  */
 function updateDates(start, end) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     // const { primaryMetric } = getState();
     //check if dates are stame
 
@@ -176,6 +186,7 @@ function reset() {
 export const Actions = {
   loading,
   load,
+  loaded,
   requestFail,
   fetchDimensions,
   updateDimension,

--- a/thirdeye/thirdeye-frontend/app/actions/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/actions/metrics.js
@@ -10,6 +10,7 @@ import { COMPARE_MODE_MAPPING, colors } from './constants';
  */
 export const ActionTypes = {
   LOADING: type('[Metric] Loading'),
+  LOADED: type('[Metric] Loaded'),
   REQUEST_FAIL: type('[Metric] Request Fail'),
   LOAD_IDS: type('[Metric] Load related Metric Ids'),
   LOAD_DATA: type('[Metric] Load related Metric Data'),
@@ -38,6 +39,15 @@ const filterMetric = (metric) => {
 function loading() {
   return {
     type: ActionTypes.LOADING
+  };
+}
+
+/**
+ * Set Metrics Status to loaded
+ */
+function loaded() {
+  return {
+    type: ActionTypes.LOADED
   };
 }
 
@@ -271,6 +281,7 @@ function reset() {
 
 export const Actions = {
   loading,
+  loaded,
   requestFail,
   fetchRelatedMetricData,
   fetchRelatedMetricIds,

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
@@ -17,8 +17,8 @@ export default Ember.Component.extend({
     this._super(...arguments);
 
     this.setProperties({
-      _subchartStart: this.get('subchartStart'),
-      _subchartEnd: this.get('subchartEnd')
+      _subchartStart: Number(this.get('subchartStart')),
+      _subchartEnd: Number(this.get('subchartEnd'))
     });
   },
 
@@ -186,6 +186,7 @@ export default Ember.Component.extend({
 
     const subchartStart = this.get('_subchartStart');
     const subchartEnd = this.get('_subchartEnd');
+
 
     this.setProperties({
       subchartStart,

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/template.hbs
@@ -28,7 +28,9 @@
             </li>
           {{else}}
             No Related Events. 
-            {{#link-to 'rca.details.events' class="thirdeye-link"}} <a {{action "scrollToSection" bubbles=true}}> (Add an event) </a>{{/link-to}}
+            {{#if (eq componentId "main-graph")}}
+              {{#link-to 'rca.details.events' class="thirdeye-link"}} <a {{action "scrollToSection" bubbles=true}}> (Add an event) </a>{{/link-to}}
+            {{/if}}
           {{/each}}
           
         </ul>
@@ -52,7 +54,9 @@
             </li>
           {{else}}
             No Dimensions.
-            {{#link-to 'rca.details.dimensions' class="thirdeye-link"}} <a {{action "scrollToSection" bubbles=true}}> (Add a dimension) </a>{{/link-to}}
+            {{#if (eq componentId "main-graph")}}
+              {{#link-to 'rca.details.dimensions' class="thirdeye-link"}} <a {{action "scrollToSection" bubbles=true}}> (Add a dimension) </a>{{/link-to}}
+            {{/if}}
           {{/each}}
         </ul>
       {{/if}}
@@ -76,7 +80,9 @@
           </li>
         {{else}}
           No Related Metrics.
-          {{#link-to 'rca.details.metrics' class="thirdeye-link"}} <a {{action "scrollToSection" bubbles=true}}> (Add a metric) </a>{{/link-to}}
+          {{#if (eq componentId "main-graph")}}
+            {{#link-to 'rca.details.metrics' class="thirdeye-link"}} <a {{action "scrollToSection" bubbles=true}}> (Add a metric) </a>{{/link-to}}
+          {{/if}}
         {{/each}}
         </ul>
       {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/contribution-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/contribution-table/component.js
@@ -43,14 +43,15 @@ export default Ember.Component.extend({
   dimensions: [],
   start: null,
   end: null,
-  loading: false,
+
+  stopLoading: () => {},
 
   // This is needed so that a loading spinner appears for long rendering
-  didUpdateAttrs(...args) {
-    Ember.run.later(() => {
-      this._super(args);
+  didRender(...args) {
+    this._super(args);
 
-      this.set('loading', false);
+    Ember.run.later(() => {
+      this.attrs.stopLoading();
     });
   },
 

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/controller.js
@@ -18,6 +18,8 @@ export default Ember.Controller.extend({
     'compareMode',
     'startDate',
     'endDate',
+    'displayStart',
+    'displayEnd',
     'analysisStart',
     'analysisEnd'
   ],
@@ -256,7 +258,9 @@ export default Ember.Controller.extend({
           subchartStart: subchartStart.valueOf(),
           subchartEnd: subchartEnd.valueOf(),
           analysisEnd: analysisEnd.valueOf(),
-          analysisStart: analysisStart.valueOf()
+          analysisStart: analysisStart.valueOf(),
+          displayStart: subchartStart.valueOf(),
+          displayEnd: subchartEnd.valueOf()
         });
 
         return value;
@@ -281,6 +285,11 @@ export default Ember.Controller.extend({
     setNewDate({ start, end }) {
       const rangeStart = moment(start).valueOf();
       const rangeEnd = moment(end).valueOf();
+
+      this.setProperties({
+        displayStart: rangeStart.valueOf(),
+        displayEnd: rangeEnd.valueOf()
+      });
 
       const {
           startDate: currentStart,

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/controller.js
@@ -10,9 +10,14 @@ export default Ember.Controller.extend({
   showDetails: false,
   selectedTab: 'details',
 
-  dimensionsStart: null,
-  dimensionsEnd: null,
+  dimensionsStart: 0,
+  dimensionsEnd: 0,
+  displayStart: 0,
+  displayEnd: 0,
   dateFormat: 'MMM D, YYYY hh:mm a',
+
+  subchartStart: 0,
+  subchartEnd: 0,
 
   actions: {
     // Sets new dimension start and end
@@ -21,8 +26,21 @@ export default Ember.Controller.extend({
       const dimensionsEnd = moment(end).valueOf();
 
       this.setProperties({
-        dimensionsStart,
         dimensionsEnd,
+        dimensionsStart
+      });
+    },
+
+    /**
+     * Setting loading state to false on component's didRender
+     */
+    onRendering() {
+      this.set('tableIsLoading', false);
+    },
+
+    onToggle(showDetails) {
+      this.setProperties({
+        showDetails,
         tableIsLoading: true
       });
     },
@@ -31,7 +49,8 @@ export default Ember.Controller.extend({
      * Handles subchart date change (debounced)
      */
     setDateParams([start, end]) {
-      Ember.run.debounce(this, this.get('actions.setNewDate'), { start, end }, 1000);
+      this.set('tableIsLoading', true);
+      Ember.run.debounce(this, this.get('actions.setNewDate'), { start, end }, 500);
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/template.hbs
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    {{#if (or dimensions.loading )}}
+    {{#if dimensions.loading}}
       <div class="spinner-wrapper">
         {{ember-spinner}}
       </div>
@@ -37,6 +37,8 @@
           selectedDimensions=summary.selectedDimensions
           analysisStart=dimensions.regionStart
           analysisEnd=dimensions.regionEnd
+          minDate=displayStart
+          maxDate=displayEnd
           onSubchartChange=(action "setDateParams")
           onSelection=(action actions.onSelection)
           showDimensions=true}}
@@ -69,7 +71,7 @@
                       theme='ios'
                       showLabels=true
                       name="splitViewToggle"
-                      onToggle=(action (mut showDetails))
+                      onToggle=(action "onToggle")
                       as |toggle|}}
                         {{#toggle.label splitView=(not showDetails)}}
                           <span class="te-label">{{if showDetails 'Hide Details' 'Show Details'}}</span>
@@ -86,7 +88,7 @@
                   end=dimensionsEnd
                   dimensions=dimensions.subdimensions
                   showDetails=showDetails
-                  loading=(mut tableIsLoading)
+                  stopLoading=(action "onRendering")
                 }} 
               {{/if}}
             </div>

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/events/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/events/controller.js
@@ -2,8 +2,11 @@ import Ember from 'ember';
 import moment from 'moment';
 
 export default Ember.Controller.extend({
-  eventStart: null,
-  eventEnd: null,
+  eventStart: 0,
+  eventEnd: 0,
+  displayStart: 0,
+  displayEnd: 0,
+
   dateFormat: 'MMM D, YYYY hh:mm a',
 
   actions: {
@@ -22,7 +25,7 @@ export default Ember.Controller.extend({
      * Handles subchart date change (debounced)
      */
     setDateParams([start, end]) {
-      Ember.run.debounce(this, this.get('actions.setNewDate'), { start, end }, 1000);
+      Ember.run.debounce(this, this.get('actions.setNewDate'), { start, end }, 500);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/events/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/events/template.hbs
@@ -21,13 +21,16 @@
             primaryMetric=summary.primaryMetric
             events=events.data
             showGraphLegend=false
-            showLegend=true
+            showLegend=false
+            height=400
             showEvents=true
             showSubchart=true
             analysisStart=events.eventStart
             analysisEnd=events.eventEnd
             onSubchartChange=(action "setDateParams")
             onSelection=(action actions.onEventSelection)
+            minDate=displayStart
+            maxDate=displayEnd
           }}
 
           {{events-table

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/controller.js
@@ -12,11 +12,18 @@ export default Ember.Controller.extend({
   splitViewLoading: false,
   dateFormat: 'MMM D, YYYY hh:mm a',
 
+  analysisStart: 0,
+  analysisEnd: 0,
+
+  displayStart:0,
+  displayEnd: 0,
+
+  subchartStart: 0,
+  subchartEnd: 0,
   // Ember concurrency task that sets new analysis start and end
   dateChangeTask: task(function* ([start, end]) {
-    yield timeout(600);
+    yield timeout(500);
 
-    this.set('loading', true);
     let startDate = moment(start).valueOf();
     let endDate = moment(end).valueOf();
 
@@ -31,6 +38,7 @@ export default Ember.Controller.extend({
   actions: {
     // Handles subgraph date change
     onDateChange(date) {
+      this.set('loading', true);
       const mostRecentTask = this.get('mostRecentTask');
       mostRecentTask && mostRecentTask.cancel();
 
@@ -39,6 +47,10 @@ export default Ember.Controller.extend({
       this.set('mostRecentTask', taskInstance);
 
       return date;
+    },
+
+    onRendering() {
+      this.set('loading', false);
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/template.hbs
@@ -49,6 +49,8 @@
                 showMetrics=true
                 showTitle=true
                 enableZoom=true
+                minDate=displayStart
+                maxDate=displayEnd
                 analysisStart=metricList.regionStart
                 analysisEnd=metricList.regionEnd
                 onSubchartChange=(action "onDateChange")
@@ -62,6 +64,8 @@
                   enableZoom=true
                   showMetrics=true
                   showTitle=true
+                  minDate=displayStart
+                  maxDate=displayEnd
                   analysisStart=metricList.regionStart
                   analysisEnd=metricList.regionEnd
                   onSelection=(action actions.onMetricSelection)
@@ -81,6 +85,8 @@
                 showSubchart=true
                 analysisStart=metricList.regionStart
                 analysisEnd=metricList.regionEnd
+                minDate=displayStart
+                maxDate=displayEnd
                 onSelection=(action actions.onMetricSelection)
                 onSubchartChange=(action "onDateChange")
               }}
@@ -116,7 +122,7 @@
                     end=analysisEnd
                     relatedMetrics=metricList.relatedMetrics
                     showDetails=(eq selectedTab "number")
-                    loading=(mut loading)
+                    stopLoading=(action "onRendering")
                   }}
                 {{/if}}
               </div>

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/route.js
@@ -14,6 +14,10 @@ const queryParamsConfig = {
   replace: false
 };
 
+const replaceConfig = {
+  replace: true
+};
+
 export default Ember.Route.extend({
   // queryParams for rca
   queryParams: {
@@ -22,8 +26,10 @@ export default Ember.Route.extend({
     granularity: queryParamsConfig,
     filters: queryParamsConfig,
     compareMode: queryParamsConfig,
-    analysisStart: {replace: true},
-    analysisEnd: {replace: true}
+    analysisStart: replaceConfig,
+    analysisEnd: replaceConfig,
+    displayStart: replaceConfig,
+    displayEnd: replaceConfig
   },
 
   redux: Ember.inject.service(),
@@ -64,6 +70,8 @@ export default Ember.Route.extend({
       endDate = moment().valueOf(),
       analysisStart,
       analysisEnd,
+      displayStart,
+      displayEnd,
       granularity = model.granularities[0],
       filters = JSON.stringify({}),
       compareMode = 'WoW'
@@ -109,8 +117,10 @@ export default Ember.Route.extend({
       analysisStart: analysisStart || initStart.valueOf(),
       analysisEnd: analysisEnd || initEnd.valueOf(),
       compareMode,
-      subchartStart: subchartStart.valueOf(),
-      subchartEnd: subchartEnd.valueOf()
+      subchartStart: displayStart || subchartStart.valueOf(),
+      subchartEnd: displayEnd || subchartEnd.valueOf(),
+      displayStart: displayStart || subchartStart.valueOf(),
+      displayEnd: displayEnd || subchartEnd.valueOf()
     };
 
     Object.assign(model, params);
@@ -134,6 +144,10 @@ export default Ember.Route.extend({
         granularity: undefined,
         startDate: undefined,
         endDate: undefined,
+        subchartStart: undefined,
+        subchartEnd: undefined,
+        displayStart: undefined,
+        displayEnd: undefined,
         compareMode: 'WoW'
       });
     }
@@ -151,21 +165,24 @@ export default Ember.Route.extend({
       analysisEnd,
       compareMode,
       subchartEnd,
-      subchartStart
+      subchartStart,
+      displayStart,
+      displayEnd
     } = model;
 
-    // other dates if analysisStart and analysisEnd exists
     controller.setProperties({
       model,
       filters,
-      analysisStart: analysisStart,
-      analysisEnd: analysisEnd,
+      analysisStart,
+      analysisEnd,
       granularity,
       startDate,
       endDate,
       compareMode,
       subchartEnd,
-      subchartStart
+      subchartStart,
+      displayStart,
+      displayEnd
     });
   },
 

--- a/thirdeye/thirdeye-frontend/app/reducers/dimensions.js
+++ b/thirdeye/thirdeye-frontend/app/reducers/dimensions.js
@@ -108,6 +108,14 @@ export default function reducer(state = INITIAL_STATE, action = {}) {
       });
     }
 
+    case ActionTypes.LOADED: {
+      return Object.assign({}, state, {
+        loaded: true,
+        loading: false,
+        failed: false
+      });
+    }
+
     case ActionTypes.REQUEST_FAIL:
       return Object.assign({}, state, {
         loaded: false,

--- a/thirdeye/thirdeye-frontend/app/reducers/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/reducers/metrics.js
@@ -49,6 +49,14 @@ export default function reducer(state = INITIAL_STATE, action = {}) {
         failed: false
       });
 
+    case ActionTypes.LOADED: {
+      return Object.assign({}, state, {
+        loaded: true,
+        loading: false,
+        failed: false
+      });
+    }
+
     case ActionTypes.LOAD_PRIMARY_METRIC: {
       let {
         primaryMetricId,

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/views/InvestigateView.js
@@ -65,7 +65,9 @@ InvestigateView.prototype = {
     const diff = anomalyRegionEnd.valueOf() - anomalyRegionStart.valueOf();
     const currentViewStart = anomalyRegionStart.valueOf() - diff;
     const currentViewEnd = anomalyRegionEnd.valueOf() + diff;
-
+    const displayStart = currentViewStart + Math.round(diff/2);
+    const displayEnd = currentViewEnd - Math.round(diff/2);
+    
     const parsedDimensions = JSON.parse(anomalyFunctionDimension);
     const dimensionKeys = Object.keys(parsedDimensions);
     const dimension = dimensionKeys.length ? dimensionKeys[0] : 'All';
@@ -88,6 +90,7 @@ InvestigateView.prototype = {
 
 
         wow.newUrl = `app#/rca/${metricId}/dimensions?analysisStart=${anomalyRegionStart.valueOf()}&analysisEnd=${anomalyRegionEnd.valueOf()}&` +
+          `displayStart=${displayStart}&displayEnd=${displayEnd}&` +
           `startDate=${currentViewStart}&endDate=${currentViewEnd}&` +
           `compareMode=${wow.compareMode}&filters=${anomalyFunctionDimension}&granularity=${granularity}`;
         return wow;


### PR DESCRIPTION
### What's new: 
- improved event's tab loading (navigating from/to the events tab should be faster)
- added `displayStart` and `displayEnd` to control the summary graph subchart's region and the bottom tabs' full region. Modifying the summary sub chart will resize the bottom chart’s region
- added some default buffer from the anomaly page
- fix forever spinner bug, it now behaves as expected