### PR TITLE
Make consumer directory configurable

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -203,6 +203,7 @@ public class CommonConstants {
 
   public static class Server {
     public static final String CONFIG_OF_INSTANCE_DATA_DIR = "pinot.server.instance.dataDir";
+    public static final String CONFIG_OF_CONSUMER_DIR = "pinot.server.instance.consumerDir";
     public static final String CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR = "pinot.server.instance.segmentTarDir";
     public static final String CONFIG_OF_INSTANCE_READ_MODE = "pinot.server.instance.readMode";
     public static final String CONFIG_OF_INSTANCE_DATA_MANAGER_CLASS = "pinot.server.instance.data.manager.class";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -26,6 +26,8 @@ public interface InstanceDataManagerConfig {
 
   String getInstanceDataDir();
 
+  String getConsumerDir();
+
   String getInstanceSegmentTarDir();
 
   String getInstanceBootstrapSegmentDir();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
@@ -30,6 +30,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 public class TableDataManagerConfig {
   private static final String TABLE_DATA_MANAGER_TYPE = "dataManagerType";
   private static final String TABLE_DATA_MANAGER_DATA_DIRECTORY = "directory";
+  private static final String TABLE_DATA_MANAGER_CONSUMER_DIRECTORY = "consumerDirectory";
   private static final String TABLE_DATA_MANAGER_NAME = "name";
 
   private final Configuration _tableDataManagerConfig;
@@ -51,6 +52,10 @@ public class TableDataManagerConfig {
     return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_DATA_DIRECTORY);
   }
 
+  public String getConsumerDir() {
+    return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_CONSUMER_DIRECTORY);
+  }
+
   public String getTableName() {
     return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_NAME);
   }
@@ -65,6 +70,7 @@ public class TableDataManagerConfig {
     defaultConfig.addProperty(TABLE_DATA_MANAGER_NAME, tableName);
     String dataDir = instanceDataManagerConfig.getInstanceDataDir() + "/" + tableName;
     defaultConfig.addProperty(TABLE_DATA_MANAGER_DATA_DIRECTORY, dataDir);
+    defaultConfig.addProperty(TABLE_DATA_MANAGER_CONSUMER_DIRECTORY, instanceDataManagerConfig.getConsumerDir());
     switch (tableType) {
       case OFFLINE:
         defaultConfig.addProperty(TABLE_DATA_MANAGER_TYPE, "offline");

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -17,11 +17,14 @@ package com.linkedin.pinot.integration.tests;
 
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import java.io.File;
 import java.util.List;
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.io.FileUtils;
 import org.apache.helix.ZNRecord;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
@@ -29,6 +32,19 @@ import org.testng.annotations.Test;
  * Integration test that extends RealtimeClusterIntegrationTest but uses low-level Kafka consumer.
  */
 public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegrationTest {
+  public static final String CONSUMER_DIRECTORY = "/tmp/consumer-test";
+
+  @BeforeClass
+  @Override
+  public void setUp() throws Exception {
+    // Remove the consumer directory
+    File consumerDirectory = new File(CONSUMER_DIRECTORY);
+    if (consumerDirectory.exists()) {
+      FileUtils.deleteDirectory(consumerDirectory);
+    }
+
+    super.setUp();
+  }
 
   @Override
   protected boolean useLlc() {
@@ -43,8 +59,14 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
 
   @Override
   protected void overrideOfflineServerConf(Configuration configuration) {
-    configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION,
-        "true");
+    configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION, "true");
+    configuration.setProperty(CommonConstants.Server.CONFIG_OF_CONSUMER_DIR, CONSUMER_DIRECTORY);
+  }
+
+  @Test
+  public void testConsumerDirectoryExists() {
+    File consumerDirectory = new File(CONSUMER_DIRECTORY, "mytable_REALTIME");
+    Assert.assertTrue(consumerDirectory.exists(), "The off heap consumer directory does not exist");
   }
 
   @Test

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -39,6 +39,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public static final String INSTANCE_ID = "id";
   // Key of instance data directory
   public static final String INSTANCE_DATA_DIR = "dataDir";
+  // Key of consumer directory
+  public static final String CONSUMER_DIR = "consumerDir";
   // Key of instance segment tar directory
   public static final String INSTANCE_SEGMENT_TAR_DIR = "segmentTarDir";
   // Key of segment directory
@@ -110,6 +112,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public String getInstanceDataDir() {
     return _instanceDataManagerConfiguration.getString(INSTANCE_DATA_DIR);
+  }
+
+  @Override
+  public String getConsumerDir() {
+    return _instanceDataManagerConfiguration.getString(CONSUMER_DIR);
   }
 
   @Override


### PR DESCRIPTION
Make the realtime off heap dictionary storage directory configurable, so
that it can be placed onto a different filesystem than the segment data.