### PR TITLE
Fix incorrect read of history on restart.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -44,7 +44,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
   // Fields to be serialzied.
   private int _cursor = 0;
   private SegmentStats[] _entries;
-  private boolean _isFull;
+  private boolean _isFull = false;
   private String _historyFilePath;
 
   // We return these values when we don't have any prior statistics.
@@ -177,8 +177,6 @@ public class RealtimeSegmentStatsHistory implements Serializable {
   private void normalize() {
     if (_entries.length == MAX_NUM_ENTRIES) {
       _arraySize = MAX_NUM_ENTRIES;
-      _cursor = 0;
-      _isFull = false;
       return;
     }
     int toCopy;
@@ -322,5 +320,15 @@ public class RealtimeSegmentStatsHistory implements Serializable {
       return getArraySize();
     }
     return getCursor();
+  }
+
+  public static void main(String[] args) throws Exception {
+    RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(new File("/tmp/stats.ser"));
+    System.out.println(history.toString());
+    for (int i = 0; i <history.getNumntriesToScan(); i++) {
+      SegmentStats segmentStats = history.getSegmentStatsAt(i);
+      System.out.println(segmentStats.toString());
+
+    }
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -150,10 +150,21 @@ public class RealtimeSegmentStatsHistoryTest {
       history.getEstimatedCardinality("0");
     }
     // Now add a new column
+    boolean savedIsFull;
+    int savedCursor;
     {
       RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
       Assert.assertEquals(history.getEstimatedAvgColSize("new"), RealtimeSegmentStatsHistory.getDefaultEstAvgColSize());
       Assert.assertEquals(history.getEstimatedCardinality("new"), RealtimeSegmentStatsHistory.getDefaultEstCardinality());
+      savedIsFull = history.isFull();
+      savedCursor = history.getCursor();
+      history.save();
+    }
+    {
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      Assert.assertEquals(history.isFull(), savedIsFull);
+      Assert.assertEquals(history.getCursor(), savedCursor);
+
     }
   }
 


### PR DESCRIPTION
On restart, we read the existing file in the disk, and end up setting _isFull to false, and the cursor to 0
effectively dropping the history so far.

Fixed and added a unit test