### PR TITLE
Reuse buffer in IntMapBasedHolder processMultiValue()

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -340,12 +340,14 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
     @Nonnull
     @Override
     public int[] processMultiValue(int index) {
-      int[] rawKeys = getIntRawKeys(index);
-      int length = rawKeys.length;
-      int[] groupIds = new int[length];
+      int[] groupIds = getIntRawKeys(index);
+
+      // Convert raw keys to group ids
+      int length = groupIds.length;
       for (int i = 0; i < length; i++) {
-        groupIds[i] = getGroupId(rawKeys[i]);
+        groupIds[i] = getGroupId(groupIds[i]);
       }
+
       return groupIds;
     }
 


### PR DESCRIPTION
Reuse the buffer for group ids to reduce garbage.