### PR TITLE
[TE] implement default authenticator to support non-ldap environments

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorDisabled.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorDisabled.java
@@ -1,0 +1,29 @@
+package com.linkedin.thirdeye.auth;
+
+import com.google.common.base.Optional;
+import io.dropwizard.auth.AuthenticationException;
+import io.dropwizard.auth.Authenticator;
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ThirdEyeAuthenticatorDisabled implements Authenticator<Credentials, ThirdEyePrincipal> {
+  private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeAuthenticatorDisabled.class);
+
+  /**
+   *  {@inheritDoc}
+   */
+  @Override
+  public Optional<ThirdEyePrincipal> authenticate(Credentials credentials) throws AuthenticationException {
+    LOG.info("Authentication is disabled. Accepting any credentials for {}.", credentials.getPrincipal());
+
+    ThirdEyePrincipal principal = new ThirdEyePrincipal();
+    principal.setName(credentials.getPrincipal());
+
+    return Optional.of(principal);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorLdap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorLdap.java
@@ -11,15 +11,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class ThirdEyeAuthenticator implements Authenticator<Credentials, ThirdEyePrincipal> {
-  private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeAuthenticator.class);
+public class ThirdEyeAuthenticatorLdap implements Authenticator<Credentials, ThirdEyePrincipal> {
+  private static final Logger LOG = LoggerFactory.getLogger(ThirdEyeAuthenticatorLdap.class);
 
   private static final String LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
 
   private final String domainSuffix;
   private final String ldapUrl;
 
-  public ThirdEyeAuthenticator(String domainSuffix, String ldapUrl) {
+  public ThirdEyeAuthenticatorLdap(String domainSuffix, String ldapUrl) {
     this.domainSuffix = domainSuffix;
     this.ldapUrl = ldapUrl;
   }


### PR DESCRIPTION
The current authentication framework does not support environments without LDAP (without completely breaking the web UI). This PR adds a default permissive authenticator that will accept any credentials passed so ThirdEye can be used in environments without LDAP.