### PR TITLE
Clean up memory map files for a segment on start

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -47,6 +47,8 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,12 +169,15 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     // lets create a new realtime segment
     segmentLogger.info("Started kafka stream provider");
+    final int capacity = kafkaStreamProviderConfig.getSizeThresholdToFlushSegment();
     realtimeSegment =
-        new RealtimeSegmentImpl(serverMetrics, this, indexLoadingConfig, kafkaStreamProviderConfig.getSizeThresholdToFlushSegment(),
+        new RealtimeSegmentImpl(serverMetrics, this, indexLoadingConfig, capacity,
             kafkaStreamProviderConfig.getStreamName());
     realtimeSegment.setSegmentMetadata(segmentMetadata, this.schema);
     notifier = realtimeTableDataManager;
 
+    LOGGER.info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}",
+        segmentName, capacity, new DateTime(segmentEndTimeThreshold, DateTimeZone.UTC).toString());
     segmentStatusTask = new TimerTask() {
       @Override
       public void run() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -62,6 +62,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import kafka.message.MessageAndOffset;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -970,6 +972,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     long now = now();
     _consumeStartTime = now;
     _consumeEndTime = now + kafkaStreamProviderConfig.getTimeThresholdToFlushSegment();
+    LOGGER.info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}",
+        _segmentName, _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC).toString());
     start();
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnMultiValueReaderWriter.java
@@ -137,7 +137,7 @@ public class FixedByteSingleColumnMultiValueReaderWriter extends BaseSingleColum
   }
 
   private void addHeaderBuffers() {
-    LOGGER.info("Allocating header buffer of size {} for column {}", headerSize, columnName);
+    LOGGER.info("Allocating header buffer of size {} for column {} segment {}", headerSize, columnName, memoryManager.getSegmentName());
     headerBuffer = memoryManager.allocate(headerSize, columnName);
     // We know that these buffers will not be copied directly into a file (or mapped from a file).
     // So, we can use native byte order here.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleColumnSingleValueReaderWriter.java
@@ -127,7 +127,7 @@ public class FixedByteSingleColumnSingleValueReaderWriter extends BaseSingleColu
   }
 
   private void addBuffer() {
-    LOGGER.info("Allocating {} bytes for column {}", chunkSizeInBytes, columnName);
+    LOGGER.info("Allocating {} bytes for column {} for segment {}", chunkSizeInBytes, columnName, memoryManager.getSegmentName());
     PinotDataBuffer buffer = memoryManager.allocate(chunkSizeInBytes, columnName);
     buffer.order(ByteOrder.nativeOrder());
     buffers.add(buffer);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/MutableOffHeapByteArrayStore.java
@@ -100,7 +100,7 @@ public class MutableOffHeapByteArrayStore implements Closeable {
       if (size >= Integer.MAX_VALUE) {
         size = Integer.MAX_VALUE - 1;
       }
-      LOGGER.info("Allocating byte array store buffer of size {} for column {}", size, columnName);
+      LOGGER.info("Allocating byte array store buffer of size {} for column {} segment {}", size, columnName, memoryManager.getSegmentName());
       _pinotDataBuffer = memoryManager.allocate(size, columnName);
       _pinotDataBuffer.order(ByteOrder.nativeOrder());
       _byteBuffer = _pinotDataBuffer.toDirectByteBuffer(0, (int) size);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -300,7 +300,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
     for (IntBuffer iBuf : oldList) {
       newList.add(iBuf);
     }
-    LOGGER.info("Allocating {} bytes for column {}", bbSize, _columnName);
+    LOGGER.info("Allocating {} bytes for column {} segment {}", bbSize, _columnName, _memoryManager.getSegmentName());
     PinotDataBuffer buffer = _memoryManager.allocate(bbSize, _columnName);
     _pinotDataBuffers.add(buffer);
     buffer.order(ByteOrder.nativeOrder());

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerFileCleanupTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerFileCleanupTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.indexsegment.utils;
+
+import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class MmapMemoryManagerFileCleanupTest {
+  private String _tmpDir;
+
+  @BeforeClass
+  public void setUp() {
+    _tmpDir = System.getProperty("java.io.tmpdir") + "/" + MmapMemoryManagerTest.class.getSimpleName();
+    File dir = new File(_tmpDir);
+    FileUtils.deleteQuietly(dir);
+    dir.mkdir();
+    dir.deleteOnExit();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    new File(_tmpDir).delete();
+  }
+
+  // Since this file leaves MmapUtils allocation contexts in place, it cannot be included in MmapMemoryManagerTest
+  @Test
+  public void testFileDelete() throws Exception {
+    final String segmentName = "someSegment";
+    final String someColumn = "column";
+    final long firstAlloc = 20;
+    final long allocAfterRestart = 200;
+    RealtimeIndexOffHeapMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    memoryManager.allocate(firstAlloc, someColumn);
+    // Now, if the host restarts, we will have a file left behind for the same consuming segment.
+    // and we should not see any exception.
+    memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    memoryManager.allocate(allocAfterRestart, someColumn);
+    // We should not see the first allocation in the total.
+    Assert.assertEquals(memoryManager.getTotalMemBytes(), allocAfterRestart);
+    memoryManager.close();
+  }
+}


### PR DESCRIPTION
If a host restarts, we will end up throwing an exception by trying to create files
with the same name for the mmap.

Added code to remove the files upon start (i.e. creation of new instance of mem manager for a segment),
and added a test for it.

Also added segment name to the logs so we can get an idea of how much mem is being allocated