### PR TITLE
Add support for datetime column in realtime segment generation

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.ObjectMapper;
@@ -303,7 +302,7 @@ public final class Schema {
   @JsonIgnore
   @Nonnull
   public List<String> getDateTimeNames() {
-    return CollectionUtils.isEmpty(_dateTimeList) ? null : _dateTimeList;
+    return _dateTimeList;
   }
 
   @JsonIgnore

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -66,7 +66,9 @@ public class RealtimeSegmentConverter {
     for (String metric : schema.getMetricNames()) {
       newSchema.addField(schema.getFieldSpecFor(metric));
     }
-
+    for (String dateTime : schema.getDateTimeNames()) {
+      newSchema.addField(schema.getFieldSpecFor(dateTime));
+    }
     newSchema.addField(newTimeSpec);
     this.realtimeSegmentImpl = realtimeSegment;
     this.outputPath = outputPath;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentRecordReader.java
@@ -55,6 +55,7 @@ public class RealtimeSegmentRecordReader extends BaseRecordReader {
     columns.addAll(dataSchema.getDimensionNames());
     columns.addAll(dataSchema.getMetricNames());
     columns.add(dataSchema.getTimeFieldSpec().getOutgoingTimeColumnName());
+    columns.addAll(dataSchema.getDateTimeNames());
   }
 
   @Override


### PR DESCRIPTION
Tested on a test cluster with datetime column setup in the time column name of table config. Verified that the segments generated contain datetime column, and it is queryable on the pinot console