### PR TITLE
Making LLC flush size configuration usable

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/RoutingTableBuilderFactory.java
@@ -20,10 +20,6 @@ import com.linkedin.pinot.broker.routing.builder.PartitionAwareRealtimeRoutingTa
 import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import com.linkedin.pinot.common.metadata.stream.KafkaStreamMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.core.realtime.StreamProviderConfig;
-import com.linkedin.pinot.core.realtime.impl.kafka.KafkaLowLevelStreamProviderConfig;
-import java.util.HashSet;
-import java.util.Set;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -43,7 +39,6 @@ import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
 public class RoutingTableBuilderFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(RoutingTableBuilderFactory.class);
 
-  private static final Set<Class<? extends RoutingTableBuilder>> _routingTableBuilders = new HashSet<>();
   private Configuration _configuration;
 
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -111,6 +111,9 @@ public class CommonConstants {
          * to server assignment changes, it's possible to end up with more (or less) than this number of rows in memory.
          */
         public static final String REALTIME_SEGMENT_FLUSH_SIZE = "realtime.segment.flush.threshold.size";
+        public static final String LLC_PROPERTY_SUFFIX = ".llc";
+        public static final String LLC_REALTIME_SEGMENT_FLUSH_SIZE = REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX;
+        public static final String LLC_REALTIME_SEGMENT_FLUSH_TIME = REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX;
 
         public static enum StreamType {
           kafka

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -216,7 +216,7 @@ public class PinotTableIdealStateBuilder {
     segmentManager.setupHelixEntries(topicName, realtimeTableName, nPartitions, realtimeInstances, nReplicas,
         kafkaMetadata.getKafkaConsumerProperties().get(Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET),
         kafkaMetadata.getBootstrapHosts(), idealState, create,
-        PinotLLCRealtimeSegmentManager.getRealtimeTableFlushSize(realtimeTableConfig));
+        PinotLLCRealtimeSegmentManager.getLLCRealtimeTableFlushSize(realtimeTableConfig));
   }
 
   public static int getPartitionCount(KafkaStreamMetadata kafkaMetadata) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -16,40 +16,6 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.math.IntRange;
-import org.apache.helix.AccessOption;
-import org.apache.helix.ControllerChangeListener;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
-import org.apache.helix.NotificationContext;
-import org.apache.helix.ZNRecord;
-import org.apache.helix.model.IdealState;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.MinMaxPriorityQueue;
@@ -84,9 +50,44 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaSimpleConsumerFactoryImp
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
-import static com.linkedin.pinot.controller.util.SegmentCompletionUtils.getSegmentNamePrefix;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.math.IntRange;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ControllerChangeListener;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.NotificationContext;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linkedin.pinot.controller.util.SegmentCompletionUtils.*;
 
 
 public class PinotLLCRealtimeSegmentManager {
@@ -697,18 +698,26 @@ public class PinotLLCRealtimeSegmentManager {
 
   public static int getRealtimeTableFlushSize(TableConfig tableConfig) {
     final Map<String, String> streamConfigs = tableConfig.getIndexingConfig().getStreamConfigs();
-    if (streamConfigs != null && streamConfigs.containsKey(
-        CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE)) {
-      final String flushSizeStr =
-          streamConfigs.get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE);
+    String flushSizeStr;
+    if (streamConfigs == null) {
+      return -1;
+    }
+    if (streamConfigs.containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE)) {
+      flushSizeStr = streamConfigs.get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE);
       try {
         return Integer.parseInt(flushSizeStr);
-      } catch (Exception e) {
-        LOGGER.warn("Failed to parse flush size of {}", flushSizeStr, e);
-        return -1;
+      } catch (Exception e1) {
+        LOGGER.warn("Failed to parse LLC flush size of {}", flushSizeStr, e1);
+        if (streamConfigs.containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE)) {
+          flushSizeStr = streamConfigs.get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE);
+          try {
+            return Integer.parseInt(flushSizeStr);
+          } catch (Exception e2) {
+            LOGGER.warn("Failed to parse flush size of {}", flushSizeStr, e2);
+          }
+        }
       }
     }
-
     return -1;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamProviderConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaLowLevelStreamProviderConfig.java
@@ -31,20 +31,19 @@ public class KafkaLowLevelStreamProviderConfig extends KafkaHighLevelStreamProvi
 
   private long llcSegmentTimeInMillis = NOT_DEFINED;
   private int llcRealtimeRecordsThreshold = NOT_DEFINED;
-  public static final String LLC_PROPERTY_SUFFIX = ".llc";
 
   @Override
   public void init(TableConfig tableConfig, InstanceZKMetadata instanceMetadata, Schema schema) {
     super.init(tableConfig, instanceMetadata, schema);
 
-    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX)) {
+    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE)) {
       llcRealtimeRecordsThreshold =
-          Integer.parseInt(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX));
+          Integer.parseInt(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE));
     }
 
-    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX)) {
+    if (tableConfig.getIndexingConfig().getStreamConfigs().containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME)) {
       llcSegmentTimeInMillis =
-          Long.parseLong(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX));
+          Long.parseLong(tableConfig.getIndexingConfig().getStreamConfigs().get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME));
     }
   }
 
@@ -52,14 +51,14 @@ public class KafkaLowLevelStreamProviderConfig extends KafkaHighLevelStreamProvi
   public void init(Map<String, String> properties, Schema schema) {
     super.init(properties, schema);
 
-    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX)) {
+    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE)) {
       llcRealtimeRecordsThreshold =
-          Integer.parseInt(properties.get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE + LLC_PROPERTY_SUFFIX));
+          Integer.parseInt(properties.get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE));
     }
 
-    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX)) {
+    if (properties.containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME)) {
       llcSegmentTimeInMillis =
-          convertToMs(properties.get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_TIME + LLC_PROPERTY_SUFFIX));
+          convertToMs(properties.get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_TIME));
     }
   }
 


### PR DESCRIPTION
Current behavior is to use the HLC flush size configuration. Configuring a very high HLC flush size
value causes issues when migrating from HLC to LLC, since we need both to be consuming at the same
time.

This commit allows admin to configure independent thresholds for HLC and LLC.

Removed unused import and variables from RoutingTableBuilderFactory