### PR TITLE
[MINION] Model multiple tasks from generateTasks() into one Helix Job so that all of them can run in parallel

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -72,11 +72,11 @@ public class PinotTaskRestletResource {
 
   @GET
   @Path("/tasks/taskconfig/{taskName}")
-  @ApiOperation("Get the task config for the given task name")
-  public PinotTaskConfig getTaskConfig(
+  @ApiOperation("Get the child task configs for the given task name")
+  public List<PinotTaskConfig> getTaskConfigs(
       @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
     try {
-      return _pinotHelixTaskResourceManager.getTaskConfig(taskName);
+      return _pinotHelixTaskResourceManager.getTaskConfigs(taskName);
     } catch (Exception e) {
       throw new WebApplicationException(e);
     }
@@ -132,7 +132,7 @@ public class PinotTaskRestletResource {
   @PUT
   @Path("/tasks/scheduletasks")
   @ApiOperation("Schedule tasks")
-  public Map<String, List<String>> scheduleTasks() {
+  public Map<String, String> scheduleTasks() {
     try {
       return _pinotTaskManager.scheduleTasks();
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/ClusterInfoProvider.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/ClusterInfoProvider.java
@@ -109,14 +109,14 @@ public class ClusterInfoProvider {
   }
 
   /**
-   * Get the task config for the given task name.
+   * Get the child task configs for the given task name.
    *
    * @param taskName Task name
-   * @return Task config
+   * @return List of child task configs
    */
   @Nonnull
-  public PinotTaskConfig getTaskConfig(@Nonnull String taskName) {
-    return _pinotHelixTaskResourceManager.getTaskConfig(taskName);
+  public List<PinotTaskConfig> getTaskConfigs(@Nonnull String taskName) {
+    return _pinotHelixTaskResourceManager.getTaskConfigs(taskName);
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/generator/ConvertToRawIndexTaskGenerator.java
@@ -63,9 +63,11 @@ public class ConvertToRawIndexTaskGenerator implements PinotTaskGenerator {
     for (Map.Entry<String, TaskState> entry : taskStates.entrySet()) {
       TaskState taskState = entry.getValue();
       if (taskState == TaskState.NOT_STARTED || taskState == TaskState.IN_PROGRESS || taskState == TaskState.STOPPED) {
-        Map<String, String> configs = _clusterInfoProvider.getTaskConfig(entry.getKey()).getConfigs();
-        runningSegments.add(
-            configs.get(MinionConstants.TABLE_NAME_KEY) + "__" + configs.get(MinionConstants.SEGMENT_NAME_KEY));
+        for (PinotTaskConfig pinotTaskConfig : _clusterInfoProvider.getTaskConfigs(entry.getKey())) {
+          Map<String, String> configs = pinotTaskConfig.getConfigs();
+          runningSegments.add(
+              configs.get(MinionConstants.TABLE_NAME_KEY) + "__" + configs.get(MinionConstants.SEGMENT_NAME_KEY));
+        }
       }
     }
 

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
@@ -102,13 +102,15 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
       }
     }
 
-    // Should create the task queues and generate 5 ConvertToRawIndexTask tasks
-    Assert.assertEquals(_taskManager.scheduleTasks().get(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 5);
+    // Should create the task queues and generate a ConvertToRawIndexTask task with 5 child tasks
+    Assert.assertEquals(_taskManager.scheduleTasks().size(), 1);
     Assert.assertEquals(_helixTaskResourceManager.getTaskQueues().size(), 1);
-    // Should generate 3 more ConvertToRawIndexTask tasks
-    Assert.assertEquals(_taskManager.scheduleTasks().get(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 3);
+
+    // Should generate one more ConvertToRawIndexTask task with 3 child tasks
+    Assert.assertEquals(_taskManager.scheduleTasks().size(), 1);
+
     // Should not generate more tasks
-    Assert.assertEquals(_taskManager.scheduleTasks().get(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 0);
+    Assert.assertTrue(_taskManager.scheduleTasks().isEmpty());
 
     // Wait at most 600 seconds for all tasks COMPLETED and new segments refreshed
     TestUtils.waitForCondition(new Function<Void, Boolean>() {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -55,7 +55,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   private static final String TABLE_NAME_1 = "testTable1";
   private static final String TABLE_NAME_2 = "testTable2";
   private static final String TABLE_NAME_3 = "testTable3";
-  private static final int NUM_MINIONS = 3;
+  private static final int NUM_MINIONS = 1;
 
   private PinotHelixTaskResourceManager _helixTaskResourceManager;
   private PinotTaskManager _taskManager;
@@ -89,17 +89,19 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
 
   @Test
   public void testStopAndResumeTaskQueue() throws Exception {
-    // Should create the task queues and generate 2 tasks
-    Assert.assertEquals(_taskManager.scheduleTasks().get(TestTaskGenerator.TASK_TYPE).size(), 2);
+    // Should create the task queues and generate a task
+    Assert.assertEquals(_taskManager.scheduleTasks().size(), 1);
     Assert.assertEquals(_helixTaskResourceManager.getTaskQueues().size(), 2);
-    // Should generate 2 more tasks
-    Assert.assertEquals(_taskManager.scheduleTasks().get(TestTaskGenerator.TASK_TYPE).size(), 2);
+
+    // Should generate one more task
+    Assert.assertEquals(_taskManager.scheduleTasks().size(), 1);
+
     // Should not generate more tasks
-    Assert.assertEquals(_taskManager.scheduleTasks().get(TestTaskGenerator.TASK_TYPE).size(), 0);
+    Assert.assertTrue(_taskManager.scheduleTasks().isEmpty());
 
     // Check if all tasks IN_PROGRESS
     Collection<TaskState> taskStates = _helixTaskResourceManager.getTaskStates(TestTaskGenerator.TASK_TYPE).values();
-    Assert.assertEquals(taskStates.size(), 4);
+    Assert.assertEquals(taskStates.size(), 2);
     for (TaskState taskState : taskStates) {
       Assert.assertEquals(taskState, TaskState.IN_PROGRESS);
     }
@@ -113,7 +115,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
       public Boolean apply(@Nullable Void aVoid) {
         Collection<TaskState> taskStates =
             _helixTaskResourceManager.getTaskStates(TestTaskGenerator.TASK_TYPE).values();
-        Assert.assertEquals(taskStates.size(), 4);
+        Assert.assertEquals(taskStates.size(), 2);
         for (TaskState taskState : taskStates) {
           if (taskState != TaskState.STOPPED) {
             return false;
@@ -132,7 +134,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
       public Boolean apply(@Nullable Void aVoid) {
         Collection<TaskState> taskStates =
             _helixTaskResourceManager.getTaskStates(TestTaskGenerator.TASK_TYPE).values();
-        Assert.assertEquals(taskStates.size(), 4);
+        Assert.assertEquals(taskStates.size(), 2);
         for (TaskState taskState : taskStates) {
           if (taskState != TaskState.COMPLETED) {
             return false;
@@ -178,8 +180,8 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     public List<PinotTaskConfig> generateTasks(@Nonnull List<TableConfig> tableConfigs) {
       Assert.assertEquals(tableConfigs.size(), 2);
 
-      // Generate at most 4 tasks
-      if (_clusterInfoProvider.getTaskStates(TASK_TYPE).size() >= 4) {
+      // Generate at most 2 tasks
+      if (_clusterInfoProvider.getTaskStates(TASK_TYPE).size() >= 2) {
         return Collections.emptyList();
       }
 


### PR DESCRIPTION
Helix does not allow multiple Jobs run on the same instance, so model multiple Pinot tasks into one Helix Job so that all Pinot tasks can run in parallel
The Pinot tasks in the same Helix Job should have the same task type