### PR TITLE
[PINOT-5314] Fix leak in OffHeapBitmapInvertedIndexCreator

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -197,9 +197,13 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         continue;
       }
 
-      OffHeapBitmapInvertedIndexCreator invertedIndexCreator =
-          new OffHeapBitmapInvertedIndexCreator(file, cardinality, totalDocs, totalNumberOfEntries, fieldSpec);
-      invertedIndexCreatorMap.put(column, invertedIndexCreator);
+      try {
+        OffHeapBitmapInvertedIndexCreator invertedIndexCreator =
+            new OffHeapBitmapInvertedIndexCreator(file, cardinality, totalDocs, totalNumberOfEntries, fieldSpec);
+        invertedIndexCreatorMap.put(column, invertedIndexCreator);
+      } catch (Exception e) {
+        LOGGER.warn("Inverted index not created for column {}", column, e);
+      }
     }
   }
 


### PR DESCRIPTION
This class makes a bunch of calls to allocate direct memory in its constructor. If second or subsequent
calls fail to allocate memory then previously allocated memory is not released.

Added a try/catch and released memory in the constructor before re-throwing the exception.