### PR TITLE
Modify hadoop dep

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -159,12 +159,10 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,30 @@
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-xc</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-server</artifactId>
+          </exclusion>
       </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-server</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
@@ -588,6 +611,12 @@
         <groupId>io.swagger</groupId>
         <artifactId>swagger-jaxrs</artifactId>
         <version>${swagger.version}</version>
+        <exclusions>
+            <exclusion>
+              <groupId>javax.ws.rs</groupId>
+              <artifactId>jsr311-api</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>
@@ -627,11 +656,7 @@
         <version>2.10.0</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-common</artifactId>
-        <version>${hadoop.version}</version>
-      </dependency>
+
     </dependencies>
 
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.1</version>
+        <version>2.5</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>


### PR DESCRIPTION
In my previous diff for the hdfs fetcher support, I set the Hadoop dep as provided because usually people generally run different versions of Hadoop and better to modify the dependency as needed. However, I noticed this will cause issues in the sample workflow (which is partially fixed in by @jfim [here](https://github.com/linkedin/pinot/pull/1970)). In order to provide user better experience while running the example, I think it is better to make the Hadoop Dep included in pom. The change is tested on local against 2.7.3 Hadoop environment