### PR TITLE
[TE] Self Serve Edit Alert Fix: missing cronExpression

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/edit/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/edit/controller.js
@@ -217,6 +217,7 @@ export default Ember.Controller.extend({
         active: true,
         name: this.get('newConfigGroupName'),
         fromAddress: 'thirdeye-dev@linkedin.com',
+        cronExpression: '0 0/5 * 1/1 * ? *',
         emailConfig: {
           functionIds: []
         }


### PR DESCRIPTION
When editing an existing alert, if you create a new config group, it contains no `cronExpression`.