### PR TITLE
Add support for virtual columns

### DIFF
--- a/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
+++ b/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
@@ -139,7 +139,7 @@ WHITESPACE: [ \t\n]+ -> skip;
 
 LINE_COMMENT: '--' ~[\r\n]* -> channel(HIDDEN);
 
-IDENTIFIER: [A-Za-z_][A-Za-z0-9_-]* | '`' (~'`')+ '`';
+IDENTIFIER: '$'?[A-Za-z_][A-Za-z0-9_-]* | '`' (~'`')+ '`';
 STRING_LITERAL: '\'' ( ~'\'' | '\'\'')* '\'' | '"' (~'"' | '""')* '"';
 INTEGER_LITERAL : SIGN? DIGIT+;
 FLOATING_POINT_LITERAL : SIGN? DIGIT+ '.' DIGIT* | SIGN? DIGIT* '.' DIGIT+;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/DimensionFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/DimensionFieldSpec.java
@@ -37,6 +37,12 @@ public final class DimensionFieldSpec extends FieldSpec {
     super(name, dataType, isSingleValueField, defaultNullValue);
   }
 
+  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
+      Class virtualColumnProviderClass) {
+    super(name, dataType, isSingleValueField);
+    _virtualColumnProvider = virtualColumnProviderClass.getName();
+  }
+
   @JsonIgnore
   @Nonnull
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -38,6 +38,7 @@ import org.apache.commons.codec.binary.Hex;
  * <p>- <code>DataType</code>: type of the data stored (e.g. INTEGER, LONG, FLOAT, DOUBLE, STRING).
  * <p>- <code>IsSingleValueField</code>: single-value or multi-value field.
  * <p>- <code>DefaultNullValue</code>: when no value found for this field, use this value. Stored in string format.
+ * <p>- <code>VirtualColumnProvider</code>: the virtual column provider to use for this field.
  */
 @SuppressWarnings("unused")
 public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLifecycleAware {
@@ -71,6 +72,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
 
   // Transform function to generate this column, can be based on other columns
   protected String _transformFunction;
+
+  @ConfigKey("virtualColumnProvider")
+  protected String _virtualColumnProvider;
 
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.
   public FieldSpec() {
@@ -123,6 +127,14 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, ConfigNodeLife
   // Required by JSON de-serializer. DO NOT REMOVE.
   public void setSingleValueField(boolean isSingleValueField) {
     _isSingleValueField = isSingleValueField;
+  }
+
+  public String getVirtualColumnProvider() {
+    return _virtualColumnProvider;
+  }
+
+  public void setVirtualColumnProvider(String virtualColumnProvider) {
+    _virtualColumnProvider = virtualColumnProvider;
   }
 
   @Nonnull

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -630,4 +630,10 @@ public final class Schema {
     result = EqualityUtils.hashCodeOf(result, _dateTimeFieldSpecs);
     return result;
   }
+
+  public boolean isVirtualColumn(String columnName) {
+    return columnName.startsWith("$") ||
+        (getFieldSpecFor(columnName).getVirtualColumnProvider() != null &&
+            !getFieldSpecFor(columnName).getVirtualColumnProvider().isEmpty());
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -46,7 +46,6 @@ public class OfflineTableDataManager extends BaseTableDataManager {
   @Override
   public void addSegment(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig) throws Exception {
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-    addBuiltInVirtualColumnsToSchema(schema);
     addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -46,6 +46,7 @@ public class OfflineTableDataManager extends BaseTableDataManager {
   @Override
   public void addSegment(@Nonnull File indexDir, @Nonnull IndexLoadingConfig indexLoadingConfig) throws Exception {
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+    addBuiltInVirtualColumnsToSchema(schema);
     addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -750,7 +750,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     if (!returnedResponse.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS)) {
       return false;
     }
-    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig);
+
+    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig, _schema);
     removeSegmentFile();
     return true;
   }
@@ -778,7 +779,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     if (descriptor == null) {
       return false;
     }
-    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig);
+
+    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig, _schema);
     return true;
   }
 
@@ -887,7 +889,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   protected void downloadSegmentAndReplace(LLCRealtimeSegmentZKMetadata metadata) {
-    _realtimeTableDataManager.downloadAndReplaceSegment(_segmentNameStr, metadata, _indexLoadingConfig);
+    _realtimeTableDataManager.downloadAndReplaceSegment(_segmentNameStr, metadata, _indexLoadingConfig, _schema);
   }
 
   protected long now() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -52,6 +52,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.io.FileUtils;
 
+import static com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSchema;
+
 
 @ThreadSafe
 public class RealtimeTableDataManager extends BaseTableDataManager {
@@ -208,14 +210,14 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     LoaderUtils.reloadFailureRecovery(indexDir);
 
     Schema schema =
-        ZKMetadataProvider.getTableSchema(_propertyStore, TableNameBuilder.REALTIME.tableNameWithType(_tableName));
+        ZKMetadataProvider.getTableSchema(_propertyStore, TableNameBuilder.REALTIME.tableNameWithType(_tableNameWithType));
 
     Preconditions.checkNotNull(schema);
     addBuiltInVirtualColumnsToSchema(schema);
 
     if (!isValid(schema, tableConfig.getIndexingConfig())) {
       _logger.error("Not adding segment {}", segmentName);
-      throw new RuntimeException("Mismatching schema/table config for " + _tableName);
+      throw new RuntimeException("Mismatching schema/table config for " + _tableNameWithType);
     }
 
     InstanceZKMetadata instanceZKMetadata = ZKMetadataProvider.getInstanceZKMetadata(_propertyStore, _instanceId);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/IndexSegment.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/IndexSegment.java
@@ -47,6 +47,13 @@ public interface IndexSegment {
   Set<String> getColumnNames();
 
   /**
+   * Returns all of the columns in the segment that are not provided by a virtual column provider.
+   *
+   * @return Set of column names
+   */
+  Set<String> getPhysicalColumnNames();
+
+  /**
    * Returns the {@link DataSource} for the given column.
    *
    * @param columnName Column name

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -366,7 +366,7 @@ public class SegmentGeneratorConfig {
       return _segmentTimeColumnName;
     }
     // TODO: if segmentTimeColumnName is null, getQualifyingFields DATETIME. If multiple found, throw exception "must specify primary timeColumnName"
-    return getQualifyingFields(FieldType.TIME);
+    return getQualifyingFields(FieldType.TIME, true);
   }
 
   public void setTimeColumnName(String timeColumnName) {
@@ -545,7 +545,7 @@ public class SegmentGeneratorConfig {
 
   @JsonIgnore
   public String getMetrics() {
-    return getQualifyingFields(FieldType.METRIC);
+    return getQualifyingFields(FieldType.METRIC, true);
   }
 
   /**
@@ -581,12 +581,12 @@ public class SegmentGeneratorConfig {
 
   @JsonIgnore
   public String getDimensions() {
-    return getQualifyingFields(FieldType.DIMENSION);
+    return getQualifyingFields(FieldType.DIMENSION, true);
   }
 
   @JsonIgnore
   public String getDateTimeColumnNames() {
-    return getQualifyingFields(FieldType.DATE_TIME);
+    return getQualifyingFields(FieldType.DATE_TIME, true);
   }
 
   public void setSegmentPartitionConfig(SegmentPartitionConfig segmentPartitionConfig) {
@@ -603,14 +603,19 @@ public class SegmentGeneratorConfig {
    * @return Comma separate qualifying fields names.
    */
   @JsonIgnore
-  private String getQualifyingFields(FieldType type) {
+  private String getQualifyingFields(FieldType type, boolean excludeVirtualColumns) {
     List<String> fields = new ArrayList<>();
 
     for (final FieldSpec spec : getSchema().getAllFieldSpecs()) {
+      if (excludeVirtualColumns && getSchema().isVirtualColumn(spec.getName())) {
+        continue;
+      }
+
       if (spec.getFieldType() == type) {
         fields.add(spec.getName());
       }
     }
+
     Collections.sort(fields);
     return StringUtils.join(fields, ",");
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/immutable/ImmutableSegment.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/immutable/ImmutableSegment.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.indexsegment.immutable;
 
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
 
@@ -29,7 +30,7 @@ public interface ImmutableSegment extends IndexSegment {
    * @param column Column name
    * @return Dictionary for the given column, or null if the given column does not have one
    */
-  ImmutableDictionaryReader getDictionary(String column);
+  Dictionary getDictionary(String column);
 
   /**
    * Returns the forward index for the given column.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -16,18 +16,24 @@
 package com.linkedin.pinot.core.indexsegment.immutable;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.segment.index.column.ColumnIndexContainer;
+import com.linkedin.pinot.core.segment.index.column.PhysicalColumnIndexContainer;
 import com.linkedin.pinot.core.segment.index.converter.SegmentFormatConverter;
 import com.linkedin.pinot.core.segment.index.converter.SegmentFormatConverterFactory;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.linkedin.pinot.core.segment.index.loader.SegmentPreProcessor;
 import com.linkedin.pinot.core.segment.store.SegmentDirectory;
 import com.linkedin.pinot.core.segment.store.SegmentDirectoryPaths;
+import com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnContext;
+import com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnProvider;
+import com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
 import com.linkedin.pinot.core.startree.OffHeapStarTree;
 import com.linkedin.pinot.core.startree.StarTree;
 import java.io.File;
@@ -105,7 +111,7 @@ public class ImmutableSegmentLoader {
     Map<String, ColumnIndexContainer> indexContainerMap = new HashMap<>();
     for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
       indexContainerMap.put(entry.getKey(),
-          new ColumnIndexContainer(segmentReader, entry.getValue(), indexLoadingConfig));
+          new PhysicalColumnIndexContainer(segmentReader, entry.getValue(), indexLoadingConfig));
     }
 
     // Load star tree index if it exists
@@ -113,6 +119,29 @@ public class ImmutableSegmentLoader {
     if (segmentReader.hasStarTree()) {
       LOGGER.info("Loading star tree for segment: {}", segmentName);
       starTree = new OffHeapStarTree(segmentReader.getStarTreeFile(), readMode);
+    }
+
+    // Synthesize schema if necessary, adding virtual columns
+    if (schema != null) {
+      VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSchema(schema);
+    } else {
+      schema = segmentMetadata.getSchema();
+    }
+
+    // Ensure that the schema in the segment metadata also has the virtual columns added
+    VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSchema(segmentMetadata.getSchema());
+
+    // Instantiate virtual columns
+    for (String columnName : schema.getColumnNames()) {
+      if (schema.isVirtualColumn(columnName)) {
+        FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
+        VirtualColumnProvider provider = VirtualColumnProviderFactory.buildProvider(fieldSpec.getVirtualColumnProvider());
+        VirtualColumnContext context =
+            new VirtualColumnContext(NetUtil.getHostnameOrAddress(), segmentMetadata.getTableName(), segmentName,
+                columnName, segmentMetadata.getTotalDocs());
+        indexContainerMap.put(columnName, provider.buildColumnIndexContainer(context));
+        segmentMetadata.getColumnMetadataMap().put(columnName, provider.buildMetadata(context));
+      }
     }
 
     return new ImmutableSegmentImpl(segmentDirectory, segmentMetadata, indexContainerMap, starTree);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.config.SegmentPartitionConfig;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.indexsegment.IndexSegmentUtils;
 import com.linkedin.pinot.core.io.reader.DataFileReader;
@@ -34,6 +35,9 @@ import com.linkedin.pinot.core.realtime.impl.invertedindex.RealtimeInvertedIndex
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.segment.index.data.source.ColumnDataSource;
+import com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnContext;
+import com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnProvider;
+import com.linkedin.pinot.core.segment.virtualcolumn.VirtualColumnProviderFactory;
 import com.linkedin.pinot.core.startree.v2.StarTreeV2;
 import com.linkedin.pinot.core.util.FixedIntArray;
 import com.linkedin.pinot.core.util.FixedIntArrayOffHeapIdMap;
@@ -41,6 +45,7 @@ import com.linkedin.pinot.core.util.IdMap;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -362,9 +367,33 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   @Override
+  public Set<String> getPhysicalColumnNames() {
+    HashSet<String> physicalColumnNames = new HashSet<>();
+
+    for (String columnName : getColumnNames()) {
+      if (!_segmentMetadata.getSchema().isVirtualColumn(columnName)) {
+        physicalColumnNames.add(columnName);
+      }
+    }
+
+    return physicalColumnNames;
+  }
+
+  @Override
   public ColumnDataSource getDataSource(String columnName) {
-    return new ColumnDataSource(_schema.getFieldSpecFor(columnName), _numDocsIndexed, _maxNumValuesMap.get(columnName),
-        _indexReaderWriterMap.get(columnName), _invertedIndexMap.get(columnName), _dictionaryMap.get(columnName));
+    if (!_schema.isVirtualColumn(columnName)) {
+      return new ColumnDataSource(_schema.getFieldSpecFor(columnName), _numDocsIndexed, _maxNumValuesMap.get(columnName),
+          _indexReaderWriterMap.get(columnName), _invertedIndexMap.get(columnName), _dictionaryMap.get(columnName));
+    } else {
+      return getVirtualDataSource(columnName);
+    }
+  }
+
+  private ColumnDataSource getVirtualDataSource(String column) {
+    VirtualColumnContext virtualColumnContext = new VirtualColumnContext(NetUtil.getHostnameOrAddress(), _segmentMetadata.getTableName(), getSegmentName(),
+        column, _numDocsIndexed + 1);
+    VirtualColumnProvider provider = VirtualColumnProviderFactory.buildProvider(_schema.getFieldSpecFor(column).getVirtualColumnProvider());
+    return new ColumnDataSource(provider.buildColumnIndexContainer(virtualColumnContext), provider.buildMetadata(virtualColumnContext));
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/SortedIndexReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/SortedIndexReader.java
@@ -15,122 +15,32 @@
  */
 package com.linkedin.pinot.core.io.reader.impl.v1;
 
-import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.Pairs;
-import com.linkedin.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
 import com.linkedin.pinot.core.io.reader.ReaderContext;
-import com.linkedin.pinot.core.io.util.FixedByteValueReaderWriter;
+import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
-import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.IOException;
 
 
-public final class SortedIndexReader extends BaseSingleColumnSingleValueReader<SortedIndexReader.Context> implements InvertedIndexReader<Pairs.IntPair> {
-  private final FixedByteValueReaderWriter _reader;
-  private final int _cardinality;
-
-  public SortedIndexReader(PinotDataBuffer dataBuffer, int cardinality) {
-    // 2 values per dictionary id
-    Preconditions.checkState(dataBuffer.size() == 2 * cardinality * Integer.BYTES);
-    _reader = new FixedByteValueReaderWriter(dataBuffer);
-    _cardinality = cardinality;
-  }
+/**
+ * Interface for sorted index readers.
+ */
+public interface SortedIndexReader<T extends ReaderContext> extends SingleColumnSingleValueReader<T>, InvertedIndexReader<Pairs.IntPair> {
+  @Override
+  int getInt(int row);
 
   @Override
-  public int getInt(int row) {
-    // Only one value in dictionary
-    if (_cardinality == 1) {
-      return 0;
-    }
-
-    return binarySearch(row, 0, _cardinality - 1);
-  }
+  int getInt(int row, T context);
 
   @Override
-  public int getInt(int row, Context context) {
-    // Only one value in dictionary
-    if (_cardinality == 1) {
-      return 0;
-    }
-
-    int contextDictId = context._dictId;
-    int contextStartOffset = context._startOffset;
-    int contextEndOffset = context._endOffset;
-    if (row >= contextStartOffset) {
-      // Same value
-      if (row <= contextEndOffset) {
-        return contextDictId;
-      }
-
-      // Next value in dictionary
-      int nextDictId = contextDictId + 1;
-      int nextEndOffset = _reader.getInt(2 * nextDictId + 1);
-      if (row <= nextEndOffset) {
-        context._dictId = nextDictId;
-        context._startOffset = contextEndOffset + 1;
-        context._endOffset = nextEndOffset;
-        return nextDictId;
-      }
-    }
-
-    int dictId;
-    if (row < contextStartOffset) {
-      dictId = binarySearch(row, 0, contextDictId - 1);
-    } else {
-      dictId = binarySearch(row, contextDictId + 2, _cardinality - 1);
-    }
-    context._dictId = dictId;
-    context._startOffset = _reader.getInt(2 * dictId);
-    context._endOffset = _reader.getInt(2 * dictId + 1);
-    return dictId;
-  }
-
-  private int binarySearch(int row, int low, int high) {
-    while (low <= high) {
-      int mid = (low + high) / 2;
-      if (_reader.getInt(2 * mid) <= row) {
-        low = mid + 1;
-      } else {
-        high = mid - 1;
-      }
-    }
-    return high;
-  }
+  void readValues(int[] rows, int rowsStartIndex, int rowSize, int[] values, int valuesStartIndex);
 
   @Override
-  public void readValues(int[] rows, int rowsStartIndex, int rowSize, int[] values, int valuesStartIndex) {
-    int rowsEndIndex = rowsStartIndex + rowSize;
-    if (_cardinality == 1) {
-      for (int i = rowsStartIndex; i < rowsEndIndex; i++) {
-        values[valuesStartIndex++] = 0;
-      }
-    } else {
-      Context context = new Context();
-      for (int i = rowsStartIndex; i < rowsEndIndex; i++) {
-        values[valuesStartIndex++] = getInt(rows[i], context);
-      }
-    }
-  }
+  T createContext();
 
   @Override
-  public Context createContext() {
-    return new Context();
-  }
+  Pairs.IntPair getDocIds(int dictId);
 
   @Override
-  public Pairs.IntPair getDocIds(int dictId) {
-    return new Pairs.IntPair(_reader.getInt(2 * dictId), _reader.getInt(2 * dictId + 1));
-  }
-
-  @Override
-  public void close() throws IOException {
-    _reader.close();
-  }
-
-  public static class Context implements ReaderContext {
-    public int _dictId = -1;
-    public int _startOffset = -1;
-    // Inclusive
-    public int _endOffset = -1;
-  }
+  void close() throws IOException;
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/SortedIndexReaderImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/SortedIndexReaderImpl.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.io.reader.impl.v1;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.utils.Pairs;
+import com.linkedin.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
+import com.linkedin.pinot.core.io.reader.ReaderContext;
+import com.linkedin.pinot.core.io.util.FixedByteValueReaderWriter;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+public final class SortedIndexReaderImpl
+    extends BaseSingleColumnSingleValueReader<SortedIndexReaderImpl.Context> implements SortedIndexReader {
+  private static final int INT_SIZE_IN_BYTES = Integer.SIZE / Byte.SIZE;
+
+  private final FixedByteValueReaderWriter _reader;
+  private final int _cardinality;
+
+  public SortedIndexReaderImpl(PinotDataBuffer dataBuffer, int cardinality) {
+    // 2 values per dictionary id
+    Preconditions.checkState(dataBuffer.size() == 2 * cardinality * INT_SIZE_IN_BYTES);
+    _reader = new FixedByteValueReaderWriter(dataBuffer);
+    _cardinality = cardinality;
+  }
+
+  @Override
+  public int getInt(int row) {
+    // Only one value in dictionary
+    if (_cardinality == 1) {
+      return 0;
+    }
+
+    return binarySearch(row, 0, _cardinality - 1);
+  }
+
+  @Override
+  public int getInt(int row, Context context) {
+    // Only one value in dictionary
+    if (_cardinality == 1) {
+      return 0;
+    }
+
+    int contextDictId = context._dictId;
+    int contextStartOffset = context._startOffset;
+    int contextEndOffset = context._endOffset;
+    if (row >= contextStartOffset) {
+      // Same value
+      if (row <= contextEndOffset) {
+        return contextDictId;
+      }
+
+      // Next value in dictionary
+      int nextDictId = contextDictId + 1;
+      int nextEndOffset = _reader.getInt(2 * nextDictId + 1);
+      if (row <= nextEndOffset) {
+        context._dictId = nextDictId;
+        context._startOffset = contextEndOffset + 1;
+        context._endOffset = nextEndOffset;
+        return nextDictId;
+      }
+    }
+
+    int dictId;
+    if (row < contextStartOffset) {
+      dictId = binarySearch(row, 0, contextDictId - 1);
+    } else {
+      dictId = binarySearch(row, contextDictId + 2, _cardinality - 1);
+    }
+    context._dictId = dictId;
+    context._startOffset = _reader.getInt(2 * dictId);
+    context._endOffset = _reader.getInt(2 * dictId + 1);
+    return dictId;
+  }
+
+  private int binarySearch(int row, int low, int high) {
+    while (low <= high) {
+      int mid = (low + high) / 2;
+      if (_reader.getInt(2 * mid) <= row) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return high;
+  }
+
+  @Override
+  public void readValues(int[] rows, int rowsStartIndex, int rowSize, int[] values, int valuesStartIndex) {
+    int rowsEndIndex = rowsStartIndex + rowSize;
+    if (_cardinality == 1) {
+      for (int i = rowsStartIndex; i < rowsEndIndex; i++) {
+        values[valuesStartIndex++] = 0;
+      }
+    } else {
+      Context context = new Context();
+      for (int i = rowsStartIndex; i < rowsEndIndex; i++) {
+        values[valuesStartIndex++] = getInt(rows[i], context);
+      }
+    }
+  }
+
+  @Override
+  public Context createContext() {
+    return new Context();
+  }
+
+  @Override
+  public Pairs.IntPair getDocIds(int dictId) {
+    return new Pairs.IntPair(_reader.getInt(2 * dictId), _reader.getInt(2 * dictId + 1));
+  }
+
+  @Override
+  public void close() {
+    _reader.close();
+  }
+
+  public static class Context implements ReaderContext {
+    public int _dictId = -1;
+    public int _startOffset = -1;
+    // Inclusive
+    public int _endOffset = -1;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/SortedIndexReaderImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/SortedIndexReaderImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,18 +21,17 @@ import com.linkedin.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
 import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.util.FixedByteValueReaderWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import java.io.IOException;
 
 
-public final class SortedIndexReaderImpl
-    extends BaseSingleColumnSingleValueReader<SortedIndexReaderImpl.Context> implements SortedIndexReader {
-  private static final int INT_SIZE_IN_BYTES = Integer.SIZE / Byte.SIZE;
-
+public class SortedIndexReaderImpl extends BaseSingleColumnSingleValueReader<SortedIndexReaderImpl.Context> implements SortedIndexReader<SortedIndexReaderImpl.Context> {
   private final FixedByteValueReaderWriter _reader;
   private final int _cardinality;
 
+
   public SortedIndexReaderImpl(PinotDataBuffer dataBuffer, int cardinality) {
     // 2 values per dictionary id
-    Preconditions.checkState(dataBuffer.size() == 2 * cardinality * INT_SIZE_IN_BYTES);
+    Preconditions.checkState(dataBuffer.size() == 2 * cardinality * Integer.BYTES);
     _reader = new FixedByteValueReaderWriter(dataBuffer);
     _cardinality = cardinality;
   }
@@ -124,7 +123,7 @@ public final class SortedIndexReaderImpl
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     _reader.close();
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/DictionaryDelegatingValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/DictionaryDelegatingValueReader.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.io.util;
+
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import java.io.IOException;
+
+
+/**
+ * Value reader that delegates to a dictionary.
+ */
+public class DictionaryDelegatingValueReader implements ValueReader {
+  private Dictionary _dictionary;
+
+  public Dictionary getDictionary() {
+    return _dictionary;
+  }
+
+  public void setDictionary(Dictionary dictionary) {
+    _dictionary = dictionary;
+  }
+
+  @Override
+  public int getInt(int index) {
+    return _dictionary.getIntValue(index);
+  }
+
+  @Override
+  public long getLong(int index) {
+    return _dictionary.getLongValue(index);
+  }
+
+  @Override
+  public float getFloat(int index) {
+    return _dictionary.getFloatValue(index);
+  }
+
+  @Override
+  public double getDouble(int index) {
+    return _dictionary.getDoubleValue(index);
+  }
+
+  @Override
+  public String getUnpaddedString(int index, int numBytesPerValue, byte paddingByte, byte[] buffer) {
+    return _dictionary.getStringValue(index);
+  }
+
+  @Override
+  public String getPaddedString(int index, int numBytesPerValue, byte[] buffer) {
+    throw new RuntimeException("Unimplemented");
+  }
+
+  @Override
+  public byte[] getBytes(int index, int numBytesPerValue, byte[] output) {
+    throw new RuntimeException("Unimplemented");
+  }
+
+  @Override
+  public void close() throws IOException {
+    _dictionary.close();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
@@ -21,29 +21,34 @@ import java.io.Closeable;
 import java.io.IOException;
 
 
-public final class FixedByteValueReaderWriter implements Closeable {
+public final class FixedByteValueReaderWriter implements Closeable, ValueReader {
   private final PinotDataBuffer _dataBuffer;
 
   public FixedByteValueReaderWriter(PinotDataBuffer dataBuffer) {
     _dataBuffer = dataBuffer;
   }
 
+  @Override
   public int getInt(int index) {
     return _dataBuffer.getInt(index * Integer.BYTES);
   }
 
+  @Override
   public long getLong(int index) {
     return _dataBuffer.getLong(index * Long.BYTES);
   }
 
+  @Override
   public float getFloat(int index) {
     return _dataBuffer.getFloat(index * Float.BYTES);
   }
 
+  @Override
   public double getDouble(int index) {
     return _dataBuffer.getDouble(index * Double.BYTES);
   }
 
+  @Override
   public String getUnpaddedString(int index, int numBytesPerValue, byte paddingByte, byte[] buffer) {
     int startOffset = index * numBytesPerValue;
     for (int i = 0; i < numBytesPerValue; i++) {
@@ -56,6 +61,7 @@ public final class FixedByteValueReaderWriter implements Closeable {
     return StringUtil.decodeUtf8(buffer);
   }
 
+  @Override
   public String getPaddedString(int index, int numBytesPerValue, byte[] buffer) {
     int startOffset = index * numBytesPerValue;
     for (int i = 0; i < numBytesPerValue; i++) {
@@ -64,6 +70,7 @@ public final class FixedByteValueReaderWriter implements Closeable {
     return StringUtil.decodeUtf8(buffer);
   }
 
+  @Override
   public byte[] getBytes(int index, int numBytesPerValue, byte[] output) {
     assert output.length == numBytesPerValue;
     int startOffset = index * numBytesPerValue;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/ValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/ValueReader.java
@@ -13,14 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.linkedin.pinot.core.segment.virtualcolumn;
+package com.linkedin.pinot.core.io.util;
+
+import java.io.IOException;
+
 
 /**
- * Virtual column provider that returns the current host name.
+ * Interface for value readers, which read a value at a given index.
  */
-public class HostNameVirtualColumnProvider extends SingleStringVirtualColumnProvider {
-  @Override
-  protected String getValue(VirtualColumnContext context) {
-    return context.getHostname();
-  }
+public interface ValueReader {
+  int getInt(int index);
+
+  long getLong(int index);
+
+  float getFloat(int index);
+
+  double getDouble(int index);
+
+  String getUnpaddedString(int index, int numBytesPerValue, byte paddingByte, byte[] buffer);
+
+  String getPaddedString(int index, int numBytesPerValue, byte[] buffer);
+
+  byte[] getBytes(int index, int numBytesPerValue, byte[] output);
+
+  void close() throws IOException;
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -86,14 +87,13 @@ public class SelectionOperatorUtils {
   public static List<String> getSelectionColumns(@Nonnull List<String> selectionColumns,
       @Nonnull IndexSegment indexSegment) {
     if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
-      List<String> allColumns = new ArrayList<>(indexSegment.getColumnNames());
-      String[] columnNames = indexSegment.getColumnNames();
+      List<String> allColumns = new LinkedList<>(indexSegment.getColumnNames());
+      Set<String> columnNames = indexSegment.getColumnNames();
 
       // Remove columns that start with $ (eg. $docId) when doing select *
-      for (int i = 0; i < columnNames.length; i++) {
-        String columnName = columnNames[i];
-        if (!columnName.startsWith("$")) {
-          allColumns.add(columnName);
+      for (String columnName : columnNames) {
+        if (columnName.startsWith("$")) {
+          allColumns.remove(columnName);
         }
       }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -87,6 +87,16 @@ public class SelectionOperatorUtils {
       @Nonnull IndexSegment indexSegment) {
     if (selectionColumns.size() == 1 && selectionColumns.get(0).equals("*")) {
       List<String> allColumns = new ArrayList<>(indexSegment.getColumnNames());
+      String[] columnNames = indexSegment.getColumnNames();
+
+      // Remove columns that start with $ (eg. $docId) when doing select *
+      for (int i = 0; i < columnNames.length; i++) {
+        String columnName = columnNames[i];
+        if (!columnName.startsWith("$")) {
+          allColumns.add(columnName);
+        }
+      }
+
       Collections.sort(allColumns);
       return allColumns;
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeSegmentStatsContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeSegmentStatsContainer.java
@@ -41,7 +41,7 @@ public class RealtimeSegmentStatsContainer implements SegmentPreIndexStatsContai
     SegmentPartitionConfig segmentPartitionConfig = _realtimeSegment.getSegmentPartitionConfig();
 
     // Create all column statistics
-    for (String columnName : realtimeSegment.getColumnNames()) {
+    for (String columnName : realtimeSegment.getPhysicalColumnNames()) {
       ColumnDataSource dataSource = realtimeSegment.getDataSource(columnName);
       if (dataSource.getDataSourceMetadata().hasDictionary()) {
         _columnStatisticsMap.put(columnName, new RealtimeColumnStatistics(realtimeSegment.getDataSource(columnName),

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -119,7 +119,14 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
     // Initialize creators for dictionary, forward index and inverted index
     for (FieldSpec fieldSpec : fieldSpecs) {
+
       String columnName = fieldSpec.getName();
+
+      // Ignore virtual columns
+      if (schema.isVirtualColumn(columnName)) {
+        continue;
+      }
+
       ColumnIndexCreationInfo indexCreationInfo = indexCreationInfoMap.get(columnName);
       Preconditions.checkNotNull(indexCreationInfo, "Missing index creation info for column: %s", columnName);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -457,6 +457,12 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
       throws Exception {
     for (FieldSpec spec : dataSchema.getAllFieldSpecs()) {
       String column = spec.getName();
+
+      // Skip adding virtual columns, so that they don't get an on-disk representation
+      if (dataSchema.isVirtualColumn(column)) {
+        continue;
+      }
+
       ColumnStatistics columnProfile = segmentStats.getColumnProfileFor(column);
       indexCreationInfoMap.put(column,
           new ColumnIndexCreationInfo(columnProfile, true/*createDictionary*/, ForwardIndexType.FIXED_BIT_COMPRESSED,

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
@@ -15,161 +15,19 @@
  */
 package com.linkedin.pinot.core.segment.index.column;
 
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.io.reader.DataFileReader;
-import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
-import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitMultiValueReader;
-import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitSingleValueReader;
-import com.linkedin.pinot.core.io.reader.impl.v1.FixedByteChunkSingleValueReader;
-import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReader;
-import com.linkedin.pinot.core.io.reader.impl.v1.VarByteChunkSingleValueReader;
-import com.linkedin.pinot.core.segment.index.ColumnMetadata;
-import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
-import com.linkedin.pinot.core.segment.index.readers.BitmapInvertedIndexReader;
-import com.linkedin.pinot.core.segment.index.readers.BytesDictionary;
-import com.linkedin.pinot.core.segment.index.readers.DoubleDictionary;
-import com.linkedin.pinot.core.segment.index.readers.FloatDictionary;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
-import com.linkedin.pinot.core.segment.index.readers.IntDictionary;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
-import com.linkedin.pinot.core.segment.index.readers.LongDictionary;
-import com.linkedin.pinot.core.segment.index.readers.OnHeapDoubleDictionary;
-import com.linkedin.pinot.core.segment.index.readers.OnHeapFloatDictionary;
-import com.linkedin.pinot.core.segment.index.readers.OnHeapIntDictionary;
-import com.linkedin.pinot.core.segment.index.readers.OnHeapLongDictionary;
-import com.linkedin.pinot.core.segment.index.readers.OnHeapStringDictionary;
-import com.linkedin.pinot.core.segment.index.readers.StringDictionary;
-import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
-import com.linkedin.pinot.core.segment.store.ColumnIndexType;
-import com.linkedin.pinot.core.segment.store.SegmentDirectory;
-import java.io.IOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
-public final class ColumnIndexContainer {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnIndexContainer.class);
+/**
+ * Interface for column index containers.
+ */
+public interface ColumnIndexContainer {
+  DataFileReader getForwardIndex();
 
-  private final DataFileReader _forwardIndex;
-  private final InvertedIndexReader _invertedIndex;
-  private final ImmutableDictionaryReader _dictionary;
+  InvertedIndexReader getInvertedIndex();
 
-  public ColumnIndexContainer(SegmentDirectory.Reader segmentReader, ColumnMetadata metadata,
-      IndexLoadingConfig indexLoadingConfig) throws IOException {
-    String columnName = metadata.getColumnName();
-    boolean loadInvertedIndex = false;
-    boolean loadOnHeapDictionary = false;
-    if (indexLoadingConfig != null) {
-      loadInvertedIndex = indexLoadingConfig.getInvertedIndexColumns().contains(columnName);
-      loadOnHeapDictionary = indexLoadingConfig.getOnHeapDictionaryColumns().contains(columnName);
-    }
-    PinotDataBuffer fwdIndexBuffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FORWARD_INDEX);
-    if (metadata.hasDictionary()) {
-      // Dictionary-based index
-      _dictionary = loadDictionary(segmentReader.getIndexFor(columnName, ColumnIndexType.DICTIONARY), metadata,
-          loadOnHeapDictionary);
-      if (metadata.isSingleValue()) {
-        // Single-value
-        if (metadata.isSorted()) {
-          // Sorted
-          SortedIndexReader sortedIndexReader = new SortedIndexReader(fwdIndexBuffer, metadata.getCardinality());
-          _forwardIndex = sortedIndexReader;
-          _invertedIndex = sortedIndexReader;
-          return;
-        } else {
-          // Unsorted
-          _forwardIndex =
-              new FixedBitSingleValueReader(fwdIndexBuffer, metadata.getTotalDocs(), metadata.getBitsPerElement());
-        }
-      } else {
-        // Multi-value
-        _forwardIndex =
-            new FixedBitMultiValueReader(fwdIndexBuffer, metadata.getTotalDocs(), metadata.getTotalNumberOfEntries(),
-                metadata.getBitsPerElement());
-      }
-      if (loadInvertedIndex) {
-        _invertedIndex =
-            new BitmapInvertedIndexReader(segmentReader.getIndexFor(columnName, ColumnIndexType.INVERTED_INDEX),
-                metadata.getCardinality());
-      } else {
-        _invertedIndex = null;
-      }
-    } else {
-      // Raw index
-      _forwardIndex = loadRawForwardIndex(fwdIndexBuffer, metadata.getDataType());
-      _invertedIndex = null;
-      _dictionary = null;
-    }
-  }
-
-  public DataFileReader getForwardIndex() {
-    return _forwardIndex;
-  }
-
-  public InvertedIndexReader getInvertedIndex() {
-    return _invertedIndex;
-  }
-
-  public ImmutableDictionaryReader getDictionary() {
-    return _dictionary;
-  }
-
-  private static ImmutableDictionaryReader loadDictionary(PinotDataBuffer dictionaryBuffer, ColumnMetadata metadata,
-      boolean loadOnHeap) throws IOException {
-    FieldSpec.DataType dataType = metadata.getDataType();
-    if (loadOnHeap) {
-      String columnName = metadata.getColumnName();
-      LOGGER.info("Loading on-heap dictionary for column: {}", columnName);
-    }
-
-    int length = metadata.getCardinality();
-    switch (dataType) {
-      case INT:
-        return (loadOnHeap) ? new OnHeapIntDictionary(dictionaryBuffer, length)
-            : new IntDictionary(dictionaryBuffer, length);
-
-      case LONG:
-        return (loadOnHeap) ? new OnHeapLongDictionary(dictionaryBuffer, length)
-            : new LongDictionary(dictionaryBuffer, length);
-
-      case FLOAT:
-        return (loadOnHeap) ? new OnHeapFloatDictionary(dictionaryBuffer, length)
-            : new FloatDictionary(dictionaryBuffer, length);
-
-      case DOUBLE:
-        return (loadOnHeap) ? new OnHeapDoubleDictionary(dictionaryBuffer, length)
-            : new DoubleDictionary(dictionaryBuffer, length);
-
-      case STRING:
-        int numBytesPerValue = metadata.getColumnMaxLength();
-        byte paddingByte = (byte) metadata.getPaddingCharacter();
-        return loadOnHeap ? new OnHeapStringDictionary(dictionaryBuffer, length, numBytesPerValue, paddingByte)
-            : new StringDictionary(dictionaryBuffer, length, numBytesPerValue, paddingByte);
-
-      case BYTES:
-        numBytesPerValue = metadata.getColumnMaxLength();
-        paddingByte = (byte) metadata.getPaddingCharacter();
-        return new BytesDictionary(dictionaryBuffer, length, numBytesPerValue, paddingByte);
-
-      default:
-        throw new IllegalStateException("Illegal data type for dictionary: " + dataType);
-    }
-  }
-
-  private static SingleColumnSingleValueReader loadRawForwardIndex(PinotDataBuffer forwardIndexBuffer,
-      FieldSpec.DataType dataType) throws IOException {
-
-    switch (dataType) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-        return new FixedByteChunkSingleValueReader(forwardIndexBuffer);
-      case STRING:
-      case BYTES:
-        return new VarByteChunkSingleValueReader(forwardIndexBuffer);
-      default:
-        throw new IllegalStateException("Illegal data type for raw forward index: " + dataType);
-    }
-  }
+  Dictionary getDictionary();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/PhysicalColumnIndexContainer.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.column;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
+import com.linkedin.pinot.core.io.compression.ChunkDecompressor;
+import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.io.reader.SingleColumnSingleValueReader;
+import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitMultiValueReader;
+import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitSingleValueReader;
+import com.linkedin.pinot.core.io.reader.impl.v1.FixedByteChunkSingleValueReader;
+import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReaderImpl;
+import com.linkedin.pinot.core.io.reader.impl.v1.VarByteChunkSingleValueReader;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
+import com.linkedin.pinot.core.segment.index.readers.BitmapInvertedIndexReader;
+import com.linkedin.pinot.core.segment.index.readers.DoubleDictionary;
+import com.linkedin.pinot.core.segment.index.readers.FloatDictionary;
+import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
+import com.linkedin.pinot.core.segment.index.readers.IntDictionary;
+import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
+import com.linkedin.pinot.core.segment.index.readers.LongDictionary;
+import com.linkedin.pinot.core.segment.index.readers.OnHeapStringDictionary;
+import com.linkedin.pinot.core.segment.index.readers.StringDictionary;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import com.linkedin.pinot.core.segment.store.ColumnIndexType;
+import com.linkedin.pinot.core.segment.store.SegmentDirectory;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PhysicalColumnIndexContainer implements ColumnIndexContainer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PhysicalColumnIndexContainer.class);
+
+  private final DataFileReader _forwardIndex;
+  private final InvertedIndexReader _invertedIndex;
+  private final ImmutableDictionaryReader _dictionary;
+
+  public PhysicalColumnIndexContainer(SegmentDirectory.Reader segmentReader, ColumnMetadata metadata,
+      IndexLoadingConfig indexLoadingConfig) throws IOException {
+    String columnName = metadata.getColumnName();
+    boolean loadInvertedIndex = false;
+    boolean loadOnHeapDictionary = false;
+    if (indexLoadingConfig != null) {
+      loadInvertedIndex = indexLoadingConfig.getInvertedIndexColumns().contains(columnName);
+      loadOnHeapDictionary = indexLoadingConfig.getOnHeapDictionaryColumns().contains(columnName);
+    }
+    PinotDataBuffer fwdIndexBuffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FORWARD_INDEX);
+    if (metadata.hasDictionary()) {
+      // Dictionary-based index
+      _dictionary = loadDictionary(segmentReader.getIndexFor(columnName, ColumnIndexType.DICTIONARY), metadata,
+          loadOnHeapDictionary);
+      if (metadata.isSingleValue()) {
+        // Single-value
+        if (metadata.isSorted()) {
+          // Sorted
+          SortedIndexReaderImpl sortedIndexReader = new SortedIndexReaderImpl(fwdIndexBuffer, metadata.getCardinality());
+          _forwardIndex = sortedIndexReader;
+          _invertedIndex = sortedIndexReader;
+          return;
+        } else {
+          // Unsorted
+          _forwardIndex =
+              new FixedBitSingleValueReader(fwdIndexBuffer, metadata.getTotalDocs(), metadata.getBitsPerElement());
+        }
+      } else {
+        // Multi-value
+        _forwardIndex =
+            new FixedBitMultiValueReader(fwdIndexBuffer, metadata.getTotalDocs(), metadata.getTotalNumberOfEntries(),
+                metadata.getBitsPerElement());
+      }
+      if (loadInvertedIndex) {
+        _invertedIndex =
+            new BitmapInvertedIndexReader(segmentReader.getIndexFor(columnName, ColumnIndexType.INVERTED_INDEX),
+                metadata.getCardinality());
+      } else {
+        _invertedIndex = null;
+      }
+    } else {
+      // Raw index
+      _forwardIndex = loadRawForwardIndex(fwdIndexBuffer, metadata.getDataType());
+      _invertedIndex = null;
+      _dictionary = null;
+    }
+  }
+
+  @Override
+  public DataFileReader getForwardIndex() {
+    return _forwardIndex;
+  }
+
+  @Override
+  public InvertedIndexReader getInvertedIndex() {
+    return _invertedIndex;
+  }
+
+  @Override
+  public ImmutableDictionaryReader getDictionary() {
+    return _dictionary;
+  }
+
+  private static ImmutableDictionaryReader loadDictionary(PinotDataBuffer dictionaryBuffer, ColumnMetadata metadata,
+      boolean loadOnHeap) throws IOException {
+    FieldSpec.DataType dataType = metadata.getDataType();
+    if (loadOnHeap && (dataType != FieldSpec.DataType.STRING)) {
+      LOGGER.warn("Only support on-heap dictionary for String data type, load off-heap dictionary for column: {}",
+          metadata.getColumnName());
+    }
+
+    int length = metadata.getCardinality();
+    switch (dataType) {
+      case INT:
+        return new IntDictionary(dictionaryBuffer, length);
+      case LONG:
+        return new LongDictionary(dictionaryBuffer, length);
+      case FLOAT:
+        return new FloatDictionary(dictionaryBuffer, length);
+      case DOUBLE:
+        return new DoubleDictionary(dictionaryBuffer, length);
+      case STRING:
+        int numBytesPerValue = metadata.getStringColumnMaxLength();
+        byte paddingByte = (byte) metadata.getPaddingCharacter();
+        return loadOnHeap ? new OnHeapStringDictionary(dictionaryBuffer, length, numBytesPerValue, paddingByte)
+            : new StringDictionary(dictionaryBuffer, length, numBytesPerValue, paddingByte);
+      default:
+        throw new IllegalStateException("Illegal data type for dictionary: " + dataType);
+    }
+  }
+
+  private static SingleColumnSingleValueReader loadRawForwardIndex(PinotDataBuffer forwardIndexBuffer,
+      FieldSpec.DataType dataType) throws IOException {
+    // TODO: Make compression/decompression configurable.
+    ChunkDecompressor decompressor = ChunkCompressorFactory.getDecompressor("snappy");
+
+    switch (dataType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        return new FixedByteChunkSingleValueReader(forwardIndexBuffer, decompressor);
+      case STRING:
+        return new VarByteChunkSingleValueReader(forwardIndexBuffer, decompressor);
+      default:
+        throw new IllegalStateException("Illegal data type for raw forward index: " + dataType);
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.primitive.ByteArray;
 import com.linkedin.pinot.core.io.util.FixedByteValueReaderWriter;
+import com.linkedin.pinot.core.io.util.ValueReader;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.IOException;
 import java.util.Arrays;
@@ -26,7 +27,7 @@ import java.util.Arrays;
 
 @SuppressWarnings("Duplicates")
 public abstract class ImmutableDictionaryReader extends BaseDictionary {
-  private final FixedByteValueReaderWriter _valueReader;
+  private final ValueReader _valueReader;
   private final int _length;
   private final int _numBytesPerValue;
   private final byte _paddingByte;
@@ -37,6 +38,13 @@ public abstract class ImmutableDictionaryReader extends BaseDictionary {
     _length = length;
     _numBytesPerValue = numBytesPerValue;
     _paddingByte = paddingByte;
+  }
+
+  protected ImmutableDictionaryReader(ValueReader valueReader, int length) {
+    _valueReader = valueReader;
+    _length = length;
+    _numBytesPerValue = -1;
+    _paddingByte = 0;
   }
 
   /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/IntDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/IntDictionary.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.index.readers;
 
+import com.linkedin.pinot.core.io.util.ValueReader;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
 
@@ -22,6 +23,10 @@ public class IntDictionary extends ImmutableDictionaryReader {
 
   public IntDictionary(PinotDataBuffer dataBuffer, int length) {
     super(dataBuffer, length, Integer.BYTES, (byte) 0);
+  }
+
+  public IntDictionary(ValueReader valueReader, int length) {
+    super(valueReader, length);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.index.readers;
 
+import com.linkedin.pinot.core.io.util.ValueReader;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 
 
@@ -22,6 +23,10 @@ public class StringDictionary extends ImmutableDictionaryReader {
 
   public StringDictionary(PinotDataBuffer dataBuffer, int length, int numBytesPerValue, byte paddingByte) {
     super(dataBuffer, length, numBytesPerValue, paddingByte);
+  }
+
+  public StringDictionary(ValueReader valueReader, int length) {
+    super(valueReader, length);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/BaseVirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/BaseVirtualColumnProvider.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+import com.linkedin.pinot.core.segment.index.column.ColumnIndexContainer;
+
+
+/**
+ * Shared implementation code between virtual column providers.
+ */
+public abstract class BaseVirtualColumnProvider implements VirtualColumnProvider {
+  @Override
+  public ColumnIndexContainer buildColumnIndexContainer(VirtualColumnContext context) {
+    return new VirtualColumnIndexContainer(buildReader(context), buildInvertedIndex(context), buildDictionary(context));
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/BaseVirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/BaseVirtualColumnProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.segment.virtualcolumn;
 
 import com.linkedin.pinot.core.segment.index.column.ColumnIndexContainer;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/DocIdVirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/DocIdVirtualColumnProvider.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.Pairs;
+import com.linkedin.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
+import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.io.reader.impl.ChunkReaderContext;
+import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReader;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.readers.BaseDictionary;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
+import java.io.IOException;
+
+
+/**
+ * Virtual column provider that returns the current document id.
+ */
+public class DocIdVirtualColumnProvider extends BaseVirtualColumnProvider {
+  @Override
+  public DataFileReader buildReader(VirtualColumnContext context) {
+    return new DocIdSingleValueReader();
+  }
+
+  @Override
+  public Dictionary buildDictionary(VirtualColumnContext context) {
+    return new DocIdDictionary(context.getTotalDocCount());
+  }
+
+  @Override
+  public ColumnMetadata buildMetadata(VirtualColumnContext context) {
+    ColumnMetadata.Builder columnMetadataBuilder = new ColumnMetadata.Builder()
+        .setColumnName(context.getColumnName())
+        .setCardinality(context.getTotalDocCount())
+        .setHasDictionary(true)
+        .setHasInvertedIndex(true)
+        .setFieldType(FieldSpec.FieldType.DIMENSION)
+        .setDataType(FieldSpec.DataType.INT)
+        .setSingleValue(true)
+        .setIsSorted(true)
+        .setTotalDocs(context.getTotalDocCount());
+
+    return columnMetadataBuilder.build();
+  }
+
+  @Override
+  public InvertedIndexReader buildInvertedIndex(VirtualColumnContext context) {
+    return new DocIdInvertedIndex();
+  }
+
+  private class DocIdSingleValueReader extends BaseSingleColumnSingleValueReader<ChunkReaderContext> {
+    @Override
+    public ChunkReaderContext createContext() {
+      return null;
+    }
+
+    @Override
+    public int getInt(int row) {
+      return row;
+    }
+
+    @Override
+    public int getInt(int rowId, ChunkReaderContext context) {
+      return rowId;
+    }
+
+    @Override
+    public long getLong(int row) {
+      return row;
+    }
+
+    @Override
+    public long getLong(int rowId, ChunkReaderContext context) {
+      return rowId;
+    }
+
+    @Override
+    public void readValues(int[] rows, int rowStartPos, int rowSize, int[] values, int valuesStartPos) {
+      System.arraycopy(rows, rowStartPos, values, valuesStartPos, rowSize);
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+
+  private class DocIdInvertedIndex implements SortedIndexReader {
+    @Override
+    public Pairs.IntPair getDocIds(int dictId) {
+      return new Pairs.IntPair(dictId, dictId);
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+
+  private class DocIdDictionary extends BaseDictionary {
+    private int _length;
+
+    public DocIdDictionary(int length) {
+      _length = length;
+    }
+
+    @Override
+    public int indexOf(Object rawValue) {
+      if (rawValue instanceof Number) {
+        return ((Number) rawValue).intValue();
+      }
+
+      if (rawValue instanceof String) {
+        try {
+          return Integer.parseInt((String) rawValue);
+        } catch (NumberFormatException e) {
+          return -1;
+        }
+      }
+
+      return -1;
+    }
+
+    @Override
+    public Object get(int dictId) {
+      return dictId;
+    }
+
+    @Override
+    public int getIntValue(int dictId) {
+      return dictId;
+    }
+
+    @Override
+    public long getLongValue(int dictId) {
+      return dictId;
+    }
+
+    @Override
+    public float getFloatValue(int dictId) {
+      return dictId;
+    }
+
+    @Override
+    public double getDoubleValue(int dictId) {
+      return dictId;
+    }
+
+    @Override
+    public String getStringValue(int dictId) {
+      return Integer.toString(dictId);
+    }
+
+    @Override
+    public int length() {
+      return _length;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/HostNameVirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/HostNameVirtualColumnProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+/**
+ * Virtual column provider that returns the current host name.
+ */
+public class HostNameVirtualColumnProvider extends SingleStringVirtualColumnProvider {
+  @Override
+  protected String getValue(VirtualColumnContext context) {
+    return context.getHostname();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/IntSingleValueDataFileReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/IntSingleValueDataFileReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.segment.virtualcolumn;
 
 import com.linkedin.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
@@ -26,7 +25,7 @@ import java.util.Arrays;
 /**
  * Forward index that contains a single integer value.
  */
-public class IntSingleValueDataFileReader extends BaseSingleColumnSingleValueReader<ChunkReaderContext> implements DataFileReader {
+public class IntSingleValueDataFileReader extends BaseSingleColumnSingleValueReader<ChunkReaderContext> implements DataFileReader<ChunkReaderContext> {
   private int _value;
 
   public IntSingleValueDataFileReader(int value) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/IntSingleValueDataFileReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/IntSingleValueDataFileReader.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+import com.linkedin.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
+import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.io.reader.impl.ChunkReaderContext;
+import java.io.IOException;
+import java.util.Arrays;
+
+
+/**
+ * Forward index that contains a single integer value.
+ */
+public class IntSingleValueDataFileReader extends BaseSingleColumnSingleValueReader<ChunkReaderContext> implements DataFileReader {
+  private int _value;
+
+  public IntSingleValueDataFileReader(int value) {
+    _value = value;
+  }
+
+  @Override
+  public int getInt(int row) {
+    return _value;
+  }
+
+  @Override
+  public int getInt(int rowId, ChunkReaderContext context) {
+    return _value;
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+
+  @Override
+  public void readValues(int[] rows, int rowStartPos, int rowSize, int[] values, int valuesStartPos) {
+    Arrays.fill(values, valuesStartPos, rowSize, 0);
+  }
+
+  @Override
+  public ChunkReaderContext createContext() {
+    return null;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/SegmentNameVirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/SegmentNameVirtualColumnProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.segment.virtualcolumn;
 
 /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/SegmentNameVirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/SegmentNameVirtualColumnProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+/**
+ * Virtual column provider that contains the current segment name.
+ */
+public class SegmentNameVirtualColumnProvider extends SingleStringVirtualColumnProvider {
+  @Override
+  protected String getValue(VirtualColumnContext context) {
+    return context.getSegmentName();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/SingleStringVirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/SingleStringVirtualColumnProvider.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.Pairs;
+import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReader;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.readers.BaseDictionary;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
+import java.io.IOException;
+
+
+/**
+ * Virtual column provider for a virtual column that contains a single string.
+ */
+public abstract class SingleStringVirtualColumnProvider extends BaseVirtualColumnProvider {
+  protected abstract String getValue(VirtualColumnContext context);
+
+  @Override
+  public DataFileReader buildReader(VirtualColumnContext context) {
+    return new IntSingleValueDataFileReader(0);
+  }
+
+  @Override
+  public Dictionary buildDictionary(VirtualColumnContext context) {
+    return new SingleStringDictionary(context.getTotalDocCount(), context);
+  }
+
+  @Override
+  public ColumnMetadata buildMetadata(VirtualColumnContext context) {
+    ColumnMetadata.Builder columnMetadataBuilder = new ColumnMetadata.Builder()
+        .setColumnName(context.getColumnName())
+        .setCardinality(1)
+        .setHasDictionary(true)
+        .setHasInvertedIndex(true)
+        .setFieldType(FieldSpec.FieldType.DIMENSION)
+        .setDataType(FieldSpec.DataType.STRING)
+        .setSingleValue(true)
+        .setIsSorted(true)
+        .setTotalDocs(context.getTotalDocCount());
+
+    return columnMetadataBuilder.build();
+  }
+
+  @Override
+  public InvertedIndexReader buildInvertedIndex(VirtualColumnContext context) {
+    return new SingleStringInvertedIndex(context.getTotalDocCount());
+  }
+
+  private class SingleStringInvertedIndex implements SortedIndexReader {
+    private int _length;
+
+    public SingleStringInvertedIndex(int length) {
+      _length = length;
+    }
+
+    @Override
+    public Pairs.IntPair getDocIds(int dictId) {
+      if (dictId == 0) {
+        return new Pairs.IntPair(0, _length);
+      } else {
+        return new Pairs.IntPair(-1, -1);
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+
+  private class SingleStringDictionary extends BaseDictionary {
+    private int _length;
+    private VirtualColumnContext _context;
+
+    public SingleStringDictionary(int length, VirtualColumnContext context) {
+      _length = length;
+      _context = context;
+    }
+
+    @Override
+    public int getIntValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getLongValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getFloatValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double getDoubleValue(int dictId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int length() {
+      return _length;
+    }
+
+    @Override
+    public int indexOf(Object rawValue) {
+      if (rawValue.equals(getValue(_context))) {
+        return 0;
+      } else {
+        return -1;
+      }
+    }
+
+    @Override
+    public Object get(int dictId) {
+      return getValue(_context);
+    }
+
+    @Override
+    public String getStringValue(int dictId) {
+      return getValue(_context);
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+/**
+ * Context used to pass arguments to the virtual column provider.
+ */
+public class VirtualColumnContext {
+  private String _hostname;
+  private String _tableName;
+  private String _segmentName;
+  private String _columnName;
+  private int _totalDocCount;
+
+  public VirtualColumnContext(String hostname, String tableName, String segmentName, String columnName,
+      int totalDocCount) {
+    _hostname = hostname;
+    _tableName = tableName;
+    _segmentName = segmentName;
+    _columnName = columnName;
+    _totalDocCount = totalDocCount;
+  }
+
+  public String getHostname() {
+    return _hostname;
+  }
+
+  public String getTableName() {
+    return _tableName;
+  }
+
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public String getColumnName() {
+    return _columnName;
+  }
+
+  public int getTotalDocCount() {
+    return _totalDocCount;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.segment.virtualcolumn;
 
 /**

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnIndexContainer.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.segment.index.column.ColumnIndexContainer;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
+
+
+/**
+ * Column index container for virtual columns.
+ */
+public class VirtualColumnIndexContainer implements ColumnIndexContainer {
+  private DataFileReader _forwardIndex;
+  private InvertedIndexReader _invertedIndex;
+  private Dictionary _dictionary;
+
+  public VirtualColumnIndexContainer(DataFileReader forwardIndex, InvertedIndexReader invertedIndex,
+      Dictionary dictionary) {
+    _forwardIndex = forwardIndex;
+    _invertedIndex = invertedIndex;
+    _dictionary = dictionary;
+  }
+
+  @Override
+  public DataFileReader getForwardIndex() {
+    return _forwardIndex;
+  }
+
+  @Override
+  public InvertedIndexReader getInvertedIndex() {
+    return _invertedIndex;
+  }
+
+  @Override
+  public Dictionary getDictionary() {
+    return _dictionary;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnIndexContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.segment.virtualcolumn;
 
 import com.linkedin.pinot.core.io.reader.DataFileReader;
 import com.linkedin.pinot.core.segment.index.column.ColumnIndexContainer;
+import com.linkedin.pinot.core.segment.index.column.PhysicalColumnIndexContainer;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProvider.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+import com.linkedin.pinot.core.io.reader.DataFileReader;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.column.ColumnIndexContainer;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
+
+
+/**
+ * Virtual column provider interface, which is used to instantiate the various components (dictionary, reader, etc) that
+ * comprise a proper column.
+ */
+public interface VirtualColumnProvider {
+  DataFileReader buildReader(VirtualColumnContext context);
+  Dictionary buildDictionary(VirtualColumnContext context);
+  ColumnMetadata buildMetadata(VirtualColumnContext context);
+  InvertedIndexReader buildInvertedIndex(VirtualColumnContext context);
+  ColumnIndexContainer buildColumnIndexContainer(VirtualColumnContext context);
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProvider.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.segment.virtualcolumn;
 
 import com.linkedin.pinot.core.io.reader.DataFileReader;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProviderFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProviderFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.core.segment.virtualcolumn;
+
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+
+
+/**
+ * Factory for virtual column providers.
+ */
+public class VirtualColumnProviderFactory {
+  public static VirtualColumnProvider buildProvider(String virtualColumnProvider) {
+    try {
+      Class<? extends VirtualColumnProvider> providerClass =
+          (Class<? extends VirtualColumnProvider>) Class.forName(virtualColumnProvider);
+      return providerClass.newInstance();
+    } catch (ReflectiveOperationException e) {
+      return null;
+    }
+  }
+
+  public static void addBuiltInVirtualColumnsToSchema(Schema schema) {
+    schema.addField(new DimensionFieldSpec("$docId", FieldSpec.DataType.INT, true, DocIdVirtualColumnProvider.class));
+    schema.addField(new DimensionFieldSpec("$hostName", FieldSpec.DataType.STRING, true, HostNameVirtualColumnProvider.class));
+    schema.addField(new DimensionFieldSpec("$segmentName", FieldSpec.DataType.STRING, true, SegmentNameVirtualColumnProvider.class));
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProviderFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/VirtualColumnProviderFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.core.segment.virtualcolumn;
 
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
@@ -36,8 +35,16 @@ public class VirtualColumnProviderFactory {
   }
 
   public static void addBuiltInVirtualColumnsToSchema(Schema schema) {
-    schema.addField(new DimensionFieldSpec("$docId", FieldSpec.DataType.INT, true, DocIdVirtualColumnProvider.class));
-    schema.addField(new DimensionFieldSpec("$hostName", FieldSpec.DataType.STRING, true, HostNameVirtualColumnProvider.class));
-    schema.addField(new DimensionFieldSpec("$segmentName", FieldSpec.DataType.STRING, true, SegmentNameVirtualColumnProvider.class));
+    if (!schema.hasColumn("$docId")) {
+      schema.addField(new DimensionFieldSpec("$docId", FieldSpec.DataType.INT, true, DocIdVirtualColumnProvider.class));
+    }
+
+    if (!schema.hasColumn("$hostName")) {
+      schema.addField(new DimensionFieldSpec("$hostName", FieldSpec.DataType.STRING, true, HostNameVirtualColumnProvider.class));
+    }
+
+    if (!schema.hasColumn("$segmentName")) {
+      schema.addField(new DimensionFieldSpec("$segmentName", FieldSpec.DataType.STRING, true, SegmentNameVirtualColumnProvider.class));
+    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/package-info.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/package-info.java
@@ -1,4 +1,19 @@
 /**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
  * Package with the virtual column API.
  */
 package com.linkedin.pinot.core.segment.virtualcolumn;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/package-info.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ * Copyright (C) 2014-2018 LinkedIn Corp. (pinot-core@linkedin.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/package-info.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/virtualcolumn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package with the virtual column API.
+ */
+package com.linkedin.pinot.core.segment.virtualcolumn;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
@@ -144,7 +144,7 @@ public class SegmentGenerationWithBytesTypeTest {
 
   @Test
   public void testDictionary() {
-    ImmutableDictionaryReader dictionary = _segment.getDictionary(FIXED_BYTE_SORTED_COLUMN);
+    ImmutableDictionaryReader dictionary = (ImmutableDictionaryReader) _segment.getDictionary(FIXED_BYTE_SORTED_COLUMN);
     Assert.assertEquals(dictionary.length(), NUM_SORTED_VALUES);
 
     // Test dictionary indexing.

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/reader/SortedForwardIndexReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/reader/SortedForwardIndexReaderTest.java
@@ -15,7 +15,9 @@
  */
 package com.linkedin.pinot.index.reader;
 
+import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReader;
+import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReaderImpl;
 import com.linkedin.pinot.core.io.writer.impl.FixedByteSingleValueMultiColWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.File;
@@ -57,7 +59,7 @@ public class SortedForwardIndexReaderTest {
     }
     writer.close();
 
-    try (SortedIndexReader reader = new SortedIndexReader(PinotDataBuffer.loadBigEndianFile(file), cardinality)) {
+    try (SortedIndexReader reader = new SortedIndexReaderImpl(PinotDataBuffer.loadBigEndianFile(file), cardinality)) {
       // without using context
       long start, end;
       start = System.currentTimeMillis();
@@ -69,7 +71,7 @@ public class SortedForwardIndexReaderTest {
       end = System.currentTimeMillis();
       System.out.println("Took " + (end - start) + " to scan " + totalDocs + " docs without using context");
       // with context
-      SortedIndexReader.Context context = reader.createContext();
+      ReaderContext context = reader.createContext();
       start = System.currentTimeMillis();
       for (int i = 0; i < cardinality; i++) {
         for (int docId = startDocIdArray[i]; docId <= endDocIdArray[i]; docId++) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
@@ -36,6 +36,7 @@ import com.linkedin.pinot.core.segment.creator.impl.stats.LongColumnPreIndexStat
 import com.linkedin.pinot.core.segment.creator.impl.stats.StringColumnPreIndexStatsCollector;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.DoubleDictionary;
 import com.linkedin.pinot.core.segment.index.readers.FloatDictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
@@ -145,8 +146,8 @@ public class DictionariesTest {
 
     for (final String column : ((SegmentMetadataImpl) mmapSegment.getSegmentMetadata()).getColumnMetadataMap()
         .keySet()) {
-      ImmutableDictionaryReader heapDictionary = heapSegment.getDictionary(column);
-      ImmutableDictionaryReader mmapDictionary = mmapSegment.getDictionary(column);
+      Dictionary heapDictionary = heapSegment.getDictionary(column);
+      Dictionary mmapDictionary = mmapSegment.getDictionary(column);
 
       switch (((SegmentMetadataImpl) mmapSegment.getSegmentMetadata()).getColumnMetadataMap()
           .get(column)
@@ -189,8 +190,8 @@ public class DictionariesTest {
     final Map<String, ColumnMetadata> metadataMap =
         ((SegmentMetadataImpl) mmapSegment.getSegmentMetadata()).getColumnMetadataMap();
     for (final String column : metadataMap.keySet()) {
-      final ImmutableDictionaryReader heapDictionary = heapSegment.getDictionary(column);
-      final ImmutableDictionaryReader mmapDictionary = mmapSegment.getDictionary(column);
+      final Dictionary heapDictionary = heapSegment.getDictionary(column);
+      final Dictionary mmapDictionary = mmapSegment.getDictionary(column);
 
       final Set<Object> uniques = uniqueEntries.get(column);
       final List<Object> list = Arrays.asList(uniques.toArray());

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
@@ -193,6 +193,11 @@ public class DictionariesTest {
       final Dictionary heapDictionary = heapSegment.getDictionary(column);
       final Dictionary mmapDictionary = mmapSegment.getDictionary(column);
 
+      // Skip virtual columns
+      if (column.startsWith("$")) {
+        continue;
+      }
+
       final Set<Object> uniques = uniqueEntries.get(column);
       final List<Object> list = Arrays.asList(uniques.toArray());
       Collections.shuffle(list);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -16,6 +16,8 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.base.Function;
+import com.linkedin.pinot.client.ResultSet;
+import com.linkedin.pinot.client.ResultSetGroup;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.util.TestUtils;
@@ -130,6 +132,22 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
             + " AVG(CAST(CRSDepTime AS DOUBLE)) FROM mytable WHERE OriginCityName > 'Beaumont/Port Arthur, TX' OR "
             + "FlightDate IN ('2014-12-09', '2014-10-05') GROUP BY ActualElapsedTime, OriginStateFips "
             + "HAVING SUM(ArrDelay) <> 6325.973 AND AVG(CAST(CRSDepTime AS DOUBLE)) <= 1569.8755 OR SUM(TaxiIn) = 1003.87274"));
+  }
+
+  public void testVirtualColumnQueries() {
+    // Check that there are no virtual columns in the query results
+    ResultSetGroup resultSetGroup = getPinotConnection().execute("select * from mytable");
+    ResultSet resultSet = resultSetGroup.getResultSet(0);
+    for (int i = 0; i < resultSet.getColumnCount(); i++) {
+      Assert.assertFalse(resultSet.getColumnName(i).startsWith("$"), "Virtual column " + resultSet.getColumnName(i) + " is present in the results!");
+    }
+
+    // Check that the virtual columns work as expected (throws no exceptions)
+    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable");
+    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable where $docId < 5 limit 50");
+    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable where $docId = 5 limit 50");
+    getPinotConnection().execute("select $docId, $segmentName, $hostName from mytable where $docId > 19998 limit 50");
+    getPinotConnection().execute("select max($docId) from mytable group by $segmentName");
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.integration.tests;
 
 import com.google.common.base.Function;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.CommonConstants;
@@ -245,6 +246,12 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   @Override
   public void testInstanceShutdown() throws Exception {
     super.testInstanceShutdown();
+  }
+
+  @Test
+  @Override
+  public void testVirtualColumnQueries() {
+    super.testVirtualColumnQueries();
   }
 
   @AfterClass

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOfflineIndexReader.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkOfflineIndexReader.java
@@ -21,7 +21,7 @@ import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.io.reader.ReaderContext;
 import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitMultiValueReader;
 import com.linkedin.pinot.core.io.reader.impl.v1.FixedBitSingleValueReader;
-import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReader;
+import com.linkedin.pinot.core.io.reader.impl.v1.SortedIndexReaderImpl;
 import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
@@ -82,7 +82,7 @@ public class BenchmarkOfflineIndexReader {
   // Forward index
   private int _numDocs;
   private FixedBitSingleValueReader _fixedBitSingleValueReader;
-  private SortedIndexReader _sortedForwardIndexReader;
+  private SortedIndexReaderImpl _sortedForwardIndexReader;
   private FixedBitMultiValueReader _fixedBitMultiValueReader;
   private int[] _buffer;
 
@@ -118,7 +118,7 @@ public class BenchmarkOfflineIndexReader {
         new FixedBitSingleValueReader(segmentReader.getIndexFor(SV_UNSORTED_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX),
             _numDocs, segmentMetadata.getColumnMetadataFor(SV_UNSORTED_COLUMN_NAME).getBitsPerElement());
     _sortedForwardIndexReader =
-        new SortedIndexReader(segmentReader.getIndexFor(SV_SORTED_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX),
+        new SortedIndexReaderImpl(segmentReader.getIndexFor(SV_SORTED_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX),
             segmentMetadata.getColumnMetadataFor(SV_SORTED_COLUMN_NAME).getCardinality());
     ColumnMetadata mvColumnMetadata = segmentMetadata.getColumnMetadataFor(MV_COLUMN_NAME);
     _fixedBitMultiValueReader =
@@ -156,7 +156,7 @@ public class BenchmarkOfflineIndexReader {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public int sortedForwardIndexReaderSequential() {
-    SortedIndexReader.Context context = _sortedForwardIndexReader.createContext();
+    SortedIndexReaderImpl.Context context = _sortedForwardIndexReader.createContext();
     int ret = 0;
     for (int i = 0; i < _numDocs; i++) {
       ret += _sortedForwardIndexReader.getInt(i, context);
@@ -168,7 +168,7 @@ public class BenchmarkOfflineIndexReader {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public int sortedForwardIndexReaderRandom() {
-    SortedIndexReader.Context context = _sortedForwardIndexReader.createContext();
+    SortedIndexReaderImpl.Context context = _sortedForwardIndexReader.createContext();
     int ret = 0;
     for (int i = 0; i < _numDocs; i++) {
       ret += _sortedForwardIndexReader.getInt(RANDOM.nextInt(_numDocs), context);

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/DictionaryDumper.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/DictionaryDumper.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.segment.ReadMode;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegment;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import java.io.File;
 import java.util.Arrays;
@@ -39,7 +40,7 @@ public class DictionaryDumper {
       System.out.println("Loading " + indexDir.getName());
 
       ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(indexDir, ReadMode.heap);
-      ImmutableDictionaryReader colDictionary = immutableSegment.getDictionary(args[1]);
+      Dictionary colDictionary = immutableSegment.getDictionary(args[1]);
       List<String> strIdList = Arrays.asList(args[2].split(","));
 
       for (String strId : strIdList) {

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/StringDictionaryPerfTest.java
@@ -26,6 +26,7 @@ import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegment;
 import com.linkedin.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import java.io.File;
 import java.util.ArrayList;
@@ -114,7 +115,7 @@ public class StringDictionaryPerfTest {
    */
   public void perfTestLookups(int numLookups) throws Exception {
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(_indexDir, ReadMode.heap);
-    ImmutableDictionaryReader dictionary = immutableSegment.getDictionary(COLUMN_NAME);
+    Dictionary dictionary = immutableSegment.getDictionary(COLUMN_NAME);
 
     Random random = new Random(System.nanoTime());
     long start = System.currentTimeMillis();

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/SegmentInfoProvider.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/query/comparison/SegmentInfoProvider.java
@@ -115,7 +115,7 @@ public class SegmentInfoProvider {
 
     // Add all single-value dimension columns.
     for (DimensionFieldSpec fieldSpec : schema.getDimensionFieldSpecs()) {
-      if (!fieldSpec.isSingleValueField()) {
+      if (!fieldSpec.isSingleValueField() || schema.isVirtualColumn(fieldSpec.getName())) {
         continue;
       }
       String column = fieldSpec.getName();


### PR DESCRIPTION
Add support for virtual columns, which are columns that have no on-disk
representation but instead contain values that are filled in at run
time.

Add support for three built-in virtual columns:
 - $docId: Returns the document id for the current row
 - $segmentName: Returns the current segment name
 - $hostName: Returns the hostname of the current server

These columns can be used for debugging purposes, such as debugging
query routing (which server answered which query) and data issues (what
are the data ranges in each segment).

Additional built-in virtual columns can be added to
VirtualColumnProviderFactory and customized virtual columns can be added
to any schema by adding a provider to the classpath and specifying the
fully qualified class name as the "virtualColumnProvider" property of
the field specification in the Pinot table schema.