### PR TITLE
Make maxInitialResultHolderCapacity for group-by executor configurable

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -37,16 +37,18 @@ public class AggregationGroupByOperator extends BaseOperator {
 
   private final AggregationFunctionContext[] _aggregationFunctionContexts;
   private final GroupBy _groupBy;
+  private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
   private final TransformExpressionOperator _transformOperator;
   private final long _numTotalRawDocs;
   private ExecutionStatistics _executionStatistics;
 
   public AggregationGroupByOperator(@Nonnull AggregationFunctionContext[] aggregationFunctionContexts,
-      @Nonnull GroupBy groupBy, int numGroupsLimit, @Nonnull TransformExpressionOperator transformOperator,
-      long numTotalRawDocs) {
+      @Nonnull GroupBy groupBy, int maxInitialResultHolderCapacity, int numGroupsLimit,
+      @Nonnull TransformExpressionOperator transformOperator, long numTotalRawDocs) {
     _aggregationFunctionContexts = aggregationFunctionContexts;
     _groupBy = groupBy;
+    _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
     _transformOperator = transformOperator;
     _numTotalRawDocs = numTotalRawDocs;
@@ -64,7 +66,8 @@ public class AggregationGroupByOperator extends BaseOperator {
 
     // Perform aggregation group-by on all the blocks.
     GroupByExecutor groupByExecutor =
-        new DefaultGroupByExecutor(_aggregationFunctionContexts, _groupBy, _numGroupsLimit);
+        new DefaultGroupByExecutor(_aggregationFunctionContexts, _groupBy, _maxInitialResultHolderCapacity,
+            _numGroupsLimit);
     groupByExecutor.init();
     TransformBlock transformBlock;
     while ((transformBlock = (TransformBlock) _transformOperator.nextBlock()) != null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -41,13 +41,15 @@ public class AggregationGroupByPlanNode implements PlanNode {
   private final List<AggregationInfo> _aggregationInfos;
   private final GroupBy _groupBy;
   private final TransformPlanNode _transformPlanNode;
+  private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
 
   public AggregationGroupByPlanNode(@Nonnull IndexSegment indexSegment, @Nonnull BrokerRequest brokerRequest,
-      int numGroupsLimit) {
+      int maxInitialResultHolderCapacity, int numGroupsLimit) {
     _indexSegment = indexSegment;
     _aggregationInfos = brokerRequest.getAggregationsInfo();
     _groupBy = brokerRequest.getGroupBy();
+    _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
     _transformPlanNode = new TransformPlanNode(_indexSegment, brokerRequest);
   }
@@ -58,7 +60,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
     SegmentMetadata segmentMetadata = _indexSegment.getSegmentMetadata();
     return new AggregationGroupByOperator(
         AggregationFunctionUtils.getAggregationFunctionContexts(_aggregationInfos, segmentMetadata), _groupBy,
-        _numGroupsLimit, transformOperator, segmentMetadata.getTotalRawDocs());
+        _maxInitialResultHolderCapacity, _numGroupsLimit, transformOperator, segmentMetadata.getTotalRawDocs());
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -58,8 +58,8 @@ import javax.annotation.Nonnull;
  */
 // TODO: Revisit to make trimming work. Currently trimming is disabled
 public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
-  private final String[] _groupByColumns;
   private final int _numGroupByColumns;
+  private final String[] _groupByColumns;
   private final int[] _cardinalities;
   private final boolean[] _isSingleValueColumn;
   private final Dictionary[] _dictionaries;
@@ -97,9 +97,11 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
    * Constructor for the class. Initializes data members (reusable arrays).
    *
    * @param transformBlock Transform block for which to generate group keys
-   * @param groupByColumns group-by columns.
+   * @param groupByColumns Group-by columns
+   * @param arrayBasedThreshold Threshold for array based result holder
    */
-  public DictionaryBasedGroupKeyGenerator(TransformBlock transformBlock, String[] groupByColumns) {
+  public DictionaryBasedGroupKeyGenerator(TransformBlock transformBlock, String[] groupByColumns,
+      int arrayBasedThreshold) {
     _numGroupByColumns = groupByColumns.length;
     _groupByColumns = groupByColumns;
 
@@ -142,7 +144,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         _rawKeyHolder = new LongMapBasedHolder();
       } else {
         _globalGroupIdUpperBound = (int) cardinalityProduct;
-        if (cardinalityProduct > DefaultGroupByExecutor.MAX_INITIAL_RESULT_HOLDER_CAPACITY) {
+        if (cardinalityProduct > arrayBasedThreshold) {
           _rawKeyHolder = new IntMapBasedHolder();
         } else {
           _rawKeyHolder = new ArrayBasedHolder();

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -63,12 +63,14 @@ public class DictionaryBasedGroupKeyGeneratorTest {
   private final long _randomSeed = System.currentTimeMillis();
   private final Random _random = new Random(_randomSeed);
   private final String _errorMessage = "Random seed is: " + _randomSeed;
-  TransformBlock _transformBlock;
 
   private static final int TEST_LENGTH = 20;
   private final int[] _testDocIdSet = new int[TEST_LENGTH];
   private final int[] _singleValueGroupKeyBuffer = new int[TEST_LENGTH];
   private final int[][] _multiValueGroupKeyBuffer = new int[TEST_LENGTH][];
+
+  private static final int ARRAY_BASED_THRESHOLD = 10_000;
+  private TransformBlock _transformBlock;
 
   @BeforeClass
   private void setup() throws Exception {
@@ -151,8 +153,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     String[] groupByColumns = {"s1"};
 
     // Test initial status.
-    DictionaryBasedGroupKeyGenerator
-        dictionaryBasedGroupKeyGenerator = new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns);
+    DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
+        new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns, ARRAY_BASED_THRESHOLD);
     Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(), UNIQUE_ROWS, _errorMessage);
     Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), UNIQUE_ROWS, _errorMessage);
 
@@ -170,8 +172,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
 
     // Test initial status.
     long expected = (long) Math.pow(UNIQUE_ROWS, groupByColumns.length);
-    DictionaryBasedGroupKeyGenerator
-        dictionaryBasedGroupKeyGenerator = new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns);
+    DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
+        new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns, ARRAY_BASED_THRESHOLD);
     Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(), expected, _errorMessage);
     Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
 
@@ -188,9 +190,10 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     String[] groupByColumns = {"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10"};
 
     // Test initial status.
-    DictionaryBasedGroupKeyGenerator
-        dictionaryBasedGroupKeyGenerator = new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns);
-    Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(), Integer.MAX_VALUE, _errorMessage);
+    DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
+        new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns, ARRAY_BASED_THRESHOLD);
+    Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound(), Integer.MAX_VALUE,
+        _errorMessage);
     Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
 
     // Test group key generation.
@@ -220,15 +223,17 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     String[] groupByColumns = {"m1"};
 
     // Test initial status.
-    DictionaryBasedGroupKeyGenerator
-        dictionaryBasedGroupKeyGenerator = new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns);
+    DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
+        new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns, ARRAY_BASED_THRESHOLD);
     int groupKeyUpperBound = dictionaryBasedGroupKeyGenerator.getGlobalGroupKeyUpperBound();
-    Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), groupKeyUpperBound, _errorMessage);
+    Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), groupKeyUpperBound,
+        _errorMessage);
 
     // Test group key generation.
     dictionaryBasedGroupKeyGenerator.generateKeysForBlock(_transformBlock, _multiValueGroupKeyBuffer);
     int numUniqueKeys = _multiValueGroupKeyBuffer[0].length + _multiValueGroupKeyBuffer[1].length;
-    Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), groupKeyUpperBound, _errorMessage);
+    Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), groupKeyUpperBound,
+        _errorMessage);
     compareMultiValueBuffer();
     testGetUniqueGroupKeys(dictionaryBasedGroupKeyGenerator.getUniqueGroupKeys(), numUniqueKeys);
   }
@@ -239,8 +244,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     String[] groupByColumns = {"m1", "m2", "s1", "s2"};
 
     // Test initial status.
-    DictionaryBasedGroupKeyGenerator
-        dictionaryBasedGroupKeyGenerator = new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns);
+    DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
+        new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns, ARRAY_BASED_THRESHOLD);
     Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
 
     // Test group key generation.
@@ -257,8 +262,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     String[] groupByColumns = {"m1", "m2", "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10"};
 
     // Test initial status.
-    DictionaryBasedGroupKeyGenerator
-        dictionaryBasedGroupKeyGenerator = new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns);
+    DictionaryBasedGroupKeyGenerator dictionaryBasedGroupKeyGenerator =
+        new DictionaryBasedGroupKeyGenerator(_transformBlock, groupByColumns, ARRAY_BASED_THRESHOLD);
     Assert.assertEquals(dictionaryBasedGroupKeyGenerator.getCurrentGroupKeyUpperBound(), 0, _errorMessage);
 
     // Test group key generation.

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/transform/TransformGroupByTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/transform/TransformGroupByTest.java
@@ -214,7 +214,8 @@ public class TransformGroupByTest {
         TransformPlanNode.buildTransformExpressionTrees(expressions));
 
     AggregationGroupByOperator groupByOperator =
-        new AggregationGroupByOperator(aggrFuncContextArray, groupBy, Integer.MAX_VALUE, transformOperator, NUM_ROWS);
+        new AggregationGroupByOperator(aggrFuncContextArray, groupBy, 10_000, Integer.MAX_VALUE, transformOperator,
+            NUM_ROWS);
 
     IntermediateResultsBlock block = (IntermediateResultsBlock) groupByOperator.nextBlock();
     return block.getAggregationGroupByResult();


### PR DESCRIPTION
This capacity will be used for both inital capacity and array based key holder threshold.
In most cases, array based key holder implementation is way faster than map based.