### PR TITLE
Kafka simple consumer fixes

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaBrokerWrapper.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaBrokerWrapper.java
@@ -71,4 +71,9 @@ public class KafkaBrokerWrapper {
     }
     return 0;
   }
+
+  @Override
+  public String toString() {
+    return host() + ":" + port();
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerWrapper.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/SimpleConsumerWrapper.java
@@ -180,6 +180,8 @@ public class SimpleConsumerWrapper implements Closeable {
       LOGGER.warn("Caught Kafka consumer exception while in state {}, disconnecting and trying again",
           _currentState.getStateValue(), e);
 
+      Uninterruptibles.sleepUninterruptibly(250, TimeUnit.MILLISECONDS);
+
       setCurrentState(new ConnectingToBootstrapNode());
     }
 
@@ -209,6 +211,7 @@ public class SimpleConsumerWrapper implements Closeable {
       _currentPort = _bootstrapPorts[randomHostIndex];
 
       try {
+        LOGGER.info("Connecting to bootstrap host {}:{}", _currentHost, _currentPort);
         _simpleConsumer = _simpleConsumerFactory.buildSimpleConsumer(_currentHost, _currentPort, SOCKET_TIMEOUT_MILLIS,
             SOCKET_BUFFER_SIZE, _clientId);
         setCurrentState(new ConnectedToBootstrapNode());


### PR DESCRIPTION
Kafka simple consumer fixes:
- Display bootstrap broker host/port on connection
- Add a 250ms delay on exceptions
- Properly display host/port when printing out Kafka broker information