### PR TITLE
[TE] Enable anomalyFeedbackFilters in ThirdEye anomaly search page

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyFeedbackType.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyFeedbackType.java
@@ -1,5 +1,18 @@
 package com.linkedin.thirdeye.constant;
 
 public enum AnomalyFeedbackType {
-  ANOMALY, NOT_ANOMALY, ANOMALY_NEW_TREND, NO_FEEDBACK
+  ANOMALY("Confirmed Anomaly"),
+  NOT_ANOMALY("False Alarm"),
+  ANOMALY_NEW_TREND("New Trend"),
+  NO_FEEDBACK("Not Resolved");
+
+  String userReadableName = null;
+
+  AnomalyFeedbackType(String userReadableName) {
+    this.userReadableName = userReadableName;
+  }
+
+  public String getUserReadableName() {
+    return this.userReadableName;
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/SearchFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/SearchFilters.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.pojo;
 
 import com.linkedin.thirdeye.anomaly.classification.ClassificationTaskRunner;
+import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -139,10 +140,14 @@ public class SearchFilters {
       boolean passed = true;
       // check feedback filter
       AnomalyFeedback feedback = mergedAnomalyResultDTO.getFeedback();
+      String status = null;
       if (feedback != null) {
-        String status = feedback.getFeedbackType().toString();
-        passed = passed && checkFilter(feedbackFilterMap, status);
+        status = feedback.getFeedbackType().getUserReadableName();
+      } else {
+        // If feedback is null, assign NO_FEEDBACK to the status
+        status = AnomalyFeedbackType.NO_FEEDBACK.getUserReadableName();
       }
+      passed = passed && checkFilter(feedbackFilterMap, status);
       // check status filter
       String functionName = mergedAnomalyResultDTO.getFunction().getFunctionName();
       passed = passed && checkFilter(functionFilterMap, functionName);
@@ -194,10 +199,14 @@ public class SearchFilters {
     for (MergedAnomalyResultDTO mergedAnomalyResultDTO : anomalies) {
       // update feedback filter
       AnomalyFeedback feedback = mergedAnomalyResultDTO.getFeedback();
+      String status = null;
       if (feedback != null) {
-        String status = feedback.getFeedbackType().toString();
-        update(feedbackFilterMap, status, mergedAnomalyResultDTO.getId());
+        status = feedback.getFeedbackType().getUserReadableName();
+      } else {
+        // If anomaly feedback is null, assign NO_FEEDBACK
+        status = AnomalyFeedbackType.NO_FEEDBACK.getUserReadableName();
       }
+      update(feedbackFilterMap, status, mergedAnomalyResultDTO.getId());
       // update status filter
       String functionName = mergedAnomalyResultDTO.getFunction().getFunctionName();
       update(functionFilterMap, functionName, mergedAnomalyResultDTO.getId());

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyFilterModel.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/javascript/models/AnomalyFilterModel.js
@@ -7,7 +7,7 @@ function AnomalyFilterModel() {
   this.viewFilters = null;
   this.selectedFilters = null;
   this.pageNumber = 1;
-  this.hiddenFilters = ['statusFilterMap'];
+  this.hiddenFilters = [];
 }
 
 AnomalyFilterModel.prototype = {


### PR DESCRIPTION
Per request from user, they need an AnomalyFeedbackFilter in the seach page to get the unlabelled anomalies or true issues. This pull request is to enable the anomaly feedback filter, and assign an user-readable name to user.

- Add user readable name to anomaly feedback type

- Add NO_FEEDBACK to null anomaly feedback status, and implement the same logic on applySearchFilters

- Enable feedbackStatusFilters in front-end