### PR TITLE
Fix memory leak issue on broker side

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -658,6 +658,8 @@ public class BrokerRequestHandler {
             serverInstance, e);
         _brokerMetrics.addMeteredTableValue(tableNameWithType, BrokerMeter.DATA_TABLE_DESERIALIZATION_EXCEPTIONS, 1L);
         processingExceptions.add(QueryException.getException(QueryException.DATA_TABLE_DESERIALIZATION_ERROR, e));
+      } finally {
+        byteBuf.release();
       }
     }
   }


### PR DESCRIPTION
After bumping up the jetty version, we have observed memory leak
error on broker side because ByteBufs were not properly released.
Tested by running load testing locally.