### PR TITLE
[TE] Change investigation comparison from Wow Total to Average values

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdeyeAuthFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdeyeAuthFilter.java
@@ -65,9 +65,11 @@ public class ThirdeyeAuthFilter extends AuthFilter<AuthRequest, PrincipalAuthCon
     AuthRequest credentials = new AuthRequest();
     try {
       Map<String, Cookie> cookies = requestContext.getCookies();
-      if (cookies != null) {
+      if (cookies != null && cookies.containsKey(AuthResource.AUTH_TOKEN_NAME)) {
         String rawToken = cookies.get(AuthResource.AUTH_TOKEN_NAME).getValue();
         credentials.setToken(rawToken);
+      } else {
+        throw new IllegalAccessException("Auth cookie is missing!");
       }
     } catch (Exception e) {
       LOG.warn(e.getMessage(), e);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -168,7 +168,7 @@ public class AnomaliesResource {
       MetricTimeSeries currentTimeSeries = anomalyDetectionInputContextBuilder.build()
           .getDimensionMapMetricTimeSeriesMap().get(dimensions);
       String metricName = anomalyFunction.getMetric();
-      double currentVal = getTotalFromTimeSeries(currentTimeSeries, metricName, dataset.isAdditive());
+      double currentVal = getAverageFromTimeSeries(currentTimeSeries, metricName);
       response.setCurrentVal(currentVal);
 
       for (AlertConfigBean.COMPARE_MODE compareMode : AlertConfigBean.COMPARE_MODE.values()) {
@@ -182,7 +182,7 @@ public class AnomaliesResource {
         MetricTimeSeries baselineTimeSeries = anomalyDetectionInputContextBuilder.build()
             .getDimensionMapMetricTimeSeriesMap().get(dimensions);
         AnomalyDataCompare.CompareResult compareResult = new AnomalyDataCompare.CompareResult();
-        double baseLineval = getTotalFromTimeSeries(baselineTimeSeries, metricName, dataset.isAdditive());
+        double baseLineval = getAverageFromTimeSeries(baselineTimeSeries, metricName);
         compareResult.setBaselineValue(baseLineval);
         compareResult.setCompareMode(compareMode);
         compareResult.setChange(calculateChange(currentVal, baseLineval));
@@ -207,23 +207,15 @@ public class AnomaliesResource {
     return (currentValue - baselineValue) / baselineValue;
   }
 
-  double getTotalFromTimeSeries (MetricTimeSeries metricTimeSeries, String metricName, boolean isAdditive) {
-    double total = 0.0;
-
+  double getAverageFromTimeSeries(MetricTimeSeries metricTimeSeries, String metricName) {
     // MetricTimeSeries will have multiple values in case of derived/multimetric
-    Number[] metricTotals = metricTimeSeries.getMetricSums();
+    Double[] metricAverages = metricTimeSeries.getMetricAvgs(0d);
     Integer metricIndex = metricTimeSeries.getSchema().getMetricIndex(metricName);
     if (metricIndex != null) {
-      total = metricTotals[metricIndex].doubleValue();
+      return metricAverages[metricIndex];
     } else {
-      total = metricTotals[0].doubleValue();
+      return metricAverages[0];
     }
-
-    if (!isAdditive) {
-      // for non Additive data sets return the average
-      total /= metricTimeSeries.getTimeWindowSet().size();
-    }
-    return total;
   }
 
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/tabs/investigate.ftl
@@ -114,7 +114,7 @@
     <ul class="investigate-wow">
       <li class="wow-card">
         <div class="wow-card-header">
-          <label class="label-medium-semibold">Current Total</label>
+          <label class="label-medium-semibold">Current Average</label>
         </div>
         <div class="wow-card-body">
           {{formatNumber (formatDouble currentValue)}}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/api/MetricTimeSeriesTest.java
@@ -171,6 +171,19 @@ public class MetricTimeSeriesTest {
   }
 
   @Test(dataProvider = "defaultMetricTimeSeries")
+  public void testGetMetricAvgs(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
+    // Fill Double.NaN for value of divided by zero
+    Double[] actualAvgs = metricTimeSeries.getMetricAvgs(Double.NaN);
+    Double[] expectedAvgs = new Double[] {2.75d, Double.NaN, 3d};
+    Assert.assertEquals(actualAvgs, expectedAvgs);
+
+    // Fill null for value of divided by zero
+    actualAvgs = metricTimeSeries.getMetricAvgs();
+    expectedAvgs = new Double[] {2.75d, null, 3d};
+    Assert.assertEquals(actualAvgs, expectedAvgs);
+  }
+
+  @Test(dataProvider = "defaultMetricTimeSeries")
   public void testGetHasValueSums(List<String> metricNames, MetricTimeSeries metricTimeSeries, long[] timestamps) {
     Integer[] actualSums = metricTimeSeries.getHasValueSums();
     Integer[] expectedSums = new Integer[] {4, 0, 3};


### PR DESCRIPTION
The WoW comparison in investigation page show Total to Total values comparison, which is not intuitive when we compare the values to those on anomaly result.

This PR changes the comparison in investigation page from Total-to-Total comparison to Average-to-Average comparison.

Tested with new unit test and on local dashbaord.