### PR TITLE
Make number of segments that can be refreshed simultaneously

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DataManager.java
@@ -56,4 +56,6 @@ public interface DataManager {
   SegmentMetadata getSegmentMetadata(@Nonnull String tableNameWithType, @Nonnull String segmentName);
 
   boolean isStarted();
+
+  int getMaxParallelRefreshThreads();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/FileBasedInstanceDataManager.java
@@ -152,6 +152,11 @@ public class FileBasedInstanceDataManager implements InstanceDataManager {
     return _isStarted;
   }
 
+  @Override
+  public int getMaxParallelRefreshThreads() {
+    return 1;
+  }
+
   public synchronized void addTableDataManager(String tableName, TableDataManager tableDataManager) {
     _tableDataManagerMap.put(tableName, tableDataManager);
   }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -287,6 +287,11 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     return _segmentMetadataLoader;
   }
 
+  @Override
+  public int getMaxParallelRefreshThreads() {
+    return _instanceDataManagerConfig.getMaxParallelRefreshThreads();
+  }
+
   @Nonnull
   @Override
   public List<SegmentMetadata> getAllSegmentsMetadata(@Nonnull String tableNameWithType) {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -27,7 +27,6 @@ import com.linkedin.pinot.common.utils.MmapUtils;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.common.utils.ZkUtils;
-import com.linkedin.pinot.core.data.manager.offline.TableDataManagerProvider;
 import com.linkedin.pinot.core.indexsegment.columnar.ColumnarSegmentMetadataLoader;
 import com.linkedin.pinot.server.conf.ServerConf;
 import com.linkedin.pinot.server.realtime.ControllerLeaderLocator;
@@ -140,7 +139,8 @@ public class HelixServerStarter {
     updateInstanceConfigInHelix(adminApiPort, false/*shutDownStatus*/);
 
     // Register message handler factory
-    SegmentMessageHandlerFactory messageHandlerFactory = new SegmentMessageHandlerFactory(fetcherAndLoader);
+    SegmentMessageHandlerFactory messageHandlerFactory = new SegmentMessageHandlerFactory(fetcherAndLoader,
+        _serverInstance.getInstanceDataManager());
     _helixManager.getMessagingService().registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(),
         messageHandlerFactory);
 


### PR DESCRIPTION
We introduced a lock on the helix threads refreshing a loaded segment, so that we do not run out of memory
with too many segments loaded. However, if segments are loaded via MMAP and the server is in a multi-tenant
(low qps) cluster, it should be fine to overload via MMAP for a brief period.

This commit makes the number of simultaneous threads configurable. A value of 0 (or less) indicates unlimited
number. Any value above 0 configures the maximum allowed threads to refresh.

Default is 1, preserving the old behvaior of a lock.

NOTE: While setting this number to a higher value (or 0) may increase segment load time, there will be more
      threads occupied loading segments, so query latencies may actually increase during refresh time