### PR TITLE
On broker side, handle empty response from server

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -58,6 +58,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -624,6 +625,14 @@ public class BrokerRequestHandler {
       @Nonnull List<ProcessingException> processingExceptions) {
     try {
       Map<ServerInstance, ByteBuf> serverResponseMap = compositeFuture.get();
+      Iterator<Entry<ServerInstance, ByteBuf>> iterator = serverResponseMap.entrySet().iterator();
+      while (iterator.hasNext()) {
+        Entry<ServerInstance, ByteBuf> entry = iterator.next();
+        if (entry.getValue().readableBytes() == 0) {
+          LOGGER.warn("Got empty response from server: {]", entry.getKey().getShortHostName());
+          iterator.remove();
+        }
+      }
       Map<ServerInstance, Long> responseTimes = compositeFuture.getResponseTimes();
       scatterGatherStats.setResponseTimeMillis(responseTimes, isOfflineTable);
       return serverResponseMap;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/query/ServerQueryRequest.java
@@ -16,112 +16,98 @@
 
 package com.linkedin.pinot.common.query;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.query.context.TimerContext;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.InstanceRequest;
-import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.common.utils.request.RequestUtils;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 /**
- * Class to encapsulate the query request and query processing
- * context within the server. Goal is to make most of the information
- * available to lower levels of code in the server for logging, tracking
- * etc.
- *
+ * Class to encapsulate the query request and query processing context within the server. Goal is to make most of the
+ * information available to lower levels of code in the server for logging, tracking etc.
  */
 public class ServerQueryRequest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ServerQueryRequest.class);
+  private final InstanceRequest _instanceRequest;
+  private final ServerMetrics _serverMetrics;
+  private final BrokerRequest _brokerRequest;
+  private final FilterQueryTree _filterQueryTree;
 
-  private final InstanceRequest instanceRequest;
-  private final FilterQueryTree filterQueryTree;
-  // Future to track result of query execution
-  private ListenableFuture<DataTable> resultFuture;
   // Timing information for different phases of query execution
-  private final TimerContext timerContext;
+  private final TimerContext _timerContext;
 
-  private final ServerMetrics serverMetrics;
-  private int segmentCountAfterPruning = -1;
+  private int _segmentCountAfterPruning = -1;
 
-  public ServerQueryRequest(InstanceRequest request, ServerMetrics serverMetrics) {
-    this.instanceRequest = request;
-    this.serverMetrics = serverMetrics;
-    BrokerRequest brokerRequest = (request == null) ? null : request.getQuery();
-    filterQueryTree = (brokerRequest == null) ? null : RequestUtils.generateFilterQueryTree(brokerRequest);
-    timerContext = new TimerContext(brokerRequest, serverMetrics);
-  }
-
-  public @Nullable String getBrokerId() {
-    return instanceRequest.getBrokerId();
+  public ServerQueryRequest(@Nonnull InstanceRequest instanceRequest, @Nonnull ServerMetrics serverMetrics) {
+    _instanceRequest = instanceRequest;
+    _serverMetrics = serverMetrics;
+    _brokerRequest = instanceRequest.getQuery();
+    _filterQueryTree = RequestUtils.generateFilterQueryTree(_brokerRequest);
+    _timerContext = new TimerContext(_brokerRequest, serverMetrics);
   }
 
   /**
-   * Convenient method to read table name for query
-   * from instance request
-   * @return
+   * Get the instance request received from broker.
    */
-  public String getTableName() {
-    return instanceRequest.getQuery().getQuerySource().getTableName();
-  }
-
-  /**
-   * Convenient method to read broker request object
-   * @return
-   */
-  public BrokerRequest getBrokerRequest() {
-    return instanceRequest.getQuery();
-  }
-
-  /**
-   * Returns the filter query tree for the server request.
-   */
-  public FilterQueryTree getFilterQueryTree() {
-    return filterQueryTree;
-  }
-
-  /**
-   * Get the instance request received from broker
-   * @return
-   */
+  @Nonnull
   public InstanceRequest getInstanceRequest() {
-    return instanceRequest;
+    return _instanceRequest;
   }
 
   /**
-   * Get server metrics
-   * @return
+   * Get the server metrics.
    */
+  @Nonnull
   public ServerMetrics getServerMetrics() {
-    return serverMetrics;
+    return _serverMetrics;
   }
 
   /**
-   *
-   * @return ListenableFuture that will used to track the result
-   * of query execution. This can be null if not set
+   * Get the broker request.
    */
-  public ListenableFuture<DataTable> getResultFuture() {
-    return resultFuture;
+  @Nonnull
+  public BrokerRequest getBrokerRequest() {
+    return _brokerRequest;
   }
 
-  public void setResultFuture(ListenableFuture<DataTable> resultFuture) {
-    this.resultFuture = resultFuture;
+  /**
+   * Get the filter query tree for the server request.
+   */
+  @Nullable
+  public FilterQueryTree getFilterQueryTree() {
+    return _filterQueryTree;
   }
 
+  /**
+   * Get the timer context.
+   */
+  @Nonnull
   public TimerContext getTimerContext() {
-    return timerContext;
+    return _timerContext;
   }
 
-  public void setSegmentCountAfterPruning(int segmentCountAfterPruning) {
-    this.segmentCountAfterPruning = segmentCountAfterPruning;
+  /**
+   * Get the table name to be queried.
+   */
+  @Nonnull
+  public String getTableName() {
+    return _brokerRequest.getQuerySource().getTableName();
   }
 
+  /**
+   * Get the segment count after pruning.
+   */
   public int getSegmentCountAfterPruning() {
-    return segmentCountAfterPruning;
+    return _segmentCountAfterPruning;
+  }
+
+  /**
+   * Set the segment count after pruning.
+   */
+  public void setSegmentCountAfterPruning(int segmentCountAfterPruning) {
+    _segmentCountAfterPruning = segmentCountAfterPruning;
   }
 }

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/request/ScheduledRequestHandler.java
@@ -18,15 +18,12 @@ package com.linkedin.pinot.server.request;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.metrics.ServerQueryPhase;
 import com.linkedin.pinot.common.query.ServerQueryRequest;
 import com.linkedin.pinot.common.query.context.TimerContext;
 import com.linkedin.pinot.common.request.InstanceRequest;
-import com.linkedin.pinot.common.utils.DataTable;
-import com.linkedin.pinot.core.common.datatable.DataTableImplV2;
 import com.linkedin.pinot.core.query.scheduler.QueryScheduler;
 import com.linkedin.pinot.serde.SerDe;
 import com.linkedin.pinot.transport.netty.NettyServer;
@@ -52,9 +49,7 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
   }
 
   @Override
-  public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext,
-      ByteBuf request) {
-
+  public ListenableFuture<byte[]> processRequest(ChannelHandlerContext channelHandlerContext, ByteBuf request) {
     final long queryStartTimeNs = System.nanoTime();
     serverMetrics.addMeteredGlobalValue(ServerMeter.QUERIES, 1);
 
@@ -65,26 +60,20 @@ public class ScheduledRequestHandler implements NettyServer.RequestHandler {
     SerDe serDe = new SerDe(new TCompactProtocol.Factory());
     final InstanceRequest instanceRequest = new InstanceRequest();
 
-    if (! serDe.deserialize(instanceRequest, byteArray)) {
+    if (!serDe.deserialize(instanceRequest, byteArray)) {
       LOGGER.error("Failed to deserialize query request from broker ip: {}",
           ((InetSocketAddress) channelHandlerContext.channel().remoteAddress()).getAddress().getHostAddress());
-      DataTable result = new DataTableImplV2();
-      result.addException(QueryException.INTERNAL_ERROR);
       serverMetrics.addMeteredGlobalValue(ServerMeter.REQUEST_DESERIALIZATION_EXCEPTIONS, 1);
-      ServerQueryRequest queryRequest = new ServerQueryRequest(null, serverMetrics);
-      queryRequest.getTimerContext().setQueryArrivalTimeNs(queryStartTimeNs);
-      return Futures.immediateFuture(QueryScheduler.serializeDataTable(queryRequest, result));
+      return Futures.immediateFuture(null);
     }
+
     final ServerQueryRequest queryRequest = new ServerQueryRequest(instanceRequest, serverMetrics);
     final TimerContext timerContext = queryRequest.getTimerContext();
-     timerContext.setQueryArrivalTimeNs(queryStartTimeNs);
-    TimerContext.Timer deserializationTimer =
-        timerContext.startNewPhaseTimerAtNs(ServerQueryPhase.REQUEST_DESERIALIZATION, queryStartTimeNs);
-    deserializationTimer.stopAndRecord();
+    timerContext.setQueryArrivalTimeNs(queryStartTimeNs);
+    timerContext.startNewPhaseTimerAtNs(ServerQueryPhase.REQUEST_DESERIALIZATION, queryStartTimeNs).stopAndRecord();
 
     LOGGER.debug("Processing requestId:{},request={}", instanceRequest.getRequestId(), instanceRequest);
-    ListenableFuture<byte[]> queryResponse = queryScheduler.submit(queryRequest);
-    return queryResponse;
+    return queryScheduler.submit(queryRequest);
   }
 
   public void setScheduler(QueryScheduler scheduler) {

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/request/ScheduledRequestHandlerTest.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/request/ScheduledRequestHandlerTest.java
@@ -98,10 +98,7 @@ public class ScheduledRequestHandlerTest {
     // The handler method is expected to return immediately
     Assert.assertTrue(response.isDone());
     byte[] responseBytes = response.get();
-    Assert.assertTrue(responseBytes.length > 0);
-    DataTable expectedDT = new DataTableImplV2();
-    expectedDT.addException(QueryException.INTERNAL_ERROR);
-    Assert.assertEquals(responseBytes, expectedDT.toBytes());
+    Assert.assertNull(responseBytes);
   }
 
   private InstanceRequest getInstanceRequest() {


### PR DESCRIPTION
Count server empty response as not responded so that client can detect the mis-behavior
For server side serialization/de-serialization exceptions, return empty response