### PR TITLE
Fix time granularity in anomalies resource

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -471,8 +471,7 @@ public class AnomalyResource {
       @QueryParam("properties") String properties,
       @QueryParam("isActive") Boolean isActive,
       @QueryParam("frequency") String frequency,
-      @QueryParam("bucketSize") Integer bucketSize,
-      @QueryParam("bucketUnit") String bucketUnit) throws Exception {
+      @QueryParam("bucket") String bucketTimeGranularity) throws Exception {
 
     AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(id);
     if (anomalyFunctionSpec == null) {
@@ -544,16 +543,16 @@ public class AnomalyResource {
       anomalyFunctionSpec.setCron(cron);
     }
 
-    if (bucketSize != null && bucketSize >= 0) {
-      // Update bucket size
-      anomalyFunctionSpec.setBucketSize(bucketSize);
-    }
-
-    if (bucketUnit != null) {
-      // Update bucket time unit
-      TimeUnit bucketTimeUnit = TimeUnit.valueOf(bucketUnit.toUpperCase());
-      if (bucketTimeUnit != null) {
-        anomalyFunctionSpec.setBucketUnit(bucketTimeUnit);
+    if (bucketTimeGranularity != null) {
+      // Update bucket size and unit
+      TimeGranularity timeGranularity = TimeGranularity.fromString(bucketTimeGranularity);
+      if (timeGranularity != null) {
+        anomalyFunctionSpec.setBucketSize(timeGranularity.getSize());
+        anomalyFunctionSpec.setBucketUnit(timeGranularity.getUnit());
+      } else {
+        LOG.warn("Non-feasible time granularity expression: {}", bucketTimeGranularity);
+        return Response.status(Response.Status.BAD_REQUEST)
+            .entity("Non-feasible time granularity expression: " + bucketTimeGranularity).build();
       }
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -470,7 +470,9 @@ public class AnomalyResource {
       @QueryParam("filters") String filters,
       @QueryParam("properties") String properties,
       @QueryParam("isActive") Boolean isActive,
-      @QueryParam("frequency") String frequency) throws Exception {
+      @QueryParam("frequency") String frequency,
+      @QueryParam("bucketSize") Integer bucketSize,
+      @QueryParam("bucketUnit") String bucketUnit) throws Exception {
 
     AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(id);
     if (anomalyFunctionSpec == null) {
@@ -540,6 +542,19 @@ public class AnomalyResource {
         throw new IllegalArgumentException("Invalid cron expression for cron : " + cron);
       }
       anomalyFunctionSpec.setCron(cron);
+    }
+
+    if (bucketSize != null && bucketSize >= 0) {
+      // Update bucket size
+      anomalyFunctionSpec.setBucketSize(bucketSize);
+    }
+
+    if (bucketUnit != null) {
+      // Update bucket time unit
+      TimeUnit bucketTimeUnit = TimeUnit.valueOf(bucketUnit.toUpperCase());
+      if (bucketTimeUnit != null) {
+        anomalyFunctionSpec.setBucketUnit(bucketTimeUnit);
+      }
     }
 
     if (StringUtils.isNotEmpty(frequency)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -471,7 +471,7 @@ public class AnomalyResource {
       @QueryParam("properties") String properties,
       @QueryParam("isActive") Boolean isActive,
       @QueryParam("frequency") String frequency,
-      @QueryParam("bucket") String bucketTimeGranularity) throws Exception {
+      @QueryParam("bucket") String userInputDataGranularity) throws Exception {
 
     AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(id);
     if (anomalyFunctionSpec == null) {
@@ -543,16 +543,16 @@ public class AnomalyResource {
       anomalyFunctionSpec.setCron(cron);
     }
 
-    if (bucketTimeGranularity != null) {
+    if (userInputDataGranularity != null) {
       // Update bucket size and unit
-      TimeGranularity timeGranularity = TimeGranularity.fromString(bucketTimeGranularity);
+      TimeGranularity timeGranularity = TimeGranularity.fromString(userInputDataGranularity);
       if (timeGranularity != null) {
         anomalyFunctionSpec.setBucketSize(timeGranularity.getSize());
         anomalyFunctionSpec.setBucketUnit(timeGranularity.getUnit());
       } else {
-        LOG.warn("Non-feasible time granularity expression: {}", bucketTimeGranularity);
+        LOG.warn("Non-feasible time granularity expression: {}", userInputDataGranularity);
         return Response.status(Response.Status.BAD_REQUEST)
-            .entity("Non-feasible time granularity expression: " + bucketTimeGranularity).build();
+            .entity("Non-feasible time granularity expression: " + userInputDataGranularity).build();
       }
     }
 


### PR DESCRIPTION
The getTimelinesViewInMonitoringWindow() takes only the bucket time granularity from dataset configs. The function also has bucket time granularity from user. This design fails when the two config are not the same. This pull request is to resolve this issue. It takes both definitions of buckets, and apply the definition from function in default. But, it also compares the definition from dataset. If the function's is smaller than the dataset's, it applies the dataset's instead.

Another part is to allow users to update function bucket time granularity via the function update endpoint.