### PR TITLE
Do not put trace info in DataTable when trace is not enabled

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/GlobalPlanImplV0.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/GlobalPlanImplV0.java
@@ -15,12 +15,11 @@
  */
 package com.linkedin.pinot.core.plan;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.common.utils.DataTable;
 import com.linkedin.pinot.core.operator.UResultOperator;
 import com.linkedin.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -60,10 +59,6 @@ public class GlobalPlanImplV0 extends Plan {
       long endTime2 = System.currentTimeMillis();
       LOGGER.debug("UResultOperator took :{}", (endTime2 - endTime1));
       _instanceResponseDataTable = instanceResponseBlock.getInstanceResponseDataTable();
-      long endTime3 = System.currentTimeMillis();
-      LOGGER.debug("Converting to InstanceResponseBlock to DataTable took :{}", (endTime3 - endTime2));
-      long endTime = System.currentTimeMillis();
-      _instanceResponseDataTable.getMetadata().put(DataTable.TIME_USED_MS_METADATA_KEY, "" + (endTime - startTime));
     } finally {
       operator.close();
     }
@@ -73,5 +68,4 @@ public class GlobalPlanImplV0 extends Plan {
   public DataTable getInstanceResponse() {
     return _instanceResponseDataTable;
   }
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.query.executor;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.DataManager;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.ServerMeter;
@@ -55,21 +56,17 @@ import org.slf4j.LoggerFactory;
 
 public class ServerQueryExecutorV1Impl implements QueryExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerQueryExecutorV1Impl.class);
+  private static final boolean PRINT_QUERY_PLAN = false;
 
   private InstanceDataManager _instanceDataManager = null;
   private SegmentPrunerService _segmentPrunerService = null;
   private PlanMaker _planMaker = null;
   private volatile boolean _isStarted = false;
   private long _defaultTimeOutMs = CommonConstants.Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS;
-  private boolean _printQueryPlan = false;
   private final Map<String, Long> _resourceTimeOutMsMap = new ConcurrentHashMap<>();
   private ServerMetrics _serverMetrics;
 
   public ServerQueryExecutorV1Impl() {
-  }
-
-  public ServerQueryExecutorV1Impl(boolean printQueryPlan) {
-    _printQueryPlan = printQueryPlan;
   }
 
   @Override
@@ -90,7 +87,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   }
 
   @Override
-  public DataTable processQuery(final ServerQueryRequest queryRequest, ExecutorService executorService) {
+  public DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService) {
     TimerContext timerContext = queryRequest.getTimerContext();
     TimerContext.Timer schedulerWaitTimer = timerContext.getPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT);
     if (schedulerWaitTimer != null) {
@@ -98,21 +95,23 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
     TimerContext.Timer queryProcessingTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PROCESSING);
 
-    DataTable dataTable;
-    List<SegmentDataManager> queryableSegmentDataManagerList = null;
     InstanceRequest instanceRequest = queryRequest.getInstanceRequest();
-    final long requestId = instanceRequest.getRequestId();
-
-    try {
+    long requestId = instanceRequest.getRequestId();
+    boolean enableTrace = instanceRequest.isEnableTrace();
+    if (enableTrace) {
       TraceContext.register(instanceRequest);
-      final BrokerRequest brokerRequest = instanceRequest.getQuery();
-      LOGGER.debug("Incoming query is : {}", brokerRequest);
+    }
+    BrokerRequest brokerRequest = instanceRequest.getQuery();
+    LOGGER.debug("Incoming request Id: {}, query: {}", requestId, brokerRequest);
+    String tableName = brokerRequest.getQuerySource().getTableName();
+    TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(tableName);
+    Preconditions.checkState(tableDataManager != null, "Failed to find data manager for table: {}", tableName);
+    List<SegmentDataManager> queryableSegmentDataManagerList =
+        acquireQueryableSegments(tableDataManager, instanceRequest);
 
+    DataTable dataTable;
+    try {
       TimerContext.Timer segmentPruneTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.SEGMENT_PRUNING);
-
-      final String tableName = instanceRequest.getQuery().getQuerySource().getTableName();
-      TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(tableName);
-      queryableSegmentDataManagerList = acquireQueryableSegments(tableDataManager, instanceRequest);
       long totalRawDocs = pruneSegments(tableDataManager, queryableSegmentDataManagerList, queryRequest);
       segmentPruneTimer.stopAndRecord();
 
@@ -120,52 +119,37 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       queryRequest.setSegmentCountAfterPruning(numSegmentsMatched);
       LOGGER.debug("Matched {} segments", numSegmentsMatched);
       if (numSegmentsMatched == 0) {
-        DataTable emptyDataTable = DataTableBuilder.buildEmptyDataTable(brokerRequest);
-        Map<String, String> metadata = emptyDataTable.getMetadata();
+        dataTable = DataTableBuilder.buildEmptyDataTable(brokerRequest);
+        Map<String, String> metadata = dataTable.getMetadata();
         metadata.put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(totalRawDocs));
         metadata.put(DataTable.NUM_DOCS_SCANNED_METADATA_KEY, "0");
         metadata.put(DataTable.NUM_ENTRIES_SCANNED_IN_FILTER_METADATA_KEY, "0");
         metadata.put(DataTable.NUM_ENTRIES_SCANNED_POST_FILTER_METADATA_KEY, "0");
+      } else {
+        TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
+        Plan globalQueryPlan =
+            _planMaker.makeInterSegmentPlan(queryableSegmentDataManagerList, brokerRequest, executorService,
+                getResourceTimeOut(brokerRequest));
+        planBuildTimer.stopAndRecord();
 
-        // Stop and record the query processing timer for early bailout.
-        queryProcessingTimer.stopAndRecord();
-        return emptyDataTable;
+        if (PRINT_QUERY_PLAN) {
+          LOGGER.debug("***************************** Query Plan for Request {} ***********************************",
+              instanceRequest.getRequestId());
+          globalQueryPlan.print();
+          LOGGER.debug("*********************************** End Query Plan ***********************************");
+        }
+
+        TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
+        globalQueryPlan.execute();
+        planExecTimer.stopAndRecord();
+
+
+        dataTable = globalQueryPlan.getInstanceResponse();
+        // Update the total docs in the metadata based on un-pruned segments.
+        dataTable.getMetadata().put(DataTable.TOTAL_DOCS_METADATA_KEY, Long.toString(totalRawDocs));
       }
-
-      TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
-      final Plan globalQueryPlan =
-          _planMaker.makeInterSegmentPlan(queryableSegmentDataManagerList, brokerRequest, executorService,
-              getResourceTimeOut(instanceRequest.getQuery()));
-      planBuildTimer.stopAndRecord();
-
-      if (_printQueryPlan) {
-        LOGGER.debug("***************************** Query Plan for Request {} ***********************************",
-            instanceRequest.getRequestId());
-        globalQueryPlan.print();
-        LOGGER.debug("*********************************** End Query Plan ***********************************");
-      }
-
-      TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
-      globalQueryPlan.execute();
-      planExecTimer.stopAndRecord();
-
-      dataTable = globalQueryPlan.getInstanceResponse();
-      Map<String, String> dataTableMetadata = dataTable.getMetadata();
-      queryProcessingTimer.stopAndRecord();
-
-      LOGGER.debug("Searching Instance for Request Id - {}, browse took: {}", instanceRequest.getRequestId(),
-          queryProcessingTimer.getDurationNs());
-      LOGGER.debug("InstanceResponse for Request Id - {} : {}", instanceRequest.getRequestId(), dataTable.toString());
-      dataTableMetadata.put(DataTable.TIME_USED_MS_METADATA_KEY, Long.toString(queryProcessingTimer.getDurationMs()));
-      dataTableMetadata.put(DataTable.REQUEST_ID_METADATA_KEY, Long.toString(instanceRequest.getRequestId()));
-      dataTableMetadata.put(DataTable.TRACE_INFO_METADATA_KEY,
-          TraceContext.getTraceInfoOfRequestId(instanceRequest.getRequestId()));
-
-      // Update the total docs in the metadata based on un-pruned segments.
-      dataTableMetadata.put(DataTable.TOTAL_DOCS_METADATA_KEY, String.valueOf(totalRawDocs));
-      return dataTable;
     } catch (Exception e) {
-      _serverMetrics.addMeteredQueryValue(instanceRequest.getQuery(), ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
+      _serverMetrics.addMeteredQueryValue(brokerRequest, ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
 
       // Do not log error for BadQueryRequestException because it's caused by bad query
       if (e instanceof BadQueryRequestException) {
@@ -175,27 +159,28 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       }
 
       dataTable = new DataTableImplV2();
-      Map<String, String> dataTableMetadata = dataTable.getMetadata();
       dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
-      TraceContext.logException("ServerQueryExecutorV1Impl", "Exception occurs in processQuery");
-      queryProcessingTimer.stopAndRecord();
-
-      LOGGER.info("Searching Instance for Request Id - {}, browse took: {}, instanceResponse: {}", requestId,
-          queryProcessingTimer.getDurationMs(), dataTable.toString());
-      dataTableMetadata.put(DataTable.TIME_USED_MS_METADATA_KEY, Long.toString(queryProcessingTimer.getDurationNs()));
-      dataTableMetadata.put(DataTable.REQUEST_ID_METADATA_KEY, Long.toString(instanceRequest.getRequestId()));
-      dataTableMetadata.put(DataTable.TRACE_INFO_METADATA_KEY,
-          TraceContext.getTraceInfoOfRequestId(instanceRequest.getRequestId()));
-      return dataTable;
-    } finally {
-      TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(queryRequest.getTableName());
-      if (tableDataManager != null && queryableSegmentDataManagerList != null) {
-        for (SegmentDataManager segmentDataManager : queryableSegmentDataManagerList) {
-          tableDataManager.releaseSegment(segmentDataManager);
-        }
+      if (enableTrace) {
+        TraceContext.logException("ServerQueryExecutorV1Impl", "Exception occurs in processQuery");
       }
+    } finally {
+      for (SegmentDataManager segmentDataManager : queryableSegmentDataManagerList) {
+        tableDataManager.releaseSegment(segmentDataManager);
+      }
+    }
+
+    queryProcessingTimer.stopAndRecord();
+    long queryProcessingTime = queryProcessingTimer.getDurationMs();
+
+    Map<String, String> dataTableMetadata = dataTable.getMetadata();
+    dataTableMetadata.put(DataTable.TIME_USED_MS_METADATA_KEY, Long.toString(queryProcessingTime));
+    if (enableTrace) {
+      dataTableMetadata.put(DataTable.TRACE_INFO_METADATA_KEY, TraceContext.getTraceInfoOfRequestId(requestId));
       TraceContext.unregister(instanceRequest);
     }
+    LOGGER.debug("Query processing time for request Id - {}: {}", requestId, queryProcessingTime);
+    LOGGER.debug("InstanceResponse for request Id - {}: {}", requestId, dataTable.toString());
+    return dataTable;
   }
 
   /**


### PR DESCRIPTION
Fix the issue where trace info is set in DataTable even when trace is not enabled
When encountered exception, still put request id into data table
Will clean up Trace in another PR for performance