### PR TITLE
Wire-in config and segment stats history for off-heap memory allocation for consuming segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -213,6 +213,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_ENABLE_DEFAULT_COLUMNS = "pinot.server.instance.enable.default.columns";
     public static final String CONFIG_OF_ENABLE_SHUTDOWN_DELAY = "pinot.server.instance.enable.shutdown.delay";
     public static final String CONFIG_OF_ENABLE_SPLIT_COMMIT = "pinot.server.instance.enable.split.commit";
+    public static final String CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/FileBasedInstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/FileBasedInstanceDataManagerConfig.java
@@ -56,6 +56,8 @@ public class FileBasedInstanceDataManagerConfig implements InstanceDataManagerCo
   private static final String ENABLE_DEFAULT_COLUMNS = "enable.default.columns";
   // Key of whether to enable split commit
   private static final String ENABLE_SPLIT_COMMIT = "enable.split.commit";
+  // Whether memory for realtime consuming segments should be allocated off-heap.
+  private static final String REALTIME_OFFHEAP_ALLOCATION = "realtime.alloc.offheap";
 
   private static String[] REQUIRED_KEYS = { INSTANCE_ID, INSTANCE_DATA_DIR, INSTANCE_TABLE_NAME };
   private Configuration _instanceDataManagerConfiguration = null;
@@ -152,6 +154,11 @@ public class FileBasedInstanceDataManagerConfig implements InstanceDataManagerCo
   @Override
   public boolean isEnableSplitCommit() {
     return _instanceDataManagerConfiguration.getBoolean(ENABLE_SPLIT_COMMIT, false);
+  }
+
+  @Override
+  public boolean isRealtimeOffHeapAllocation() {
+    return _instanceDataManagerConfiguration.getBoolean(REALTIME_OFFHEAP_ALLOCATION, false);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -41,4 +41,6 @@ public interface InstanceDataManagerConfig {
   boolean isEnableDefaultColumns();
 
   boolean isEnableSplitCommit();
+
+  boolean isRealtimeOffHeapAllocation();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/AbstractTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/AbstractTableDataManager.java
@@ -65,7 +65,6 @@ public abstract class AbstractTableDataManager implements TableDataManager {
     _serverMetrics = serverMetrics;
 
     _tableName = _tableDataManagerConfig.getTableName();
-    doInit();
 
     _tableDataDir = _tableDataManagerConfig.getDataDir();
     _indexDir = new File(_tableDataDir);
@@ -73,6 +72,7 @@ public abstract class AbstractTableDataManager implements TableDataManager {
       _indexDir.mkdirs();
     }
 
+    doInit();
     LOGGER.info("Initialized table: {} with data directory: {}", _tableName, _tableDataDir);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -96,6 +96,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       final ServerMetrics serverMetrics)
       throws Exception {
     super();
+    initStatsHistory(realtimeTableDataManager);
     _realtimeTableDataManager = realtimeTableDataManager;
     _segmentVersion = indexLoadingConfig.getSegmentVersion();
     this.schema = schema;
@@ -103,6 +104,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     this.serverMetrics =serverMetrics;
     this.segmentName = segmentMetadata.getSegmentName();
     this.tableName = tableConfig.getTableName();
+    initMemoryManager(realtimeTableDataManager, indexLoadingConfig.isRealtimeOffheapAllocation(), segmentName);
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -859,6 +859,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       InstanceZKMetadata instanceZKMetadata, RealtimeTableDataManager realtimeTableDataManager, String resourceDataDir,
       IndexLoadingConfig indexLoadingConfig, Schema schema, ServerMetrics serverMetrics)
       throws Exception {
+    initStatsHistory(realtimeTableDataManager);
     _segmentZKMetadata = (LLCRealtimeSegmentZKMetadata) segmentZKMetadata;
     _tableConfig = tableConfig;
     _realtimeTableDataManager = realtimeTableDataManager;
@@ -887,6 +888,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     segmentLogger = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class.getName() +
         "_" + _segmentNameStr);
     _tableStreamName = _tableName + "_" + kafkaStreamProviderConfig.getStreamName();
+    initMemoryManager(realtimeTableDataManager, indexLoadingConfig.isRealtimeOffheapAllocation(), _segmentNameStr);
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -18,11 +18,18 @@ package com.linkedin.pinot.core.data.manager.realtime;
 
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
+import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import java.io.File;
 import java.util.List;
 
 
 public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
+  protected RealtimeSegmentStatsHistory _statsHistory;
+  protected RealtimeIndexOffHeapMemoryManager _memoryManager;
+
   public abstract String getTableName();
 
   public abstract Schema getSchema();
@@ -32,4 +39,24 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
   public abstract List<String> getInvertedIndexColumns();
 
   public abstract File getTableDataDir();
+
+  protected void initStatsHistory(RealtimeTableDataManager realtimeTableDataManager) {
+    _statsHistory = realtimeTableDataManager.getStatsHistory();
+  }
+
+  public RealtimeSegmentStatsHistory getStatsHistory() {
+    return _statsHistory;
+  }
+
+  protected void initMemoryManager(RealtimeTableDataManager realtimeTableDataManager, boolean isOffHeapAllocation, String segmentName) {
+    if (isOffHeapAllocation) {
+      _memoryManager = new MmapMemoryManager(realtimeTableDataManager.getConsumerDir(), segmentName);
+    } else {
+      _memoryManager = new DirectMemoryManager(segmentName);
+    }
+  }
+
+  public RealtimeIndexOffHeapMemoryManager getMemoryManager() {
+    return _memoryManager;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -105,7 +105,7 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
   }
 
   public String getConsumerDir() {
-    return _tableDataDir + "/" + CONSUMERS_DIR;
+    return _tableDataDir + File.separator + CONSUMERS_DIR;
   }
 
   public void notifySegmentCommitted(RealtimeSegmentZKMetadata metadata, IndexSegment segment) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -35,11 +35,14 @@ import com.linkedin.pinot.core.data.manager.offline.AbstractTableDataManager;
 import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentLoader;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaConsumerManager;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.linkedin.pinot.core.segment.index.loader.LoaderUtils;
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
@@ -49,13 +52,16 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.slf4j.LoggerFactory;
 
-// TODO Use the refcnt object inside SegmentDataManager
 public class RealtimeTableDataManager extends AbstractTableDataManager {
 
   private final ExecutorService _segmentAsyncExecutorService = Executors
       .newSingleThreadExecutor(new NamedThreadFactory("SegmentAsyncExecutorService"));
   private ZkHelixPropertyStore<ZNRecord> _helixPropertyStore;
   private SegmentBuildTimeLeaseExtender _leaseExtender;
+  private RealtimeSegmentStatsHistory _statsHistory;
+
+  private static final String CONSUMERS_DIR = "consumers";
+  private static final String STATS_FILE_NAME = "stats.ser";
 
   public RealtimeTableDataManager() {
     super();
@@ -76,6 +82,30 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
   protected void doInit() {
     _leaseExtender = SegmentBuildTimeLeaseExtender.create(getServerInstance());
     LOGGER = LoggerFactory.getLogger(_tableName + "-RealtimeTableDataManager");
+    File consumersDir = new File(_tableDataDir, CONSUMERS_DIR);
+    consumersDir.mkdirs();
+    File statsFile = new File(consumersDir, STATS_FILE_NAME);
+    try {
+      _statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsFile);
+    } catch (IOException |ClassNotFoundException e) {
+      LOGGER.error("Error reading history object for table {} from {}", _tableName, statsFile.getAbsolutePath(), e);
+      File savedFile = new File(consumersDir, STATS_FILE_NAME + "." + UUID.randomUUID());
+      try {
+        FileUtils.moveFile(statsFile, savedFile);
+      } catch (IOException e1) {
+        LOGGER.error("Could not move {} to {}", statsFile.getAbsolutePath(), savedFile.getAbsolutePath(), e1);
+        throw new RuntimeException(e);
+      }
+      LOGGER.warn("Saved unreadable {} into {}", statsFile.getAbsolutePath(), savedFile.getAbsolutePath());
+    }
+  }
+
+  public RealtimeSegmentStatsHistory getStatsHistory() {
+    return _statsHistory;
+  }
+
+  public String getConsumerDir() {
+    return _tableDataDir + "/" + CONSUMERS_DIR;
   }
 
   public void notifySegmentCommitted(RealtimeSegmentZKMetadata metadata, IndexSegment segment) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
@@ -35,6 +35,7 @@ import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 public abstract class RealtimeIndexOffHeapMemoryManager implements Closeable {
   private final List<PinotDataBuffer> _buffers = new LinkedList<>();
   private final String _segmentName;
+  private long _totalMemBytes = 0;
 
   protected RealtimeIndexOffHeapMemoryManager(String segmentName) {
     _segmentName = segmentName;
@@ -60,6 +61,7 @@ public abstract class RealtimeIndexOffHeapMemoryManager implements Closeable {
    */
   public PinotDataBuffer allocate(long size, String columnName) {
     PinotDataBuffer buffer = allocateInternal(size, columnName);
+    _totalMemBytes += size;
     _buffers.add(buffer);
     return buffer;
   }
@@ -85,5 +87,9 @@ public abstract class RealtimeIndexOffHeapMemoryManager implements Closeable {
     }
     doClose();
     _buffers.clear();
+  }
+
+  public long getTotalMemBytes() {
+    return _totalMemBytes;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.core.io.writer.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -80,12 +81,7 @@ import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
  *
  */
 public class MutableOffHeapByteArrayStore implements Closeable {
-  private static final int START_SIZE = 32 * 1024;
   private static final int INT_SIZE = V1Constants.Numbers.INTEGER_SIZE;
-
-  public static int getStartSize() {
-    return START_SIZE;
-  }
 
   private static class Buffer implements Closeable {
 
@@ -174,11 +170,19 @@ public class MutableOffHeapByteArrayStore implements Closeable {
   private final RealtimeIndexOffHeapMemoryManager _memoryManager;
   private final String _columnName;
   private long _totalStringSize = 0;
+  private final int _startSize;
 
-  public MutableOffHeapByteArrayStore(RealtimeIndexOffHeapMemoryManager memoryManager, String columnName) {
+  @VisibleForTesting
+  public int getStartSize() {
+    return _startSize;
+  }
+
+  public MutableOffHeapByteArrayStore(RealtimeIndexOffHeapMemoryManager memoryManager, String columnName, int numArrays,
+      int avgArrayLen) {
     _memoryManager = memoryManager;
     _columnName = columnName;
-    expand(START_SIZE, 0L);
+    _startSize = numArrays * (avgArrayLen + 4); // For each array, we store the array and its startoffset (4 bytes)
+    expand(_startSize, 0L);
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -567,7 +567,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       segmentStats.setNumRowsConsumed(numDocsIndexed);
       segmentStats.setMemUsedBytes(memoryManager.getTotalMemBytes());
       final long now = System.currentTimeMillis();
-      segmentStats.setNumSeconds((int)(now - startTimeMillis/1000));
+      segmentStats.setNumSeconds((int)((now - startTimeMillis)/1000));
       statsHistory.addSegmentStats(segmentStats);
       statsHistory.save();
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -566,6 +566,7 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       }
       segmentStats.setNumRowsConsumed(numDocsIndexed);
       segmentStats.setMemUsedBytes(memoryManager.getTotalMemBytes());
+      LOGGER.info("Segment used {} bytes of memory", memoryManager.getTotalMemBytes());
       final long now = System.currentTimeMillis();
       segmentStats.setNumSeconds((int)((now - startTimeMillis)/1000));
       statsHistory.addSegmentStats(segmentStats);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -15,21 +15,6 @@
  */
 package com.linkedin.pinot.core.realtime.impl;
 
-import com.linkedin.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
-import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
-import org.roaringbitmap.IntIterator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.config.SegmentPartitionConfig;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
@@ -45,13 +30,13 @@ import com.linkedin.pinot.common.utils.time.TimeConverterProvider;
 import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.common.Predicate;
 import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import com.linkedin.pinot.core.data.readers.RecordReader;
 import com.linkedin.pinot.core.indexsegment.IndexType;
 import com.linkedin.pinot.core.io.reader.DataFileReader;
 import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
-import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.realtime.RealtimeSegment;
 import com.linkedin.pinot.core.realtime.impl.datasource.RealtimeColumnDataSource;
 import com.linkedin.pinot.core.realtime.impl.dictionary.MutableDictionary;
@@ -62,7 +47,21 @@ import com.linkedin.pinot.core.realtime.impl.invertedIndex.RealtimeInvertedIndex
 import com.linkedin.pinot.core.realtime.impl.invertedIndex.TimeInvertedIndex;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.linkedin.pinot.core.startree.StarTree;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.roaringbitmap.IntIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class RealtimeSegmentImpl implements RealtimeSegment {
@@ -103,6 +102,9 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   private SegmentPartitionConfig segmentPartitionConfig = null;
   private final List<String> consumingNoDictionaryColumns = new ArrayList<>();
   private final RealtimeIndexOffHeapMemoryManager memoryManager;
+  private final boolean isOffHeapAllocation;
+  private final RealtimeSegmentStatsHistory statsHistory;
+  private final long startTimeMillis = System.currentTimeMillis();
 
   // TODO Dynamcally adjust these variables, maybe on a per column basis
 
@@ -121,11 +123,13 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     dictionaryMap = new HashMap<String, MutableDictionary>();
     maxNumberOfMultivaluesMap = new HashMap<String, Integer>();
     outgoingTimeColumnName = dataSchema.getTimeFieldSpec().getOutgoingTimeColumnName();
-    this.memoryManager = new DirectMemoryManager(segmentName);
     final List<String> noDictionaryColumns = segmentDataManager.getNoDictionaryColumns();
     final List<String> invertedIndexColumns = segmentDataManager.getInvertedIndexColumns();
     final String tableName = segmentDataManager.getTableName();
     final int avgMultiValueCount = indexLoadingConfig.getRealtimeAvgMultiValueCount();
+    statsHistory = segmentDataManager.getStatsHistory();
+    isOffHeapAllocation = indexLoadingConfig.isRealtimeOffheapAllocation();
+    memoryManager = segmentDataManager.getMemoryManager();
 
     for (final String column : noDictionaryColumns) {
       // Not all no-dictionary columns can be so while the segment is being consumed.
@@ -146,16 +150,30 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
     // dictionary assignment for dimensions and time column
     for (String column : dataSchema.getDimensionNames()) {
       if (!consumingNoDictionaryColumns.contains(column)) {
-        dictionaryMap.put(column, MutableDictionaryFactory.getMutableDictionary(dataSchema.getFieldSpecFor(column).getDataType()));
+        FieldSpec.DataType dataType = dataSchema.getFieldSpecFor(column).getDataType();
+        MutableDictionary dictionary = MutableDictionaryFactory.getMutableDictionary(dataType, isOffHeapAllocation, memoryManager,
+            getColSize(statsHistory, dataType, column),
+            statsHistory.getEstimatedCardinality(column), column);
+        dictionaryMap.put(column, dictionary);
       }
     }
 
+    FieldSpec.DataType timeColDataType = dataSchema.getFieldSpecFor(outgoingTimeColumnName).getDataType();
+
     dictionaryMap.put(outgoingTimeColumnName, MutableDictionaryFactory.getMutableDictionary(
-        dataSchema.getFieldSpecFor(outgoingTimeColumnName).getDataType()));
+        timeColDataType, isOffHeapAllocation,
+        memoryManager, getColSize(statsHistory, timeColDataType, outgoingTimeColumnName),
+        statsHistory.getEstimatedCardinality(outgoingTimeColumnName),
+        outgoingTimeColumnName));
 
     for (String metric : dataSchema.getMetricNames()) {
       if (!consumingNoDictionaryColumns.contains(metric)) {
-        dictionaryMap.put(metric, MutableDictionaryFactory.getMutableDictionary(dataSchema.getFieldSpecFor(metric).getDataType()));
+        FieldSpec.DataType dataType = dataSchema.getFieldSpecFor(metric).getDataType();
+        MutableDictionary dictionary = MutableDictionaryFactory.getMutableDictionary(dataType, isOffHeapAllocation,
+            memoryManager,
+            getColSize(statsHistory, dataType, metric),
+            statsHistory.getEstimatedCardinality(metric), metric);
+        dictionaryMap.put(metric, dictionary);
       }
     }
 
@@ -208,6 +226,23 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
             outgoingTimeColumnName));
 
     tableAndStreamName = tableName + "-" + streamName;
+  }
+
+  private int getColSize(RealtimeSegmentStatsHistory statsHistory, FieldSpec.DataType dataType, String columnName) {
+    switch(dataType) {
+      case INT:
+        return V1Constants.Numbers.INTEGER_SIZE;
+      case LONG:
+        return V1Constants.Numbers.LONG_SIZE;
+      case FLOAT:
+        return V1Constants.Numbers.FLOAT_SIZE;
+      case DOUBLE:
+        return V1Constants.Numbers.DOUBLE_SIZE;
+      case STRING:
+        return statsHistory.getEstimatedAvgColSize(columnName);
+      default:
+        throw new RuntimeException("Unknown data type " + dataType.toString() + " for column " + columnName);
+    }
   }
 
   /**
@@ -519,6 +554,24 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   @Override
   public void destroy() {
     LOGGER.info("Trying to close RealtimeSegmentImpl : {}", this.getSegmentName());
+
+    // If offHeapAllocation, then gather some statistics before  destroying the segment.
+    if (isOffHeapAllocation) {
+      RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
+      for (Map.Entry<String, MutableDictionary> entry : dictionaryMap.entrySet()) {
+        RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
+        columnStats.setCardinality(entry.getValue().length());
+        columnStats.setAvgColumnSize(entry.getValue().getAvgValueSize());
+        segmentStats.setColumnStats(entry.getKey(), columnStats);
+      }
+      segmentStats.setNumRowsConsumed(numDocsIndexed);
+      segmentStats.setMemUsedBytes(memoryManager.getTotalMemBytes());
+      final long now = System.currentTimeMillis();
+      segmentStats.setNumSeconds((int)(now - startTimeMillis/1000));
+      statsHistory.addSegmentStats(segmentStats);
+      statsHistory.save();
+    }
+
     for (DataFileReader dfReader : columnIndexReaderWriterMap.values()) {
       try {
         dfReader.close();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOnHeapMutableDictionary.java
@@ -52,6 +52,11 @@ public abstract class BaseOnHeapMutableDictionary extends MutableDictionary {
     return _entriesIndexed;
   }
 
+  @Override
+  public int getAvgValueSize() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
   public boolean isEmpty() {
     return _entriesIndexed == 0;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -125,6 +125,11 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   @Override
+  public int getAvgValueSize() {
+    return V1Constants.Numbers.DOUBLE_SIZE;
+  }
+
+  @Override
   protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setDouble(dictId, (Double) value);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -125,6 +125,11 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
+  public int getAvgValueSize() {
+    return V1Constants.Numbers.FLOAT_SIZE;
+  }
+
+  @Override
   protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setFloat(dictId, (Float) value);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -125,6 +125,11 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
+  public int getAvgValueSize() {
+    return V1Constants.Numbers.INTEGER_SIZE;
+  }
+
+  @Override
   protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setInt(dictId, (Integer) value);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -125,6 +125,11 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
+  public int getAvgValueSize() {
+    return V1Constants.Numbers.LONG_SIZE;
+  }
+
+  @Override
   protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
     _dictIdToValue.setLong(dictId, (Long) value);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
@@ -83,6 +83,8 @@ public abstract class MutableDictionary implements Dictionary, Closeable {
   @Nonnull
   public abstract Object getSortedValues();
 
+  public abstract int getAvgValueSize();
+
   public abstract boolean isEmpty();
 
   public abstract void close() throws IOException;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
@@ -16,26 +16,50 @@
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 
 
 public class MutableDictionaryFactory {
   private MutableDictionaryFactory() {
   }
 
-  public static MutableDictionary getMutableDictionary(FieldSpec.DataType dataType) {
-    switch (dataType) {
-      case INT:
-        return new IntOnHeapMutableDictionary();
-      case LONG:
-        return new LongOnHeapMutableDictionary();
-      case FLOAT:
-        return new FloatOnHeapMutableDictionary();
-      case DOUBLE:
-        return new DoubleOnHeapMutableDictionary();
-      case STRING:
-        return new StringOnHeapMutableDictionary();
-      default:
-        throw new UnsupportedOperationException();
+  public static MutableDictionary getMutableDictionary(FieldSpec.DataType dataType, boolean isOffHeapAllocation,
+      RealtimeIndexOffHeapMemoryManager memoryManager, int avgStringLen, int cardinality, String columnName) {
+    if (isOffHeapAllocation) {
+      // OnHeap allocation
+      int maxOverflowSize = cardinality/10;
+      switch (dataType) {
+        case INT:
+          return new IntOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+        case LONG:
+          return new LongOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+        case FLOAT:
+          return new FloatOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+        case DOUBLE:
+          return new DoubleOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+        case STRING:
+          return new StringOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName,
+              avgStringLen);
+        default:
+          throw new UnsupportedOperationException();
+      }
+    } else {
+      // OnHeap allocation
+      switch (dataType) {
+        case INT:
+          return new IntOnHeapMutableDictionary();
+        case LONG:
+          return new LongOnHeapMutableDictionary();
+        case FLOAT:
+          return new FloatOnHeapMutableDictionary();
+        case DOUBLE:
+          return new DoubleOnHeapMutableDictionary();
+        case STRING:
+          return new StringOnHeapMutableDictionary();
+        default:
+          throw new UnsupportedOperationException();
+      }
+
     }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -31,10 +31,10 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   private String _min = null;
   private String _max = null;
 
-  public StringOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize, RealtimeIndexOffHeapMemoryManager memoryManager,
-      String columnName) {
+  public StringOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize,
+      RealtimeIndexOffHeapMemoryManager memoryManager, String columnName, int avgStringLen) {
     super(estimatedCardinality, maxOverflowHashSize, memoryManager, columnName);
-    _byteStore = new MutableOffHeapByteArrayStore(memoryManager, columnName);
+    _byteStore = new MutableOffHeapByteArrayStore(memoryManager, columnName, estimatedCardinality, avgStringLen);
   }
 
   @Override
@@ -157,7 +157,8 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
     return super.getTotalOffHeapMemUsed() + _byteStore.getTotalOffHeapMemUsed();
   }
 
-  public int getAvgStringSize() {
+  @Override
+  public int getAvgValueSize() {
     return (int)_byteStore.getAvgValueSize();
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -48,6 +48,7 @@ public class IndexLoadingConfig {
   private ColumnMinMaxValueGeneratorMode _columnMinMaxValueGeneratorMode = ColumnMinMaxValueGeneratorMode.DEFAULT_MODE;
   private int _realtimeAvgMultiValueCount = DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT;
   private boolean _enableSplitCommit;
+  private boolean _isRealtimeOffheapAllocation;
 
   public IndexLoadingConfig(@Nonnull InstanceDataManagerConfig instanceDataManagerConfig,
       @Nullable TableConfig tableConfig) {
@@ -116,6 +117,8 @@ public class IndexLoadingConfig {
     _enableDefaultColumns = instanceDataManagerConfig.isEnableDefaultColumns();
 
     _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
+
+    _isRealtimeOffheapAllocation = instanceDataManagerConfig.isRealtimeOffHeapAllocation();
 
     String avgMultiValueCount = instanceDataManagerConfig.getAvgMultiValueCount();
     if (avgMultiValueCount != null) {
@@ -198,6 +201,10 @@ public class IndexLoadingConfig {
 
   public boolean isEnableSplitCommit() {
     return _enableSplitCommit;
+  }
+
+  public boolean isRealtimeOffheapAllocation() {
+    return _isRealtimeOffheapAllocation;
   }
 
   @Nonnull

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -26,6 +26,7 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
@@ -118,6 +119,10 @@ public class LLRealtimeSegmentDataManagerTest {
     SegmentBuildTimeLeaseExtender.create(instanceId);
     RealtimeTableDataManager tableDataManager = mock(RealtimeTableDataManager.class);
     when(tableDataManager.getServerInstance()).thenReturn(instanceId);
+    RealtimeSegmentStatsHistory statsHistory = mock(RealtimeSegmentStatsHistory.class);
+    when(statsHistory.getEstimatedCardinality(any(String.class))).thenReturn(200);
+    when(statsHistory.getEstimatedAvgColSize(any(String.class))).thenReturn(32);
+    when(tableDataManager.getStatsHistory()).thenReturn(statsHistory);
     return tableDataManager;
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -635,6 +635,7 @@ public class LLRealtimeSegmentDataManagerTest {
       when(dataManagerConfig.getSegmentFormatVersion()).thenReturn(null);
       when(dataManagerConfig.isEnableDefaultColumns()).thenReturn(false);
       when(dataManagerConfig.isEnableSplitCommit()).thenReturn(false);
+      when(dataManagerConfig.isRealtimeOffHeapAllocation()).thenReturn(false);
       return dataManagerConfig;
     }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
@@ -42,8 +42,8 @@ public class MutableOffHeapByteArrayStoreTest {
 
   @Test
   public void maxValueTest() throws Exception {
-    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore(_memoryManager, "stringColumn");
-    final int arrSize = MutableOffHeapByteArrayStore.getStartSize();
+    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore(_memoryManager, "stringColumn", 1024, 32);
+    final int arrSize = store.getStartSize();
     byte[] dataIn = new byte[arrSize-4];
     for (int i = 0; i < dataIn.length; i++) {
       dataIn[i] = (byte)(i % Byte.MAX_VALUE);
@@ -56,8 +56,8 @@ public class MutableOffHeapByteArrayStoreTest {
 
   @Test
   public void overflowTest() throws Exception {
-    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore(_memoryManager, "stringColumn");
-    final int maxSize = MutableOffHeapByteArrayStore.getStartSize() - 4;
+    MutableOffHeapByteArrayStore store = new MutableOffHeapByteArrayStore(_memoryManager, "stringColumn", 1024, 32);
+    final int maxSize = store.getStartSize() - 4;
 
     byte[] b1 = new byte[3];
     for (int i = 0; i < b1.length; i++) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeSegmentTest.java
@@ -16,6 +16,8 @@
 package com.linkedin.pinot.core.realtime;
 
 import com.linkedin.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import java.io.File;
 import java.util.ArrayList;
@@ -97,6 +99,11 @@ public class RealtimeSegmentTest {
     when(segmentDataManager.getInvertedIndexColumns()).thenReturn(invertedIdxCols);
     when(segmentDataManager.getNoDictionaryColumns()).thenReturn(new ArrayList<String>());
     when(segmentDataManager.getSchema()).thenReturn(schema);
+    when(segmentDataManager.getMemoryManager()).thenReturn(new DirectMemoryManager("noSegment"));
+    RealtimeSegmentStatsHistory statsHistory = mock(RealtimeSegmentStatsHistory.class);
+    when(statsHistory.getEstimatedAvgColSize(any(String.class))).thenReturn(32);
+    when(statsHistory.getEstimatedCardinality(any(String.class))).thenReturn(200);
+    when(segmentDataManager.getStatsHistory()).thenReturn(statsHistory);
 
     IndexLoadingConfig indexLoadingConfig = mock(IndexLoadingConfig.class);
     when(indexLoadingConfig.getRealtimeAvgMultiValueCount()).thenReturn(2);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -17,21 +17,25 @@
 package com.linkedin.pinot.core.realtime.impl;
 
 import java.io.File;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
 public class RealtimeSegmentStatsHistoryTest {
   private static final String STATS_FILE_NAME = RealtimeSegmentStatsHistoryTest.class.getSimpleName() + ".ser";
+  private static final String COL1 = "col1";
+  private static final String COL2 = "col2";
 
   private void addSegmentStats(int segmentId, RealtimeSegmentStatsHistory history) {
     RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
-    segmentStats.setMemUsed(segmentId);
-    segmentStats.setNumMinutes(segmentId);
+    segmentStats.setMemUsedBytes(segmentId);
+    segmentStats.setNumSeconds(segmentId);
     segmentStats.setNumRowsConsumed(segmentId);
     for (int i = 0; i < 2; i++) {
       RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
-      columnStats.setAvgStringSize(segmentId*100 + i);
+      columnStats.setAvgColumnSize(segmentId*100 + i);
       columnStats.setCardinality(segmentId*100 + i);
       segmentStats.setColumnStats(String.valueOf(i), columnStats);
     }
@@ -43,11 +47,13 @@ public class RealtimeSegmentStatsHistoryTest {
     final String tmpDir = System.getProperty("java.io.tmpdir");
     File serializedFile = new File(tmpDir, STATS_FILE_NAME);
     serializedFile.deleteOnExit();
+    FileUtils.deleteQuietly(serializedFile);
 
     int maxNumEntries = RealtimeSegmentStatsHistory.getMaxNumEntries();
     int segmentId = 0;
     {
-      RealtimeSegmentStatsHistory history = new RealtimeSegmentStatsHistory();
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      // We should have got an empty one here.
 
       history.getEstimatedAvgColSize("1");
       history.getEstimatedCardinality("1");
@@ -59,7 +65,7 @@ public class RealtimeSegmentStatsHistoryTest {
         Assert.assertEquals(history.isFull(), false);
       }
       Assert.assertEquals(history.getArraySize(), maxNumEntries);
-      history.serializeInto(serializedFile);
+      history.save();
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
     }
@@ -74,6 +80,7 @@ public class RealtimeSegmentStatsHistoryTest {
       Assert.assertEquals(history.isFull(), false);
       Assert.assertEquals(history.getArraySize(), maxNumEntries);
       Assert.assertEquals(history.getCursor(), prevMax-1);
+      history.save();
       // Add one segment
       addSegmentStats(segmentId++, history);
       Assert.assertEquals(history.isFull(), false);
@@ -82,6 +89,7 @@ public class RealtimeSegmentStatsHistoryTest {
       Assert.assertEquals(history.getCursor(), segmentId);
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
+      history.save();
     // Now add 2 more segments for it to go over.
       addSegmentStats(segmentId++, history);
       Assert.assertEquals(history.isFull(), false);
@@ -90,6 +98,7 @@ public class RealtimeSegmentStatsHistoryTest {
       Assert.assertEquals(history.getCursor(), segmentId);
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
+      history.save();
 
       addSegmentStats(segmentId++, history);
       Assert.assertEquals(history.isFull(), true);
@@ -97,6 +106,7 @@ public class RealtimeSegmentStatsHistoryTest {
       Assert.assertEquals(history.getCursor(), 0);
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
+      history.save();
 
       // And then one more to bump the cursor.
 
@@ -105,7 +115,7 @@ public class RealtimeSegmentStatsHistoryTest {
       Assert.assertEquals(history.getArraySize(), maxNumEntries);
       Assert.assertEquals(history.getCursor(), 1);
       // Rewrite the history file
-      history.serializeInto(serializedFile);
+      history.save();
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
     }
@@ -120,7 +130,7 @@ public class RealtimeSegmentStatsHistoryTest {
       Assert.assertEquals(history.getArraySize(), maxNumEntries);
       Assert.assertEquals(history.getCursor(), 0);
 
-      history.serializeInto(serializedFile);
+      history.save();
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
     }
@@ -137,6 +147,81 @@ public class RealtimeSegmentStatsHistoryTest {
       Assert.assertEquals(history.getCursor(), prevMax);
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
+    }
+  }
+
+  @Test
+  public void testMultiThreadedUse() throws Exception {
+    final int numThreads = 8;
+    final int numIterations = 10;
+    final long avgSleepTimeMs = 300;
+    Thread[] threads = new Thread[numThreads];
+    final String tmpDir = System.getProperty("java.io.tmpdir");
+    File serializedFile = new File(tmpDir, STATS_FILE_NAME);
+    FileUtils.deleteQuietly(serializedFile);
+    serializedFile.deleteOnExit();
+    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+
+    for (int i = 0; i < numThreads; i++) {
+      threads[i] = new Thread(new StatsUpdater(statsHistory, numIterations, avgSleepTimeMs));
+      threads[i].start();
+    }
+
+    for (int i = 0; i < numThreads; i++) {
+      threads[i].join();
+    }
+
+    System.out.println(statsHistory.getEstimatedCardinality(COL1));
+    System.out.println(statsHistory.getEstimatedCardinality(COL2));
+    System.out.println(statsHistory.getEstimatedAvgColSize(COL1));
+    System.out.println(statsHistory.getEstimatedAvgColSize(COL2));
+
+    FileUtils.deleteQuietly(serializedFile);
+  }
+
+  private static class StatsUpdater implements Runnable {
+    private final RealtimeSegmentStatsHistory _statsHistory;
+    private final int _numIterations;
+    private final long _avgSleepTimeMs;
+    private final int _sleepVariationMs;
+    private final Random _random = new Random();
+
+    private static final int MAX_AVGLEN = 200;
+    private static final int MAX_CARDINALITY = 50000;
+
+    private StatsUpdater(RealtimeSegmentStatsHistory statsHistory, int numInterations, long avgSleepTimeMs){
+      _statsHistory = statsHistory;
+      _numIterations = numInterations;
+      _avgSleepTimeMs = avgSleepTimeMs;
+      _sleepVariationMs = (int)_avgSleepTimeMs/10;
+    }
+
+    @Override
+    public void run() {
+      for (int i = 0; i < _numIterations; i++) {
+        try {
+          Thread.sleep(_avgSleepTimeMs - _sleepVariationMs + _random.nextInt(2 * _sleepVariationMs));
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+        RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
+        RealtimeSegmentStatsHistory.ColumnStats columnStats;
+
+        columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
+        columnStats.setAvgColumnSize(_random.nextInt(MAX_AVGLEN));
+        columnStats.setCardinality(_random.nextInt(MAX_CARDINALITY));
+        segmentStats.setColumnStats(COL1, columnStats);
+        System.out.println("Setting column stats for " + COL1 + ":" + columnStats.toString());
+
+        columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
+        columnStats.setAvgColumnSize(_random.nextInt(MAX_AVGLEN));
+        columnStats.setCardinality(_random.nextInt(MAX_CARDINALITY));
+        segmentStats.setColumnStats(COL2, columnStats);
+        System.out.println("Setting column stats for " + COL2 + ":" + columnStats.toString());
+
+        _statsHistory.addSegmentStats(segmentStats);
+        _statsHistory.save();
+      }
     }
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -148,6 +148,12 @@ public class RealtimeSegmentStatsHistoryTest {
       history.getEstimatedAvgColSize("0");
       history.getEstimatedCardinality("0");
     }
+    // Now add a new column
+    {
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      Assert.assertEquals(history.getEstimatedAvgColSize("new"), RealtimeSegmentStatsHistory.getDefaultEstAvgColSize());
+      Assert.assertEquals(history.getEstimatedCardinality("new"), RealtimeSegmentStatsHistory.getDefaultEstCardinality());
+    }
   }
 
   @Test
@@ -170,11 +176,6 @@ public class RealtimeSegmentStatsHistoryTest {
     for (int i = 0; i < numThreads; i++) {
       threads[i].join();
     }
-
-    System.out.println(statsHistory.getEstimatedCardinality(COL1));
-    System.out.println(statsHistory.getEstimatedCardinality(COL2));
-    System.out.println(statsHistory.getEstimatedAvgColSize(COL1));
-    System.out.println(statsHistory.getEstimatedAvgColSize(COL2));
 
     FileUtils.deleteQuietly(serializedFile);
   }
@@ -211,13 +212,11 @@ public class RealtimeSegmentStatsHistoryTest {
         columnStats.setAvgColumnSize(_random.nextInt(MAX_AVGLEN));
         columnStats.setCardinality(_random.nextInt(MAX_CARDINALITY));
         segmentStats.setColumnStats(COL1, columnStats);
-        System.out.println("Setting column stats for " + COL1 + ":" + columnStats.toString());
 
         columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
         columnStats.setAvgColumnSize(_random.nextInt(MAX_AVGLEN));
         columnStats.setCardinality(_random.nextInt(MAX_CARDINALITY));
         segmentStats.setColumnStats(COL2, columnStats);
-        System.out.println("Setting column stats for " + COL2 + ":" + columnStats.toString());
 
         _statsHistory.addSegmentStats(segmentStats);
         _statsHistory.save();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
@@ -64,7 +64,7 @@ public class MutableDictionaryTest {
       }
       {
         MutableDictionary dictionary =
-            new StringOffHeapMutableDictionary(EST_CARDINALITY, 2000, _memoryManager, "stringColumn");
+            new StringOffHeapMutableDictionary(EST_CARDINALITY, 2000, _memoryManager, "stringColumn", 32);
         testSingleReaderSingleWriter(dictionary, FieldSpec.DataType.STRING);
         dictionary.close();
       }
@@ -98,7 +98,7 @@ public class MutableDictionaryTest {
       }
       {
         MutableDictionary dictionary =
-            new StringOffHeapMutableDictionary(EST_CARDINALITY, 2000, _memoryManager, "stringColumn");
+            new StringOffHeapMutableDictionary(EST_CARDINALITY, 2000, _memoryManager, "stringColumn", 32);
         testMultiReadersSingleWriter(dictionary, FieldSpec.DataType.STRING);
         dictionary.close();
       }
@@ -125,7 +125,7 @@ public class MutableDictionaryTest {
   public void testOnHeapMutableDictionary() {
     try {
       for (FieldSpec.DataType dataType : DATA_TYPES) {
-        MutableDictionary dictionary = MutableDictionaryFactory.getMutableDictionary(dataType);
+        MutableDictionary dictionary = MutableDictionaryFactory.getMutableDictionary(dataType, false, null, 0, 0, null);
         testMutableDictionary(dictionary, dataType);
         dictionary.close();
       }
@@ -179,7 +179,7 @@ public class MutableDictionaryTest {
       case DOUBLE:
         return new DoubleOffHeapMutableDictionary(estCardinality, maxOverflowSize, _memoryManager, "doubleColumn");
       case STRING:
-        return new StringOffHeapMutableDictionary(estCardinality, maxOverflowSize, _memoryManager, "stringColumn");
+        return new StringOffHeapMutableDictionary(estCardinality, maxOverflowSize, _memoryManager, "stringColumn", 32);
       default:
         throw new UnsupportedOperationException("Unsupported data type: " + dataType);
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/kafka/RealtimeSegmentImplTest.java
@@ -20,7 +20,9 @@ import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
+import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.yammer.metrics.core.MetricsRegistry;
 import java.io.IOException;
@@ -46,6 +48,11 @@ public class RealtimeSegmentImplTest {
     when(segmentDataManager.getNoDictionaryColumns()).thenReturn(new ArrayList<String>());
     when(segmentDataManager.getSegmentName()).thenReturn(segmentName);
     when(segmentDataManager.getInvertedIndexColumns()).thenReturn(new ArrayList<String>());
+    RealtimeSegmentStatsHistory statsHistory = mock(RealtimeSegmentStatsHistory.class);
+    when(statsHistory.getEstimatedCardinality(any(String.class))).thenReturn(200);
+    when(statsHistory.getEstimatedAvgColSize(any(String.class))).thenReturn(32);
+    when(segmentDataManager.getStatsHistory()).thenReturn(statsHistory);
+    when(segmentDataManager.getMemoryManager()).thenReturn(new DirectMemoryManager(segmentName));
 
     IndexLoadingConfig indexLoadingConfig = mock(IndexLoadingConfig.class);
     when(indexLoadingConfig.getRealtimeAvgMultiValueCount()).thenReturn(2);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import java.util.List;
 import org.apache.avro.reflect.Nullable;
+import org.apache.commons.configuration.Configuration;
 import org.apache.helix.ZNRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -38,6 +39,12 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
   @Override
   protected String getLoadMode() {
     return "MMAP";
+  }
+
+  @Override
+  protected void overrideOfflineServerConf(Configuration configuration) {
+    configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION,
+        "true");
   }
 
   @Test

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkStringDictionary.java
@@ -82,7 +82,8 @@ public class BenchmarkStringDictionary {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public StringOffHeapMutableDictionary benchmarkOffHeapStringDictionary() {
-    StringOffHeapMutableDictionary dictionary = new StringOffHeapMutableDictionary(10, 10, _memoryManager, "stringColumn");
+    StringOffHeapMutableDictionary dictionary = new StringOffHeapMutableDictionary(5000, 10, _memoryManager, "stringColumn",
+        32);
 
     for (int i = 0; i < stringValues.length; i++) {
       dictionary.index(stringValues[i]);

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -59,6 +59,9 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   // Key of whether to enable split commit
   private static final String ENABLE_SPLIT_COMMIT = "enable.split.commit";
 
+  // Whether memory for realtime consuming segments should be allocated off-heap.
+  private static final String REALTIME_OFFHEAP_ALLOCATION = "realtime.alloc.offheap";
+
   private final static String[] REQUIRED_KEYS = { INSTANCE_ID, INSTANCE_DATA_DIR, READ_MODE };
   private Configuration _instanceDataManagerConfiguration = null;
 
@@ -129,6 +132,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public boolean isEnableSplitCommit() {
     return _instanceDataManagerConfiguration.getBoolean(ENABLE_SPLIT_COMMIT, false);
+  }
+
+  @Override
+  public boolean isRealtimeOffHeapAllocation() {
+    return _instanceDataManagerConfiguration.getBoolean(REALTIME_OFFHEAP_ALLOCATION, false);
   }
 
   @Override

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -27,6 +27,7 @@ import com.linkedin.pinot.common.utils.MmapUtils;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.common.utils.ZkUtils;
+import com.linkedin.pinot.core.data.manager.offline.TableDataManagerProvider;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentMetadataLoader;
 import com.linkedin.pinot.server.conf.ServerConf;
 import com.linkedin.pinot.server.realtime.ControllerLeaderLocator;

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/integration/realtime/RealtimeTableDataManagerTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/integration/realtime/RealtimeTableDataManagerTest.java
@@ -125,6 +125,7 @@ public class RealtimeTableDataManagerTest {
     when(dataManagerConfig.getSegmentFormatVersion()).thenReturn(null);
     when(dataManagerConfig.isEnableDefaultColumns()).thenReturn(false);
     when(dataManagerConfig.isEnableSplitCommit()).thenReturn(false);
+    when(dataManagerConfig.isRealtimeOffHeapAllocation()).thenReturn(false);
     return dataManagerConfig;
   }
 


### PR DESCRIPTION
Added a server config (pinot.server.instance.realtime.alloc.offheap to be set to "true") for off-heap
allocation of memory for dictionary. Currently, off-heap dictionary is always memory-mapped.

Mmap files for dictionary are in <dataDir>/<tableName>/consumers/<segmentName>.{0, 1, ...}. Multiple columns
use the same file (0.5g in size), until the entire file is mapped, and then a new file is created if any column
needs more memory.

Past history of column statistics are stored in <dataDir>/<tableName>/consumers/stats.ser. History is saved
in a circular buffer that has room for 16 segments. The file is persisted across restarts of the same server.
The handle for the stats file is created when the TableDataManager is created for that
table (i.e when the first segment for that table is assigned to a server).

The same stats object is kept around in memory until the server shuts down.
The file is modified by adding new segment statistics each time a consuming segment is destroyed.