### PR TITLE
Parameterizing message decoders

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 
 @NotThreadSafe
-public class KafkaAvroMessageDecoder implements KafkaMessageDecoder {
+public class KafkaAvroMessageDecoder implements KafkaMessageDecoder<byte[]> {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaAvroMessageDecoder.class);
 
   private static final String SCHEMA_REGISTRY_REST_URL = "schema.registry.rest.url";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaJSONMessageDecoder.java
@@ -31,7 +31,7 @@ import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.readers.AvroRecordReader;
 
 
-public class KafkaJSONMessageDecoder implements KafkaMessageDecoder {
+public class KafkaJSONMessageDecoder implements KafkaMessageDecoder<byte[]> {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaJSONMessageDecoder.class);
 
   private Schema schema;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaMessageDecoder.java
@@ -21,7 +21,7 @@ import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.core.data.GenericRow;
 
 
-public interface KafkaMessageDecoder {
+public interface KafkaMessageDecoder<T> {
 
   /**
    *
@@ -35,7 +35,7 @@ public interface KafkaMessageDecoder {
    * @param payload
    * @return
    */
-  GenericRow decode(byte[] payload, GenericRow destination);
+  GenericRow decode(T payload, GenericRow destination);
 
   /**
    * Decodes a row.
@@ -46,5 +46,5 @@ public interface KafkaMessageDecoder {
    * @param destination The {@link GenericRow} to write the decoded row into
    * @return A new row decoded from the buffer
    */
-  GenericRow decode(byte[] payload, int offset, int length, GenericRow destination);
+  GenericRow decode(T payload, int offset, int length, GenericRow destination);
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -274,7 +274,7 @@ public abstract class ClusterTest extends ControllerTest {
         _controllerRequestURLBuilder.forTableDelete(TableNameBuilder.OFFLINE.tableNameWithType(tableName)));
   }
 
-  public static class AvroFileSchemaKafkaAvroMessageDecoder implements KafkaMessageDecoder {
+  public static class AvroFileSchemaKafkaAvroMessageDecoder implements KafkaMessageDecoder<byte[]> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AvroFileSchemaKafkaAvroMessageDecoder.class);
     public static File avroFile;
     private org.apache.avro.Schema _avroSchema;


### PR DESCRIPTION
* Prepare for likafka migration
* Allows message decoders to take in either byte[] or IndexedRecord