### PR TITLE
Optimize OrDocIdIterator

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockDocIdIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/BlockDocIdIterator.java
@@ -15,29 +15,32 @@
  */
 package com.linkedin.pinot.core.common;
 
+/**
+ * The interface <code>BlockDocIdIterator</code> represents the iterator for <code>BlockDocIdSet</code>. The document
+ * ids returned from the iterator should be in ascending order.
+ */
 public interface BlockDocIdIterator {
-  /**
-   * returns the currentDocId the iterator is currently pointing to, -1 if
-   * next/advance is not yet called, EOF if the iteration has exhausted
-   *
-   * @return
-   */
-  int currentDocId();
 
   /**
-   * advances to next document in the set and returns the nextDocId, EOF if
-   * there are no more docs
+   * Get the next document id.
    *
-   * @return
+   * @return Next document id or EOF if there is no more documents
    */
   int next();
 
   /**
-   * Moves to first entry beyond current docId whose docId is equal or greater
-   * than targetDocId
-   * @param targetDocId
-   * @return docId that is beyond current docId or EOF if no documents exists that is &gt;= targetDocId
+   * Advance to the first document whose id is equal or greater than the given target document id.
+   * <p>If the given target document id is smaller or equal to the current document id, then return the current one.
+   *
+   * @param targetDocId The target document id
+   * @return First document id that is equal or greater than target or EOF if no document matches
    */
   int advance(int targetDocId);
 
+  /**
+   * Get the current document id that was returned by the previous call to next() or advance().
+   *
+   * @return The current document id, -1 if next/advance is not called yet, EOF if the iteration has exhausted
+   */
+  int currentDocId();
 }

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOrDocIdIterator.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOrDocIdIterator.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.perf;
+
+import com.linkedin.pinot.core.common.BlockDocIdIterator;
+import com.linkedin.pinot.core.common.Constants;
+import com.linkedin.pinot.core.operator.dociditerators.OrDocIdIterator;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkOrDocIdIterator {
+  private static final int MAX_DOC_ID = 100000;
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public int arrayBased2() {
+    OrDocIdIterator iterator = setUpArrayBased(2);
+    int ret = 0;
+    int docId;
+    while ((docId = iterator.next()) != Constants.EOF) {
+      ret += docId;
+    }
+    return ret;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public int arrayBased5() {
+    OrDocIdIterator iterator = setUpArrayBased(5);
+    int ret = 0;
+    int docId;
+    while ((docId = iterator.next()) != Constants.EOF) {
+      ret += docId;
+    }
+    return ret;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public int arrayBased10() {
+    OrDocIdIterator iterator = setUpArrayBased(10);
+    int ret = 0;
+    int docId;
+    while ((docId = iterator.next()) != Constants.EOF) {
+      ret += docId;
+    }
+    return ret;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public int arrayBased20() {
+    OrDocIdIterator iterator = setUpArrayBased(20);
+    int ret = 0;
+    int docId;
+    while ((docId = iterator.next()) != Constants.EOF) {
+      ret += docId;
+    }
+    return ret;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public int arrayBased50() {
+    OrDocIdIterator iterator = setUpArrayBased(50);
+    int ret = 0;
+    int docId;
+    while ((docId = iterator.next()) != Constants.EOF) {
+      ret += docId;
+    }
+    return ret;
+  }
+
+  private OrDocIdIterator setUpArrayBased(int numIterators) {
+    BlockDocIdIterator[] iterators = new BlockDocIdIterator[numIterators];
+    for (int i = 0; i < numIterators; i++) {
+      iterators[i] = new FixedStepsDocIdIterator(MAX_DOC_ID, i + 1);
+    }
+    return new OrDocIdIterator(iterators, 0, MAX_DOC_ID);
+  }
+
+  private class FixedStepsDocIdIterator implements BlockDocIdIterator {
+    private final int _maxDocId;
+    private final int _steps;
+
+    private int _currentDocId = -1;
+
+    public FixedStepsDocIdIterator(int maxDocId, int steps) {
+      _maxDocId = maxDocId;
+      _steps = steps;
+    }
+
+    @Override
+    public int next() {
+      if (_currentDocId == Constants.EOF) {
+        return Constants.EOF;
+      }
+      int nextDocId = (_currentDocId + _steps) / _steps * _steps;
+      if (nextDocId > _maxDocId) {
+        _currentDocId = Constants.EOF;
+      } else {
+        _currentDocId = nextDocId;
+      }
+      return _currentDocId;
+    }
+
+    @Override
+    public int advance(int targetDocId) {
+      int nextDocId = (targetDocId + _steps - 1) / _steps * _steps;
+      if (nextDocId > _maxDocId) {
+        _currentDocId = Constants.EOF;
+      } else {
+        _currentDocId = nextDocId;
+      }
+      return _currentDocId;
+    }
+
+    @Override
+    public int currentDocId() {
+      return _currentDocId;
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    Options opt = new OptionsBuilder().include(BenchmarkOrDocIdIterator.class.getSimpleName())
+        .warmupTime(TimeValue.seconds(5))
+        .warmupIterations(2)
+        .measurementTime(TimeValue.seconds(5))
+        .measurementIterations(3)
+        .forks(1)
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
Currently OrDocIdIterator is based on PriorityQueue, and the overhead of using PriorityQueue make it very slow
Re-implemented the OrDocIdIterator based on array (loop over all iterators inside)
Fixed the bug in ArrayBasedDocIdIterator where mixing call to advance() and next() will return duplicate doc id.
Verified that even with 50 iterators, it's still way faster than the old implementation

Benchmark                              Mode  Cnt      Score      Error  Units
BenchmarkOrDocIdIterator.arrayBased2   avgt    3   1742.943 ±   17.665  us/op
BenchmarkOrDocIdIterator.arrayBased5   avgt    3   2845.901 ±  139.131  us/op
BenchmarkOrDocIdIterator.arrayBased10  avgt    3   4473.418 ±  124.593  us/op
BenchmarkOrDocIdIterator.arrayBased20  avgt    3   8050.464 ±  140.682  us/op
BenchmarkOrDocIdIterator.arrayBased50  avgt    3  14618.601 ±  147.558  us/op
BenchmarkOrDocIdIterator.heapBased2    avgt    3  14534.728 ±  532.522  us/op
BenchmarkOrDocIdIterator.heapBased5    avgt    3  21284.697 ±  692.490  us/op
BenchmarkOrDocIdIterator.heapBased10   avgt    3  34858.201 ± 2341.998  us/op
BenchmarkOrDocIdIterator.heapBased20   avgt    3  54647.907 ± 2132.005  us/op
BenchmarkOrDocIdIterator.heapBased50   avgt    3  82754.187 ± 3432.884  us/op