### PR TITLE
Helix 0.6.8 has the fix for correct number of replicas on a rebalance.

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -135,7 +135,7 @@ public class PinotHelixTaskResourceManager {
    *
    * @param taskType Task type
    */
-  public synchronized void stopTaskQueue(@Nonnull String taskType) {
+  public synchronized void stopTaskQueue(@Nonnull String taskType) throws InterruptedException {
     String helixJobQueueName = getHelixJobQueueName(taskType);
     LOGGER.info("Stopping task queue: {} for task type: {}", helixJobQueueName, taskType);
     _taskDriver.stop(helixJobQueueName);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -49,7 +49,6 @@ import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.tools.ClusterStateVerifier;
-import org.apache.helix.tools.ClusterStateVerifier.Verifier;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -305,7 +304,13 @@ public class PerfBenchmarkDriver {
   public static void waitForExternalViewUpdate(String zkAddress, final String clusterName, long timeoutInMilliseconds) {
     final ZKHelixAdmin helixAdmin = new ZKHelixAdmin(zkAddress);
 
-    Verifier customVerifier = new Verifier() {
+    /* Use one of these three classes instead of deprecated ClusterStateVerifier.
+    BestPossibleExternalViewVerifier
+    StrictMatchExternalViewVerifier
+    ClusterLiveNodesVerifier
+    */
+
+    org.apache.helix.tools.ClusterVerifiers.ClusterStateVerifier.Verifier customVerifier = new org.apache.helix.tools.ClusterVerifiers.ClusterStateVerifier.Verifier() {
 
       @Override
       public boolean verify() {

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.7.6</avro.version>
-    <helix.version>0.6.7</helix.version>
+    <helix.version>0.6.8</helix.version>
     <!-- jfim: for Kafka 0.9.0.0, use zkclient 0.7 -->
     <kafka.version>0.9.0.1</kafka.version>
     <zkclient.version>0.7</zkclient.version>


### PR DESCRIPTION
Helix 0.6.8 has fixed https://issues.apache.org/jira/browse/HELIX-631
that we can use for internal rebalance API