### PR TITLE
[TE] Distinguish missing data and zero

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 public class TimeBasedAnomalyMerger {
   private final static Logger LOG = LoggerFactory.getLogger(TimeBasedAnomalyMerger.class);
+  private final static Double NULL_DOUBLE = Double.NaN;
   private final static double NORMALIZATION_FACTOR = 1000; // to prevent from double overflow
 
   private final MergedAnomalyResultManager mergedResultDAO;
@@ -293,7 +294,7 @@ public class TimeBasedAnomalyMerger {
    */
   public static double computeImpactToGlobalMetric(MetricTimeSeries globalMetricTimeSerise, MetricTimeSeries subMetricTimeSeries,
       MergedAnomalyResultDTO mergedAnomaly) {
-    double impactToTotal = Double.NaN;
+    double impactToTotal = NULL_DOUBLE;
     if (globalMetricTimeSerise == null || globalMetricTimeSerise.getTimeWindowSet().isEmpty()) {
       return impactToTotal;
     }
@@ -311,13 +312,13 @@ public class TimeBasedAnomalyMerger {
     // Calculate the average traffic
     for (long timestamp : globalMetricTimeSerise.getTimeWindowSet()) {
       if (timestamp < mergedAnomaly.getStartTime()) {
-        double globalMetricValue = globalMetricTimeSerise.get(timestamp, globalMetric).doubleValue();
-        double subMetricValue = subMetricTimeSeries.get(timestamp, anomalyMetric).doubleValue();
-        if (globalMetricValue != Double.NaN) {
+        double globalMetricValue = globalMetricTimeSerise.getOrDefault(timestamp, globalMetric, NULL_DOUBLE).doubleValue();
+        double subMetricValue = subMetricTimeSeries.getOrDefault(timestamp, anomalyMetric, NULL_DOUBLE).doubleValue();
+        if (Double.compare(globalMetricValue, NULL_DOUBLE) != 0) {
           avgGlobal += globalMetricValue;
           countGlobal++;
         }
-        if (subMetricValue != Double.NaN) {
+        if (Double.compare(subMetricValue, NULL_DOUBLE) != 0) {
           avgSub += subMetricValue;
           countSub++;
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/TimeSeries.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/TimeSeries.java
@@ -3,11 +3,10 @@ package com.linkedin.thirdeye.anomalydetection.context;
 import java.io.IOException;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.joda.time.Interval;
@@ -134,19 +133,16 @@ public class TimeSeries implements MetricTimeSeries {
     if (this == o) {
       return true;
     }
-
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     TimeSeries that = (TimeSeries) o;
-
-    return new EqualsBuilder().append(timeSeries, that.timeSeries)
-        .append(getTimeSeriesInterval(), that.getTimeSeriesInterval()).isEquals();
+    return Objects.equals(timeSeries, that.timeSeries) && Objects
+        .equals(getTimeSeriesInterval(), that.getTimeSeriesInterval());
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(timeSeries).append(getTimeSeriesInterval()).toHashCode();
+    return Objects.hash(timeSeries, getTimeSeriesInterval());
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AverageThresholdDataFilter extends BaseDataFilter {
   private static final Logger LOG = LoggerFactory.getLogger(AverageThresholdDataFilter.class);
+  private static final Double NULL_DOUBLE = Double.NaN;
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   public static final String METRIC_NAME_KEY = "metricName";
@@ -128,9 +129,8 @@ public class AverageThresholdDataFilter extends BaseDataFilter {
       if (timestamp < windowStart || timestamp >= windowEnd) {
         continue;
       }
-      double value = metricTimeSeries.get(timestamp, metricName).doubleValue();
-      // TODO: Distinguish 0 and empty value
-      if (Double.compare(0d, value) == 0) {
+      double value = metricTimeSeries.getOrDefault(timestamp, metricName, NULL_DOUBLE).doubleValue();
+      if (Double.compare(NULL_DOUBLE, value) == 0) {
         continue;
       }
       ++totalCount;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilter.java
@@ -130,10 +130,10 @@ public class AverageThresholdDataFilter extends BaseDataFilter {
         continue;
       }
       double value = metricTimeSeries.getOrDefault(timestamp, metricName, NULL_DOUBLE).doubleValue();
+      ++totalCount;
       if (Double.compare(NULL_DOUBLE, value) == 0) {
         continue;
       }
-      ++totalCount;
       if (isLiveBucket(value, minLiveZone, maxLiveZone)) {
         sum += value;
         ++count;
@@ -141,10 +141,10 @@ public class AverageThresholdDataFilter extends BaseDataFilter {
     }
 
     if (count > 0) {
-      double liveBucketPercentage = count / totalCount;
-      if (liveBucketPercentage > liveBucketPercentageThreshold) {
+      double liveBucketPercentage = (double) count / (double) totalCount;
+      if (Double.compare(liveBucketPercentage, liveBucketPercentageThreshold) >= 0) {
         double average = sum / count;
-        return average > threshold;
+        return Double.compare(average, threshold) >= 0;
       }
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtils.java
@@ -17,6 +17,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 public class BackwardAnomalyFunctionUtils {
+  private static final Double NULL_DOUBLE = Double.NaN;
 
   public static List<Pair<Long, Long>> toBackwardCompatibleDataRanges(
       List<Interval> timeSeriesIntervals) {
@@ -56,8 +57,10 @@ public class BackwardAnomalyFunctionUtils {
     for (long timestamp : metricTimeSeries.getTimeWindowSet()) {
       for (TimeSeries timeSeries : timeSeriesList) {
         if (timeSeries.getTimeSeriesInterval().contains(timestamp)) {
-          double value = metricTimeSeries.get(timestamp, metricName).doubleValue();
-          timeSeries.set(timestamp, value);
+          double value = metricTimeSeries.getOrDefault(timestamp, metricName, NULL_DOUBLE).doubleValue();
+          if (Double.compare(value, NULL_DOUBLE) != 0) {
+            timeSeries.set(timestamp, value);
+          }
         }
       }
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricTimeSeries.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricTimeSeries.java
@@ -281,7 +281,7 @@ public class MetricTimeSeries {
     return result;
   }
 
-  private Integer[] getHasValueSums() {
+  public Integer[] getHasValueSums() {
     Integer[] result = new Integer[schema.getNumMetrics()];
 
     for (int i = 0; i < schema.getNumMetrics(); i++) {
@@ -291,10 +291,8 @@ public class MetricTimeSeries {
     for (Long time : hasValue.keySet()) {
       boolean[] booleans = hasValue.get(time);
       for (int i = 0; i < schema.getNumMetrics(); i++) {
-        for (boolean aBoolean : booleans) {
-          if (aBoolean) {
-            result[i] = result[i] + 1;
-          }
+        if (booleans[i]) {
+          result[i] = result[i] + 1;
         }
       }
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricTimeSeries.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricTimeSeries.java
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ import com.linkedin.thirdeye.util.NumberUtils;
  */
 public class MetricTimeSeries {
   private static final Logger LOGGER = LoggerFactory.getLogger(MetricTimeSeries.class);
+  private static final String NULL_NUMBER_TOSTRING_STRING = "null";
 
   // Mapping from timestamp to the value of metrics. (One value per metric and multiple metrics per timestamp.)
   private Map<Long, ByteBuffer> metricsValue;
@@ -86,6 +88,7 @@ public class MetricTimeSeries {
    *
    * @return the metric value if exists; otherwise, 0 is returned.
    */
+  @Deprecated
   public Number get(long timeWindow, String name) {
     return getOrDefault(timeWindow, name, 0);
   }
@@ -230,7 +233,7 @@ public class MetricTimeSeries {
           sb.append(number);
         } else {
           // TODO: read user specified null value from schema
-          sb.append("null");
+          sb.append(NULL_NUMBER_TOSTRING_STRING);
         }
       }
       sb.append("]");
@@ -254,7 +257,7 @@ public class MetricTimeSeries {
       for (int i = 0; i < schema.getNumMetrics(); i++) {
         String metricName = schema.getMetricName(i);
         MetricType metricType = schema.getMetricType(i);
-        Number metricValue = get(time, metricName);
+        Number metricValue = getOrDefault(time, metricName, 0);
 
         switch (metricType) {
         case INT:
@@ -302,12 +305,15 @@ public class MetricTimeSeries {
 
   @Override
   public int hashCode() {
-    return metricsValue.keySet().hashCode() + 13 * schema.hashCode();
+    return Objects.hash(metricsValue.keySet(), getSchema());
   }
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof MetricTimeSeries)) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricTimeSeries.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/api/MetricTimeSeries.java
@@ -81,16 +81,15 @@ public class MetricTimeSeries {
   }
 
   /**
-   * Gets the metric value with the timestamp if the value exists; otherwise, 0 is returned.
+   * Gets the metric value with the timestamp if the value exists; otherwise, null is returned.
    *
    * @param timeWindow the timestamp.
    * @param name the metric name.
    *
-   * @return the metric value if exists; otherwise, 0 is returned.
+   * @return the metric value if exists; otherwise, null is returned.
    */
-  @Deprecated
   public Number get(long timeWindow, String name) {
-    return getOrDefault(timeWindow, name, 0);
+    return getOrDefault(timeWindow, name, null);
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/BaseAnomalyFunction.java
@@ -99,8 +99,8 @@ public abstract class BaseAnomalyFunction implements AnomalyFunction {
           new TimeBucket(currentBucketMillis, currentBucketMillis + bucketMillis, baselineBucketMillis,
               baselineBucketMillis + bucketMillis);
       anomalyTimelinesView.addTimeBuckets(timebucket);
-      anomalyTimelinesView.addCurrentValues(timeSeries.get(currentBucketMillis, metric).doubleValue());
-      anomalyTimelinesView.addBaselineValues(timeSeries.get(baselineBucketMillis, metric).doubleValue());
+      anomalyTimelinesView.addCurrentValues(timeSeries.getOrDefault(currentBucketMillis, metric, 0).doubleValue());
+      anomalyTimelinesView.addBaselineValues(timeSeries.getOrDefault(baselineBucketMillis, metric, 0).doubleValue());
     }
 
     return anomalyTimelinesView;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/RatioOutlierFunction.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/RatioOutlierFunction.java
@@ -84,7 +84,7 @@ public class RatioOutlierFunction extends BaseAnomalyFunction {
       // Compute the weight of this time series (average across whole)
       double averageValue = 0;
       for (Long time : timeSeries.getTimeWindowSet()) {
-        averageValue += timeSeries.get(time, m).doubleValue();
+        averageValue += timeSeries.getOrDefault(time, m, 0).doubleValue();
       }
 
       // avg value of this time series
@@ -97,8 +97,8 @@ public class RatioOutlierFunction extends BaseAnomalyFunction {
     String m_b = getSpec().getMetrics().get(1);
 
     for (Long timeBucket : timeSeries.getTimeWindowSet()) {
-      double value_a = timeSeries.get(timeBucket, m_a).doubleValue();
-      double value_b = timeSeries.get(timeBucket, m_b).doubleValue();
+      double value_a = timeSeries.getOrDefault(timeBucket, m_a, 0).doubleValue();
+      double value_b = timeSeries.getOrDefault(timeBucket, m_b, 0).doubleValue();
 
       if (value_b == 0.0d) continue;
 
@@ -156,8 +156,8 @@ public class RatioOutlierFunction extends BaseAnomalyFunction {
               baselineBucketMillis + bucketMillis);
       view.addTimeBuckets(timebucket);
 
-      double value_a = timeSeries.get(currentBucketMillis, m_a).doubleValue();
-      double value_b = timeSeries.get(currentBucketMillis, m_b).doubleValue();
+      double value_a = timeSeries.getOrDefault(currentBucketMillis, m_a, 0).doubleValue();
+      double value_b = timeSeries.getOrDefault(currentBucketMillis, m_b, 0).doubleValue();
 
       if (value_b != 0.0d) {
         double ratio = value_a / value_b;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/MetricTransfer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/MetricTransfer.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 public class MetricTransfer {
   private static final Logger LOG = LoggerFactory.getLogger(MetricTransfer.class);
+  private static final Double NULL_DOUBLE = Double.NaN;
   private static final boolean DEBUG = true;
 
   public static final String SEASONAL_SIZE = "seasonalSize";
@@ -66,19 +67,27 @@ public class MetricTransfer {
     for (long ts : timeWindowSet) {
       for (ScalingFactor sf: scalingFactorList) {
         if (sf.isInTimeWindow(ts)) {
-          if (ts < windowStartTime) { // the timestamp belongs to a baseline time series
+          if (ts < windowStartTime) { // the timestamp belongs to a baseline time series and will be removed.
             if (DEBUG) {
-              double originalValue = metricsToModify.get(ts, metricName).doubleValue();
-              scaledValues.add(new ScaledValue(ts, originalValue, 0.0));
+              double originalValue = metricsToModify.getOrDefault(ts, metricName, NULL_DOUBLE).doubleValue();
+              scaledValues.add(new ScaledValue(ts, originalValue, NULL_DOUBLE));
             }
-            metricsToModify.set(ts, metricName, 0.0); // zero will be removed in analyze function
+            metricsToModify.set(ts, metricName, NULL_DOUBLE);
           } else { // the timestamp belongs to the current time series
             for (int i = 1; i <= baselineSeasonalPeriod; ++i) {
               long baseTs = ts - i * seasonalMillis;
               if (timeWindowSet.contains(baseTs)) {
-                double originalValue = metricsToModify.get(baseTs, metricName).doubleValue();
-                double scaledValue = originalValue * sf.getScalingFactor();
+                double originalValue = metricsToModify.getOrDefault(baseTs, metricName, NULL_DOUBLE).doubleValue();
+                double scaledValue;
+                // If original or scaled value is an empty value, then remove the timestamp from
+                if (Double.compare(originalValue, NULL_DOUBLE) == 0
+                    || Double.compare(sf.getScalingFactor(), NULL_DOUBLE) == 0) {
+                  scaledValue = NULL_DOUBLE;
+                } else {
+                  scaledValue = originalValue * sf.getScalingFactor();
+                }
                 metricsToModify.set(baseTs, metricName, scaledValue);
+
                 if (DEBUG) {
                   scaledValues.add(new ScaledValue(baseTs, originalValue, scaledValue));
                 }
@@ -101,6 +110,13 @@ public class MetricTransfer {
         LOG.info("Transformed values: {}", sb.toString());
       }
     }
+  }
+
+  public static void main(String[] args) {
+    double emptyValue = Double.MIN_VALUE;
+    double value = 0.3;
+    System.out.println(Double.toString(emptyValue * value));
+    System.out.println(Double.toString(emptyValue));
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/MetricTransfer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/metric/transfer/MetricTransfer.java
@@ -112,13 +112,6 @@ public class MetricTransfer {
     }
   }
 
-  public static void main(String[] args) {
-    double emptyValue = Double.MIN_VALUE;
-    double value = 0.3;
-    System.out.println(Double.toString(emptyValue * value));
-    System.out.println(Double.toString(emptyValue));
-  }
-
   /**
    * This class is used to store debugging information, which is used to show the status of the
    * transformed time series.

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilterTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/datafilter/AverageThresholdDataFilterTest.java
@@ -3,14 +3,22 @@ package com.linkedin.thirdeye.anomalydetection.datafilter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.api.MetricSchema;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.api.MetricType;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class AverageThresholdDataFilterTest {
+  private static final double NULL_DOUBLE = Double.NaN;
+
   @Test
   public void testCreate() {
     Map<String, String> dataFilter = new HashMap<>();
@@ -42,6 +50,164 @@ public class AverageThresholdDataFilterTest {
       e.printStackTrace();
       Assert.fail();
     }
+  }
+
+  @DataProvider
+  public static Object[][] basicMetricTimeSeries() {
+    List<String> metricNames = new ArrayList<String>() {{
+      add("metricName");
+    }};
+    List<MetricType> types = new ArrayList<MetricType>() {{
+      add(MetricType.DOUBLE);
+    }};
+
+    MetricSchema schema = new MetricSchema(metricNames, types);
+
+    MetricTimeSeries metricTimeSeries = new MetricTimeSeries(schema);
+
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    for (int i = 0; i < timestamps.length; i++) {
+      double doubleValue = doubleValues[i];
+      if (Double.compare(doubleValue, NULL_DOUBLE) != 0) {
+        metricTimeSeries.set(timestamps[i], metricNames.get(0), doubleValue);
+      }
+    }
+
+    return new Object[][] {
+        {metricNames, metricTimeSeries}
+    };
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testBasicAveragePassThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "2.75");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "0");
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertTrue(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testBasicAverageFailedThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "2.76");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "0");
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertFalse(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testMinLiveBucketAveragePassThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "3.333");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "2.0");
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertTrue(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testLiveBucketAveragePassThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "3.33");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "2.0");
+    dataFilter.put(AverageThresholdDataFilter.MAX_LIVE_ZONE_KEY, "5.0");
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertTrue(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testLiveBucketAverageFailThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "3.33");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "2.0");
+    dataFilter.put(AverageThresholdDataFilter.MAX_LIVE_ZONE_KEY, "4.9");
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertFalse(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testLiveBucketsPctThresholdPassThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "1");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "3.0");
+    dataFilter.put(AverageThresholdDataFilter.LIVE_BUCKETS_PERCENTAGE_KEY, "0.50");
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertTrue(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testLiveBucketsPctThresholdFailThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "1");
+    dataFilter.put(AverageThresholdDataFilter.MIN_LIVE_ZONE_KEY, "3.0");
+    dataFilter.put(AverageThresholdDataFilter.LIVE_BUCKETS_PERCENTAGE_KEY, "0.51");
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertFalse(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testOverrideThreshold(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    Map<String, String> dataFilter = new HashMap<>();
+    dataFilter.put(DataFilterFactory.FILTER_TYPE_KEY, "aVerAge_THrEShOLd");
+    dataFilter.put(AverageThresholdDataFilter.METRIC_NAME_KEY, metricNames.get(0));
+    dataFilter.put(AverageThresholdDataFilter.THRESHOLD_KEY, "1000.0");
+
+    NavigableMap<DimensionMap, Double> overrideThreshold = new TreeMap<>();
+
+    DimensionMap dimensionMap = new DimensionMap();
+    dimensionMap.put("K1", "V1");
+    overrideThreshold.put(dimensionMap, 2.75);
+
+    try {
+      ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+      String writeValueAsString = OBJECT_MAPPER.writeValueAsString(overrideThreshold);
+      dataFilter.put(AverageThresholdDataFilter.OVERRIDE_THRESHOLD_KEY, writeValueAsString);
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+      Assert.fail();
+    }
+
+    AverageThresholdDataFilter averageThresholdDataFilter = new AverageThresholdDataFilter();
+    averageThresholdDataFilter.setParameters(dataFilter);
+
+    Assert.assertTrue(averageThresholdDataFilter.isQualified(metricTimeSeries, dimensionMap));
+    Assert.assertFalse(averageThresholdDataFilter.isQualified(metricTimeSeries, new DimensionMap()));
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomalydetection/function/BackwardAnomalyFunctionUtilsTest.java
@@ -1,0 +1,80 @@
+package com.linkedin.thirdeye.anomalydetection.function;
+
+import com.linkedin.thirdeye.anomalydetection.context.TimeSeries;
+import com.linkedin.thirdeye.api.MetricSchema;
+import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.api.MetricType;
+import java.util.ArrayList;
+import java.util.List;
+import org.joda.time.Interval;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class BackwardAnomalyFunctionUtilsTest {
+  private static final double NULL_DOUBLE = Double.NaN;
+
+  @DataProvider
+  public static Object[][] basicMetricTimeSeries() {
+    List<String> metricNames = new ArrayList<String>() {{
+      add("metricName");
+    }};
+    List<MetricType> types = new ArrayList<MetricType>() {{
+      add(MetricType.DOUBLE);
+    }};
+
+    MetricSchema schema = new MetricSchema(metricNames, types);
+
+    MetricTimeSeries metricTimeSeries = new MetricTimeSeries(schema);
+
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    for (int i = 0; i < timestamps.length; i++) {
+      double doubleValue = doubleValues[i];
+      if (Double.compare(doubleValue, NULL_DOUBLE) != 0) {
+        metricTimeSeries.set(timestamps[i], metricNames.get(0), doubleValue);
+      }
+    }
+
+    return new Object[][] {
+        {metricNames, metricTimeSeries}
+    };
+  }
+
+  @Test(dataProvider = "basicMetricTimeSeries")
+  public void testSplitSetsOfTimeSeries(List<String> metricNames, MetricTimeSeries metricTimeSeries) throws Exception {
+    List<Interval> intervals = new ArrayList<Interval>() {{
+      add(new Interval(1L, 4L));
+      add(new Interval(3L, 6L));
+    }};
+
+    List<TimeSeries> actualTimeSeriesList =
+        BackwardAnomalyFunctionUtils.splitSetsOfTimeSeries(metricTimeSeries, metricNames.get(0), intervals);
+
+    List<Long> timestamps1 = new ArrayList<Long>() {{
+      add(3L); add(5L);
+    }};
+    List<Double> values1 = new ArrayList<Double>() {{
+      add(3.0); add(5.0);
+    }};
+    final TimeSeries timeSeries1 = new TimeSeries(timestamps1, values1);
+    timeSeries1.setTimeSeriesInterval(new Interval(3L, 6L));
+
+    List<Long> timestamps2 = new ArrayList<Long>() {{
+      add(1L); add(2L); add(3L);
+    }};
+    List<Double> values2 = new ArrayList<Double>() {{
+      add(1.0); add(2.0); add(3.0);
+    }};
+    final TimeSeries timeSeries2 = new TimeSeries(timestamps2, values2);
+    timeSeries2.setTimeSeriesInterval(new Interval(1L, 4L));
+
+    List<TimeSeries> expectedTimeSeriesList = new ArrayList<TimeSeries>() {{
+      add(timeSeries1);
+      add(timeSeries2);
+    }};
+
+    Assert.assertEquals(actualTimeSeriesList, expectedTimeSeriesList);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
@@ -1,0 +1,233 @@
+package com.linkedin.thirdeye.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class MetricTimeSeriesTest {
+  private static final Logger LOG = LoggerFactory.getLogger(MetricTimeSeriesTest.class);
+  private static final double NULL_DOUBLE = Double.NaN;
+  private static final int NULL_INT = Integer.MIN_VALUE;
+  private static final long NULL_LONG = Long.MIN_VALUE;
+
+  @DataProvider
+  public static Object[][] emptyMetricTimeSeries() {
+    List<String> metricNames = new ArrayList<String>() {{
+      add("mDouble");
+      add("mInteger");
+      add("mLong");
+    }};
+    List<MetricType> types = new ArrayList<MetricType>() {{
+      add(MetricType.DOUBLE);
+      add(MetricType.INT);
+      add(MetricType.LONG);
+    }};
+
+    MetricSchema schema = new MetricSchema(metricNames, types);
+
+    MetricTimeSeries metricTimeSeries = new MetricTimeSeries(schema);
+
+    return new Object[][] {
+        {metricNames, metricTimeSeries}
+    };
+  }
+
+  @DataProvider
+  public static Object[][] emptyTwoMetricTimeSeries() {
+    List<String> metricNames = new ArrayList<String>() {{
+      add("mDouble");
+      add("mInteger");
+      add("mLong");
+    }};
+    List<MetricType> types = new ArrayList<MetricType>() {{
+      add(MetricType.DOUBLE);
+      add(MetricType.INT);
+      add(MetricType.LONG);
+    }};
+    MetricSchema schema = new MetricSchema(metricNames, types);
+
+    MetricTimeSeries metricTimeSeries1 = new MetricTimeSeries(schema);
+    MetricTimeSeries metricTimeSeries2 = new MetricTimeSeries(schema);
+
+    return new Object[][] {
+        {metricNames, metricTimeSeries1, metricTimeSeries2}
+    };
+  }
+
+  @Test(dataProvider = "emptyMetricTimeSeries")
+  public void testGetOrDefault(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+
+    checkActualWithNullValues(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+  }
+
+  @Test(dataProvider = "emptyMetricTimeSeries")
+  public void testGet(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+
+    double[] expectedDValues = new double[] {1.0, 2.0, 3.0, 0.0, 5.0};
+    int[] expectedIValues = new int[] {0, 0, 0, 0, 0};
+    long[] expectedLValues = new long[] { 1, 0, 3, 0, 5 };
+
+    double[] actualDValues = new double[5];
+    int[] actualIValues = new int[5];
+    long[] actualLValues = new long[5];
+    for (int i = 0; i < timestamps.length; i++) {
+      actualDValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(0)).doubleValue();
+      actualIValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(1)).intValue();
+      actualLValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(2)).longValue();
+    }
+
+    Assert.assertEquals(actualDValues, expectedDValues);
+    Assert.assertEquals(actualIValues, expectedIValues);
+    Assert.assertEquals(actualLValues, expectedLValues);
+  }
+
+  @Test(dataProvider = "emptyMetricTimeSeries")
+  public void testIncrement(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+
+    double[] doubleDeltas = new double[] {1.0, NULL_DOUBLE, NULL_DOUBLE, 4.0, 5.0};
+    int[] intDeltas = new int[] {1, NULL_INT, 3, NULL_INT, 5};
+    long[] longDeltas = new long[] { NULL_LONG, 2, 2, NULL_LONG, 3 };
+
+    for (int i = 0; i < timestamps.length; i++) {
+      double doubleDelta = doubleDeltas[i];
+      if (Double.compare(doubleDelta, NULL_DOUBLE) != 0) {
+        metricTimeSeries.increment(timestamps[i], metricNames.get(0), doubleDelta);
+      }
+
+      int intDelta = intDeltas[i];
+      if (Integer.compare(intDelta, NULL_INT) != 0) {
+        metricTimeSeries.increment(timestamps[i], metricNames.get(1), intDelta);
+      }
+
+      long longDelta = longDeltas[i];
+      if (Long.compare(longDelta, NULL_LONG) != 0) {
+        metricTimeSeries.increment(timestamps[i], metricNames.get(2), longDelta);
+      }
+    }
+
+    double[] expectedDValues = new double[] {2.0, 2.0, 3.0, 4.0, 10.0};
+    int[] expectedIValues = new int[] {1, NULL_INT, 3, NULL_INT, 5};
+    long[] expectedLValues = new long[] { 1, 2, 5, NULL_LONG, 8 };
+
+    checkActualWithNullValues(metricNames, metricTimeSeries, timestamps, expectedDValues, expectedIValues,
+        expectedLValues);
+  }
+
+  @Test(dataProvider = "emptyTwoMetricTimeSeries")
+  public void testAggregate(List<String> metricNames, MetricTimeSeries metricTimeSeries1, MetricTimeSeries metricTimeSeries2) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues1 = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues1 = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues1 = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+    initializeMetricTimeSeries(metricNames, metricTimeSeries1, timestamps, doubleValues1, intValues1, longValues1);
+
+    double[] doubleValues2 = new double[] {1.0, NULL_DOUBLE, NULL_DOUBLE, 4.0, 5.0};
+    int[] intValues2 = new int[] {1, NULL_INT, 3, NULL_INT, 5};
+    long[] longValues2 = new long[] { NULL_LONG, 2, 2, NULL_LONG, 3 };
+    initializeMetricTimeSeries(metricNames, metricTimeSeries2, timestamps, doubleValues2, intValues2, longValues2);
+
+    metricTimeSeries1.aggregate(metricTimeSeries2);
+
+    double[] expectedDValues = new double[] {2.0, 2.0, 3.0, 4.0, 10.0};
+    int[] expectedIValues = new int[] {1, NULL_INT, 3, NULL_INT, 5};
+    long[] expectedLValues = new long[] { 1, 2, 5, NULL_LONG, 8 };
+
+    checkActualWithNullValues(metricNames, metricTimeSeries1, timestamps, expectedDValues, expectedIValues,
+        expectedLValues);
+  }
+
+  @Test(dataProvider = "emptyTwoMetricTimeSeries")
+  public void testAggregateWithTimeRange(List<String> metricNames, MetricTimeSeries metricTimeSeries1, MetricTimeSeries metricTimeSeries2) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues1 = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues1 = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues1 = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+    initializeMetricTimeSeries(metricNames, metricTimeSeries1, timestamps, doubleValues1, intValues1, longValues1);
+
+    double[] doubleValues2 = new double[] {1.0, NULL_DOUBLE, NULL_DOUBLE, 4.0, 5.0};
+    int[] intValues2 = new int[] {1, NULL_INT, 3, NULL_INT, 5};
+    long[] longValues2 = new long[] { NULL_LONG, 2, 2, NULL_LONG, 3 };
+    initializeMetricTimeSeries(metricNames, metricTimeSeries2, timestamps, doubleValues2, intValues2, longValues2);
+
+    TimeRange timeRange = new TimeRange(2L, 4L);
+    metricTimeSeries1.aggregate(metricTimeSeries2, timeRange);
+
+    double[] expectedDValues = new double[] {1.0, 2.0, 3.0, 4.0, 5.0};
+    int[] expectedIValues = new int[] {NULL_INT, NULL_INT, 3, NULL_INT, NULL_INT};
+    long[] expectedLValues = new long[] { 1, 2, 5, NULL_LONG, 5 };
+
+    checkActualWithNullValues(metricNames, metricTimeSeries1, timestamps, expectedDValues, expectedIValues,
+        expectedLValues);
+  }
+
+  @Test(dataProvider = "emptyMetricTimeSeries")
+  public void testToString(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+    LOG.info(metricTimeSeries.toString());
+  }
+
+  private void initializeMetricTimeSeries(List<String> metricNames, MetricTimeSeries metricTimeSeries,
+      long[] timestamps, double[] doubleValues, int[] intValues, long[] longValues) {
+    for (int i = 0; i < timestamps.length; i++) {
+      double doubleValue = doubleValues[i];
+      if (Double.compare(doubleValue, NULL_DOUBLE) != 0) {
+        metricTimeSeries.set(timestamps[i], metricNames.get(0), doubleValue);
+      }
+
+      int intValue = intValues[i];
+      if (Integer.compare(intValue, NULL_INT) != 0) {
+        metricTimeSeries.set(timestamps[i], metricNames.get(1), intValue);
+      }
+
+      long longValue = longValues[i];
+      if (Long.compare(longValue, NULL_LONG) != 0) {
+        metricTimeSeries.set(timestamps[i], metricNames.get(2), longValue);
+      }
+    }
+  }
+
+  private void checkActualWithNullValues(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps,
+      double[] expectedDValues, int[] expectedIValues, long[] expectedLValues) {
+
+    double[] actualDValues = new double[5];
+    int[] actualIValues = new int[5];
+    long[] actualLValues = new long[5];
+    for (int i = 0; i < timestamps.length; i++) {
+      actualDValues[i] = metricTimeSeries.getOrDefault(timestamps[i], metricNames.get(0), NULL_DOUBLE).doubleValue();
+      actualIValues[i] = metricTimeSeries.getOrDefault(timestamps[i], metricNames.get(1), NULL_INT).intValue();
+      actualLValues[i] = metricTimeSeries.getOrDefault(timestamps[i], metricNames.get(2), NULL_LONG).longValue();
+    }
+
+    Assert.assertEquals(actualDValues, expectedDValues);
+    Assert.assertEquals(actualIValues, expectedIValues);
+    Assert.assertEquals(actualLValues, expectedLValues);
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
@@ -60,9 +60,9 @@ public class MetricTimeSeriesTest {
 
   @Test(dataProvider = "defaultMetricTimeSeries")
   public void testGet(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
-    double[] expectedDValues = new double[] {1.0, 2.0, 3.0, 0.0, 5.0};
-    int[] expectedIValues = new int[] {0, 0, 0, 0, 0};
-    long[] expectedLValues = new long[] { 1, 0, 3, 0, 5 };
+    double[] expectedDValues = new double[] {1.0, 2.0, 3.0, 5.0};
+    int[] expectedIValues = new int[] {};
+    long[] expectedLValues = new long[] { 1, 3, 5 };
 
     checkActualWithPresetNullValues(metricNames, metricTimeSeries, timestamps, expectedDValues, expectedIValues,
         expectedLValues);
@@ -238,13 +238,37 @@ public class MetricTimeSeriesTest {
   private static void checkActualWithPresetNullValues(List<String> metricNames, MetricTimeSeries metricTimeSeries,
       long[] timestamps, double[] expectedDValues, int[] expectedIValues, long[] expectedLValues) {
 
-    double[] actualDValues = new double[5];
-    int[] actualIValues = new int[5];
-    long[] actualLValues = new long[5];
-    for (int i = 0; i < timestamps.length; i++) {
-      actualDValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(0)).doubleValue();
-      actualIValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(1)).intValue();
-      actualLValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(2)).longValue();
+    List<Double> doubleList = new ArrayList<>();
+    List<Integer> intList = new ArrayList<>();
+    List<Long> longList = new ArrayList<>();
+
+    for (long timestamp : timestamps) {
+      Number doubleNumber = metricTimeSeries.get(timestamp, metricNames.get(0));
+      if (doubleNumber != null) {
+        doubleList.add(doubleNumber.doubleValue());
+      }
+      Number intNumber = metricTimeSeries.get(timestamp, metricNames.get(1));
+      if (intNumber != null) {
+        intList.add(intNumber.intValue());
+      }
+      Number longNumber = metricTimeSeries.get(timestamp, metricNames.get(2));
+      if (longNumber != null) {
+        longList.add(longNumber.longValue());
+      }
+    }
+
+    double[] actualDValues = new double[doubleList.size()];
+    int[] actualIValues = new int[intList.size()];
+    long[] actualLValues = new long[longList.size()];
+
+    for (int i = 0; i < doubleList.size(); i++) {
+      actualDValues[i] = doubleList.get(i);
+    }
+    for (int i = 0; i < intList.size(); i++) {
+      actualIValues[i] = intList.get(i);
+    }
+    for (int i = 0; i < longList.size(); i++) {
+      actualLValues[i] = longList.get(i);
     }
 
     Assert.assertEquals(actualDValues, expectedDValues);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
@@ -1,7 +1,9 @@
 package com.linkedin.thirdeye.api;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -183,6 +185,25 @@ public class MetricTimeSeriesTest {
   }
 
   @Test(dataProvider = "emptyMetricTimeSeries")
+  public void testGetTimeWindowSet(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5};
+
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+
+    Set<Long> expectedTimestamps = new HashSet<Long>() {{
+      add(1L);
+      add(2L);
+      add(3L);
+      add(5L);
+    }};
+
+    Assert.assertEquals(metricTimeSeries.getTimeWindowSet(), expectedTimestamps);
+  }
+
+  @Test(dataProvider = "emptyMetricTimeSeries")
   public void testToString(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
     long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
     double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
@@ -191,6 +212,32 @@ public class MetricTimeSeriesTest {
 
     initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
     LOG.info(metricTimeSeries.toString());
+  }
+
+  @Test(dataProvider = "emptyMetricTimeSeries")
+  public void testGetMetricSums(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+    Number[] actualSums = metricTimeSeries.getMetricSums();
+    Number[] expectedSums = new Number[] {11.0, 0, 9L};
+    Assert.assertEquals(actualSums, expectedSums);
+  }
+
+  @Test(dataProvider = "emptyMetricTimeSeries")
+  public void testGetHasValueSums(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+    Integer[] actualSums = metricTimeSeries.getHasValueSums();
+    Integer[] expectedSums = new Integer[] {4, 0, 3};
+    Assert.assertEquals(actualSums, expectedSums);
   }
 
   private void initializeMetricTimeSeries(List<String> metricNames, MetricTimeSeries metricTimeSeries,

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
@@ -17,97 +17,59 @@ public class MetricTimeSeriesTest {
   private static final long NULL_LONG = Long.MIN_VALUE;
 
   @DataProvider
-  public static Object[][] emptyMetricTimeSeries() {
-    List<String> metricNames = new ArrayList<String>() {{
-      add("mDouble");
-      add("mInteger");
-      add("mLong");
-    }};
-    List<MetricType> types = new ArrayList<MetricType>() {{
-      add(MetricType.DOUBLE);
-      add(MetricType.INT);
-      add(MetricType.LONG);
-    }};
+  public static Object[][] defaultMetricTimeSeries() {
+    Object[] objectsArray = buildEmptyMetricTimeSeries()[0];
+    List<String> metricNames = (List<String>) objectsArray[0];
+    MetricTimeSeries metricTimeSeries = (MetricTimeSeries) objectsArray[1];
 
-    MetricSchema schema = new MetricSchema(metricNames, types);
+    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
+    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
 
-    MetricTimeSeries metricTimeSeries = new MetricTimeSeries(schema);
+    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
 
     return new Object[][] {
-        {metricNames, metricTimeSeries}
+        {metricNames, metricTimeSeries, timestamps}
     };
   }
 
   @DataProvider
   public static Object[][] emptyTwoMetricTimeSeries() {
-    List<String> metricNames = new ArrayList<String>() {{
-      add("mDouble");
-      add("mInteger");
-      add("mLong");
-    }};
-    List<MetricType> types = new ArrayList<MetricType>() {{
-      add(MetricType.DOUBLE);
-      add(MetricType.INT);
-      add(MetricType.LONG);
-    }};
-    MetricSchema schema = new MetricSchema(metricNames, types);
+    Object[] objectsArray1 = buildEmptyMetricTimeSeries()[0];
+    List<String> metricNames = (List<String>) objectsArray1[0];
+    MetricTimeSeries metricTimeSeries1 = (MetricTimeSeries) objectsArray1[1];
 
-    MetricTimeSeries metricTimeSeries1 = new MetricTimeSeries(schema);
-    MetricTimeSeries metricTimeSeries2 = new MetricTimeSeries(schema);
+    Object[] objectsArray2 = buildEmptyMetricTimeSeries()[0];
+    MetricTimeSeries metricTimeSeries2 = (MetricTimeSeries) objectsArray2[1];
 
     return new Object[][] {
         {metricNames, metricTimeSeries1, metricTimeSeries2}
     };
   }
 
-  @Test(dataProvider = "emptyMetricTimeSeries")
-  public void testGetOrDefault(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
-    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
-    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
-    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
-    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
+  @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testGetOrDefault(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
+    double[] expectedDValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
+    int[] expectedIValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
+    long[] expectedLValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
 
-    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
-
-    checkActualWithNullValues(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+    checkActualWithNullValues(metricNames, metricTimeSeries, timestamps, expectedDValues, expectedIValues,
+        expectedLValues);
   }
 
-  @Test(dataProvider = "emptyMetricTimeSeries")
-  public void testGet(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
-    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
-    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
-    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
-    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
-
-    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
-
+  @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testGet(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
     double[] expectedDValues = new double[] {1.0, 2.0, 3.0, 0.0, 5.0};
     int[] expectedIValues = new int[] {0, 0, 0, 0, 0};
     long[] expectedLValues = new long[] { 1, 0, 3, 0, 5 };
 
-    double[] actualDValues = new double[5];
-    int[] actualIValues = new int[5];
-    long[] actualLValues = new long[5];
-    for (int i = 0; i < timestamps.length; i++) {
-      actualDValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(0)).doubleValue();
-      actualIValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(1)).intValue();
-      actualLValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(2)).longValue();
-    }
-
-    Assert.assertEquals(actualDValues, expectedDValues);
-    Assert.assertEquals(actualIValues, expectedIValues);
-    Assert.assertEquals(actualLValues, expectedLValues);
+    checkActualWithPresetNullValues(metricNames, metricTimeSeries, timestamps, expectedDValues, expectedIValues,
+        expectedLValues);
   }
 
-  @Test(dataProvider = "emptyMetricTimeSeries")
-  public void testIncrement(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
-    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
-    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
-    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
-    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
-
-    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
-
+  @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testIncrement(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
     double[] doubleDeltas = new double[] {1.0, NULL_DOUBLE, NULL_DOUBLE, 4.0, 5.0};
     int[] intDeltas = new int[] {1, NULL_INT, 3, NULL_INT, 5};
     long[] longDeltas = new long[] { NULL_LONG, 2, 2, NULL_LONG, 3 };
@@ -184,15 +146,8 @@ public class MetricTimeSeriesTest {
         expectedLValues);
   }
 
-  @Test(dataProvider = "emptyMetricTimeSeries")
-  public void testGetTimeWindowSet(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
-    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
-    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
-    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
-    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5};
-
-    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
-
+  @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testGetTimeWindowSet(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
     Set<Long> expectedTimestamps = new HashSet<Long>() {{
       add(1L);
       add(2L);
@@ -203,44 +158,47 @@ public class MetricTimeSeriesTest {
     Assert.assertEquals(metricTimeSeries.getTimeWindowSet(), expectedTimestamps);
   }
 
-  @Test(dataProvider = "emptyMetricTimeSeries")
-  public void testToString(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
-    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
-    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
-    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
-    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
-
-    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+  @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testToString(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
     LOG.info(metricTimeSeries.toString());
   }
 
-  @Test(dataProvider = "emptyMetricTimeSeries")
-  public void testGetMetricSums(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
-    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
-    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
-    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
-    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
-
-    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+  @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testGetMetricSums(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
     Number[] actualSums = metricTimeSeries.getMetricSums();
     Number[] expectedSums = new Number[] {11.0, 0, 9L};
     Assert.assertEquals(actualSums, expectedSums);
   }
 
-  @Test(dataProvider = "emptyMetricTimeSeries")
-  public void testGetHasValueSums(List<String> metricNames, MetricTimeSeries metricTimeSeries) {
-    long[] timestamps = new long[] { 1, 2, 3, 4, 5 };
-    double[] doubleValues = new double[] {1.0, 2.0, 3.0, NULL_DOUBLE, 5.0};
-    int[] intValues = new int[] {NULL_INT, NULL_INT, NULL_INT, NULL_INT, NULL_INT};
-    long[] longValues = new long[] { 1, NULL_LONG, 3, NULL_LONG, 5 };
-
-    initializeMetricTimeSeries(metricNames, metricTimeSeries, timestamps, doubleValues, intValues, longValues);
+  @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testGetHasValueSums(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
     Integer[] actualSums = metricTimeSeries.getHasValueSums();
     Integer[] expectedSums = new Integer[] {4, 0, 3};
     Assert.assertEquals(actualSums, expectedSums);
   }
 
-  private void initializeMetricTimeSeries(List<String> metricNames, MetricTimeSeries metricTimeSeries,
+  private static Object[][] buildEmptyMetricTimeSeries() {
+    List<String> metricNames = new ArrayList<String>() {{
+      add("mDouble");
+      add("mInteger");
+      add("mLong");
+    }};
+    List<MetricType> types = new ArrayList<MetricType>() {{
+      add(MetricType.DOUBLE);
+      add(MetricType.INT);
+      add(MetricType.LONG);
+    }};
+
+    MetricSchema schema = new MetricSchema(metricNames, types);
+
+    MetricTimeSeries metricTimeSeries = new MetricTimeSeries(schema);
+
+    return new Object[][] {
+        {metricNames, metricTimeSeries}
+    };
+  }
+
+  private static void initializeMetricTimeSeries(List<String> metricNames, MetricTimeSeries metricTimeSeries,
       long[] timestamps, double[] doubleValues, int[] intValues, long[] longValues) {
     for (int i = 0; i < timestamps.length; i++) {
       double doubleValue = doubleValues[i];
@@ -260,8 +218,8 @@ public class MetricTimeSeriesTest {
     }
   }
 
-  private void checkActualWithNullValues(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps,
-      double[] expectedDValues, int[] expectedIValues, long[] expectedLValues) {
+  private static void checkActualWithNullValues(List<String> metricNames, MetricTimeSeries metricTimeSeries,
+      long[] timestamps, double[] expectedDValues, int[] expectedIValues, long[] expectedLValues) {
 
     double[] actualDValues = new double[5];
     int[] actualIValues = new int[5];
@@ -270,6 +228,23 @@ public class MetricTimeSeriesTest {
       actualDValues[i] = metricTimeSeries.getOrDefault(timestamps[i], metricNames.get(0), NULL_DOUBLE).doubleValue();
       actualIValues[i] = metricTimeSeries.getOrDefault(timestamps[i], metricNames.get(1), NULL_INT).intValue();
       actualLValues[i] = metricTimeSeries.getOrDefault(timestamps[i], metricNames.get(2), NULL_LONG).longValue();
+    }
+
+    Assert.assertEquals(actualDValues, expectedDValues);
+    Assert.assertEquals(actualIValues, expectedIValues);
+    Assert.assertEquals(actualLValues, expectedLValues);
+  }
+
+  private static void checkActualWithPresetNullValues(List<String> metricNames, MetricTimeSeries metricTimeSeries,
+      long[] timestamps, double[] expectedDValues, int[] expectedIValues, long[] expectedLValues) {
+
+    double[] actualDValues = new double[5];
+    int[] actualIValues = new int[5];
+    long[] actualLValues = new long[5];
+    for (int i = 0; i < timestamps.length; i++) {
+      actualDValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(0)).doubleValue();
+      actualIValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(1)).intValue();
+      actualLValues[i] = metricTimeSeries.get(timestamps[i], metricNames.get(2)).longValue();
     }
 
     Assert.assertEquals(actualDValues, expectedDValues);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
@@ -44,7 +44,7 @@ public class testMetricTransfer {
     double [] m1_expected = {0.8, 0.8, Double.NaN, 1.0, 1.0, 1.0};
     double [] m_actual = new double[6];
     for (int i=0; i<=5; i++) {
-      m_actual[i]= metrics.get(i, mName).doubleValue();
+      m_actual[i]= metrics.getOrDefault(i, mName, 0).doubleValue();
     }
     Assert.assertEquals(m_actual, m1_expected);
 
@@ -54,7 +54,7 @@ public class testMetricTransfer {
     sfList0.add(sf1);
     MetricTransfer.rescaleMetric(metrics, 3, sfList0, mName, properties);
     for (int i=0; i<=5; i++) {
-      m_actual[i]= metrics.get(i, mName).doubleValue();
+      m_actual[i]= metrics.getOrDefault(i, mName, 0).doubleValue();
     }
     Assert.assertEquals(m_actual, m1_expected);
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/metric/transfer/testMetricTransfer.java
@@ -41,24 +41,12 @@ public class testMetricTransfer {
     properties.put(MetricTransfer.BASELINE_SEASONAL_PERIOD, "2"); // mistakenly set 2 on purpose
 
     MetricTransfer.rescaleMetric(metrics, 3, sfList0, mName, properties);
-    double [] m1_expected = {0.8, 0.8, 0.0, 1.0, 1.0, 1.0};
+    double [] m1_expected = {0.8, 0.8, Double.NaN, 1.0, 1.0, 1.0};
     double [] m_actual = new double[6];
     for (int i=0; i<=5; i++) {
       m_actual[i]= metrics.get(i, mName).doubleValue();
     }
     Assert.assertEquals(m_actual, m1_expected);
-
-//    // revert to the original cases
-//    ScalingFactor _sf0 = new ScalingFactor(2l, 4l, 1.25);
-//    // no points in time range and no change
-//    sfList0.remove(0);
-//    Assert.assertEquals(sfList0.size(), 0);
-//    sfList0.add(_sf0);
-//    MetricTransfer.rescaleMetric(metrics, , sfList0, mName);
-//    for (int i=0; i<=5; i++) {
-//      m_actual[i]= metrics.get(i, mName).doubleValue();
-//    }
-//    Assert.assertEquals(m_actual, m0);
 
     //should not affect
     sfList0.remove(0);


### PR DESCRIPTION
Problem:
Previously, we could not distinguish zero value and missing data in time series. The reason is ThirdEye fills zero value to missing data points in order to not to crash the UI. However, anomaly detection needs to distinguish the difference because zero values could be true anomaly.

Solution:
We add a flag In the data storage, MetricTimeSeries, to indicate whether a data point is available. If the flag is false, then the data point is missing and user could specify the return value.

To compatible with old UI code, MetricTimeSeries returns 0 for missing data if the default return value is not specified.

Tests:
Tested with new unit tests and integration test is performed on a local detector.