### PR TITLE
Support for time bucketing with time zone offset for timeConvert UDF.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ConstantBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/ConstantBlockValSet.java
@@ -127,4 +127,24 @@ public class ConstantBlockValSet extends BaseBlockValSet {
   public int getNumDocs() {
     return _numDocs;
   }
+
+  public int getIntValue() {
+    return Integer.parseInt(_value);
+  }
+
+  public long getLongValue() {
+    return Long.parseLong(_value);
+  }
+
+  public float getFloatValue() {
+    return Float.parseFloat(_value);
+  }
+
+  public double getDoubleValue() {
+    return Double.parseDouble(_value);
+  }
+
+  public String getStringValue() {
+    return _value;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/TimeConversionTransform.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/TimeConversionTransform.java
@@ -18,12 +18,14 @@ package com.linkedin.pinot.core.operator.transform.function;
 import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.BlockValSet;
+import com.linkedin.pinot.core.operator.docvalsets.ConstantBlockValSet;
 import com.linkedin.pinot.core.operator.transform.function.time.converter.TimeConverterFactory;
 import com.linkedin.pinot.core.operator.transform.function.time.converter.TimeUnitConverter;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import com.linkedin.pinot.core.query.exception.BadQueryRequestException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.NotThreadSafe;
+import org.joda.time.DateTimeZone;
 
 
 /**
@@ -51,11 +53,18 @@ public class TimeConversionTransform implements TransformFunction {
 
   @Override
   public <T> T transform(int length, BlockValSet... input) {
-    Preconditions.checkArgument(input.length == 3, TRANSFORM_NAME + " expects three arguments");
+    int numArgs = input.length;
+    Preconditions.checkArgument(numArgs <= 5, TRANSFORM_NAME + " expects upto five arguments");
 
     long[] inputTime = input[0].getLongValuesSV();
     String[] inputTimeUnits = input[1].getStringValuesSV();
     String[] outputTimeUnits = input[2].getStringValuesSV();
+
+    int granularity = (numArgs >= 4) ? ((ConstantBlockValSet) input[3]).getIntValue() : 1;
+    Preconditions.checkArgument(granularity > 0, "Time granularity must be greater than zero.");
+
+    DateTimeZone outputTimeZone =
+        (numArgs == 5) ? DateTimeZone.forID(((ConstantBlockValSet) input[4]).getStringValue()) : DateTimeZone.UTC;
 
     Preconditions.checkState(inputTime.length >= length && inputTimeUnits.length >= length,
         outputTimeUnits.length >= length);
@@ -66,7 +75,7 @@ public class TimeConversionTransform implements TransformFunction {
     if (_output == null || _output.length < length) {
       _output = new long[Math.max(length, DocIdSetPlanNode.MAX_DOC_PER_CALL)];
     }
-    converter.convert(inputTime, inputTimeUnit, length, _output);
+    converter.convert(inputTime, inputTimeUnit, length, granularity, outputTimeZone, _output);
     return (T) _output;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/time/converter/CustomTimeUnitConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/time/converter/CustomTimeUnitConverter.java
@@ -59,6 +59,12 @@ public class CustomTimeUnitConverter implements TimeUnitConverter {
 
   @Override
   public void convert(long[] inputTime, TimeUnit inputTimeUnit, int length, long[] outputTime) {
+    convert(inputTime, inputTimeUnit, length, 1, DateTimeZone.UTC, outputTime);
+  }
+
+  @Override
+  public void convert(long[] inputTime, TimeUnit inputTimeUnit, int length, int granularity,
+      DateTimeZone outputTimeZone, long[] outputTime) {
     MutableDateTime inputDateTime = new MutableDateTime(0L, DateTimeZone.UTC);
 
     // For loop within switch better than switch within for loop (may be??).
@@ -66,6 +72,7 @@ public class CustomTimeUnitConverter implements TimeUnitConverter {
       case WEEKS:
         for (int i = 0; i < length; i++) {
           long inputTimeMillis = TimeUnit.MILLISECONDS.convert(inputTime[i], inputTimeUnit);
+          inputTimeMillis = (inputTimeMillis + outputTimeZone.getOffset(inputTimeMillis)) / granularity;
           inputDateTime.setDate(inputTimeMillis);
           outputTime[i] = Weeks.weeksBetween(EPOCH_START_DATE, inputDateTime).getWeeks();
         }
@@ -74,6 +81,7 @@ public class CustomTimeUnitConverter implements TimeUnitConverter {
       case MONTHS:
         for (int i = 0; i < length; i++) {
           long inputTimeMillis = TimeUnit.MILLISECONDS.convert(inputTime[i], inputTimeUnit);
+          inputTimeMillis = (inputTimeMillis + outputTimeZone.getOffset(inputTimeMillis)) / granularity;
           inputDateTime.setDate(inputTimeMillis);
           outputTime[i] = Months.monthsBetween(EPOCH_START_DATE, inputDateTime).getMonths();
         }
@@ -82,6 +90,7 @@ public class CustomTimeUnitConverter implements TimeUnitConverter {
       case YEARS:
         for (int i = 0; i < length; i++) {
           long inputTimeMillis = TimeUnit.MILLISECONDS.convert(inputTime[i], inputTimeUnit);
+          inputTimeMillis = (inputTimeMillis + outputTimeZone.getOffset(inputTimeMillis)) / granularity;
           inputDateTime.setDate(inputTimeMillis);
           outputTime[i] = Years.yearsBetween(EPOCH_START_DATE, inputDateTime).getYears();
         }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/time/converter/JavaTimeUnitConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/time/converter/JavaTimeUnitConverter.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.operator.transform.function.time.converter;
 
 import java.util.concurrent.TimeUnit;
+import org.joda.time.DateTimeZone;
 
 
 /**
@@ -30,8 +31,17 @@ public class JavaTimeUnitConverter implements TimeUnitConverter {
 
   @Override
   public void convert(long[] inputTime, TimeUnit inputTimeUnit, int length, long[] outputTime) {
+    convert(inputTime, inputTimeUnit, length, 1, DateTimeZone.UTC, outputTime);
+  }
+
+  @Override
+  public void convert(long[] inputTime, TimeUnit inputTimeUnit, int length, int granularity,
+      DateTimeZone outputTimeZone, long[] outputTime) {
     for (int i = 0; i < length; i++) {
-      outputTime[i] = _timeUnit.convert(inputTime[i], inputTimeUnit);
+      long inputTimeMillis = TimeUnit.MILLISECONDS.convert(inputTime[i], inputTimeUnit);
+      int timeOffset = outputTimeZone.getOffset(inputTimeMillis);
+      long inputTimeInZone = inputTime[i] + inputTimeUnit.convert(timeOffset, TimeUnit.MILLISECONDS);
+      outputTime[i] = _timeUnit.convert(inputTimeInZone, inputTimeUnit) / granularity;
     }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/time/converter/TimeUnitConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/time/converter/TimeUnitConverter.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.operator.transform.function.time.converter;
 
 import java.util.concurrent.TimeUnit;
+import org.joda.time.DateTimeZone;
 
 
 /**
@@ -34,4 +35,19 @@ public interface TimeUnitConverter {
    * @param outputTime Array where output is to be stored.
    */
   void convert(long[] inputTime, TimeUnit inputTimeUnit, int length, long[] outputTime);
+
+  /**
+   * This method converts an array of input times from the specified {@link TimeUnit} into
+   * implementation's timeUnit. It also allows for rolling up to custom granularity (eg 15 minutes),
+   * and applying time offset before rolling up.
+   *
+   * @param inputTime Input times
+   * @param inputTimeUnit Time unit for the input
+   * @param length Length of input array to process
+   * @param granularity Time granularity (for example 15 minutes)
+   * @param outputTimeZone Output time zone.
+   * @param outputTime Array where output is to be stored.
+   */
+  void convert(long[] inputTime, TimeUnit inputTimeUnit, int length, int granularity, DateTimeZone outputTimeZone,
+      long[] outputTime);
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/transform/TimeConversionTransformTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/transform/TimeConversionTransformTest.java
@@ -108,4 +108,42 @@ public class TimeConversionTransformTest {
       Assert.assertEquals(output[i], expectedYears[i]);
     }
   }
+
+  @Test
+  public void testBucketing() {
+    long inputs[] = new long[NUM_ROWS];
+    long outputs[] = new long[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      inputs[i] = i;
+    }
+
+    int granularity = 4;
+    TimeUnitConverter converter = TimeConverterFactory.getTimeConverter("DaYs");
+    converter.convert(inputs, TimeUnit.DAYS, NUM_ROWS, granularity, DateTimeZone.UTC, outputs);
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(outputs[i], inputs[i] / granularity);
+    }
+  }
+
+  @Test
+  public void testTimeZone() {
+    long inputs[] = new long[NUM_ROWS];
+    long outputs[] = new long[NUM_ROWS];
+
+    Random random = new Random(System.nanoTime());
+    for (int i = 0; i < NUM_ROWS; i++) {
+      inputs[i] = Math.abs(random.nextLong());
+    }
+
+    int granularity = 4;
+    DateTimeZone timeZone = DateTimeZone.forID("America/Los_Angeles");
+    TimeUnitConverter converter = TimeConverterFactory.getTimeConverter("MiLliSEconDs");
+    converter.convert(inputs, TimeUnit.MILLISECONDS, NUM_ROWS, granularity, timeZone, outputs);
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      long offset = timeZone.getOffset(inputs[i]);
+      Assert.assertEquals(outputs[i], (inputs[i] + offset) / granularity, "i: " + i);
+    }
+  }
 }


### PR DESCRIPTION
Added support for bucketing on arbitrary time windows (eg 15 minutes),
with option of applying time zone offset before bucketing. Note, this
requires the column to be in epoch time units.

Added tests for the new feature.

Example: ```select count(*) from myTable group by timeConvert(timeColumn,
'MILLIS', 'DAYS', 5, 'America/Los_Angeles')```

The query above will apply a transform on the 'timeColumn' that:
- First applies a time offset to the raw value (supports day light
  savings aware offsets).
- Then converts it into buckets of 5 days, generating unique groups for
  the query.

List of supported time zone strings can be found at:
http://joda-time.sourceforge.net/timezones.html