### PR TITLE
[PINOT-5350] Protection against file system timeout when fetching segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
@@ -281,10 +281,14 @@ public class FileUploadUtils {
           throw new PermanentDownloadException(errMsg);
         }
       } else {
-        long ret = httpget.getResponseContentLength();
+        long ret = httpget.getResponseContentLength();  // Expected to be -1 if there is no content-length header.
         BufferedOutputStream output = new BufferedOutputStream(new FileOutputStream(file));
         IOUtils.copyLarge(httpget.getResponseBodyAsStream(), output);
         IOUtils.closeQuietly(output);
+        if (ret != -1 && ret != file.length()) {
+          // The content-length header was present and does not match the file length.
+          throw new RuntimeException("File length " + file.length() + " does not match content length " + ret);
+        }
         return ret;
       }
     } catch (Exception ex) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -85,13 +85,13 @@ public class LLCSegmentCompletionHandlers {
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withOffset(offset).withExtraTimeSec(
         extraTimeSec);
-    LOGGER.info(requestParams.toString());
+    LOGGER.info("Processing extendBuildTime:{}", requestParams.toString());
 
     SegmentCompletionProtocol.Response response =
         SegmentCompletionManager.getInstance().extendBuildTime(requestParams);
 
     final String responseStr = response.toJsonString();
-    LOGGER.info(responseStr);
+    LOGGER.info("Response to extendBuildTime:{}", responseStr);
     return responseStr;
   }
 
@@ -111,12 +111,12 @@ public class LLCSegmentCompletionHandlers {
     }
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withOffset(offset).withReason(stopReason);
-    LOGGER.info(requestParams.toString());
+    LOGGER.info("Processing segmentConsumed:{}", requestParams.toString());
 
     SegmentCompletionProtocol.Response response =
         SegmentCompletionManager.getInstance().segmentConsumed(requestParams);
     final String responseStr = response.toJsonString();
-    LOGGER.info(responseStr);
+    LOGGER.info("Response to segmentConsumed:{}", responseStr);
     return responseStr;
   }
 
@@ -136,12 +136,12 @@ public class LLCSegmentCompletionHandlers {
     }
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withOffset(offset).withReason(stopReason);
-    LOGGER.info(requestParams.toString());
+    LOGGER.info("Processing segmentStoppedConsuming:{}", requestParams.toString());
 
     SegmentCompletionProtocol.Response response =
         SegmentCompletionManager.getInstance().segmentStoppedConsuming(requestParams);
     final String responseStr = response.toJsonString();
-    LOGGER.info(responseStr);
+    LOGGER.info("Response to segmentStoppedConsuming:{}", responseStr);
     return responseStr;
   }
 
@@ -160,12 +160,12 @@ public class LLCSegmentCompletionHandlers {
 
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withOffset(offset);
-    LOGGER.info(requestParams.toString());
+    LOGGER.info("Processing segmentCommitStart:{}", requestParams.toString());
 
     SegmentCompletionProtocol.Response response =
           SegmentCompletionManager.getInstance().segmentCommitStart(requestParams);
     final String responseStr = response.toJsonString();
-    LOGGER.info(responseStr);
+    LOGGER.info("Response to segmentCommitStart:{}", responseStr);
     return responseStr;
   }
 
@@ -186,7 +186,7 @@ public class LLCSegmentCompletionHandlers {
 
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withOffset(offset).withSegmentLocation(segmentLocation);
-    LOGGER.info(requestParams.toString());
+    LOGGER.info("Processing segmentCommitEnd:{}", requestParams.toString());
 
     final boolean isSuccess = true;
     final boolean isSplitCommit = true;
@@ -194,7 +194,7 @@ public class LLCSegmentCompletionHandlers {
     SegmentCompletionProtocol.Response response =
         SegmentCompletionManager.getInstance().segmentCommitEnd(requestParams, isSuccess, isSplitCommit);
     final String responseStr = response.toJsonString();
-    LOGGER.info(responseStr);
+    LOGGER.info("Response to segmentCommitEnd:{}", responseStr);
     return responseStr;
   }
 
@@ -210,7 +210,7 @@ public class LLCSegmentCompletionHandlers {
   ) {
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withOffset(offset);
-    LOGGER.info(requestParams.toString());
+    LOGGER.info("Processing segmentCommit:{}", requestParams.toString());
 
     final SegmentCompletionManager segmentCompletionManager = SegmentCompletionManager.getInstance();
     SegmentCompletionProtocol.Response response = segmentCompletionManager.segmentCommitStart(requestParams);
@@ -221,7 +221,7 @@ public class LLCSegmentCompletionHandlers {
       response = segmentCompletionManager.segmentCommitEnd(requestParams, success, false);
     }
 
-    LOGGER.info("Response: instance={}  segment={} status={} offset={}", requestParams.getInstanceId(), requestParams.getSegmentName(),
+    LOGGER.info("Response to segmentCommit: instance={}  segment={} status={} offset={}", requestParams.getInstanceId(), requestParams.getSegmentName(),
         response.getStatus(), response.getOffset());
 
     return response.toJsonString();
@@ -241,7 +241,7 @@ public class LLCSegmentCompletionHandlers {
   ) {
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withOffset(offset);
-    LOGGER.info(requestParams.toString());
+    LOGGER.info("Processing segmentUpload:{}", requestParams.toString());
 
     final String segmentLocation = uploadSegment(multiPart, instanceId, segmentName, true);
     if (segmentLocation == null) {
@@ -252,7 +252,11 @@ public class LLCSegmentCompletionHandlers {
         .withSegmentLocation(segmentLocation)
         .withStatus(SegmentCompletionProtocol.ControllerResponseStatus.UPLOAD_SUCCESS);
 
-    return new SegmentCompletionProtocol.Response(responseParams).toJsonString();
+    String response = new SegmentCompletionProtocol.Response(responseParams).toJsonString();
+
+    LOGGER.info("Response to segmentUpload:{}", response);
+
+    return response;
   }
 
   private @Nullable String uploadSegment(FormDataMultiPart multiPart, final String instanceId, final String segmentName,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -174,6 +174,7 @@ public class PinotSegmentUploadRestletResource {
     }
     Response.ResponseBuilder builder = Response.ok(dataFile);
     builder.header("Content-Disposition", "attachment; filename=" + dataFile.getName());
+    builder.header("Content-Length", dataFile.length());
     return builder.build();
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -387,7 +387,7 @@ public class SegmentCompletionManager {
       if (savedCommitTime != null && savedCommitTime > initialCommitTimeMs) {
         initialCommitTimeMs = savedCommitTime;
       }
-      LOGGER = LoggerFactory.getLogger("SegmentFinalizerFSM_"  + segmentName.getSegmentName());
+      LOGGER = LoggerFactory.getLogger("SegmentCompletionFSM_"  + segmentName.getSegmentName());
       if (initialCommitTimeMs > MAX_COMMIT_TIME_FOR_ALL_SEGMENTS_SECONDS * 1000) {
         // The table has a really high value configured for max commit time. Set it to a higher value than default
         // and go from there.
@@ -522,7 +522,7 @@ public class SegmentCompletionManager {
 
     public SegmentCompletionProtocol.Response stoppedConsuming(String instanceId, long offset, String reason) {
       synchronized (this) {
-        LOGGER.info("Processing segmentCommit({}, {})", instanceId, offset);
+        LOGGER.info("Processing stoppedConsuming({}, {})", instanceId, offset);
         _excludedServerStateMap.add(instanceId);
         switch (_state) {
           case PARTIAL_CONSUMING:

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -180,7 +180,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         }
       } catch (Exception e) {
         if (LOGGER.isErrorEnabled()) {
-          LOGGER.error("Caught exception in state transition for OFFLINE -> ONLINE for partition"
+          LOGGER.error("Caught exception in state transition for OFFLINE -> ONLINE for partitionl "
               + message.getPartitionName() + " of table " + message.getResourceName(), e);
         }
         Utils.rethrowException(e);


### PR DESCRIPTION
It is possible that the controller times out while reading from a (possibly remote) file system.
In this case, the controller already sends out a 200 OK, but the request times out, closing the socket
connection to the server. The server assumes the file received is complete, but untar fails, and an exception
is thrown, resulting in the segment transitioning to ERROR state.

While we can add retries on specific exceptions from untar, it is best to send the content length from the
controller and compare it with the length of the received file in the server. The existing retry mechanisms
will then kick-in, and the file may be received correctly on a subsequent retry.

Tested with the controller not sending the header as well, in case there are servers that talk to the older
controllers