### PR TITLE
[TE] rootcause - max-score entity set

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/Entity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/Entity.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -62,5 +63,24 @@ public class Entity {
   @Override
   public String toString() {
     return String.format("%s(urn=%s, score=%.3f)", getClass().getSimpleName(), this.urn, this.score);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Entity)) {
+      return false;
+    }
+    Entity entity = (Entity) o;
+    return Double.compare(entity.score, score) == 0
+        && Objects.equals(urn, entity.urn)
+        && Objects.equals(related, entity.related);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(urn, score, related);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventsPipeline.java
@@ -75,7 +75,7 @@ public class AnomalyEventsPipeline extends Pipeline {
     ScoreUtils.TimeRangeStrategy strategyAnomaly = ScoreUtils.build(this.strategy, analysis.getStart(), anomaly.getStart(), anomaly.getEnd());
     ScoreUtils.TimeRangeStrategy strategyBaseline = ScoreUtils.build(this.strategy, baseline.getStart(), baseline.getStart(), baseline.getEnd());
 
-    Set<AnomalyEventEntity> entities = new HashSet<>();
+    Set<AnomalyEventEntity> entities = new MaxScoreSet<>();
     for(MetricEntity me : metrics) {
       entities.addAll(EntityUtils.addRelated(score(strategyAnomaly, this.anomalyDAO.findAnomaliesByMetricIdAndTimeRange(me.getId(), analysis.getStart(), anomaly.getEnd()), anomaly.getScore()), Arrays.asList(anomaly, me)));
       entities.addAll(EntityUtils.addRelated(score(strategyBaseline, this.anomalyDAO.findAnomaliesByMetricIdAndTimeRange(me.getId(), baseline.getStart(), baseline.getEnd()), baseline.getScore()), Arrays.asList(baseline, me)));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionAnalysisPipeline.java
@@ -127,7 +127,7 @@ public class DimensionAnalysisPipeline extends Pipeline {
 
           if(!scores.containsKey(d))
             scores.put(d, 0.0d);
-          scores.put(d, scores.get(d) + score * me.getScore());
+          scores.put(d, Math.max(scores.get(d), score * me.getScore()));
 
           related.put(d, me);
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.rootcause.Entity;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
@@ -133,6 +133,9 @@ public class HolidayEventsPipeline extends Pipeline {
     double score(EventDTO dto, Map<String, DimensionEntity> urn2entity);
   }
 
+  /**
+   * Wrapper for ScoreUtils time-based strategies
+   */
   private static class ScoreWrapper implements ScoringStrategy {
     private final ScoreUtils.TimeRangeStrategy delegate;
 
@@ -146,6 +149,9 @@ public class HolidayEventsPipeline extends Pipeline {
     }
   }
 
+  /**
+   * Uses the highest score of dimension entities as they relate to an event
+   */
   private static class DimensionStrategy implements ScoringStrategy {
     @Override
     public double score(EventDTO dto, Map<String, DimensionEntity> urn2entity) {
@@ -153,14 +159,14 @@ public class HolidayEventsPipeline extends Pipeline {
     }
 
     private static double makeDimensionScore(Map<String, DimensionEntity> urn2entity, Map<String, List<String>> dimensionFilterMap) {
-      double sum = 0.0;
+      double max = 0.0;
       Set<String> urns = filter2urns(dimensionFilterMap);
       for(String urn : urns) {
         if(urn2entity.containsKey(urn)) {
-          sum += urn2entity.get(urn).getScore();
+          max = Math.max(urn2entity.get(urn).getScore(), max);
         }
       }
-      return sum;
+      return max;
     }
 
     private static Set<String> filter2urns(Map<String, List<String>> dimensionFilterMap) {
@@ -174,6 +180,9 @@ public class HolidayEventsPipeline extends Pipeline {
     }
   }
 
+  /**
+   * Compound strategy that considers both event time as well as the presence of related dimension entities
+   */
   private static class CompoundStrategy implements ScoringStrategy {
     private final ScoreUtils.TimeRangeStrategy delegateTime;
     private final ScoringStrategy delegateDimension = new DimensionStrategy();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
@@ -8,12 +8,10 @@ import com.linkedin.thirdeye.rootcause.Pipeline;
 import com.linkedin.thirdeye.rootcause.PipelineContext;
 import com.linkedin.thirdeye.rootcause.PipelineResult;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +30,8 @@ public class HolidayEventsPipeline extends Pipeline {
     LINEAR,
     TRIANGULAR,
     QUADRATIC,
-    DIMENSION
+    DIMENSION,
+    COMPOUND
   }
 
   private static final String PROP_K = "k";
@@ -86,32 +85,18 @@ public class HolidayEventsPipeline extends Pipeline {
     Set<DimensionEntity> dimensionEntities = context.filter(DimensionEntity.class);
     Map<String, DimensionEntity> urn2entity = EntityUtils.mapEntityURNs(dimensionEntities);
 
-    Set<HolidayEventEntity> entities = new HashSet<>();
-    entities.addAll(EntityUtils.addRelated(score(strategyAnomaly, this.getHolidayEvents(analysis.getStart(), anomaly.getEnd(), dimensionEntities), urn2entity, anomaly.getScore()), anomaly));
-    entities.addAll(EntityUtils.addRelated(score(strategyBaseline, this.getHolidayEvents(baseline.getStart(), baseline.getEnd(), dimensionEntities), urn2entity, baseline.getScore()), baseline));
+    Set<HolidayEventEntity> entities = new MaxScoreSet<>();
+    entities.addAll(EntityUtils.addRelated(score(strategyAnomaly, this.getHolidayEvents(analysis.getStart(), anomaly.getEnd()), urn2entity, anomaly.getScore()), anomaly));
+    entities.addAll(EntityUtils.addRelated(score(strategyBaseline, this.getHolidayEvents(baseline.getStart(), baseline.getEnd()), urn2entity, baseline.getScore()), baseline));
 
     return new PipelineResult(context, EntityUtils.topk(entities, this.k));
   }
 
-  private List<EventDTO> getHolidayEvents(long start, long end, Set<DimensionEntity> dimensionEntities) {
+  private List<EventDTO> getHolidayEvents(long start, long end) {
     EventFilter filter = new EventFilter();
     filter.setEventType(EventType.HOLIDAY.toString());
     filter.setStartTime(start);
     filter.setEndTime(end);
-
-    Map<String, List<String>> filterMap = new HashMap<>();
-    if (CollectionUtils.isNotEmpty(dimensionEntities)) {
-      for (DimensionEntity dimensionEntity : dimensionEntities) {
-        String dimensionName = dimensionEntity.getName();
-        String dimensionValue = dimensionEntity.getValue();
-        if (!filterMap.containsKey(dimensionName)) {
-          filterMap.put(dimensionName, new ArrayList<String>());
-        }
-        filterMap.get(dimensionName).add(dimensionValue);
-      }
-    }
-    filter.setTargetDimensionMap(filterMap);
-
     return eventDataProvider.getEvents(filter);
   }
 
@@ -137,6 +122,8 @@ public class HolidayEventsPipeline extends Pipeline {
         return new ScoreWrapper(new ScoreUtils.QuadraticTriangularStartTimeStrategy(lookback, start, end));
       case DIMENSION:
         return new DimensionStrategy();
+      case COMPOUND:
+        return new CompoundStrategy(new ScoreUtils.QuadraticTriangularStartTimeStrategy(lookback, start, end));
       default:
         throw new IllegalArgumentException(String.format("Invalid strategy type '%s'", this.strategy));
     }
@@ -149,7 +136,7 @@ public class HolidayEventsPipeline extends Pipeline {
   private static class ScoreWrapper implements ScoringStrategy {
     private final ScoreUtils.TimeRangeStrategy delegate;
 
-    public ScoreWrapper(ScoreUtils.TimeRangeStrategy delegate) {
+    ScoreWrapper(ScoreUtils.TimeRangeStrategy delegate) {
       this.delegate = delegate;
     }
 
@@ -185,6 +172,23 @@ public class HolidayEventsPipeline extends Pipeline {
       }
       return urns;
     }
+  }
 
+  private static class CompoundStrategy implements ScoringStrategy {
+    private final ScoreUtils.TimeRangeStrategy delegateTime;
+    private final ScoringStrategy delegateDimension = new DimensionStrategy();
+
+    CompoundStrategy(ScoreUtils.TimeRangeStrategy delegateTime) {
+      this.delegateTime = delegateTime;
+    }
+
+    @Override
+    public double score(EventDTO dto, Map<String, DimensionEntity> urn2entity) {
+      double scoreTime = this.delegateTime.score(dto.getStartTime(), dto.getEndTime());
+      double scoreDimension = this.delegateDimension.score(dto, urn2entity);
+      double scoreHasDimension = scoreDimension > 0 ? 1 : 0;
+
+      return 0.1 * scoreTime + 0.9 * Math.max(scoreTime, scoreHasDimension) + Math.min(scoreDimension, 1);
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MaxAggregationPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MaxAggregationPipeline.java
@@ -59,37 +59,6 @@ public class MaxAggregationPipeline extends Pipeline {
 
   @Override
   public PipelineResult run(PipelineContext context) {
-    Multimap<String, Entity> entities = ArrayListMultimap.create();
-    for(Map.Entry<String, Set<Entity>> input : context.getInputs().entrySet()) {
-      for(Entity e : input.getValue()) {
-        entities.put(e.getUrn(), e);
-      }
-    }
-
-    Set<Entity> output = new HashSet<>();
-    for(String urn : entities.keySet()) {
-      double maxScore = Double.MIN_VALUE;
-      Entity maxEntity = null;
-
-      Collection<Entity> values = entities.get(urn);
-      List<Entity> related = new ArrayList<>();
-
-      for(Entity e : values) {
-        if(maxScore < e.getScore()) {
-          maxScore = e.getScore();
-          maxEntity = e;
-        }
-        related.addAll(e.getRelated());
-      }
-
-      if(maxEntity == null) {
-        LOG.warn("Could not determine max for urn '{}'. Skipping.", urn);
-        continue;
-      }
-
-      output.add(maxEntity.withScore(maxScore).withRelated(related));
-    }
-
-    return new PipelineResult(context, EntityUtils.topk(output, this.k));
+    return new PipelineResult(context, EntityUtils.topk(new MaxScoreSet<>(context.filter(Entity.class)), this.k));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MaxScoreSet.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MaxScoreSet.java
@@ -1,0 +1,143 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+
+public class MaxScoreSet<T extends Entity> implements Set<T> {
+  private final Map<String, T> delegate = new HashMap<>();
+
+  public MaxScoreSet() {
+    // left blank
+  }
+
+  public MaxScoreSet(Collection<T> entities) {
+    this.addAll(entities);
+  }
+
+  @Override
+  public int size() {
+    return this.delegate.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return this.delegate.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    if (!(o instanceof Entity))
+      return false;
+    final Entity e = (Entity) o;
+    final String urn = e.getUrn();
+
+    if (!this.delegate.containsKey(urn))
+      return false;
+    return this.delegate.get(urn).equals(e);
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return this.delegate.values().iterator();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return this.delegate.values().toArray();
+  }
+
+  @Override
+  public <T1> T1[] toArray(T1[] a) {
+    return this.delegate.values().toArray(a);
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    if (!(o instanceof Entity))
+      return false;
+    final Entity e = (Entity) o;
+    final String urn = e.getUrn();
+
+    if (!this.delegate.containsKey(urn))
+      return false;
+    if (!this.delegate.get(urn).equals(e))
+      return false;
+
+    this.delegate.remove(urn);
+    return true;
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    for (Object o : c) {
+      if (!this.contains(o)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends T> c) {
+    boolean changed = false;
+    for (T e : c) {
+      changed |= this.add(e);
+    }
+    return changed;
+  }
+
+  @Override
+  public boolean add(T t) {
+    final String urn = t.getUrn();
+    if (!this.delegate.containsKey(urn) || this.delegate.get(urn).getScore() < t.getScore()) {
+      this.delegate.put(urn, t);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    Map<String, Entity> valid = new HashMap<>();
+    for (Object o : c) {
+      if (!(o instanceof Entity))
+        continue;
+      final Entity e = (Entity) o;
+      valid.put(e.getUrn(), e);
+    }
+
+    boolean changed = false;
+    final Iterator<Map.Entry<String, T>> it = this.delegate.entrySet().iterator();
+    while (it.hasNext()) {
+      Map.Entry<String, T> entry = it.next();
+      final String urn = entry.getKey();
+      final Entity entity = entry.getValue();
+
+      if (!valid.containsKey(urn) || !valid.get(urn).equals(entity)) {
+        it.remove();
+        changed = true;
+      }
+    }
+
+    return changed;
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    boolean changed = false;
+    for (Object o : c) {
+      changed |= this.remove(o);
+    }
+    return changed;
+  }
+
+  @Override
+  public void clear() {
+    this.delegate.clear();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricCorrelationRankingPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricCorrelationRankingPipeline.java
@@ -260,7 +260,7 @@ public class MetricCorrelationRankingPipeline extends Pipeline {
           if (!scores.containsKey(candidateMetric)) {
             scores.put(candidateMetric, 0.0);
           }
-          scores.put(candidateMetric, scores.get(candidateMetric) + score);
+          scores.put(candidateMetric, Math.max(scores.get(candidateMetric), score));
 
           related.put(candidateMetric, targetMetric);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/ScoreUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/ScoreUtils.java
@@ -1,5 +1,14 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.joda.time.Period;
 
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MaxScoreSetTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MaxScoreSetTest.java
@@ -1,0 +1,48 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.Collections;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MaxScoreSetTest {
+  @Test
+  public void testContains() {
+    MaxScoreSet<Entity> s = new MaxScoreSet<>();
+    s.add(makeEntity(1.0));
+
+    Assert.assertTrue(s.contains(makeEntity(1.0)));
+    Assert.assertFalse(s.contains(makeEntity(0.9)));
+  }
+
+  @Test
+  public void testAdd() {
+    MaxScoreSet<Entity> s = new MaxScoreSet<>();
+    s.add(makeEntity(1.0));
+
+    s.add(makeEntity(0.9));
+    Assert.assertTrue(s.contains(makeEntity(1.0)));
+    Assert.assertFalse(s.contains(makeEntity(0.9)));
+
+    s.add(makeEntity(1.1));
+    Assert.assertTrue(s.contains(makeEntity(1.1)));
+    Assert.assertFalse(s.contains(makeEntity(1.0)));
+  }
+
+  @Test
+  public void testRemove() {
+    MaxScoreSet<Entity> s = new MaxScoreSet<>();
+    s.add(makeEntity(1.0));
+
+    s.remove(makeEntity(0.9));
+    Assert.assertTrue(s.contains(makeEntity(1.0)));
+
+    s.remove(makeEntity(1.0));
+    Assert.assertFalse(s.contains(makeEntity(1.0)));
+  }
+
+  private static Entity makeEntity(double score) {
+    return new Entity("aaa", score, Collections.<Entity>emptyList());
+  }
+}


### PR DESCRIPTION
* max score set for entities to simplify conflict resolution between multiple instances of the same entity within a pipeline

* use max-score set to implement anomaly and holiday pipelines

* standardize pipelines to resolve conflicts via max score

* compound scoring strategy for holidays taking advantage of max dimension scores