### PR TITLE
[TE] Dataframe multi index

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthFilter.java
@@ -92,7 +92,7 @@ public class ThirdEyeAuthFilter extends AuthFilter<Credentials, ThirdEyePrincipa
         LOG.error("Empty cookie. Skipping.");
         return credentials;
       }
-
+      
       AuthCookie cookie = this.serializer.deserializeCookie(rawCookie);
       credentials.setPrincipal(cookie.getPrincipal());
       credentials.setPassword(cookie.getPassword()); // TODO replace with token in DB

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthFilter.java
@@ -92,7 +92,7 @@ public class ThirdEyeAuthFilter extends AuthFilter<Credentials, ThirdEyePrincipa
         LOG.error("Empty cookie. Skipping.");
         return credentials;
       }
-      
+
       AuthCookie cookie = this.serializer.deserializeCookie(rawCookie);
       credentials.setPrincipal(cookie.getPrincipal());
       credentials.setPassword(cookie.getPassword()); // TODO replace with token in DB

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
@@ -372,7 +372,7 @@ public class TimeSeriesResource {
   private static Map<String, List<? extends Number>> convertDataToMap(DataFrame data) {
     Map<String, List<? extends Number>> output = new HashMap<>();
     for (String name : data.getSeriesNames()) {
-      if (data.getIndexName().equals(name)) {
+      if (data.getIndexNames().contains(name)) {
         output.put(name, data.getLongs(name).toList());
         continue;
       }
@@ -479,7 +479,7 @@ public class TimeSeriesResource {
   private DataFrame transformTimeSeriesCumulative(DataFrame data) {
     Grouping.DataFrameGrouping group = data.groupByExpandingWindow();
     for (String id : data.getSeriesNames()) {
-      if (data.getIndexName().equals(id))
+      if (data.getIndexNames().contains(id))
         continue;
       data.addSeries(id, group.aggregate(id, DoubleSeries.SUM).getValues());
     }
@@ -494,7 +494,7 @@ public class TimeSeriesResource {
    */
   private DataFrame transformTimeSeriesDifference(DataFrame data) {
     for (String id : data.getSeriesNames()) {
-      if (data.getIndexName().equals(id))
+      if (data.getIndexNames().contains(id))
         continue;
       DoubleSeries s = data.getDoubles(id);
       data.addSeries(id, s.subtract(s.shift(1)));
@@ -536,7 +536,7 @@ public class TimeSeriesResource {
       public long apply(long... values) {
         return granularity.toMillis(values[0]) + start;
       }
-    }, data.getIndexName());
+    }, data.getIndexNames().get(0));
     return data;
   }
 
@@ -548,7 +548,7 @@ public class TimeSeriesResource {
    */
   private DataFrame transformTimeSeriesChange(DataFrame data) {
     for (String id : data.getSeriesNames()) {
-      if (data.getIndexName().equals(id))
+      if (data.getIndexNames().contains(id))
         continue;
       DoubleSeries s = data.getDoubles(id);
       data.addSeries(id, s.divide(s.shift(1).replace(0d, DoubleSeries.NULL)).subtract(1));
@@ -564,7 +564,7 @@ public class TimeSeriesResource {
    */
   private DataFrame transformTimeSeriesRelative(DataFrame data) {
     for (String id : data.getSeriesNames()) {
-      if (data.getIndexName().equals(id))
+      if (data.getIndexNames().contains(id))
         continue;
       DoubleSeries s = data.getDoubles(id);
       if (s.size() <= 0)
@@ -587,7 +587,7 @@ public class TimeSeriesResource {
    */
   private DataFrame transformTimeSeriesOffset(DataFrame data) {
     for (String id : data.getSeriesNames()) {
-      if (data.getIndexName().equals(id))
+      if (data.getIndexNames().contains(id))
         continue;
       DoubleSeries s = data.getDoubles(id);
       if (s.size() <= 0)
@@ -606,7 +606,7 @@ public class TimeSeriesResource {
    */
   private DataFrame transformTimeSeriesLog(DataFrame data) {
     for (String id : data.getSeriesNames()) {
-      if (data.getIndexName().equals(id))
+      if (data.getIndexNames().contains(id))
         continue;
       data.mapInPlace(new Series.DoubleFunction() {
         @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
@@ -1269,6 +1269,16 @@ public class DataFrame {
   }
 
   /**
+   * Returns a copy of the DataFrame sorted by series values referenced by its index.
+   *
+   * @throws IllegalArgumentException if the series does not exist
+   * @return sorted DataFrame copy
+   */
+  public DataFrame sortedByIndex() {
+    return this.sortedBy(this.indexNames);
+  }
+
+  /**
    * Returns a copy of the DataFrame sorted by series values referenced by {@code seriesNames}.
    * The resulting sorted order is the equivalent of applying a stable sort to the nth series
    * first, and then sorting iteratively by series until the 1st series.
@@ -1951,7 +1961,13 @@ public class DataFrame {
 
     for(int i=0; i<numSeries; i++)
       joined.addSeries(joinKeyNames.get(i), joinKeys[i]);
-    joined.setIndex(joinKeyNames);
+
+    List<String> newIndex = new ArrayList<>();
+    for (String name : joinKeyNames) {
+      if (left.indexNames.contains(name))
+        newIndex.add(name);
+    }
+    joined.setIndex(newIndex);
 
     for(String name : seriesRight) {
       Series s = rightData.get(name);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
@@ -1447,6 +1447,20 @@ public class DataFrame {
    * @return DataFrameGrouping
    */
   public Grouping.DataFrameGrouping groupByValue(String... seriesNames) {
+    return this.groupByValue(Arrays.asList(seriesNames));
+  }
+
+  /**
+   * Returns a DataFrameGrouping based on the labels provided by the series referenced by
+   * {@code seriesNames} row by row.  The method can group across multiple columns.  It returns
+   * the key column as object series of {@code Tuples} constructed from the input columns.
+   *
+   * @see Grouping.GroupingByValue
+   *
+   * @param seriesNames series containing grouping labels
+   * @return DataFrameGrouping
+   */
+  public Grouping.DataFrameGrouping groupByValue(List<String> seriesNames) {
     return new Grouping.DataFrameGrouping(Grouping.GROUP_KEY, this, Grouping.GroupingByValue.from(names2series(seriesNames)));
   }
 
@@ -2149,9 +2163,13 @@ public class DataFrame {
   }
 
   Series[] names2series(String... names) {
-    Series[] inputSeries = new Series[names.length];
-    for(int i=0; i<names.length; i++) {
-      inputSeries[i] = assertSeriesExists(names[i]);
+    return names2series(Arrays.asList(names));
+  }
+
+  Series[] names2series(List<String> names) {
+    Series[] inputSeries = new Series[names.size()];
+    for(int i=0; i<names.size(); i++) {
+      inputSeries[i] = assertSeriesExists(names.get(i));
     }
     return inputSeries;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
@@ -216,8 +216,8 @@ public class DataFrame {
     }
   }
 
-  String indexName = null;
-  Map<String, Series> series = new LinkedHashMap<>();
+  final List<String> indexNames = new ArrayList<>();
+  final Map<String, Series> series = new LinkedHashMap<>();
 
   /**
    * Returns a DoubleSeries wrapping the values array
@@ -356,7 +356,7 @@ public class DataFrame {
       indexValues[i] = i;
     }
     this.addSeries(COLUMN_INDEX_DEFAULT, LongSeries.buildFrom(indexValues));
-    this.indexName = COLUMN_INDEX_DEFAULT;
+    this.indexNames.add(COLUMN_INDEX_DEFAULT);
   }
 
   /**
@@ -367,7 +367,7 @@ public class DataFrame {
    */
   public DataFrame(long... indexValues) {
     this.addSeries(COLUMN_INDEX_DEFAULT, LongSeries.buildFrom(indexValues));
-    this.indexName = COLUMN_INDEX_DEFAULT;
+    this.indexNames.add(COLUMN_INDEX_DEFAULT);
   }
 
   /**
@@ -378,7 +378,7 @@ public class DataFrame {
    */
   public DataFrame(Series index) {
     this.addSeries(COLUMN_INDEX_DEFAULT, index);
-    this.indexName = COLUMN_INDEX_DEFAULT;
+    this.indexNames.add(COLUMN_INDEX_DEFAULT);
   }
 
   /**
@@ -389,8 +389,8 @@ public class DataFrame {
    * @param df DataFrame to copy properties from
    */
   public DataFrame(DataFrame df) {
-    this.indexName = df.indexName;
-    this.series = new HashMap<>(df.series);
+    this.indexNames.addAll(df.indexNames);
+    this.series.putAll(df.series);
   }
 
   /**
@@ -404,13 +404,25 @@ public class DataFrame {
   /**
    * Sets the index name to the specified series name in-place.
    *
-   * @param seriesName index series name
+   * @param seriesNames index series names
    * @throws IllegalArgumentException if the series does not exist
    * @return reference to the modified DataFrame (this)
    */
-  public DataFrame setIndex(String seriesName) {
-    assertSeriesExists(seriesName);
-    this.indexName = seriesName;
+  public DataFrame setIndex(String... seriesNames) {
+    return this.setIndex(Arrays.asList(seriesNames));
+  }
+
+  /**
+   * Sets the index name to the specified series name in-place.
+   *
+   * @param seriesNames index series names
+   * @throws IllegalArgumentException if the series does not exist
+   * @return reference to the modified DataFrame (this)
+   */
+  public DataFrame setIndex(List<String> seriesNames) {
+    assertSeriesExist(seriesNames);
+    this.indexNames.clear();
+    this.indexNames.addAll(seriesNames);
     return this;
   }
 
@@ -420,18 +432,33 @@ public class DataFrame {
    * @return reference to the modified DataFrame (this)
    */
   public DataFrame resetIndex() {
-    this.indexName = null;
+    this.indexNames.clear();
     return this;
   }
 
   /**
-   * Returns the series referenced by indexName.
+   * Returns the series referenced by indexName, if there is exactly one index column.
    *
    * @throws IllegalArgumentException if the series does not exist
    * @return index series
    */
-  public Series getIndex() {
-    return assertSeriesExists(this.indexName);
+  public Series getIndexSingleton() {
+    if (this.indexNames.size() != 1)
+      throw new IllegalArgumentException("Must have exactly one index column");
+    return assertSeriesExists(this.indexNames.get(0));
+  }
+
+  /**
+   * Returns the series referenced by indexNames.
+   *
+   * @throws IllegalArgumentException if the series does not exist
+   * @return index series
+   */
+  public List<Series> getIndexSeries() {
+    List<Series> series = new ArrayList<>();
+    for (String name : this.indexNames)
+      series.add(this.get(name));
+    return series;
   }
 
   /**
@@ -440,7 +467,7 @@ public class DataFrame {
    * @return {@code true} if a valid index name is set, {@code false} otherwise
    */
   public boolean hasIndex() {
-    return this.indexName != null;
+    return !this.indexNames.isEmpty();
   }
 
   /**
@@ -448,8 +475,8 @@ public class DataFrame {
    *
    * @return index series name
    */
-  public String getIndexName() {
-    return this.indexName;
+  public List<String> getIndexNames() {
+    return new ArrayList<>(this.indexNames);
   }
 
   /**
@@ -522,12 +549,14 @@ public class DataFrame {
    */
   public DataFrame slice(Iterable<String> seriesNames) {
     DataFrame df = new DataFrame();
+    List<String> index = new ArrayList<>();
     df.series.clear();
     for(String name : seriesNames) {
       df.addSeries(name, this.get(name).copy());
-      if(name.equals(this.getIndexName()))
-        df.setIndex(name);
+      if(this.indexNames.contains(name))
+        index.add(name);
     }
+    df.setIndex(index);
     return df;
   }
 
@@ -709,15 +738,23 @@ public class DataFrame {
       return this;
 
     // fast - if indexes match
-    if(this.getIndex().equals(source.getIndex())) {
+    if(this.getIndexSeries().equals(source.getIndexSeries())) {
       for(String name : seriesNames)
         addSeries(name, source.get(name));
       return this;
     }
 
     // left join - on minimal structure
-    DataFrame dfLeft = new DataFrame(this.getIndex());
-    DataFrame dfRight = new DataFrame(source.getIndex());
+    DataFrame dfLeft = new DataFrame();
+    for (String name : this.indexNames)
+      dfLeft.addSeries(name, this.get(name));
+    dfLeft.setIndex(this.indexNames);
+
+    DataFrame dfRight = new DataFrame();
+    for (String name : source.indexNames)
+      dfRight.addSeries(name, source.get(name));
+    dfRight.setIndex(source.indexNames);
+
     for(String name : seriesNames)
       dfRight.addSeries(name, source.get(name));
 
@@ -743,22 +780,35 @@ public class DataFrame {
    */
   public DataFrame addSeries(DataFrame source) {
     Collection<String> seriesNames = new HashSet<>(source.getSeriesNames());
-    seriesNames.remove(source.getIndexName());
-    return this.addSeries(source, seriesNames.toArray(new String[seriesNames.size()]));
+    for (String name : source.indexNames)
+      seriesNames.remove(name);
+    return this.addSeries(source, seriesNames);
   }
 
   /**
    * Removes a series from the DataFrame in-place.
    *
-   * @param seriesName
+   * @param seriesNames
    * @throws IllegalArgumentException if the series does not exist
    * @return reference to the modified DataFrame (this)
    */
-  public DataFrame dropSeries(String seriesName) {
-    assertSeriesExists(seriesName);
-    this.series.remove(seriesName);
-    if(seriesName.equals(this.indexName))
-      this.indexName = null;
+  public DataFrame dropSeries(String... seriesNames) {
+    return this.dropSeries(Arrays.asList(seriesNames));
+  }
+
+  /**
+   * Removes a series from the DataFrame in-place.
+   *
+   * @param seriesNames
+   * @throws IllegalArgumentException if the series does not exist
+   * @return reference to the modified DataFrame (this)
+   */
+  public DataFrame dropSeries(List<String> seriesNames) {
+    assertSeriesExist(seriesNames);
+    for (String name : seriesNames) {
+      this.series.remove(name);
+      this.indexNames.remove(name);
+    }
     return this;
   }
 
@@ -773,12 +823,17 @@ public class DataFrame {
    */
   public DataFrame renameSeries(String oldName, String newName) {
     Series s = assertSeriesExists(oldName);
-    String indexName = this.indexName;
+    List<String> indexNames = new ArrayList<>(this.indexNames);
 
     this.dropSeries(oldName).addSeries(newName, s);
 
-    if(oldName.equals(indexName))
-      this.indexName = newName;
+    for (int i=0; i<indexNames.size(); i++)
+      if (indexNames.get(i).equals(oldName))
+        indexNames.set(i, newName);
+
+    this.indexNames.clear();
+    this.indexNames.addAll(indexNames);
+
     return this;
   }
 
@@ -1583,7 +1638,7 @@ public class DataFrame {
    */
   public DataFrame joinInner(DataFrame other) {
     assertIndex(this, other);
-    return this.joinInner(other, new String[] { this.getIndexName() }, new String[] { other.getIndexName() });
+    return this.joinInner(other, this.indexNames, other.indexNames);
   }
 
   /**
@@ -1594,6 +1649,17 @@ public class DataFrame {
    * @return joined DataFrame
    */
   public DataFrame joinInner(DataFrame other, String... onSeries) {
+    return this.joinInner(other, onSeries, onSeries);
+  }
+
+  /**
+   * Performs an inner join on the {@code onSeries} columns of two DataFrames.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinInner(DataFrame other, List<String> onSeries) {
     return this.joinInner(other, onSeries, onSeries);
   }
 
@@ -1610,6 +1676,18 @@ public class DataFrame {
   }
 
   /**
+   * Performs an inner join on the {@code onSeriesLeft} columns of this DataFrame and
+   * the {@code onSeriesLeft} columns of the {@code other} DataFrame.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinInner(DataFrame other, List<String> onSeriesLeft, List<String> onSeriesRight) {
+    return DataFrame.join(this, other, onSeriesLeft, onSeriesRight, Series.JoinType.INNER);
+  }
+
+  /**
    * Performs a left outer join on the index column of two DataFrames.
    * @see DataFrame#join(DataFrame, DataFrame, String[], String[], Series.JoinType)
    *
@@ -1618,7 +1696,7 @@ public class DataFrame {
    */
   public DataFrame joinLeft(DataFrame other) {
     assertIndex(this, other);
-    return this.joinLeft(other, new String[] { this.getIndexName() }, new String[] { other.getIndexName() });
+    return this.joinLeft(other, this.indexNames, other.indexNames);
   }
 
   /**
@@ -1629,6 +1707,17 @@ public class DataFrame {
    * @return joined DataFrame
    */
   public DataFrame joinLeft(DataFrame other, String... onSeries) {
+    return this.joinLeft(other, onSeries, onSeries);
+  }
+
+  /**
+   * Performs a left outer join on the {@code onSeries} columns of two DataFrames.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinLeft(DataFrame other, List<String> onSeries) {
     return this.joinLeft(other, onSeries, onSeries);
   }
 
@@ -1645,6 +1734,18 @@ public class DataFrame {
   }
 
   /**
+   * Performs a left outer join on the {@code onSeriesLeft} columns of this DataFrame and
+   * the {@code onSeriesLeft} columns of the {@code other} DataFrame.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinLeft(DataFrame other, List<String> onSeriesLeft, List<String> onSeriesRight) {
+    return DataFrame.join(this, other, onSeriesLeft, onSeriesRight, Series.JoinType.LEFT);
+  }
+
+  /**
    * Performs a right outer join on the index column of two DataFrames.
    * @see DataFrame#join(DataFrame, DataFrame, String[], String[], Series.JoinType)
    *
@@ -1653,7 +1754,18 @@ public class DataFrame {
    */
   public DataFrame joinRight(DataFrame other) {
     assertIndex(this, other);
-    return this.joinRight(other, new String[] { this.getIndexName() }, new String[] { other.getIndexName() });
+    return this.joinRight(other, this.indexNames, other.indexNames);
+  }
+
+  /**
+   * Performs a right outer join on the {@code onSeries} columns of two DataFrames.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinRight(DataFrame other, List<String> onSeries) {
+    return this.joinRight(other, onSeries, onSeries);
   }
 
   /**
@@ -1680,6 +1792,18 @@ public class DataFrame {
   }
 
   /**
+   * Performs a right outer join on the {@code onSeriesLeft} columns of this DataFrame and
+   * the {@code onSeriesLeft} columns of the {@code other} DataFrame.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinRight(DataFrame other, List<String> onSeriesLeft, List<String> onSeriesRight) {
+    return DataFrame.join(this, other, onSeriesLeft, onSeriesRight, Series.JoinType.RIGHT);
+  }
+
+  /**
    * Performs an outer join on the index column of two DataFrames.
    * @see DataFrame#join(DataFrame, DataFrame, String[], String[], Series.JoinType)
    *
@@ -1688,17 +1812,28 @@ public class DataFrame {
    */
   public DataFrame joinOuter(DataFrame other) {
     assertIndex(this, other);
-    return this.joinOuter(other, new String[] { this.getIndexName() }, new String[] { other.getIndexName() });
+    return this.joinOuter(other, this.indexNames, other.indexNames);
   }
 
   /**
    * Performs an outer join on the {@code onSeries} columns of two DataFrames.
-   * @see DataFrame#join(DataFrame, DataFrame, String[], String[], Series.JoinType)
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
    *
    * @param other right DataFrame
    * @return joined DataFrame
    */
   public DataFrame joinOuter(DataFrame other, String... onSeries) {
+    return this.joinOuter(other, onSeries, onSeries);
+  }
+
+  /**
+   * Performs an outer join on the {@code onSeries} columns of two DataFrames.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinOuter(DataFrame other, List<String> onSeries) {
     return this.joinOuter(other, onSeries, onSeries);
   }
 
@@ -1711,6 +1846,18 @@ public class DataFrame {
    * @return joined DataFrame
    */
   public DataFrame joinOuter(DataFrame other, String[] onSeriesLeft, String[] onSeriesRight) {
+    return DataFrame.join(this, other, onSeriesLeft, onSeriesRight, Series.JoinType.OUTER);
+  }
+
+  /**
+   * Performs an outer join on the {@code onSeriesLeft} columns of this DataFrame and
+   * the {@code onSeriesLeft} columns of the {@code other} DataFrame.
+   * @see DataFrame#join(DataFrame, DataFrame, List, List, Series.JoinType)
+   *
+   * @param other right DataFrame
+   * @return joined DataFrame
+   */
+  public DataFrame joinOuter(DataFrame other, List<String> onSeriesLeft, List<String> onSeriesRight) {
     return DataFrame.join(this, other, onSeriesLeft, onSeriesRight, Series.JoinType.OUTER);
   }
 
@@ -1730,19 +1877,38 @@ public class DataFrame {
    * @return joined DataFrame
    */
   public static DataFrame join(DataFrame left, DataFrame right, String[] onSeriesLeft, String[] onSeriesRight, Series.JoinType joinType) {
-    if(onSeriesLeft.length != onSeriesRight.length)
+    return join(left, right, Arrays.asList(onSeriesLeft), Arrays.asList(onSeriesRight), joinType);
+  }
+
+  /**
+   * Performs a join between two DataFrames and returns the result as a new DataFrame. The join
+   * can be performed across multiple series. If (non-joined) series with the same name exist
+   * in both DataFrames, their names are appended with {@code COLUMN_JOIN_LEFT} and
+   * {@code COLUMN_JOIN_RIGHT} in the returned DataFrame.
+   *
+   * <b>NOTE:</b> the series names of the left join series survive.
+   *
+   * @param left left DataFrame
+   * @param right right DataFrame
+   * @param onSeriesLeft left series names to join on
+   * @param onSeriesRight right series names to join on
+   * @param joinType type of join to perform
+   * @return joined DataFrame
+   */
+  public static DataFrame join(DataFrame left, DataFrame right, List<String> onSeriesLeft, List<String> onSeriesRight, Series.JoinType joinType) {
+    if(onSeriesLeft.size() != onSeriesRight.size())
       throw new IllegalArgumentException("Number of series on the left side of the join must equal the number of series on the right side");
 
-    final int numSeries = onSeriesLeft.length;
+    final int numSeries = onSeriesLeft.size();
 
     // extract source series
     Series[] leftSeries = new Series[numSeries];
     for(int i=0; i<numSeries; i++)
-      leftSeries[i] = left.get(onSeriesLeft[i]);
+      leftSeries[i] = left.get(onSeriesLeft.get(i));
 
     Series[] rightSeries = new Series[numSeries];
     for(int i=0; i<numSeries; i++)
-      rightSeries[i] = right.get(onSeriesRight[i]);
+      rightSeries[i] = right.get(onSeriesRight.get(i));
 
     // perform join, generate row pairs
     Series.JoinPairs pairs = filterJoinPairs(Series.hashJoinOuter(leftSeries, rightSeries), joinType);
@@ -1769,25 +1935,23 @@ public class DataFrame {
     // merge values of join columns
     Series[] joinKeys = new Series[numSeries];
     for(int i=0; i<numSeries; i++)
-      joinKeys[i] = leftData.get(onSeriesLeft[i]).set(BooleanSeries.buildFrom(maskValues), rightData.get(onSeriesRight[i]));
+      joinKeys[i] = leftData.get(onSeriesLeft.get(i)).set(BooleanSeries.buildFrom(maskValues), rightData.get(onSeriesRight.get(i)));
 
     // select series names
     Set<String> seriesLeft = new HashSet<>(left.getSeriesNames());
     Set<String> seriesRight = new HashSet<>(right.getSeriesNames());
 
-    seriesLeft.removeAll(Arrays.asList(onSeriesLeft));
-    seriesRight.removeAll(Arrays.asList(onSeriesRight));
+    seriesLeft.removeAll(onSeriesLeft);
+    seriesRight.removeAll(onSeriesRight);
 
-    String[] joinKeyNames = onSeriesLeft;
+    final List<String> joinKeyNames = onSeriesLeft;
 
     // construct result
     DataFrame joined = new DataFrame();
 
     for(int i=0; i<numSeries; i++)
-      joined.addSeries(joinKeyNames[i], joinKeys[i]);
-
-    if(joined.contains(left.getIndexName()))
-      joined.setIndex(left.getIndexName());
+      joined.addSeries(joinKeyNames.get(i), joinKeys[i]);
+    joined.setIndex(joinKeyNames);
 
     for(String name : seriesRight) {
       Series s = rightData.get(name);
@@ -1868,15 +2032,13 @@ public class DataFrame {
 
   @Override
   public String toString() {
-    StringBuilder builder = new StringBuilder();
-
     List<String> names = new ArrayList<>(this.getSeriesNames());
-    if(this.hasIndex()) {
-      names.remove(this.getIndexName());
-      names.add(0, this.getIndexName());
+    for (int i=0; i<this.indexNames.size(); i++) {
+      names.remove(this.indexNames.get(i));
+      names.add(i, this.indexNames.get(i));
     }
 
-    return this.toString(DEFAULT_MAX_COLUMN_WIDTH, names.toArray(new String[names.size()]));
+    return this.toString(DEFAULT_MAX_COLUMN_WIDTH, names);
   }
 
   public String toString(String... seriesNames) {
@@ -1982,6 +2144,13 @@ public class DataFrame {
     if(!series.containsKey(name))
       throw new IllegalArgumentException(String.format("Unknown series '%s'", name));
     return series.get(name);
+  }
+
+  List<Series> assertSeriesExist(List<String> names) {
+    List<Series> series = new ArrayList<>();
+    for (String n : names)
+      series.add(assertSeriesExists(n));
+    return series;
   }
 
   void assertSameLength(Series s) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/Grouping.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/Grouping.java
@@ -425,8 +425,8 @@ public abstract class Grouping {
      * @return group sizes
      */
     public GroupingDataFrame count() {
-      // TODO data frames without index
-      return this.grouping.count(this.source.getIndex());
+      Series anySeries = this.source.series.values().iterator().next();
+      return this.grouping.count(anySeries);
     }
 
     public GroupingDataFrame sum(String seriesName) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/Grouping.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/Grouping.java
@@ -350,7 +350,7 @@ public abstract class Grouping {
     /**
      * Evaluates the {@code aggregationExpressions} and returns the result as a DataFrame with
      * the index corresponding to the grouping key column. Each expression takes the format
-     * {@code seriesName:operation[:outputName]}, where {@code seriesName} is a valid column name in the
+     * {@code seriesName[:operation[:outputName]]}, where {@code seriesName} is a valid column name in the
      * underlying DataFrame and {@code operation} is one of {@code SUM, PRODUCT, MIN, MAX,
      * FIRST, LAST, MEAN, MEDIAN, STD} and {@code outputName} is the name of the result series.
      *
@@ -373,11 +373,13 @@ public abstract class Grouping {
       for(String expression : aggregationExpressions) {
         // parse expression
         String[] parts = expression.split(":", 3);
-        if(parts.length < 2 || parts.length > 3)
+        if(parts.length > 3)
           throw new IllegalArgumentException(String.format("Could not parse expression '%s'", expression));
 
         String name = parts[0];
-        String operation = parts[1];
+        String operation = OP_FIRST;
+        if (parts.length >= 2)
+          operation = parts[1];
         String outName = name;
         if (parts.length >= 3)
           outName = parts[2];

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
@@ -1986,6 +1986,72 @@ public class DataFrameTest {
   }
 
   @Test
+  public void testJoinMultiIndex() {
+    DataFrame dfLeft = new DataFrame()
+        .addSeries("A", 1, 1, 1, 2, 2)
+        .addSeries("B", "a", "b", "c", "d", "e")
+        .addSeries("V", 0, 1, 2, 3, 4)
+        .setIndex("A", "B");
+
+    DataFrame dfRight = new DataFrame()
+        .addSeries("A", 1, 1, 2, 2, 2)
+        .addSeries("B", "a", "b", "c", "d", "e")
+        .addSeries("W", "a", "aa", "aaa", "aaaa", "aaaaa")
+        .setIndex("A", "B");
+
+    DataFrame joined = dfLeft.joinOuter(dfRight).sortedByIndex();
+
+    Assert.assertEquals(joined.size(), 6);
+    Assert.assertEquals(joined.getSeriesNames().size(), 4);
+    Assert.assertEquals(joined.getIndexNames().size(), 2);
+    assertEquals(joined.getLongs("A"), 1, 1, 1, 2, 2, 2);
+    assertEquals(joined.getStrings("B"), "a", "b", "c", "c", "d", "e");
+    assertEquals(joined.getLongs("V"), 0, 1, 2, LNULL, 3, 4);
+    assertEquals(joined.getStrings("W"), "a", "aa", SNULL, "aaa", "aaaa", "aaaaa");
+  }
+
+  @Test
+  public void testAddSeriesMultiIndex() {
+    DataFrame dfLeft = new DataFrame()
+        .addSeries("A", 1, 1, 1, 2, 2)
+        .addSeries("B", "a", "b", "c", "d", "e")
+        .addSeries("V", 0, 1, 2, 3, 4)
+        .setIndex("A", "B");
+
+    DataFrame dfRight = new DataFrame()
+        .addSeries("A", 1, 1, 2, 2, 2)
+        .addSeries("B", "a", "b", "c", "d", "e")
+        .addSeries("W", "a", "aa", "aaa", "aaaa", "aaaaa")
+        .setIndex("A", "B");
+
+    dfLeft.addSeries(dfRight, "W");
+
+    Assert.assertEquals(dfLeft.size(), 5);
+    Assert.assertEquals(dfLeft.getSeriesNames().size(), 4);
+    Assert.assertEquals(dfLeft.getIndexNames().size(), 2);
+    assertEquals(dfLeft.getStrings("W"), "a", "aa", SNULL, "aaaa", "aaaaa");
+  }
+
+  @Test
+  public void testJoinIndexRetention() {
+    DataFrame dfLeft = new DataFrame()
+        .addSeries("a", 0)
+        .addSeries("b", 0)
+        .setIndex("a");
+
+    DataFrame dfRight = new DataFrame()
+        .addSeries("a", 0)
+        .addSeries("b", 0)
+        .setIndex("a", "b");
+
+    DataFrame joined = dfLeft.joinOuter(dfRight, Arrays.asList("a", "b"));
+
+    Assert.assertEquals(joined.getSeriesNames().size(), 2);
+    Assert.assertEquals(joined.getIndexNames().size(), 1);
+    Assert.assertEquals(joined.getIndexNames().get(0), "a");
+  }
+
+  @Test
   public void testBooleanHasTrueFalseNull() {
     BooleanSeries s1 = DataFrame.toSeries(new boolean[0]);
     Assert.assertFalse(s1.hasFalse());

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
@@ -1153,7 +1153,7 @@ public class DataFrameTest {
 
     Assert.assertEquals(out.getSeriesNames().size(), 10);
     Assert.assertEquals(out.size(), 2);
-    assertEquals(out.getIndex().getLongs(), 0, 1);
+    assertEquals(out.getIndexSingleton().getLongs(), 0, 1);
     assertEquals(out.getLongs("sum"), 6, 9);
     assertEquals(out.getLongs("product"), 6, 20);
     assertEquals(out.getLongs("min"), 1, 4);
@@ -1946,7 +1946,7 @@ public class DataFrameTest {
     DataFrame dfRight = new DataFrame(5)
         .addSeries("two", 11, 12, 13, 14, 15);
 
-    Assert.assertEquals(dfLeft.getIndex(), dfRight.getIndex());
+    Assert.assertEquals(dfLeft.getIndexSingleton(), dfRight.getIndexSingleton());
 
     dfLeft.addSeries(dfRight);
 
@@ -2259,7 +2259,9 @@ public class DataFrameTest {
   public void testIndexNone() {
     DataFrame df = new DataFrame();
     Assert.assertFalse(df.hasIndex());
-    df.getIndex();
+    Assert.assertEquals(df.getIndexNames().size(), 0);
+    Assert.assertEquals(df.getIndexSeries().size(), 0);
+    df.getIndexSingleton();
   }
 
   @Test
@@ -2274,7 +2276,10 @@ public class DataFrameTest {
     DataFrame df = new DataFrame(5)
         .addSeries("test", DataFrame.toSeries(VALUES_BOOLEAN))
         .setIndex("test");
-    Assert.assertEquals(df.copy().getIndexName(), "test");
+    Assert.assertTrue(df.copy().hasIndex());
+    Assert.assertEquals(df.copy().getIndexSeries().size(), 1);
+    Assert.assertEquals(df.copy().getIndexNames().size(), 1);
+    Assert.assertEquals(df.copy().getIndexNames().get(0), "test");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -2286,11 +2291,11 @@ public class DataFrameTest {
   @Test
   public void testIndexRename() {
     DataFrame df = new DataFrame(0);
-    Series index = df.getIndex();
-    df.renameSeries(df.getIndexName(), "test");
+    Series index = df.getIndexSeries().get(0);
+    df.renameSeries(df.getIndexNames().get(0), "test");
     df.addSeries(DataFrame.COLUMN_INDEX_DEFAULT, DataFrame.toSeries(new double[0]));
-    Assert.assertEquals(df.getIndexName(), "test");
-    Assert.assertEquals(df.getIndex(), index);
+    Assert.assertEquals(df.getIndexNames().get(0), "test");
+    Assert.assertEquals(df.getIndexSeries().get(0), index);
   }
 
   @Test
@@ -3566,7 +3571,7 @@ public class DataFrameTest {
 
     Assert.assertEquals(out.size(), 4);
     Assert.assertEquals(out.getSeriesNames().size(), 2);
-    Assert.assertEquals(out.getIndexName(), "one");
+    Assert.assertEquals(out.getIndexNames().get(0), "one");
     assertEquals(out.getStrings("three"), "1", "2", "3", "4");
     assertEquals(out.getLongs("one"), 1, 2, 3, 4);
   }
@@ -3582,7 +3587,7 @@ public class DataFrameTest {
 
     Assert.assertEquals(out.size(), 4);
     Assert.assertEquals(out.getSeriesNames().size(), 1);
-    Assert.assertEquals(out.getIndexName(), null);
+    Assert.assertFalse(out.hasIndex());
     assertEquals(out.getLongs("one"), 1, 2, 3, 4);
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
@@ -1166,6 +1166,22 @@ public class DataFrameTest {
   }
 
   @Test
+  public void testGroupingExpressionDefaultOperation() {
+    DataFrame out = new DataFrame()
+        .addSeries("a", 1, 1, 2, 2, 2)
+        .addSeries("b", "1", "1", "2", "2", "2")
+        .groupByValue("a", "b")
+        .aggregate("a", "a:first:first", "b");
+
+    Assert.assertEquals(out.getSeriesNames().size(), 4);
+    Assert.assertEquals(out.size(), 2);
+    Assert.assertEquals(out.getIndexSingleton().type(), Series.SeriesType.OBJECT);
+    assertEquals(out.getLongs("a"), 1, 2);
+    assertEquals(out.getLongs("first"), 1, 2);
+    assertEquals(out.getStrings("b"), "1", "2");
+  }
+
+  @Test
   public void testStableMultiSortDoubleLong() {
     DataFrame mydf = new DataFrame(new long[] { 1, 2, 3, 4, 5, 6, 7, 8 })
         .addSeries("double", 1.0, 1.0, 2.0, 2.0, 1.0, 1.0, 2.0, 2.0)


### PR DESCRIPTION
The current implementation allows only a single index column per dataframe. This limitation can be worked around by using an Objectseries of Tuples, but is cumbersome. This PR adds support for multiple index columns and integrates directly with the existing join and grouping logic.

* multiple index columns (use getIndexSingleton() instead of legacy getIndex())

* join() and addSeries() use multiple index columns automatically

* tweaks to grouping. Still generates a tuple column, but also supports aggregation expression for individual keys.

* Continuation of List<String> and String... interface refactoring