### PR TITLE
Limit the number of segment builds on a server

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -45,4 +45,6 @@ public interface InstanceDataManagerConfig {
   boolean isRealtimeOffHeapAllocation();
 
   boolean isDirectRealtimeOffheapAllocation();
+
+  int getMaxParallelSegmentBuilds();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/config/TableDataManagerConfig.java
@@ -32,6 +32,7 @@ public class TableDataManagerConfig {
   private static final String TABLE_DATA_MANAGER_DATA_DIRECTORY = "directory";
   private static final String TABLE_DATA_MANAGER_CONSUMER_DIRECTORY = "consumerDirectory";
   private static final String TABLE_DATA_MANAGER_NAME = "name";
+  private static final String TABLE_DATA_MANAGER_MAX_PARALLEL_SEGMENT_BUILDS = "maxParallelSegmentBuilds";
 
   private final Configuration _tableDataManagerConfig;
 
@@ -60,6 +61,10 @@ public class TableDataManagerConfig {
     return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_NAME);
   }
 
+  public int getMaxParallelSegmentBuilds() {
+    return _tableDataManagerConfig.getInt(TABLE_DATA_MANAGER_MAX_PARALLEL_SEGMENT_BUILDS);
+  }
+
   public static TableDataManagerConfig getDefaultHelixTableDataManagerConfig(
       @Nonnull InstanceDataManagerConfig instanceDataManagerConfig, @Nonnull String tableName)
       throws ConfigurationException {
@@ -71,6 +76,7 @@ public class TableDataManagerConfig {
     String dataDir = instanceDataManagerConfig.getInstanceDataDir() + "/" + tableName;
     defaultConfig.addProperty(TABLE_DATA_MANAGER_DATA_DIRECTORY, dataDir);
     defaultConfig.addProperty(TABLE_DATA_MANAGER_CONSUMER_DIRECTORY, instanceDataManagerConfig.getConsumerDir());
+    defaultConfig.addProperty(TABLE_DATA_MANAGER_MAX_PARALLEL_SEGMENT_BUILDS, instanceDataManagerConfig.getMaxParallelSegmentBuilds());
     switch (tableType) {
       case OFFLINE:
         defaultConfig.addProperty(TABLE_DATA_MANAGER_TYPE, "offline");

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -57,6 +57,12 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   // Key of whether to enable default columns
   private static final String ENABLE_DEFAULT_COLUMNS = "enable.default.columns";
 
+  // Key of how many parallel realtime segments can be built.
+  // A value of <= 0 indicates unlimited.
+  // Unlimited parallel builds can cause high GC pauses during segment builds, causing
+  // response times to suffer.
+  private static final String MAX_PARALLEL_SEGMENT_BUILDS = "realtime.max.parallel.segment.builds";
+
   // Key of whether to enable split commit
   private static final String ENABLE_SPLIT_COMMIT = "enable.split.commit";
 
@@ -170,6 +176,10 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   public int getMaxParallelRefreshThreads() {
     return _instanceDataManagerConfiguration.getInt(MAX_PARALLEL_REFRESH_THREADS, 1);
+  }
+
+  public int getMaxParallelSegmentBuilds() {
+    return _instanceDataManagerConfiguration.getInt(MAX_PARALLEL_SEGMENT_BUILDS, 0);
   }
 
   @Override


### PR DESCRIPTION
Default behavior is to keep this unlimited. However, in some use cases that may have
a loq latency requirement, with a high QPS, and also a large number of columns, we
may incur heavy GC pauses during segment builds.

The only down-side of enabling this limit is that we will pause the consumption if
segment build is delayed on the committer. Since we are consuming on a per-partition
basis, the consumption should catch up quickly.

Alternative is to add more servers.