### PR TITLE
Limit the number of segment builds on a server

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -43,4 +43,6 @@ public interface InstanceDataManagerConfig {
   boolean isEnableSplitCommit();
 
   boolean isRealtimeOffHeapAllocation();
+
+  int getMaxParallelSegmentBuilds();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -57,6 +57,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -150,6 +151,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private static final long TIME_THRESHOLD_FOR_LOG_MINUTES = 1;
   private static final long TIME_EXTENSION_ON_EMPTY_SEGMENT_HOURS = 1;
   private static final int MSG_COUNT_THRESHOLD_FOR_LOG = 100000;
+  private static final int BUILD_TIME_LEASE_SECONDS = 30;
   private final int MAX_CONSECUTIVE_ERROR_COUNT = 5;
 
   private final LLCRealtimeSegmentZKMetadata _segmentZKMetadata;
@@ -209,6 +211,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private long _lastLogTime = 0;
   private int _lastConsumedCount = 0;
   private String _stopReason = null;
+  private final Semaphore _segBuildSemaphore;
 
 
   // TODO each time this method is called, we print reason for stop. Good to print only once.
@@ -565,7 +568,14 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         removeSegmentFile();
       }
       if (buildTimeLeaseMs <= 0) {
-        buildTimeLeaseMs = SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds() * 1000L;
+        if (_segBuildSemaphore == null) {
+          buildTimeLeaseMs = SegmentCompletionProtocol.getDefaultMaxSegmentCommitTimeSeconds() * 1000L;
+        } else {
+          // We know we are going to use a semaphore to limit number of segment builds, and could be
+          // blocked for a long time. The controller has not provided a lease time, so set one to
+          // some reasonable guess here.
+          buildTimeLeaseMs = BUILD_TIME_LEASE_SECONDS * 1000;
+        }
       }
       _leaseExtender.addSegment(_segmentNameStr, buildTimeLeaseMs, _currentOffset);
       String segTarFile =  buildSegmentInternal(true);
@@ -577,49 +587,62 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   protected String buildSegmentInternal(boolean forCommit) {
-    long startTimeMillis = System.currentTimeMillis();
-    // Build a segment from in-memory rows.If buildTgz is true, then build the tar.gz file as well
-    // TODO Use an auto-closeable object to delete temp resources.
-    File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + _segmentNameStr + "-" + String.valueOf(now()));
-    // lets convert the segment now
-    RealtimeSegmentConverter converter =
-        new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
-            _segmentZKMetadata.getTableName(), _segmentZKMetadata.getSegmentName(), _sortedColumn,
-            _invertedIndexColumns, _noDictionaryColumns, _starTreeIndexSpec);
-    logStatistics();
-    segmentLogger.info("Trying to build segment");
-    final long buildStartTime = now();
     try {
-      converter.build(_segmentVersion, _serverMetrics);
-    } catch (Exception e) {
-      segmentLogger.error("Could not build segment", e);
-      FileUtils.deleteQuietly(tempSegmentFolder);
-      return null;
-    }
-    final long buildEndTime = now();
-    segmentLogger.info("Successfully built segment in {} ms", (buildEndTime - buildStartTime));
-    File destDir = makeSegmentDirPath();
-    FileUtils.deleteQuietly(destDir);
-    try {
-      FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], destDir);
-      if (forCommit) {
-        TarGzCompressionUtils.createTarGzOfDirectory(destDir.getAbsolutePath());
+      if (_segBuildSemaphore != null) {
+        segmentLogger.info("Waiting to acquire semaphore for building segment");
+        _segBuildSemaphore.acquire();
       }
-    } catch (IOException e) {
-      segmentLogger.error("Exception during move/tar segment", e);
+      long startTimeMillis = System.currentTimeMillis();
+      // Build a segment from in-memory rows.If buildTgz is true, then build the tar.gz file as well
+      // TODO Use an auto-closeable object to delete temp resources.
+      File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + _segmentNameStr + "-" + String.valueOf(now()));
+      // lets convert the segment now
+      RealtimeSegmentConverter converter =
+          new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
+              _segmentZKMetadata.getTableName(), _segmentZKMetadata.getSegmentName(), _sortedColumn,
+              _invertedIndexColumns, _noDictionaryColumns, _starTreeIndexSpec);
+      logStatistics();
+      segmentLogger.info("Trying to build segment");
+      final long buildStartTime = now();
+      try {
+        converter.build(_segmentVersion, _serverMetrics);
+      } catch (Exception e) {
+        segmentLogger.error("Could not build segment", e);
+        FileUtils.deleteQuietly(tempSegmentFolder);
+        return null;
+      }
+      final long buildEndTime = now();
+      segmentLogger.info("Successfully built segment in {} ms", (buildEndTime - buildStartTime));
+      File destDir = makeSegmentDirPath();
+      FileUtils.deleteQuietly(destDir);
+      try {
+        FileUtils.moveDirectory(tempSegmentFolder.listFiles()[0], destDir);
+        if (forCommit) {
+          TarGzCompressionUtils.createTarGzOfDirectory(destDir.getAbsolutePath());
+        }
+      } catch (IOException e) {
+        segmentLogger.error("Exception during move/tar segment", e);
+        FileUtils.deleteQuietly(tempSegmentFolder);
+        return null;
+      }
       FileUtils.deleteQuietly(tempSegmentFolder);
+      long endTimeMillis = System.currentTimeMillis();
+
+      _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS,
+          TimeUnit.MILLISECONDS.toSeconds(endTimeMillis - startTimeMillis));
+
+      if (forCommit) {
+        return destDir.getAbsolutePath() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENTION;
+      }
+      return destDir.getAbsolutePath();
+    } catch (InterruptedException e) {
+      segmentLogger.error("Interrupted while waiting for semaphore");
       return null;
+    } finally {
+      if (_segBuildSemaphore != null) {
+        _segBuildSemaphore.release();
+      }
     }
-    FileUtils.deleteQuietly(tempSegmentFolder);
-    long endTimeMillis = System.currentTimeMillis();
-
-    _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LAST_REALTIME_SEGMENT_CREATION_DURATION_SECONDS,
-        TimeUnit.MILLISECONDS.toSeconds(endTimeMillis - startTimeMillis));
-
-    if (forCommit) {
-      return destDir.getAbsolutePath() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENTION;
-    }
-    return destDir.getAbsolutePath();
   }
 
   protected SegmentCompletionProtocol.Response doSplitCommit(File segmentTarFile, SegmentCompletionProtocol.Response prevResponse) {
@@ -857,6 +880,12 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       IndexLoadingConfig indexLoadingConfig, Schema schema, ServerMetrics serverMetrics)
       throws Exception {
     initStatsHistory(realtimeTableDataManager);
+    int maxParallelBuilds = indexLoadingConfig.getMaxParallelSegmentBuilds();
+    if (maxParallelBuilds > 0) {
+      _segBuildSemaphore = new Semaphore(indexLoadingConfig.getMaxParallelSegmentBuilds(), true);
+    } else {
+      _segBuildSemaphore = null;
+    }
     _segmentZKMetadata = (LLCRealtimeSegmentZKMetadata) segmentZKMetadata;
     _tableConfig = tableConfig;
     _realtimeTableDataManager = realtimeTableDataManager;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
  */
 public class IndexLoadingConfig {
   private static final int DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT = 2;
+  private static final int DEFAULT_MAX_PARALLEL_SEGMENT_BUILDS = 0;
 
   private ReadMode _readMode = ReadMode.DEFAULT_MODE;
   private List<String> _sortedColumns = Collections.emptyList();
@@ -47,6 +48,7 @@ public class IndexLoadingConfig {
   private boolean _enableDefaultColumns = true;
   private ColumnMinMaxValueGeneratorMode _columnMinMaxValueGeneratorMode = ColumnMinMaxValueGeneratorMode.DEFAULT_MODE;
   private int _realtimeAvgMultiValueCount = DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT;
+  private int _maxParallelSegmentBuilds = DEFAULT_MAX_PARALLEL_SEGMENT_BUILDS;
   private boolean _enableSplitCommit;
   private boolean _isRealtimeOffheapAllocation;
 
@@ -111,6 +113,8 @@ public class IndexLoadingConfig {
       _segmentVersion = SegmentVersion.valueOf(instanceSegmentVersion.toLowerCase());
     }
 
+    _maxParallelSegmentBuilds = instanceDataManagerConfig.getMaxParallelSegmentBuilds();
+
     _enableDefaultColumns = instanceDataManagerConfig.isEnableDefaultColumns();
 
     _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
@@ -149,6 +153,10 @@ public class IndexLoadingConfig {
   @Nonnull
   public Set<String> getInvertedIndexColumns() {
     return _invertedIndexColumns;
+  }
+
+  public int getMaxParallelSegmentBuilds() {
+    return _maxParallelSegmentBuilds;
   }
 
   /**

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -57,6 +57,12 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   // Key of whether to enable default columns
   private static final String ENABLE_DEFAULT_COLUMNS = "enable.default.columns";
 
+  // Key of how many parallel realtime segments can be built.
+  // A value of <= 0 indicates unlimited.
+  // Unlimited parallel builds can cause high GC pauses during segment builds, causing
+  // response times to suffer.
+  private static final String MAX_PARALLEL_SEGMENT_BUILDS = "realtime.max.parallel.segment.builds";
+
   // Key of whether to enable split commit
   private static final String ENABLE_SPLIT_COMMIT = "enable.split.commit";
 
@@ -161,6 +167,10 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   public int getMaxParallelRefreshThreads() {
     return _instanceDataManagerConfiguration.getInt(MAX_PARALLEL_REFRESH_THREADS, 1);
+  }
+
+  public int getMaxParallelSegmentBuilds() {
+    return _instanceDataManagerConfiguration.getInt(MAX_PARALLEL_SEGMENT_BUILDS, 0);
   }
 
   @Override


### PR DESCRIPTION
Default behavior is to keep this unlimited. However, in some use cases that may have
a loq latency requirement, with a high QPS, and also a large number of columns, we
may incur heavy GC pauses during segment builds.

The only down-side of enabling this limit is that we will pause the consumption if
segment build is delayed on the committer. Since we are consuming on a per-partition
basis, the consumption should catch up quickly.

Alternative is to add more servers.