### PR TITLE
Handle consumder dir not configured, and cleanup old consuming mmap files if any

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -39,6 +39,7 @@ import com.linkedin.pinot.core.realtime.impl.kafka.KafkaConsumerManager;
 import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
 import com.linkedin.pinot.core.segment.index.loader.LoaderUtils;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -55,6 +56,7 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
   private RealtimeSegmentStatsHistory _statsHistory;
 
   private static final String STATS_FILE_NAME = "stats.ser";
+  private static final String CONSUMERS_DIR = "consumers";
 
   @Override
   protected void doInit() {
@@ -80,6 +82,25 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
         Utils.rethrowException(e2);
       }
     }
+
+    String consumerDirPath = getConsumerDir();
+    File consumerDir = new File(consumerDirPath);
+
+    if (consumerDir.exists()) {
+      File[] segmentFiles = consumerDir.listFiles(new FilenameFilter() {
+        @Override
+        public boolean accept(File dir, String name) {
+          return ! name.equals(STATS_FILE_NAME);
+        }
+      });
+      for (File file : segmentFiles) {
+        if (file.delete()) {
+          _logger.info("Deleted old file {}", file.getAbsolutePath());
+        } else {
+          _logger.error("Cannot delete file {}", file.getAbsolutePath());
+        }
+      }
+    }
   }
 
   @Override
@@ -99,7 +120,17 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
   }
 
   public String getConsumerDir() {
-    File consumerDir = new File(_tableDataManagerConfig.getConsumerDir(), _tableName);
+    String consumerDirPath = _tableDataManagerConfig.getConsumerDir();
+    File consumerDir;
+    // If a consumer directory has been configured, use it to create a per-table path under the consumer dir.
+    // Otherwise, create a sub-dir under the table-specific data director and use it for consumer mmaps
+    if (consumerDirPath != null) {
+       consumerDir = new File(consumerDirPath, _tableName);
+    } else {
+      consumerDirPath = _tableDataDir + File.separator + CONSUMERS_DIR;
+      consumerDir = new File(consumerDirPath);
+    }
+
     if (!consumerDir.exists()) {
       if (!consumerDir.mkdirs()) {
         _logger.error("Failed to create consumer directory {}", consumerDir.getAbsolutePath());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -90,7 +90,7 @@ public class RealtimeTableDataManager extends AbstractTableDataManager {
       File[] segmentFiles = consumerDir.listFiles(new FilenameFilter() {
         @Override
         public boolean accept(File dir, String name) {
-          return ! name.equals(STATS_FILE_NAME);
+          return !name.equals(STATS_FILE_NAME);
         }
       });
       for (File file : segmentFiles) {

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -41,6 +41,7 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
   @BeforeClass
   @Override
   public void setUp() throws Exception {
+    // TODO Avoid printing to stdout. Instead, we need to add the seed to every assert in this (and super-classes)
     System.out.println("========== Using random seed value " + seed);
     // Remove the consumer directory
     File consumerDirectory = new File(CONSUMER_DIRECTORY);

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import java.io.File;
 import java.util.List;
+import java.util.Random;
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.io.FileUtils;
@@ -33,11 +34,14 @@ import org.testng.annotations.Test;
  */
 public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegrationTest {
   public static final String CONSUMER_DIRECTORY = "/tmp/consumer-test";
-  public static final boolean isDirectAlloc = Math.random() < 0.5;
+  public static final long seed = System.currentTimeMillis();
+  public static final Random RANDOM = new Random(seed);
+  public static final boolean isDirectAlloc = RANDOM.nextDouble() < 0.5;
 
   @BeforeClass
   @Override
   public void setUp() throws Exception {
+    System.out.println("========== Using random seed value " + seed);
     // Remove the consumer directory
     File consumerDirectory = new File(CONSUMER_DIRECTORY);
     if (consumerDirectory.exists()) {
@@ -62,7 +66,9 @@ public class LLCRealtimeClusterIntegrationTest extends RealtimeClusterIntegratio
   protected void overrideServerConf(Configuration configuration) {
     configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION, "true");
     configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION, Boolean.toString(isDirectAlloc));
-    configuration.setProperty(CommonConstants.Server.CONFIG_OF_CONSUMER_DIR, CONSUMER_DIRECTORY);
+    if (RANDOM.nextDouble() < 0.5) {
+      configuration.setProperty(CommonConstants.Server.CONFIG_OF_CONSUMER_DIR, CONSUMER_DIRECTORY);
+    }
   }
 
   @Test


### PR DESCRIPTION
If the consumer directory is not configured, when we create the consumer dir in some
unknown place (depending on the path env of the application). Changed it to be under the datadir.

Also, it is possible that segments may be re-assigned after a server restart, causing old
mmaped segments to remain (if the last shutdown was a hard kill of the process).
It is best to clean out all mmap files under the consumer directory when the table data manager
is inited.