### PR TITLE
[MINION] Clean up rest APIS and add API to clean up finished tasks

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -122,7 +122,6 @@ public class ControllerStarter {
       LOGGER.info("Starting task manager");
       _taskManager =
           new PinotTaskManager(taskDriver, helixResourceManager, _helixTaskResourceManager, config, controllerMetrics);
-      _taskManager.ensureTaskQueuesExist();
       int taskManagerFrequencyInSeconds = config.getTaskManagerFrequencyInSeconds();
       if (taskManagerFrequencyInSeconds > 0) {
         LOGGER.info("Starting task manager with running frequency of {} seconds", taskManagerFrequencyInSeconds);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/StringResultResponse.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/StringResultResponse.java
@@ -15,14 +15,14 @@
  */
 package com.linkedin.pinot.controller.api.resources;
 
-public final class SuccessResponse {
-  private final String _status;
+public final class StringResultResponse {
+  private final String _result;
 
-  public SuccessResponse(String status) {
-    _status = status;
+  public StringResultResponse(String result) {
+    _result = result;
   }
 
-  public String getStatus() {
-    return _status;
+  public String getResult() {
+    return _result;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -81,6 +81,18 @@ public class PinotHelixTaskResourceManager {
   }
 
   /**
+   * Clean up a task queue for the given task type.
+   *
+   * @param taskType Task type
+   */
+  // TODO: Seems the node under PROPERTYSTORE/TaskRebalancer is not cleaned up properly
+  public synchronized void cleanUpTaskQueue(@Nonnull String taskType) {
+    String helixJobQueueName = getHelixJobQueueName(taskType);
+    LOGGER.info("Cleaning up task queue: {} for task type: {}", helixJobQueueName, taskType);
+    _taskDriver.cleanupJobQueue(helixJobQueueName);
+  }
+
+  /**
    * Stop the task queue for the given task type.
    *
    * @param taskType Task type

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
@@ -108,7 +108,7 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
       @Override
       public Boolean apply(@Nullable Void aVoid) {
-        return _helixTaskResourceManager.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size() == 5;
+        return _helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size() == 5;
       }
     }, 60_000L, "Failed to get all tasks showing up in the cluster");
 
@@ -118,14 +118,13 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
       @Override
       public Boolean apply(@Nullable Void aVoid) {
-        return _helixTaskResourceManager.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size() == 8;
+        return _helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size() == 8;
       }
     }, 60_000L, "Failed to get all tasks showing up in the cluster");
 
     // Should not generate more tasks
     _taskManager.scheduleTasks();
-    Assert.assertEquals(_helixTaskResourceManager.getTaskStates(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(),
-        8);
+    Assert.assertEquals(_helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 8);
 
     // Wait at most 600 seconds for all tasks COMPLETED and new segments refreshed
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
@@ -182,6 +181,10 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
         }
       }
     }, 600_000L, "Failed to get all tasks COMPLETED and new segments refreshed");
+
+    // Clean up the COMPLETED tasks
+    _helixTaskResourceManager.cleanUpTaskQueue(MinionConstants.ConvertToRawIndexTask.TASK_TYPE);
+    Assert.assertEquals(_helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 0);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -80,7 +80,6 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
 
     // Register the test task generator into task manager
     _pinotTaskManager.registerTaskGenerator(new TestTaskGenerator(_pinotTaskManager.getClusterInfoProvider()));
-    _pinotTaskManager.ensureTaskQueuesExist();
 
     Map<String, Class<? extends PinotTaskExecutor>> taskExecutorsToRegister = new HashMap<>(1);
     taskExecutorsToRegister.put(TestTaskGenerator.TASK_TYPE, TestTaskExecutor.class);
@@ -97,7 +96,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
       @Override
       public Boolean apply(@Nullable Void aVoid) {
-        return _pinotHelixTaskResourceManager.getTaskStates(TestTaskGenerator.TASK_TYPE).size() == 4;
+        return _pinotHelixTaskResourceManager.getTasks(TestTaskGenerator.TASK_TYPE).size() == 4;
       }
     }, 60_000L, "Failed to get all tasks showing up in the cluster");
 
@@ -142,6 +141,10 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
         return true;
       }
     }, 60_000L, "Failed to get all tasks COMPLETED");
+
+    // Clean up the COMPLETED tasks
+    _pinotHelixTaskResourceManager.cleanUpTaskQueue(TestTaskGenerator.TASK_TYPE);
+    Assert.assertEquals(_pinotHelixTaskResourceManager.getTasks(TestTaskGenerator.TASK_TYPE).size(), 0);
 
     // Delete the task queue
     _pinotHelixTaskResourceManager.deleteTaskQueue(TestTaskGenerator.TASK_TYPE);


### PR DESCRIPTION
Fixed the issue where TaskResource is not attached to the rest server
Always return result in JSON format (Added StringResultResponse class)
Removed rest APIs to create task/task queue because they should only be created by the scheduleTasks()
Added rest API to clean up finished tasks
Modified tests to test clean up API
Also Fixed the NPE in SimpleMinionClusterIntegrationTest by ensuring task queues show up in ZK when create them