### PR TITLE
Update partition information of SegmentZKMetadata during commit

### DIFF
--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -852,6 +852,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
       verify(segmentMetadata, times(2)).getTimeInterval();
       verify(segmentMetadata, times(1)).getVersion();
       verify(segmentMetadata, times(1)).getTotalRawDocs();
+      verify(segmentMetadata, times(1)).getColumnMetadataMap();
       verifyNoMoreInteractions(segmentMetadata);
     }
 


### PR DESCRIPTION
When creating a SegmentZKMetadata, current implementation derives
the partition information from table config and segment name information.
This works with consuming segments; however, the partition information has
to be updated with the most recent version, which is stored in segment
metadata file.