### PR TITLE
[TE] Decouple Pinot data source and cache loader for future extension

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.auto.onboard;
 
+import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -239,8 +240,9 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
     ThirdEyeCacheRegistry CACHE_REGISTRY = ThirdEyeCacheRegistry.getInstance();
     String sql = String.format("select count(*) from %s group by %s top 10", dataset, metricNamesColumn);
     try {
-
-      ResultSetGroup result = CACHE_REGISTRY.getResultSetGroupCache().get(new PinotQuery(sql, dataset));
+      PinotThirdEyeDataSource pinotThirdEyeDataSource = (PinotThirdEyeDataSource) CACHE_REGISTRY.getQueryCache()
+          .getDataSource(PinotThirdEyeDataSource.DATA_SOURCE_NAME);
+      ResultSetGroup result = pinotThirdEyeDataSource.executePQL(new PinotQuery(sql, dataset));
       ResultSet resultSet = result.getResultSet(0);
       int rowCount = resultSet.getRowCount();
       for (int i = 0; i < rowCount; i++) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -32,7 +32,8 @@ public class AutoOnboardPinotMetricsUtils {
   private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardPinotMetricsUtils.class);
 
   public AutoOnboardPinotMetricsUtils(DataSourceConfig dataSourceConfig) {
-      PinotThirdEyeDataSourceConfig pinotThirdeyeDataSourceConfig = PinotThirdEyeDataSourceConfig.createPinotThirdeyeDataSourceConfig(dataSourceConfig);
+    PinotThirdEyeDataSourceConfig pinotThirdeyeDataSourceConfig =
+        PinotThirdEyeDataSourceConfig.createFromDataSourceConfig(dataSourceConfig);
       this.pinotControllerClient = HttpClients.createDefault();
       this.pinotControllerHost = new HttpHost(pinotThirdeyeDataSourceConfig.getControllerHost(),
           pinotThirdeyeDataSourceConfig.getControllerPort());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/completeness/checker/DataCompletenessUtils.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.completeness.checker;
 
+import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -208,7 +209,9 @@ public class DataCompletenessUtils {
         dataset, sb.toString(), timeSpec.getColumnName(), top);
     Map<Long, Long> timeValueToCount = new HashMap<>();
     try {
-      ResultSetGroup resultSetGroup = CACHE_REGISTRY.getResultSetGroupCache().get(new PinotQuery(pql, dataset));
+      PinotThirdEyeDataSource pinotThirdEyeDataSource = (PinotThirdEyeDataSource) CACHE_REGISTRY.getQueryCache()
+          .getDataSource(PinotThirdEyeDataSource.DATA_SOURCE_NAME);
+      ResultSetGroup resultSetGroup = pinotThirdEyeDataSource.executePQL(new PinotQuery(pql, dataset));
       if (resultSetGroup == null || resultSetGroup.getResultSetCount() <= 0) {
         return bucketNameToCountStar;
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/Utils.java
@@ -1,24 +1,6 @@
 package com.linkedin.thirdeye.dashboard;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
@@ -26,76 +8,29 @@ import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
-import com.linkedin.thirdeye.datalayer.bao.DashboardConfigManager;
-import com.linkedin.thirdeye.datalayer.dto.DashboardConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datasource.MetricExpression;
 import com.linkedin.thirdeye.datasource.MetricFunction;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
-import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
-import com.linkedin.thirdeye.datasource.ThirdEyeResponse;
-import com.linkedin.thirdeye.datasource.ThirdEyeRequest.ThirdEyeRequestBuilder;
-import com.linkedin.thirdeye.datasource.cache.QueryCache;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Utils {
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static ThirdEyeCacheRegistry CACHE_REGISTRY = ThirdEyeCacheRegistry.getInstance();
-
-  public static List<ThirdEyeRequest> generateFilterRequests(String dataset, String requestReference,
-      MetricFunction metricFunction, List<String> dimensions, DateTime start, DateTime end, String dataSource) {
-
-    List<ThirdEyeRequest> requests = new ArrayList<>();
-
-    for (String dimension : dimensions) {
-      ThirdEyeRequestBuilder requestBuilder = new ThirdEyeRequestBuilder();
-      List<MetricFunction> metricFunctions = Arrays.asList(metricFunction);
-      requestBuilder.setMetricFunctions(metricFunctions);
-
-      requestBuilder.setStartTimeInclusive(start);
-      requestBuilder.setEndTimeExclusive(end);
-      requestBuilder.setGroupBy(dimension);
-      requestBuilder.setDataSource(dataSource);
-      ThirdEyeRequest request = requestBuilder.build(requestReference);
-      requests.add(request);
-    }
-
-    return requests;
-  }
-
-  public static Map<String, List<String>> getFilters(QueryCache queryCache, String dataset,
-      String requestReference, List<String> dimensions, DateTime start,
-      DateTime end) throws Exception {
-
-    DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(dataset);
-    MetricFunction metricFunction = new MetricFunction(MetricAggFunction.COUNT, "*", null, dataset, null, datasetConfig);
-
-    List<ThirdEyeRequest> requests =
-        generateFilterRequests(dataset, requestReference, metricFunction, dimensions, start, end, datasetConfig.getDataSource());
-
-    Map<ThirdEyeRequest, Future<ThirdEyeResponse>> queryResultMap =
-        queryCache.getQueryResultsAsync(requests);
-
-    Map<String, List<String>> result = new HashMap<>();
-    for (Map.Entry<ThirdEyeRequest, Future<ThirdEyeResponse>> entry : queryResultMap.entrySet()) {
-      ThirdEyeRequest request = entry.getKey();
-      String dimension = request.getGroupBy().get(0);
-      ThirdEyeResponse thirdEyeResponse = entry.getValue().get();
-      int n = thirdEyeResponse.getNumRowsFor(metricFunction);
-
-      List<String> values = new ArrayList<>();
-      for (int i = 0; i < n; i++) {
-        Map<String, String> row = thirdEyeResponse.getRow(metricFunction, i);
-        String dimensionValue = row.get(dimension);
-        values.add(dimensionValue);
-      }
-      Collections.sort(values);
-      result.put(dimension, values);
-    }
-    return result;
-  }
 
   public static List<String> getSortedDimensionNames(String collection)
       throws Exception {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeCacheRegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeCacheRegistry.java
@@ -1,8 +1,6 @@
 package com.linkedin.thirdeye.datasource;
 
-import com.google.common.cache.Weigher;
-
-import com.linkedin.pinot.client.ResultSet;
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -14,8 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.LoadingCache;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
 import com.linkedin.pinot.client.ResultSetGroup;
 import com.linkedin.thirdeye.common.ThirdEyeConfiguration;
 import com.linkedin.thirdeye.dashboard.resources.CacheResource;
@@ -34,112 +30,85 @@ import com.linkedin.thirdeye.datasource.cache.DimensionFiltersCacheLoader;
 import com.linkedin.thirdeye.datasource.cache.MetricConfigCacheLoader;
 import com.linkedin.thirdeye.datasource.cache.MetricDataset;
 import com.linkedin.thirdeye.datasource.cache.QueryCache;
-import com.linkedin.thirdeye.datasource.cache.ResultSetGroupCacheLoader;
 import com.linkedin.thirdeye.datasource.pinot.PinotQuery;
-import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSourceConfig;
 
 public class ThirdEyeCacheRegistry {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThirdEyeCacheRegistry.class);
+  static final ThirdEyeCacheRegistry INSTANCE = new ThirdEyeCacheRegistry();
 
-  private LoadingCache<String, DatasetConfigDTO> datasetConfigCache;
-  private LoadingCache<MetricDataset, MetricConfigDTO> metricConfigCache;
-  private LoadingCache<String, List<DashboardConfigDTO>> dashboardConfigsCache;
-  private LoadingCache<PinotQuery, ResultSetGroup> resultSetGroupCache;
-  private LoadingCache<String, Long> datasetMaxDataTimeCache;
-  private LoadingCache<String, String> dimensionFiltersCache;
-  private DatasetListCache datasetsCache;
-  private QueryCache queryCache;
+  public static final long CACHE_EXPIRATION_HOURS = 1;
 
+  // DAO to ThirdEye's data and meta-data storage.
+  private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
   private static DatasetConfigManager datasetConfigDAO;
   private static MetricConfigManager metricConfigDAO;
   private static DashboardConfigManager dashboardConfigDAO;
   private static AnomalyFunctionManager anomalyFunctionDAO;
 
+  // Data sources to time series databases.
   private static Map<String, ThirdEyeDataSource> thirdEyeDataSourcesMap;
-  private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
+  // TODO: Rename QueryCache to a name like DataSrouceCache.
+  private QueryCache queryCache;
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ThirdEyeCacheRegistry.class);
-
-  private static ThirdEyeConfiguration thirdeyeConfig = null;
-  private static DataSources dataSources = null;
-
-  // TODO: make default cache size configurable
-  private static final int DEFAULT_HEAP_PERCENTAGE_FOR_RESULTSETGROUP_CACHE = 50;
-  private static final int DEFAULT_LOWER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB = 100;
-  private static final int DEFAULT_UPPER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB = 8192;
-  private static final long CACHE_EXPIRATION_HOURS = 1;
-
-  private static class Holder {
-    static final ThirdEyeCacheRegistry INSTANCE = new ThirdEyeCacheRegistry();
-  }
+  // Meta-data caches
+  private LoadingCache<String, DatasetConfigDTO> datasetConfigCache;
+  private LoadingCache<MetricDataset, MetricConfigDTO> metricConfigCache;
+  private LoadingCache<String, List<DashboardConfigDTO>> dashboardConfigsCache;
+  private LoadingCache<String, Long> datasetMaxDataTimeCache;
+  private LoadingCache<String, String> dimensionFiltersCache;
+  private DatasetListCache datasetsCache;
 
   public static ThirdEyeCacheRegistry getInstance() {
-    return Holder.INSTANCE;
+    return INSTANCE;
   }
 
-
   /**
-   * Initializes webapp caches
-   * @param config
+   * Initializes data sources and caches.
+   *
+   * @param config ThirdEye's configurations.
    */
-  public static void initializeCaches(ThirdEyeConfiguration config) throws Exception {
-
-    thirdeyeConfig = config;
-    init();
-    initCaches();
+  public static void initializeCaches(ThirdEyeConfiguration thirdeyeConfig) throws Exception {
+    initDataSources(thirdeyeConfig);
+    initMetaDataCaches(thirdeyeConfig);
     initPeriodicCacheRefresh();
   }
 
-  private static void init() {
+  /**
+   * Initializes the adaptor to data sources such as Pinot, MySQL, etc.
+   */
+  private static void initDataSources(ThirdEyeConfiguration thirdeyeConfig) {
     try {
+      // Initialize adaptors to time series databases.
       String dataSourcesPath = thirdeyeConfig.getDataSourcesPath();
-      dataSources = DataSourcesLoader.fromDataSourcesPath(dataSourcesPath);
+      DataSources dataSources = DataSourcesLoader.fromDataSourcesPath(dataSourcesPath);
       if (dataSources == null) {
         throw new IllegalStateException("Could not create data sources from path " + dataSourcesPath);
       }
+      // Query Cache
       thirdEyeDataSourcesMap = DataSourcesLoader.getDataSourceMap(dataSources);
+      QueryCache queryCache = new QueryCache(thirdEyeDataSourcesMap, Executors.newFixedThreadPool(10));
+      ThirdEyeCacheRegistry.getInstance().registerQueryCache(queryCache);
+
+      // Initialize connection to ThirdEye's anomaly and meta-data storage.
       datasetConfigDAO = DAO_REGISTRY.getDatasetConfigDAO();
       metricConfigDAO = DAO_REGISTRY.getMetricConfigDAO();
       dashboardConfigDAO = DAO_REGISTRY.getDashboardConfigDAO();
       anomalyFunctionDAO = DAO_REGISTRY.getAnomalyFunctionDAO();
-
     } catch (Exception e) {
      LOGGER.info("Caught exception while initializing caches", e);
     }
   }
 
-  private static void initCaches() throws Exception {
+  /**
+   * Initialize the cache for meta data. This method has to be invoked after data sources are connected.
+   *
+   * @throws Exception
+   */
+  private static void initMetaDataCaches(ThirdEyeConfiguration thirdeyeConfig) throws Exception {
     ThirdEyeCacheRegistry cacheRegistry = ThirdEyeCacheRegistry.getInstance();
-
-    RemovalListener<PinotQuery, ResultSetGroup> listener = new RemovalListener<PinotQuery, ResultSetGroup>() {
-      @Override
-      public void onRemoval(RemovalNotification<PinotQuery, ResultSetGroup> notification) {
-        LOGGER.info("Expired {}", notification.getKey().getPql());
-      }
-    };
-
-    // ResultSetGroup Cache. The size of this cache is limited by the total number of buckets in all ResultSetGroup.
-    // We estimate that 1 bucket (including overhead) consumes 1KB and this cache is allowed to use up to 50% of max
-    // heap space.
-    PinotThirdEyeDataSourceConfig pinotThirdeyeDataSourceConfig = PinotThirdEyeDataSourceConfig.createPinotThirdeyeDataSourceConfig(dataSources);
-    long maxBucketNumber = getApproximateMaxBucketNumber(DEFAULT_HEAP_PERCENTAGE_FOR_RESULTSETGROUP_CACHE);
-    LoadingCache<PinotQuery, ResultSetGroup> resultSetGroupCache = CacheBuilder.newBuilder()
-        .removalListener(listener)
-        .expireAfterWrite(CACHE_EXPIRATION_HOURS, TimeUnit.HOURS)
-        .maximumWeight(maxBucketNumber)
-        .weigher(new Weigher<PinotQuery, ResultSetGroup>() {
-          @Override public int weigh(PinotQuery pinotQuery, ResultSetGroup resultSetGroup) {
-            int resultSetCount = resultSetGroup.getResultSetCount();
-            int weight = 0;
-            for (int idx = 0; idx < resultSetCount; ++idx) {
-              ResultSet resultSet = resultSetGroup.getResultSet(idx);
-              weight += (resultSet.getColumnCount() * resultSet.getRowCount());
-            }
-            return weight;
-          }
-        })
-        .build(new ResultSetGroupCacheLoader(pinotThirdeyeDataSourceConfig));
-    cacheRegistry.registerResultSetGroupCache(resultSetGroupCache);
-    LOGGER.info("Max bucket number for ResultSetGroup cache is set to {}", maxBucketNumber);
+    QueryCache queryCache = cacheRegistry.getQueryCache();
+    Preconditions.checkNotNull(queryCache,
+        "Data sources are not initialzed. Please invoke initDataSources() before this method.");
 
     // DatasetConfig cache
     LoadingCache<String, DatasetConfigDTO> datasetConfigCache = CacheBuilder.newBuilder()
@@ -156,10 +125,6 @@ public class ThirdEyeCacheRegistry {
         .expireAfterWrite(CACHE_EXPIRATION_HOURS, TimeUnit.HOURS).build(new DashboardConfigCacheLoader(dashboardConfigDAO));
     cacheRegistry.registerDashboardConfigsCache(dashboardConfigsCache);
 
-    // Query Cache
-    QueryCache queryCache = new QueryCache(thirdEyeDataSourcesMap, Executors.newFixedThreadPool(10));
-    cacheRegistry.registerQueryCache(queryCache);
-
     // DatasetMaxDataTime Cache
     LoadingCache<String, Long> datasetMaxDataTimeCache = CacheBuilder.newBuilder()
         .refreshAfterWrite(5, TimeUnit.MINUTES)
@@ -167,14 +132,14 @@ public class ThirdEyeCacheRegistry {
     cacheRegistry.registerDatasetMaxDataTimeCache(datasetMaxDataTimeCache);
 
     // Dimension Filter cache
-    LoadingCache<String, String> dimensionFiltersCache = CacheBuilder.newBuilder()
-        .expireAfterWrite(CACHE_EXPIRATION_HOURS, TimeUnit.HOURS).build(new DimensionFiltersCacheLoader(queryCache, datasetConfigDAO));
+    LoadingCache<String, String> dimensionFiltersCache =
+        CacheBuilder.newBuilder().expireAfterWrite(CACHE_EXPIRATION_HOURS, TimeUnit.HOURS)
+            .build(new DimensionFiltersCacheLoader(queryCache, datasetConfigDAO));
     cacheRegistry.registerDimensionFiltersCache(dimensionFiltersCache);
 
     // Collections cache
     DatasetListCache datasetsCache = new DatasetListCache(anomalyFunctionDAO, datasetConfigDAO, thirdeyeConfig);
     cacheRegistry.registerDatasetsCache(datasetsCache);
-
   }
 
   private static void initPeriodicCacheRefresh() {
@@ -242,14 +207,6 @@ public class ThirdEyeCacheRegistry {
     }, 7, 7, TimeUnit.DAYS);
   }
 
-  public LoadingCache<PinotQuery, ResultSetGroup> getResultSetGroupCache() {
-    return resultSetGroupCache;
-  }
-
-  public void registerResultSetGroupCache(LoadingCache<PinotQuery, ResultSetGroup> resultSetGroupCache) {
-    this.resultSetGroupCache = resultSetGroupCache;
-  }
-
   public LoadingCache<String, Long> getDatasetMaxDataTimeCache() {
     return datasetMaxDataTimeCache;
   }
@@ -305,31 +262,4 @@ public class ThirdEyeCacheRegistry {
   public void registerDashboardConfigsCache(LoadingCache<String, List<DashboardConfigDTO>> dashboardConfigsCache) {
     this.dashboardConfigsCache = dashboardConfigsCache;
   }
-
-  /**
-   * Returns the suggested max weight for LoadingCache according to the given percentage of max heap space.
-   *
-   * The approximate weight is calculated by following rules:
-   * 1. We estimate that a bucket, including its overhead, occupies 1 KB.
-   * 2. Cache size (in bytes) = System's maxMemory * percentage
-   * 3. We also bound the cache size between DEFAULT_LOWER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB and
-   *    DEFAULT_UPPER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB if max heap size is unavailable.
-   * 4. Weight (number of buckets) = cache size / 1KB.
-   *
-   * @param percentage the percentage of JVM max heap space
-   * @return the suggested max weight for LoadingCache
-   */
-  private static long getApproximateMaxBucketNumber(int percentage) {
-    long jvmMaxMemoryInBytes = Runtime.getRuntime().maxMemory();
-    if (jvmMaxMemoryInBytes == Long.MAX_VALUE) { // Check upper bound
-      jvmMaxMemoryInBytes = DEFAULT_UPPER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB * 1048576L; // MB to Bytes
-    } else { // Check lower bound
-      long lowerBoundInBytes = DEFAULT_LOWER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB * 1048576L; // MB to Bytes
-      if (jvmMaxMemoryInBytes < lowerBoundInBytes) {
-        jvmMaxMemoryInBytes = lowerBoundInBytes;
-      }
-    }
-    return (jvmMaxMemoryInBytes / 102400) * percentage;
-  }
-
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/cache/QueryCache.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/cache/QueryCache.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import com.linkedin.thirdeye.datasource.ThirdEyeDataSource;
 import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
@@ -20,10 +19,6 @@ public class QueryCache {
   public QueryCache(Map<String, ThirdEyeDataSource> dataSourceMap, ExecutorService executorService) {
     this.executorService = executorService;
     this.dataSourceMap = dataSourceMap;
-  }
-
-  public Map<String, ThirdEyeDataSource> getDataSourceMap() {
-    return dataSourceMap;
   }
 
   public ThirdEyeDataSource getDataSource(String dataSource) {
@@ -68,29 +63,7 @@ public class QueryCache {
     return responseFuturesMap;
   }
 
-  public Map<ThirdEyeRequest, ThirdEyeResponse> getQueryResultsAsyncAndWait(
-      final List<ThirdEyeRequest> requests) throws Exception {
-    return getQueryResultsAsyncAndWait(requests, 60);
-  }
-
-  public Map<ThirdEyeRequest, ThirdEyeResponse> getQueryResultsAsyncAndWait(
-      final List<ThirdEyeRequest> requests, int timeoutSeconds) throws Exception {
-    Map<ThirdEyeRequest, ThirdEyeResponse> responseMap = new LinkedHashMap<>();
-    for (final ThirdEyeRequest request : requests) {
-      Future<ThirdEyeResponse> responseFuture =
-          executorService.submit(new Callable<ThirdEyeResponse>() {
-            @Override
-            public ThirdEyeResponse call() throws Exception {
-              return getQueryResult(request);
-            }
-          });
-      responseMap.put(request, responseFuture.get(timeoutSeconds, TimeUnit.SECONDS));
-    }
-    return responseMap;
-  }
-
   public void clear() throws Exception {
     dataSourceMap.clear();
   }
-
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
@@ -1,16 +1,14 @@
-package com.linkedin.thirdeye.datasource.cache;
+package com.linkedin.thirdeye.datasource.pinot;
 
-import com.google.common.cache.CacheLoader;
 import com.linkedin.pinot.client.Connection;
 import com.linkedin.pinot.client.ConnectionFactory;
 import com.linkedin.pinot.client.PinotClientException;
 import com.linkedin.pinot.client.ResultSet;
 import com.linkedin.pinot.client.ResultSetGroup;
-import com.linkedin.thirdeye.datasource.pinot.PinotQuery;
-import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSourceConfig;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -23,8 +21,8 @@ import org.apache.helix.model.InstanceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ResultSetGroupCacheLoader extends CacheLoader<PinotQuery, ResultSetGroup> {
-  private static final Logger LOG = LoggerFactory.getLogger(ResultSetGroupCacheLoader.class);
+public class PinotControllerResponseCacheLoader extends PinotResponseCacheLoader {
+  private static final Logger LOG = LoggerFactory.getLogger(PinotControllerResponseCacheLoader.class);
 
   private static final long CONNECTION_TIMEOUT = 60000;
 
@@ -40,8 +38,44 @@ public class ResultSetGroupCacheLoader extends CacheLoader<PinotQuery, ResultSet
 
   private static final String BROKER_PREFIX = "Broker_";
 
-  public ResultSetGroupCacheLoader(PinotThirdEyeDataSourceConfig pinotThirdEyeDataSourceConfig) throws Exception {
+  /**
+   * Constructs a empty {@link PinotControllerResponseCacheLoader}. Please use init() to setup the connection of the
+   * constructed cache loader.
+   */
+  public PinotControllerResponseCacheLoader() { }
 
+  /**
+   * Constructs a {@link PinotControllerResponseCacheLoader} using the given data source config.
+   *
+   * @param pinotThirdEyeDataSourceConfig the data source config that provides controller's information.
+   *
+   * @throws Exception when an error occurs connecting to the Pinot controller.
+   */
+  public PinotControllerResponseCacheLoader(PinotThirdEyeDataSourceConfig pinotThirdEyeDataSourceConfig)
+      throws Exception {
+    this.init(pinotThirdEyeDataSourceConfig);
+  }
+
+  /**
+   * Initializes the cache loader using the given property map.
+   *
+   * @param properties the property map that provides controller's information.
+   *
+   * @throws Exception when an error occurs connecting to the Pinot controller.
+   */
+  void init(Map<String, String> properties) throws Exception {
+    PinotThirdEyeDataSourceConfig dataSourceConfig = PinotThirdEyeDataSourceConfig.createFromProperties(properties);
+    this.init(dataSourceConfig);
+  }
+
+  /**
+   * Initializes the cache loader using the given data source config.
+   *
+   * @param pinotThirdEyeDataSourceConfig the data source config that provides controller's information.
+   *
+   * @throws Exception when an error occurs connecting to the Pinot controller.
+   */
+  private void init(PinotThirdEyeDataSourceConfig pinotThirdEyeDataSourceConfig) throws Exception {
     if (pinotThirdEyeDataSourceConfig.getBrokerUrl() != null
         && pinotThirdEyeDataSourceConfig.getBrokerUrl().trim().length() > 0) {
       ZkClient zkClient = new ZkClient(pinotThirdEyeDataSourceConfig.getZookeeperUrl());
@@ -60,8 +94,11 @@ public class ResultSetGroupCacheLoader extends CacheLoader<PinotQuery, ResultSet
             + instanceConfig.getPort();
       }
       this.connections = fromHostList(thirdeyeBrokers);
+      LOG.info("Created PinotControllerResponseCacheLoader with brokers {}", thirdeyeBrokers);
     } else {
       this.connections = fromZookeeper(pinotThirdEyeDataSourceConfig);
+      LOG.info("Created PinotControllerResponseCacheLoader with controller {}:{}",
+          pinotThirdEyeDataSourceConfig.getControllerHost(), pinotThirdEyeDataSourceConfig.getControllerPort());
     }
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotControllerResponseCacheLoader.java
@@ -63,7 +63,7 @@ public class PinotControllerResponseCacheLoader extends PinotResponseCacheLoader
    *
    * @throws Exception when an error occurs connecting to the Pinot controller.
    */
-  void init(Map<String, String> properties) throws Exception {
+  public void init(Map<String, String> properties) throws Exception {
     PinotThirdEyeDataSourceConfig dataSourceConfig = PinotThirdEyeDataSourceConfig.createFromProperties(properties);
     this.init(dataSourceConfig);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
@@ -1,21 +1,39 @@
 package com.linkedin.thirdeye.datasource.pinot;
 
+import com.linkedin.thirdeye.constant.MetricAggFunction;
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datasource.MetricFunction;
+import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
+import com.linkedin.thirdeye.datasource.ThirdEyeResponse;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.thirdeye.dashboard.Utils;
-import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
 
 /**
  * This class helps return dimension filters for a dataset from the Pinot data source
  */
 public class PinotDataSourceDimensionFilters {
   private static final Logger LOG = LoggerFactory.getLogger(PinotDataSourceDimensionFilters.class);
-  private static final ThirdEyeCacheRegistry CACHE_REGISTRY = ThirdEyeCacheRegistry.getInstance();
+  private static final ExecutorService executorService = Executors.newFixedThreadPool(10);
+  private final PinotThirdEyeDataSource pinotThirdEyeDataSource;
+
+  public PinotDataSourceDimensionFilters(PinotThirdEyeDataSource pinotThirdEyeDataSource) {
+    this.pinotThirdEyeDataSource = pinotThirdEyeDataSource;
+  }
 
   /**
    * This method gets the dimension filters for the given dataset from the pinot data source,
@@ -31,11 +49,69 @@ public class PinotDataSourceDimensionFilters {
     try {
       LOG.debug("Loading dimension filters cache {}", dataset);
       List<String> dimensions = Utils.getSortedDimensionNames(dataset);
-      filters = Utils.getFilters(CACHE_REGISTRY.getQueryCache(), dataset, "filters", dimensions, startDateTime, endDateTime);
+      filters = getFilters(dataset, dimensions, startDateTime, endDateTime);
     } catch (Exception e) {
       LOG.error("Error while fetching dimension values in filter drop down for collection: {}", dataset, e);
     }
     return filters;
   }
 
+  private Map<String, List<String>> getFilters(String dataset, List<String> dimensions, DateTime start, DateTime end)
+      throws Exception {
+    DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(dataset);
+    MetricFunction metricFunction =
+        new MetricFunction(MetricAggFunction.COUNT, "*", null, dataset, null, datasetConfig);
+    List<ThirdEyeRequest> requests =
+        generateFilterRequests(metricFunction, dimensions, start, end, datasetConfig.getDataSource());
+
+    Map<ThirdEyeRequest, Future<ThirdEyeResponse>> responseFuturesMap = new LinkedHashMap<>();
+    for (final ThirdEyeRequest request : requests) {
+      Future<ThirdEyeResponse> responseFuture = executorService.submit(new Callable<ThirdEyeResponse>() {
+        @Override
+        public ThirdEyeResponse call() throws Exception {
+          return pinotThirdEyeDataSource.execute(request);
+        }
+      });
+      responseFuturesMap.put(request, responseFuture);
+    }
+
+    Map<String, List<String>> result = new HashMap<>();
+    for (Map.Entry<ThirdEyeRequest, Future<ThirdEyeResponse>> entry : responseFuturesMap.entrySet()) {
+      ThirdEyeRequest request = entry.getKey();
+      String dimension = request.getGroupBy().get(0);
+      ThirdEyeResponse thirdEyeResponse = entry.getValue().get();
+      int n = thirdEyeResponse.getNumRowsFor(metricFunction);
+
+      List<String> values = new ArrayList<>();
+      for (int i = 0; i < n; i++) {
+        Map<String, String> row = thirdEyeResponse.getRow(metricFunction, i);
+        String dimensionValue = row.get(dimension);
+        values.add(dimensionValue);
+      }
+      Collections.sort(values);
+      result.put(dimension, values);
+    }
+    return result;
+  }
+
+  private static List<ThirdEyeRequest> generateFilterRequests(MetricFunction metricFunction, List<String> dimensions,
+      DateTime start, DateTime end, String dataSource) {
+
+    List<ThirdEyeRequest> requests = new ArrayList<>();
+
+    for (String dimension : dimensions) {
+      ThirdEyeRequest.ThirdEyeRequestBuilder requestBuilder = new ThirdEyeRequest.ThirdEyeRequestBuilder();
+      List<MetricFunction> metricFunctions = Collections.singletonList(metricFunction);
+      requestBuilder.setMetricFunctions(metricFunctions);
+
+      requestBuilder.setStartTimeInclusive(start);
+      requestBuilder.setEndTimeExclusive(end);
+      requestBuilder.setGroupBy(dimension);
+      requestBuilder.setDataSource(dataSource);
+      ThirdEyeRequest request = requestBuilder.build("filters");
+      requests.add(request);
+    }
+
+    return requests;
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotResponseCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotResponseCacheLoader.java
@@ -12,5 +12,5 @@ public abstract class PinotResponseCacheLoader extends CacheLoader<PinotQuery, R
    *
    * @throws Exception when an error occurs connecting to the Pinot controller.
    */
-  abstract void init(Map<String, String> properties) throws Exception;
+  public abstract void init(Map<String, String> properties) throws Exception;
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotResponseCacheLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotResponseCacheLoader.java
@@ -1,0 +1,16 @@
+package com.linkedin.thirdeye.datasource.pinot;
+
+import com.google.common.cache.CacheLoader;
+import com.linkedin.pinot.client.ResultSetGroup;
+import java.util.Map;
+
+public abstract class PinotResponseCacheLoader extends CacheLoader<PinotQuery, ResultSetGroup> {
+  /**
+   * Initializes the cache loader using the given property map.
+   *
+   * @param properties the property map that provides the information to connect to the data source.
+   *
+   * @throws Exception when an error occurs connecting to the Pinot controller.
+   */
+  abstract void init(Map<String, String> properties) throws Exception;
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -1,8 +1,15 @@
 package com.linkedin.thirdeye.datasource.pinot;
 
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.cache.Weigher;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -14,8 +21,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkClient;
 import org.apache.http.HttpHost;
@@ -42,56 +49,72 @@ import com.linkedin.thirdeye.datasource.TimeRangeUtils;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
 
 public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
-
   private static final Logger LOG = LoggerFactory.getLogger(PinotThirdEyeDataSource.class);
   private static final ThirdEyeCacheRegistry CACHE_REGISTRY_INSTANCE = ThirdEyeCacheRegistry.getInstance();
-
-  private final HttpHost controllerHost;
-  private final CloseableHttpClient controllerClient;
   public static final String DATA_SOURCE_NAME = PinotThirdEyeDataSource.class.getSimpleName();
-  private PinotDataSourceMaxTime pinotDataSourceMaxTime;
-  private PinotDataSourceDimensionFilters pinotDataSourceDimensionFilters;
 
-  public PinotThirdEyeDataSource(Map<String, String> properties) {
-    if (!isValidProperties(properties)) {
-      throw new IllegalStateException("Invalid properties for data source " + DATA_SOURCE_NAME + " " + properties);
+  public static final String CACHE_LOADER_CLASS_NAME_STRING = "cacheLoaderClassName";
+  // TODO: make default cache size configurable
+  private static final int DEFAULT_HEAP_PERCENTAGE_FOR_RESULTSETGROUP_CACHE = 50;
+  private static final int DEFAULT_LOWER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB = 100;
+  private static final int DEFAULT_UPPER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB = 8192;
+  protected LoadingCache<PinotQuery, ResultSetGroup> pinotResponseCache;
+
+  protected PinotDataSourceMaxTime pinotDataSourceMaxTime;
+  protected PinotDataSourceDimensionFilters pinotDataSourceDimensionFilters;
+
+  /**
+   * Construct a Pinot data source, which connects to a Pinot controller, using {@link PinotThirdEyeDataSourceConfig}.
+   *
+   * @param pinotThirdEyeDataSourceConfig the configuration that provides the information of the Pinot controller.
+   *
+   * @throws Exception when failed to connect to the controller.
+   */
+  public PinotThirdEyeDataSource(PinotThirdEyeDataSourceConfig pinotThirdEyeDataSourceConfig) throws Exception {
+    PinotResponseCacheLoader pinotResponseCacheLoader = new PinotControllerResponseCacheLoader(pinotThirdEyeDataSourceConfig);
+    pinotResponseCache = buildResponseCache(pinotResponseCacheLoader);
+
+    pinotDataSourceMaxTime = new PinotDataSourceMaxTime(this);
+    pinotDataSourceDimensionFilters = new PinotDataSourceDimensionFilters(this);
+  }
+
+  /**
+   * This constructor is invoked by Java Reflection for initialize a ThirdEyeDataSource.
+   *
+   * @param properties the property to initialize this data source.
+   */
+  public PinotThirdEyeDataSource(Map<String, String> properties) throws Exception {
+    Preconditions.checkNotNull(properties, "Data source property cannot be empty.");
+
+    PinotResponseCacheLoader pinotResponseCacheLoader = getCacheLoaderInstance(properties);
+    pinotResponseCacheLoader.init(properties);
+    pinotResponseCache = buildResponseCache(pinotResponseCacheLoader);
+
+    pinotDataSourceMaxTime = new PinotDataSourceMaxTime(this);
+    pinotDataSourceDimensionFilters = new PinotDataSourceDimensionFilters(this);
+  }
+
+  /**
+   * Constructs a PinotResponseCacheLoader from the given property map and initialize the loader with that map.
+   *
+   * @param properties the property map of the cache loader, which contains the class path of the cache loader.
+   *
+   * @return a constructed PinotResponseCacheLoader.
+   *
+   * @throws Exception when an error occurs connecting to the Pinot controller.
+   */
+  static PinotResponseCacheLoader getCacheLoaderInstance(Map<String, String> properties)
+      throws Exception {
+    final String cacheLoaderClassName;
+    if (properties.containsKey(CACHE_LOADER_CLASS_NAME_STRING)) {
+      cacheLoaderClassName = properties.get(CACHE_LOADER_CLASS_NAME_STRING);
+    } else {
+      cacheLoaderClassName = PinotControllerResponseCacheLoader.class.getName();
     }
-    String host = properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue());
-    int port = Integer.valueOf(properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue()));
-    String zookeeperUrl = properties.get(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue());
-
-    ZkClient zkClient = new ZkClient(zookeeperUrl);
-    zkClient.setZkSerializer(new ZNRecordSerializer());
-    zkClient.waitUntilConnected();
-    this.controllerHost = new HttpHost(host, port);
-    this.controllerClient = HttpClients.createDefault();
-
-    pinotDataSourceMaxTime = new PinotDataSourceMaxTime();
-    pinotDataSourceDimensionFilters = new PinotDataSourceDimensionFilters();
-    LOG.info("Created PinotThirdEyeDataSource with controller {}", controllerHost);
+    Constructor<?> constructor = Class.forName(cacheLoaderClassName).getConstructor();
+    PinotResponseCacheLoader pinotResponseCacheLoader = (PinotResponseCacheLoader) constructor.newInstance();
+    return pinotResponseCacheLoader;
   }
-
-  protected PinotThirdEyeDataSource(String host, int port) {
-    this.controllerHost = new HttpHost(host, port);
-    this.controllerClient = HttpClients.createDefault();
-    pinotDataSourceMaxTime = new PinotDataSourceMaxTime();
-    pinotDataSourceDimensionFilters = new PinotDataSourceDimensionFilters();
-    LOG.info("Created PinotThirdEyeDataSource with controller {}", controllerHost);
-  }
-
-  public static PinotThirdEyeDataSource fromZookeeper(String controllerHost, int controllerPort, String zkUrl) {
-    ZkClient zkClient = new ZkClient(zkUrl);
-    zkClient.setZkSerializer(new ZNRecordSerializer());
-    zkClient.waitUntilConnected();
-    PinotThirdEyeDataSource pinotThirdEyeDataSource = new PinotThirdEyeDataSource(controllerHost, controllerPort);
-    LOG.info("Created PinotThirdEyeDataSource to zookeeper: {} controller: {}:{}", zkUrl, controllerHost, controllerPort);
-    return pinotThirdEyeDataSource;
-  }
-
-  public static ThirdEyeDataSource fromDataSourceConfig(PinotThirdEyeDataSourceConfig pinotDataSourceConfig) {
-    return fromZookeeper(pinotDataSourceConfig.getControllerHost(), pinotDataSourceConfig.getControllerPort(), pinotDataSourceConfig.getZookeeperUrl());
-  }
-
 
   @Override
   public String getName() {
@@ -100,6 +123,9 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
 
   @Override
   public PinotThirdEyeResponse execute(ThirdEyeRequest request) throws Exception {
+    Preconditions.checkNotNull(this.pinotResponseCache, "{} doesn't connect to Pinot or cache is not initialized.",
+        getName());
+
     long tStart = System.nanoTime();
     try {
       LinkedHashMap<MetricFunction, List<ResultSet>> metricFunctionToResultSetList = new LinkedHashMap<>();
@@ -132,7 +158,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
         } else {
           pql = PqlUtils.getPql(request, metricFunction, decoratedFilterSet, dataTimeSpec);
         }
-        ResultSetGroup resultSetGroup = CACHE_REGISTRY_INSTANCE.getResultSetGroupCache().get(new PinotQuery(pql, tableName));
+        ResultSetGroup resultSetGroup = this.executePQL(new PinotQuery(pql, tableName));
         metricFunctionToResultSetList.put(metricFunction, getResultSetList(resultSetGroup));
       }
 
@@ -198,6 +224,38 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     return decoratedFilterSet;
   }
 
+  /**
+   * Returns the cached ResultSetGroup corresponding to the given Pinot query.
+   *
+   * @param pinotQuery the query that is specifically constructed for Pinot.
+   * @return the corresponding ResultSetGroup to the given Pinot query.
+   *
+   * @throws ExecutionException is thrown if failed to connect to Pinot or gets results from Pinot.
+   */
+  public ResultSetGroup executePQL(PinotQuery pinotQuery) throws ExecutionException {
+    Preconditions
+        .checkNotNull(this.pinotResponseCache, "{} doesn't connect to Pinot or cache is not initialized.", getName());
+
+    return this.pinotResponseCache.get(pinotQuery);
+  }
+
+  /**
+   * Refreshes and returns the cached ResultSetGroup corresponding to the given Pinot query.
+   *
+   * @param pinotQuery the query that is specifically constructed for Pinot.
+   * @return the corresponding ResultSetGroup to the given Pinot query.
+   *
+   * @throws ExecutionException is thrown if failed to connect to Pinot or gets results from Pinot.
+   */
+  public ResultSetGroup refreshPQL(PinotQuery pinotQuery) throws ExecutionException {
+    Preconditions
+        .checkNotNull(this.pinotResponseCache, "{} doesn't connect to Pinot or cache is not initialized.", getName());
+
+    pinotResponseCache.refresh(pinotQuery);
+
+    return pinotResponseCache.get(pinotQuery);
+  }
+
   private static List<ResultSet> getResultSetList(ResultSetGroup resultSetGroup) {
     List<ResultSet> resultSets = new ArrayList<>();
     for (int i = 0; i < resultSetGroup.getResultSetCount(); i++) {
@@ -205,7 +263,6 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     }
     return resultSets;
   }
-
 
   private List<String[]> parseResultSets(ThirdEyeRequest request,
       Map<MetricFunction, List<ResultSet>> metricFunctionToResultSetList) throws ExecutionException {
@@ -324,7 +381,6 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     return CACHE_REGISTRY_INSTANCE.getDatasetsCache().getDatasets();
   }
 
-
   @Override
   public long getMaxDataTime(String dataset) throws Exception {
     return pinotDataSourceMaxTime.getMaxDateTime(dataset);
@@ -344,41 +400,114 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     controllerClient.close();
   }
 
-  private boolean isValidProperties(Map<String, String> properties) {
-    boolean valid = true;
-    if (MapUtils.isEmpty(properties)) {
-      valid = false;
-      LOG.error("PinotThirdEyeDataSource is missing properties {}", properties);
+  /**
+   * Initialzes the cache and cache loader for the response of this data source.
+   *
+   * @param pinotThirdeyeDataSourceConfig the properties to initialize this cache.
+   *
+   * @throws Exception is thrown when Pinot brokers are unable to be reached.
+   */
+  private static LoadingCache<PinotQuery, ResultSetGroup> buildResponseCache(
+      PinotResponseCacheLoader pinotResponseCacheLoader) throws Exception {
+    Preconditions.checkNotNull(pinotResponseCacheLoader, "A loader that sends query to Pinot is required.");
+
+    // Initializes listener that prints expired entries in debuggin mode.
+    RemovalListener<PinotQuery, ResultSetGroup> listener;
+    if (LOG.isDebugEnabled()) {
+      listener = new RemovalListener<PinotQuery, ResultSetGroup>() {
+        @Override
+        public void onRemoval(RemovalNotification<PinotQuery, ResultSetGroup> notification) {
+          LOG.debug("Expired {}", notification.getKey().getPql());
+        }
+      };
+    } else {
+      listener = new RemovalListener<PinotQuery, ResultSetGroup>() {
+        @Override public void onRemoval(RemovalNotification<PinotQuery, ResultSetGroup> notification) { }
+      };
     }
-    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue())) {
-      valid = false;
-      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue());
-    }
-    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue())) {
-      valid = false;
-      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue());
-    }
-    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue())) {
-      valid = false;
-      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue());
-    }
-    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue())) {
-      valid = false;
-      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue());
-    }
-    return valid;
+
+    // ResultSetGroup Cache. The size of this cache is limited by the total number of buckets in all ResultSetGroup.
+    // We estimate that 1 bucket (including overhead) consumes 1KB and this cache is allowed to use up to 50% of max
+    // heap space.
+    long maxBucketNumber = getApproximateMaxBucketNumber(DEFAULT_HEAP_PERCENTAGE_FOR_RESULTSETGROUP_CACHE);
+    LOG.debug("Max bucket number for {}'s cache is set to {}", DATA_SOURCE_NAME, maxBucketNumber);
+
+    return CacheBuilder.newBuilder()
+        .removalListener(listener)
+        .expireAfterWrite(ThirdEyeCacheRegistry.CACHE_EXPIRATION_HOURS, TimeUnit.HOURS)
+        .maximumWeight(maxBucketNumber)
+        .weigher(new Weigher<PinotQuery, ResultSetGroup>() {
+          @Override public int weigh(PinotQuery pinotQuery, ResultSetGroup resultSetGroup) {
+            int resultSetCount = resultSetGroup.getResultSetCount();
+            int weight = 0;
+            for (int idx = 0; idx < resultSetCount; ++idx) {
+              ResultSet resultSet = resultSetGroup.getResultSet(idx);
+              weight += (resultSet.getColumnCount() * resultSet.getRowCount());
+            }
+            return weight;
+          }
+        })
+        .build(pinotResponseCacheLoader);
   }
 
+  /**
+   * Returns the suggested max weight for LoadingCache according to the given percentage of max heap space.
+   *
+   * The approximate weight is calculated by following rules:
+   * 1. We estimate that a bucket, including its overhead, occupies 1 KB.
+   * 2. Cache size (in bytes) = System's maxMemory * percentage
+   * 3. We also bound the cache size between DEFAULT_LOWER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB and
+   *    DEFAULT_UPPER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB if max heap size is unavailable.
+   * 4. Weight (number of buckets) = cache size / 1KB.
+   *
+   * @param percentage the percentage of JVM max heap space
+   * @return the suggested max weight for LoadingCache
+   */
+  private static long getApproximateMaxBucketNumber(int percentage) {
+    long jvmMaxMemoryInBytes = Runtime.getRuntime().maxMemory();
+    if (jvmMaxMemoryInBytes == Long.MAX_VALUE) { // Check upper bound
+      jvmMaxMemoryInBytes = DEFAULT_UPPER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB * 1048576L; // MB to Bytes
+    } else { // Check lower bound
+      long lowerBoundInBytes = DEFAULT_LOWER_BOUND_OF_RESULTSETGROUP_CACHE_SIZE_IN_MB * 1048576L; // MB to Bytes
+      if (jvmMaxMemoryInBytes < lowerBoundInBytes) {
+        jvmMaxMemoryInBytes = lowerBoundInBytes;
+      }
+    }
+    return (jvmMaxMemoryInBytes / 102400) * percentage;
+  }
+
+
   /** TESTING ONLY - WE SHOULD NOT BE USING THIS. */
+  @Deprecated
+  private HttpHost controllerHost;
+  @Deprecated
+  private CloseableHttpClient controllerClient;
+
+  @Deprecated
+  protected PinotThirdEyeDataSource(String host, int port) {
+    this.controllerHost = new HttpHost(host, port);
+    this.controllerClient = HttpClients.createDefault();
+    this.pinotDataSourceMaxTime = new PinotDataSourceMaxTime(this);
+    this.pinotDataSourceDimensionFilters = new PinotDataSourceDimensionFilters(this);
+    LOG.info("Created PinotThirdEyeDataSource with controller {}", controllerHost);
+  }
+
+  @Deprecated
+  public static PinotThirdEyeDataSource fromZookeeper(String controllerHost, int controllerPort, String zkUrl) {
+    ZkClient zkClient = new ZkClient(zkUrl);
+    zkClient.setZkSerializer(new ZNRecordSerializer());
+    zkClient.waitUntilConnected();
+    PinotThirdEyeDataSource pinotThirdEyeDataSource = new PinotThirdEyeDataSource(controllerHost, controllerPort);
+    LOG.info("Created PinotThirdEyeDataSource to zookeeper: {} controller: {}:{}", zkUrl, controllerHost, controllerPort);
+    return pinotThirdEyeDataSource;
+  }
+
   @Deprecated
   public static PinotThirdEyeDataSource getDefaultTestDataSource() {
     // TODO REPLACE WITH CONFIGS
     String controllerHost = "localhost";
     int controllerPort = 11984;
-    String zkUrl =
-        "localhost:12913/pinot-cluster";
+    String zkUrl = "localhost:12913/pinot-cluster";
     return fromZookeeper(controllerHost, controllerPort, zkUrl);
   }
-
-
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
@@ -2,32 +2,33 @@ package com.linkedin.thirdeye.datasource.pinot;
 
 import java.util.Map;
 
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.linkedin.thirdeye.datasource.DataSourceConfig;
-import com.linkedin.thirdeye.datasource.DataSources;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * An immutable configurations for setting up {@link PinotThirdEyeDataSource}'s connection to Pinot.
+ */
 public class PinotThirdEyeDataSourceConfig {
+  private static final Logger LOG = LoggerFactory.getLogger(PinotThirdEyeDataSourceConfig.class);
 
-  String zookeeperUrl;
-
-  String controllerHost;
-
-  int controllerPort;
-
-  String clusterName;
-
-  String brokerUrl;
-
-  String tag;
+  private String zookeeperUrl;
+  private String controllerHost;
+  private int controllerPort;
+  private String clusterName;
+  private String brokerUrl;
+  private String tag;
 
   public String getZookeeperUrl() {
     return zookeeperUrl;
   }
 
-  public void setZookeeperUrl(String zookeeperUrl) {
+  private void setZookeeperUrl(String zookeeperUrl) {
     this.zookeeperUrl = zookeeperUrl;
   }
 
@@ -35,7 +36,7 @@ public class PinotThirdEyeDataSourceConfig {
     return controllerHost;
   }
 
-  public void setControllerHost(String controllerHost) {
+  private void setControllerHost(String controllerHost) {
     this.controllerHost = controllerHost;
   }
 
@@ -43,7 +44,7 @@ public class PinotThirdEyeDataSourceConfig {
     return controllerPort;
   }
 
-  public void setControllerPort(int controllerPort) {
+  private void setControllerPort(int controllerPort) {
     this.controllerPort = controllerPort;
   }
 
@@ -51,7 +52,7 @@ public class PinotThirdEyeDataSourceConfig {
     return tag;
   }
 
-  public void setTag(String tag) {
+  private void setTag(String tag) {
     this.tag = tag;
   }
 
@@ -59,7 +60,7 @@ public class PinotThirdEyeDataSourceConfig {
     return brokerUrl;
   }
 
-  public void setBrokerUrl(String brokerUrl) {
+  private void setBrokerUrl(String brokerUrl) {
     this.brokerUrl = brokerUrl;
   }
 
@@ -67,10 +68,9 @@ public class PinotThirdEyeDataSourceConfig {
     return clusterName;
   }
 
-  public void setClusterName(String clusterName) {
+  private void setClusterName(String clusterName) {
     this.clusterName = clusterName;
   }
-
 
   @Override
   public String toString() {
@@ -82,49 +82,43 @@ public class PinotThirdEyeDataSourceConfig {
   }
 
   /**
-   * Returns pinot thirdeye datasource config from all datasource configs. There can be only ONE datasource of each type
-   * @param dataSources
-   * @return
-   */
-  public static PinotThirdEyeDataSourceConfig createPinotThirdeyeDataSourceConfig(DataSources dataSources) {
-    PinotThirdEyeDataSourceConfig pinotDataSourceConfig = null;
-    for (DataSourceConfig dataSourceConfig : dataSources.getDataSourceConfigs()) {
-      if (dataSourceConfig.getClassName().equals(PinotThirdEyeDataSource.class.getCanonicalName())) {
-        if (pinotDataSourceConfig == null) {
-          pinotDataSourceConfig = createPinotDataSourceFromProperties(dataSourceConfig.getProperties());
-        } else {
-          throw new IllegalStateException("Found another data source of type PinotThirdEyeDataSource. "
-              + "There can only be ONE data source of each type" + dataSources);
-        }
-      }
-    }
-    return pinotDataSourceConfig;
-  }
-
-  /**
    * Returns pinot thirdeye datasource config given datasource config. There can be only ONE datasource of pinot type
-   * @param dataSources
+   * @param dataSourceConfig
    * @return
    */
-  public static PinotThirdEyeDataSourceConfig createPinotThirdeyeDataSourceConfig(DataSourceConfig dataSourceConfig) {
+  public static PinotThirdEyeDataSourceConfig createFromDataSourceConfig(DataSourceConfig dataSourceConfig) {
     if (dataSourceConfig == null ||
         !dataSourceConfig.getClassName().equals(PinotThirdEyeDataSource.class.getCanonicalName())) {
       throw new IllegalStateException("Data source config is not of type pinot " + dataSourceConfig);
     }
-    return createPinotDataSourceFromProperties(dataSourceConfig.getProperties());
+    return createFromProperties(dataSourceConfig.getProperties());
   }
 
-  private static PinotThirdEyeDataSourceConfig createPinotDataSourceFromProperties(Map<String, String> properties) {
-    PinotThirdEyeDataSourceConfig pinotDataSourceConfig = null;
+  /**
+   * Returns PinotThirdEyeDataSourceConfig from the given property map.
+   *
+   * @param properties the properties to setup a PinotThirdEyeDataSourceConfig.
+   *
+   * @return a PinotThirdEyeDataSourceConfig.
+   *
+   * @throws IllegalStateException is thrown if the property map does not contain all necessary fields, i.e., controller
+   *                               host and port, cluster name, and the URL to zoo keeper.
+   */
+  public static PinotThirdEyeDataSourceConfig createFromProperties(Map<String, String> properties) {
+    if (!isValidProperties(properties)) {
+      throw new IllegalStateException(
+          "Invalid properties for data source " + PinotThirdEyeDataSource.DATA_SOURCE_NAME + " " + properties);
+    }
 
     String controllerHost = properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue());
     int controllerPort = Integer.valueOf(properties.get(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue()));
     String clusterName = properties.get(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue());
     String zookeeperUrl = properties.get(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue());
+    // brokerUrl and tag are optional
     String brokerUrl = properties.get(PinotThirdeyeDataSourceProperties.BROKER_URL.getValue());
     String tag = properties.get(PinotThirdeyeDataSourceProperties.TAG.getValue());
 
-    pinotDataSourceConfig = new PinotThirdEyeDataSourceConfig();
+    PinotThirdEyeDataSourceConfig pinotDataSourceConfig = new PinotThirdEyeDataSourceConfig();
     pinotDataSourceConfig.setControllerHost(controllerHost);
     pinotDataSourceConfig.setControllerPort(controllerPort);
     pinotDataSourceConfig.setClusterName(clusterName);
@@ -136,5 +130,39 @@ public class PinotThirdEyeDataSourceConfig {
       pinotDataSourceConfig.setTag(tag);
     }
     return pinotDataSourceConfig;
+  }
+
+  /**
+   * Checks if the given property map could be used to construct a PinotThirdEyeDataSourceConfig. The essential fields
+   * are controller host and port, cluster name, and the URL to zoo keeper. This method prints out all missing essential
+   * fields before returning false.
+   *
+   * @param properties the property map to be checked.
+   *
+   * @return true if the property map has all the essential fields.
+   */
+  private static boolean isValidProperties(Map<String, String> properties) {
+    boolean valid = true;
+    if (MapUtils.isEmpty(properties)) {
+      valid = false;
+      LOG.error("PinotThirdEyeDataSource is missing properties {}", properties);
+    }
+    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue())) {
+      valid = false;
+      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue());
+    }
+    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue())) {
+      valid = false;
+      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue());
+    }
+    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue())) {
+      valid = false;
+      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue());
+    }
+    if (!properties.containsKey(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue())) {
+      valid = false;
+      LOG.error("PinotThirdEyeDataSource is missing required property {}", PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue());
+    }
+    return valid;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdeyeDataSourceProperties.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdeyeDataSourceProperties.java
@@ -10,7 +10,7 @@ public enum PinotThirdeyeDataSourceProperties {
 
   private final String value;
 
-  private PinotThirdeyeDataSourceProperties(String value) {
+  PinotThirdeyeDataSourceProperties(String value) {
     this.value = value;
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfigTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfigTest.java
@@ -1,0 +1,108 @@
+package com.linkedin.thirdeye.datasource.pinot;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class PinotThirdEyeDataSourceConfigTest {
+  private static final String CONTROLLER_HOST = "host";
+  private static final String CONTROLLER_PORT = "1234";
+  private static final String ZOOKEEPER_URL = "zookeeper";
+  private static final String CLUSTER_NAME = "clusterName";
+  private static final String BROKER_URL = "brokerURL";
+  private static final String TAG = "tag";
+  private static final String SPACE_STRING = "      ";
+
+  ImmutableMap<String, String> processedProperties;
+
+  @Test
+  public void testCreateProcessedPropertyMap() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue(), SPACE_STRING + CONTROLLER_HOST);
+    properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue(), CONTROLLER_PORT + SPACE_STRING);
+    properties.put(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue(), ZOOKEEPER_URL + SPACE_STRING);
+    properties.put(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue(), SPACE_STRING + CLUSTER_NAME);
+    properties.put(PinotThirdeyeDataSourceProperties.BROKER_URL.getValue(), SPACE_STRING + BROKER_URL);
+    properties.put(PinotThirdeyeDataSourceProperties.TAG.getValue(), TAG + SPACE_STRING);
+
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    builder.put(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue(), CONTROLLER_HOST);
+    builder.put(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue(), CONTROLLER_PORT);
+    builder.put(PinotThirdeyeDataSourceProperties.ZOOKEEPER_URL.getValue(), ZOOKEEPER_URL);
+    builder.put(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue(), CLUSTER_NAME);
+    builder.put(PinotThirdeyeDataSourceProperties.BROKER_URL.getValue(), BROKER_URL);
+    builder.put(PinotThirdeyeDataSourceProperties.TAG.getValue(), TAG);
+    ImmutableMap<String, String> expectedProperties = builder.build();
+
+    processedProperties = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
+
+    Assert.assertEquals(processedProperties, expectedProperties);
+  }
+
+  @Test
+  public void testCreateProcessedPropertyMapWithEmptyMap() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+
+    ImmutableMap<String, String> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
+
+    Assert.assertNull(processPropertyMap);
+  }
+
+  @Test
+  public void testCreateProcessedPropertyMapWithNullMap() throws Exception {
+    ImmutableMap<String, String> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(null);
+
+    Assert.assertNull(processPropertyMap);
+  }
+
+  @Test
+  public void testProcessPropertyMapWithMissingProperties() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_HOST.getValue(), SPACE_STRING + CONTROLLER_HOST);
+    properties.put(PinotThirdeyeDataSourceProperties.CONTROLLER_PORT.getValue(), CONTROLLER_PORT + SPACE_STRING);
+    // Missing ZOOKEEPER_URL
+    properties.put(PinotThirdeyeDataSourceProperties.CLUSTER_NAME.getValue(), SPACE_STRING + CLUSTER_NAME);
+    // Returned a null property map
+    ImmutableMap<String, String> processPropertyMap = PinotThirdEyeDataSourceConfig.processPropertyMap(properties);
+
+    Assert.assertNull(processPropertyMap);
+  }
+
+  @Test(dependsOnMethods = "testCreateProcessedPropertyMap")
+  public void testCreateFromProperties() throws Exception {
+    PinotThirdEyeDataSourceConfig.Builder builder =
+        PinotThirdEyeDataSourceConfig.builder().setControllerHost(CONTROLLER_HOST)
+            .setControllerPort(Integer.parseInt(CONTROLLER_PORT)).setZookeeperUrl(ZOOKEEPER_URL)
+            .setClusterName(CLUSTER_NAME).setBrokerUrl(BROKER_URL).setTag(TAG);
+
+    PinotThirdEyeDataSourceConfig expectedDataSourceConfig = builder.build();
+
+    PinotThirdEyeDataSourceConfig actualDataSourceConfig =
+        PinotThirdEyeDataSourceConfig.createFromProperties(processedProperties);
+
+    Assert.assertEquals(actualDataSourceConfig, expectedDataSourceConfig);
+  }
+
+  @Test(expectedExceptions= {IllegalArgumentException.class})
+  public void testBuilderWithIllegalArgument() throws Exception {
+    PinotThirdEyeDataSourceConfig.Builder builder =
+        PinotThirdEyeDataSourceConfig.builder().setControllerHost(CONTROLLER_HOST).setZookeeperUrl(ZOOKEEPER_URL)
+            .setClusterName(CLUSTER_NAME);
+
+    builder.build();
+  }
+
+  @Test(expectedExceptions= {NullPointerException.class})
+  public void testBuilderWithNullArgument() throws Exception {
+    PinotThirdEyeDataSourceConfig.Builder builder =
+        PinotThirdEyeDataSourceConfig.builder().setControllerHost(CONTROLLER_HOST)
+            .setControllerPort(Integer.parseInt(CONTROLLER_PORT)).setClusterName(CLUSTER_NAME);
+
+    builder.build();
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
@@ -1,0 +1,29 @@
+package com.linkedin.thirdeye.datasource.pinot;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PinotThirdEyeDataSourceTest {
+
+  @Test
+  public void testInitializeCacheLoaderFromGivenClass() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(PinotThirdEyeDataSource.CACHE_LOADER_CLASS_NAME_STRING,
+        PinotControllerResponseCacheLoader.class.getName());
+
+    PinotResponseCacheLoader cacheLoaderInstance = PinotThirdEyeDataSource.getCacheLoaderInstance(properties);
+    Assert.assertTrue(PinotControllerResponseCacheLoader.class.equals(cacheLoaderInstance.getClass()));
+  }
+
+  @Test
+  public void testInitializeCacheLoaderFromEmptyClass() throws Exception {
+    Map<String, String> properties = Collections.emptyMap();
+
+    PinotResponseCacheLoader cacheLoaderInstance = PinotThirdEyeDataSource.getCacheLoaderInstance(properties);
+    Assert.assertTrue(PinotControllerResponseCacheLoader.class.equals(cacheLoaderInstance.getClass()));
+  }
+
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -1,8 +1,6 @@
 package com.linkedin.thirdeye.integration;
 
 import com.google.common.cache.LoadingCache;
-import com.linkedin.pinot.client.ResultSet;
-import com.linkedin.pinot.client.ResultSetGroup;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.alert.v2.AlertJobSchedulerV2;
 import com.linkedin.thirdeye.anomaly.classification.classifier.AnomalyClassifierFactory;
@@ -34,7 +32,6 @@ import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
 import com.linkedin.thirdeye.datasource.ThirdEyeResponse;
 import com.linkedin.thirdeye.datasource.cache.MetricDataset;
 import com.linkedin.thirdeye.datasource.cache.QueryCache;
-import com.linkedin.thirdeye.datasource.pinot.PinotQuery;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeResponse;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
@@ -154,21 +151,6 @@ public class AnomalyApplicationEndToEndTest extends AbstractManagerTestBase {
     LoadingCache<String, DatasetConfigDTO> mockDatasetConfigCache = Mockito.mock(LoadingCache.class);
     Mockito.when(mockDatasetConfigCache.get(collection)).thenReturn(getTestDatasetConfig(collection));
     cacheRegistry.registerDatasetConfigCache(mockDatasetConfigCache);
-
-    ResultSet mockResultSet = Mockito.mock(ResultSet.class);
-    Mockito.when(mockResultSet.getRowCount()).thenReturn(0);
-    final ResultSetGroup mockResultSetGroup = Mockito.mock(ResultSetGroup.class);
-    Mockito.when(mockResultSetGroup.getResultSet(0)).thenReturn(mockResultSet);
-    LoadingCache<PinotQuery, ResultSetGroup> mockResultSetGroupCache = Mockito.mock(LoadingCache.class);
-    Mockito.when(mockResultSetGroupCache.get(Matchers.any(PinotQuery.class)))
-    .thenAnswer(new Answer<ResultSetGroup>() {
-
-      @Override
-      public ResultSetGroup answer(InvocationOnMock invocation) throws Throwable {
-        return mockResultSetGroup;
-      }
-    });
-    cacheRegistry.registerResultSetGroupCache(mockResultSetGroupCache);
 
     // Application config
     thirdeyeAnomalyConfig = new ThirdEyeAnomalyConfiguration();


### PR DESCRIPTION
This PR decouple the cache of Pinot response from Cache Registry and move into Pinot data source. The idea is that Cache Registry provides the cache for meta-data, e.g., dataset names, filters, etc., and DATA cache is hidden in the corresponding data source. Consequently, we could connect to the same data source via different type of connection (e.g., direct connection to controller or indirect connection through Rest.li).

This PR also removes the queries that are directly sent to the database instead of via the data source. Specifically, any explicit calls to the cache of a data source are refactored to invoke data source's method instead.

Tested on local dashboard to ensure the connection to Pinot is not broken due to this change.