### PR TITLE
Catch LinkageError when initializing fetcher

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactory.java
@@ -111,8 +111,10 @@ public class SegmentFetcherFactory {
         SEGMENT_FETCHER_MAP.put(protocol, fetcher);
       }
       fetcher.init(configs);
-    } catch (Exception e) {
+    } catch (Exception | LinkageError e) {
       LOGGER.error("Failed to init SegmentFetcher: " + protocol, e);
+      // If initialization fails, remove the protocol from the fetcher map.
+      SEGMENT_FETCHER_MAP.remove(protocol);
     }
   }
 


### PR DESCRIPTION
Adding a check to catch LinkageError when initializing fetcher to
avoid linkage issues due to Hadoop JARs.