### PR TITLE
[TE] Build index for raw and merged anomaly table

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFeedbackDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AnomalyFeedbackDTO.java
@@ -4,6 +4,7 @@ import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
 import java.io.Serializable;
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFeedbackBean;
+import org.apache.commons.lang3.StringUtils;
 
 public class AnomalyFeedbackDTO extends AnomalyFeedbackBean implements AnomalyFeedback, Serializable {
   private static final long serialVersionUID = 1L;
@@ -19,7 +20,7 @@ public class AnomalyFeedbackDTO extends AnomalyFeedbackBean implements AnomalyFe
       if (anomalyFeedback.getFeedbackType() != null) {
         this.setFeedbackType(anomalyFeedback.getFeedbackType());
       }
-      if (anomalyFeedback.getFeedbackType() != null) {
+      if (StringUtils.isNotBlank(anomalyFeedback.getComment())) {
         this.setComment(anomalyFeedback.getComment());
       }
     }

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -103,6 +103,7 @@ create index raw_anomaly_result_job_idx on raw_anomaly_result_index(job_id);
 create index raw_anomaly_result_merged_idx on raw_anomaly_result_index(merged);
 create index raw_anomaly_result_data_missing_idx on raw_anomaly_result_index(data_missing);
 create index raw_anomaly_result_start_time_idx on raw_anomaly_result_index(start_time);
+create index raw_anomaly_result_base_id_idx on raw_anomaly_result_index(base_id);
 
 create table if not exists merged_anomaly_result_index (
     function_id bigint(20),
@@ -123,6 +124,7 @@ create index merged_anomaly_result_function_idx on merged_anomaly_result_index(f
 create index merged_anomaly_result_feedback_idx on merged_anomaly_result_index(anomaly_feedback_id);
 create index merged_anomaly_result_metric_idx on merged_anomaly_result_index(metric_id);
 create index merged_anomaly_result_start_time_idx on merged_anomaly_result_index(start_time);
+create index merged_anomaly_result_base_id_idx on merged_anomaly_result_index(base_id);
 
 create table if not exists dataset_config_index (
     dataset varchar(200) not null,


### PR DESCRIPTION
Problem:
Timeout when deleting any raw anomaly by its id. The reason is that there are too many raw and merged anomaly results in the database and their ids are not indexed.

Solution:
Build index for raw and merged anomalies' 'base_id'.

Tested on a cloned local database to make sure the problem has gone away.