### PR TITLE
Add partition width metric

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -33,7 +33,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   LAST_REALTIME_SEGMENT_COMPLETION_DURATION_SECONDS("seconds", false),
   KAFKA_PARTITION_OFFSET_LAG("messages", false),
   REALTIME_OFFHEAP_MEMORY_USED("bytes", false),
-  RUNNING_QUERIES("runningQueries", false);
+  RUNNING_QUERIES("runningQueries", false),
+  REALTIME_SEGMENT_PARTITION_WIDTH("realtimeSegmentPartitionWidth", false);
 
   private final String gaugeName;
   private final String unit;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -271,7 +271,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
           segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();
-          converter.build(_segmentVersion);
+          converter.build(_segmentVersion, serverMetrics);
           final long buildEndTime = System.nanoTime();
           segmentLogger.info("Built segment in {} ms",
               TimeUnit.MILLISECONDS.convert((buildEndTime - buildStartTime), TimeUnit.NANOSECONDS));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -590,7 +590,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     segmentLogger.info("Trying to build segment");
     final long buildStartTime = now();
     try {
-      converter.build(_segmentVersion);
+      converter.build(_segmentVersion, _serverMetrics);
     } catch (Exception e) {
       segmentLogger.error("Could not build segment", e);
       FileUtils.deleteQuietly(tempSegmentFolder);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -15,10 +15,14 @@
  */
 package com.linkedin.pinot.core.realtime.converter;
 
+import com.linkedin.pinot.common.config.ColumnPartitionConfig;
+import com.linkedin.pinot.common.config.SegmentPartitionConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.data.TimeFieldSpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
+import com.linkedin.pinot.common.metrics.ServerGauge;
+import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.realtime.converter.stats.RealtimeSegmentSegmentCreationDataSource;
@@ -27,6 +31,7 @@ import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverIm
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 
@@ -83,7 +88,7 @@ public class RealtimeSegmentConverter {
         new ArrayList<String>(), null/*StarTreeIndexSpec*/);
   }
 
-  public void build(@Nullable SegmentVersion segmentVersion) throws Exception {
+  public void build(@Nullable SegmentVersion segmentVersion, ServerMetrics serverMetrics) throws Exception {
     // lets create a record reader
     RealtimeSegmentRecordReader reader;
     if (sortedColumn == null) {
@@ -115,9 +120,20 @@ public class RealtimeSegmentConverter {
     genConfig.setTableName(tableName);
     genConfig.setOutDir(outputPath);
     genConfig.setSegmentName(segmentName);
-    genConfig.setSegmentPartitionConfig(realtimeSegmentImpl.getSegmentPartitionConfig());
+    SegmentPartitionConfig segmentPartitionConfig = realtimeSegmentImpl.getSegmentPartitionConfig();
+    genConfig.setSegmentPartitionConfig(segmentPartitionConfig);
     final SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(genConfig, new RealtimeSegmentSegmentCreationDataSource(realtimeSegmentImpl, reader, dataSchema));
+    RealtimeSegmentSegmentCreationDataSource dataSource =
+        new RealtimeSegmentSegmentCreationDataSource(realtimeSegmentImpl, reader, dataSchema);
+    driver.init(genConfig, dataSource);
     driver.build();
+
+    if (segmentPartitionConfig != null && segmentPartitionConfig.getColumnPartitionMap() != null) {
+      Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
+      for (String columnName : columnPartitionMap.keySet()) {
+        int partitionRangeWidth = driver.getSegmentStats().getColumnProfileFor(columnName).getPartitionRangeWidth();
+        serverMetrics.addValueToTableGauge(tableName, ServerGauge.REALTIME_SEGMENT_PARTITION_WIDTH, partitionRangeWidth);
+      }
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeColumnStatistics.java
@@ -202,4 +202,9 @@ public class RealtimeColumnStatistics implements ColumnStatistics {
       }
     }
   }
+
+  @Override
+  public int getPartitionRangeWidth() {
+    return partitionRangeEnd - partitionRangeStart + 1;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeNoDictionaryColStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeNoDictionaryColStatistics.java
@@ -206,4 +206,9 @@ public class RealtimeNoDictionaryColStatistics implements ColumnStatistics {
   public List<IntRange> getPartitionRanges() {
     return null;
   }
+
+  @Override
+  public int getPartitionRangeWidth() {
+    return 0;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/ColumnStatistics.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/ColumnStatistics.java
@@ -78,4 +78,9 @@ public interface ColumnStatistics {
     int getNumPartitions();
 
     List<IntRange> getPartitionRanges();
+
+    /**
+     * Returns the width of the partition range for this column, used when doing per-column partitioning.
+     */
+    int getPartitionRangeWidth();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -630,4 +630,8 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
           "Unexpected data type encountered while updating StarTree node" + inputArray.getClass().getName());
     }
   }
+
+  public SegmentPreIndexStatsContainer getSegmentStats() {
+    return segmentStats;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -190,4 +190,9 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
       }
     }
   }
+
+  @Override
+  public int getPartitionRangeWidth() {
+    return partitionRangeEnd - partitionRangeStart + 1;
+  }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeFileBasedReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/RealtimeFileBasedReaderTest.java
@@ -99,7 +99,7 @@ public class RealtimeFileBasedReaderTest {
 
     RealtimeSegmentConverter conveter =
         new RealtimeSegmentConverter(realtimeSegment, "/tmp/realtime", schema, tableName, segmentName, null);
-    conveter.build(segmentVersion);
+    conveter.build(segmentVersion, new ServerMetrics(new MetricsRegistry()));
 
     offlineSegment = Loaders.IndexSegment.load(new File("/tmp/realtime").listFiles()[0], ReadMode.mmap);
   }


### PR DESCRIPTION
Add a metric that tracks the width of the per-segment partition width
(the number of partitions assigned to a segment when doing data
partitioning), as to allow alerting when upstream partitioning function
does not match with the expected partitioning.