### PR TITLE
Fix the problem of directly memory leaking in scatter-gather

### DIFF
--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/common/AsyncResponseFuture.java
@@ -110,12 +110,6 @@ public class AsyncResponseFuture<T> implements Callback<T>, ServerResponseFuture
       _futureLock.lock();
       if (_state.isCompleted()) {
         LOGGER.info("{} Request is no longer pending. Cannot cancel !!", _ctxt);
-        // Potential fix for a leak when cancel gets called after a response is in.
-        // If a call is made to get the response before the cancel in a different thread,
-        // and we release it here, then the thread that processes the response may cause
-        // JVM crash.
-//        releaseResource(_delayedResponse);
-//        _delayedResponse = null;
         return false;
       }
       isCancelled = _cancellable.cancel();
@@ -134,11 +128,6 @@ public class AsyncResponseFuture<T> implements Callback<T>, ServerResponseFuture
       _futureLock.lock();
       if (_state.isCompleted()) {
         LOGGER.debug("{} Request has already been completed. Discarding this response !!", _ctxt, result);
-        // Potential fix for a leak when cancel has been called before the response comes back.
-        // If a call is made to get the response before the cancel in a different thread,
-        // and we release it here, then the thread that processes the response may cause
-        // JVM crash.
-//        releaseResource(result);
         return;
       }
       _delayedResponse = result;
@@ -146,10 +135,6 @@ public class AsyncResponseFuture<T> implements Callback<T>, ServerResponseFuture
     } finally {
       _futureLock.unlock();
     }
-  }
-
-  // It is expected that this method is called with the _state variable protected under lock
-  protected void releaseResource(T result) {
   }
 
   /**

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyClientConnection.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyClientConnection.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.transport.netty;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.common.AsyncResponseFuture;
 import com.linkedin.pinot.transport.common.Callback;
@@ -26,6 +24,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -121,7 +121,7 @@ public abstract class NettyClientConnection {
    * Future Handle provided to the request sender to asynchronously wait for response.
    * We use guava API for implementing Futures.
    */
-  public static class ResponseFuture extends AsyncResponseFuture<ByteBuf> {
+  public static class ResponseFuture extends AsyncResponseFuture<byte[]> {
 
     public ResponseFuture(ServerInstance key, String ctxt) {
       super(key, ctxt);
@@ -134,15 +134,6 @@ public abstract class NettyClientConnection {
      */
     public ResponseFuture(ServerInstance key, Throwable error, String ctxt) {
       super(key, error, ctxt);
-    }
-
-    @Override
-    protected void releaseResource(ByteBuf result) {
-      // Potential fix for a a leak during a race between calling cancel() and receiving response from the server.
-      // If a call is made to get the response before the cancel in a different thread,
-      // and we release it here, then the thread that processes the response may cause
-      // JVM crash.
-//      result.release();
     }
   }
 

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/netty/NettyTCPClientConnection.java
@@ -15,11 +15,6 @@
  */
 package com.linkedin.pinot.transport.netty;
 
-import java.net.ConnectException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import com.linkedin.pinot.common.metrics.MetricsHelper;
 import com.linkedin.pinot.common.metrics.MetricsHelper.TimerContext;
 import com.linkedin.pinot.common.response.ServerInstance;
@@ -41,6 +36,11 @@ import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.util.Timeout;
 import io.netty.util.Timer;
 import io.netty.util.TimerTask;
+import java.net.ConnectException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 
 /**
@@ -276,36 +276,44 @@ public class NettyTCPClientConnection extends NettyClientConnection  {
 
     @Override
     public synchronized void channelRead(ChannelHandlerContext ctx, Object msg) {
+      ByteBuf responseByteBuf = (ByteBuf) msg;
+      try {
+        // Cancel outstanding timer
+        cancelLastRequestTimeout();
 
-      //Cancel outstanding timer
-      cancelLastRequestTimeout();
+        //checkTransition(State.GOT_RESPONSE);
+        _lastResponseLatency.stop();
 
-      ByteBuf result = (ByteBuf) msg;
-      //checkTransition(State.GOT_RESPONSE);
-      _lastResponseSizeInBytes = result.readableBytes();
-      _lastResponseLatency.stop();
+        int numReadableBytes = responseByteBuf.readableBytes();
+        byte[] responseBytes = new byte[numReadableBytes];
+        if (numReadableBytes > 0) {
+          responseByteBuf.readBytes(responseBytes);
+        }
+        _lastResponseSizeInBytes = numReadableBytes;
 
-      State prevState = _connState;
-      _connState = State.GOT_RESPONSE;
+        State prevState = _connState;
+        _connState = State.GOT_RESPONSE;
 
-      _outstandingFuture.get().onSuccess(result);
-      _clientMetric.addRequestResponseStats(_lastRequsetSizeInBytes, 1, _lastResponseSizeInBytes, false,
-          _lastSendRequestLatency.getLatencyMs(), _lastResponseLatency.getLatencyMs());
+        _outstandingFuture.get().onSuccess(responseBytes);
+        _clientMetric.addRequestResponseStats(_lastRequsetSizeInBytes, 1, _lastResponseSizeInBytes, false,
+            _lastSendRequestLatency.getLatencyMs(), _lastResponseLatency.getLatencyMs());
 
-      /**
-       * IMPORTANT:
-       * There could be 2 netty threads one running the sendRequest() code (the ones after flush()
-       * and another for response/error handling (this one)
-       * simultaneously. Netty does not provide guarantees around this. So in worst case, the thread that
-       * is flushing request could block for sometime and gets executed after the response is obtained.
-       * We should checkin the connection to the pool only after all outstanding callbacks are complete.
-       * We do this by trancking the connection state. If we detect that response/error arrives before sendRequest
-       * completes, we will let the sendRequest to checkin/destroy the connection.
-       */
-      if ((null != _requestCallback) && (prevState == State.REQUEST_SENT)) {
-        _requestCallback.onSuccess(null);
+        /**
+         * IMPORTANT:
+         * There could be 2 netty threads one running the sendRequest() code (the ones after flush()
+         * and another for response/error handling (this one)
+         * simultaneously. Netty does not provide guarantees around this. So in worst case, the thread that
+         * is flushing request could block for sometime and gets executed after the response is obtained.
+         * We should checkin the connection to the pool only after all outstanding callbacks are complete.
+         * We do this by trancking the connection state. If we detect that response/error arrives before sendRequest
+         * completes, we will let the sendRequest to checkin/destroy the connection.
+         */
+        if ((null != _requestCallback) && (prevState == State.REQUEST_SENT)) {
+          _requestCallback.onSuccess(null);
+        }
+      } finally {
+        responseByteBuf.release();
       }
-
     }
 
     @Override

--- a/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGather.java
+++ b/pinot-transport/src/main/java/com/linkedin/pinot/transport/scattergather/ScatterGather.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.transport.scattergather;
 
 import com.linkedin.pinot.common.metrics.BrokerMetrics;
 import com.linkedin.pinot.transport.common.CompositeFuture;
-import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -47,17 +46,16 @@ public interface ScatterGather {
    * @param scatterGatherStats scatter-gather statistics.
    * @param isOfflineTable whether the scatter-gather target is an OFFLINE table.
    * @param brokerMetrics broker metrics to track execution statistics.
-   * @return future containing response from all services queried. The response is in ByteBuf ( not the byte[] ).
-   * Hence, the client is responsible for calling release() on the response.
+   * @return future containing response from all services queried.
    */
   @Nonnull
-  CompositeFuture<ByteBuf> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
+  CompositeFuture<byte[]> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
       @Nonnull ScatterGatherStats scatterGatherStats, @Nullable Boolean isOfflineTable,
       @Nonnull BrokerMetrics brokerMetrics)
       throws InterruptedException;
 
   @Nonnull
-  CompositeFuture<ByteBuf> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
+  CompositeFuture<byte[]> scatterGather(@Nonnull ScatterGatherRequest scatterGatherRequest,
       @Nonnull ScatterGatherStats scatterGatherStats, @Nonnull BrokerMetrics brokerMetrics)
       throws InterruptedException;
 }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettyCloseChannelTest.java
@@ -18,7 +18,6 @@ package com.linkedin.pinot.transport.netty;
 import com.linkedin.pinot.common.response.ServerInstance;
 import com.linkedin.pinot.transport.metrics.NettyClientMetrics;
 import com.linkedin.pinot.transport.netty.NettyClientConnection.ResponseFuture;
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -69,7 +68,7 @@ public class NettyCloseChannelTest {
     NettyTestUtils.closeClientConnection(_nettyTCPClientConnection);
 
     _countDownLatch.countDown();
-    ByteBuf serverResponse = responseFuture.getOne();
+    byte[] serverResponse = responseFuture.getOne();
     Assert.assertNull(serverResponse);
     Assert.assertFalse(responseFuture.isCancelled());
     Assert.assertNotNull(responseFuture.getError());
@@ -89,7 +88,7 @@ public class NettyCloseChannelTest {
     NettyTestUtils.closeServerConnection(_nettyTCPServer);
 
     _countDownLatch.countDown();
-    ByteBuf serverResponse = responseFuture.getOne();
+    byte[] serverResponse = responseFuture.getOne();
     Assert.assertNull(serverResponse);
     Assert.assertFalse(responseFuture.isCancelled());
     Assert.assertNotNull(responseFuture.getError());

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/netty/NettySingleConnectionIntegrationTest.java
@@ -31,7 +31,6 @@ import com.linkedin.pinot.transport.pool.AsyncPoolResourceManagerAdapter;
 import com.linkedin.pinot.transport.pool.KeyedPool;
 import com.linkedin.pinot.transport.pool.KeyedPoolImpl;
 import com.yammer.metrics.core.MetricsRegistry;
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.HashedWheelTimer;
@@ -89,9 +88,7 @@ public class NettySingleConnectionIntegrationTest {
       _requestHandler.setResponse(response);
       ResponseFuture responseFuture =
           _nettyTCPClientConnection.sendRequest(Unpooled.wrappedBuffer(request.getBytes()), 1L, 5000L);
-      ByteBuf byteBuf = responseFuture.getOne();
-      byte[] bytes = new byte[byteBuf.readableBytes()];
-      byteBuf.readBytes(bytes);
+      byte[] bytes = responseFuture.getOne();
       Assert.assertEquals(new String(bytes), response);
       Assert.assertEquals(_requestHandler.getRequest(), request);
     }
@@ -111,9 +108,7 @@ public class NettySingleConnectionIntegrationTest {
       _requestHandler.setResponse(response);
       ResponseFuture responseFuture =
           _nettyTCPClientConnection.sendRequest(Unpooled.wrappedBuffer(request.getBytes()), 1L, 5000L);
-      ByteBuf byteBuf = responseFuture.getOne();
-      byte[] bytes = new byte[byteBuf.readableBytes()];
-      byteBuf.readBytes(bytes);
+      byte[] bytes = responseFuture.getOne();
       Assert.assertEquals(new String(bytes), response);
       Assert.assertEquals(_requestHandler.getRequest(), request);
     }
@@ -146,9 +141,7 @@ public class NettySingleConnectionIntegrationTest {
     } catch (IllegalStateException e) {
       // Pass
     }
-    ByteBuf response = responseFuture.getOne();
-    byte[] bytes = new byte[response.readableBytes()];
-    response.readBytes(bytes);
+    byte[] bytes = responseFuture.getOne();
     Assert.assertEquals(new String(bytes), NettyTestUtils.DUMMY_RESPONSE);
     Assert.assertEquals(_requestHandler.getRequest(), NettyTestUtils.DUMMY_REQUEST);
   }

--- a/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
+++ b/pinot-transport/src/test/java/com/linkedin/pinot/transport/scattergather/ScatterGatherTest.java
@@ -91,14 +91,14 @@ public class ScatterGatherTest {
 
     // Send the request
     ScatterGatherRequest scatterGatherRequest = new TestScatterGatherRequest(routingTable, 10_000L);
-    CompositeFuture<ByteBuf> future =
+    CompositeFuture<byte[]> future =
         scatterGather.scatterGather(scatterGatherRequest, scatterGatherStats, brokerMetrics);
 
     // Should have response from all servers
-    Map<ServerInstance, ByteBuf> serverToResponseMap = future.get();
+    Map<ServerInstance, byte[]> serverToResponseMap = future.get();
     Assert.assertEquals(serverToResponseMap.size(), NUM_SERVERS);
     for (int i = 0; i < NUM_SERVERS; i++) {
-      Assert.assertEquals(getResponse(serverToResponseMap.get(serverInstances[i])),
+      Assert.assertEquals(new String(serverToResponseMap.get(serverInstances[i])),
           routingTable.get(serverNames[i]).get(0));
     }
 
@@ -152,14 +152,14 @@ public class ScatterGatherTest {
 
     // Send the request
     ScatterGatherRequest scatterGatherRequest = new TestScatterGatherRequest(routingTable, 1000L);
-    CompositeFuture<ByteBuf> future =
+    CompositeFuture<byte[]> future =
         scatterGather.scatterGather(scatterGatherRequest, scatterGatherStats, brokerMetrics);
 
     // Should have no response from the error server
-    Map<ServerInstance, ByteBuf> serverToResponseMap = future.get();
+    Map<ServerInstance, byte[]> serverToResponseMap = future.get();
     Assert.assertEquals(serverToResponseMap.size(), NUM_SERVERS - 1);
     for (int i = 1; i < NUM_SERVERS; i++) {
-      Assert.assertEquals(getResponse(serverToResponseMap.get(serverInstances[i])),
+      Assert.assertEquals(new String(serverToResponseMap.get(serverInstances[i])),
           routingTable.get(serverNames[i]).get(0));
     }
 
@@ -215,14 +215,14 @@ public class ScatterGatherTest {
 
     // Send the request
     ScatterGatherRequest scatterGatherRequest = new TestScatterGatherRequest(routingTable, 10_000L);
-    CompositeFuture<ByteBuf> future =
+    CompositeFuture<byte[]> future =
         scatterGather.scatterGather(scatterGatherRequest, scatterGatherStats, brokerMetrics);
 
     // Should have no response from the error server
-    Map<ServerInstance, ByteBuf> serverToResponseMap = future.get();
+    Map<ServerInstance, byte[]> serverToResponseMap = future.get();
     Assert.assertEquals(serverToResponseMap.size(), NUM_SERVERS - 1);
     for (int i = 1; i < NUM_SERVERS; i++) {
-      Assert.assertEquals(getResponse(serverToResponseMap.get(serverInstances[i])),
+      Assert.assertEquals(new String(serverToResponseMap.get(serverInstances[i])),
           routingTable.get(serverNames[i]).get(0));
     }
 
@@ -251,12 +251,6 @@ public class ScatterGatherTest {
         new KeyedPoolImpl<>(1, 1, 300000, 1, resourceManager, timedExecutor, poolExecutor, metricsRegistry);
     resourceManager.setPool(connectionPool);
     return connectionPool;
-  }
-
-  private String getResponse(ByteBuf byteBuf) {
-    byte[] bytes = new byte[byteBuf.readableBytes()];
-    byteBuf.readBytes(bytes);
-    return new String(bytes);
   }
 
   private static class TestScatterGatherRequest implements ScatterGatherRequest {


### PR DESCRIPTION
Whenever we get the response from the server, read it into a byte[] and directly release the ByteBuf
In normal case, this won't add overhead because when deserializing the response into a DataTable, we need to first read it into a byte[]