### PR TITLE
Fix off heap inverted index creation on MacOS X

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
@@ -231,7 +231,10 @@ public final class OffHeapBitmapInvertedIndexCreator implements InvertedIndexCre
       // Append the bitmap data file to the inverted index file
       try (FileChannel out = new FileOutputStream(_invertedIndexFile, true).getChannel();
           FileChannel in = new FileInputStream(tempBitmapDataFile).getChannel()) {
-        out.transferFrom(in, 0, in.size());
+        // jfim: For some reason, it seems like the second argument of transferFrom is relative on Linux while it is
+        // an absolute position on MacOS X. As such, we reposition the stream to 0 on both platforms to make it an
+        // absolute position call.
+        out.position(0).transferFrom(in, out.size(), in.size());
       }
     } catch (Exception e) {
       FileUtils.deleteQuietly(_invertedIndexFile);


### PR DESCRIPTION
Fix the off heap inverted index creation on MacOS X. It seems that on
MacOS X, the behavior for the position on a file channel is to be
absolute while on Linux it is relative to the current file position.

Rewrite the transferFrom call to use an absolute position on all
platforms.