### PR TITLE
Remove jetty dependency from broker

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -70,25 +70,14 @@
     </profile>
   </profiles>
   <dependencies>
-    <!-- Jetty -->
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-grizzly2-http</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
+      <groupId>org.glassfish.jersey.containers</groupId>
+      <artifactId>jersey-container-grizzly2-servlet</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <!-- End jetty -->
-
     <dependency>
       <groupId>com.linkedin.pinot</groupId>
       <artifactId>pinot-transport</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.glassfish.jersey.containers</groupId>
+        <artifactId>jersey-container-grizzly2-servlet</artifactId>
+        <version>2.24</version>
+      </dependency>
+      <dependency>
         <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-server</artifactId>
         <version>${jersey.version}</version>


### PR DESCRIPTION
Currently, we are using jetty server for broker rest api. The recent version
of jetty only supports jvm 1.8. In order to support jvm 1.7, we are replacing
from jetty to grizzly http server.