### PR TITLE
[TE] Create tables and DAOs for alert email refactoring

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFeedConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFeedConfig.java
@@ -1,0 +1,79 @@
+package com.linkedin.thirdeye.alert.commons;
+
+import com.linkedin.thirdeye.alert.fetcher.BaseAnomalyFetcher;
+import com.linkedin.thirdeye.datalayer.util.StringUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+
+public class AnomalyFeedConfig {
+  private String anomalyFeedType;
+  private AnomalySource anomalySourceType;
+  private String anomalySource;
+  private Long alertSnapshotId;
+  private List<AnomalyFetcherConfig> anomalyFetcherConfigs;
+  private List<Map<String, String>> alertFilterConfigs;
+
+  public String getAnomalyFeedType() {
+    return anomalyFeedType;
+  }
+
+  public void setAnomalyFeedType(String anomalyFeedType) {
+    this.anomalyFeedType = anomalyFeedType;
+  }
+
+  public AnomalySource getAnomalySourceType() {
+    return anomalySourceType;
+  }
+
+  public void setAnomalySourceType(AnomalySource anomalySourceType) {
+    this.anomalySourceType = anomalySourceType;
+  }
+
+  public String getAnomalySource() {
+    return anomalySource;
+  }
+
+  public void setAnomalySource(String anomalySource) {
+    this.anomalySource = anomalySource;
+  }
+
+  public List<AnomalyFetcherConfig> getAnomalyFetcherConfigs() {
+    if (anomalyFetcherConfigs == null) {
+      anomalyFetcherConfigs = Collections.EMPTY_LIST;
+    }
+    for (AnomalyFetcherConfig anomalyFetcherConfig : anomalyFetcherConfigs) {
+      Properties properties = StringUtils.decodeCompactedProperties(anomalyFetcherConfig.getProperties());
+      anomalyFetcherConfig.setAnomalySourceType(anomalySourceType);
+      anomalyFetcherConfig.setAnomalySource(anomalySource);
+      anomalyFetcherConfig.setProperties(StringUtils.encodeCompactedProperties(properties));
+    }
+    return anomalyFetcherConfigs;
+  }
+
+  public void setAnomalyFetcherConfigs(List<AnomalyFetcherConfig> anomalyFetcherConfigs) {
+    this.anomalyFetcherConfigs = anomalyFetcherConfigs;
+  }
+
+  public List<Map<String, String>> getAlertFilterConfigs() {
+    if (alertFilterConfigs == null) {
+      alertFilterConfigs = Collections.EMPTY_LIST;
+    }
+    return alertFilterConfigs;
+  }
+
+  public void setAlertFilterConfigs(List<Map<String, String>> alertFilterConfigs) {
+    this.alertFilterConfigs = alertFilterConfigs;
+  }
+
+  public Long getAlertSnapshotId() {
+    return alertSnapshotId;
+  }
+
+  public void setAlertSnapshotId(Long alertSnapshotId) {
+    this.alertSnapshotId = alertSnapshotId;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFeedConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFeedConfig.java
@@ -41,7 +41,7 @@ public class AnomalyFeedConfig {
 
   public List<AnomalyFetcherConfig> getAnomalyFetcherConfigs() {
     if (anomalyFetcherConfigs == null) {
-      anomalyFetcherConfigs = Collections.EMPTY_LIST;
+      anomalyFetcherConfigs = Collections.emptyList();
     }
     for (AnomalyFetcherConfig anomalyFetcherConfig : anomalyFetcherConfigs) {
       Properties properties = StringUtils.decodeCompactedProperties(anomalyFetcherConfig.getProperties());
@@ -58,7 +58,7 @@ public class AnomalyFeedConfig {
 
   public List<Map<String, String>> getAlertFilterConfigs() {
     if (alertFilterConfigs == null) {
-      alertFilterConfigs = Collections.EMPTY_LIST;
+      alertFilterConfigs = Collections.emptyList();
     }
     return alertFilterConfigs;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFeedConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFeedConfig.java
@@ -1,8 +1,6 @@
 package com.linkedin.thirdeye.alert.commons;
 
-import com.linkedin.thirdeye.alert.fetcher.BaseAnomalyFetcher;
 import com.linkedin.thirdeye.datalayer.util.StringUtils;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFetcherConfig.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyFetcherConfig.java
@@ -1,0 +1,40 @@
+package com.linkedin.thirdeye.alert.commons;
+
+public class AnomalyFetcherConfig {
+  private String type;
+  private AnomalySource anomalySourceType;
+  private String anomalySource;
+  private String properties;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public AnomalySource getAnomalySourceType() {
+    return anomalySourceType;
+  }
+
+  public void setAnomalySourceType(AnomalySource anomalySourceType) {
+    this.anomalySourceType = anomalySourceType;
+  }
+
+  public String getAnomalySource() {
+    return anomalySource;
+  }
+
+  public void setAnomalySource(String anomalySource) {
+    this.anomalySource = anomalySource;
+  }
+
+  public String getProperties() {
+    return properties;
+  }
+
+  public void setProperties(String properties) {
+    this.properties = properties;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyNotifiedStatus.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalyNotifiedStatus.java
@@ -1,0 +1,29 @@
+package com.linkedin.thirdeye.alert.commons;
+
+public class AnomalyNotifiedStatus {
+  public AnomalyNotifiedStatus() {
+
+  }
+  public AnomalyNotifiedStatus(long time, double severity){
+    this.lastNotifyTime = time;
+    this.lastNotifySeverity = severity;
+  }
+  private long lastNotifyTime;
+  private double lastNotifySeverity;
+
+  public long getLastNotifyTime() {
+    return lastNotifyTime;
+  }
+
+  public void setLastNotifyTime(long lastNotifyTime) {
+    this.lastNotifyTime = lastNotifyTime;
+  }
+
+  public double getLastNotifySeverity() {
+    return lastNotifySeverity;
+  }
+
+  public void setLastNotifySeverity(double lastNotifySeverity) {
+    this.lastNotifySeverity = lastNotifySeverity;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalySource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/commons/AnomalySource.java
@@ -1,0 +1,31 @@
+package com.linkedin.thirdeye.alert.commons;
+
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+
+
+public enum AnomalySource {
+  DATASET {
+    @Override
+    public Predicate getPredicate(String predicateValue) {
+      return Predicate.IN("collection", predicateValue.split(","));
+    }
+  },
+  METRIC {
+    @Override
+    public Predicate getPredicate(String predicateValue) {
+      return Predicate.IN("metric", predicateValue.split(","));
+    }
+  },
+  ANOMALY_FUNCTION {
+    @Override
+    public Predicate getPredicate(String predicateValue) {
+      return Predicate.IN("functionId", predicateValue.split(","));
+    }
+  };
+
+  AnomalySource(){
+
+  }
+
+  public abstract Predicate getPredicate(String predicateValue);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AlertSnapshotManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AlertSnapshotManager.java
@@ -1,0 +1,7 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import com.linkedin.thirdeye.datalayer.dto.AlertSnapshotDTO;
+
+
+public interface AlertSnapshotManager extends AbstractManager<AlertSnapshotDTO> {
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AlertSnapshotManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AlertSnapshotManagerImpl.java
@@ -1,0 +1,14 @@
+package com.linkedin.thirdeye.datalayer.bao.jdbc;
+
+import com.linkedin.thirdeye.datalayer.bao.AlertSnapshotManager;
+import com.linkedin.thirdeye.datalayer.dto.AlertSnapshotDTO;
+import com.linkedin.thirdeye.datalayer.pojo.AlertSnapshotBean;
+
+
+public class AlertSnapshotManagerImpl extends AbstractManagerImpl<AlertSnapshotDTO>
+    implements AlertSnapshotManager {
+
+  public AlertSnapshotManagerImpl() {
+    super(AlertSnapshotDTO.class, AlertSnapshotBean.class);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -472,4 +472,13 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
     return mergedAnomalyResultDTOList;
   }
 
+  @Override
+  public List<MergedAnomalyResultDTO> findByPredicate(Predicate predicate) {
+    List<MergedAnomalyResultDTO> dtoList = super.findByPredicate(predicate);
+    List<MergedAnomalyResultBean> beanList = new ArrayList<>();
+    for (MergedAnomalyResultDTO mergedAnomalyResultDTO :  dtoList) {
+      beanList.add(mergedAnomalyResultDTO);
+    }
+    return convertMergedAnomalyBean2DTO(beanList, true);
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -10,6 +10,7 @@ import com.linkedin.thirdeye.datalayer.entity.AbstractEntity;
 import com.linkedin.thirdeye.datalayer.entity.AbstractIndexEntity;
 import com.linkedin.thirdeye.datalayer.entity.AbstractJsonEntity;
 import com.linkedin.thirdeye.datalayer.entity.AlertConfigIndex;
+import com.linkedin.thirdeye.datalayer.entity.AlertSnapshotIndex;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFeedbackIndex;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFunctionIndex;
 import com.linkedin.thirdeye.datalayer.entity.ApplicationIndex;
@@ -33,6 +34,7 @@ import com.linkedin.thirdeye.datalayer.entity.RawAnomalyResultIndex;
 import com.linkedin.thirdeye.datalayer.entity.TaskIndex;
 import com.linkedin.thirdeye.datalayer.pojo.AbstractBean;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
+import com.linkedin.thirdeye.datalayer.pojo.AlertSnapshotBean;
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFeedbackBean;
 import com.linkedin.thirdeye.datalayer.pojo.AnomalyFunctionBean;
 import com.linkedin.thirdeye.datalayer.pojo.ApplicationBean;
@@ -126,7 +128,8 @@ public class GenericPojoDao {
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, ConfigIndex.class));
     pojoInfoMap.put(ApplicationBean.class,
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, ApplicationIndex.class));
-
+    pojoInfoMap.put(AlertSnapshotBean.class,
+        newPojoInfo(DEFAULT_BASE_TABLE_NAME, AlertSnapshotIndex.class));
   }
 
   private static PojoInfo newPojoInfo(String baseTableName,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AlertSnapshotDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/AlertSnapshotDTO.java
@@ -1,0 +1,127 @@
+package com.linkedin.thirdeye.datalayer.dto;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.alert.commons.AnomalyNotifiedStatus;
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.dashboard.resources.v2.AnomaliesResource;
+import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.pojo.AlertSnapshotBean;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class AlertSnapshotDTO extends AlertSnapshotBean {
+  private static final Logger LOG = LoggerFactory.getLogger(AlertSnapshotDTO.class);
+  public static final TimeGranularity EXPIRE_TIME = TimeGranularity.fromString("7_DAYS");
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public Multimap<String, AnomalyNotifiedStatus> getSnapshot() {
+    Multimap<String, AnomalyNotifiedStatus> snapshot = HashMultimap.create();
+    if (snapshotString == null || snapshotString.size() == 0) {
+      LOG.info("SnapshotString in AlertSnapshotBean {} is empty, return an empty map instead", getId());
+    } else {
+      for (Map.Entry<String, List<String>> entry : snapshotString.entrySet()) {
+        for (String statusString : entry.getValue()) {
+          try {
+            AnomalyNotifiedStatus status = OBJECT_MAPPER.readValue(statusString, AnomalyNotifiedStatus.class);
+            snapshot.put(entry.getKey(), status);
+          } catch (IOException e) {
+            LOG.error("Unable to parse String {} to Status", statusString);
+          }
+        }
+      }
+    }
+    return snapshot;
+  }
+
+  public void setSnapshot(Multimap<String, AnomalyNotifiedStatus> snapshot) {
+    this.snapshotString = new HashMap<>();
+    for (Map.Entry<String, AnomalyNotifiedStatus> entry : snapshot.entries()) {
+      String valueString;
+      try {
+        valueString = OBJECT_MAPPER.writeValueAsString(entry.getValue());
+      } catch (IOException e) {
+        LOG.error("Unable to parse Status {} to String", entry.getValue());
+        continue;
+      }
+      if(!snapshotString.containsKey(entry.getKey())) {
+        snapshotString.put(entry.getKey(), new ArrayList<String>());
+      }
+      snapshotString.get(entry.getKey()).add(valueString);
+    }
+  }
+
+  public void updateSnapshot(DateTime alertTime, List<MergedAnomalyResultDTO> alertedAnomalies) {
+    MergedAnomalyResultManager mergedAnomalyResultDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
+    // Set the lastNotifyTime to current time if there is alerted anomalies
+    if (alertedAnomalies.size() > 0) {
+      lastNotifyTime = alertTime.getMillis();
+    }
+
+    Multimap<String, AnomalyNotifiedStatus> snapshot = getSnapshot();
+    // update snapshots based on anomalies
+    for (MergedAnomalyResultDTO anomaly : alertedAnomalies) {
+      String snapshotKey = getSnapshotKey(anomaly).toString();
+      AnomalyNotifiedStatus lastNotifyStatus = getLatestStatus(snapshot, snapshotKey);
+      AnomalyNotifiedStatus statusToBeUpdated = new AnomalyNotifiedStatus(alertTime.getMillis(), anomaly.getWeight());
+      if (lastNotifyStatus.getLastNotifyTime() > anomaly.getStartTime()) {
+        // anomaly is a continuing issue, and the status should be appended to the end of snapshot
+        snapshot.put(snapshotKey, statusToBeUpdated);
+      } else {
+        // anomaly is a new issue, override the status list
+        snapshot.removeAll(snapshotKey);
+        snapshot.put(snapshotKey, statusToBeUpdated);
+      }
+
+      // Set notified flag
+      anomaly.setNotified(true);
+      mergedAnomalyResultDAO.update(anomaly);
+    }
+
+    // cleanup stale status in snapshot
+    DateTime expiredTime = alertTime.minus(EXPIRE_TIME.toPeriod());
+    List<String> keysToBeRemoved = new ArrayList<>();
+    for (String snapshotKey : snapshot.keySet()) {
+      AnomalyNotifiedStatus latestStatus = getLatestStatus(snapshot, snapshotKey);
+      if (latestStatus.getLastNotifyTime() < expiredTime.getMillis()) {
+        keysToBeRemoved.add(snapshotKey);
+      }
+    }
+    for (String key : keysToBeRemoved) {
+      snapshot.removeAll(key);
+    }
+    setSnapshot(snapshot);
+  }
+
+  public AnomalyNotifiedStatus getLatestStatus(Multimap<String, AnomalyNotifiedStatus> snapshot, String statusKey) {
+    if (!snapshot.containsKey(statusKey)) {
+      return new AnomalyNotifiedStatus(0, 0);
+    }
+    Collection<AnomalyNotifiedStatus> notifyStatus = snapshot.get(statusKey);
+    AnomalyNotifiedStatus recentStatus = null;
+
+    for (AnomalyNotifiedStatus status : notifyStatus) {
+      if (recentStatus == null) {
+        recentStatus = status;
+      } else if (recentStatus.getLastNotifyTime() < status.getLastNotifyTime()) {
+        recentStatus = status;
+      }
+    }
+
+    return recentStatus;
+  }
+
+  public static String getSnapshotKey(MergedAnomalyResultDTO anomaly) {
+    return anomaly.getMetric() + "::" + AnomaliesResource.generateFilterSetForTimeSeriesQuery(anomaly);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/AlertSnapshotIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/AlertSnapshotIndex.java
@@ -1,0 +1,5 @@
+package com.linkedin.thirdeye.datalayer.entity;
+
+public class AlertSnapshotIndex extends AbstractIndexEntity{
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
@@ -2,10 +2,13 @@ package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.linkedin.thirdeye.alert.commons.AnomalyFeedConfig;
+import com.linkedin.thirdeye.datalayer.util.StringUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.jetty.util.StringUtil;
+
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AlertConfigBean extends AbstractBean {
@@ -17,7 +20,7 @@ public class AlertConfigBean extends AbstractBean {
   EmailConfig emailConfig;
   ReportConfigCollection reportConfigCollection;
   AlertGroupConfig alertGroupConfig;
-  String emailFormatterType;
+  EmailFormatterConfig emailFormatterConfig;
   String recipients;
   String fromAddress;
 
@@ -101,12 +104,12 @@ public class AlertConfigBean extends AbstractBean {
     this.alertGroupConfig = alertGroupConfig;
   }
 
-  public String getEmailFormatterType() {
-    return emailFormatterType;
+  public EmailFormatterConfig getEmailFormatterConfig() {
+    return emailFormatterConfig;
   }
 
-  public void setEmailFormatterType(String emailFormatterType) {
-    this.emailFormatterType = emailFormatterType;
+  public void setEmailFormatterConfig(EmailFormatterConfig emailFormatterConfig) {
+    this.emailFormatterConfig = emailFormatterConfig;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -136,6 +139,34 @@ public class AlertConfigBean extends AbstractBean {
           "functionIds=" + functionIds +
           ", anomalyWatermark=" + anomalyWatermark +
           '}';
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static class EmailFormatterConfig {
+    String type;
+    String properties;
+
+    public String getType() {
+      if (StringUtil.isBlank(type)) {
+        return "";
+      }
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getProperties() {
+      if (StringUtil.isBlank(properties)) {
+        return "";
+      }
+      return properties;
+    }
+
+    public void setProperties(String properties) {
+      this.properties = properties;
     }
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.linkedin.thirdeye.alert.commons.AnomalyFeedConfig;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,9 +13,11 @@ public class AlertConfigBean extends AbstractBean {
   String application;
   String cronExpression;
   boolean active;
+  AnomalyFeedConfig anomalyFeedConfig;
   EmailConfig emailConfig;
   ReportConfigCollection reportConfigCollection;
   AlertGroupConfig alertGroupConfig;
+  String emailFormatterType;
   String recipients;
   String fromAddress;
 
@@ -48,6 +51,14 @@ public class AlertConfigBean extends AbstractBean {
 
   public void setCronExpression(String cronExpression) {
     this.cronExpression = cronExpression;
+  }
+
+  public AnomalyFeedConfig getAnomalyFeedConfig() {
+    return anomalyFeedConfig;
+  }
+
+  public void setAnomalyFeedConfig(AnomalyFeedConfig anomalyFeedConfig) {
+    this.anomalyFeedConfig = anomalyFeedConfig;
   }
 
   public EmailConfig getEmailConfig() {
@@ -88,6 +99,14 @@ public class AlertConfigBean extends AbstractBean {
 
   public void setAlertGroupConfig(AlertGroupConfig alertGroupConfig) {
     this.alertGroupConfig = alertGroupConfig;
+  }
+
+  public String getEmailFormatterType() {
+    return emailFormatterType;
+  }
+
+  public void setEmailFormatterType(String emailFormatterType) {
+    this.emailFormatterType = emailFormatterType;
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertSnapshotBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertSnapshotBean.java
@@ -1,0 +1,45 @@
+package com.linkedin.thirdeye.datalayer.pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AlertSnapshotBean extends AbstractBean {
+  protected long lastNotifyTime;
+  protected long alertConfigId;
+
+  // key: metric::dimension
+  protected Map<String, List<String>> snapshotString;
+
+  public long getLastNotifyTime() {
+    return lastNotifyTime;
+  }
+
+  public void setLastNotifyTime(long lastNotifyTime) {
+    this.lastNotifyTime = lastNotifyTime;
+  }
+
+  public Map<String, List<String>> getSnapshotString() {
+    return snapshotString;
+  }
+
+  public void setSnapshotString(Map<String, List<String>> snapshot) {
+    this.snapshotString = snapshot;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof AlertSnapshotBean)) {
+      return false;
+    }
+    AlertSnapshotBean as = (AlertSnapshotBean) o;
+    return Objects.equals(snapshotString, as.getSnapshotString()) && Objects.equals(lastNotifyTime, as.getLastNotifyTime());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(snapshotString, lastNotifyTime);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datalayer.util;
 
 import com.linkedin.thirdeye.datalayer.entity.AlertConfigIndex;
+import com.linkedin.thirdeye.datalayer.entity.AlertSnapshotIndex;
 import com.linkedin.thirdeye.datalayer.entity.ApplicationIndex;
 import com.linkedin.thirdeye.datalayer.entity.ClassificationConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.ConfigIndex;
@@ -146,6 +147,8 @@ public abstract class DaoProviderUtil {
             convertCamelCaseToUnderscore(ConfigIndex.class.getSimpleName()));
         entityMappingHolder.register(conn, ApplicationIndex.class,
             convertCamelCaseToUnderscore(ApplicationIndex.class.getSimpleName()));
+        entityMappingHolder.register(conn, AlertSnapshotIndex.class,
+            convertCamelCaseToUnderscore(AlertSnapshotIndex.class.getSimpleName()));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/StringUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/StringUtils.java
@@ -15,8 +15,11 @@ public class StringUtils {
   private static Joiner SEMICOLON = Joiner.on(";");
   private static Joiner EQUALS = Joiner.on("=");
 
-  // the following two functions encode and decode properties are moved from class
-  // com.linkedin.thirdeye.controller.mp.function.ThirdEyeAnomalyFunctionUtil
+  /**
+   * Encode the properties into String, which is in the format of field1=value1;field2=value2 and so on
+   * @param props the properties instance
+   * @return a String representation of the given properties
+   */
   public static String encodeCompactedProperties(Properties props) {
     List<String> parts = new ArrayList<>();
     for (Map.Entry<Object, Object> entry : props.entrySet()) {
@@ -25,6 +28,11 @@ public class StringUtils {
     return SEMICOLON.join(parts);
   }
 
+  /**
+   * Decode the properties string (e.g. field1=value1;field2=value2) to a properties instance
+   * @param propStr a properties string in the format of field1=value1;field2=value2
+   * @return a properties instance
+   */
   public static Properties decodeCompactedProperties(String propStr) {
     Properties props = new Properties();
     for (String part : SEMICOLON_SPLITTER.split(propStr)) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/StringUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/StringUtils.java
@@ -1,0 +1,36 @@
+package com.linkedin.thirdeye.datalayer.util;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+
+public class StringUtils {
+  private static Splitter SEMICOLON_SPLITTER = Splitter.on(";").omitEmptyStrings();
+  private static Splitter EQUALS_SPLITTER = Splitter.on("=").omitEmptyStrings();
+
+  private static Joiner SEMICOLON = Joiner.on(";");
+  private static Joiner EQUALS = Joiner.on("=");
+
+  // the following two functions encode and decode properties are moved from class
+  // com.linkedin.thirdeye.controller.mp.function.ThirdEyeAnomalyFunctionUtil
+  public static String encodeCompactedProperties(Properties props) {
+    List<String> parts = new ArrayList<>();
+    for (Map.Entry<Object, Object> entry : props.entrySet()) {
+      parts.add(EQUALS.join(entry.getKey(), entry.getValue()));
+    }
+    return SEMICOLON.join(parts);
+  }
+
+  public static Properties decodeCompactedProperties(String propStr) {
+    Properties props = new Properties();
+    for (String part : SEMICOLON_SPLITTER.split(propStr)) {
+      List<String> kvPair = EQUALS_SPLITTER.splitToList(part);
+      props.setProperty(kvPair.get(0), kvPair.get(1));
+    }
+    return props;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DAORegistry.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datasource;
 
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.AlertSnapshotManager;
 import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
 import com.linkedin.thirdeye.datalayer.bao.ApplicationManager;
 import com.linkedin.thirdeye.datalayer.bao.AutotuneConfigManager;
@@ -21,6 +22,7 @@ import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertConfigManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertSnapshotManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AnomalyFunctionManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.ApplicationManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AutotuneConfigManagerImpl;
@@ -157,5 +159,9 @@ public class DAORegistry {
 
   public ApplicationManager getApplicationDAO() {
     return DaoProviderUtil.getInstance(ApplicationManagerImpl.class);
+  }
+
+  public AlertSnapshotManager getAlertSnapshotDAO() {
+    return DaoProviderUtil.getInstance(AlertSnapshotManagerImpl.class);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
@@ -1,6 +1,12 @@
 package com.linkedin.thirdeye.datalayer;
 
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.alert.commons.AnomalyFeedConfig;
+import com.linkedin.thirdeye.alert.commons.AnomalyFetcherConfig;
+import com.linkedin.thirdeye.alert.commons.AnomalyNotifiedStatus;
+import com.linkedin.thirdeye.alert.commons.AnomalySource;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.override.OverrideConfigHelper;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
@@ -9,6 +15,7 @@ import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.api.MetricType;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.AlertSnapshotDTO;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.AutotuneConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.ClassificationConfigDTO;
@@ -18,6 +25,7 @@ import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.DetectionStatusDTO;
 import com.linkedin.thirdeye.datalayer.dto.EntityToEntityMappingDTO;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
 import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
@@ -26,6 +34,7 @@ import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
 import com.linkedin.thirdeye.detector.email.filter.AlphaBetaAlertFilter;
 import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
 import com.linkedin.thirdeye.util.ThirdEyeUtils;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -235,5 +244,62 @@ public class DaoTestUtils {
     dto.setName(name);
     dto.setValue(value);
     return dto;
+  }
+
+  public static AlertSnapshotDTO getTestAlertSnapshot(){
+    AlertSnapshotDTO alertSnapshot = new AlertSnapshotDTO();
+    alertSnapshot.setLastNotifyTime(0);
+    Multimap<String, AnomalyNotifiedStatus> snapshot = HashMultimap.create();
+    snapshot.put("test::{dimension=[test]}", new AnomalyNotifiedStatus(0,-0.1));
+    snapshot.put("test::{dimension=[test]}", new AnomalyNotifiedStatus(2,-0.2));
+    snapshot.put("test::{dimension=[test2]}", new AnomalyNotifiedStatus(4,-0.4));
+    alertSnapshot.setSnapshot(snapshot);
+    return alertSnapshot;
+  }
+
+  public static AnomalyFeedConfig getTestAnomalyFeedConfig() {
+    AnomalyFeedConfig anomalyFeedConfig = new AnomalyFeedConfig();
+    anomalyFeedConfig.setAnomalyFeedType("UnionAnomalyFeed");
+    anomalyFeedConfig.setAnomalySourceType(AnomalySource.METRIC);
+    anomalyFeedConfig.setAnomalySource("test");
+    anomalyFeedConfig.setAlertSnapshotId(1l);
+
+    AnomalyFetcherConfig anomalyFetcherConfig = getTestAnomalyFetcherConfig();
+    List<AnomalyFetcherConfig> fetcherConfigs = new ArrayList<>();
+    fetcherConfigs.add(anomalyFetcherConfig);
+    anomalyFeedConfig.setAnomalyFetcherConfigs(fetcherConfigs);
+
+    Map<String, String> alertFilterConfig = new HashMap<>();
+    alertFilterConfig.put(AlphaBetaAlertFilter.TYPE, "DUMMY");
+    alertFilterConfig.put("properties", "");
+    List<Map<String, String>> filterConfigs = new ArrayList<>();
+    filterConfigs.add(alertFilterConfig);
+    anomalyFeedConfig.setAlertFilterConfigs(filterConfigs);
+
+    return anomalyFeedConfig;
+  }
+
+  public static AnomalyFetcherConfig getTestAnomalyFetcherConfig(){
+    AnomalyFetcherConfig anomalyFetcherConfig = new AnomalyFetcherConfig();
+    anomalyFetcherConfig.setType("UnnotifiedAnomalyFetcher");
+    anomalyFetcherConfig.setProperties("");
+    anomalyFetcherConfig.setAnomalySourceType(AnomalySource.METRIC);
+    anomalyFetcherConfig.setAnomalySource("test");
+    return anomalyFetcherConfig;
+  }
+
+  public static MergedAnomalyResultDTO getTestMergedAnomalyResult(long startTime, long endTime, String collection,
+      String metric, double weight, long functionId, long createdTime) {
+    // Add mock anomalies
+    MergedAnomalyResultDTO anomaly = new MergedAnomalyResultDTO();
+    anomaly.setStartTime(startTime);
+    anomaly.setEndTime(endTime);
+    anomaly.setCollection(collection);
+    anomaly.setMetric(metric);
+    anomaly.setWeight(weight);
+    anomaly.setFunctionId(functionId);
+    anomaly.setCreatedTime(createdTime);
+
+    return anomaly;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
@@ -36,7 +36,7 @@ public class TestAlertConfigManager{
     Assert.assertTrue(alertConfigid > 0);
   }
 
-  @Test
+  @Test (dependsOnMethods = {"testDeleteAlertConfig"})
   public void testCreateAlertConfigWithAnomalyFeedConfig() {
     AlertConfigDTO dto = new AlertConfigDTO();
     dto.setActive(true);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import com.linkedin.thirdeye.alert.commons.AnomalyFeedConfig;
+import com.linkedin.thirdeye.datalayer.DaoTestUtils;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import org.testng.Assert;
@@ -32,6 +34,22 @@ public class TestAlertConfigManager{
     request.setName("my alert config");
     alertConfigid = alertConfigDAO.save(request);
     Assert.assertTrue(alertConfigid > 0);
+  }
+
+  @Test
+  public void testCreateAlertConfigWithAnomalyFeedConfig() {
+    AlertConfigDTO dto = new AlertConfigDTO();
+    dto.setActive(true);
+    dto.setName("my alert config");
+    dto.setAnomalyFeedConfig(DaoTestUtils.getTestAnomalyFeedConfig());
+    long dtoId = alertConfigDAO.save(dto);
+    AlertConfigDTO newDto = alertConfigDAO.findById(dtoId);
+    AnomalyFeedConfig feedConfig = dto.getAnomalyFeedConfig();
+    AnomalyFeedConfig newFeedConfig = newDto.getAnomalyFeedConfig();
+
+    Assert.assertEquals(newFeedConfig.getAnomalyFetcherConfigs().size(), feedConfig.getAnomalyFetcherConfigs().size());
+    Assert.assertEquals(newFeedConfig.getAlertFilterConfigs(), feedConfig.getAlertFilterConfigs());
+    Assert.assertEquals(newFeedConfig.getAnomalySource(), feedConfig.getAnomalySource());
   }
 
   @Test (dependsOnMethods = {"testCreateAlertConfig"})

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertSnapshotManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertSnapshotManager.java
@@ -1,0 +1,54 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.alert.commons.AnomalyNotifiedStatus;
+import com.linkedin.thirdeye.datalayer.DaoTestUtils;
+import com.linkedin.thirdeye.datalayer.dto.AlertSnapshotDTO;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestAlertSnapshotManager {
+  private DAOTestBase testDAOProvider;
+  private AlertSnapshotManager alerSnapshotDAO;
+
+  @BeforeClass
+  void beforeClass() {
+    testDAOProvider = DAOTestBase.getInstance();
+    DAORegistry daoRegistry = DAORegistry.getInstance();
+    alerSnapshotDAO = daoRegistry.getAlertSnapshotDAO();
+  }
+
+  @AfterClass(alwaysRun = true)
+  void afterClass() {
+    testDAOProvider.cleanup();
+  }
+
+  @Test
+  public void testAlertSnapshotManagerCRUD(){
+    // test create
+    AlertSnapshotDTO originalDto = DaoTestUtils.getTestAlertSnapshot();
+    Assert.assertEquals(originalDto.getSnapshot().size(), 3);
+    long id = alerSnapshotDAO.save(originalDto);
+    Assert.assertEquals(alerSnapshotDAO.findAll().size(), 1);
+
+    // test read
+    AlertSnapshotDTO fetchedDto = alerSnapshotDAO.findById(id);
+    Assert.assertEquals(fetchedDto, originalDto);
+
+    // test update
+    Multimap<String, AnomalyNotifiedStatus> snapshot = originalDto.getSnapshot();
+    snapshot.put("test::{country=[NA]}", new AnomalyNotifiedStatus(15l, 0.2));
+    originalDto.setSnapshot(snapshot);
+    long updateId = alerSnapshotDAO.update(originalDto);
+    Assert.assertEquals(updateId, id);
+    Assert.assertEquals(alerSnapshotDAO.findById(updateId).getSnapshot().size(), 4);
+
+    // test delete
+    alerSnapshotDAO.delete(originalDto);
+    Assert.assertEquals(alerSnapshotDAO.findAll().size(), 0);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -334,3 +334,9 @@ create table application_index (
   recipients VARCHAR(1000) NOT NULL,
   base_id bigint(20) not null
 );
+
+create table if not exists alert_snapshot_index (
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp
+) ENGINE=InnoDB;

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -338,5 +338,6 @@ create table application_index (
 create table if not exists alert_snapshot_index (
     base_id bigint(20) not null,
     create_time timestamp,
-    update_time timestamp default current_timestamp
+    update_time timestamp default current_timestamp,
+    version int(10)
 ) ENGINE=InnoDB;

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
@@ -22,4 +22,5 @@ DROP TABLE IF EXISTS grouped_anomaly_results_index;
 DROP TABLE IF EXISTS onboard_dataset_metric_index;
 DROP TABLE IF EXISTS config_index;
 DROP TABLE IF EXISTS application_index;
+DROP TABLE IF EXISTS alert_snapshot_index;
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
We are working on the redesign of alerts. The first pr is to build up the database environment to generate and enable customized logic on alerts. The following pr will be pushed in to 1) introduce anomaly re-alert logic, and 2) enable email customization. 