### PR TITLE
Split overloaded api 'indexOf' in dictionary into 'indexOf' and 'insertionIndexOf'.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -105,12 +105,12 @@ public class RangePredicateEvaluatorFactory {
       if (lower.equals("*")) {
         _rangeStartIndex = 0;
       } else {
-        _rangeStartIndex = dictionary.indexOf(lower);
+        _rangeStartIndex = dictionary.insertionIndexOf(lower);
       }
       if (upper.equals("*")) {
         _rangeEndIndex = dictionary.length() - 1;
       } else {
-        _rangeEndIndex = dictionary.indexOf(upper);
+        _rangeEndIndex = dictionary.insertionIndexOf(upper);
       }
 
       if (_rangeStartIndex < 0) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -44,6 +44,12 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Double.valueOf((String) rawValue), null);
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
@@ -25,6 +25,12 @@ public class DoubleOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Double.valueOf((String) rawValue));
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -44,6 +44,12 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Float.valueOf((String) rawValue), null);
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
@@ -25,6 +25,12 @@ public class FloatOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Float.valueOf((String) rawValue));
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -44,6 +44,12 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Integer.valueOf((String) rawValue), null);
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
@@ -25,6 +25,12 @@ public class IntOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Integer.valueOf((String) rawValue));
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -44,6 +44,12 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Long.valueOf((String) rawValue), null);
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
@@ -25,6 +25,12 @@ public class LongOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     if (rawValue instanceof String) {
       return getDictId(Long.valueOf((String) rawValue));
     } else {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -104,6 +104,12 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     byte[] serializedValue = ((String)rawValue).getBytes(UTF_8);
     return getDictId(rawValue, serializedValue);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
@@ -25,6 +25,12 @@ public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     return getDictId(rawValue);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
@@ -114,9 +114,14 @@ public final class ColumnIndexContainer {
   private static ImmutableDictionaryReader loadDictionary(PinotDataBuffer dictionaryBuffer, ColumnMetadata metadata,
       boolean loadOnHeap) throws IOException {
     FieldSpec.DataType dataType = metadata.getDataType();
-    if (loadOnHeap && (dataType != FieldSpec.DataType.STRING)) {
-      LOGGER.warn("Only support on-heap dictionary for String data type, load off-heap dictionary for column: {}",
-          metadata.getColumnName());
+    if (loadOnHeap) {
+      String columnName = metadata.getColumnName();
+      if ((dataType != FieldSpec.DataType.STRING)) {
+        LOGGER.warn("Only support on-heap dictionary for String data type, load off-heap dictionary for column: {}",
+            columnName);
+      } else {
+        LOGGER.info("Loading on-heap dictionary for column: {}", columnName);
+      }
     }
 
     int length = metadata.getCardinality();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
@@ -21,7 +21,26 @@ import java.io.Closeable;
 public interface Dictionary extends Closeable {
   int NULL_VALUE_INDEX = -1;
 
+  /**
+   * Returns index of the object in the dictionary.
+   * Returns -1, if the object does not exist in the dictionary.
+   *
+   * @param rawValue Object for which to find the index.
+   * @return Index of object, or -1 if not found.
+   */
   int indexOf(Object rawValue);
+
+  /**
+   * Returns the insertion index of object in the dictionary.
+   * <ul>
+   *   <li> If the object already exists, then returns the current index. </li>
+   *   <li> If the object does not exist, then returns the index at which the object would be inserted, with -ve sign.
+   *        Sign of index is inverted to indicate that the object was not found in the dictionary. </li>
+   * </ul>
+   * @param rawValue Object for which to find the insertion index
+   * @return Insertion index of the object (as defined above).
+   */
+  int insertionIndexOf(Object rawValue);
 
   Object get(int dictId);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/DoubleDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/DoubleDictionary.java
@@ -27,6 +27,12 @@ public class DoubleDictionary extends ImmutableDictionaryReader {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     double value;
     if (rawValue instanceof String) {
       value = Double.parseDouble((String) rawValue);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/FloatDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/FloatDictionary.java
@@ -27,6 +27,12 @@ public class FloatDictionary extends ImmutableDictionaryReader {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     float value;
     if (rawValue instanceof String) {
       value = Float.parseFloat((String) rawValue);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/IntDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/IntDictionary.java
@@ -27,6 +27,12 @@ public class IntDictionary extends ImmutableDictionaryReader {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     int value;
     if (rawValue instanceof String) {
       value = Integer.parseInt((String) rawValue);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/LongDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/LongDictionary.java
@@ -27,6 +27,12 @@ public class LongDictionary extends ImmutableDictionaryReader {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     long value;
     if (rawValue instanceof String) {
       value = Long.parseLong((String) rawValue);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/StringDictionary.java
@@ -26,6 +26,12 @@ public class StringDictionary extends ImmutableDictionaryReader {
 
   @Override
   public int indexOf(Object rawValue) {
+    int index = insertionIndexOf(rawValue);
+    return (index >= 0) ? index : -1;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
     return binarySearch((String) rawValue);
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/RangeOfflineDictionaryPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/RangeOfflineDictionaryPredicateEvaluatorTest.java
@@ -208,8 +208,8 @@ public class RangeOfflineDictionaryPredicateEvaluatorTest {
 
   private ImmutableDictionaryReader createReader(int rangeStart, int rangeEnd) {
     ImmutableDictionaryReader reader = mock(ImmutableDictionaryReader.class);
-    when(reader.indexOf("lower")).thenReturn(rangeStart);
-    when(reader.indexOf("upper")).thenReturn(rangeEnd);
+    when(reader.insertionIndexOf("lower")).thenReturn(rangeStart);
+    when(reader.insertionIndexOf("upper")).thenReturn(rangeEnd);
     when(reader.length()).thenReturn(DICT_LEN);
     return reader;
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoadersTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/loader/LoadersTest.java
@@ -182,8 +182,8 @@ public class LoadersTest {
     Assert.assertEquals(dict.getStringValue(1), "lynda 2.0");
     Assert.assertEquals(dict.get(0), "lynda");
     Assert.assertEquals(dict.get(1), "lynda 2.0");
-    Assert.assertEquals(dict.indexOf("lynda\0"), -2);
-    Assert.assertEquals(dict.indexOf("lynda\0\0"), -2);
+    Assert.assertEquals(dict.insertionIndexOf("lynda\0"), -2);
+    Assert.assertEquals(dict.insertionIndexOf("lynda\0\0"), -2);
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
@@ -59,7 +59,8 @@ public class ImmutableDictionaryReaderTest {
   private int _numBytesPerStringValue;
 
   @BeforeClass
-  public void setUp() throws Exception {
+  public void setUp()
+      throws Exception {
     FileUtils.deleteQuietly(TEMP_DIR);
 
     IntOpenHashSet intSet = new IntOpenHashSet();
@@ -121,7 +122,8 @@ public class ImmutableDictionaryReaderTest {
   }
 
   @Test
-  public void testIntDictionary() throws Exception {
+  public void testIntDictionary()
+      throws Exception {
     try (IntDictionary intDictionary = new IntDictionary(
         PinotDataBuffer.fromFile(new File(TEMP_DIR, INT_COLUMN_NAME + DICT_FILE_EXT), ReadMode.mmap,
             FileChannel.MapMode.READ_ONLY, INT_COLUMN_NAME), NUM_VALUES)) {
@@ -136,13 +138,14 @@ public class ImmutableDictionaryReaderTest {
         Assert.assertEquals(intDictionary.indexOf(_intValues[i]), i);
 
         int randomInt = RANDOM.nextInt();
-        Assert.assertEquals(intDictionary.indexOf(randomInt), Arrays.binarySearch(_intValues, randomInt));
+        Assert.assertEquals(intDictionary.insertionIndexOf(randomInt), Arrays.binarySearch(_intValues, randomInt));
       }
     }
   }
 
   @Test
-  public void testLongDictionary() throws Exception {
+  public void testLongDictionary()
+      throws Exception {
     try (LongDictionary longDictionary = new LongDictionary(
         PinotDataBuffer.fromFile(new File(TEMP_DIR, LONG_COLUMN_NAME + DICT_FILE_EXT), ReadMode.mmap,
             FileChannel.MapMode.READ_ONLY, LONG_COLUMN_NAME), NUM_VALUES)) {
@@ -157,13 +160,14 @@ public class ImmutableDictionaryReaderTest {
         Assert.assertEquals(longDictionary.indexOf(_longValues[i]), i);
 
         long randomLong = RANDOM.nextLong();
-        Assert.assertEquals(longDictionary.indexOf(randomLong), Arrays.binarySearch(_longValues, randomLong));
+        Assert.assertEquals(longDictionary.insertionIndexOf(randomLong), Arrays.binarySearch(_longValues, randomLong));
       }
     }
   }
 
   @Test
-  public void testFloatDictionary() throws Exception {
+  public void testFloatDictionary()
+      throws Exception {
     try (FloatDictionary floatDictionary = new FloatDictionary(
         PinotDataBuffer.fromFile(new File(TEMP_DIR, FLOAT_COLUMN_NAME + DICT_FILE_EXT), ReadMode.mmap,
             FileChannel.MapMode.READ_ONLY, FLOAT_COLUMN_NAME), NUM_VALUES)) {
@@ -178,13 +182,15 @@ public class ImmutableDictionaryReaderTest {
         Assert.assertEquals(floatDictionary.indexOf(_floatValues[i]), i);
 
         float randomFloat = RANDOM.nextFloat();
-        Assert.assertEquals(floatDictionary.indexOf(randomFloat), Arrays.binarySearch(_floatValues, randomFloat));
+        Assert.assertEquals(floatDictionary.insertionIndexOf(randomFloat),
+            Arrays.binarySearch(_floatValues, randomFloat));
       }
     }
   }
 
   @Test
-  public void testDoubleDictionary() throws Exception {
+  public void testDoubleDictionary()
+      throws Exception {
     try (DoubleDictionary doubleDictionary = new DoubleDictionary(
         PinotDataBuffer.fromFile(new File(TEMP_DIR, DOUBLE_COLUMN_NAME + DICT_FILE_EXT), ReadMode.mmap,
             FileChannel.MapMode.READ_ONLY, DOUBLE_COLUMN_NAME), NUM_VALUES)) {
@@ -199,13 +205,15 @@ public class ImmutableDictionaryReaderTest {
         Assert.assertEquals(doubleDictionary.indexOf(_doubleValues[i]), i);
 
         double randomDouble = RANDOM.nextDouble();
-        Assert.assertEquals(doubleDictionary.indexOf(randomDouble), Arrays.binarySearch(_doubleValues, randomDouble));
+        Assert.assertEquals(doubleDictionary.insertionIndexOf(randomDouble),
+            Arrays.binarySearch(_doubleValues, randomDouble));
       }
     }
   }
 
   @Test
-  public void testStringDictionary() throws Exception {
+  public void testStringDictionary()
+      throws Exception {
     try (StringDictionary stringDictionary = new StringDictionary(
         PinotDataBuffer.fromFile(new File(TEMP_DIR, STRING_COLUMN_NAME + DICT_FILE_EXT), ReadMode.mmap,
             FileChannel.MapMode.READ_ONLY, STRING_COLUMN_NAME), NUM_VALUES, _numBytesPerStringValue, (byte) 0)) {
@@ -214,7 +222,8 @@ public class ImmutableDictionaryReaderTest {
   }
 
   @Test
-  public void testOnHeapStringDictionary() throws Exception {
+  public void testOnHeapStringDictionary()
+      throws Exception {
     try (OnHeapStringDictionary onHeapStringDictionary = new OnHeapStringDictionary(
         PinotDataBuffer.fromFile(new File(TEMP_DIR, STRING_COLUMN_NAME + DICT_FILE_EXT), ReadMode.mmap,
             FileChannel.MapMode.READ_ONLY, STRING_COLUMN_NAME), NUM_VALUES, _numBytesPerStringValue, (byte) 0)) {
@@ -231,7 +240,8 @@ public class ImmutableDictionaryReaderTest {
 
       // Test String longer than MAX_STRING_LENGTH
       String randomString = RandomStringUtils.random(RANDOM.nextInt(2 * MAX_STRING_LENGTH)).replace('\0', ' ');
-      Assert.assertEquals(stringDictionary.indexOf(randomString), Arrays.binarySearch(_stringValues, randomString));
+      Assert.assertEquals(stringDictionary.insertionIndexOf(randomString),
+          Arrays.binarySearch(_stringValues, randomString));
     }
   }
 


### PR DESCRIPTION
The existing indexOf api on Dictionary interface performs binary search
to find out the actual index of the object, or possible insertion index
if the object does not exist. Calls to indexOf that are not interested
in possible insertionIndex of the object can be optimized by making the
dictionary map based, and thus avoiding binary search.

Renamed existing 'indexOf' to 'insertionIndexOf' that preserves existing
behavior. Added new 'indexOf' that returns -1 if object is not found.

Enhanced OnHeapStringDictioanry to use a map for 'indexOf' and thus
avoid unnecessary binary search.

For rest of the implementations, 'indexOf' currently just calls
'insertionIndexOf', and overwrites the result to -1 if object not found.
There's no additional penalty of doing so. But this opens the door for
other implementatinos to also make use of map based lookup in future.