### PR TITLE
Add list of DateTimeFieldSpec to Schema

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
@@ -32,6 +32,12 @@ import com.linkedin.pinot.common.utils.EqualityUtils;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class DateTimeFieldSpec extends FieldSpec {
 
+  private static final String FORMAT_TOKENS_ERROR_STR = "format must be of pattern size:timeunit:timeformat(:pattern)";
+  private static final String FORMAT_PATTERN_ERROR_STR = "format must be of format [0-9]+:<TimeUnit>:<TimeFormat>(:pattern)";
+  private static final String TIME_FORMAT_ERROR_STR =
+      "format must be of format [0-9]+:<TimeUnit>:EPOCH or [0-9]+:<TimeUnit>:SIMPLE_DATE_FORMAT:<format>";
+  private static final String GRANULARITY_TOKENS_ERROR_STR = "granularity must be of format size:timeunit";
+  private static final String GRANULARITY_PATTERN_ERROR_STR = "granularity must be of format [0-9]+:<TimeUnit>";
   private static final String NUMBER_REGEX = "[1-9][0-9]*";
   private static final String COLON_SEPARATOR = ":";
 
@@ -150,22 +156,22 @@ public final class DateTimeFieldSpec extends FieldSpec {
     Preconditions.checkNotNull(format);
     String[] formatTokens = format.split(COLON_SEPARATOR);
     Preconditions.checkArgument(formatTokens.length == 3 || formatTokens.length == 4,
-        "format must be of format size:timeunit:timeformat(:pattern)");
+        FORMAT_TOKENS_ERROR_STR);
     Preconditions.checkArgument(formatTokens[0].matches(NUMBER_REGEX)
-        && EnumUtils.isValidEnum(TimeUnit.class, formatTokens[1]), "format must be of format [0-9]+:<TimeUnit>:<TimeFormat>(:pattern)");
+        && EnumUtils.isValidEnum(TimeUnit.class, formatTokens[1]), FORMAT_PATTERN_ERROR_STR);
     if (formatTokens.length == 3) {
       Preconditions.checkArgument(formatTokens[2].equals(TimeFormat.EPOCH.toString()),
-          "format must be of format [0-9]+:<TimeUnit>:EPOCH or [0-9]+:<TimeUnit>:SIMPLE_DATE_FORMAT:<format>");
+          TIME_FORMAT_ERROR_STR);
     } else {
       Preconditions.checkArgument(formatTokens[2].equals(TimeFormat.SIMPLE_DATE_FORMAT.toString()),
-          "format must be of format [0-9]+:<TimeUnit>:EPOCH or [0-9]+:<TimeUnit>:SIMPLE_DATE_FORMAT:<format>");
+          TIME_FORMAT_ERROR_STR);
     }
 
     Preconditions.checkNotNull(granularity);
     String[] granularityTokens = granularity.split(COLON_SEPARATOR);
-    Preconditions.checkArgument(granularityTokens.length == 2, "granularity must be of format size:timeunit");
+    Preconditions.checkArgument(granularityTokens.length == 2, GRANULARITY_TOKENS_ERROR_STR);
     Preconditions.checkArgument(granularityTokens[0].matches(NUMBER_REGEX)
-        && EnumUtils.isValidEnum(TimeUnit.class, granularityTokens[1]), "granularity must be of format [0-9]+:<TimeUnit>");
+        && EnumUtils.isValidEnum(TimeUnit.class, granularityTokens[1]), GRANULARITY_PATTERN_ERROR_STR);
 
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
@@ -95,57 +95,12 @@ public final class DateTimeFieldSpec extends FieldSpec {
    *          the granularity will be 1:HOURS
    */
   public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
-      @Nonnull String granularity, Object defaultNullValue) {
-    super(name, dataType, true, defaultNullValue);
-    check(name, dataType, format, granularity);
-
-    _format = format;
-    _granularity = granularity;
-  }
-
-
-  /**
-   *
-   * @param name
-   * @param dataType
-   * @param format - size:timeunit:timeformat eg: 1:MILLISECONDS:EPOCH, 5:MINUTES:EPOCH, 1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd
-   * @param granularity - size:timeunit eg: 5:MINUTES
-   * @param dateTimeType
-   * @param defaultNullValue
-   */
-  public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
-      @Nonnull String granularity, DateTimeType dateTimeType, Object defaultNullValue) {
-    this(name, dataType, format, granularity, defaultNullValue);
-    _dateTimeType = dateTimeType;
-  }
-
-
-  /**
-   * @param name
-   * @param dataType
-   * @param format - size:timeunit:timeformat eg: 1:MILLISECONDS:EPOCH, 5:MINUTES:EPOCH, 1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd
-   * @param granularity - size:timeunit eg: 5:MINUTES
-   */
-  public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
-      @Nonnull String granularity) {
+      @Nonnull String granularity, DateTimeType dateTimeType) {
     super(name, dataType, true);
     check(name, dataType, format, granularity);
 
     _format = format;
     _granularity = granularity;
-  }
-
-
-  /**
-   * @param name
-   * @param dataType
-   * @param format - size:timeunit:timeformat eg: 1:MILLISECONDS:EPOCH, 5:MINUTES:EPOCH, 1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd
-   * @param granularity - size:timeunit eg: 5:MINUTES
-   * @param dateTimeType
-   */
-  public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
-      @Nonnull String granularity, DateTimeType dateTimeType) {
-    this(name, dataType, format, granularity);
     _dateTimeType = dateTimeType;
   }
 
@@ -188,6 +143,10 @@ public final class DateTimeFieldSpec extends FieldSpec {
     return _format;
   }
 
+  /**
+   * Required by JSON deserializer. DO NOT USE. DO NOT REMOVE.
+   * @param format
+   */
   public void setFormat(String format) {
     _format = format;
   }
@@ -197,6 +156,10 @@ public final class DateTimeFieldSpec extends FieldSpec {
     return _granularity;
   }
 
+  /**
+   * Required by JSON deserializer. DO NOT USE. DO NOT REMOVE.
+   * @param granularity
+   */
   public void setGranularity(String granularity) {
     _granularity = granularity;
   }
@@ -206,6 +169,10 @@ public final class DateTimeFieldSpec extends FieldSpec {
     return _dateTimeType;
   }
 
+  /**
+   * Required by JSON deserializer. DO NOT USE. DO NOT REMOVE.
+   * @param dateTimeType
+   */
   public void setDateTimeType(DateTimeType dateTimeType) {
     _dateTimeType = dateTimeType;
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
@@ -71,6 +71,15 @@ public final class DateTimeFieldSpec extends FieldSpec {
   }
 
 
+  /**
+   *
+   * @param name
+   * @param dataType
+   * @param format - size:timeunit:timeformat eg: 1:MILLISECONDS:EPOCH, 5:MINUTES:EPOCH, 1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd
+   * @param granularity - size:timeunit eg: 5:MINUTES
+   * @param dateTimeType
+   * @param defaultNullValue
+   */
   public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
       @Nonnull String granularity, DateTimeType dateTimeType, Object defaultNullValue) {
     this(name, dataType, format, granularity, defaultNullValue);
@@ -78,6 +87,12 @@ public final class DateTimeFieldSpec extends FieldSpec {
   }
 
 
+  /**
+   * @param name
+   * @param dataType
+   * @param format - size:timeunit:timeformat eg: 1:MILLISECONDS:EPOCH, 5:MINUTES:EPOCH, 1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd
+   * @param granularity - size:timeunit eg: 5:MINUTES
+   */
   public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
       @Nonnull String granularity) {
     super(name, dataType, true);
@@ -88,6 +103,13 @@ public final class DateTimeFieldSpec extends FieldSpec {
   }
 
 
+  /**
+   * @param name
+   * @param dataType
+   * @param format - size:timeunit:timeformat eg: 1:MILLISECONDS:EPOCH, 5:MINUTES:EPOCH, 1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd
+   * @param granularity - size:timeunit eg: 5:MINUTES
+   * @param dateTimeType
+   */
   public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
       @Nonnull String granularity, DateTimeType dateTimeType) {
     this(name, dataType, format, granularity);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DateTimeFieldSpec.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.data;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.EqualityUtils;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class DateTimeFieldSpec extends FieldSpec {
+
+  private static final String NUMBER_REGEX = "[0-9]+";
+  private static final String COLON_SEPARATOR = ":";
+
+  private String _format;
+  private String _granularity;
+  private DateTimeType _dateTimeType;
+
+  public enum DateTimeType {
+    PRIMARY,
+    SECONDARY,
+    DERIVED
+  }
+
+  public enum TimeFormat {
+    EPOCH,
+    SIMPLE_DATE_FORMAT
+  }
+
+  // Default constructor required by JSON de-serializer. DO NOT REMOVE.
+  public DateTimeFieldSpec() {
+    super();
+  }
+
+  /**
+   * @param name
+   * @param dataType
+   * @param format - size:timeunit:timeformat eg: 1:MILLISECONDS:EPOCH, 5:MINUTES:EPOCH, 1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd
+   * @param granularity - size:timeunit eg: 5:MINUTES
+   */
+  public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
+      @Nonnull String granularity, Object defaultNullValue) {
+    super(name, dataType, true, defaultNullValue);
+    check(name, dataType, format, granularity);
+
+    _format = format;
+    _granularity = granularity;
+  }
+
+
+  public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
+      @Nonnull String granularity, DateTimeType dateTimeType, Object defaultNullValue) {
+    this(name, dataType, format, granularity, defaultNullValue);
+    _dateTimeType = dateTimeType;
+  }
+
+
+  public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
+      @Nonnull String granularity) {
+    super(name, dataType, true);
+    check(name, dataType, format, granularity);
+
+    _format = format;
+    _granularity = granularity;
+  }
+
+
+  public DateTimeFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
+      @Nonnull String granularity, DateTimeType dateTimeType) {
+    this(name, dataType, format, granularity);
+    _dateTimeType = dateTimeType;
+  }
+
+  private void check(String name, DataType dataType, String format, String granularity) {
+    Preconditions.checkNotNull(name);
+    Preconditions.checkNotNull(dataType);
+
+    Preconditions.checkNotNull(format);
+    String[] formatTokens = format.split(COLON_SEPARATOR);
+    Preconditions.checkArgument(formatTokens.length == 3 || formatTokens.length == 4,
+        "format must be of format size:timeunit:timeformat(:pattern)");
+    Preconditions.checkArgument(formatTokens[0].matches(NUMBER_REGEX)
+        && EnumUtils.isValidEnum(TimeUnit.class, formatTokens[1]), "format must be of format [0-9]+:<TimeUnit>:<TimeFormat>(:pattern)");
+    if (formatTokens.length == 3) {
+      Preconditions.checkArgument(formatTokens[2].equals(TimeFormat.EPOCH.toString()),
+          "format must be of format [0-9]+:<TimeUnit>:EPOCH or [0-9]+:<TimeUnit>:SIMPLE_DATE_FORMAT:<format>");
+    } else {
+      Preconditions.checkArgument(formatTokens[2].equals(TimeFormat.SIMPLE_DATE_FORMAT.toString()),
+          "format must be of format [0-9]+:<TimeUnit>:EPOCH or [0-9]+:<TimeUnit>:SIMPLE_DATE_FORMAT:<format>");
+    }
+
+    Preconditions.checkNotNull(granularity);
+    String[] granularityTokens = granularity.split(COLON_SEPARATOR);
+    Preconditions.checkArgument(granularityTokens.length == 2, "granularity must be of format size:timeunit");
+    Preconditions.checkArgument(granularityTokens[0].matches(NUMBER_REGEX)
+        && EnumUtils.isValidEnum(TimeUnit.class, granularityTokens[1]), "granularity must be of format [0-9]+:<TimeUnit>");
+
+  }
+
+
+  @JsonIgnore
+  @Nonnull
+  @Override
+  public FieldType getFieldType() {
+    return FieldType.DATE_TIME;
+  }
+
+  @Nonnull
+  public String getFormat() {
+    return _format;
+  }
+
+  public void setFormat(String format) {
+    _format = format;
+  }
+
+  @Nonnull
+  public String getGranularity() {
+    return _granularity;
+  }
+
+  public void setGranularity(String granularity) {
+    _granularity = granularity;
+  }
+
+  @Nullable
+  public DateTimeType getDateTimeType() {
+    return _dateTimeType;
+  }
+
+  public void setDateTimeType(DateTimeType dateTimeType) {
+    _dateTimeType = dateTimeType;
+  }
+
+  public static String constructFormat(int columnSize, TimeUnit columnUnit, String columnTimeFormat) {
+    return Joiner.on(COLON_SEPARATOR).join(columnSize, columnUnit, columnTimeFormat);
+  }
+
+  public static String constructGranularity(int columnSize, TimeUnit columnUnit) {
+    return Joiner.on(COLON_SEPARATOR).join(columnSize, columnUnit);
+  }
+
+  @Override
+  public String toString() {
+    return "< field type: DATE_TIME, field name: " + getName() + ", datatype: " + getDataType()
+        + ", time column format: " + getFormat() + ", time field granularity: " + getGranularity()
+        + ", date time type:" + getDateTimeType() + " >";
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object instanceof DateTimeFieldSpec) {
+      DateTimeFieldSpec that = (DateTimeFieldSpec) object;
+      return getName().equals(that.getName())
+          && getDataType().equals(that.getDataType())
+          && getFormat().equals(that.getFormat())
+          && getGranularity().equals(that.getGranularity())
+          && getDateTimeType() == that.getDateTimeType()
+          && getDefaultNullValue().equals(that.getDefaultNullValue());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getName().hashCode();
+    result = EqualityUtils.hashCodeOf(result, getDataType());
+    result = EqualityUtils.hashCodeOf(result, getFormat());
+    result = EqualityUtils.hashCodeOf(result, getGranularity());
+    result = EqualityUtils.hashCodeOf(result, getDateTimeType());
+    return result;
+  }
+
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -196,7 +196,7 @@ public abstract class FieldSpec {
   public enum FieldType {
     DIMENSION,
     METRIC,
-    @Deprecated TIME,
+    TIME,
     DATE_TIME
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -150,6 +150,7 @@ public abstract class FieldSpec {
             break;
           case DIMENSION:
           case TIME:
+          case DATE_TIME:
             switch (_dataType) {
               case INT:
                 _cachedDefaultNullValue = DEFAULT_DIM_NULL_VALUE_OF_INT;
@@ -189,12 +190,14 @@ public abstract class FieldSpec {
    * <p><code>DIMENSION</code>: columns used to filter records.
    * <p><code>METRIC</code>: columns used to apply aggregation on. <code>METRIC</code> field only contains numeric data.
    * <p><code>TIME</code>: time column (at most one per {@link Schema}). <code>TIME</code> field can be used to prune
+   * <p><code>DATE_TIME</code>: time column (at most one per {@link Schema}). <code>TIME</code> field can be used to prune
    * segments, otherwise treated the same as <code>DIMENSION</code> field.
    */
   public enum FieldType {
     DIMENSION,
     METRIC,
-    TIME
+    @Deprecated TIME,
+    DATE_TIME
   }
 
   /**

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -286,21 +286,18 @@ public final class Schema {
 
   @JsonIgnore
   @Nullable
-  @Deprecated
   public String getTimeColumnName() {
     return (_timeFieldSpec != null) ? _timeFieldSpec.getName() : null;
   }
 
   @JsonIgnore
   @Nullable
-  @Deprecated
   public TimeUnit getIncomingTimeUnit() {
     return (_timeFieldSpec != null) ? _timeFieldSpec.getIncomingGranularitySpec().getTimeType() : null;
   }
 
   @JsonIgnore
   @Nullable
-  @Deprecated
   public TimeUnit getOutgoingTimeUnit() {
     return (_timeFieldSpec != null) ? _timeFieldSpec.getOutgoingGranularitySpec().getTimeType() : null;
   }
@@ -442,21 +439,18 @@ public final class Schema {
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType) {
       _schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit));
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType, @Nonnull Object defaultNullValue) {
       _schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnit, defaultNullValue));
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType, @Nonnull String outgoingName, @Nonnull TimeUnit outgoingTimeUnit,
         @Nonnull DataType outgoingDataType) {
@@ -466,7 +460,6 @@ public final class Schema {
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, @Nonnull TimeUnit incomingTimeUnit,
         @Nonnull DataType incomingDataType, @Nonnull String outgoingName, @Nonnull TimeUnit outgoingTimeUnit,
         @Nonnull DataType outgoingDataType, @Nonnull Object defaultNullValue) {
@@ -476,14 +469,12 @@ public final class Schema {
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, int incomingTimeUnitSize,
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType) {
       _schema.addField(new TimeFieldSpec(incomingName, incomingDataType, incomingTimeUnitSize, incomingTimeUnit));
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, int incomingTimeUnitSize,
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType, @Nonnull Object defaultNullValue) {
       _schema.addField(
@@ -491,7 +482,6 @@ public final class Schema {
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, int incomingTimeUnitSize,
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType, @Nonnull String outgoingName,
         int outgoingTimeUnitSize, @Nonnull TimeUnit outgoingTimeUnit, @Nonnull DataType outgoingDataType) {
@@ -501,7 +491,6 @@ public final class Schema {
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull String incomingName, int incomingTimeUnitSize,
         @Nonnull TimeUnit incomingTimeUnit, @Nonnull DataType incomingDataType, @Nonnull String outgoingName,
         int outgoingTimeUnitSize, @Nonnull TimeUnit outgoingTimeUnit, @Nonnull DataType outgoingDataType,
@@ -512,27 +501,23 @@ public final class Schema {
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec) {
       _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec));
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec,
         @Nonnull Object defaultNullValue) {
       _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, defaultNullValue));
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec,
         @Nonnull TimeGranularitySpec outgoingTimeGranularitySpec) {
       _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec));
       return this;
     }
 
-    @Deprecated
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec,
         @Nonnull TimeGranularitySpec outgoingTimeGranularitySpec, @Nonnull Object defaultNullValue) {
       _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec, defaultNullValue));

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.common.data;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.linkedin.pinot.common.data.DateTimeFieldSpec.DateTimeType;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.FieldSpec.FieldType;
@@ -109,6 +108,12 @@ public final class Schema {
     return _dimensionFieldSpecs;
   }
 
+  /**
+   * Required by JSON deserializer. DO NOT USE. DO NOT REMOVE.
+   * Adding @Deprecated to prevent usage
+   * @param dimensionFieldSpecs
+   */
+  @Deprecated
   public void setDimensionFieldSpecs(@Nonnull List<DimensionFieldSpec> dimensionFieldSpecs) {
     Preconditions.checkState(_dimensionFieldSpecs.isEmpty());
 
@@ -122,6 +127,12 @@ public final class Schema {
     return _metricFieldSpecs;
   }
 
+  /**
+   * Required by JSON deserializer. DO NOT USE. DO NOT REMOVE.
+   * Adding @Deprecated to prevent usage
+   * @param metricFieldSpecs
+   */
+  @Deprecated
   public void setMetricFieldSpecs(@Nonnull List<MetricFieldSpec> metricFieldSpecs) {
     Preconditions.checkState(_metricFieldSpecs.isEmpty());
 
@@ -130,11 +141,18 @@ public final class Schema {
     }
   }
 
+
   @Nonnull
   public List<DateTimeFieldSpec> getDateTimeFieldSpecs() {
     return _dateTimeFieldSpecs;
   }
 
+  /**
+   * Required by JSON deserializer. DO NOT USE. DO NOT REMOVE.
+   * Adding @Deprecated to prevent usage
+   * @param dateTimeFieldSpecs
+   */
+  @Deprecated
   public void setDateTimeFieldSpecs(@Nonnull List<DateTimeFieldSpec> dateTimeFieldSpecs) {
     Preconditions.checkState(_dateTimeFieldSpecs.isEmpty());
 
@@ -148,6 +166,12 @@ public final class Schema {
     return _timeFieldSpec;
   }
 
+  /**
+   * Required by JSON deserializer. DO NOT USE. DO NOT REMOVE.
+   * Adding @Deprecated to prevent usage
+   * @param timeFieldSpec
+   */
+  @Deprecated
   public void setTimeFieldSpec(@Nullable TimeFieldSpec timeFieldSpec) {
     if (timeFieldSpec != null) {
       addField(timeFieldSpec);
@@ -519,25 +543,6 @@ public final class Schema {
     public SchemaBuilder addTime(@Nonnull TimeGranularitySpec incomingTimeGranularitySpec,
         @Nonnull TimeGranularitySpec outgoingTimeGranularitySpec, @Nonnull Object defaultNullValue) {
       _schema.addField(new TimeFieldSpec(incomingTimeGranularitySpec, outgoingTimeGranularitySpec, defaultNullValue));
-      return this;
-    }
-
-    public SchemaBuilder addDateTime(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
-        @Nonnull String granularity, @Nonnull Object defaultNullValue) {
-      _schema.addField(new DateTimeFieldSpec(name, dataType, format, granularity, defaultNullValue));
-      return this;
-    }
-
-    public SchemaBuilder addDateTime(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
-        @Nonnull String granularity, DateTimeType dateTimeType, @Nonnull Object defaultNullValue) {
-      _schema.addField(new DateTimeFieldSpec(name, dataType, format, granularity, dateTimeType, defaultNullValue));
-      return this;
-    }
-
-
-    public SchemaBuilder addDateTime(@Nonnull String name, @Nonnull DataType dataType, @Nonnull String format,
-        @Nonnull String granularity) {
-      _schema.addField(new DateTimeFieldSpec(name, dataType, format, granularity));
       return this;
     }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -144,12 +144,10 @@ public final class Schema {
   }
 
   @Nullable
-  @Deprecated
   public TimeFieldSpec getTimeFieldSpec() {
     return _timeFieldSpec;
   }
 
-  @Deprecated
   public void setTimeFieldSpec(@Nullable TimeFieldSpec timeFieldSpec) {
     if (timeFieldSpec != null) {
       addField(timeFieldSpec);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
@@ -23,6 +23,7 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
+@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TimeFieldSpec extends FieldSpec {
   private TimeGranularitySpec _incomingGranularitySpec;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeFieldSpec.java
@@ -23,7 +23,6 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 
-@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class TimeFieldSpec extends FieldSpec {
   private TimeGranularitySpec _incomingGranularitySpec;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeGranularitySpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeGranularitySpec.java
@@ -31,7 +31,7 @@ import org.joda.time.DateTime;
  * <p>- <code>DataType</code>: data type of the time column (e.g. INT, LONG).
  * <p>- <code>TimeType</code>: time unit of the time column (e.g. MINUTES, HOURS).
  * <p>- <code>TimeUnitSize</code>: size of the time buckets (e.g. 10 MINUTES, 2 HOURS). By default this is set to 1.
- * <p>- <code>TimeFormat</code>: Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd 
+ * <p>- <code>TimeFormat</code>: Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd
  * <p>- <code>Name</code>: name of the time column.
  * <p>E.g.
  * <p>If the time column is in millisecondsSinceEpoch, constructor can be invoked as:
@@ -41,28 +41,29 @@ import org.joda.time.DateTime;
  * <p>If the time column is in Simple Date Format:
  * <p><code>new TimeGranularitySpec(DataType.STRING, 1, TimeUnit.HOURS, TimeFormat.SIMPLE_DATE_FORMAT.toString() +":yyyyMMdd", "hour");</code>
  */
+@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TimeGranularitySpec {
   private static final int DEFAULT_TIME_UNIT_SIZE = 1;
-  
+
   private DataType _dataType;
   private TimeUnit _timeType;
   private int _timeUnitSize = DEFAULT_TIME_UNIT_SIZE;
   private String _timeFormat = TimeFormat.EPOCH.toString();
   private String _name;
   /*
-   * Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd 
+   * Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd
    */
   public enum TimeFormat {
     EPOCH, //default
-    SIMPLE_DATE_FORMAT 
+    SIMPLE_DATE_FORMAT
   }
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.
   public TimeGranularitySpec() {
   }
 
   /**
-   * 
+   *
    * @param dataType
    * @param timeType
    * @param name
@@ -76,10 +77,10 @@ public class TimeGranularitySpec {
     _name = name;
   }
   /**
-   * 
+   *
    * @param dataType
    * @param timeType
-   * @param timeFormat Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd 
+   * @param timeFormat Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd
    * @param name
    */
   public TimeGranularitySpec(@Nonnull DataType dataType, @Nonnull TimeUnit timeType, @Nonnull String timeFormat,
@@ -95,7 +96,7 @@ public class TimeGranularitySpec {
     _timeFormat = timeFormat;
   }
   /**
-   * 
+   *
    * @param dataType
    * @param timeUnitSize
    * @param timeType
@@ -113,11 +114,11 @@ public class TimeGranularitySpec {
   }
 
   /**
-   * 
+   *
    * @param dataType
    * @param timeUnitSize
    * @param timeType
-   * @param timeFormat Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd 
+   * @param timeFormat Can be either EPOCH (default) or SIMPLE_DATE_FORMAT:pattern e.g SIMPLE_DATE_FORMAT:yyyyMMdd
    * @param name
    */
   public TimeGranularitySpec(@Nonnull DataType dataType, int timeUnitSize, @Nonnull TimeUnit timeType,
@@ -133,7 +134,7 @@ public class TimeGranularitySpec {
     _name = name;
     _timeFormat = timeFormat;
   }
-  
+
   public DataType getDataType() {
     return _dataType;
   }
@@ -183,11 +184,11 @@ public class TimeGranularitySpec {
   public void setTimeFormat(String timeFormat) {
     this._timeFormat = timeFormat;
   }
-  
+
   public String getTimeFormat() {
     return _timeFormat;
   }
-  
+
   /**
    * Convert the units of time since epoch to {@link DateTime} format using current <code>TimeGranularitySpec</code>.
    */

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeGranularitySpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/TimeGranularitySpec.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.common.data;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
-import com.linkedin.pinot.common.data.TimeGranularitySpec.TimeFormat;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
@@ -41,7 +40,6 @@ import org.joda.time.DateTime;
  * <p>If the time column is in Simple Date Format:
  * <p><code>new TimeGranularitySpec(DataType.STRING, 1, TimeUnit.HOURS, TimeFormat.SIMPLE_DATE_FORMAT.toString() +":yyyyMMdd", "hour");</code>
  */
-@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TimeGranularitySpec {
   private static final int DEFAULT_TIME_UNIT_SIZE = 1;

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.data.DateTimeFieldSpec.DateTimeType;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -26,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -221,39 +223,62 @@ public class FieldSpecTest {
 
   }
 
-  @Test(expectedExceptions = {IllegalArgumentException.class})
-  public void testDateTimeFormat() {
+
+  @Test(dataProvider = "testFormatDataProvider")
+  public void testDateTimeFormat(String name, DataType dataType, String format, String granularity,
+      boolean exceptionExpected, DateTimeFieldSpec dateTimeFieldExpected) {
+
+    DateTimeFieldSpec dateTimeFieldActual = null;
+    boolean exceptionActual = false;
+    try {
+      dateTimeFieldActual = new DateTimeFieldSpec(name, dataType, format, granularity);
+    } catch (IllegalArgumentException e) {
+      exceptionActual = true;
+    }
+    Assert.assertEquals(exceptionActual, exceptionExpected);
+    Assert.assertEquals(dateTimeFieldActual, dateTimeFieldExpected);
+  }
+
+  @DataProvider(name = "testFormatDataProvider")
+  public Object[][] provideTestFormatData() {
+
     String name = "Date";
     DataType dataType = DataType.LONG;
-    String format = null;
     String granularity = "1:HOURS";
 
-    DateTimeFieldSpec dateTimeFieldSpec = null;
-    format = "1";
-    dateTimeFieldSpec= new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNull(dateTimeFieldSpec);
-    format = "1:hours";
-    dateTimeFieldSpec = new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNull(dateTimeFieldSpec);
-    format = "one_hours";
-    dateTimeFieldSpec = new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNull(dateTimeFieldSpec);
-    format = "1:HOURS:SIMPLE_DATE_FORMAT";
-    dateTimeFieldSpec = new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNull(dateTimeFieldSpec);
-    format = "1:hour:EPOCH";
-    dateTimeFieldSpec = new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNull(dateTimeFieldSpec);
-    format = "1:HOUR:EPOCH:yyyyMMdd";
-    dateTimeFieldSpec = new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNull(dateTimeFieldSpec);
-    format = "1:HOURS:EPOCH";
-    dateTimeFieldSpec = new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNotNull(dateTimeFieldSpec);
-    dateTimeFieldSpec = null;
-    format = "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd";
-    dateTimeFieldSpec = new DateTimeFieldSpec(name, dataType, format, granularity);
-    Assert.assertNotNull(dateTimeFieldSpec);
+    List<Object[]> entries = new ArrayList<>();
+    entries.add(new Object[] {
+        name, dataType, "1:hours", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "one_hours", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "1:HOURS:SIMPLE_DATE_FORMAT", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "1:hour:EPOCH", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "1:HOUR:EPOCH:yyyyMMdd", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "0:HOURS:EPOCH", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "-1:HOURS:EPOCH", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "0.1:HOURS:EPOCH", granularity, true, null
+    });
+    entries.add(new Object[] {
+        name, dataType, "1:HOURS:EPOCH", granularity, false, new DateTimeFieldSpec(name, dataType, "1:HOURS:EPOCH", granularity)
+    });
+    entries.add(new Object[] {
+        name, dataType, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", granularity, false, new DateTimeFieldSpec(name, dataType, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", granularity)
+    });
+
+    return entries.toArray(new Object[entries.size()][]);
   }
 
 

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
@@ -205,21 +205,13 @@ public class FieldSpecTest {
     DataType dataType = DataType.LONG;
     String format = "1:HOURS:EPOCH";
     String granularity = "1:HOURS";
-    int defaultNullValue = 17050;
 
-    DateTimeFieldSpec dateTimeFieldSpec1 = new DateTimeFieldSpec(name, dataType, format, granularity);
-    DateTimeFieldSpec dateTimeFieldSpec2 = new DateTimeFieldSpec(name, dataType, format, granularity, defaultNullValue);
-
+    DateTimeFieldSpec dateTimeFieldSpec1 = new DateTimeFieldSpec(name, dataType, format, granularity, DateTimeType.PRIMARY);
+    DateTimeFieldSpec dateTimeFieldSpec2 = new DateTimeFieldSpec(name, dataType, format, granularity, DateTimeType.SECONDARY);
     Assert.assertFalse(dateTimeFieldSpec1.equals(dateTimeFieldSpec2));
-    dateTimeFieldSpec1.setDefaultNullValue(defaultNullValue);
-    Assert.assertEquals(dateTimeFieldSpec1, dateTimeFieldSpec2);
 
     DateTimeFieldSpec dateTimeFieldSpec3 = new DateTimeFieldSpec(name, dataType, format, granularity, DateTimeType.PRIMARY);
-    DateTimeFieldSpec dateTimeFieldSpec4 = new DateTimeFieldSpec(name, dataType, format, granularity, DateTimeType.PRIMARY, defaultNullValue);
-
-    Assert.assertFalse(dateTimeFieldSpec3.equals(dateTimeFieldSpec4));
-    dateTimeFieldSpec3.setDefaultNullValue(defaultNullValue);
-    Assert.assertEquals(dateTimeFieldSpec3, dateTimeFieldSpec4);
+    Assert.assertEquals(dateTimeFieldSpec1, dateTimeFieldSpec3);
 
   }
 
@@ -231,7 +223,7 @@ public class FieldSpecTest {
     DateTimeFieldSpec dateTimeFieldActual = null;
     boolean exceptionActual = false;
     try {
-      dateTimeFieldActual = new DateTimeFieldSpec(name, dataType, format, granularity);
+      dateTimeFieldActual = new DateTimeFieldSpec(name, dataType, format, granularity, DateTimeType.PRIMARY);
     } catch (IllegalArgumentException e) {
       exceptionActual = true;
     }
@@ -272,10 +264,10 @@ public class FieldSpecTest {
         name, dataType, "0.1:HOURS:EPOCH", granularity, true, null
     });
     entries.add(new Object[] {
-        name, dataType, "1:HOURS:EPOCH", granularity, false, new DateTimeFieldSpec(name, dataType, "1:HOURS:EPOCH", granularity)
+        name, dataType, "1:HOURS:EPOCH", granularity, false, new DateTimeFieldSpec(name, dataType, "1:HOURS:EPOCH", granularity, DateTimeType.PRIMARY)
     });
     entries.add(new Object[] {
-        name, dataType, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", granularity, false, new DateTimeFieldSpec(name, dataType, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", granularity)
+        name, dataType, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", granularity, false, new DateTimeFieldSpec(name, dataType, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", granularity, DateTimeType.PRIMARY)
     });
 
     return entries.toArray(new Object[entries.size()][]);
@@ -324,11 +316,10 @@ public class FieldSpecTest {
     Assert.assertEquals(timeFieldSpec1.getDefaultNullValue(), -1, ERROR_MESSAGE);
 
     // Date time field with default null value.
-    String[] dateTimeFields = {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"defaultNullValue\":-1"};
+    String[] dateTimeFields = {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"dateTimeType\":\"PRIMARY\""};
     DateTimeFieldSpec dateTimeFieldSpec1 = MAPPER.readValue(getRandomOrderJsonString(dateTimeFields), DateTimeFieldSpec.class);
-    DateTimeFieldSpec dateTimeFieldSpec2 = new DateTimeFieldSpec("Date", DataType.LONG, "1:MILLISECONDS:EPOCH", "5:MINUTES", -1);
+    DateTimeFieldSpec dateTimeFieldSpec2 = new DateTimeFieldSpec("Date", DataType.LONG, "1:MILLISECONDS:EPOCH", "5:MINUTES", DateTimeType.PRIMARY);
     Assert.assertEquals(dateTimeFieldSpec1, dateTimeFieldSpec2, ERROR_MESSAGE);
-    Assert.assertEquals((long)dateTimeFieldSpec1.getDefaultNullValue(), -1, ERROR_MESSAGE);
   }
 
   /**
@@ -369,7 +360,7 @@ public class FieldSpecTest {
     Assert.assertEquals(first, second, ERROR_MESSAGE);
 
     // DateTime field
-    String[] dateTimeFields = {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"defaultNullValue\":-1"};
+    String[] dateTimeFields = {"\"name\":\"Date\"", "\"dataType\":\"LONG\"", "\"format\":\"1:MILLISECONDS:EPOCH\"", "\"granularity\":\"5:MINUTES\"", "\"dateTimeType\":\"PRIMARY\""};
     first = MAPPER.readValue(getRandomOrderJsonString(dateTimeFields), DateTimeFieldSpec.class);
     second = MAPPER.readValue(MAPPER.writeValueAsString(first), DateTimeFieldSpec.class);
     Assert.assertEquals(first, second, ERROR_MESSAGE);

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/SchemaTest.java
@@ -15,12 +15,15 @@
  */
 package com.linkedin.pinot.common.data;
 
+import com.linkedin.pinot.common.data.DateTimeFieldSpec.DateTimeType;
 import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.data.TimeGranularitySpec.TimeFormat;
 import com.linkedin.pinot.common.utils.SchemaUtils;
+
 import java.io.File;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -60,7 +63,10 @@ public class SchemaTest {
         + "  \"timeFieldSpec\":{"
         + "    \"incomingGranularitySpec\":{\"dataType\":\"LONG\",\"timeType\":\"MILLISECONDS\",\"name\":\"time\"},"
         + "    \"defaultNullValue\":12345"
-        + "  }"
+        + "  },"
+        + "  \"dateTimeFieldSpecs\":["
+        + "    {\"name\":\"Date\", \"dataType\":\"LONG\", \"format\":\"1:MILLISECONDS:EPOCH\", \"granularity\":\"5:MINUTES\", \"dateTimeType\":\"PRIMARY\"}"
+        + "  ]"
         + "}";
   }
 
@@ -78,6 +84,7 @@ public class SchemaTest {
         .addMetric("derivedMetricWithDefault", DataType.FLOAT, 10, MetricFieldSpec.DerivedMetricType.HLL,
             defaultFloat.toString())
         .addTime("time", TimeUnit.DAYS, FieldSpec.DataType.LONG)
+        .addDateTime("dateTime", DataType.LONG, "1:HOURS:EPOCH", "1:HOURS", DateTimeType.PRIMARY)
         .build();
 
     FieldSpec fieldSpec;
@@ -134,6 +141,11 @@ public class SchemaTest {
     Assert.assertEquals(fieldSpec.isSingleValueField(), true);
     Assert.assertEquals(fieldSpec.getDataType(), FieldSpec.DataType.LONG);
     Assert.assertEquals(fieldSpec.getDefaultNullValue(), Long.MIN_VALUE);
+
+    fieldSpec = schema.getDateTimeSpec("dateTime");
+    Assert.assertNotNull(fieldSpec);
+    Assert.assertEquals(fieldSpec.isSingleValueField(), true);
+    Assert.assertEquals(fieldSpec.getDataType(), FieldSpec.DataType.LONG);
   }
 
   @Test


### PR DESCRIPTION
Introduce DateTimeFieldSpec to pinot Schema for the following reasons:
1. Have an ability in the pinot schema to distinguish between time column format and data granularity. Currently there's no way to specify data granularity, and the timeSpec is being used stretched to do both in one shot.
2. Bring in a placeholder for creating a uniform time column across all pinot tables (will be useful in doing rollups)
3. Provision for supporting multiple time columns of different type (PRIMARY, DERIVED etc).