### PR TITLE
[TE] Extend autotune to take user configurable parameters

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutoTune.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutoTune.java
@@ -4,11 +4,13 @@ import java.util.Map;
 
 
 /**
- * Created by ychung on 2/9/17.
+ * The interface of AlertFilterAutoTuning.
+ * Tuning based on user provided labels with machine learning methodology
  */
 public interface AlertFilterAutoTune {
 
-  // Tune alert filter based on training data
+  // Tune alert filter based on training data and model configuration
+  // Returns the tuned alert filter configuration
   Map<String, String> tuneAlertFilter() throws Exception;
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutoTune.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutoTune.java
@@ -1,10 +1,6 @@
 package com.linkedin.thirdeye.anomalydetection.alertFilterAutotune;
 
-import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
-import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
-import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 
 /**
@@ -12,15 +8,7 @@ import java.util.Properties;
  */
 public interface AlertFilterAutoTune {
 
-  // get initiated alert filter when input has no positive label, use nExpectedAnomalies
-  // return the alert filter that can guarantee top nExpectedAnomalies to recommend to clients
-  Map<String, String> initiateAutoTune(List<MergedAnomalyResultDTO> anomalyResults, int nExpectedAnomalies) throws Exception;
-
-  // Tune the alert filter properties using labeled anomalies
-  // precision and recall need to be improved over old setting
-  Map<String, String> tuneAlertFilter(List<MergedAnomalyResultDTO> anomalyResults, double currentPrecision, double currentRecall) throws Exception;
-
-  // True if model has been updated (improved)
-  boolean isUpdated();
+  // Tune alert filter based on training data
+  Map<String, String> tuneAlertFilter() throws Exception;
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutotuneFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutotuneFactory.java
@@ -1,14 +1,18 @@
 package com.linkedin.thirdeye.anomalydetection.alertFilterAutotune;
 
-import com.linkedin.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
-import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
-import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
-import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
-import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
+import com.linkedin.thirdeye.anomaly.detection.lib.AutotuneMethodType;
+import com.linkedin.thirdeye.anomalydetection.performanceEvaluation.PerformanceEvaluate;
+import com.linkedin.thirdeye.anomalydetection.performanceEvaluation.PerformanceEvaluationMethod;
+import com.linkedin.thirdeye.datalayer.bao.AutotuneConfigManager;
+import com.linkedin.thirdeye.datalayer.dto.AutotuneConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilter;
+import com.linkedin.thirdeye.detector.email.filter.BaseAlertFilter;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
@@ -51,18 +55,21 @@ public class AlertFilterAutotuneFactory {
     }
   }
 
-  public AlertFilterAutoTune fromSpec(String AutoTuneType) {
-    AlertFilterAutoTune alertFilterAutoTune = new DummyAlertFilterAutoTune();
+  public BaseAlertFilterAutoTune fromSpec(String AutoTuneType) {
+    BaseAlertFilterAutoTune alertFilterAutoTune = new DummyAlertFilterAutoTune();
     if (!props.containsKey(AutoTuneType)) {
       LOGGER.warn("AutoTune from Spec: Unsupported type " + AutoTuneType);
     } else{
       try {
         String className = props.getProperty(AutoTuneType);
-        alertFilterAutoTune = (AlertFilterAutoTune) Class.forName(className).newInstance();
+        alertFilterAutoTune = (BaseAlertFilterAutoTune) Class.forName(className).newInstance();
       } catch (Exception e) {
         LOGGER.warn("Failed to init AutoTune from Spec: {}", e.getMessage());
       }
     }
     return alertFilterAutoTune;
   }
+
+
+
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutotuneFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/AlertFilterAutotuneFactory.java
@@ -55,7 +55,7 @@ public class AlertFilterAutotuneFactory {
     }
   }
 
-  public BaseAlertFilterAutoTune fromSpec(String AutoTuneType) {
+  public BaseAlertFilterAutoTune fromSpec(String AutoTuneType, AutotuneConfigDTO autotuneConfigDTO, List<MergedAnomalyResultDTO> anomalies) {
     BaseAlertFilterAutoTune alertFilterAutoTune = new DummyAlertFilterAutoTune();
     if (!props.containsKey(AutoTuneType)) {
       LOGGER.warn("AutoTune from Spec: Unsupported type " + AutoTuneType);
@@ -63,6 +63,7 @@ public class AlertFilterAutotuneFactory {
       try {
         String className = props.getProperty(AutoTuneType);
         alertFilterAutoTune = (BaseAlertFilterAutoTune) Class.forName(className).newInstance();
+        alertFilterAutoTune.init(anomalies, autotuneConfigDTO);
       } catch (Exception e) {
         LOGGER.warn("Failed to init AutoTune from Spec: {}", e.getMessage());
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
@@ -12,6 +12,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The abstract class for Alert Filter AutoTune
+ * BaseAlertFilterAutoTune initiates the AutoTune class by assigning training and tuning configuration
+ * BaseAlertFilterAutoTune is designed to be extended by specific AlertFilterAutoTune class
  */
 public abstract class BaseAlertFilterAutoTune implements AlertFilterAutoTune {
   private final static Logger LOG = LoggerFactory.getLogger(BaseAlertFilterAutoTune.class);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
@@ -5,6 +5,7 @@ import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilter;
 import com.linkedin.thirdeye.detector.email.filter.PrecisionRecallEvaluator;
 import java.util.List;
+import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,19 @@ public abstract class BaseAlertFilterAutoTune implements AlertFilterAutoTune {
 
   public AutotuneConfigDTO getAutotuneConfig() {
     return this.autotuneConfig;
+  }
+
+
+  public Properties getTuningProperties() {
+    return this.autotuneConfig.getTuningProps();
+  }
+
+  public void setAutotuneConfig(AutotuneConfigDTO autotuneConfig) {
+    this.autotuneConfig = autotuneConfig;
+  }
+
+  public void setTuningProperties(Properties tuningProps) {
+    this.autotuneConfig.setTuningProps(tuningProps);
   }
 
   public List<MergedAnomalyResultDTO> getTrainingAnomalies() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
@@ -1,0 +1,40 @@
+package com.linkedin.thirdeye.anomalydetection.alertFilterAutotune;
+
+import com.linkedin.thirdeye.datalayer.dto.AutotuneConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilter;
+import com.linkedin.thirdeye.detector.email.filter.PrecisionRecallEvaluator;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public abstract class BaseAlertFilterAutoTune implements AlertFilterAutoTune {
+  private final static Logger LOG = LoggerFactory.getLogger(BaseAlertFilterAutoTune.class);
+
+  protected AutotuneConfigDTO autotuneConfig;
+  protected List<MergedAnomalyResultDTO> trainingAnomalies;
+
+  public void init(List<MergedAnomalyResultDTO> anomalies, AutotuneConfigDTO autotuneConfig) {
+    this.trainingAnomalies = anomalies;
+    this.autotuneConfig = autotuneConfig;
+  }
+
+  public PrecisionRecallEvaluator getEvaluator(AlertFilter alertFilter, List<MergedAnomalyResultDTO> anomalies){
+    return new PrecisionRecallEvaluator(alertFilter, anomalies);
+  }
+
+  public AutotuneConfigDTO getAutotuneConfig() {
+    return this.autotuneConfig;
+  }
+
+  public List<MergedAnomalyResultDTO> getTrainingAnomalies() {
+    return this.trainingAnomalies;
+  }
+
+  public AlertFilter getAlertFilter() {
+    return this.autotuneConfig.getAlertFilter();
+  }
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/BaseAlertFilterAutoTune.java
@@ -10,6 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+/**
+ * The abstract class for Alert Filter AutoTune
+ */
 public abstract class BaseAlertFilterAutoTune implements AlertFilterAutoTune {
   private final static Logger LOG = LoggerFactory.getLogger(BaseAlertFilterAutoTune.class);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/DummyAlertFilterAutoTune.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/DummyAlertFilterAutoTune.java
@@ -1,28 +1,16 @@
 package com.linkedin.thirdeye.anomalydetection.alertFilterAutotune;
 
-import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 
-public class DummyAlertFilterAutoTune implements AlertFilterAutoTune {
+public class DummyAlertFilterAutoTune extends BaseAlertFilterAutoTune {
 
   @Override
-  public Map<String, String> initiateAutoTune(List<MergedAnomalyResultDTO> anomalyResults, int nExpectedAnomalies)
-      throws Exception {
-    return Collections.emptyMap();
-  }
-
-  @Override
-  public Map<String, String> tuneAlertFilter(List<MergedAnomalyResultDTO> anomalyResults, double currentPrecision,
-      double currentRecall) throws Exception {
+  public Map<String, String> tuneAlertFilter() throws Exception {
     // do nothing and return empty map
     return Collections.emptyMap();
   }
 
-  @Override
-  public boolean isUpdated() {
-    return false;
-  }
+
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/FilterPattern.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/FilterPattern.java
@@ -1,6 +1,0 @@
-package com.linkedin.thirdeye.anomalydetection.alertFilterAutotune;
-
-public enum FilterPattern {
-  UP,
-  DOWN
-}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/FilterPattern.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/alertFilterAutotune/FilterPattern.java
@@ -1,0 +1,6 @@
+package com.linkedin.thirdeye.anomalydetection.alertFilterAutotune;
+
+public enum FilterPattern {
+  UP,
+  DOWN
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -590,11 +590,8 @@ public class DetectionJobResource {
     // get current alert filter, TODO: if no need to create blank alert filter
     BaseAlertFilter alertFilter = alertFilterFactory.fromSpec(anomalyFunctionSpec.getAlertFilter());
     // create alert filter auto tune
-    BaseAlertFilterAutoTune alertFilterAutotune = alertFilterAutotuneFactory.fromSpec(autoTuneType);
     AutotuneConfigDTO autotuneConfig = new AutotuneConfigDTO(alertFilter);
-
-    //init
-    alertFilterAutotune.init(anomalies, autotuneConfig);
+    BaseAlertFilterAutoTune alertFilterAutotune = alertFilterAutotuneFactory.fromSpec(autoTuneType, autotuneConfig, anomalies);
     LOG.info("initiated alertFilterAutoTune of Type {}", alertFilterAutotune.getClass().toString());
 
     String autotuneId = null;
@@ -671,8 +668,7 @@ public class DetectionJobResource {
     AutotuneConfigDTO autotuneConfig = new AutotuneConfigDTO(tuningProperties);
 
     // create alert filter auto tune
-    BaseAlertFilterAutoTune alertFilterAutotune = alertFilterAutotuneFactory.fromSpec(autoTuneType);
-    alertFilterAutotune.init(anomalies, autotuneConfig);
+    BaseAlertFilterAutoTune alertFilterAutotune = alertFilterAutotuneFactory.fromSpec(autoTuneType, autotuneConfig, anomalies);
     LOG.info("initiated alertFilterAutoTune of Type {}", alertFilterAutotune.getClass().toString());
 
     String autotuneId = null;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -2,7 +2,6 @@ package com.linkedin.thirdeye.dashboard.resources;
 
 
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.BaseAlertFilterAutoTune;
-import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.FilterPattern;
 import com.linkedin.thirdeye.detector.email.filter.BaseAlertFilter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,7 +41,6 @@ import com.linkedin.thirdeye.anomaly.detection.lib.AutotuneMethodType;
 import com.linkedin.thirdeye.anomaly.detection.lib.FunctionReplayRunnable;
 import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
-import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutoTune;
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.anomalydetection.performanceEvaluation.PerformanceEvaluateHelper;
 import com.linkedin.thirdeye.anomalydetection.performanceEvaluation.PerformanceEvaluationMethod;
@@ -680,6 +678,8 @@ public class DetectionJobResource {
       LOG.warn("Exception when tune alert filter, {}", e.getMessage());
     }
     // write to DB
+    autotuneConfig.setFunctionId(id);
+    autotuneConfig.setAutotuneMethod(AutotuneMethodType.INITIATE_ALERT_FILTER_LOGISTIC_AUTO_TUNE);
     autotuneId = DAO_REGISTRY.getAutotuneConfigDAO().save(autotuneConfig).toString();
 
     return Response.ok(autotuneId).build();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -604,6 +604,7 @@ public class DetectionJobResource {
     }
 
     // write to DB
+    autotuneConfig.setFunctionId(id);
     autotuneId = DAO_REGISTRY.getAutotuneConfigDAO().save(autotuneConfig).toString();
     return Response.ok(autotuneId).build();
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/EmailResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/EmailResource.java
@@ -294,7 +294,7 @@ public class EmailResource {
 
     return generateAnomalyReportForAnomalies(anomalyReportGenerator, anomalies, isApplyFilter, startTime, endTime, null,
         null, subject, includeSentAnomaliesOnly, toAddr, fromAddr, "Thirdeye Anomaly Report", true,
-        teHost, smtpHost, smtpPort);
+        teHost, smtpConfiguration.getSmtpHost(), smtpConfiguration.getSmtpPort());
   }
 
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AutotuneConfigDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AutotuneConfigDTO.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 public class AutotuneConfigDTO extends AutotuneConfigBean {
   private static final Logger LOGGER = LoggerFactory.getLogger(AutotuneConfigDTO.class);
   private AlertFilter alertFilter = new DummyAlertFilter();
-  private Properties properties;
+  private Properties tuningProps = new Properties();
 
   public AutotuneConfigDTO() {
 
@@ -26,11 +26,11 @@ public class AutotuneConfigDTO extends AutotuneConfigBean {
   // populate alert filter to autotune configuration as tuning properties
   public AutotuneConfigDTO(BaseAlertFilter alertFilter){
     setAlertFilter(alertFilter);
-    this.properties = alertFilter.toProperties();
+    this.tuningProps = alertFilter.toProperties();
   }
 
   public AutotuneConfigDTO(Properties properties) {
-    setProperties(properties);
+    setTuningProps(properties);
   }
 
 
@@ -42,12 +42,12 @@ public class AutotuneConfigDTO extends AutotuneConfigBean {
     return this.alertFilter;
   }
 
-  public void setProperties(Properties properties) {
-    this.properties = properties;
+  public void setTuningProps(Properties tuningProps) {
+    this.tuningProps = tuningProps;
   }
 
-  public Properties getProperties() {
-    return this.properties;
+  public Properties getTuningProps() {
+    return this.tuningProps;
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AutotuneConfigDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AutotuneConfigDTO.java
@@ -1,11 +1,53 @@
 package com.linkedin.thirdeye.datalayer.dto;
 
 import com.linkedin.thirdeye.datalayer.pojo.AutotuneConfigBean;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilter;
+import com.linkedin.thirdeye.detector.email.filter.BaseAlertFilter;
+import com.linkedin.thirdeye.detector.email.filter.DummyAlertFilter;
+import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+/**
+ * Auto Tune Configuration DTO. Given Alert filter, add alert filter setting to autotune config properties
+ * When autotune being triggered, autotuneConfig will be passed to tuning steps
+ */
 public class AutotuneConfigDTO extends AutotuneConfigBean {
   private static final Logger LOGGER = LoggerFactory.getLogger(AutotuneConfigDTO.class);
+  private AlertFilter alertFilter = new DummyAlertFilter();
+  private Properties properties;
+
+  public AutotuneConfigDTO() {
+
+  }
+
+  // set current alert filter for comparison;
+  // populate alert filter to autotune configuration as tuning properties
+  public AutotuneConfigDTO(BaseAlertFilter alertFilter){
+    setAlertFilter(alertFilter);
+    this.properties = alertFilter.toProperties();
+  }
+
+  public AutotuneConfigDTO(Properties properties) {
+    setProperties(properties);
+  }
+
+
+  public void setAlertFilter(AlertFilter alertFilter) {
+    this.alertFilter = alertFilter;
+  }
+
+  public AlertFilter getAlertFilter() {
+    return this.alertFilter;
+  }
+
+  public void setProperties(Properties properties) {
+    this.properties = properties;
+  }
+
+  public Properties getProperties() {
+    return this.properties;
+  }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AutotuneConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AutotuneConfigBean.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.MoreObjects;
 import com.linkedin.thirdeye.anomaly.detection.lib.AutotuneMethodType;
 import com.linkedin.thirdeye.anomalydetection.performanceEvaluation.PerformanceEvaluationMethod;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.joda.time.DateTime;
@@ -26,7 +27,7 @@ public class AutotuneConfigBean extends AbstractBean {
   // The goal of the autotune
   private double goal;
   // The tuned properties configuration
-  private Map<String, String> configuration;
+  private Map<String, String> configuration = new HashMap<>();
   // The average running time for each thread while doing autotune
   private long avgRunningTime;
   // The overall running time  while doing autotune

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlertFilterFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/AlertFilterFactory.java
@@ -59,18 +59,18 @@ public class AlertFilterFactory {
    * does not have an alert filter spec or this method fails to initiates an alert filter from the
    * spec.
    */
-  public AlertFilter fromSpec(Map<String, String> alertFilterSpec) {
+  public BaseAlertFilter fromSpec(Map<String, String> alertFilterSpec) {
     if (alertFilterSpec == null) {
       alertFilterSpec = Collections.emptyMap();
     }
     // the default alert filter is DummyAlertFilter
-    AlertFilter alertFilter = new DummyAlertFilter();
+    BaseAlertFilter alertFilter = new DummyAlertFilter();
     if (alertFilterSpec.containsKey(FILTER_TYPE_KEY)) {
       String alertFilterType = alertFilterSpec.get(FILTER_TYPE_KEY);
       if(props.containsKey(alertFilterType.toUpperCase())) {
         String className = props.getProperty(alertFilterType.toUpperCase());
         try {
-          alertFilter = (AlertFilter) Class.forName(className).newInstance();
+          alertFilter = (BaseAlertFilter) Class.forName(className).newInstance();
         } catch (Exception e) {
           LOGGER.warn(e.getMessage());
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.detector.email.filter;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.Properties;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +10,6 @@ import org.slf4j.LoggerFactory;
 
 public abstract class BaseAlertFilter implements AlertFilter {
   private final static Logger LOG = LoggerFactory.getLogger(BaseAlertFilter.class);
-
 
 
   /**
@@ -76,5 +76,10 @@ public abstract class BaseAlertFilter implements AlertFilter {
         LOG.warn("Failed to set the field {} for class {} exception: {}", fieldName, c.getSimpleName(), e.toString());
       }
     }
+  }
+
+
+  public Properties toProperties(){
+    return new Properties();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/DummyAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/DummyAlertFilter.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Properties;
 
 
-public class DummyAlertFilter implements AlertFilter {
+public class DummyAlertFilter extends BaseAlertFilter {
   @Override
   public List<String> getPropertyNames() {
     return Collections.EMPTY_LIST;


### PR DESCRIPTION
Cloned from https://github.com/linkedin/pinot/pull/1736
Previously auto-tuning is taking fixed parameters. Now extend auto-tuning to take free-formed configuration and complete a two-sided tuning.