### PR TITLE
Fix the package for unit test

### DIFF
--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/TestBackwardAnoamlyFunctionUtils.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.joda.time.Interval;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 
 public class TestBackwardAnoamlyFunctionUtils {


### PR DESCRIPTION
When running testNG on ThirdEye, this test case isn't executed. It is because of different test package is used in the testBackwardAnomalyFunctionUtils. The test package, org.testng.annotations.Test, is used in all the other unit tests. This pull request is to change the test package in the unit test class. 