### PR TITLE
[TE] Distinguish different anomaly result source

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/classification/ClassificationTaskRunner.java
@@ -393,10 +393,9 @@ public class ClassificationTaskRunner implements TaskRunner {
 
         ListMultimap<DimensionMap, RawAnomalyResultDTO> resultRawAnomalies = ArrayListMultimap.create();
         resultRawAnomalies.putAll(dimensions, adhocRawAnomalies);
-        final boolean isBackfill = false;
         TimeBasedAnomalyMerger timeBasedAnomalyMerger = new TimeBasedAnomalyMerger(anomalyFunctionFactory);
         ListMultimap<DimensionMap, MergedAnomalyResultDTO> resultMergedAnomalies =
-            timeBasedAnomalyMerger.mergeAnomalies(anomalyFunctionSpec, resultRawAnomalies, isBackfill);
+            timeBasedAnomalyMerger.mergeAnomalies(anomalyFunctionSpec, resultRawAnomalies);
         // The list of mergedAnomalies might contain the anomalies that are located inside the original monitoring
         // window, because the window might be extended to satisfy the min detection window.
         List<MergedAnomalyResultDTO> mergedAnomalies = resultMergedAnomalies.get(dimensions);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -123,20 +123,18 @@ public class DetectionTaskRunner implements TaskRunner {
     ListMultimap<DimensionMap, RawAnomalyResultDTO> resultRawAnomalies = dimensionalShuffleAndUnifyAnalyze(windowStart, windowEnd, adContext);
     detectionTaskSuccessCounter.inc();
 
-    boolean isBackfill = false;
     // If the current job is a backfill (adhoc) detection job, set notified flag to true so the merged anomalies do not
     // induce alerts and emails.
     if (detectionJobType != null && (detectionJobType.equals(DetectionJobType.BACKFILL) ||
         detectionJobType.equals(DetectionJobType.OFFLINE))) {
       LOG.info("BACKFILL is triggered for Detection Job {}. Notified flag is set to be true", jobExecutionId);
-      isBackfill = true;
       anomalyResultSource = AnomalyResultSource.ANOMALY_REPLAY;
     }
 
     // Update merged anomalies
     TimeBasedAnomalyMerger timeBasedAnomalyMerger = new TimeBasedAnomalyMerger(anomalyFunctionFactory);
     ListMultimap<DimensionMap, MergedAnomalyResultDTO> resultMergedAnomalies =
-      timeBasedAnomalyMerger.mergeAnomalies(anomalyFunctionSpec, resultRawAnomalies, isBackfill);
+      timeBasedAnomalyMerger.mergeAnomalies(anomalyFunctionSpec, resultRawAnomalies);
 
     // Set anomaly source on raw anomaly results
     for (RawAnomalyResultDTO rawAnomaly : resultRawAnomalies.values()) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -138,6 +138,12 @@ public class DetectionTaskRunner implements TaskRunner {
     ListMultimap<DimensionMap, MergedAnomalyResultDTO> resultMergedAnomalies =
       timeBasedAnomalyMerger.mergeAnomalies(anomalyFunctionSpec, resultRawAnomalies, isBackfill);
 
+    // Set anomaly source on raw anomaly results
+    for (RawAnomalyResultDTO rawAnomaly : resultRawAnomalies.values()) {
+      rawAnomaly.setAnomalyResultSource(anomalyResultSource);
+    }
+
+    // Set anomaly source on merged anomaly results
     for (MergedAnomalyResultDTO mergedAnomaly : resultMergedAnomalies.values()) {
       mergedAnomaly.setAnomalyResultSource(anomalyResultSource);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -6,6 +6,7 @@ import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionInputContext;
 import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionInputContextBuilder;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricTimeSeries;
+import com.linkedin.thirdeye.constant.AnomalyResultSource;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
@@ -72,12 +73,11 @@ public class TimeBasedAnomalyMerger {
    * Step 5: persist merged anomalies
    *
    * @param functionSpec the spec of the function that detects anomalies
-   * @param isBackfill set to true to disable the alert of the merged anomalies
    *
    * @return the number of merged anomalies after merging
    */
   public ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergeAnomalies(AnomalyFunctionDTO functionSpec,
-      ListMultimap<DimensionMap, RawAnomalyResultDTO> unmergedAnomalies, boolean isBackfill) {
+      ListMultimap<DimensionMap, RawAnomalyResultDTO> unmergedAnomalies) {
 
     int rawAnomaliesCount = 0;
     for (DimensionMap dimensionMap : unmergedAnomalies.keySet()) {
@@ -109,9 +109,6 @@ public class TimeBasedAnomalyMerger {
 
       // Update information of merged anomalies
       for (MergedAnomalyResultDTO mergedAnomalyResultDTO : mergedAnomalies.values()) {
-        if (isBackfill) {
-          mergedAnomalyResultDTO.setNotified(isBackfill);
-        } // else notified flag is left as is
         updateMergedAnomalyInfo(mergedAnomalyResultDTO, mergeConfig);
       }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyResultSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyResultSource.java
@@ -1,0 +1,6 @@
+package com.linkedin.thirdeye.constant;
+
+public enum AnomalyResultSource {
+  DEFAULT_ANOMALY_DETECTION,
+  ANOMALY_REPLAY
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyResultSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/constant/AnomalyResultSource.java
@@ -2,5 +2,6 @@ package com.linkedin.thirdeye.constant;
 
 public enum AnomalyResultSource {
   DEFAULT_ANOMALY_DETECTION,
-  ANOMALY_REPLAY
+  ANOMALY_REPLAY,
+  USER_LABELED_ANOMALY
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -23,7 +23,7 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
   private double score; // confidence level
   private double weight; // change percentage, whose absolute value is severity
   private double impactToGlobal; // the impact of this anomaly to the global metric
-  private AnomalyResultSource anomalyResultSource;
+  private AnomalyResultSource anomalyResultSource = AnomalyResultSource.DEFAULT_ANOMALY_DETECTION;
   // Additional anomaly detection properties (e.g., patter=UP, etc.)
   // Being used as identifying if two merged anomalies have same anomaly detection properties, thus can be mergeable
   private Map<String, String> properties = new HashMap<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MergedAnomalyResultBean.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.constant.AnomalyResultSource;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
   private double score; // confidence level
   private double weight; // change percentage, whose absolute value is severity
   private double impactToGlobal; // the impact of this anomaly to the global metric
+  private AnomalyResultSource anomalyResultSource;
   // Additional anomaly detection properties (e.g., patter=UP, etc.)
   // Being used as identifying if two merged anomalies have same anomaly detection properties, thus can be mergeable
   private Map<String, String> properties = new HashMap<>();
@@ -170,9 +172,17 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
     this.impactToGlobal = impactToGlobal;
   }
 
+  public AnomalyResultSource getAnomalyResultSource() {
+    return anomalyResultSource;
+  }
+
+  public void setAnomalyResultSource(AnomalyResultSource anomalyResultSource) {
+    this.anomalyResultSource = anomalyResultSource;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(getId(), startTime, endTime, collection, metric, dimensions, score, impactToGlobal, avgBaselineVal, avgCurrentVal);
+    return Objects.hash(getId(), startTime, endTime, collection, metric, dimensions, score, impactToGlobal, avgBaselineVal, avgCurrentVal, anomalyResultSource);
   }
 
   @Override
@@ -185,7 +195,8 @@ public class MergedAnomalyResultBean extends AbstractBean implements Comparable<
         .equals(endTime, m.getEndTime()) && Objects.equals(collection, m.getCollection()) && Objects
         .equals(metric, m.getMetric()) && Objects.equals(dimensions, m.getDimensions()) && Objects
         .equals(score, m.getScore()) && Objects.equals(avgBaselineVal, m.getAvgBaselineVal()) && Objects
-        .equals(avgCurrentVal, m.getAvgCurrentVal()) && Objects.equals(impactToGlobal, m.getImpactToGlobal());
+        .equals(avgCurrentVal, m.getAvgCurrentVal()) && Objects.equals(impactToGlobal, m.getImpactToGlobal()) &&
+        Objects.equals(anomalyResultSource, m.getAnomalyResultSource());
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RawAnomalyResultBean.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.linkedin.thirdeye.api.DimensionMap;
+import com.linkedin.thirdeye.constant.AnomalyResultSource;
 import java.util.Objects;
 import org.apache.commons.lang.ObjectUtils;
 import org.joda.time.DateTime;
@@ -14,6 +15,7 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
   private Long endTime;
   private DimensionMap dimensions;
   private Long jobId;
+  private AnomalyResultSource anomalyResultSource = AnomalyResultSource.DEFAULT_ANOMALY_DETECTION;
 
   // significance level
   private double score;
@@ -153,6 +155,14 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
     AnomalyFeedbackId = anomalyFeedbackId;
   }
 
+  public AnomalyResultSource getAnomalyResultSource() {
+    return anomalyResultSource;
+  }
+
+  public void setAnomalyResultSource(AnomalyResultSource anomalyResultSource) {
+    this.anomalyResultSource = anomalyResultSource;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof RawAnomalyResultBean)) {
@@ -163,7 +173,8 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
         && Objects.equals(dimensions, r.getDimensions()) && Objects.equals(endTime, r.getEndTime())
         && Objects.equals(score, r.getScore()) && Objects.equals(weight, r.getWeight())
         && Objects.equals(properties, r.getProperties()) && Objects.equals(message, r.getMessage())
-        && Objects.equals(avgBaselineVal, r.getAvgBaselineVal()) && Objects.equals(avgCurrentVal, r.getAvgCurrentVal());
+        && Objects.equals(avgBaselineVal, r.getAvgBaselineVal()) && Objects.equals(avgCurrentVal, r.getAvgCurrentVal())
+        && Objects.equals(anomalyResultSource, r.anomalyResultSource);
     // Intentionally omit creationTimeUtc, since start/end are the truly significant dates for
     // anomalies
   }
@@ -171,7 +182,7 @@ public class RawAnomalyResultBean extends AbstractBean implements Comparable<Raw
   @Override
   public int hashCode() {
     return Objects.hash(dimensions, startTime, endTime, score, weight, properties,
-        message, avgBaselineVal, avgCurrentVal);
+        message, avgBaselineVal, avgCurrentVal, anomalyResultSource);
     // Intentionally omit creationTimeUtc, since start/end are the truly significant dates for
     // anomalies
   }


### PR DESCRIPTION
We are working on re-design the alert pipeline, removing the notified flag from anomaly results. One problem is that we need to distinguish anomalies from scheduled detection from others. Users are not expect to receive any backfill anomalies in their alerts. To achieve that, a label should be applied to distinguish the difference.

- Add AnomalyResultSource to distinguish the default anomaly detection from others

- Update the anomaly result source in detection task runner