### PR TITLE
[TE] Frontend dataset mapping support

### DIFF
--- a/thirdeye/thirdeye-frontend/app/actions/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/actions/metrics.js
@@ -143,10 +143,13 @@ function fetchRelatedMetricIds() {
 
     const filters = JSON.parse(filterJson);
     const filterUrns = Object.keys(filters).map(key => 'thirdeye:dimension:' + key + ':' + filters[key] + ':provided');
-    const urns = [`thirdeye:metric:${metricId}`].concat(filterUrns).join(',');
+    const primaryUrn = `thirdeye:metric:${metricId}`;
+
+    const urns = [primaryUrn].concat(filterUrns).join(',');
 
     return fetch(`/rootcause/query?framework=relatedMetrics&anomalyStart=${anomalyStart}&anomalyEnd=${anomalyEnd}&baselineStart=${baselineStart}&baselineEnd=${baselineEnd}&analysisStart=${analysisStart}&analysisEnd=${analysisEnd}&urns=${urns}`)
       .then(res => res.json())
+      .then(res => res.filter(m => m.urn != primaryUrn))
       .then(res => dispatch(loadRelatedMetricIds(res)));
   };
 }

--- a/thirdeye/thirdeye-frontend/app/actions/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/actions/metrics.js
@@ -149,7 +149,7 @@ function fetchRelatedMetricIds() {
 
     return fetch(`/rootcause/query?framework=relatedMetrics&anomalyStart=${anomalyStart}&anomalyEnd=${anomalyEnd}&baselineStart=${baselineStart}&baselineEnd=${baselineEnd}&analysisStart=${analysisStart}&analysisEnd=${analysisEnd}&urns=${urns}`)
       .then(res => res.json())
-      .then(res => res.filter(m => m.urn != primaryUrn))
+      .then(res => res.filter(metric => metric.urn != primaryUrn))
       .then(res => dispatch(loadRelatedMetricIds(res)));
   };
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -873,18 +873,4 @@ public class DataResource {
     }
     return dataGranularity;
   }
-
-  public enum EntityType {
-    METRIC,
-    SERVICE,
-    DIMENSION,
-    DIMENSION_VAL,
-    CUSTOM
-  }
-
-  @GET
-  @Path("/entityTypes")
-  public List<EntityType> getEntityTypes() {
-    return Arrays.asList(EntityType.values());
-  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DatasetEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DatasetEntity.java
@@ -1,0 +1,56 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * DatasetEntity represents a group of metrics tightly associated with each other. It typically serves
+ * as a convenience to describe entity mappings common to whole groups of entities.
+ * 'thirdeye:dataset:{name}'.
+ */
+public class DatasetEntity extends Entity {
+  public static final EntityType TYPE = new EntityType("thirdeye:dataset:");
+
+  private final String name;
+
+  protected DatasetEntity(String urn, double score, List<? extends Entity> related, String name) {
+    super(urn, score, related);
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public DatasetEntity withScore(double score) {
+    return new DatasetEntity(this.getUrn(), score, this.getRelated(), this.name);
+  }
+
+  @Override
+  public DatasetEntity withRelated(List<? extends Entity> related) {
+    return new DatasetEntity(this.getUrn(), this.getScore(), related, this.name);
+  }
+
+  public static DatasetEntity fromName(double score, String name) {
+    String urn = TYPE.formatURN(name);
+    return new DatasetEntity(urn, score, new ArrayList<Entity>(), name);
+  }
+
+  public static DatasetEntity fromName(double score, Collection<? extends Entity> related, String name) {
+    String urn = TYPE.formatURN(name);
+    return new DatasetEntity(urn, score, new ArrayList<>(related), name);
+  }
+
+  public static DatasetEntity fromURN(String urn, double score) {
+    if(!TYPE.isType(urn))
+      throw new IllegalArgumentException(String.format("URN '%s' is not type '%s'", urn, TYPE.getPrefix()));
+    String[] parts = urn.split(":", 3);
+    if(parts.length != 3)
+      throw new IllegalArgumentException(String.format("URN must have 3 parts but has '%d'", parts.length));
+    return new DatasetEntity(urn, score, new ArrayList<Entity>(), parts[2]);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
@@ -166,6 +166,9 @@ public class EntityUtils {
     } else if(ServiceEntity.TYPE.isType(urn)) {
       return ServiceEntity.fromURN(urn, score);
 
+    } else if(DatasetEntity.TYPE.isType(urn)) {
+      return DatasetEntity.fromURN(urn, score);
+
     } else if(HyperlinkEntity.TYPE.isType(urn)) {
       return HyperlinkEntity.fromURL(urn, score);
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/NullPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/NullPipeline.java
@@ -10,9 +10,8 @@ import java.util.Set;
 
 
 /**
- * NullPipeline serves as a dummy implementation or sink that may receive inputs, but does not
- * emit any output. Can be used to construct an validate a DAG without a full implementation
- * of component pipelines.
+ * NullPipeline serves as a dummy implementation or sink that emits as output any received inputs.
+ * Can be used to construct an validate a DAG without a full implementation of component pipelines.
  */
 public class NullPipeline extends Pipeline {
   /**
@@ -38,6 +37,6 @@ public class NullPipeline extends Pipeline {
 
   @Override
   public PipelineResult run(PipelineContext context) {
-    return new PipelineResult(context, Collections.<Entity>emptySet());
+    return new PipelineResult(context, context.filter(Entity.class));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/self-service-mappings.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/self-service-mappings.js
@@ -172,6 +172,12 @@ function updateEntityMapping() {
     return;
   }
 
+  if (fromUrn.includes(" ") || fromUrn.includes(",") || fromUrn.includes(";")
+      || toUrn.includes(" ") || toUrn.includes(",") || toUrn.includes(";")) {
+    alert("Cannot contain separators except ':' (colon)");
+    return;
+  }
+
   submitData("/entityMapping/create", payload, "admin", "html").success(function (data) {
     console.log("Adding mapping : ");
     fetchAndDisplayMappings(entityType1);

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/self-service-mappings.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/lib/self-service-mappings.js
@@ -1,4 +1,14 @@
+const MAPPING_TYPES = [
+  'METRIC',
+  'DIMENSION',
+  'SERVICE',
+  'DATASET',
+  'LIXTAG',
+  'CUSTOM'
+];
+
 var services;
+var datasets;
 
 function renderMappingsSelection() {
   var html = "<table style='border: 1px;width: 80%'>"
@@ -11,18 +21,22 @@ function renderMappingsSelection() {
       + "<hr/><table id='existing-mappings-data-table'></table>";
   $("#mappings-place-holder").html(html);
 
-  getData("/data/entityTypes", "admin").done(function (data) {
-    var select = "<option value='select'>Select</option>";
-    for (var i in data) {
-      select += "<option value='" + data[i] + "'>" + data[i] + "</option>";
-    }
-    $("#entityTypeSelector1").html(select);
-    $("#entityTypeSelector2").html(select);
+  // dropdown options
+  var select = "<option value='select'>Select</option>";
+  for (var i in MAPPING_TYPES) {
+    select += "<option value='" + MAPPING_TYPES[i] + "'>" + MAPPING_TYPES[i] + "</option>";
+  }
+  $("#entityTypeSelector1").html(select);
+  $("#entityTypeSelector2").html(select);
 
-    // pre load the services
-    getData("/external/services/all", "admin-mappings").done(function (data) {
-      services = data;
-    })
+  // pre load the services
+  getData("/external/services/all", "admin").done(function (data) {
+    services = data;
+  });
+
+  // pre load the datasets
+  getData("/data/datasets", "admin").done(function (data) {
+    datasets = data;
   });
 }
 
@@ -67,6 +81,7 @@ function renderEntityTypeSelector(divId) {
       }
       entityUrn.val(getUrnForPrefixEntityType(entityType) + metricId);
     });
+
   } else if (entityType === 'SERVICE') {
     entitySelect.select2({
       placeholder: "select a service",
@@ -79,6 +94,20 @@ function renderEntityTypeSelector(divId) {
         entityUrn.val(getUrnForPrefixEntityType(entityType) + serviceArr[0]['id']);
       }
     });
+
+  } else if (entityType === 'DATASET') {
+    entitySelect.select2({
+      placeholder: "select a dataset",
+      data: datasets
+    });
+    entitySelect.on("change", function (e) {
+      const $selectedElement = $(e.currentTarget);
+      const datasetArr = $selectedElement.select2('data');
+      if (datasetArr.length) {
+        entityUrn.val(getUrnForPrefixEntityType(entityType) + datasetArr[0]['id']);
+      }
+    });
+
   } else {
     entityUrn.val(getUrnForPrefixEntityType(entityType));
   }
@@ -91,8 +120,11 @@ function getUrnForPrefixEntityType(entityType) {
     case "SERVICE":
       return "thirdeye:service:";
     case "DIMENSION":
-    case "DIMENSION_VAL":
       return "thirdeye:dimension:";
+    case "LIXTAG":
+      return "thirdeye:lixtag:";
+    case "DATASET":
+      return "thirdeye:dataset:";
     default:
       return "thirdeye:";
   }
@@ -111,15 +143,11 @@ function getEntitySpecificSelectionOptions(baseId, entityType) {
 
   switch (entityType) {
     case "METRIC":
-      html += "<select style='width:100%' id='" + baseId + "_" + entityType + "'></select><div id='"
-          + baseId + "_final_urn' ></div>";
-      break;
     case "SERVICE":
+    case "DATASET":
       html += "<select style='width:100%' id='" + baseId + "_" + entityType + "'></select><div id='"
           + baseId + "_final_urn' ></div>";
       break;
-    case "DIMENSION":
-    case "DIMENSION_VAL":
     default:
       // do nothing
   }


### PR DESCRIPTION
Currently related metrics and entities are defined on a per-metric basis. While the entity mapping pipeline supports convex hull exploration, this is has side-effects that are hard understand for our users. Instead, they fall back to repetitive entry of similar entity relationships.

This PR introduces a DatasetEntity that logically groups together multiple metrics. Common relationships of a group of metrics can now explicitly be expressed on the dataset level, as well as on an individual per-metric level as before.

* introduced DatasetEntity

* refactored MetricDatasetPipeline

* adaptations to frontend and thirdeye-admin