### PR TITLE
Retry segment download only on 5xx error codes.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/exception/PermanentDownloadException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/exception/PermanentDownloadException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PermanentDownloadException extends RuntimeException {
+  public static Logger LOGGER = LoggerFactory.getLogger(PermanentDownloadException.class);
+
+  public  PermanentDownloadException(String errorMsg) {
+    super(errorMsg);
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.common.segment.fetcher;
 
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.common.exception.PermanentDownloadException;
 import java.io.File;
 import java.util.Map;
 
@@ -50,6 +52,9 @@ public class HttpSegmentFetcher implements SegmentFetcher {
             "Downloaded file from {} to {}; Length of httpGetResponseContent: {}; Length of downloaded file: {}", uri,
             tempFile, httpGetResponseContentLength, tempFile.length());
         return;
+      } catch (PermanentDownloadException e) {
+        LOGGER.error("Failed to download file from {}", uri, e);
+        Utils.rethrowException(e);
       } catch (Exception e) {
         LOGGER.error("Failed to download file from {}, retry: {}", uri, retry, e);
         if (retry == maxRetryCount) {


### PR DESCRIPTION
When a segment download fails with 4xx (esp 404) no amount of retry is going to help us get
the segment. We waste significant time (30s per segment) if we reach such a condition, unable to
report startup complete because the state transition is still being attempted.

Not to mention that a thread is held up sleeping for a long time.

Introduced a new PermanentDownloadException that callers can examine before attempting a retry.