### PR TITLE
[TE] Fix Anomaly Merge Logic

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyTimeBasedSummarizer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyTimeBasedSummarizer.java
@@ -79,6 +79,7 @@ public abstract class AnomalyTimeBasedSummarizer {
         MergedAnomalyResultDTO currAnomaly = new MergedAnomalyResultDTO();
         populateMergedResult(currAnomaly, currentResult);
         // if the merging is applying sequential gap and current anomaly has gap time larger than sequentialAllowedGap
+        // or the duration of the anomaly to be merged is longer than the maxMergedDurationMillis
         // or current anomaly is not equal on mergeable keys with mergedAnomaly
         // should not merge the two and split from here
         if ((applySequentialGapBasedSplit

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyTimeBasedSummarizer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyTimeBasedSummarizer.java
@@ -83,6 +83,8 @@ public abstract class AnomalyTimeBasedSummarizer {
         // should not merge the two and split from here
         if ((applySequentialGapBasedSplit
             && (currentResult.getStartTime() - mergedAnomaly.getEndTime()) > sequentialAllowedGap)
+            || ( applyMaxDurationBasedSplit
+            && (currentResult.getEndTime() - mergedAnomaly.getStartTime()) > maxMergedDurationMillis)
             || (!isEqualOnMergeableKeys(mergedAnomaly, currAnomaly, mergeablePropertyKeys))) {
 
           // Split here
@@ -103,21 +105,6 @@ public abstract class AnomalyTimeBasedSummarizer {
             mergedAnomaly.getAnomalyResults().add(currentResult);
             currentResult.setMerged(true);
           }
-        }
-      }
-
-      // till this point merged result contains current raw result
-      if (applyMaxDurationBasedSplit
-          // check if Max Duration for merged has passed, if so, create new one
-          && mergedAnomaly.getEndTime() - mergedAnomaly.getStartTime() >= maxMergedDurationMillis) {
-        // check if next anomaly has same start time as current one, that should be merged with current one too
-        if (i < (anomalies.size() - 1) && anomalies.get(i + 1).getStartTime()
-            .equals(currentResult.getStartTime())) {
-          // no need to split as we want to include the next raw anomaly into the current one
-        } else {
-          // Split here
-          mergedAnomalies.add(mergedAnomaly);
-          mergedAnomaly = null;
         }
       }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/merge/TestAnomalyTimeBasedSummarizer.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/merge/TestAnomalyTimeBasedSummarizer.java
@@ -45,6 +45,7 @@ public class TestAnomalyTimeBasedSummarizer {
     List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
         .mergeAnomalies(mergedAnomaly, rawAnomalyResults, anomalyMergeConfig);
 
+    // There should be two merged anomaly: 1) mergedAnomaly + rawAnomalyResult1 and 2) rawAnomalyResult2
     assert(mergedResults.size() == 2);
     // Check if the first raw anomaly is merged with the merged anomaly
     MergedAnomalyResultDTO firstMergedAnomaly = mergedResults.get(0);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/merge/TestAnomalyTimeBasedSummarizer.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/merge/TestAnomalyTimeBasedSummarizer.java
@@ -1,0 +1,59 @@
+package com.linkedin.thirdeye.anomaly.merge;
+
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
+import com.linkedin.thirdeye.util.JodaDateTimeUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+
+public class TestAnomalyTimeBasedSummarizer {
+  @Test
+  public void testMergeAnomalies(){
+    AnomalyFunctionDTO anomalyFunction = new AnomalyFunctionDTO();
+    anomalyFunction.setCollection("test");
+    // anomaly merge config initialization
+    AnomalyMergeConfig anomalyMergeConfig = new AnomalyMergeConfig();
+    anomalyMergeConfig.setSequentialAllowedGap(TimeUnit.MINUTES.toMillis(30)); // merge anomalies apart 30 minutes
+    anomalyMergeConfig.setMaxMergeDurationLength(TimeUnit.DAYS.toMillis(2)); // break anomaly longer than 1 days 23 hours
+    anomalyMergeConfig.setMergeStrategy(AnomalyMergeStrategy.FUNCTION_DIMENSIONS);
+    anomalyMergeConfig.setMergeablePropertyKeys(Collections.EMPTY_LIST);
+
+    // Target Merged Anomaly
+    MergedAnomalyResultDTO mergedAnomaly = new MergedAnomalyResultDTO();
+    mergedAnomaly.setCollection(anomalyFunction.getCollection());
+    mergedAnomaly.setFunction(anomalyFunction);
+    mergedAnomaly.setStartTime(JodaDateTimeUtils.toDateTime("2017-07-04T00:00:00Z").getMillis());
+    mergedAnomaly.setEndTime(JodaDateTimeUtils.toDateTime("2017-07-04T23:59:59Z").getMillis());
+
+    List<RawAnomalyResultDTO> rawAnomalyResults = new ArrayList<>();
+    RawAnomalyResultDTO rawAnomalyResult1 = new RawAnomalyResultDTO();
+    rawAnomalyResult1.setFunction(anomalyFunction);
+    rawAnomalyResult1.setStartTime(JodaDateTimeUtils.toDateTime("2017-07-05T00:00:00Z").getMillis());
+    rawAnomalyResult1.setEndTime(JodaDateTimeUtils.toDateTime("2017-07-05T23:59:59Z").getMillis());
+    RawAnomalyResultDTO rawAnomalyResult2 = new RawAnomalyResultDTO();
+    rawAnomalyResult2.setFunction(anomalyFunction);
+    rawAnomalyResult2.setStartTime(JodaDateTimeUtils.toDateTime("2017-07-06T00:00:00Z").getMillis());
+    rawAnomalyResult2.setEndTime(JodaDateTimeUtils.toDateTime("2017-07-06T23:59:59Z").getMillis());
+    rawAnomalyResults.add(rawAnomalyResult1);
+    rawAnomalyResults.add(rawAnomalyResult2);
+
+    List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
+        .mergeAnomalies(mergedAnomaly, rawAnomalyResults, anomalyMergeConfig);
+
+    assert(mergedResults.size() == 2);
+    // Check if the first raw anomaly is merged with the merged anomaly
+    MergedAnomalyResultDTO firstMergedAnomaly = mergedResults.get(0);
+    assert(firstMergedAnomaly.getStartTime() == mergedAnomaly.getStartTime());
+    assert(firstMergedAnomaly.getEndTime() == rawAnomalyResult1.getEndTime());
+
+    MergedAnomalyResultDTO secondMergedAnomaly = mergedResults.get(1);
+    assert(secondMergedAnomaly.getStartTime() == rawAnomalyResult2.getStartTime());
+    assert(secondMergedAnomaly.getEndTime() == rawAnomalyResult2.getEndTime());
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/merge/TestAnomalyTimeBasedSummarizer.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/merge/TestAnomalyTimeBasedSummarizer.java
@@ -42,6 +42,7 @@ public class TestAnomalyTimeBasedSummarizer {
     rawAnomalyResults.add(rawAnomalyResult1);
     rawAnomalyResults.add(rawAnomalyResult2);
 
+    // Test when raw anomalies come in bulk
     List<MergedAnomalyResultDTO> mergedResults = AnomalyTimeBasedSummarizer
         .mergeAnomalies(mergedAnomaly, rawAnomalyResults, anomalyMergeConfig);
 
@@ -52,7 +53,31 @@ public class TestAnomalyTimeBasedSummarizer {
     assert(firstMergedAnomaly.getStartTime() == mergedAnomaly.getStartTime());
     assert(firstMergedAnomaly.getEndTime() == rawAnomalyResult1.getEndTime());
 
+    // Check if the second anomaly is not merged with the merged anomaly
     MergedAnomalyResultDTO secondMergedAnomaly = mergedResults.get(1);
+    assert(secondMergedAnomaly.getStartTime() == rawAnomalyResult2.getStartTime());
+    assert(secondMergedAnomaly.getEndTime() == rawAnomalyResult2.getEndTime());
+
+    rawAnomalyResults.clear();
+
+    // Test when raw anomalies come one-by-one
+    rawAnomalyResults.add(rawAnomalyResult1);
+    mergedResults = AnomalyTimeBasedSummarizer
+        .mergeAnomalies(mergedAnomaly, rawAnomalyResults, anomalyMergeConfig);
+    assert(mergedResults.size() == 1);
+    rawAnomalyResults.clear();
+    rawAnomalyResults.add(rawAnomalyResult2);
+    mergedResults = AnomalyTimeBasedSummarizer
+        .mergeAnomalies(mergedAnomaly, rawAnomalyResults, anomalyMergeConfig);
+    assert(mergedResults.size() == 2);
+
+    // Check if the first raw anomaly is merged with the merged anomaly
+    firstMergedAnomaly = mergedResults.get(0);
+    assert(firstMergedAnomaly.getStartTime() == mergedAnomaly.getStartTime());
+    assert(firstMergedAnomaly.getEndTime() == rawAnomalyResult1.getEndTime());
+
+    // Check if the second anomaly is not merged with the merged anomaly
+    secondMergedAnomaly = mergedResults.get(1);
     assert(secondMergedAnomaly.getStartTime() == rawAnomalyResult2.getStartTime());
     assert(secondMergedAnomaly.getEndTime() == rawAnomalyResult2.getEndTime());
   }


### PR DESCRIPTION
During the onboard of multiple anomaly functions, we discover that the anomalies are merged more than 7 days (default max duration). The logic in AnomalyTimeBasedSummarizer merges the anomaly first and then decide to split if the anomaly duration is too long. It works in some situation, but not feasible in real-life situation. If every time there is only one raw anomaly to merge, the anomaly is merged without checking the duration. This pull request move the duration-checker to the if condition, where the split decision is made. A test function is provided to prove the correctness.