### PR TITLE
Fix the default config value for direct mem allocation

### DIFF
--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -166,7 +166,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   @Override
   public boolean isDirectRealtimeOffheapAllocation() {
-    return _instanceDataManagerConfiguration.getBoolean(DIRECT_REALTIME_OFFHEAP_ALLOCATION, true);
+    return _instanceDataManagerConfiguration.getBoolean(DIRECT_REALTIME_OFFHEAP_ALLOCATION, false);
   }
 
   @Override


### PR DESCRIPTION
To keep the behavior consistent, we need to have the default value of
direct memory allocation to be false, so that offheap => mmap.
Otherwise, we will run out of memory if maxDirect is not condigured
correctly.