### PR TITLE
[TE] expand future time series endpoint to support time-range aggregation

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -40,6 +40,7 @@ import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.TimeSeriesResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.rootcause.DefaultEntityFormatter;
 import com.linkedin.thirdeye.dashboard.resources.v2.rootcause.FormatterLoader;
+import com.linkedin.thirdeye.dashboard.resources.v2.timeseries.DefaultTimeSeriesLoader;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
@@ -135,7 +136,8 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new OverrideConfigResource());
     env.jersey().register(new DataResource(anomalyFunctionFactory, alertFilterFactory));
     env.jersey().register(new AnomaliesResource(anomalyFunctionFactory, alertFilterFactory));
-    env.jersey().register(new TimeSeriesResource(Executors.newFixedThreadPool(10)));
+    env.jersey().register(new TimeSeriesResource(Executors.newFixedThreadPool(10),
+        new DefaultTimeSeriesLoader(DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(), ThirdEyeCacheRegistry.getInstance().getQueryCache())));
     env.jersey().register(new OnboardResource());
     env.jersey().register(new EventResource(config));
     env.jersey().register(new DataCompletenessResource(DAO_REGISTRY.getDataCompletenessConfigDAO()));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
@@ -69,7 +69,7 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
     }
 
     if (granularity == null) {
-      throw new IllegalArgumentException("Must provide time granularity");
+      granularity = dataset.bucketTimeGranularity();
     }
 
     List<MetricFunction> functions = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
@@ -43,17 +43,12 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
   }
 
   /**
-   * Returns the metric time series for a given time range and filter set, with a specified
-   * time granularity. If the underlying time series resolution does not correspond to the desired
-   * time granularity, it is up-sampled (via forward fill) or down-sampled (via sum if additive, or
-   * last value otherwise) transparently.
-   *
-   * <br/><b>NOTE:</b> if the start timestamp does not align with the time
-   * resolution, it is aligned with the nearest lower time stamp.
+   * Default implementation using metricDAO, datasetDAO, and QueryCache
    *
    * @param slice metric slice to fetch
    * @param granularity time granularity
-   * @return dataframe with aligned timestamps and values
+   * @return Dataframe with timestamps and metric values
+   * @throws Exception
    */
   @Override
   public DataFrame load(MetricSlice slice, TimeGranularity granularity) throws Exception {
@@ -74,7 +69,7 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
     }
 
     if (granularity == null) {
-      granularity = dataset.bucketTimeGranularity();
+      throw new IllegalArgumentException("Must provide time granularity");
     }
 
     List<MetricFunction> functions = new ArrayList<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
@@ -1,0 +1,168 @@
+package com.linkedin.thirdeye.dashboard.resources.v2.timeseries;
+
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.dashboard.resources.v2.TimeSeriesResource;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.Series;
+import com.linkedin.thirdeye.dataframe.util.DataFrameUtils;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.datasource.MetricExpression;
+import com.linkedin.thirdeye.datasource.MetricFunction;
+import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
+import com.linkedin.thirdeye.datasource.ThirdEyeResponse;
+import com.linkedin.thirdeye.datasource.cache.QueryCache;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultTimeSeriesLoader.class);
+
+  private static final String COL_TIME = TimeSeriesResource.COL_TIME;
+  private static final String COL_VALUE = TimeSeriesResource.COL_VALUE;
+
+  private final MetricConfigManager metricDAO;
+  private final DatasetConfigManager datasetDAO;
+  private final QueryCache cache;
+
+  public DefaultTimeSeriesLoader(MetricConfigManager metricDAO, DatasetConfigManager datasetDAO, QueryCache cache) {
+    this.metricDAO = metricDAO;
+    this.datasetDAO = datasetDAO;
+    this.cache = cache;
+  }
+
+  /**
+   * Returns the metric time series for a given time range and filter set, with a specified
+   * time granularity. If the underlying time series resolution does not correspond to the desired
+   * time granularity, it is up-sampled (via forward fill) or down-sampled (via sum if additive, or
+   * last value otherwise) transparently.
+   *
+   * <br/><b>NOTE:</b> if the start timestamp does not align with the time
+   * resolution, it is aligned with the nearest lower time stamp.
+   *
+   * @param slice metric slice to fetch
+   * @param granularity time granularity
+   * @return dataframe with aligned timestamps and values
+   */
+  @Override
+  public DataFrame load(MetricSlice slice, TimeGranularity granularity) throws Exception {
+    final long metricId = slice.getMetricId();
+    final long start = slice.getStart();
+    final long end = slice.getEnd();
+    final Multimap<String, String> filters = slice.getFilters();
+
+    // fetch meta data
+    MetricConfigDTO metric = this.metricDAO.findById(metricId);
+    if (metric == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve metric id %d", metricId));
+    }
+
+    DatasetConfigDTO dataset = this.datasetDAO.findByDataset(metric.getDataset());
+    if (dataset == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve dataset '%s'", metric.getDataset()));
+    }
+
+    if (granularity == null) {
+      granularity = dataset.bucketTimeGranularity();
+    }
+
+    List<MetricFunction> functions = new ArrayList<>();
+    List<MetricExpression> expressions = Arrays.asList(ThirdEyeUtils.getMetricExpressionFromMetricConfig(metric));
+    for(MetricExpression exp : expressions) {
+      functions.addAll(exp.computeMetricFunctions());
+    }
+
+    // aligned timestamps
+    // NOTE: the method over-fetches data in front of the time series to fill-forward correctly
+    final long alignedStart = granularity.toMillis(granularity.convertToUnit(start));
+    final long dataAlignedStart = dataset.bucketTimeGranularity().toMillis(
+        dataset.bucketTimeGranularity().convertToUnit(start));
+
+    // build request
+    ThirdEyeRequest.ThirdEyeRequestBuilder builder = ThirdEyeRequest.newBuilder()
+        .setStartTimeInclusive(dataAlignedStart)
+        .setEndTimeExclusive(end)
+        .setMetricFunctions(functions)
+        .setGroupBy(dataset.getTimeColumn())
+        .setGroupByTimeGranularity(granularity)
+        .setDataSource(dataset.getDataSource());
+
+    if (filters != null) {
+      builder.setFilterSet(filters);
+    }
+
+    ThirdEyeRequest request = builder.build("ref");
+
+    // fetch result
+    ThirdEyeResponse response = this.cache.getQueryResult(request);
+
+    DataFrame df = DataFrameUtils.parseResponse(response);
+    DataFrameUtils.evaluateExpressions(df, expressions);
+
+    // generate time stamps
+    DataFrame output = new DataFrame();
+    output.addSeries(COL_TIME, makeTimeRangeIndex(dataAlignedStart, end, granularity));
+    output.setIndex(COL_TIME);
+
+    LOG.info("Metric id {} has {} data points for time range {}-{}, need {} for time range {}-{}", metricId, df.size(), dataAlignedStart, end, output.size(), alignedStart, end);
+
+    // handle down-sampling - group by timestamp
+    output.addSeries(df.groupByValue(COL_TIME).aggregate(COL_VALUE, getGroupingFunction(dataset)));
+
+    // NOTE: up-sampling handled outside
+
+    // project onto (aligned) start timestamp
+    int fromIndex = (int) granularity.convertToUnit(alignedStart - dataAlignedStart);
+    if (fromIndex > 0) {
+      LOG.info("Metric id {} resampling over-generated {} data points (out of {}). Truncating.", metricId, fromIndex, output.size());
+      output = output.sliceFrom(fromIndex);
+
+      LongSeries timestamps = output.getLongs(COL_TIME);
+      output.addSeries(COL_TIME, timestamps.subtract(timestamps.min()));
+    }
+
+    return output;
+  }
+
+  /**
+   * Returns a LongSeries with length {@code N}, where {@code N} corresponds to the number of time
+   * buckets between {@code start} and {@code end} with the given time granularity.
+   *
+   * @param start start timestamp (inclusive, in millis)
+   * @param end end timestamp (exclusive, in millis)
+   * @param granularity time granularity
+   * @return long series
+   */
+  private static LongSeries makeTimeRangeIndex(long start, long end, TimeGranularity granularity) {
+    long roundUp = granularity.toMillis(1) - 1;
+    int maxCount = (int) granularity.convertToUnit(end - start + roundUp);
+    long[] values = new long[maxCount];
+    for(int i=0; i<maxCount; i++) {
+      values[i] = i;
+    }
+    return LongSeries.buildFrom(values);
+  }
+
+  /**
+   * Returns the grouping function based on whether the dataset is additive or not.
+   *
+   * @param dataset dataset config
+   * @return grouping function
+   */
+  private static Series.DoubleFunction getGroupingFunction(DatasetConfigDTO dataset) {
+    if(dataset.isAdditive())
+      return DoubleSeries.SUM;
+    return DoubleSeries.LAST;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/TimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/TimeSeriesLoader.java
@@ -5,6 +5,22 @@ import com.linkedin.thirdeye.dataframe.DataFrame;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 
 
+/**
+ * Loader for metric series based on slice and an (optinal) granularity. Must be thread safe.
+ */
 public interface TimeSeriesLoader {
+  /**
+   * Returns the metric time series for a given time range and filter set, with a specified
+   * time granularity. If the underlying time series resolution does not correspond to the desired
+   * time granularity, it is up-sampled (via forward fill) or down-sampled (via sum if additive, or
+   * last value otherwise) transparently.
+   *
+   * <br/><b>NOTE:</b> if the start timestamp does not align with the time
+   * resolution, it is aligned with the nearest lower time stamp.
+   *
+   * @param slice metric slice to fetch
+   * @param granularity time granularity
+   * @return dataframe with aligned timestamps and values
+   */
   DataFrame load(MetricSlice slice, TimeGranularity granularity) throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/TimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/TimeSeriesLoader.java
@@ -1,0 +1,10 @@
+package com.linkedin.thirdeye.dashboard.resources.v2.timeseries;
+
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+
+
+public interface TimeSeriesLoader {
+  DataFrame load(MetricSlice slice, TimeGranularity granularity) throws Exception;
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
@@ -1,0 +1,153 @@
+package com.linkedin.thirdeye.dashboard.resource;
+
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.dashboard.resources.v2.TimeSeriesResource;
+import com.linkedin.thirdeye.dashboard.resources.v2.timeseries.TimeSeriesLoader;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TimeSeriesResourceTest {
+  private static final String COL_TIME = TimeSeriesResource.COL_TIME;
+  private static final String COL_VALUE = TimeSeriesResource.COL_VALUE;
+
+  private static final String RANGE = "10:70";
+
+  private static class MockTimeSeriesLoader implements TimeSeriesLoader {
+    @Override
+    public DataFrame load(MetricSlice slice, TimeGranularity granularity) throws Exception {
+      final long mid = slice.getMetricId();
+
+      return new DataFrame()
+          .addSeries(COL_TIME, 0, 10, 20, 30, 40, 50)
+          .addSeries(COL_VALUE, mid + 1, mid, mid - 1, mid, mid + 1, DoubleSeries.NULL)
+          .setIndex(COL_TIME);
+    }
+  }
+
+  TimeSeriesResource resource;
+
+  @BeforeMethod
+  public void before() {
+    this.resource = new TimeSeriesResource(Executors.newSingleThreadExecutor(), new MockTimeSeriesLoader());
+  }
+
+  @Test
+  public void testBasic() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "0", RANGE, null, null, null, null);
+
+    Assert.assertEquals(out.size(), 1);
+    Assert.assertTrue(out.containsKey(RANGE));
+
+    Map<String, List<? extends Number>> ts = out.get(RANGE);
+
+    Assert.assertEquals(ts.size(), 2);
+    Assert.assertTrue(ts.containsKey(COL_TIME));
+    Assert.assertTrue(ts.containsKey("0"));
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
+    assertEquals(ts.get("0"), Arrays.asList(1d, 0d, -1d, 0d, 1d, null));
+  }
+
+  @Test
+  public void testTranformationCumulative() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "0", RANGE, null, null, "cumulative", null);
+    Map<String, List<? extends Number>> ts = out.get(RANGE);
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
+    assertEquals(ts.get("0"), Arrays.asList(1d, 1d, 0d, 0d, 1d, 1d));
+  }
+
+  @Test
+  public void testTranformationForwardFill() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "0", RANGE, null, null, "forwardfill", null);
+    Map<String, List<? extends Number>> ts = out.get(RANGE);
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
+    assertEquals(ts.get("0"), Arrays.asList(1d, 0d, -1d, 0d, 1d, 1d));
+  }
+
+  @Test
+  public void testTranformationTimestamp() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "0", RANGE, null, "10_MILLISECONDS", "timestamp", null);
+    Map<String, List<? extends Number>> ts = out.get(RANGE);
+
+    // NOTE: assumes output from loader to be in granularity rather than millis
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(10L, 110L, 210L, 310L, 410L, 510L));
+    assertEquals(ts.get("0"), Arrays.asList(1d, 0d, -1d, 0d, 1d, null));
+  }
+
+  @Test
+  public void testTranformationChange() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "2", RANGE, null, null, "change", null);
+    Map<String, List<? extends Number>> ts = out.get(RANGE);
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
+    assertEquals(ts.get("2"), Arrays.asList(null, -1d/3, -0.5d, 1d, 0.5d, null));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testTranformationChangeNoGranularityFail() throws Exception {
+    this.resource.getTimeSeries("0", RANGE, null, null, "timestamp", null);
+  }
+
+  @Test
+  public void testAggregationSingleRange() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "0,1", RANGE, null, null, null, "sum");
+
+    Map<String, List<? extends Number>> ts = out.get("sum");
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 1L, 2L, 3L, 4L, 5L));
+    assertEquals(ts.get("0"), Arrays.asList(1d, 0d, -1d, 0d, 1d, null));
+    assertEquals(ts.get("1"), Arrays.asList(2d, 1d, 0d, 1d, 2d, null));
+  }
+
+  @Test
+  public void testAggregationMultiRange() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "0,1", RANGE + ",20:80", null, null, null, "sum");
+
+    Map<String, List<? extends Number>> ts = out.get("sum");
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 1L, 2L, 3L, 4L, 5L));
+    assertEquals(ts.get("0"), Arrays.asList(2d, 0d, -2d, 0d, 2d, null));
+    assertEquals(ts.get("1"), Arrays.asList(4d, 2d, 0d, 2d, 4d, null));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testAggregationMultiRangeDifferentLengthFail() throws Exception {
+    this.resource.getTimeSeries("0,1", RANGE + ",20:90", null, null, null, "sum");
+  }
+
+  @Test
+  public void testNoAggregationMultiRangeDifferentLengthPass() throws Exception {
+    this.resource.getTimeSeries("0,1", RANGE + ",20:90", null, null, null, null);
+  }
+
+  private static void assertEquals(List<? extends Number> actual, List<Double> expected) {
+    Assert.assertEquals(actual.size(), expected.size());
+    for (int i = 0; i < actual.size(); i++) {
+      if (actual.get(i) == null) {
+        Assert.assertEquals(actual.get(i), expected.get(i), "index=" + i);
+      } else {
+        Assert.assertEquals(actual.get(i).doubleValue(), expected.get(i), 0.001, "index=" + i);
+      }
+    }
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
@@ -79,6 +79,16 @@ public class TimeSeriesResourceTest {
   }
 
   @Test
+  public void testTranformationFillZero() throws Exception {
+    Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
+        "0", RANGE, null, null, "fillzero", null);
+    Map<String, List<? extends Number>> ts = out.get(RANGE);
+
+    Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
+    assertEquals(ts.get("0"), Arrays.asList(1d, 0d, -1d, 0d, 1d, 0d));
+  }
+
+  @Test
   public void testTranformationTimestamp() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
         "0", RANGE, null, "10_MILLISECONDS", "timestamp", null);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
@@ -69,9 +69,9 @@ public class TimeSeriesResourceTest {
   }
 
   @Test
-  public void testTranformationForwardFill() throws Exception {
+  public void testTranformationFillForward() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0", RANGE, null, null, "forwardfill", null);
+        "0", RANGE, null, null, "fillforward", null);
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -128,7 +128,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testMultiTranformation() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "2", RANGE, null, null, "change,forwardfill,cumulative", null);
+        "2", RANGE, null, null, "change,fillforward,cumulative", null);
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -189,7 +189,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testMultiTransformationMultiAggregationMultiRange() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0,1", RANGE + ",20:80", null, null, "forwardfill,cumulative", "sum,product");
+        "0,1", RANGE + ",20:80", null, null, "fillforward,cumulative", "sum,product");
 
     // 0: 1d, 0d, -1d, 0d, 1d, null
     // 1: 2d, 1d,  0d, 1d, 2d, null


### PR DESCRIPTION
Enhanced prototype for a metric time series endpoint that supports online transformation and aggregation across multiple time ranges. This is a necessary building block for complex baselines in TE's frontend, such as multi-week averages. Transformations can still be chained, aggregations return separate result blocks. The PR furthermore adds several transformations and performs refactoring to add a battery of unit tests.

Supported time range aggregation: SUM, PRODUCT, MEAN, MEDIAN, STD, MIN, MAX
