### PR TITLE
Fix file descriptor leak during off-heap allocation for realtime consuming segments

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
@@ -25,11 +25,14 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 // TODO Check if MMAP allows us to pack more partitions on a single machine.
 public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColumnSingleValueReaderWriter {
 
+  public static Logger LOGGER = LoggerFactory.getLogger(FixedByteSingleColumnSingleValueReaderWriter.class);
   WriterWithOffset currentWriter;
   private List<WriterWithOffset> writers = new ArrayList<>();
   private List<ReaderWithOffset> readers = new ArrayList<>();
@@ -124,6 +127,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
   }
 
   private void addBuffer() {
+    LOGGER.info("Allocating {} bytes for column {}", chunkSizeInBytes, columnName);
     PinotDataBuffer buffer = memoryManager.allocate(chunkSizeInBytes, columnName);
     buffer.order(ByteOrder.nativeOrder());
     buffers.add(buffer);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -17,15 +17,17 @@
 package com.linkedin.pinot.core.io.writer.impl;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.LinkedList;
 import java.util.List;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
-import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -82,6 +84,7 @@ import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
  */
 public class MutableOffHeapByteArrayStore implements Closeable {
   private static final int INT_SIZE = V1Constants.Numbers.INTEGER_SIZE;
+  public static Logger LOGGER = LoggerFactory.getLogger(MutableOffHeapByteArrayStore.class);
 
   private static class Buffer implements Closeable {
 
@@ -97,6 +100,7 @@ public class MutableOffHeapByteArrayStore implements Closeable {
       if (size >= Integer.MAX_VALUE) {
         size = Integer.MAX_VALUE - 1;
       }
+      LOGGER.info("Allocating byte array store buffer of size {} for column {}", size, columnName);
       _pinotDataBuffer = memoryManager.allocate(size, columnName);
       _pinotDataBuffer.order(ByteOrder.nativeOrder());
       _byteBuffer = _pinotDataBuffer.toDirectByteBuffer(0, (int) size);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/OffHeapStringStore.java
@@ -25,6 +25,8 @@ import java.util.List;
 import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -84,6 +86,7 @@ import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 public class OffHeapStringStore implements Closeable {
   private static final int START_SIZE = 32 * 1024;
   private static final int INT_SIZE = V1Constants.Numbers.INTEGER_SIZE;
+  public static Logger LOGGER = LoggerFactory.getLogger(OffHeapStringStore.class);
 
   public static int getStartSize() {
     return START_SIZE;
@@ -104,6 +107,7 @@ public class OffHeapStringStore implements Closeable {
       if (size >= Integer.MAX_VALUE) {
         size = Integer.MAX_VALUE - 1;
       }
+      LOGGER.info("Allocationg string buffer of size {} for column {}", size, columnName);
       _pinotDataBuffer = memoryManager.allocate(size, columnName);
       _pinotDataBuffer.order(ByteOrder.nativeOrder());
       _byteBuffer = _pinotDataBuffer.toDirectByteBuffer(0, (int) size);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -425,10 +425,12 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
       }
       segmentStats.setNumRowsConsumed(numDocsIndexed);
       segmentStats.setMemUsedBytes(memoryManager.getTotalMemBytes());
-      LOGGER.info("Segment used {} bytes of memory", memoryManager.getTotalMemBytes());
       final long now = System.currentTimeMillis();
-      segmentStats.setNumSeconds((int)((now - startTimeMillis)/1000));
+      final int numSeconds  = (int)((now - startTimeMillis)/1000);
+      segmentStats.setNumSeconds(numSeconds);
       statsHistory.addSegmentStats(segmentStats);
+      LOGGER.info("Segment used {} bytes of memory for {} rows consumed in {} seconds",
+          memoryManager.getTotalMemBytes(), numDocsIndexed, numSeconds);
       statsHistory.save();
     }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -28,6 +28,8 @@ import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -150,6 +152,8 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
   // Whether to start with 0 off-heap storage. Items are added to the overflow map first, until it reaches
   // a threshold, and then the off-heap structures are allocated.
   private static final boolean HEAP_FIRST = true;
+
+  public static Logger LOGGER = LoggerFactory.getLogger(BaseOffHeapMutableDictionary.class);
 
   private final int _maxItemsInOverflowHash;
 
@@ -296,6 +300,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
     for (IntBuffer iBuf : oldList) {
       newList.add(iBuf);
     }
+    LOGGER.info("Allocating {} bytes for column {}", bbSize, _columnName);
     PinotDataBuffer buffer = _memoryManager.allocate(bbSize, _columnName);
     _pinotDataBuffers.add(buffer);
     buffer.order(ByteOrder.nativeOrder());

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerTest.java
@@ -16,18 +16,21 @@
 
 package com.linkedin.pinot.core.indexsegment.utils;
 
+import com.linkedin.pinot.common.utils.MmapUtils;
+import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
-import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
-import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
 
 public class MmapMemoryManagerTest {
@@ -93,6 +96,8 @@ public class MmapMemoryManagerTest {
 
     memoryManager.close();
 
+    List<Pair<MmapUtils.AllocationContext, Integer>> allocationContexts = MmapUtils.getAllocationsAndSizes();
+    Assert.assertEquals(allocationContexts.size(), 0);
     Assert.assertEquals(new File(_tmpDir).listFiles().length, 0);
   }
 
@@ -123,6 +128,9 @@ public class MmapMemoryManagerTest {
     buf2.close();
 
     memoryManager.close();
+
+    List<Pair<MmapUtils.AllocationContext, Integer>> allocationContexts = MmapUtils.getAllocationsAndSizes();
+    Assert.assertEquals(allocationContexts.size(), 0);
 
     Assert.assertEquals(dir.listFiles().length, 0);
   }
@@ -168,5 +176,7 @@ public class MmapMemoryManagerTest {
     Assert.assertEquals(bb3.get(0), v3);
 
     memoryManager.close();
+    List<Pair<MmapUtils.AllocationContext, Integer>> allocationContexts = MmapUtils.getAllocationsAndSizes();
+    Assert.assertEquals(allocationContexts.size(), 0);
   }
 }


### PR DESCRIPTION
We were deleting the files, but not releasing the associated mapping.
Fixed and added a unit test.

Also added logs for each allocation , and improved the log during segment close