### PR TITLE
[TE] Move metricAsDimension config from dataset to metric level

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DatasetConfigResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DatasetConfigResource.java
@@ -48,13 +48,19 @@ public class DatasetConfigResource {
 
   @GET
   @Path("/create")
-  public String createDatasetConfig(@QueryParam("dataset") String dataset, @QueryParam("dimensions") String dimensions,
-      @QueryParam("dimensionsHaveNoPreAggregation") String dimensionsHaveNoPreAggregation, @QueryParam("active") boolean active,
-      @QueryParam("additive") boolean additive, @QueryParam("metricAsDimension") boolean metricAsDimension,
-      @QueryParam("metricValuesColumn") String metricValuesColumn, @QueryParam("metricNamesColumn") String metricNamesColumn,
-      @QueryParam("nonAdditiveBucketSize") Integer nonAdditiveBucketSize, @QueryParam("nonAdditiveBucketUnit") String nonAdditiveBucketUnit,
-      @QueryParam("preAggregatedKeyword") String preAggregatedKeyword, @QueryParam("timeColumn") String timeColumn,
-      @QueryParam("timeDuration") Integer timeDuration, @QueryParam("timeFormat") String timeFormat, @QueryParam("timezone") TimeUnit timeUnit,
+  public String createDatasetConfig(
+      @QueryParam("dataset") String dataset,
+      @QueryParam("dimensions") String dimensions,
+      @QueryParam("dimensionsHaveNoPreAggregation") String dimensionsHaveNoPreAggregation,
+      @QueryParam("active") boolean active,
+      @QueryParam("additive") boolean additive,
+      @QueryParam("nonAdditiveBucketSize") Integer nonAdditiveBucketSize,
+      @QueryParam("nonAdditiveBucketUnit") String nonAdditiveBucketUnit,
+      @QueryParam("preAggregatedKeyword") String preAggregatedKeyword,
+      @QueryParam("timeColumn") String timeColumn,
+      @QueryParam("timeDuration") Integer timeDuration,
+      @QueryParam("timeFormat") String timeFormat,
+      @QueryParam("timezone") TimeUnit timeUnit,
       @QueryParam("timezone") String timezone) {
     try {
       DatasetConfigDTO datasetConfigDTO = new DatasetConfigDTO();
@@ -65,9 +71,6 @@ public class DatasetConfigResource {
       }
       datasetConfigDTO.setActive(active);
       datasetConfigDTO.setAdditive(additive);
-      datasetConfigDTO.setMetricAsDimension(metricAsDimension);
-      datasetConfigDTO.setMetricNamesColumn(metricNamesColumn);
-      datasetConfigDTO.setMetricValuesColumn(metricValuesColumn);
       datasetConfigDTO.setNonAdditiveBucketSize(nonAdditiveBucketSize);
       datasetConfigDTO.setNonAdditiveBucketUnit(TimeUnit.valueOf(nonAdditiveBucketUnit));
       datasetConfigDTO.setPreAggregatedKeyword(preAggregatedKeyword);
@@ -95,13 +98,20 @@ public class DatasetConfigResource {
 
   @GET
   @Path("/update")
-  public String updateDatasetConfig(@NotNull @QueryParam("id") long datasetConfigId, @QueryParam("dataset") String dataset,
-      @QueryParam("dimensions") String dimensions, @QueryParam("dimensionsHaveNoPreAggregation") String dimensionsHaveNoPreAggregation,
-      @QueryParam("active") boolean active, @QueryParam("additive") boolean additive, @QueryParam("metricAsDimension") boolean metricAsDimension,
-      @QueryParam("metricValuesColumn") String metricValuesColumn, @QueryParam("metricNamesColumn") String metricNamesColumn,
-      @QueryParam("nonAdditiveBucketSize") Integer nonAdditiveBucketSize, @QueryParam("nonAdditiveBucketUnit") String nonAdditiveBucketUnit,
-      @QueryParam("preAggregatedKeyword") String preAggregatedKeyword, @QueryParam("timeColumn") String timeColumn,
-      @QueryParam("timeDuration") Integer timeDuration, @QueryParam("timeFormat") String timeFormat, @QueryParam("timezone") TimeUnit timeUnit,
+  public String updateDatasetConfig(
+      @NotNull @QueryParam("id") long datasetConfigId,
+      @QueryParam("dataset") String dataset,
+      @QueryParam("dimensions") String dimensions,
+      @QueryParam("dimensionsHaveNoPreAggregation") String dimensionsHaveNoPreAggregation,
+      @QueryParam("active") boolean active,
+      @QueryParam("additive") boolean additive,
+      @QueryParam("nonAdditiveBucketSize") Integer nonAdditiveBucketSize,
+      @QueryParam("nonAdditiveBucketUnit") String nonAdditiveBucketUnit,
+      @QueryParam("preAggregatedKeyword") String preAggregatedKeyword,
+      @QueryParam("timeColumn") String timeColumn,
+      @QueryParam("timeDuration") Integer timeDuration,
+      @QueryParam("timeFormat") String timeFormat,
+      @QueryParam("timezone") TimeUnit timeUnit,
       @QueryParam("timezone") String timezone) {
     try {
       DatasetConfigDTO datasetConfigDTO = datasetConfigDAO.findById(datasetConfigId);
@@ -110,8 +120,6 @@ public class DatasetConfigResource {
       datasetConfigDTO.setDimensionsHaveNoPreAggregation(toList(dimensionsHaveNoPreAggregation));
       datasetConfigDTO.setActive(active);
       datasetConfigDTO.setAdditive(additive);
-      datasetConfigDTO.setMetricAsDimension(metricAsDimension);
-      datasetConfigDTO.setMetricValuesColumn(metricValuesColumn);
       datasetConfigDTO.setNonAdditiveBucketSize(nonAdditiveBucketSize);
       datasetConfigDTO.setNonAdditiveBucketUnit(TimeUnit.valueOf(nonAdditiveBucketUnit));
       datasetConfigDTO.setPreAggregatedKeyword(preAggregatedKeyword);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -37,15 +37,6 @@ public class DatasetConfigBean extends AbstractBean {
   /** Introduce this as a dataset property because count* queries will have no metric information **/
   private String dataSource = PinotThirdEyeDataSource.DATA_SOURCE_NAME;
 
-  private boolean metricAsDimension = false;
-
-  private String metricNamesColumn;
-
-  private String metricValuesColumn;
-
-  /** Autodiscover metrics in case of metricAsDimension */
-  private boolean autoDiscoverMetrics = false;
-
   private boolean active = true;
 
   /** Configuration for non-additive dataset **/
@@ -163,39 +154,6 @@ public class DatasetConfigBean extends AbstractBean {
     this.dataSource = dataSource;
   }
 
-  public boolean isMetricAsDimension() {
-    return metricAsDimension;
-  }
-
-  public void setMetricAsDimension(boolean metricAsDimension) {
-    this.metricAsDimension = metricAsDimension;
-  }
-
-  public String getMetricNamesColumn() {
-    return metricNamesColumn;
-  }
-
-  public void setMetricNamesColumn(String metricNamesColumn) {
-    this.metricNamesColumn = metricNamesColumn;
-  }
-
-  public String getMetricValuesColumn() {
-    return metricValuesColumn;
-  }
-
-  public void setMetricValuesColumn(String metricValuesColumn) {
-    this.metricValuesColumn = metricValuesColumn;
-  }
-
-
-  public boolean isAutoDiscoverMetrics() {
-    return autoDiscoverMetrics;
-  }
-
-  public void setAutoDiscoverMetrics(boolean autoDiscoverMetrics) {
-    this.autoDiscoverMetrics = autoDiscoverMetrics;
-  }
-
   public boolean isActive() {
     return active;
   }
@@ -303,10 +261,6 @@ public class DatasetConfigBean extends AbstractBean {
         && Objects.equals(timeFormat, dc.getTimeFormat())
         && Objects.equals(timezone, dc.getTimezone())
         && Objects.equals(dataSource, dc.getDataSource())
-        && Objects.equals(metricAsDimension, dc.isMetricAsDimension())
-        && Objects.equals(metricNamesColumn, dc.getMetricNamesColumn())
-        && Objects.equals(metricValuesColumn, dc.getMetricValuesColumn())
-        && Objects.equals(autoDiscoverMetrics, dc.isAutoDiscoverMetrics())
         && Objects.equals(active, dc.isActive())
         && Objects.equals(additive, dc.isAdditive())
         && Objects.equals(dimensionsHaveNoPreAggregation, dc.getDimensionsHaveNoPreAggregation())
@@ -323,10 +277,10 @@ public class DatasetConfigBean extends AbstractBean {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getId(), dataset, dimensions, timeColumn, timeUnit, timeDuration, timeFormat, timezone, dataSource,
-        metricAsDimension, metricNamesColumn, metricValuesColumn, autoDiscoverMetrics, active, additive,
-        dimensionsHaveNoPreAggregation, preAggregatedKeyword, nonAdditiveBucketSize, nonAdditiveBucketUnit, realtime,
-        requiresCompletenessCheck, expectedDelay, dataCompletenessAlgorithm, expectedCompleteness, dataSource);
+    return Objects.hash(getId(), dataset, dimensions, timeColumn, timeUnit, timeDuration, timeFormat, timezone,
+        dataSource, active, additive, dimensionsHaveNoPreAggregation, preAggregatedKeyword, nonAdditiveBucketSize,
+        nonAdditiveBucketUnit, realtime, requiresCompletenessCheck, expectedDelay, dataCompletenessAlgorithm,
+        expectedCompleteness, dataSource);
   }
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/MetricConfigBean.java
@@ -16,6 +16,54 @@ public class MetricConfigBean extends AbstractBean {
   public static final String URL_TEMPLATE_START_TIME = "startTime";
   public static final String URL_TEMPLATE_END_TIME = "endTime";
   public static final MetricAggFunction DEFAULT_AGG_FUNCTION = MetricAggFunction.SUM;
+  public static final String METRIC_PROPERTIES_SEPARATOR = ",";
+
+  /**
+   * Properties to set in metricProperties, in order to express a metric as a metricAsDimension case.
+   *
+   * eg: If a dataset has columns as follows:
+   * counter_name - a column which stores the name of the metric being expressed in that row
+   * counter_value - a column which stores the metric value corresponding to the counter_name in that row
+   * If we are interested in a metric called records_processed,
+   * it means we are interested in counter_value from rows which have counter_name=records_processed
+   * Thus the metric definition would be
+   * {
+   *   name : "RecordsProcessed",
+   *   dataset : "myDataset",
+   *   dimensionAsMetric : true,
+   *   metricProperties : {
+   *     "METRIC_NAMES" : "records_processed",
+   *     "METRIC_NAMES_COLUMNS" : "counter_name",
+   *     "METRIC_VALUES_COLUMN" : "counter_value"
+   *   }
+   * }
+   *
+   * eg: If a dataset has columns as follows:
+   * counter_name_primary - a column which stores the name of the metric being expressed in that row
+   * counter_name_secondary - another column which stores the name of the metric being expressed in that row
+   * counter_value - a column which stores the metric value corresponding to the counter_name_primary and counter_name_secondary in that row
+   * If we are interested in a metric called primary=records_processed secondary=internal,
+   * it means we are interested in counter_value from rows which have counter_name_primary=records_processed and counter_name_secondary=internal
+   * Thus the metric definition would be
+   * {
+   *   name : "RecordsProcessedInternal",
+   *   dataset : "myDataset",
+   *   dimensionAsMetric : true,
+   *   metricProperties : {
+   *     "METRIC_NAMES" : "records_processed,internal",
+   *     "METRIC_NAMES_COLUMNS" : "counter_name_primary,counter_name_secondary",
+   *     "METRIC_VALUES_COLUMN" : "counter_value"
+   *   }
+   * }
+   */
+  public enum DimensionAsMetricProperties {
+    /** The actual names of the metrics, comma separated */
+    METRIC_NAMES,
+    /** The columns in which to look for the metric names, comma separated */
+    METRIC_NAMES_COLUMNS,
+    /** The column from which to get the metric value */
+    METRIC_VALUES_COLUMN
+  }
 
   private String name;
 
@@ -45,6 +93,7 @@ public class MetricConfigBean extends AbstractBean {
 
   private Map<String, String> metricProperties = null;
 
+  private boolean dimensionAsMetric = false;
 
   public String getName() {
     return name;
@@ -100,6 +149,14 @@ public class MetricConfigBean extends AbstractBean {
 
   public void setDefaultAggFunction(MetricAggFunction defaultAggFunction) {
     this.defaultAggFunction = defaultAggFunction;
+  }
+
+  public boolean isDimensionAsMetric() {
+    return dimensionAsMetric;
+  }
+
+  public void setDimensionAsMetric(boolean dimensionAsMetric) {
+    this.dimensionAsMetric = dimensionAsMetric;
   }
 
   public Double getRollupThreshold() {
@@ -171,6 +228,7 @@ public class MetricConfigBean extends AbstractBean {
         && Objects.equals(derived, mc.isDerived())
         && Objects.equals(derivedMetricExpression, mc.getDerivedMetricExpression())
         && Objects.equals(defaultAggFunction, mc.getDefaultAggFunction())
+        && Objects.equals(dimensionAsMetric, mc.isDimensionAsMetric())
         && Objects.equals(rollupThreshold, mc.getRollupThreshold())
         && Objects.equals(inverseMetric, mc.isInverseMetric())
         && Objects.equals(cellSizeExpression, mc.getCellSizeExpression())

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -9,6 +9,7 @@ import com.google.common.cache.Weigher;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
+
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,8 +21,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.manager.zk.ZkClient;
@@ -41,6 +42,7 @@ import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datasource.MetricFunction;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.datasource.ThirdEyeDataSource;
@@ -153,8 +155,9 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
         // By default, query only offline, unless dataset has been marked as realtime
         String tableName = ThirdEyeUtils.computeTableName(dataset);
         String pql = null;
-        if (datasetConfig.isMetricAsDimension()) {
-          pql = PqlUtils.getMetricAsDimensionPql(request, metricFunction, decoratedFilterSet, dataTimeSpec, datasetConfig);
+        MetricConfigDTO metricConfig = metricFunction.getMetricConfig();
+        if (metricConfig != null && metricConfig.isDimensionAsMetric()) {
+          pql = PqlUtils.getDimensionAsMetricPql(request, metricFunction, decoratedFilterSet, dataTimeSpec, datasetConfig);
         } else {
           pql = PqlUtils.getPql(request, metricFunction, decoratedFilterSet, dataTimeSpec);
         }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
@@ -15,12 +15,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
+import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean.DimensionAsMetricProperties;
 import com.linkedin.thirdeye.datasource.MetricFunction;
 import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
@@ -102,33 +105,49 @@ public class PqlUtils {
    * @return
    * @throws Exception
    */
-  public static String getMetricAsDimensionPql(ThirdEyeRequest request, MetricFunction metricFunction,
+  public static String getDimensionAsMetricPql(ThirdEyeRequest request, MetricFunction metricFunction,
       Multimap<String, String> filterSet, TimeSpec dataTimeSpec, DatasetConfigDTO datasetConfig) throws Exception {
 
     // select sum(metric_values_column) from collection
-    // where time_clause and metric_names_column=function.getMetricName
-    String metricValuesColumn = datasetConfig.getMetricValuesColumn();
-    String metricNamesColumn = datasetConfig.getMetricNamesColumn();
+    // where time_clause and metric_names_column=metric_name
+    MetricConfigDTO metricConfig = metricFunction.getMetricConfig();
+    Map<String, String> metricProperties = metricConfig.getMetricProperties();
+    if (metricProperties == null || metricProperties.isEmpty()) {
+      throw new RuntimeException("Metric properties must have properties " + DimensionAsMetricProperties.values());
+    }
+    String metricNames = metricProperties.get(DimensionAsMetricProperties.METRIC_NAMES.toString());
+    String metricNamesColumns = metricProperties.get(DimensionAsMetricProperties.METRIC_NAMES_COLUMNS.toString());
+    String metricValuesColumn = metricProperties.get(DimensionAsMetricProperties.METRIC_VALUES_COLUMN.toString());
+    if (StringUtils.isBlank(metricNames) || StringUtils.isBlank(metricNamesColumns) || StringUtils.isBlank(metricValuesColumn)) {
+      throw new RuntimeException("Metric properties must have properties " + DimensionAsMetricProperties.values());
+    }
+    List<String> metricNamesList = Lists.newArrayList(metricNames.split(MetricConfigBean.METRIC_PROPERTIES_SEPARATOR));
+    List<String> metricNamesColumnsList = Lists.newArrayList(metricNamesColumns.split(MetricConfigBean.METRIC_PROPERTIES_SEPARATOR));
+    if (metricNamesList.size() != metricNamesColumnsList.size()) {
+      throw new RuntimeException("Must provide same number of metricNames in " + metricNames
+          + " as metricNamesColumns in " + metricNamesColumns);
+    }
 
-    String metricAsDimensionPql = getMetricAsDimensionPql(metricFunction,
+    String dimensionAsMetricPql = getDimensionAsMetricPql(metricFunction,
         request.getStartTimeInclusive(), request.getEndTimeExclusive(), filterSet,
         request.getGroupBy(), request.getGroupByTimeGranularity(), dataTimeSpec,
-        metricValuesColumn, metricNamesColumn);
+        metricNamesList, metricNamesColumnsList, metricValuesColumn);
 
-    return metricAsDimensionPql;
+    return dimensionAsMetricPql;
   }
 
 
-  private static String getMetricAsDimensionPql(MetricFunction metricFunction, DateTime startTime,
+  private static String getDimensionAsMetricPql(MetricFunction metricFunction, DateTime startTime,
       DateTime endTimeExclusive, Multimap<String, String> filterSet, List<String> groupBy,
-      TimeGranularity timeGranularity, TimeSpec dataTimeSpec, String metricValuesColumn,
-      String metricNamesColumn) throws ExecutionException {
+      TimeGranularity timeGranularity, TimeSpec dataTimeSpec,
+      List<String> metricNames, List<String> metricNamesColumns, String metricValuesColumn)
+          throws ExecutionException {
 
-    MetricConfigDTO metricConfig = ThirdEyeUtils.getMetricConfigFromId(metricFunction.getMetricId());
+    MetricConfigDTO metricConfig = metricFunction.getMetricConfig();
     String dataset = metricFunction.getDataset();
 
     StringBuilder sb = new StringBuilder();
-    String selectionClause = getMetricAsDimensionSelectionClause(metricFunction, metricValuesColumn);
+    String selectionClause = getDimensionAsMetricSelectionClause(metricFunction, metricValuesColumn);
 
     String tableName = ThirdEyeUtils.computeTableName(dataset);
 
@@ -136,7 +155,7 @@ public class PqlUtils {
     String betweenClause = getBetweenClause(startTime, endTimeExclusive, dataTimeSpec, dataset);
     sb.append(" WHERE ").append(betweenClause);
 
-    String metricWhereClause = getMetricWhereClause(metricConfig, metricFunction, metricNamesColumn);
+    String metricWhereClause = getMetricWhereClause(metricConfig, metricFunction, metricNames, metricNamesColumns);
     sb.append(metricWhereClause);
 
     String dimensionWhereClause = getDimensionWhereClause(filterSet);
@@ -154,17 +173,22 @@ public class PqlUtils {
   }
 
 
-  private static String getMetricWhereClause(MetricConfigDTO metricConfig, MetricFunction metricFunction, String metricNameColumn) {
+  private static String getMetricWhereClause(MetricConfigDTO metricConfig, MetricFunction metricFunction,
+      List<String> metricNames, List<String> metricNamesColumns) {
     StringBuilder builder = new StringBuilder();
     if (!metricFunction.getMetricName().equals("*")) {
-      builder.append(" AND ");
-      builder.append(String.format("%s='%s'", metricNameColumn, metricConfig.getName()));
+      for (int i = 0; i < metricNamesColumns.size(); i++) {
+        String metricName = metricNames.get(i);
+        String metricNamesColumn = metricNamesColumns.get(i);
+        builder.append(" AND ");
+        builder.append(String.format("%s='%s'", metricNamesColumn, metricName));
+      }
     }
     return builder.toString();
   }
 
 
-  private static String getMetricAsDimensionSelectionClause(MetricFunction metricFunction, String metricValueColumn) {
+  private static String getDimensionAsMetricSelectionClause(MetricFunction metricFunction, String metricValueColumn) {
     StringBuilder builder = new StringBuilder();
     String metricName = metricValueColumn;
     if (metricFunction.getMetricName().equals("*")) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PqlUtils.java
@@ -115,14 +115,19 @@ public class PqlUtils {
     if (metricProperties == null || metricProperties.isEmpty()) {
       throw new RuntimeException("Metric properties must have properties " + DimensionAsMetricProperties.values());
     }
-    String metricNames = metricProperties.get(DimensionAsMetricProperties.METRIC_NAMES.toString());
-    String metricNamesColumns = metricProperties.get(DimensionAsMetricProperties.METRIC_NAMES_COLUMNS.toString());
-    String metricValuesColumn = metricProperties.get(DimensionAsMetricProperties.METRIC_VALUES_COLUMN.toString());
+    String metricNames =
+        metricProperties.get(DimensionAsMetricProperties.METRIC_NAMES.toString());
+    String metricNamesColumns =
+        metricProperties.get(DimensionAsMetricProperties.METRIC_NAMES_COLUMNS.toString());
+    String metricValuesColumn =
+        metricProperties.get(DimensionAsMetricProperties.METRIC_VALUES_COLUMN.toString());
     if (StringUtils.isBlank(metricNames) || StringUtils.isBlank(metricNamesColumns) || StringUtils.isBlank(metricValuesColumn)) {
       throw new RuntimeException("Metric properties must have properties " + DimensionAsMetricProperties.values());
     }
-    List<String> metricNamesList = Lists.newArrayList(metricNames.split(MetricConfigBean.METRIC_PROPERTIES_SEPARATOR));
-    List<String> metricNamesColumnsList = Lists.newArrayList(metricNamesColumns.split(MetricConfigBean.METRIC_PROPERTIES_SEPARATOR));
+    List<String> metricNamesList =
+        Lists.newArrayList(metricNames.split(MetricConfigBean.METRIC_PROPERTIES_SEPARATOR));
+    List<String> metricNamesColumnsList =
+        Lists.newArrayList(metricNamesColumns.split(MetricConfigBean.METRIC_PROPERTIES_SEPARATOR));
     if (metricNamesList.size() != metricNamesColumnsList.size()) {
       throw new RuntimeException("Must provide same number of metricNames in " + metricNames
           + " as metricNamesColumns in " + metricNamesColumns);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -235,7 +235,7 @@ public abstract class ThirdEyeUtils {
 
   private static String getSDFPatternFromTimeFormat(String timeFormat) {
     String pattern = timeFormat;
-    String[] tokens = timeFormat.split(":");
+    String[] tokens = timeFormat.split(":", 2);
     if (tokens.length == 2) {
       pattern = tokens[1];
     }
@@ -280,7 +280,7 @@ public abstract class ThirdEyeUtils {
     } else {
       derivedMetricExpression = MetricConfigBean.DERIVED_METRIC_ID_PREFIX + metricConfig.getId();
     }
-    
+
     return derivedMetricExpression;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/thirdeye/dataset-config.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/thirdeye/dataset-config.js
@@ -39,7 +39,7 @@ function listDatasetConfigs() {
       },
       dimensionsHaveNoPreAggregation : {
         title : 'dimensionsHaveNoPreAggregation',
-        visibility : 'hidden'  
+        visibility : 'hidden'
       },
       active : {
         title : 'Active',
@@ -50,19 +50,6 @@ function listDatasetConfigs() {
         title : 'Additive',
         defaultValue : true,
         options : [ false, true ]
-      },
-      metricAsDimension : {
-        title : 'metricAsDimension',
-        defaultValue : true,
-        options : [ false, true ]
-      },
-      metricNamesColumn : {
-        title : 'metricNamesColumn',
-        visibility: 'hidden'
-      },
-      metricValuesColumn : {
-        title : 'metricValuesColumn',
-        visibility: 'hidden'
       },
       nonAdditiveBucketSize : {
         title : 'nonAdditiveBucketSize',
@@ -92,7 +79,7 @@ function listDatasetConfigs() {
         title : 'timezone',
         visibility: 'hidden'
       },
-    
+
     }
   });
   $("#dataset-config-place-holder" ).jtable('load');

--- a/thirdeye/thirdeye-pinot/src/main/resources/assets/js/thirdeye/metric-config.js
+++ b/thirdeye/thirdeye-pinot/src/main/resources/assets/js/thirdeye/metric-config.js
@@ -90,6 +90,11 @@ function updateMetricConfigTable(dataset, metrics) {
         defaultValue : false,
         options : [ false, true ]
       },
+      metricAsDimension : {
+        title : 'MetricAsDimension',
+        defaultValue : false,
+        options : [ false, true ]
+      },
       derived : {
         title : 'Derived',
         defaultValue : false,

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestDatasetConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestDatasetConfigManager.java
@@ -55,12 +55,12 @@ public class TestDatasetConfigManager extends AbstractManagerTestBase {
   public void testUpdate() {
     DatasetConfigDTO datasetConfig = datasetConfigDAO.findById(datasetConfigId1);
     Assert.assertNotNull(datasetConfig);
-    Assert.assertFalse(datasetConfig.isMetricAsDimension());
-    datasetConfig.setMetricAsDimension(true);
+    Assert.assertFalse(datasetConfig.isRealtime());
+    datasetConfig.setRealtime(true);
     datasetConfigDAO.update(datasetConfig);
     datasetConfig = datasetConfigDAO.findById(datasetConfigId1);
     Assert.assertNotNull(datasetConfig);
-    Assert.assertTrue(datasetConfig.isMetricAsDimension());
+    Assert.assertTrue(datasetConfig.isRealtime());
   }
 
   @Test(dependsOnMethods = { "testUpdate" })


### PR DESCRIPTION
Moving metricAsDimension configs from dataset to metric. We are encountering usecases where we can havedifferent metric configs for different metrics of a dataset, and having a dataset level flag for this doesn't make sense anymore. This PR gives us the ability to setup a metric with flag dimensionAsMetric. The other configs needed by the metric, such as metric anmes, metric names column and metric values column can be set in metricProperties.


Tested for a dataset which has dimensionAsMetric for certain metrics, and not for others.