### PR TITLE
[TE] Enable HttpUtils to pass Authentication tokens

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AbstractResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AbstractResourceHttpUtils.java
@@ -1,6 +1,5 @@
 package com.linkedin.thirdeye.anomaly.utils;
 
-import com.sun.xml.internal.ws.api.policy.PolicyResolver;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AbstractResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AbstractResourceHttpUtils.java
@@ -31,6 +31,13 @@ public abstract class AbstractResourceHttpUtils {
     cookieStore.addCookie(cookie);
   }
 
+  public void addAuthenticationCookie(String authToken) {
+    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
+    cookie.setDomain(resourceHttpHost.getHostName());
+    cookie.setPath("/");
+    addCookie(cookie);
+  }
+
   protected HttpHost getResourceHttpHost() {
     return resourceHttpHost;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AlertResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AlertResourceHttpUtils.java
@@ -19,10 +19,7 @@ public class AlertResourceHttpUtils extends AbstractResourceHttpUtils {
 
   public AlertResourceHttpUtils(String alertHost, int alertPort, String authToken) {
     super(new HttpHost(alertHost, alertPort));
-    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
-    cookie.setDomain(alertHost);
-    cookie.setPath("/");
-    super.addCookie(cookie);
+    addAuthenticationCookie(authToken);
   }
 
   public String enableEmailConfiguration(String id) throws ClientProtocolException, IOException {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AlertResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/AlertResourceHttpUtils.java
@@ -6,6 +6,8 @@ import org.apache.http.HttpHost;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.cookie.BasicClientCookie;
+
 
 /**
  * Utility classes for calling detector endpoints to execute/schedule jobs
@@ -15,8 +17,12 @@ public class AlertResourceHttpUtils extends AbstractResourceHttpUtils {
   private static String ALERT_JOB_ENDPOINT = "/api/alert-job/";
   private static String ADHOC = "/ad-hoc";
 
-  public AlertResourceHttpUtils(String alertHost, int alertPort) {
+  public AlertResourceHttpUtils(String alertHost, int alertPort, String authToken) {
     super(new HttpHost(alertHost, alertPort));
+    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
+    cookie.setDomain(alertHost);
+    cookie.setPath("/");
+    super.addCookie(cookie);
   }
 
   public String enableEmailConfiguration(String id) throws ClientProtocolException, IOException {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/DetectionResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/DetectionResourceHttpUtils.java
@@ -7,6 +7,8 @@ import org.apache.http.HttpHost;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.cookie.BasicClientCookie;
+
 
 /**
  * Utility classes for calling detector endpoints to execute/schedule jobs
@@ -23,8 +25,12 @@ public class DetectionResourceHttpUtils extends AbstractResourceHttpUtils {
   private static final String INIT_AUTOTUNE = "initautotune/filter/";
   private static final String REPLAY_FUNCTION = "replay/function/";
 
-  public DetectionResourceHttpUtils(String detectionHost, int detectionPort) {
+  public DetectionResourceHttpUtils(String detectionHost, int detectionPort, String authToken) {
     super(new HttpHost(detectionHost, detectionPort));
+    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
+    cookie.setDomain(detectionHost);
+    cookie.setPath("/");
+    super.addCookie(cookie);
   }
 
   public String enableAnomalyFunction(String id) throws ClientProtocolException, IOException {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/DetectionResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/DetectionResourceHttpUtils.java
@@ -27,10 +27,7 @@ public class DetectionResourceHttpUtils extends AbstractResourceHttpUtils {
 
   public DetectionResourceHttpUtils(String detectionHost, int detectionPort, String authToken) {
     super(new HttpHost(detectionHost, detectionPort));
-    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
-    cookie.setDomain(detectionHost);
-    cookie.setPath("/");
-    super.addCookie(cookie);
+    addAuthenticationCookie(authToken);
   }
 
   public String enableAnomalyFunction(String id) throws ClientProtocolException, IOException {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/OnboardResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/OnboardResourceHttpUtils.java
@@ -17,10 +17,7 @@ public class OnboardResourceHttpUtils extends AbstractResourceHttpUtils {
 
   public OnboardResourceHttpUtils(String onboardHost, int onboardPost, String authToken) {
     super(new HttpHost(onboardHost, onboardPost));
-    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
-    cookie.setDomain(onboardHost);
-    cookie.setPath("/");
-    super.addCookie(cookie);
+    addAuthenticationCookie(authToken);
   }
 
   public String getClonedFunctionID(long functionId, String tag, boolean isCloneAnomaly) throws IOException{

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/OnboardResourceHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/OnboardResourceHttpUtils.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.anomaly.utils;
 import java.io.IOException;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.cookie.BasicClientCookie;
 
 
 /**
@@ -14,8 +15,12 @@ public class OnboardResourceHttpUtils extends AbstractResourceHttpUtils {
   private static final String CLONE_KEY = "clone";
   private static final String DELETE_EXISTING_ANOMALIES = "deleteExistingAnomalies";
 
-  public OnboardResourceHttpUtils(String onboardHost, int onboardPost) {
+  public OnboardResourceHttpUtils(String onboardHost, int onboardPost, String authToken) {
     super(new HttpHost(onboardHost, onboardPost));
+    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
+    cookie.setDomain(onboardHost);
+    cookie.setPath("/");
+    super.addCookie(cookie);
   }
 
   public String getClonedFunctionID(long functionId, String tag, boolean isCloneAnomaly) throws IOException{

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/DetectorHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/DetectorHttpUtils.java
@@ -22,10 +22,7 @@ public class DetectorHttpUtils extends AbstractResourceHttpUtils {
 
   public DetectorHttpUtils(String detectorHost, int detectorPort, String authToken) {
     super(new HttpHost(detectorHost, detectorPort));
-    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
-    cookie.setDomain(detectorHost);
-    cookie.setPath("/");
-    super.addCookie(cookie);
+    addAuthenticationCookie(authToken);
   }
 
   public String enableAnomalyFunction(String id) throws ClientProtocolException, IOException {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/DetectorHttpUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/DetectorHttpUtils.java
@@ -8,6 +8,8 @@ import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
 
 import com.linkedin.thirdeye.anomaly.utils.AbstractResourceHttpUtils;
+import org.apache.http.impl.cookie.BasicClientCookie;
+
 
 /**
  * Utility classes for calling detector endpoints to execute/schedule jobs
@@ -18,8 +20,12 @@ public class DetectorHttpUtils extends AbstractResourceHttpUtils {
   private static String EMAIL_JOBS_ENDPOINT = "/api/email-jobs/";
   private static String ADHOC = "/ad-hoc";
 
-  public DetectorHttpUtils(String detectorHost, int detectorPort) {
+  public DetectorHttpUtils(String detectorHost, int detectorPort, String authToken) {
     super(new HttpHost(detectorHost, detectorPort));
+    BasicClientCookie cookie = new BasicClientCookie("te_auth", authToken);
+    cookie.setDomain(detectorHost);
+    cookie.setPath("/");
+    super.addCookie(cookie);
   }
 
   public String enableAnomalyFunction(String id) throws ClientProtocolException, IOException {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/AutoTuneAlertFilterTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/AutoTuneAlertFilterTool.java
@@ -36,18 +36,21 @@ public class AutoTuneAlertFilterTool {
 
   private static final int APPLICATION_PORT = 1867;
   private static final String LOCALHOST = "localhost";
+  private DetectionResourceHttpUtils httpUtils;
+
 
   public static String CSVSEPERATOR = ",";
   public static String CSVESCAPE = ";";
 
 
-  public AutoTuneAlertFilterTool(File persistenceFile){
+  public AutoTuneAlertFilterTool(File persistenceFile, String authToken){
     DaoProviderUtil.init(persistenceFile);
     anomalyFunctionDAO = DaoProviderUtil
         .getInstance(com.linkedin.thirdeye.datalayer.bao.jdbc.AnomalyFunctionManagerImpl.class);
     autotuneConfigDAO = DaoProviderUtil
         .getInstance(com.linkedin.thirdeye.datalayer.bao.jdbc.AutotuneConfigManagerImpl.class);
 
+    httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT, authToken);
   }
 
   public static class EvaluationNode{
@@ -66,7 +69,8 @@ public class AutoTuneAlertFilterTool {
       return headers;
     }
 
-    public EvaluationNode(Long Id, String metricName, String collection, String alertFilterStr, Properties alertFilterEvaluations){
+    public EvaluationNode(Long Id, String metricName, String collection, String alertFilterStr,
+        Properties alertFilterEvaluations){
 
       alertFilterEvaluations.put(ID, Id);
       alertFilterEvaluations.put(METRICNAME, metricName);
@@ -92,7 +96,6 @@ public class AutoTuneAlertFilterTool {
 
 
   public String getTunedAlertFilterByFunctionId(Long functionId, String startTimeISO, String endTimeISO, String AUTOTUNE_TYPE, String holidayStarts, String holidayEnds) throws Exception{
-    DetectionResourceHttpUtils httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT);
     try {
       return httpUtils.runAutoTune(functionId, startTimeISO, endTimeISO, AUTOTUNE_TYPE, holidayStarts, holidayEnds);
     } catch (Exception e) {
@@ -103,7 +106,6 @@ public class AutoTuneAlertFilterTool {
 
 
   public String evaluateAlertFilterByFunctionId(Long functionId, String startTimeISO, String endTimeISO, String holidayStarts, String holidayEnds){
-    DetectionResourceHttpUtils httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT);
     try{
       return httpUtils.getEvalStatsAlertFilter(functionId, startTimeISO, endTimeISO, holidayStarts, holidayEnds);
     } catch (Exception e) {
@@ -113,7 +115,6 @@ public class AutoTuneAlertFilterTool {
   }
 
   public String evaluateAlertFilterByAutoTuneId(Long autotuneId, String startTimeISO, String endTimeISO, String holidayStarts, String holidayEnds){
-    DetectionResourceHttpUtils httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT);
     try{
       return httpUtils.evalAutoTune(autotuneId, startTimeISO, endTimeISO, holidayStarts, holidayEnds);
     } catch (Exception e){
@@ -184,8 +185,8 @@ public class AutoTuneAlertFilterTool {
     return functionIds;
   }
 
-  public Boolean checkAnomaliesHasLabels(Long functionId, String startTimeISO, String endTimeISO, String holidayStarts, String holidayEnds){
-    DetectionResourceHttpUtils httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT);
+  public Boolean checkAnomaliesHasLabels(Long functionId, String startTimeISO, String endTimeISO, String holidayStarts, String holidayEnds, String authToken){
+    DetectionResourceHttpUtils httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT, authToken);
     try{
       return Boolean.valueOf(httpUtils.checkHasLabels(functionId, startTimeISO, endTimeISO, holidayStarts, holidayEnds));
     } catch (Exception e) {
@@ -194,8 +195,8 @@ public class AutoTuneAlertFilterTool {
     return null;
   }
 
-  public String getInitAutoTuneByFunctionId(Long functionId, String startTimeISO, String endTimeISO, String AUTOTUNE_TYPE, int nExpected,String holidayStarts, String holidayEnds) throws Exception{
-    DetectionResourceHttpUtils httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT);
+  public String getInitAutoTuneByFunctionId(Long functionId, String startTimeISO, String endTimeISO, String AUTOTUNE_TYPE, int nExpected,String holidayStarts, String holidayEnds, String authToken) throws Exception{
+    DetectionResourceHttpUtils httpUtils = new DetectionResourceHttpUtils(LOCALHOST, APPLICATION_PORT, authToken);
     try {
       return httpUtils.initAutoTune(functionId, startTimeISO, endTimeISO, AUTOTUNE_TYPE, nExpected, holidayStarts, holidayEnds);
     } catch (Exception e) {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesTool.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/CleanupAndRegenerateAnomaliesTool.java
@@ -48,13 +48,13 @@ public class CleanupAndRegenerateAnomaliesTool {
   private DetectionResourceHttpUtils detectionResourceHttpUtils;
 
   public CleanupAndRegenerateAnomaliesTool(String startTime, String endTime, String datasets, String functionIds,
-      File persistenceFile, String detectionHost, int detectionPort)
+      File persistenceFile, String detectionHost, int detectionPort, String token)
       throws Exception {
     init(persistenceFile);
     this.monitoringWindowStartTime = startTime;
     this.monitoringWindowEndTime = endTime;
     this.functionIds = getFunctionIds(datasets, functionIds);
-    detectionResourceHttpUtils = new DetectionResourceHttpUtils(detectionHost, detectionPort);
+    detectionResourceHttpUtils = new DetectionResourceHttpUtils(detectionHost, detectionPort, token);
   }
 
   public void init(File persistenceFile) throws Exception {
@@ -226,8 +226,10 @@ public class CleanupAndRegenerateAnomaliesTool {
       doForceBackfill = Boolean.parseBoolean(forceBackfill);
     }
 
+    String authToken = "";
+
     CleanupAndRegenerateAnomaliesTool tool = new CleanupAndRegenerateAnomaliesTool(startTimeIso,
-        endTimeIso, datasets, functionIds, persistenceFile, detectorHost, detectorPort);
+        endTimeIso, datasets, functionIds, persistenceFile, detectorHost, detectorPort, authToken);
 
     if (runMode.equals(Mode.DELETE)) {
       // DELETE mode deletes *ALL* anomalies for all functions in functionIds or datasets

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/FetchAutoTuneResult.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/tools/FetchAutoTuneResult.java
@@ -47,13 +47,14 @@ public class FetchAutoTuneResult {
     String DIR_TO_FILE = args[5];
     String holidayStarts = args[6];
     String holidayEnds = args[7];
-    AutoTuneAlertFilterTool executor = new AutoTuneAlertFilterTool(new File(path2PersistenceFile));
+    String authToken = "";
+    AutoTuneAlertFilterTool executor = new AutoTuneAlertFilterTool(new File(path2PersistenceFile), authToken);
     List<Long> functionIds = executor.getAllFunctionIdsByCollection(Collection);
 
     if(AUTOTUNE_MODE.equals(AUTOTUNE)){
       reTuneAndEvalToCSVByCollection(executor, functionIds, STARTTIME, ENDTIME, holidayStarts, holidayEnds, DIR_TO_FILE + Collection + CSVSUFFIX);
     } else if (AUTOTUNE_MODE.equals(INITTUNE)){
-      initFilterAndEvalToCSVByCollection(executor, functionIds, STARTTIME, ENDTIME, holidayStarts, holidayEnds, DIR_TO_FILE + Collection + CSVSUFFIX);
+      initFilterAndEvalToCSVByCollection(executor, functionIds, STARTTIME, ENDTIME, holidayStarts, holidayEnds, DIR_TO_FILE + Collection + CSVSUFFIX, authToken);
     } else {
       System.out.println("Error! no such autotune mode!");
     }
@@ -116,7 +117,7 @@ public class FetchAutoTuneResult {
    * @throws Exception
    */
   public static void initFilterAndEvalToCSVByCollection(AutoTuneAlertFilterTool executor, List<Long> functionIds,
-      String STARTTIME, String ENDTIME, String holidayStarts, String holidayEnds, String fileName) throws Exception {
+      String STARTTIME, String ENDTIME, String holidayStarts, String holidayEnds, String fileName, String authToken) throws Exception {
     Map<String, String> outputMap = new HashMap<>();
     for (Long functionId : functionIds) {
       StringBuilder outputVal = new StringBuilder();
@@ -126,7 +127,7 @@ public class FetchAutoTuneResult {
 
       long autotuneId = Long.valueOf(
           executor.getInitAutoTuneByFunctionId(functionId, STARTTIME, ENDTIME, AUTOTUNE, DEFAULT_NEXPECTEDANOMALIES,
-              holidayStarts, holidayEnds));
+              holidayStarts, holidayEnds, authToken));
 
       boolean isUpdated = autotuneId != -1;
       String tunedEvals = "";


### PR DESCRIPTION
With the enable of authentication on ThirdEye, httpUtils are blocked because of fail to authenticate. This pull request is to allow http utils to include authentication tokens in the http request cookies, and pass the authentication check on ThirdEye.