### PR TITLE
Improve the time column error message

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -510,14 +510,12 @@ public class PinotSegmentUploadRestletResource {
     long endMillis = interval.getEndMillis();
 
     if (!TimeUtils.timeValueInValidRange(startMillis) || !TimeUtils.timeValueInValidRange(endMillis)) {
-      Date startDate = new Date(interval.getStartMillis());
-      Date endDate = new Date(interval.getEndMillis());
-
       Date minDate = new Date(TimeUtils.getValidMinTimeMillis());
       Date maxDate = new Date(TimeUtils.getValidMaxTimeMillis());
 
-      LOGGER.error("Invalid start time '{}' or end time '{}' for segment, must be between '{}' and '{}'", startDate,
-          endDate, minDate, maxDate);
+      LOGGER.error("Invalid start time '{}ms' or end time '{}ms' for segment {}, must be between '{}' and '{}' (timecolumn {}, timeunit {})",
+          interval.getStartMillis(), interval.getEndMillis(), metadata.getName(), minDate, maxDate, metadata.getTimeColumn(),
+          metadata.getTimeUnit().toString());
       return false;
     }
 


### PR DESCRIPTION
Push errors seem to happen when a time column or time units are incorrectly configured.
Adding segment name, time column name and unit, and the actual value found, to the
error message