### PR TITLE
[TE] Separate granularity of timestamp and data point

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/DatasetConfigDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/DatasetConfigDTO.java
@@ -9,23 +9,21 @@ public class DatasetConfigDTO extends DatasetConfigBean {
   private TimeGranularity bucketTimeGranularity;
 
   /**
-   * Returns the granularity of a bucket (a data point) of this dataset. The granularity of a bucket, which may be
-   * different from the granularity that is defined in dataset configuration, which actually defines the granularity of
-   * the timestamp of each data point. This variable provides the actual granularity when the granularity defined in
-   * the dataset config is different from the granularity of data point. This information is crucial for non-additive
-   * dataset.
+   * Returns the granularity of a bucket (i.e., a data point) of this dataset if such information is available.
    *
-   * @return the granularity of a bucket (a data point) of this dataset
+   * The granularity that is defined in dataset configuration actually defines the granularity of the timestamp of each
+   * data point. For instance, timestamp's granularity (in database) could be 1-MILLISECONDS but the bucket's
+   * granularity is 1-HOURS. In real applications, the granularity of timestamp is never being used. Therefore, this
+   * method returns the actual granularity of the bucket (data point) if such information is available in the cnofig.
+   * This information is crucial for non-additive dataset.
+   *
+   * @return the granularity of a bucket (a data point) of this dataset.
    */
   public TimeGranularity bucketTimeGranularity() {
     if (bucketTimeGranularity == null) {
-      if (this.isAdditive()) {
-        bucketTimeGranularity = new TimeGranularity(getTimeDuration(), getTimeUnit());
-      } else {
         int size = getNonAdditiveBucketSize() != null ? getNonAdditiveBucketSize() : getTimeDuration();
         TimeUnit timeUnit = getNonAdditiveBucketUnit() != null ? getNonAdditiveBucketUnit() : getTimeUnit();
         bucketTimeGranularity = new TimeGranularity(size, timeUnit);
-      }
     }
     return bucketTimeGranularity;
   }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/dto/DatasetConfigDTOTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/dto/DatasetConfigDTOTest.java
@@ -1,0 +1,41 @@
+package com.linkedin.thirdeye.datalayer.dto;
+
+import com.linkedin.thirdeye.api.TimeGranularity;
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class DatasetConfigDTOTest {
+
+  @Test
+  public void testBucketTimeGranularity() {
+    DatasetConfigDTO datasetConfigDTOEmptyBucketInfo = new DatasetConfigDTO();
+    datasetConfigDTOEmptyBucketInfo.setTimeDuration(1);
+    datasetConfigDTOEmptyBucketInfo.setTimeUnit(TimeUnit.MILLISECONDS);
+    Assert.assertEquals(datasetConfigDTOEmptyBucketInfo.bucketTimeGranularity(),
+        new TimeGranularity(1, TimeUnit.MILLISECONDS));
+
+    DatasetConfigDTO datasetConfigDTOEmptyBucketSize = new DatasetConfigDTO();
+    datasetConfigDTOEmptyBucketSize.setTimeDuration(1);
+    datasetConfigDTOEmptyBucketSize.setTimeUnit(TimeUnit.MILLISECONDS);
+    datasetConfigDTOEmptyBucketSize.setNonAdditiveBucketUnit(TimeUnit.MINUTES);
+    Assert.assertEquals(datasetConfigDTOEmptyBucketSize.bucketTimeGranularity(),
+        new TimeGranularity(1, TimeUnit.MINUTES));
+
+    DatasetConfigDTO datasetConfigDTOEmptyBucketUnit = new DatasetConfigDTO();
+    datasetConfigDTOEmptyBucketUnit.setTimeDuration(1);
+    datasetConfigDTOEmptyBucketUnit.setTimeUnit(TimeUnit.MILLISECONDS);
+    datasetConfigDTOEmptyBucketUnit.setNonAdditiveBucketSize(5);
+    Assert.assertEquals(datasetConfigDTOEmptyBucketUnit.bucketTimeGranularity(),
+        new TimeGranularity(5, TimeUnit.MILLISECONDS));
+
+    DatasetConfigDTO datasetConfigDTOFullOverride = new DatasetConfigDTO();
+    datasetConfigDTOFullOverride.setTimeDuration(1);
+    datasetConfigDTOFullOverride.setTimeUnit(TimeUnit.MILLISECONDS);
+    datasetConfigDTOFullOverride.setNonAdditiveBucketSize(5);
+    datasetConfigDTOFullOverride.setNonAdditiveBucketUnit(TimeUnit.MINUTES);
+    Assert.assertEquals(datasetConfigDTOFullOverride.bucketTimeGranularity(),
+        new TimeGranularity(5, TimeUnit.MINUTES));
+  }
+
+}


### PR DESCRIPTION
Dataset now can specify the granularity of its data point if the granularity is different from that of timestamp.

For example, a dataset might have timestamp in MILLISECOND granularity but its data point is in MINUTES granularity. This PR allows user to provide such information in dataset config.

Test:
Tested with unit test. The front end is tested on local dashboard.