### PR TITLE
Add support for star tree segments with udfs

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/request/RequestUtils.java
@@ -207,22 +207,7 @@ public class RequestUtils {
     // Ensure that none of the group-by columns are metric or skipped for materialization.
     GroupBy groupBy = brokerRequest.getGroupBy();
     if (groupBy != null) {
-      Set<String> allGroupByColumns = new HashSet<>();
-
-      List<String> groupByColumns = groupBy.getColumns();
-      if (groupByColumns != null) {
-        allGroupByColumns.addAll(groupByColumns);
-      }
-
-      List<String> groupByExpressions = groupBy.getExpressions();
-      if (groupByExpressions != null) {
-        for (String expression : groupByExpressions) {
-          TransformExpressionTree expressionTree = PQL2_COMPILER.compileToExpressionTree(expression);
-          List<String> columns = new ArrayList<>();
-          expressionTree.getColumns(columns);
-          allGroupByColumns.addAll(columns);
-        }
-      }
+      Set<String> allGroupByColumns = getAllGroupByColumns(groupBy);
 
       for (String groupByColumn : allGroupByColumns) {
         if (metricColumnSet.contains(groupByColumn)) {
@@ -303,5 +288,32 @@ public class RequestUtils {
     }
     String useStarTreeString = debugOptions.get(USE_STAR_TREE_KEY);
     return (useStarTreeString != null) ? Boolean.valueOf(useStarTreeString) : true;
+  }
+
+  /**
+   * Helper method to extract all column names from group by columns and expressions
+   * @param groupBy
+   * @return
+   */
+  public static Set<String> getAllGroupByColumns(GroupBy groupBy) {
+    Set<String> allGroupByColumns = new HashSet<>();
+
+    if (groupBy != null) {
+      List<String> groupByColumns = groupBy.getColumns();
+      if (groupByColumns != null) {
+        allGroupByColumns.addAll(groupByColumns);
+      }
+
+      List<String> groupByExpressions = groupBy.getExpressions();
+      if (groupByExpressions != null) {
+        for (String expression : groupByExpressions) {
+          TransformExpressionTree expressionTree = PQL2_COMPILER.compileToExpressionTree(expression);
+          List<String> columns = new ArrayList<>();
+          expressionTree.getColumns(columns);
+          allGroupByColumns.addAll(columns);
+        }
+      }
+    }
+    return allGroupByColumns;
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/RequestUtilsTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import com.google.common.collect.Lists;
+import com.linkedin.pinot.common.request.GroupBy;
+import com.linkedin.pinot.common.utils.request.RequestUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for the Utils class.
+ *
+ */
+public class RequestUtilsTest {
+  @Test(dataProvider = "getAllGroupByColumnsDataProvider")
+  public void testGetAllGroupByColumns(GroupBy groupBy, List<String> expectedColumns) {
+    List<String> allGroupByColumns = Lists.newArrayList(RequestUtils.getAllGroupByColumns(groupBy));
+    Collections.sort(allGroupByColumns);
+    Assert.assertEquals(allGroupByColumns, expectedColumns);
+  }
+
+  @DataProvider(name = "getAllGroupByColumnsDataProvider")
+  public Object[][] getAllGroupByColumnsDataProvider() {
+    List<Object[]> entries = new ArrayList<>();
+    GroupBy groupBy = null;
+
+    entries.add(new Object[]{
+        groupBy, Lists.newArrayList()
+      });
+
+    groupBy = new GroupBy();
+    groupBy.setColumns(Lists.newArrayList("country"));
+    entries.add(new Object[]{
+      groupBy, Lists.newArrayList("country")
+    });
+
+    groupBy = new GroupBy();
+    groupBy.setColumns(Lists.newArrayList("country", "food"));
+    entries.add(new Object[]{
+      groupBy, Lists.newArrayList("country", "food")
+    });
+
+    groupBy = new GroupBy();
+    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')"));
+    entries.add(new Object[]{
+      groupBy, Lists.newArrayList("time")
+    });
+
+    groupBy = new GroupBy();
+    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')", "dateTimeConvert(date, 'HOURS', 'DAYS')"));
+    entries.add(new Object[]{
+      groupBy, Lists.newArrayList("date", "time")
+    });
+
+    groupBy = new GroupBy();
+    groupBy.setColumns(Lists.newArrayList("country"));
+    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')"));
+    entries.add(new Object[]{
+      groupBy, Lists.newArrayList("country", "time")
+    });
+
+    groupBy = new GroupBy();
+    groupBy.setColumns(Lists.newArrayList("country", "time"));
+    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')", "dateTimeConvert(date, 'HOURS', 'DAYS')"));
+    entries.add(new Object[]{
+      groupBy, Lists.newArrayList("country", "date", "time")
+    });
+
+    groupBy = new GroupBy();
+    entries.add(new Object[]{
+      groupBy, Lists.newArrayList()
+    });
+
+    return entries.toArray(new Object[entries.size()][]);
+  }
+}


### PR DESCRIPTION
Adding support in RequestUtils to parse expressions and check those columns in star tree segments case. Eventually we will move the logic for compiling expressions one level up, into ServerQueryRequest, and resuse them, instead of compiling multiple times in the lifespan of the query