### PR TITLE
Add request ID to broker connection logs.

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/CompositeFuture.java
@@ -112,7 +112,9 @@ public class CompositeFuture<V> extends AbstractCompositeListenableFuture<V> {
    */
   @Override
   protected void cancelUnderlyingFutures() {
+    LOGGER.info("Cancelling all underlying futures for {}", getName());
     for (ServerResponseFuture<V> entry : _futures) {
+      LOGGER.info("Cancelling future {}", entry.getName());
       entry.cancel(true);
     }
   }

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyClientConnection.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyClientConnection.java
@@ -135,6 +135,15 @@ public abstract class NettyClientConnection {
     public ResponseFuture(ServerInstance key, Throwable error, String ctxt) {
       super(key, error, ctxt);
     }
+
+    @Override
+    protected void releaseResource(ByteBuf result) {
+      // Potential fix for a a leak during a race between calling cancel() and receiving response from the server.
+      // If a call is made to get the response before the cancel in a different thread,
+      // and we release it here, then the thread that processes the response may cause
+      // JVM crash.
+//      result.release();
+    }
   }
 
   /**

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
@@ -172,7 +172,7 @@ public class NettyTCPClientConnection extends NettyClientConnection  {
     _lastSendRequestLatency = MetricsHelper.startTimer();
     _lastResponseLatency = MetricsHelper.startTimer();
 
-    _outstandingFuture.set(new ResponseFuture(_server, "Response Future for request " + requestId + " to server " + _server + " connId " + getConnId()));
+    _outstandingFuture.set(new ResponseFuture(_server, "Server response future for reqId " + requestId + " to server " + _server + " connId " + getConnId()));
     _lastRequestTimeoutMS = timeoutMS;
     _lastRequestId = requestId;
     _lastError = null;

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPool.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPool.java
@@ -59,9 +59,10 @@ public interface KeyedPool<T> extends PoolStatsProvider<Histogram> {
    * <code>checkinObject</code>.
    *
    * @param key the key identifying the inner pool which manages the resources.
+   * @param context A string to be used in logs during allocation
    * @return A {@link AsyncResponseFuture} whose get() method will return the actual resource
    */
-  public ServerResponseFuture<T> checkoutObject(ServerInstance key);
+  public ServerResponseFuture<T> checkoutObject(ServerInstance key, String context);
 
   /**
    * Validates all object in the pool with key.

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
@@ -117,7 +117,7 @@ public class KeyedPoolImpl<T> implements KeyedPool<T> {
   }
 
   @Override
-  public ServerResponseFuture<T> checkoutObject(ServerInstance key) {
+  public ServerResponseFuture<T> checkoutObject(ServerInstance key, String context) {
     AsyncPool<T> pool = _keyedPool.get(key);
 
     if (null == pool) {
@@ -137,7 +137,7 @@ public class KeyedPoolImpl<T> implements KeyedPool<T> {
       }
     }
 
-    AsyncResponseFuture<T> future = new AsyncResponseFuture<T>(key, "Checkout future for key " + key);
+    AsyncResponseFuture<T> future = new AsyncResponseFuture<T>(key, "ConnPool checkout future for key " + key);
     Cancellable cancellable = pool.get(future);
     future.setCancellable(cancellable);
     return future;
@@ -178,7 +178,7 @@ public class KeyedPoolImpl<T> implements KeyedPool<T> {
       List<ServerResponseFuture< NoneType>> futureList = new ArrayList<ServerResponseFuture<NoneType>>();
       for (Entry<ServerInstance, AsyncPool<T>> poolEntry : _keyedPool.entrySet()) {
         AsyncResponseFuture<NoneType> shutdownFuture = new AsyncResponseFuture<NoneType>(poolEntry.getKey(),
-            "Shutdown future for pool entry " + poolEntry.getKey());
+            "ConnPool shutdown future for pool entry " + poolEntry.getKey());
         poolEntry.getValue().shutdown(shutdownFuture);
         futureList.add(shutdownFuture);
         //Cancel waiters and notify them

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/pool/KeyedPoolImpl.java
@@ -137,7 +137,7 @@ public class KeyedPoolImpl<T> implements KeyedPool<T> {
       }
     }
 
-    AsyncResponseFuture<T> future = new AsyncResponseFuture<T>(key, "ConnPool checkout future for key " + key);
+    AsyncResponseFuture<T> future = new AsyncResponseFuture<T>(key, "ConnPool checkout future for key " + key + "(" + context + ")");
     Cancellable cancellable = pool.get(future);
     future.setCancellable(cancellable);
     return future;

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -239,7 +239,7 @@ public class NettySingleConnectionIntegrationTest {
       // The act of calling checkoutObject() creates a new AsyncPool and places a request for a new connection
       // NOTE: since no connections are available in the beginning, and the min connections are still being filled, we
       // always end up creating one more connection than the min connections
-      Assert.assertNotNull(keyedPool.checkoutObject(_clientServer).getOne());
+      Assert.assertNotNull(keyedPool.checkoutObject(_clientServer, "none").getOne());
 
       // Use reflection to get the pool and the waiters queue
       Field keyedPoolField = KeyedPoolImpl.class.getDeclaredField("_keyedPool");
@@ -261,8 +261,8 @@ public class NettySingleConnectionIntegrationTest {
       Assert.assertEquals(waitersQueue.size(), 0);
 
       // Get two more connections to the server and leak them
-      Assert.assertNotNull(keyedPool.checkoutObject(_clientServer).getOne());
-      Assert.assertNotNull(keyedPool.checkoutObject(_clientServer).getOne());
+      Assert.assertNotNull(keyedPool.checkoutObject(_clientServer, "none").getOne());
+      Assert.assertNotNull(keyedPool.checkoutObject(_clientServer, "none").getOne());
       stats = pool.getStats();
       Assert.assertEquals(stats.getPoolSize(), 3);
       Assert.assertEquals(stats.getIdleCount(), 0);
@@ -272,7 +272,7 @@ public class NettySingleConnectionIntegrationTest {
       // Try to get one more connection
       // We should get an exception because we don't have a free connection to the server
       ServerResponseFuture<PooledNettyClientResourceManager.PooledClientConnection> serverResponseFuture =
-          keyedPool.checkoutObject(_clientServer);
+          keyedPool.checkoutObject(_clientServer, "none");
       try {
         serverResponseFuture.getOne(1, TimeUnit.SECONDS);
         Assert.fail("Get connection even no connections available");
@@ -296,7 +296,7 @@ public class NettySingleConnectionIntegrationTest {
 
       // Try to get 3 new connections
       for (int i = 0; i < 3; i++) {
-        Assert.assertNotNull(keyedPool.checkoutObject(_clientServer).getOne());
+        Assert.assertNotNull(keyedPool.checkoutObject(_clientServer, "none").getOne());
       }
     } finally {
       keyedPool.shutdown();

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/KeyedPoolImplTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/pool/KeyedPoolImplTest.java
@@ -60,7 +60,7 @@ public class KeyedPoolImplTest {
         new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
 
     kPool.start();
-    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0), "none");
     boolean isTimedout = false;
     try {
       f.get(2, TimeUnit.SECONDS);
@@ -90,7 +90,7 @@ public class KeyedPoolImplTest {
         new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
 
     kPool.start();
-    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0), "none");
     String s1 = f.getOne();
 
     // checkin with invalid key
@@ -125,7 +125,7 @@ public class KeyedPoolImplTest {
         new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
 
     kPool.start();
-    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0), "none");
     boolean isTimedout = false;
     try {
       f.get(2, TimeUnit.SECONDS);
@@ -159,7 +159,7 @@ public class KeyedPoolImplTest {
 
     KeyedPool<String> kPool =
         new KeyedPoolImpl<>(0, 1, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
-    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0), "none");
     Assert.assertTrue(f.isDone());
     Assert.assertNull(f.get());
     Assert.assertNotNull(f.getError());
@@ -182,7 +182,7 @@ public class KeyedPoolImplTest {
 
     KeyedPool<String> kPool =
         new KeyedPoolImpl<>(0, 5, 1000L, 1000 * 60 * 60, rm, timedExecutor, service, null);
-    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0));
+    AsyncResponseFuture<String> f = (AsyncResponseFuture<String>) kPool.checkoutObject(getKey(0), "none");
     String r = f.getOne();
     Assert.assertTrue(f.isDone());
     Assert.assertNull(f.getError());
@@ -234,7 +234,7 @@ public class KeyedPoolImplTest {
     // checkout and checkin back all
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i), "none");
         String resource = rFuture.getOne();
       }
     }
@@ -292,7 +292,7 @@ public class KeyedPoolImplTest {
     int c = 1;
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i), "none");
         String resource = rFuture.getOne();
         Assert.assertEquals(resource, getResource(i, j));
         s.refresh();
@@ -317,7 +317,7 @@ public class KeyedPoolImplTest {
     c = 1;
     int d = 1;
     for (int i = 0; i < numKeys; i++) {
-      ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+      ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i), "none");
       String resource = rFuture.getOne();
       Assert.assertEquals(resource, getResource(i, 0));
       CountDownLatch latch = new CountDownLatch(1);
@@ -368,7 +368,7 @@ public class KeyedPoolImplTest {
     int c = 1;
     for (int j = 0; j < numResourcesPerKey; j++) {
       for (int i = 0; i < numKeys; i++) {
-        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+        ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i), "none");
         String resource = rFuture.getOne();
         Assert.assertEquals(resource, getResource(i, j));
         s.refresh();
@@ -391,7 +391,7 @@ public class KeyedPoolImplTest {
     // Check out 1 object for each key
     c = 1;
     for (int i = 0; i < numKeys; i++) {
-      ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i));
+      ServerResponseFuture<String> rFuture = kPool.checkoutObject(getKey(i), "none");
       String resource = rFuture.getOne();
       Assert.assertEquals(resource, getResource(i, 0));
       s.refresh();


### PR DESCRIPTION
The broker connection logs are missing the request ID. Having these will help us trace a particular
request through conneciton phases