### PR TITLE
fix file upload not working against latest pinot controller

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
@@ -40,9 +40,11 @@ import org.apache.commons.httpclient.methods.multipart.PartSource;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HTTP;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 public class FileUploadUtils {
 
@@ -184,6 +186,7 @@ public class FileUploadUtils {
       method = httpMethod.forUri("http://" + host + ":" + port + "/" + SEGMENTS_PATH);
       method.setRequestHeader(UPLOAD_TYPE, FileUploadType.URI.toString());
       method.setRequestHeader(DOWNLOAD_URI, uri);
+      method.setRequestHeader(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
       FILE_UPLOAD_HTTP_CLIENT.executeMethod(method);
       if (method.getStatusCode() >= 400) {
         String errorString = "POST Status Code: " + method.getStatusCode() + "\n";

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadUtils.java
@@ -241,6 +241,7 @@ public class FileUploadUtils {
       postMethod = new PostMethod("http://" + host + ":" + port + "/" + SEGMENTS_PATH);
       postMethod.setRequestEntity(requestEntity);
       postMethod.setRequestHeader(UPLOAD_TYPE, FileUploadType.JSON.toString());
+      postMethod.setRequestHeader(HTTP.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
       int statusCode = FILE_UPLOAD_HTTP_CLIENT.executeMethod(postMethod);
       if (statusCode >= 400) {
         String errorString = "POST Status Code: " + statusCode + "\n";

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProvider.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/FileUploadPathProvider.java
@@ -55,7 +55,7 @@ public class FileUploadPathProvider {
       }
       _vip = _controllerConf.generateVipUrl();
     } catch (Exception e) {
-      throw new InvalidControllerConfigException("Bad controller configuration");
+      throw new InvalidControllerConfigException("Bad controller configuration", e);
     }
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/InvalidControllerConfigException.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/InvalidControllerConfigException.java
@@ -20,4 +20,8 @@ public class InvalidControllerConfigException extends Exception {
   public InvalidControllerConfigException(final String s) {
     super(s);
   }
+
+  public InvalidControllerConfigException(final String s, final Exception ex) {
+    super(s, ex);
+  }
 }


### PR DESCRIPTION
FileUploadUtils.sendSegmentUriImpl(...) has issue sending segment file URI to pinot controller. In the recent Pinot controller changes, we enforced the checking of "Content-Type" of the requests and reject (by returning 400) the caller if it doesn't contain a valid information. This is usually fine in other Java request code section as Apache Http libs can infer and generate the content type from the entity provided to it. However, when the entity is empty (like the case we have here), it will not generate a proper content-type and Pinot Controller will reject such request. This fix and the unit-test should ensure that file upload request should do the correct thing.