### PR TITLE
Fix for a segment having no statistics

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.core.io.readerwriter;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.metrics.ServerGauge;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
@@ -78,6 +79,7 @@ public abstract class RealtimeIndexOffHeapMemoryManager implements Closeable {
    * @return PinotDataBuffer
    */
   public PinotDataBuffer allocate(long size, String columnName) {
+    Preconditions.checkArgument(size > 0, "Illegal memory allocation " + size + " for segment " + _segmentName);
     PinotDataBuffer buffer = allocateInternal(size, columnName);
     _totalMemBytes += size;
     _buffers.add(buffer);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -237,18 +237,21 @@ public class RealtimeSegmentStatsHistory implements Serializable {
     if (numEntriesToScan == 0) {
       return DEFAULT_EST_CARDINALITY;
     }
-    int estCardinality = 0;
+    int totalCardinality = 0;
     int numValidValues = 0;
     for (int i = 0; i < numEntriesToScan; i++) {
       SegmentStats segmentStats = getSegmentStatsAt(i);
       ColumnStats columnStats = segmentStats.getColumnStats(columnName);
       if (columnStats != null) {
-        estCardinality += columnStats.getCardinality();
+        totalCardinality += columnStats.getCardinality();
         numValidValues++;
       }
     }
     if (numValidValues > 0) {
-      return estCardinality / numValidValues;
+      int avgEstimatedCardinality = totalCardinality /numValidValues;
+      if (avgEstimatedCardinality > 0) {
+        return avgEstimatedCardinality;
+      }
     }
     return DEFAULT_EST_CARDINALITY;
   }
@@ -263,21 +266,23 @@ public class RealtimeSegmentStatsHistory implements Serializable {
   public synchronized int getEstimatedAvgColSize(@Nonnull String columnName) {
     int numEntriesToScan = getNumntriesToScan();
     if (numEntriesToScan == 0) {
-
       return DEFAULT_EST_AVG_COL_SIZE;
     }
-    int estAvgColSize = 0;
+    int totalColSize = 0;
     int numValidValues = 0;
     for (int i = 0; i < numEntriesToScan; i++) {
       SegmentStats segmentStats = getSegmentStatsAt(i);
       ColumnStats columnStats = segmentStats.getColumnStats(columnName);
       if (columnStats != null) {
-        estAvgColSize += columnStats.getAvgColumnSize();
+        totalColSize += columnStats.getAvgColumnSize();
         numValidValues++;
       }
     }
     if (numValidValues > 0) {
-      return estAvgColSize / numValidValues;
+      int avgColSize = totalColSize / numValidValues;
+      if (avgColSize > 0) {
+        return avgColSize;
+      }
     }
     return DEFAULT_EST_AVG_COL_SIZE;
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -44,6 +44,37 @@ public class RealtimeSegmentStatsHistoryTest {
   }
 
   @Test
+  public void zeroStatTest() throws Exception {
+    final String tmpDir = System.getProperty("java.io.tmpdir");
+    File serializedFile = new File(tmpDir, STATS_FILE_NAME);
+    serializedFile.deleteOnExit();
+    FileUtils.deleteQuietly(serializedFile);
+    String columName = "col1";
+
+    {
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
+      segmentStats.setMemUsedBytes(100);
+      segmentStats.setNumSeconds(101);
+      segmentStats.setNumRowsConsumed(102);
+
+      RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
+      columnStats.setAvgColumnSize(0);
+      columnStats.setCardinality(0);
+      segmentStats.setColumnStats(columName, columnStats);
+
+      history.addSegmentStats(segmentStats);
+
+      history.save();
+    }
+    {
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      Assert.assertTrue(history.getEstimatedAvgColSize(columName) > 0);
+      Assert.assertTrue(history.getEstimatedCardinality(columName) > 0);
+    }
+  }
+
+  @Test
   public void serdeTest() throws Exception {
     final String tmpDir = System.getProperty("java.io.tmpdir");
     File serializedFile = new File(tmpDir, STATS_FILE_NAME);
@@ -164,7 +195,6 @@ public class RealtimeSegmentStatsHistoryTest {
       RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
       Assert.assertEquals(history.isFull(), savedIsFull);
       Assert.assertEquals(history.getCursor(), savedCursor);
-
     }
   }
 


### PR DESCRIPTION
If a table is dropped when no rows have been consumed, the statistics will get filled with zeros
and that can cause an index-out-of bounds exception the next time table is created and
consumption starts.

This is because the RealtimeTableDataManager is not removed when a table is dropped.

There are also other conditions that can cause 0 stats to happen, so this PR ensures that
stats returned is never 0.