### PR TITLE
Avoid unnecessary split/join for in-clauses.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -84,12 +84,15 @@ public class BrokerRequestHandler {
 
   private static final int DEFAULT_BROKER_QUERY_RESPONSE_LIMIT = Integer.MAX_VALUE;
   private static final String BROKER_QUERY_RESPONSE_LIMIT_CONFIG = "pinot.broker.query.response.limit";
+  private static final String BROKER_QUERY_SPLIT_IN_CLAUSE = "pinot.broker.query.split.in.clause";
   public static final long DEFAULT_BROKER_TIME_OUT_MS = 10 * 1000L;
   private static final String BROKER_TIME_OUT_CONFIG = "pinot.broker.timeoutMs";
   private static final String DEFAULT_BROKER_ID;
   public static final String BROKER_ID_CONFIG_KEY = "pinot.broker.id";
   private static final ResponseType DEFAULT_BROKER_RESPONSE_TYPE = ResponseType.BROKER_RESPONSE_TYPE_NATIVE;
+  private static final boolean DEFAULT_BROKER_QUERY_SPLIT_IN_CLAUSE = false;
   private final SegmentZKMetadataPrunerService _segmentPrunerService;
+  private final boolean _splitInClause;
 
   static {
     String defaultBrokerId = "";
@@ -126,6 +129,7 @@ public class BrokerRequestHandler {
     _optimizer = new BrokerRequestOptimizer();
     _requestIdGenerator = new AtomicLong(0);
     _queryResponseLimit = config.getInt(BROKER_QUERY_RESPONSE_LIMIT_CONFIG, DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
+    _splitInClause = config.getBoolean(BROKER_QUERY_SPLIT_IN_CLAUSE, DEFAULT_BROKER_QUERY_SPLIT_IN_CLAUSE);
     _brokerTimeOutMs = config.getLong(BROKER_TIME_OUT_CONFIG, DEFAULT_BROKER_TIME_OUT_MS);
     _brokerId = config.getString(BROKER_ID_CONFIG_KEY, DEFAULT_BROKER_ID);
     _segmentPrunerService = segmentPrunerService;
@@ -167,7 +171,7 @@ public class BrokerRequestHandler {
     long compilationStartTime = System.nanoTime();
     BrokerRequest brokerRequest;
     try {
-      brokerRequest = REQUEST_COMPILER.compileToBrokerRequest(pql);
+      brokerRequest = REQUEST_COMPILER.compileToBrokerRequest(pql, _splitInClause);
     } catch (Exception e) {
       LOGGER.info("Parsing error on requestId {}: {}, {}", requestId, pql, e.getMessage());
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1L);

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2AstListener.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2AstListener.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.pql.parsers;
 
-import com.linkedin.pinot.common.request.AggregationInfo;
-import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.pql.parsers.pql2.ast.AstNode;
 import com.linkedin.pinot.pql.parsers.pql2.ast.BetweenPredicateAstNode;
 import com.linkedin.pinot.pql.parsers.pql2.ast.BinaryMathOpAstNode;
@@ -59,9 +57,11 @@ public class Pql2AstListener extends PQL2BaseListener {
   Stack<AstNode> _nodeStack = new Stack<>();
   AstNode _rootNode = null;
   private String _expression;
+  private final boolean _splitInClause;
 
-  public Pql2AstListener(String expression) {
+  public Pql2AstListener(String expression, boolean splitInClause) {
     _expression = expression; // Original expression being parsed.
+    _splitInClause = splitInClause;
   }
 
   private void pushNode(AstNode node) {
@@ -271,7 +271,7 @@ public class Pql2AstListener extends PQL2BaseListener {
     if ("not".equalsIgnoreCase(ctx.getChild(0).getChild(1).getText())) {
       isNotInClause = true;
     }
-    pushNode(new InPredicateAstNode(isNotInClause));
+    pushNode(new InPredicateAstNode(isNotInClause, _splitInClause));
   }
 
   @Override
@@ -333,13 +333,12 @@ public class Pql2AstListener extends PQL2BaseListener {
   @Override
   public void enterLimit(@NotNull PQL2Parser.LimitContext ctx) {
     // Can either be LIMIT <maxRows> or LIMIT <offset>, <maxRows> (the second is a MySQL syntax extension)
-    if (ctx.getChild(0).getChildCount() == 2)
+    if (ctx.getChild(0).getChildCount() == 2) {
       pushNode(new LimitAstNode(Integer.parseInt(ctx.getChild(0).getChild(1).getText())));
-    else
-      pushNode(new LimitAstNode(
-          Integer.parseInt(ctx.getChild(0).getChild(3).getText()),
-          Integer.parseInt(ctx.getChild(0).getChild(1).getText())
-      ));
+    } else {
+      pushNode(new LimitAstNode(Integer.parseInt(ctx.getChild(0).getChild(3).getText()),
+          Integer.parseInt(ctx.getChild(0).getChild(1).getText())));
+    }
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/InPredicateAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/InPredicateAstNode.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.request.FilterOperator;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.pql.parsers.Pql2CompilationException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.TreeSet;
 
@@ -27,11 +28,14 @@ import java.util.TreeSet;
  * AST node for IN predicates.
  */
 public class InPredicateAstNode extends PredicateAstNode {
+  private static final String DELIMITER = "\t\t";
   private final boolean _isNotInClause;
   private String _identifier;
+  private final boolean _splitInClause;
 
-  public InPredicateAstNode(boolean isNotInClause) {
+  public InPredicateAstNode(boolean isNotInClause, boolean splitInClause) {
     _isNotInClause = isNotInClause;
+    _splitInClause = splitInClause;
   }
 
   @Override
@@ -72,14 +76,19 @@ public class InPredicateAstNode extends PredicateAstNode {
       }
     }
 
-    String[] valueArray = values.toArray(new String[values.size()]);
     FilterOperator filterOperator;
     if (_isNotInClause) {
       filterOperator = FilterOperator.NOT_IN;
     } else {
       filterOperator = FilterOperator.IN;
     }
-    return new FilterQueryTree(_identifier, Collections.singletonList(StringUtil.join("\t\t", valueArray)),
-        filterOperator, null);
+
+    if (_splitInClause) {
+      return new FilterQueryTree(_identifier, new ArrayList<>(values), filterOperator, null);
+    } else {
+      String[] valueArray = values.toArray(new String[values.size()]);
+      return new FilterQueryTree(_identifier, Collections.singletonList(StringUtil.join(DELIMITER, valueArray)),
+          filterOperator, null);
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/InPredicate.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/InPredicate.java
@@ -30,12 +30,17 @@ public class InPredicate extends Predicate {
 
   @Override
   public String toString() {
+    List<String> rhs = getRhs();
     return "Predicate: type: " + getType() + ", left : " + getLhs() + ", right : "
-        + Arrays.toString(getRhs().toArray(new String[0])) + "\n";
+        + Arrays.toString(rhs.toArray(new String[rhs.size()])) + "\n";
   }
 
   public String[] getInRange() {
-    return getRhs().get(0).split(DELIMITER);
+    /* To maintain backward compatibility, we always split if number of values is one. We do not support
+       case where DELIMITER is a sub-string of value.
+     */
+    List<String> values = getRhs();
+    return (values.size() == 1) ? values.get(0).split(DELIMITER) : values.toArray(new String[values.size()]);
   }
 
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/InPredicateTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/InPredicateTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.predicate;
+
+import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.common.utils.request.FilterQueryTree;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import com.linkedin.pinot.core.common.Predicate;
+import com.linkedin.pinot.core.common.predicate.InPredicate;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link InPredicate}
+ */
+public class InPredicateTest {
+
+  /**
+   * This test ensures the FilterQueryTree & InPredicate are constructed correctly for both cases of:
+   * <ul>
+   *   <li> Splitting the in clause values. </li>
+   *   <li> Joining the in clause values with delimiter. </li>
+   * </ul>
+   */
+  @Test
+  public void testSplitInClause() {
+    Pql2Compiler compiler = new Pql2Compiler();
+    String query = "select * from foo where values in ('abc', 'xyz', '123')";
+
+    String[] expectedValues = new String[]{"abc", "xyz", "123"};
+    Arrays.sort(expectedValues); /* InPredicateAstNode sorts the predicate values. */
+
+    /* Test split case */
+    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query, true /*splitInClause*/);
+    FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    InPredicate predicate = (InPredicate) Predicate.newPredicate(filterQueryTree);
+    String[] actualValues = predicate.getInRange();
+
+    Assert.assertEquals(actualValues, expectedValues);
+    Assert.assertEquals(filterQueryTree.getValue(), Arrays.asList(expectedValues));
+
+    /* Test join case */
+    brokerRequest = compiler.compileToBrokerRequest(query, false /*splitInClause*/);
+    filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
+    predicate = (InPredicate) Predicate.newPredicate(filterQueryTree);
+    actualValues = predicate.getInRange();
+
+    Assert.assertEquals(actualValues, expectedValues);
+    Assert.assertEquals(filterQueryTree.getValue().get(0), StringUtil.join(InPredicate.DELIMITER, expectedValues));
+  }
+}
+


### PR DESCRIPTION
Current broker code joins the values in in-clause with '\t\t', that
requires server to get the individual values using String.split(). This
becomes extrememly inefficient for queries with large number of values
in the in clause (hundreds). This change elimiates this unwarranted
join/split, thus improving perfomance of affected queries. To avoid
breaking any broker/server compatibility:

1. Added config (off-by-default) in broker to not join the values, and
send them as list. Server checks if the size of list > 1, then
recognizes then skips split, or else falls back to original behavior.

2. Brokers and servers can be deployed with this feature off. Once all
are updated, the feature can be turned ON in broker, and ther servers
would already have been updated to handle the new protocol.

3. The config will be removed eventually to keep the code clean.

Added unit test for the new code.