### PR TITLE
[TE] rootcause - metric analysis pipeline with quantile predictor

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
@@ -382,6 +382,17 @@ public class DataFrame {
   }
 
   /**
+   * Creates a new DataFrame with a column {@code indexName} referencing the Series {@code index}.
+   *
+   * @param indexName index series column name
+   * @param index index series
+   */
+  public DataFrame(String indexName, Series index) {
+    this.addSeries(indexName, index);
+    this.indexNames.add(indexName);
+  }
+
+  /**
    * Creates a new DataFrame that copies the properties of {@code df}.
    *
    * <br/><b>NOTE:</b> the copy is shallow, i.e. the contained series are not copied but referenced.

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/LongSeries.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/LongSeries.java
@@ -185,9 +185,13 @@ public final class LongSeries extends TypedSeries<LongSeries> {
   }
 
   public static LongSeries sequence(long from, int count) {
+    return sequence(from, count, 1);
+  }
+
+  public static LongSeries sequence(long from, int count, long interval) {
     long[] values = new long[count];
     for(int i=0; i<count; i++) {
-      values[i] = from + i;
+      values[i] = from + i * interval;
     }
     return buildFrom(values);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/DataFrameUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/DataFrameUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.dataframe.util;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import com.linkedin.thirdeye.dataframe.DoubleSeries;
@@ -25,6 +26,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 
 /**
@@ -129,20 +131,28 @@ public class DataFrameUtils {
   }
 
   /**
-   * Returns the DataFrame with timestamps offset with by a start offset and an interval.
+   * Returns the DataFrame with timestamps aligned to a start offset and an interval. Also, missing
+   * rows (between {@code start} and {@code end} in {@code interval} steps) are fill in with NULL
+   * values.
    *
    * @param df thirdeye response dataframe
    * @param start start offset
+   * @param end end offset
    * @param interval timestep multiple
    * @return dataframe with modified timestamps
    */
-  public static DataFrame offsetTimestamps(DataFrame df, final long start, final long interval) {
-    return df.mapInPlace(new Series.LongFunction() {
+  public static DataFrame alignTimestamps(DataFrame df, final long start, final long end, final long interval) {
+    int count = (int)((end - start) / interval);
+    LongSeries timestamps = LongSeries.sequence(start, count, interval);
+    DataFrame dfTime = new DataFrame(COL_TIME, timestamps);
+    DataFrame dfOffset = new DataFrame(df).mapInPlace(new Series.LongFunction() {
       @Override
       public long apply(long... values) {
         return (values[0] * interval) + start;
       }
     }, COL_TIME);
+
+    return dfTime.joinLeft(dfOffset);
   }
 
   /**
@@ -173,8 +183,9 @@ public class DataFrameUtils {
    * @return response as dataframe
    */
   public static DataFrame evaluateResponse(ThirdEyeResponse response, TimeSeriesRequestContainer rc) throws Exception {
-    long start = (long) Math.ceil(rc.start / (double) rc.interval) * rc.interval;
-    return offsetTimestamps(evaluateExpressions(parseResponse(response), rc.getExpressions()), start, rc.getInterval());
+    long start = ((rc.start + rc.interval - 1) / rc.interval) * rc.interval;
+    long end = ((rc.end + rc.interval - 1) / rc.interval) * rc.interval;
+    return alignTimestamps(evaluateExpressions(parseResponse(response), rc.getExpressions()), start, end, rc.getInterval());
   }
 
   /**
@@ -246,6 +257,44 @@ public class DataFrameUtils {
 
   /**
    * Constructs and wraps a request for a metric with derived expressions. Resolves all
+   * required dependencies from the Thirdeye database. Also aligns start and end timestamps by
+   * rounding them down (start) and up (end) to align with metric time granularity boundaries.
+   * <br/><b>NOTE:</b> the aligned end timestamp is still exclusive.
+   *
+   * @param slice metric data slice
+   * @param reference unique identifier for request
+   * @param metricDAO metric config DAO
+   * @param datasetDAO dataset config DAO
+   * @return TimeSeriesRequestContainer
+   * @throws Exception
+   */
+  public static TimeSeriesRequestContainer makeTimeSeriesRequestAligned(MetricSlice slice, String reference, MetricConfigManager metricDAO, DatasetConfigManager datasetDAO) throws Exception {
+    MetricConfigDTO metric = metricDAO.findById(slice.metricId);
+    if(metric == null)
+      throw new IllegalArgumentException(String.format("Could not resolve metric id %d", slice.metricId));
+
+    DatasetConfigDTO dataset = datasetDAO.findByDataset(metric.getDataset());
+    if(dataset == null)
+      throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for metric id '%d'", metric.getDataset(), metric.getId()));
+
+    List<MetricExpression> expressions = Utils.convertToMetricExpressions(metric.getName(),
+        metric.getDefaultAggFunction(), metric.getDataset());
+
+    long timeGranularity = dataset.bucketTimeGranularity().toMillis();
+    long start = (slice.start / timeGranularity) * timeGranularity;
+    long end = ((slice.end + timeGranularity - 1) / timeGranularity) * timeGranularity;
+
+    MetricSlice alignedSlice = MetricSlice.from(slice.metricId, start, end, slice.filters);
+
+    ThirdEyeRequest request = makeThirdEyeRequestBuilder(alignedSlice, metric, dataset, expressions)
+        .setGroupByTimeGranularity(dataset.bucketTimeGranularity())
+        .build(reference);
+
+    return new TimeSeriesRequestContainer(request, expressions, start, end, timeGranularity);
+  }
+
+  /**
+   * Constructs and wraps a request for a metric with derived expressions. Resolves all
    * required dependencies from the Thirdeye database.
    *
    * @param slice metric data slice
@@ -264,30 +313,14 @@ public class DataFrameUtils {
     if(dataset == null)
       throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for metric id '%d'", metric.getDataset(), metric.getId()));
 
-    List<MetricFunction> functions = new ArrayList<>();
     List<MetricExpression> expressions = Utils.convertToMetricExpressions(metric.getName(),
         metric.getDefaultAggFunction(), metric.getDataset());
-    for(MetricExpression exp : expressions) {
-      functions.addAll(exp.computeMetricFunctions());
-    }
 
-    Multimap<String, String> effectiveFilters = ArrayListMultimap.create();
-    for (String dimName : slice.filters.keySet()) {
-      if (dataset.getDimensions().contains(dimName)) {
-        effectiveFilters.putAll(dimName, slice.filters.get(dimName));
-      }
-    }
-
-    ThirdEyeRequest request = ThirdEyeRequest.newBuilder()
-        .setStartTimeInclusive(slice.start)
-        .setEndTimeExclusive(slice.end)
-        .setFilterSet(effectiveFilters)
-        .setMetricFunctions(functions)
+    ThirdEyeRequest request = makeThirdEyeRequestBuilder(slice, metric, dataset, expressions)
         .setGroupByTimeGranularity(dataset.bucketTimeGranularity())
-        .setDataSource(dataset.getDataSource())
         .build(reference);
 
-    final long timeGranularity = dataset.bucketTimeGranularity().toMillis();
+    long timeGranularity = dataset.bucketTimeGranularity().toMillis();
 
     return new TimeSeriesRequestContainer(request, expressions, slice.start, slice.end, timeGranularity);
   }
@@ -313,9 +346,28 @@ public class DataFrameUtils {
     if(dataset == null)
       throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for metric id '%d'", metric.getDataset(), metric.getId()));
 
-    List<MetricFunction> functions = new ArrayList<>();
     List<MetricExpression> expressions = Utils.convertToMetricExpressions(metric.getName(),
         metric.getDefaultAggFunction(), metric.getDataset());
+
+    ThirdEyeRequest request = makeThirdEyeRequestBuilder(slice, metric, dataset, expressions)
+        .setGroupBy(dimensions)
+        .build(reference);
+
+    return new RequestContainer(request, expressions);
+  }
+
+  /**
+   * Helper: Returns a pre-populated ThirdeyeRequestBuilder instance.
+   *
+   * @param slice metric data slice
+   * @param metric metric dto
+   * @param dataset dataset dto
+   * @param expressions metric expressions
+   * @return ThirdeyeRequestBuilder
+   * @throws ExecutionException
+   */
+  private static ThirdEyeRequest.ThirdEyeRequestBuilder makeThirdEyeRequestBuilder(MetricSlice slice, MetricConfigDTO metric, DatasetConfigDTO dataset, List<MetricExpression> expressions) throws ExecutionException {
+    List<MetricFunction> functions = new ArrayList<>();
     for(MetricExpression exp : expressions) {
       functions.addAll(exp.computeMetricFunctions());
     }
@@ -327,15 +379,13 @@ public class DataFrameUtils {
       }
     }
 
-    ThirdEyeRequest request = ThirdEyeRequest.newBuilder()
+    return ThirdEyeRequest.newBuilder()
         .setStartTimeInclusive(slice.start)
         .setEndTimeExclusive(slice.end)
         .setFilterSet(effectiveFilters)
         .setMetricFunctions(functions)
-        .setDataSource(dataset.getDataSource())
-        .setGroupBy(dimensions)
-        .build(reference);
+        .setDataSource(dataset.getDataSource());
 
-    return new RequestContainer(request, expressions);
   }
+
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeRequest.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/ThirdEyeRequest.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.datasource;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 
 import java.util.ArrayList;
@@ -41,12 +42,12 @@ public class ThirdEyeRequest {
 
   private ThirdEyeRequest(String requestReference, ThirdEyeRequestBuilder builder) {
     this.requestReference = requestReference;
-    this.metricFunctions = builder.metricFunctions;
+    this.metricFunctions = new ArrayList<>(builder.metricFunctions);
     this.startTime = builder.startTime;
     this.endTime = builder.endTime;
-    this.filterSet = builder.filterSet;
+    this.filterSet = ArrayListMultimap.create(builder.filterSet);
     this.filterClause = builder.filterClause;
-    this.groupByDimensions = builder.groupBy;
+    this.groupByDimensions = new ArrayList<>(builder.groupBy);
     this.groupByTimeGranularity = builder.groupByTimeGranularity;
     this.dataSource = builder.dataSource;
     metricNames = new ArrayList<>();
@@ -97,43 +98,38 @@ public class ThirdEyeRequest {
     return groupByDimensions;
   }
 
-
   public String getDataSource() {
     return dataSource;
   }
 
   @Override
-  public int hashCode() {
-    // TODO do we intentionally omit request reference here?
-    return Objects.hash(metricFunctions, startTime, endTime, filterSet, filterClause,
-        groupByDimensions, groupByTimeGranularity);
-  };
-
-  @Override
   public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
     if (!(o instanceof ThirdEyeRequest)) {
       return false;
     }
-    ThirdEyeRequest other = (ThirdEyeRequest) o;
-    // TODO do we intentionally omit request reference here?
-    return Objects.equals(getMetricFunctions(), other.getMetricFunctions())
-        && Objects.equals(getStartTimeInclusive(), other.getStartTimeInclusive())
-        && Objects.equals(getEndTimeExclusive(), other.getEndTimeExclusive())
-        && Objects.equals(getFilterSet(), other.getFilterSet())
-        && Objects.equals(getFilterClause(), other.getFilterClause())
-        && Objects.equals(getGroupBy(), other.getGroupBy())
-        && Objects.equals(getGroupByTimeGranularity(), other.getGroupByTimeGranularity());
+    ThirdEyeRequest that = (ThirdEyeRequest) o;
+    return Objects.equals(metricFunctions, that.metricFunctions) && Objects.equals(startTime, that.startTime) && Objects
+        .equals(endTime, that.endTime) && Objects.equals(filterSet, that.filterSet) && Objects.equals(filterClause,
+        that.filterClause) && Objects.equals(groupByDimensions, that.groupByDimensions) && Objects.equals(
+        groupByTimeGranularity, that.groupByTimeGranularity) && Objects.equals(metricNames, that.metricNames) && Objects
+        .equals(dataSource, that.dataSource) && Objects.equals(requestReference, that.requestReference);
+  }
 
-  };
+  @Override
+  public int hashCode() {
+    return Objects.hash(metricFunctions, startTime, endTime, filterSet, filterClause, groupByDimensions,
+        groupByTimeGranularity, metricNames, dataSource, requestReference);
+  }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("requestReference", requestReference)
-        .add("metricFunctions", metricFunctions)
-        .add("startTime", startTime).add("endTime", endTime).add("filterSet", filterSet)
-        .add("filterClause", filterClause).add("groupBy", groupByDimensions)
-        .add("groupByTimeGranularity", groupByTimeGranularity)
-        .add("dataSource", dataSource).toString();
+    return "ThirdEyeRequest{" + "metricFunctions=" + metricFunctions + ", startTime=" + startTime + ", endTime="
+        + endTime + ", filterSet=" + filterSet + ", filterClause='" + filterClause + '\'' + ", groupByDimensions="
+        + groupByDimensions + ", groupByTimeGranularity=" + groupByTimeGranularity + ", metricNames=" + metricNames
+        + ", dataSource='" + dataSource + '\'' + ", requestReference='" + requestReference + '\'' + '}';
   }
 
   public static class ThirdEyeRequestBuilder {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricAnalysisPipeline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricAnalysisPipeline.java
@@ -1,0 +1,347 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.Series;
+import com.linkedin.thirdeye.dataframe.util.DataFrameUtils;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import com.linkedin.thirdeye.dataframe.util.TimeSeriesRequestContainer;
+import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
+import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
+import com.linkedin.thirdeye.datasource.ThirdEyeResponse;
+import com.linkedin.thirdeye.datasource.cache.QueryCache;
+import com.linkedin.thirdeye.rootcause.Entity;
+import com.linkedin.thirdeye.rootcause.Pipeline;
+import com.linkedin.thirdeye.rootcause.PipelineContext;
+import com.linkedin.thirdeye.rootcause.PipelineResult;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections.MapUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The MetricAnalysisPipeline ranks metrics based on the degree of anomalous behavior during
+ * the anomaly period.
+ *
+ * <br/><b>NOTE:</b> this is the successor to {@code MetricCorrelationRankingPipeline}
+ *
+ * @see MetricCorrelationRankingPipeline
+ */
+public class MetricAnalysisPipeline extends Pipeline {
+  private static final Logger LOG = LoggerFactory.getLogger(MetricAnalysisPipeline.class);
+
+  private static final long TIMEOUT = 60000;
+
+  private static final long TRAINING_OFFSET = TimeUnit.DAYS.toMillis(7);
+
+  private static final String STRATEGY_THRESHOLD = "threshold";
+
+  private static final String PROP_STRATEGY = "strategy";
+  private static final String PROP_STRATEGY_DEFAULT = STRATEGY_THRESHOLD;
+
+  private static final String PRE_TOTAL = "total:";
+
+  private static final String COL_TIME = DataFrameUtils.COL_TIME;
+  private static final String COL_VALUE = DataFrameUtils.COL_VALUE;
+  private static final String COL_CURRENT = "current";
+  private static final String COL_BASELINE = "baseline";
+
+  private final QueryCache cache;
+  private final MetricConfigManager metricDAO;
+  private final DatasetConfigManager datasetDAO;
+  private final ScoringStrategyFactory strategyFactory;
+
+  /**
+   * Constructor for dependency injection
+   *
+   * @param outputName pipeline output name
+   * @param inputNames input pipeline names
+   * @param strategyFactory scoring strategy for differences
+   * @param cache query cache
+   * @param metricDAO metric config DAO
+   * @param datasetDAO datset config DAO
+   */
+  public MetricAnalysisPipeline(String outputName, Set<String> inputNames, ScoringStrategyFactory strategyFactory, QueryCache cache, MetricConfigManager metricDAO, DatasetConfigManager datasetDAO) {
+    super(outputName, inputNames);
+    this.cache = cache;
+    this.metricDAO = metricDAO;
+    this.datasetDAO = datasetDAO;
+    this.strategyFactory = strategyFactory;
+  }
+
+  /**
+   * Alternate constructor for RCAFrameworkLoader
+   *
+   * @param outputName pipeline output name
+   * @param inputNames input pipeline names
+   * @param properties configuration properties ({@code PROP_STRATEGY})
+   */
+  public MetricAnalysisPipeline(String outputName, Set<String> inputNames, Map<String, Object> properties) {
+    super(outputName, inputNames);
+    this.metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
+    this.datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();
+    this.cache = ThirdEyeCacheRegistry.getInstance().getQueryCache();
+    this.strategyFactory = parseStrategyFactory(MapUtils.getString(properties, PROP_STRATEGY, PROP_STRATEGY_DEFAULT));
+  }
+
+  @Override
+  public PipelineResult run(PipelineContext context) {
+    Set<MetricEntity> metrics = context.filter(MetricEntity.class);
+
+    TimeRangeEntity anomalyRange = TimeRangeEntity.getTimeRangeAnomaly(context);
+    TimeRangeEntity baselineRange = TimeRangeEntity.getTimeRangeBaseline(context);
+
+    // NOTE: baseline lookback only affects amount of training data, training is always WoW
+    // NOTE: data window is aligned to metric time granularity
+    final long trainingBaselineStart = baselineRange.getStart() - TRAINING_OFFSET;
+    final long trainingBaselineEnd = anomalyRange.getStart() - TRAINING_OFFSET;
+    final long trainingCurrentStart = baselineRange.getStart();
+    final long trainingCurrentEnd = anomalyRange.getStart();
+
+    final long testBaselineStart = baselineRange.getStart();
+    final long testBaselineEnd = baselineRange.getEnd();
+    final long testCurrentStart = anomalyRange.getStart();
+    final long testCurrentEnd = anomalyRange.getEnd();
+
+    Multimap<String, String> filters = DimensionEntity.makeFilterSet(context);
+
+    LOG.info("Processing {} metrics", metrics.size());
+
+    // generate requests
+    List<TimeSeriesRequestContainer> requestList = new ArrayList<>();
+    requestList.addAll(makeRequests(metrics, trainingBaselineStart, testCurrentEnd, filters, PRE_TOTAL));
+
+    LOG.info("Requesting {} time series", requestList.size());
+    List<ThirdEyeRequest> thirdeyeRequests = new ArrayList<>();
+    Map<String, TimeSeriesRequestContainer> requests = new HashMap<>();
+    for(TimeSeriesRequestContainer rc : requestList) {
+      final ThirdEyeRequest req = rc.getRequest();
+      requests.put(req.getRequestReference(), rc);
+      thirdeyeRequests.add(req);
+    }
+
+    Collection<Future<ThirdEyeResponse>> futures = submitRequests(thirdeyeRequests);
+
+    // fetch responses and calculate derived metrics
+    int i = 0;
+    Map<String, DataFrame> responses = new HashMap<>();
+    for(Future<ThirdEyeResponse> future : futures) {
+      ThirdEyeResponse response;
+      try {
+        response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      } catch (Exception e) {
+        LOG.warn("Error executing request '{}'. Skipping.", requestList.get(i).getRequest().getRequestReference(), e);
+        continue;
+      } finally {
+        i++;
+      }
+
+      // parse time series
+      String id = response.getRequest().getRequestReference();
+      DataFrame df;
+      try {
+        df = DataFrameUtils.evaluateResponse(response, requests.get(id));
+      } catch (Exception e) {
+        LOG.warn("Could not parse response for '{}'. Skipping.", id, e);
+        continue;
+      }
+
+      // store time series
+      responses.put(id, df);
+    }
+
+    // score metrics
+    Set<MetricEntity> output = new HashSet<>();
+    for(MetricEntity me : metrics) {
+      try {
+        String id = makeIdentifier(me.getUrn(), PRE_TOTAL);
+
+        if(!responses.containsKey(id)) {
+          LOG.warn("Did not receive response for '{}'. Skipping.", me.getUrn());
+          continue;
+        }
+
+        DataFrame timeseries = responses.get(id);
+        if (timeseries.isEmpty()) {
+          LOG.warn("No data for '{}'. Skipping.", me.getUrn());
+          continue;
+        }
+
+        LOG.info("Preparing training and test data for metric '{}'", me.getUrn());
+        DataFrame trainingBaseline = extractTimeRange(timeseries, trainingBaselineStart, trainingBaselineEnd);
+        DataFrame trainingCurrent = extractTimeRange(timeseries, trainingCurrentStart, trainingCurrentEnd);
+        DataFrame testBaseline = extractTimeRange(timeseries, testBaselineStart, testBaselineEnd);
+        DataFrame testCurrent = extractTimeRange(timeseries, testCurrentStart, testCurrentEnd);
+
+//        LOG.info("timeseries ({} rows): {}", timeseries.size(), timeseries.head(20));
+//        LOG.info("trainingBaseline ({} rows): from {} to {}", trainingBaseline.size(), trainingBaselineStart, trainingBaselineEnd);
+//        LOG.info("trainingCurrent ({} rows): from {} to {}", trainingCurrent.size(), trainingCurrentStart, trainingCurrentEnd);
+//        LOG.info("testBaseline ({} rows): from {} to {}", testBaseline.size(), testBaselineStart, testBaselineEnd);
+//        LOG.info("testCurrent ({} rows): from {} to {}", testCurrent.size(), testCurrentStart, testCurrentEnd);
+
+        DataFrame trainingDiff = diffTimeseries(trainingCurrent, trainingBaseline);
+        DataFrame testDiff = diffTimeseries(testCurrent, testBaseline);
+
+        double score = this.strategyFactory.fit(trainingDiff).apply(testDiff);
+
+        List<Entity> related = new ArrayList<>();
+        related.add(anomalyRange);
+        related.add(baselineRange);
+
+        output.add(me.withScore(score).withRelated(related));
+
+      } catch (Exception e) {
+        LOG.warn("Error processing '{}'. Skipping", me.getUrn(), e);
+      }
+    }
+
+    LOG.info("Generated {} MetricEntities with valid scores", output.size());
+
+    return new PipelineResult(context, output);
+  }
+
+  private DataFrame extractTimeRange(DataFrame data, final long start, final long end) {
+    if (data.size() <= 1) {
+      return data;
+    }
+
+    final LongSeries timestamps = data.getLongs(COL_TIME);
+    final long granularity = timestamps.subtract(timestamps.shift(1)).dropNull().head(1).longValue();
+    if ((start / granularity) == (end / granularity)) {
+      // not crossing bucket boundary, return nearest lower timestamp
+      return data.filterEquals(COL_TIME, (start / granularity) * granularity).dropNull();
+    }
+
+    return data.filter(new Series.LongConditional() {
+          @Override
+          public boolean apply(long... values) {
+            return values[0] >= start && values[0] < end;
+          }
+        }, COL_TIME).dropNull();
+  }
+
+  private DataFrame diffTimeseries(DataFrame current, DataFrame baseline) {
+    final long currentOffset = current.getLongs(COL_TIME).min().fillNull().longValue();
+
+    DataFrame offsetCurrent = new DataFrame()
+        .addSeries(COL_TIME, current.getLongs(COL_TIME).subtract(currentOffset))
+        .addSeries(COL_CURRENT, current.getDoubles(COL_VALUE))
+        .setIndex(COL_TIME);
+    DataFrame offsetBaseline = new DataFrame()
+        .addSeries(COL_TIME, baseline.getLongs(COL_TIME).subtract(currentOffset - TRAINING_OFFSET))
+        .addSeries(COL_BASELINE, baseline.getDoubles(COL_VALUE))
+        .setIndex(COL_TIME);
+    DataFrame joined = offsetCurrent.joinInner(offsetBaseline);
+    return joined.addSeries(COL_VALUE, joined.getDoubles(COL_CURRENT).subtract(joined.get(COL_BASELINE)))
+        .dropSeries(COL_CURRENT, COL_BASELINE);
+  }
+
+  private Collection<Future<ThirdEyeResponse>> submitRequests(List<ThirdEyeRequest> thirdeyeRequests) {
+    try {
+      return this.cache.getQueryResultsAsync(thirdeyeRequests).values();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<TimeSeriesRequestContainer> makeRequests(Collection<MetricEntity> metrics, long start, long end, Multimap<String, String> filters, String prefix) {
+    List<TimeSeriesRequestContainer> requests = new ArrayList<>();
+    for(MetricEntity e : metrics) {
+      String id = makeIdentifier(e.getUrn(), prefix);
+      MetricSlice slice = MetricSlice.from(e.getId(), start, end, filters);
+      try {
+        requests.add(DataFrameUtils.makeTimeSeriesRequestAligned(slice, id, this.metricDAO, this.datasetDAO));
+      } catch (Exception ex) {
+        LOG.warn(String.format("Could not make request for '%s'. Skipping.", id), ex);
+      }
+    }
+    return requests;
+  }
+
+  private static String makeIdentifier(String urn, String prefix) {
+    return prefix + urn;
+  }
+
+  private static ScoringStrategyFactory parseStrategyFactory(String strategy) {
+    switch(strategy) {
+      case STRATEGY_THRESHOLD:
+        return new ThresholdStrategyFactory(0.90, 0.95, 0.975, 0.99, 1.00);
+      default:
+        throw new IllegalArgumentException(String.format("Unknown strategy '%s'", strategy));
+    }
+  }
+
+  private interface ScoringStrategyFactory {
+    ScoringStrategy fit(DataFrame training);
+  }
+
+  private interface ScoringStrategy {
+    double apply(DataFrame data);
+  }
+
+  private static class ThresholdStrategyFactory implements ScoringStrategyFactory {
+    final double[] quantiles;
+
+    ThresholdStrategyFactory(double... quantiles) {
+      this.quantiles = quantiles;
+    }
+
+    @Override
+    public ScoringStrategy fit(DataFrame training) {
+      DoubleSeries train = training.getDoubles(COL_VALUE);
+      double[] thresholds = new double[this.quantiles.length];
+      for (int i = 0; i < thresholds.length; i++) {
+        thresholds[i] = train.abs().quantile(this.quantiles[i]).fillNull(Double.POSITIVE_INFINITY).doubleValue();
+      }
+      return new ThresholdStrategy(thresholds);
+    }
+  }
+
+  private static class ThresholdStrategy implements ScoringStrategy {
+    final double[] thresholds;
+
+    ThresholdStrategy(double... thresholds) {
+      this.thresholds = thresholds;
+    }
+
+    @Override
+    public double apply(DataFrame data) {
+      DoubleSeries test = data.getDoubles(COL_VALUE);
+
+      LOG.info("thresholds: {}", this.thresholds);
+
+      long sumViolations = 0;
+      for (final double t : thresholds) {
+        sumViolations += test.abs().map(new Series.DoubleConditional() {
+          @Override
+          public boolean apply(double... values) {
+            return values[0] > t;
+          }
+        }).sum().fillNull().longValue();
+      }
+
+      final int max = test.size() * this.thresholds.length;
+      if (max <= 0) {
+        return 0;
+      }
+
+      return sumViolations / (double) max;
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
@@ -2627,6 +2627,45 @@ public class DataFrameTest {
   }
 
   @Test
+  public void testDoubleQuantile() {
+    DoubleSeries base = DataFrame.toSeries(DNULL, 1, 2, 3, 4, 5);
+    assertEquals(base.quantile(0.00), 1d);
+    assertEquals(base.quantile(0.25), 2d);
+    assertEquals(base.quantile(0.50), 3d);
+    assertEquals(base.quantile(0.75), 4d);
+    assertEquals(base.quantile(1.00), 5d);
+  }
+
+  @Test
+  public void testDoubleQuantileInterpolation() {
+    DoubleSeries base = DataFrame.toSeries(DNULL, 1, 2, 3, 4, 5);
+    assertEquals(base.quantile(0.0000), 1.00);
+    assertEquals(base.quantile(0.0625), 1.25);
+    assertEquals(base.quantile(0.1250), 1.50);
+    assertEquals(base.quantile(0.1875), 1.75);
+    assertEquals(base.quantile(0.2500), 2.00);
+  }
+
+  @Test
+  public void testDoubleQuantileNull() {
+    DoubleSeries base = DataFrame.toSeries(DNULL);
+    assertEquals(base.quantile(0.00), DNULL);
+    assertEquals(base.quantile(1.00), DNULL);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDoubleQuantileFailLowQ() {
+    DoubleSeries base = DataFrame.toSeries(DNULL);
+    assertEquals(base.quantile(-0.01), DNULL);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testDoubleQuantileFailHighQ() {
+    DoubleSeries base = DataFrame.toSeries(DNULL);
+    assertEquals(base.quantile(1.01), DNULL);
+  }
+
+  @Test
   public void testLongOperationsSeries() {
     LongSeries base = DataFrame.toSeries(LNULL, 0, 1, 5, 10);
     LongSeries mod = DataFrame.toSeries(1, 1, 1, 0, LNULL);


### PR DESCRIPTION
The existing MetricCorrelationRankingPipeline makes a number of assumptions about the type of metrics being compared that no longer hold in practice. This PR add a more generic MetricAnalysisPipeline that allows related metric to be ranked with more generic strategies. The PR furthermore adds small missing features and fixes bugs that turned up during the implementation of this pipeline.

* adds MetricAnalysisPipeline

* adds quantile-based ranking strategy

* adds quantile function to dataframe double series

* adds helper to fetch timeseries with aligned timestamps

* fixes race condition in thirdeye request builder