### PR TITLE
[TE] Rootcause hyperbola time-range scoring

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/AnomalyEventsPipeline.java
@@ -31,6 +31,7 @@ public class AnomalyEventsPipeline extends Pipeline {
     LINEAR,
     TRIANGULAR,
     QUADRATIC,
+    HYPERBOLA,
     DIMENSION,
     COMPOUND
   }
@@ -119,10 +120,12 @@ public class AnomalyEventsPipeline extends Pipeline {
         return new ScoreWrapper(new ScoreUtils.TriangularStartTimeStrategy(lookback, start, end));
       case QUADRATIC:
         return new ScoreWrapper(new ScoreUtils.QuadraticTriangularStartTimeStrategy(lookback, start, end));
+      case HYPERBOLA:
+        return new ScoreWrapper(new ScoreUtils.HyperbolaStrategy(start, end));
       case DIMENSION:
         return new DimensionStrategy();
       case COMPOUND:
-        return new CompoundStrategy(new ScoreUtils.QuadraticTriangularStartTimeStrategy(lookback, start, end));
+        return new CompoundStrategy(new ScoreUtils.HyperbolaStrategy(start, end));
       default:
         throw new IllegalArgumentException(String.format("Invalid strategy type '%s'", this.strategy));
     }
@@ -194,6 +197,10 @@ public class AnomalyEventsPipeline extends Pipeline {
       double scoreTime = this.delegateTime.score(dto.getStartTime(), dto.getEndTime());
       double scoreDimension = this.delegateDimension.score(dto, urn2entity);
       double scoreHasDimension = scoreDimension > 0 ? 1 : 0;
+
+      // ignore truncated results
+      if (scoreTime <= 0)
+        return 0;
 
       return 0.1 * scoreTime + 0.9 * Math.max(scoreTime, scoreHasDimension) + Math.min(scoreDimension, 1);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/HolidayEventsPipeline.java
@@ -31,6 +31,7 @@ public class HolidayEventsPipeline extends Pipeline {
     LINEAR,
     TRIANGULAR,
     QUADRATIC,
+    HYPERBOLA,
     DIMENSION,
     COMPOUND
   }
@@ -124,10 +125,12 @@ public class HolidayEventsPipeline extends Pipeline {
         return new ScoreWrapper(new ScoreUtils.TriangularStartTimeStrategy(lookback, start, end));
       case QUADRATIC:
         return new ScoreWrapper(new ScoreUtils.QuadraticTriangularStartTimeStrategy(lookback, start, end));
+      case HYPERBOLA:
+        return new ScoreWrapper(new ScoreUtils.HyperbolaStrategy(start, end));
       case DIMENSION:
         return new DimensionStrategy();
       case COMPOUND:
-        return new CompoundStrategy(new ScoreUtils.QuadraticTriangularStartTimeStrategy(lookback, start, end));
+        return new CompoundStrategy(new ScoreUtils.HyperbolaStrategy(start, end));
       default:
         throw new IllegalArgumentException(String.format("Invalid strategy type '%s'", this.strategy));
     }
@@ -200,6 +203,10 @@ public class HolidayEventsPipeline extends Pipeline {
       double scoreTime = this.delegateTime.score(dto.getStartTime(), dto.getEndTime());
       double scoreDimension = this.delegateDimension.score(dto, urn2entity);
       double scoreHasDimension = scoreDimension > 0 ? 1 : 0;
+
+      // ignore truncated results
+      if (scoreTime <= 0)
+        return 0;
 
       return 0.1 * scoreTime + 0.9 * Math.max(scoreTime, scoreHasDimension) + Math.min(scoreDimension, 1);
     }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/ScoreUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/ScoreUtilsTest.java
@@ -45,6 +45,16 @@ public class ScoreUtilsTest {
   }
 
   @Test
+  public void testHyperbolaStrategy() {
+    ScoreUtils.TimeRangeStrategy scorer = new ScoreUtils.HyperbolaStrategy(3600000, 7200000);
+    Assert.assertEquals(scorer.score(0, -1), 0.5d, EPSILON);
+    Assert.assertEquals(scorer.score(1800000, -1), 0.6666d, EPSILON);
+    Assert.assertEquals(scorer.score(3600000, -1), 1.0d, EPSILON);
+    Assert.assertEquals(scorer.score(5300000, -1), 0.6792d, EPSILON);
+    Assert.assertEquals(scorer.score(5400000, -1), 0.0d, EPSILON);
+  }
+
+  @Test
   public void testParsePeriod() {
     Assert.assertEquals(ScoreUtils.parsePeriod("1w"), TimeUnit.DAYS.toMillis(7));
     Assert.assertEquals(ScoreUtils.parsePeriod("2d"), TimeUnit.DAYS.toMillis(2));


### PR DESCRIPTION
Current time-based scoring strategies depend on the display region or show irrelevant results at the end of the anomaly region. We add this new strategy to address both range dependency and user feedback.

* add a new time-based scoring strategy based on truncated hyperbola

* make hyperbola the default time-component for compound strategies