### PR TITLE
[TE] Remove empty entries from query response

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -168,7 +168,10 @@ public class AnomaliesResource {
       MetricTimeSeries currentTimeSeries = anomalyDetectionInputContextBuilder.build()
           .getDimensionMapMetricTimeSeriesMap().get(dimensions);
       String metricName = anomalyFunction.getMetric();
-      double currentVal = getAverageFromTimeSeries(currentTimeSeries, metricName);
+      double currentVal = 0d;
+      if (currentTimeSeries != null) {
+        currentVal = getAverageFromTimeSeries(currentTimeSeries, metricName);
+      }
       response.setCurrentVal(currentVal);
 
       for (AlertConfigBean.COMPARE_MODE compareMode : AlertConfigBean.COMPARE_MODE.values()) {
@@ -182,7 +185,10 @@ public class AnomaliesResource {
         MetricTimeSeries baselineTimeSeries = anomalyDetectionInputContextBuilder.build()
             .getDimensionMapMetricTimeSeriesMap().get(dimensions);
         AnomalyDataCompare.CompareResult compareResult = new AnomalyDataCompare.CompareResult();
-        double baseLineval = getAverageFromTimeSeries(baselineTimeSeries, metricName);
+        double baseLineval = 0d;
+        if (baselineTimeSeries != null) {
+          baseLineval = getAverageFromTimeSeries(baselineTimeSeries, metricName);
+        }
         compareResult.setBaselineValue(baseLineval);
         compareResult.setCompareMode(compareMode);
         compareResult.setChange(calculateChange(currentVal, baseLineval));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/timeseries/BaseTimeSeriesResponseParser.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/timeseries/BaseTimeSeriesResponseParser.java
@@ -50,13 +50,15 @@ public abstract class BaseTimeSeriesResponseParser implements TimeSeriesResponse
       Range<DateTime> timeRange = ranges.get(timeBucketId);
       ThirdEyeResponseRow responseRow = responseMap.get(String.valueOf(timeBucketId));
 
-      TimeSeriesRow.Builder builder = new TimeSeriesRow.Builder();
-      builder.setStart(timeRange.lowerEndpoint());
-      builder.setEnd(timeRange.upperEndpoint());
+      if (responseRow != null) {
+        TimeSeriesRow.Builder builder = new TimeSeriesRow.Builder();
+        builder.setStart(timeRange.lowerEndpoint());
+        builder.setEnd(timeRange.upperEndpoint());
 
-      addMetric(metricFunctions, responseRow, builder);
-      TimeSeriesRow row = builder.build();
-      rows.add(row);
+        addMetric(metricFunctions, responseRow, builder);
+        TimeSeriesRow row = builder.build();
+        rows.add(row);
+      }
     }
 
     return rows;
@@ -80,15 +82,17 @@ public abstract class BaseTimeSeriesResponseParser implements TimeSeriesResponse
 
       ThirdEyeResponseRow responseRow = responseMap.get(timeDimensionValue);
 
-      TimeSeriesRow.Builder builder = new TimeSeriesRow.Builder();
-      builder.setStart(timeRange.lowerEndpoint());
-      builder.setEnd(timeRange.upperEndpoint());
-      builder.setDimensionNames(dimensionNames);
-      builder.setDimensionValues(dimensionValues);
-      addMetric(metricFunctions, responseRow, builder);
+      if (responseRow != null) {
+        TimeSeriesRow.Builder builder = new TimeSeriesRow.Builder();
+        builder.setStart(timeRange.lowerEndpoint());
+        builder.setEnd(timeRange.upperEndpoint());
+        builder.setDimensionNames(dimensionNames);
+        builder.setDimensionValues(dimensionValues);
+        addMetric(metricFunctions, responseRow, builder);
 
-      TimeSeriesRow row = builder.build();
-      thresholdRows.add(row);
+        TimeSeriesRow row = builder.build();
+        thresholdRows.add(row);
+      }
     }
 
     return thresholdRows;


### PR DESCRIPTION
When querying a time series, ThirdEye fills in empty rows to the query response for the time range of the time series. Consequently, it fills in value zero to missing data points, which is an unwanted behavior.

This PR removes the code where the empty rows are filled in.