### PR TITLE
[MINION] While cleaning up finished tasks, explicitly remove task contexts

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -44,7 +44,6 @@ import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.PreConnectCallback;
-import org.apache.helix.task.TaskDriver;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,13 +114,10 @@ public class ControllerStarter {
       helixResourceManager.start();
 
       LOGGER.info("Starting task resource manager");
-      // Helix resource manager must be started in order to get TaskDriver
-      TaskDriver taskDriver = new TaskDriver(helixResourceManager.getHelixZkManager());
-      _helixTaskResourceManager = new PinotHelixTaskResourceManager(taskDriver);
+      _helixTaskResourceManager = new PinotHelixTaskResourceManager(helixResourceManager.getHelixZkManager());
 
       LOGGER.info("Starting task manager");
-      _taskManager =
-          new PinotTaskManager(taskDriver, helixResourceManager, _helixTaskResourceManager, config, controllerMetrics);
+      _taskManager = new PinotTaskManager(_helixTaskResourceManager, helixResourceManager, config, controllerMetrics);
       int taskManagerFrequencyInSeconds = config.getTaskManagerFrequencyInSeconds();
       if (taskManagerFrequencyInSeconds > 0) {
         LOGGER.info("Starting task manager with running frequency of {} seconds", taskManagerFrequencyInSeconds);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.controller.helix.core.minion.PinotTaskManager;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
@@ -131,10 +132,9 @@ public class PinotTaskRestletResource {
   @PUT
   @Path("/tasks/scheduletasks")
   @ApiOperation("Schedule tasks")
-  public SuccessResponse scheduleTasks() {
+  public Map<String, List<String>> scheduleTasks() {
     try {
-      _pinotTaskManager.scheduleTasks();
-      return new SuccessResponse("Successfully scheduled tasks");
+      return _pinotTaskManager.scheduleTasks();
     } catch (Exception e) {
       throw new WebApplicationException(e);
     }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
@@ -102,29 +102,13 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
       }
     }
 
-    // Should generate 5 ConvertToRawIndexTask tasks
-    _taskManager.scheduleTasks();
-    // Wait at most 60 seconds for all 5 tasks showing up in the cluster
-    TestUtils.waitForCondition(new Function<Void, Boolean>() {
-      @Override
-      public Boolean apply(@Nullable Void aVoid) {
-        return _helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size() == 5;
-      }
-    }, 60_000L, "Failed to get all tasks showing up in the cluster");
-
+    // Should create the task queues and generate 5 ConvertToRawIndexTask tasks
+    Assert.assertEquals(_taskManager.scheduleTasks().get(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 5);
+    Assert.assertEquals(_helixTaskResourceManager.getTaskQueues().size(), 1);
     // Should generate 3 more ConvertToRawIndexTask tasks
-    _taskManager.scheduleTasks();
-    // Wait at most 60 seconds for all 8 tasks showing up in the cluster
-    TestUtils.waitForCondition(new Function<Void, Boolean>() {
-      @Override
-      public Boolean apply(@Nullable Void aVoid) {
-        return _helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size() == 8;
-      }
-    }, 60_000L, "Failed to get all tasks showing up in the cluster");
-
+    Assert.assertEquals(_taskManager.scheduleTasks().get(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 3);
     // Should not generate more tasks
-    _taskManager.scheduleTasks();
-    Assert.assertEquals(_helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 8);
+    Assert.assertEquals(_taskManager.scheduleTasks().get(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 0);
 
     // Wait at most 600 seconds for all tasks COMPLETED and new segments refreshed
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
@@ -181,10 +165,6 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
         }
       }
     }, 600_000L, "Failed to get all tasks COMPLETED and new segments refreshed");
-
-    // Clean up the COMPLETED tasks
-    _helixTaskResourceManager.cleanUpTaskQueue(MinionConstants.ConvertToRawIndexTask.TASK_TYPE);
-    Assert.assertEquals(_helixTaskResourceManager.getTasks(MinionConstants.ConvertToRawIndexTask.TASK_TYPE).size(), 0);
   }
 
   @Test


### PR DESCRIPTION
There is a Helix bug that causes task contexts not removed properly. Added a work around to explicitly remove them.
Added prepareTaskQueues() to ensure all task queues exist and clean up all finished tasks, which should be called before scheduleTasks().
This way, the clean up will happen automatically.