### PR TITLE
Allow alert filter autotune to absorb different feature set from user  input

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -75,7 +75,6 @@ public class DetectionJobResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(DetectionJobResource.class);
   public static final String AUTOTUNE_FEATURE_KEY = "features";
-  public static final String PREVIOUS_FEATURE_KEY = "oldFeatures";
 
   public DetectionJobResource(DetectionJobScheduler detectionJobScheduler, AlertFilterFactory alertFilterFactory, AlertFilterAutotuneFactory alertFilterAutotuneFactory, EmailResource emailResource) {
     this.detectionJobScheduler = detectionJobScheduler;
@@ -597,9 +596,7 @@ public class DetectionJobResource {
     if (StringUtils.isNotBlank(features)) {
       Properties autotuneProperties = autotuneConfig.getTuningProps();
       String previousFetrues = autotuneProperties.getProperty(AUTOTUNE_FEATURE_KEY);
-      if (StringUtils.isNotBlank(previousFetrues)) { // If there exists an old feature set, log in the properties.
-        autotuneProperties.setProperty(PREVIOUS_FEATURE_KEY, previousFetrues);
-      }
+      LOG.info("The previous features for autotune is {}; now change to {}", previousFetrues, features);
       autotuneProperties.setProperty(AUTOTUNE_FEATURE_KEY, features);
       autotuneConfig.setTuningProps(autotuneProperties);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -74,6 +74,7 @@ public class DetectionJobResource {
   private EmailResource emailResource;
 
   private static final Logger LOG = LoggerFactory.getLogger(DetectionJobResource.class);
+  public static final String AUTOTUNE_FEATURE_KEY = "features";
 
   public DetectionJobResource(DetectionJobScheduler detectionJobScheduler, AlertFilterFactory alertFilterFactory, AlertFilterAutotuneFactory alertFilterAutotuneFactory, EmailResource emailResource) {
     this.detectionJobScheduler = detectionJobScheduler;
@@ -577,7 +578,8 @@ public class DetectionJobResource {
       @QueryParam("end") String endTimeIso,
       @QueryParam("autoTuneType") @DefaultValue("AUTOTUNE") String autoTuneType,
       @QueryParam("holidayStarts") @DefaultValue("") String holidayStarts,
-      @QueryParam("holidayEnds") @DefaultValue("") String holidayEnds) {
+      @QueryParam("holidayEnds") @DefaultValue("") String holidayEnds,
+      @QueryParam("tuningFeatures") String features) {
 
     long startTime = ISODateTimeFormat.dateTimeParser().parseDateTime(startTimeIso).getMillis();
     long endTime = ISODateTimeFormat.dateTimeParser().parseDateTime(endTimeIso).getMillis();
@@ -589,6 +591,9 @@ public class DetectionJobResource {
     BaseAlertFilter alertFilter = alertFilterFactory.fromSpec(anomalyFunctionSpec.getAlertFilter());
     // create alert filter auto tune
     AutotuneConfigDTO autotuneConfig = new AutotuneConfigDTO(alertFilter);
+    Properties autotuneProperties = autotuneConfig.getTuningProps();
+    autotuneProperties.setProperty(AUTOTUNE_FEATURE_KEY, features);
+    autotuneConfig.setTuningProps(autotuneProperties);
     BaseAlertFilterAutoTune alertFilterAutotune = alertFilterAutotuneFactory.fromSpec(autoTuneType, autotuneConfig, anomalies);
     LOG.info("initiated alertFilterAutoTune of Type {}", alertFilterAutotune.getClass().toString());
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -591,9 +591,11 @@ public class DetectionJobResource {
     BaseAlertFilter alertFilter = alertFilterFactory.fromSpec(anomalyFunctionSpec.getAlertFilter());
     // create alert filter auto tune
     AutotuneConfigDTO autotuneConfig = new AutotuneConfigDTO(alertFilter);
-    Properties autotuneProperties = autotuneConfig.getTuningProps();
-    autotuneProperties.setProperty(AUTOTUNE_FEATURE_KEY, features);
-    autotuneConfig.setTuningProps(autotuneProperties);
+    if (StringUtils.isNotBlank(features)) {
+      Properties autotuneProperties = autotuneConfig.getTuningProps();
+      autotuneProperties.setProperty(AUTOTUNE_FEATURE_KEY, features);
+      autotuneConfig.setTuningProps(autotuneProperties);
+    }
     BaseAlertFilterAutoTune alertFilterAutotune = alertFilterAutotuneFactory.fromSpec(autoTuneType, autotuneConfig, anomalies);
     LOG.info("initiated alertFilterAutoTune of Type {}", alertFilterAutotune.getClass().toString());
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -75,6 +75,7 @@ public class DetectionJobResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(DetectionJobResource.class);
   public static final String AUTOTUNE_FEATURE_KEY = "features";
+  public static final String PREVIOUS_FEATURE_KEY = "oldFeatures";
 
   public DetectionJobResource(DetectionJobScheduler detectionJobScheduler, AlertFilterFactory alertFilterFactory, AlertFilterAutotuneFactory alertFilterAutotuneFactory, EmailResource emailResource) {
     this.detectionJobScheduler = detectionJobScheduler;
@@ -569,6 +570,8 @@ public class DetectionJobResource {
    * @param autoTuneType the type of auto tune to invoke (default is "AUTOTUNE")
    * @param holidayStarts: holidayStarts in ISO Format, ex: 2016-5-23T00:00:00Z,2016-6-23T00:00:00Z,...
    * @param holidayEnds: holidayEnds in in ISO Format, ex: 2016-5-23T00:00:00Z,2016-6-23T00:00:00Z,...
+   * @param features: a list of features separated by comma, ex: weight,score.
+   *                Note that, the feature must be a existing field name in MergedAnomalyResult or a pre-set feature name
    * @return HTTP response of request: string of alert filter
    */
   @POST
@@ -593,6 +596,10 @@ public class DetectionJobResource {
     AutotuneConfigDTO autotuneConfig = new AutotuneConfigDTO(alertFilter);
     if (StringUtils.isNotBlank(features)) {
       Properties autotuneProperties = autotuneConfig.getTuningProps();
+      String previousFetrues = autotuneProperties.getProperty(AUTOTUNE_FEATURE_KEY);
+      if (StringUtils.isNotBlank(previousFetrues)) { // If there exists an old feature set, log in the properties.
+        autotuneProperties.setProperty(PREVIOUS_FEATURE_KEY, previousFetrues);
+      }
       autotuneProperties.setProperty(AUTOTUNE_FEATURE_KEY, features);
       autotuneConfig.setTuningProps(autotuneProperties);
     }


### PR DESCRIPTION
To expend the usage of alert filter autotune, the endpoint is updated to allow user to indicate the feature set to be used in the autotune. 