### PR TITLE
Bubbling up error during Avro -> JSON schema conversion

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
@@ -69,6 +69,11 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
   public boolean execute() throws Exception {
     Schema schema = null;
 
+    if (_dimensions == null && _metrics == null) {
+      LOGGER.error("Error: Missing required argument, please specify -dimensions, -metrics, or both");
+      return false;
+    }
+    
     if (_avroSchemaFileName != null) {
       schema = AvroUtils.getPinotSchemaFromAvroSchemaFile(_avroSchemaFileName, buildFieldTypesMap(), _timeUnit);
     } else if (_avroDataFileName != null) {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
@@ -49,10 +49,10 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
   @Option(name = "-pinotSchemaFileName", required = false, metaVar = "<string>", usage = "Path to pinot schema file.")
   String _pinotSchemaFileName;
 
-  @Option(name = "-dimensions", required = false, metaVar = "<string>", forbids = {"-metrics"}, usage = "Comma separated dimension columns.")
+  @Option(name = "-dimensions", required = false, metaVar = "<string>", usage = "Comma separated dimension columns.")
   String _dimensions;
 
-  @Option(name = "-metrics", required = false, metaVar = "<string>", forbids = {"-dimensions"}, usage = "Comma separated metric columns.")
+  @Option(name = "-metrics", required = false, metaVar = "<string>", usage = "Comma separated metric columns.")
   String _metrics;
 
   @Option(name = "-timeColumnName", required = false, metaVar = "<string>", usage = "Name of Time Column.")

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
@@ -49,10 +49,10 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
   @Option(name = "-pinotSchemaFileName", required = false, metaVar = "<string>", usage = "Path to pinot schema file.")
   String _pinotSchemaFileName;
 
-  @Option(name = "-dimensions", required = false, metaVar = "<string>", usage = "Comma seperated dimension columns.")
+  @Option(name = "-dimensions", required = false, metaVar = "<string>", forbids = {"-metrics"}, usage = "Comma separated dimension columns.")
   String _dimensions;
 
-  @Option(name = "-metrics", required = false, metaVar = "<string>", usage = "Comma seperated metric columns.")
+  @Option(name = "-metrics", required = false, metaVar = "<string>", forbids = {"-dimensions"}, usage = "Comma separated metric columns.")
   String _metrics;
 
   @Option(name = "-timeColumnName", required = false, metaVar = "<string>", usage = "Name of Time Column.")
@@ -73,7 +73,7 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
       LOGGER.error("Error: Missing required argument, please specify -dimensions, -metrics, or both");
       return false;
     }
-    
+
     if (_avroSchemaFileName != null) {
       schema = AvroUtils.getPinotSchemaFromAvroSchemaFile(_avroSchemaFileName, buildFieldTypesMap(), _timeUnit);
     } else if (_avroDataFileName != null) {


### PR DESCRIPTION
Currently, when we try to convert schemas, we will ignore the fact that neither dimensions nor metrics is presented as an argument by the user. This is confusing because it ends up printing out an error after it tries to convert the schema and doesn't mention the real cause.

Now we check that at least one of dimensions or metrics is passed in at the beginning and print out the relevant error message.

Tested by running pinot-admin.