### PR TITLE
Fix lease extend protocol handling in the controller

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -871,7 +871,7 @@ public class SegmentCompletionManager {
       SegmentCompletionProtocol.Response response = abortIfTooLateAndReturnHold(now, instanceId, offset);
       if (response == null) {
         long maxTimeAllowedToCommitMs = now + extTimeSec * 1000;
-        if (maxTimeAllowedToCommitMs > MAX_COMMIT_TIME_FOR_ALL_SEGMENTS_SECONDS * 1000) {
+        if (maxTimeAllowedToCommitMs > _startTimeMs + MAX_COMMIT_TIME_FOR_ALL_SEGMENTS_SECONDS * 1000) {
           LOGGER.warn("Not accepting lease extension from {} startTime={} requestedTime={}", instanceId, _startTimeMs, maxTimeAllowedToCommitMs);
           return abortAndReturnFailed();
         }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -751,8 +751,8 @@ public class SegmentCompletionTest {
   public void testHappyPathSlowCommit() throws Exception {
     SegmentCompletionProtocol.Response response;
     Request.Params params;
-    // s1 sends offset of 20, gets HOLD at t = 5s;
-    final long startTime = 5;
+    // s1 sends offset of 20, gets HOLD at t = 1509242466s;
+    final long startTime = 1509242466;
     final String tableName = new LLCSegmentName(segmentNameStr).getTableName();
     Assert.assertNull(commitTimeMap.get(tableName));
     segmentCompletionMgr._secconds = startTime;


### PR DESCRIPTION
The extend lease message from the server was aborting the FSM all the time in the controller
because the comparison of max segment commit time did not take into account the start time
of the FSM.

Fixed, and changed the unit test (unit test with the change failed without the fix)