### PR TITLE
Added an option to allocate Direct Offheap memory for realtime consuming segments

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerGauge.java
@@ -34,6 +34,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   KAFKA_PARTITION_OFFSET_LAG("messages", false),
   REALTIME_OFFHEAP_MEMORY_USED("bytes", false),
   RUNNING_QUERIES("runningQueries", false),
+  NUM_SEGMENTS_SEARCHED("numSegmentsSearched", false),
   REALTIME_SEGMENT_PARTITION_WIDTH("realtimeSegmentPartitionWidth", false);
 
   private final String gaugeName;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -222,6 +222,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_ENABLE_SHUTDOWN_DELAY = "pinot.server.instance.enable.shutdown.delay";
     public static final String CONFIG_OF_ENABLE_SPLIT_COMMIT = "pinot.server.instance.enable.split.commit";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap";
+    public static final String CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap.direct";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -43,4 +43,6 @@ public interface InstanceDataManagerConfig {
   boolean isEnableSplitCommit();
 
   boolean isRealtimeOffHeapAllocation();
+
+  boolean isDirectRealtimeOffheapAllocation();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -106,7 +106,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     this.serverMetrics =serverMetrics;
     this.segmentName = segmentMetadata.getSegmentName();
     this.tableName = tableConfig.getTableName();
-    initMemoryManager(realtimeTableDataManager, indexLoadingConfig.isRealtimeOffheapAllocation(), segmentName);
+    initMemoryManager(realtimeTableDataManager, indexLoadingConfig.isRealtimeOffheapAllocation(), indexLoadingConfig.isDirectRealtimeOffheapAllocation(), segmentName);
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -887,7 +887,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     segmentLogger = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class.getName() +
         "_" + _segmentNameStr);
     _tableStreamName = _tableName + "_" + kafkaStreamProviderConfig.getStreamName();
-    initMemoryManager(realtimeTableDataManager, indexLoadingConfig.isRealtimeOffheapAllocation(), _segmentNameStr);
+    initMemoryManager(realtimeTableDataManager, indexLoadingConfig.isRealtimeOffheapAllocation(), indexLoadingConfig.isDirectRealtimeOffheapAllocation(),
+        _segmentNameStr);
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {
@@ -1027,8 +1028,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     final long prevTime = _lastConsumedCount == 0 ? _consumeStartTime : _lastLogTime;
     // Log every minute or 100k events
     if (now - prevTime > TimeUnit.MINUTES.toMillis(TIME_THRESHOLD_FOR_LOG_MINUTES) || rowsConsumed >= MSG_COUNT_THRESHOLD_FOR_LOG) {
-      segmentLogger.info("Consumed {} events from (rate:{}/s), currentOffset={}", rowsConsumed,
-            (float) (rowsConsumed) * 1000 / (now - prevTime), _currentOffset);
+      segmentLogger.info("Consumed {} events from (rate:{}/s), currentOffset={}, numRowsSoFar={}", rowsConsumed,
+            (float) (rowsConsumed) * 1000 / (now - prevTime), _currentOffset, _numRowsConsumed);
       _lastConsumedCount = _numRowsConsumed;
       _lastLogTime = now;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -49,13 +49,14 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
     return _statsHistory;
   }
 
-  protected void initMemoryManager(RealtimeTableDataManager realtimeTableDataManager, boolean isOffHeapAllocation, String segmentName) {
+  protected void initMemoryManager(RealtimeTableDataManager realtimeTableDataManager, boolean isOffHeapAllocation,
+      boolean isDirectAllocation, String segmentName) {
     ServerMetrics serverMetrics = realtimeTableDataManager.getServerMetrics();
-    if (isOffHeapAllocation) {
+    if (isOffHeapAllocation && !isDirectAllocation) {
       _memoryManager = new MmapMemoryManager(realtimeTableDataManager.getConsumerDir(), segmentName,
-          realtimeTableDataManager.getServerMetrics());
+          serverMetrics);
     } else {
-      _memoryManager = new DirectMemoryManager(segmentName, realtimeTableDataManager.getServerMetrics());
+      _memoryManager = new DirectMemoryManager(segmentName, serverMetrics);
     }
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -56,6 +56,8 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
       _memoryManager = new MmapMemoryManager(realtimeTableDataManager.getConsumerDir(), segmentName,
           serverMetrics);
     } else {
+      // It could on-heap allocation, in which case we still need a mem manager for fwd-index.
+      // Dictionary will be allocated on heap.
       _memoryManager = new DirectMemoryManager(segmentName, serverMetrics);
     }
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
@@ -79,7 +79,7 @@ public abstract class RealtimeIndexOffHeapMemoryManager implements Closeable {
    * @return PinotDataBuffer
    */
   public PinotDataBuffer allocate(long size, String columnName) {
-    Preconditions.checkArgument(size > 0, "Illegal memory allocation " + size + " for segment " + _segmentName);
+    Preconditions.checkArgument(size > 0, "Illegal memory allocation " + size + " for segment " + _segmentName + " column " + columnName);
     PinotDataBuffer buffer = allocateInternal(size, columnName);
     _totalMemBytes += size;
     _buffers.add(buffer);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/scheduler/QueryScheduler.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import com.linkedin.pinot.common.exception.QueryException;
+import com.linkedin.pinot.common.metrics.ServerGauge;
 import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.common.metrics.ServerQueryPhase;
@@ -163,6 +164,7 @@ public abstract class QueryScheduler {
         getMetadataValue(resultMeta, DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY),
         getMetadataValue(resultMeta, DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY),
         name());
+    serverMetrics.setValueOfTableGauge(request.getTableName(), ServerGauge.NUM_SEGMENTS_SEARCHED, request.getSegmentCountAfterPruning());
 
     return responseData;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImpl.java
@@ -58,6 +58,9 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
   private final Logger LOGGER;
   public static final int[] EMPTY_DICTIONARY_IDS_ARRAY = new int[0];
 
+  private static final String MMGR_DICTIONARY_SUFFIX = ".dict";
+  private static final String MMGR_FWDINDEX_SUFFIX = ".fwd";
+
   private SegmentMetadataImpl _segmentMetadata;
   private final Schema dataSchema;
 
@@ -139,19 +142,19 @@ public class RealtimeSegmentImpl implements RealtimeSegment {
         }
         MutableDictionary dictionary =
             MutableDictionaryFactory.getMutableDictionary(dataType, isOffHeapAllocation, memoryManager,
-                dictionaryColumnSize, statsHistory.getEstimatedCardinality(columnName), columnName);
+                dictionaryColumnSize, statsHistory.getEstimatedCardinality(columnName), columnName + MMGR_DICTIONARY_SUFFIX);
         dictionaryMap.put(columnName, dictionary);
       }
 
       DataFileReader dataFileReader;
       if (fieldSpec.isSingleValueField()) {
         dataFileReader =
-            new FixedByteSingleColumnSingleValueReaderWriter(capacity, indexColumnSize, memoryManager, columnName);
+            new FixedByteSingleColumnSingleValueReaderWriter(capacity, indexColumnSize, memoryManager, columnName + MMGR_FWDINDEX_SUFFIX);
       } else {
         // TODO: Start with a smaller capacity on FixedByteSingleColumnMultiValueReaderWriter and let it expand
         dataFileReader =
             new FixedByteSingleColumnMultiValueReaderWriter(MAX_MULTI_VALUES_PER_ROW, avgMultiValueCount, capacity,
-                indexColumnSize, memoryManager, columnName);
+                indexColumnSize, memoryManager, columnName + MMGR_FWDINDEX_SUFFIX);
       }
       columnIndexReaderWriterMap.put(columnName, dataFileReader);
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -49,6 +49,7 @@ public class IndexLoadingConfig {
   private int _realtimeAvgMultiValueCount = DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT;
   private boolean _enableSplitCommit;
   private boolean _isRealtimeOffheapAllocation;
+  private boolean _isDirectRealtimeOffheapAllocation;
 
   public IndexLoadingConfig(@Nonnull InstanceDataManagerConfig instanceDataManagerConfig,
       @Nonnull TableConfig tableConfig) {
@@ -116,6 +117,7 @@ public class IndexLoadingConfig {
     _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
 
     _isRealtimeOffheapAllocation = instanceDataManagerConfig.isRealtimeOffHeapAllocation();
+    _isDirectRealtimeOffheapAllocation = instanceDataManagerConfig.isDirectRealtimeOffheapAllocation();
 
     String avgMultiValueCount = instanceDataManagerConfig.getAvgMultiValueCount();
     if (avgMultiValueCount != null) {
@@ -202,6 +204,10 @@ public class IndexLoadingConfig {
 
   public boolean isRealtimeOffheapAllocation() {
     return _isRealtimeOffheapAllocation;
+  }
+
+  public boolean isDirectRealtimeOffheapAllocation() {
+    return _isDirectRealtimeOffheapAllocation;
   }
 
   @Nonnull

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
  */
 public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegrationTest {
   public static final String CONSUMER_DIRECTORY = "/tmp/consumer-test";
+  public static final boolean isDirectAlloc = Math.random() < 0.5;
 
   @BeforeClass
   @Override
@@ -60,13 +61,16 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
   @Override
   protected void overrideServerConf(Configuration configuration) {
     configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION, "true");
+    configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION, Boolean.toString(isDirectAlloc));
     configuration.setProperty(CommonConstants.Server.CONFIG_OF_CONSUMER_DIR, CONSUMER_DIRECTORY);
   }
 
   @Test
   public void testConsumerDirectoryExists() {
     File consumerDirectory = new File(CONSUMER_DIRECTORY, "mytable_REALTIME");
-    Assert.assertTrue(consumerDirectory.exists(), "The off heap consumer directory does not exist");
+    if (!isDirectAlloc) {
+      Assert.assertTrue(consumerDirectory.exists(), "The off heap consumer directory does not exist");
+    }
   }
 
   @Test

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -62,6 +62,10 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   // Whether memory for realtime consuming segments should be allocated off-heap.
   private static final String REALTIME_OFFHEAP_ALLOCATION = "realtime.alloc.offheap";
+  // And whether the allocation should be direct (default is to allocate via mmap)
+  // Direct memory allocation may mean setting heap size appropriately when starting JVM.
+  // The metric ServerGauge.REALTIME_OFFHEAP_MEMORY_USED should indicate how much memory is needed.
+  private static final String DIRECT_REALTIME_OFFHEAP_ALLOCATION = "realtime.alloc.offheap.direct";
 
   // Number of simultaneous segments that can be refreshed on one server.
   // Segment refresh works by loading the old as well as new versions of segments in memory, assigning
@@ -152,6 +156,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public boolean isRealtimeOffHeapAllocation() {
     return _instanceDataManagerConfiguration.getBoolean(REALTIME_OFFHEAP_ALLOCATION, false);
+  }
+
+  @Override
+  public boolean isDirectRealtimeOffheapAllocation() {
+    return _instanceDataManagerConfiguration.getBoolean(DIRECT_REALTIME_OFFHEAP_ALLOCATION, true);
   }
 
   @Override


### PR DESCRIPTION
So far, off-heap allocation for realtime consuming segments meant MMAP-based allocation.
This may generate excessive disk i/o depending on the configuaration. Added a setting
to allocate this memory via direct allocation.

Since direct memory translates to an internal memory allocation call, we may end up
allocating more than what we actually need. Fragmentation is also possible, since multiple
threads will be allocating memory of different sizes, and may release them in different order.

A more fancy algorithm may be to do a bit of memory management in this code (like how mmap
does, but at a smaller mem level, perhaps). For now, we leave it at this.

Changed some logs to be more informative, and added one metric on the server to have it
report the number of segments scanned in a query as a gauge.

Tested LLRealtimeClusterIntegrationTest with both direct and mmap allocations