### PR TITLE
[TE] Resolve most duplicate class issues and remove old version of kafka client

### DIFF
--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -50,12 +50,8 @@
           <artifactId>log4j-over-slf4j</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.fasterxml.jackson</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson</groupId>
-          <artifactId>jackson-databind</artifactId>
+          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>aopalliance-repackaged</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -95,11 +91,34 @@
           <groupId>javax.mail</groupId>
           <artifactId>mail</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>com.linkedin.pinot</groupId>
       <artifactId>pinot-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <!-- This version of kafka is way too old -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -124,6 +143,12 @@
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-persist</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.inject</groupId>
+          <artifactId>javax.inject</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>
@@ -245,7 +270,7 @@
 
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.1.0</version>
         <configuration>
           <createDependencyReducedPom>true</createDependencyReducedPom>
           <transformers>


### PR DESCRIPTION
1. Bump up the version of maven-shade-plugin to output better clues for resolving the issue of "Duplicate classes".
2. Resolved most issues of duplicated classes.
3. Remove out-of-dated kafka-client from the final fat jar.

Tested by running the built jar on local setup.