### PR TITLE
Remove repo directory from Pinot distribution

### DIFF
--- a/contrib/pinot-druid-benchmark/pom.xml
+++ b/contrib/pinot-druid-benchmark/pom.xml
@@ -79,6 +79,8 @@
           <platforms>
             <platform>unix</platform>
           </platforms>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
         </configuration>
         <executions>
           <execution>

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -75,19 +75,9 @@
     </fileSet>
     <fileSet>
       <useDefaultExcludes>false</useDefaultExcludes>
-      <directory>${pinot.root}/pinot-tools/target/pinot-tools-pkg/repo</directory>
-      <outputDirectory>repo</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <useDefaultExcludes>false</useDefaultExcludes>
       <directory>${pinot.root}/pinot-tools/target/pinot-tools-pkg/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <fileMode>0755</fileMode>
-    </fileSet>
-    <fileSet>
-      <useDefaultExcludes>false</useDefaultExcludes>
-      <directory>${pinot.root}/pinot-controller/src/main/resources</directory>
-      <outputDirectory>repo</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -60,6 +60,8 @@
               </jvmSettings>
             </program>
           </programs>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
         </configuration>
       </plugin>
     </plugins>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -107,6 +107,8 @@
               <name>pinot-perfBenchmarkRunner</name>
             </program>
           </programs>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
           <binFileExtensions>
             <unix>.sh</unix>
           </binFileExtensions>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -194,8 +194,9 @@
               <mainClass>com.linkedin.pinot.server.starter.InteractiveBroker</mainClass>
               <name>interactive-broker</name>
             </program>
-
           </programs>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
         </configuration>
       </plugin>
       <plugin>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -242,6 +242,8 @@
           <platforms>
             <platform>unix</platform>
           </platforms>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
         </configuration>
       </plugin>
       <plugin>

--- a/pinot-transport/pom.xml
+++ b/pinot-transport/pom.xml
@@ -98,6 +98,8 @@
               <name>perf-tester</name>
             </program>
           </programs>
+          <repositoryLayout>flat</repositoryLayout>
+          <repositoryName>lib</repositoryName>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -673,6 +673,8 @@
               <platform>windows</platform>
               <platform>unix</platform>
             </platforms>
+            <repositoryLayout>flat</repositoryLayout>
+            <repositoryName>lib</repositoryName>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Remove the repo directory from the Pinot distribution, which contains a
copy of the lib folder. This roughly halves the size of the Pinot
distribution and slightly reduces build time.