### PR TITLE
[TE] Enable Performance Evaluation when User Report Anomaly

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
@@ -1,7 +1,6 @@
 package com.linkedin.thirdeye.anomaly.alert.util;
 
 import com.linkedin.thirdeye.anomaly.classification.ClassificationTaskRunner;
-import com.linkedin.thirdeye.detector.email.filter.DummyAlertFilter;
 import com.linkedin.thirdeye.detector.email.filter.PrecisionRecallEvaluator;
 
 import java.io.ByteArrayOutputStream;
@@ -194,7 +193,7 @@ public class AnomalyReportGenerator {
         }
       }
 
-      PrecisionRecallEvaluator precisionRecallEvaluator = new PrecisionRecallEvaluator(new DummyAlertFilter(), anomalies);
+      PrecisionRecallEvaluator precisionRecallEvaluator = new PrecisionRecallEvaluator(anomalies);
 
       HtmlEmail email = new HtmlEmail();
 
@@ -207,11 +206,11 @@ public class AnomalyReportGenerator {
       templateData.put("endTime", getDateString(endTime, timeZone));
       templateData.put("anomalyCount", anomalies.size());
       templateData.put("metricsCount", metrics.size());
-      templateData.put("notifiedCount", precisionRecallEvaluator.getTotalReports());
+      templateData.put("notifiedCount", precisionRecallEvaluator.getTotalAlerts());
       templateData.put("feedbackCount", precisionRecallEvaluator.getTotalResponses());
-      templateData.put("trueAlertCount", precisionRecallEvaluator.getQualifiedTrueAnomaly());
+      templateData.put("trueAlertCount", precisionRecallEvaluator.getNotifiedTrueAnomaly());
       templateData.put("falseAlertCount", precisionRecallEvaluator.getFalseAlarm());
-      templateData.put("newTrendCount", precisionRecallEvaluator.getQualifiedTrueAnomalyNewTrend());
+      templateData.put("newTrendCount", precisionRecallEvaluator.getNotifiedTrueAnomalyNewTrend());
       templateData.put("anomalyDetails", anomalyReportDTOList);
       templateData.put("alertConfigName", alertConfigName);
       templateData.put("includeSummary", includeSummary);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/AnomalyReportGenerator.java
@@ -208,9 +208,9 @@ public class AnomalyReportGenerator {
       templateData.put("metricsCount", metrics.size());
       templateData.put("notifiedCount", precisionRecallEvaluator.getTotalAlerts());
       templateData.put("feedbackCount", precisionRecallEvaluator.getTotalResponses());
-      templateData.put("trueAlertCount", precisionRecallEvaluator.getNotifiedTrueAnomaly());
+      templateData.put("trueAnomalyCount", precisionRecallEvaluator.getTrueAnomalies());
       templateData.put("falseAlertCount", precisionRecallEvaluator.getFalseAlarm());
-      templateData.put("newTrendCount", precisionRecallEvaluator.getNotifiedTrueAnomalyNewTrend());
+      templateData.put("newTrendCount", precisionRecallEvaluator.getTrueAnomalyNewTrend());
       templateData.put("anomalyDetails", anomalyReportDTOList);
       templateData.put("alertConfigName", alertConfigName);
       templateData.put("includeSummary", includeSummary);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
@@ -15,7 +15,7 @@ import java.util.Properties;
  * Precision and Recall Evaluator with two constructor
  * 1) Anomaly Detection System evaluation: calculate on-going performance using "notified" flag
  * 2) Alert Filter evaluation: calculate performance of alert filter on a list of anomalies
-*/
+ */
 public class PrecisionRecallEvaluator {
 
   /**
@@ -23,7 +23,7 @@ public class PrecisionRecallEvaluator {
    * in order to get the performance of whole anomaly detection system
    * @param anomalies The list of anomalies to be evaluated
    */
-  public PrecisionRecallEvaluator(List<MergedAnomalyResultDTO> anomalies){
+  public PrecisionRecallEvaluator(List<MergedAnomalyResultDTO> anomalies) {
     init(anomalies);
   }
 
@@ -33,7 +33,7 @@ public class PrecisionRecallEvaluator {
    * @param alertFilter the alert filter to be evaluated
    * @param anomalies the list of anomalies as data for alert filter
    */
-  public PrecisionRecallEvaluator(AlertFilter alertFilter, List<MergedAnomalyResultDTO> anomalies){
+  public PrecisionRecallEvaluator(AlertFilter alertFilter, List<MergedAnomalyResultDTO> anomalies) {
     this.alertFilter = alertFilter;
     init(anomalies);
   }
@@ -58,7 +58,8 @@ public class PrecisionRecallEvaluator {
   public static final String NEWTREND = "newTrend";
   public static final String USER_REPORT = "userReportAnomaly";
 
-  public static final Double WEIGHT_OF_NULL_LABEL = 0.5; // the weight used for NA labeled data point when calculating precision
+  public static final Double WEIGHT_OF_NULL_LABEL = 0.5;
+      // the weight used for NA labeled data point when calculating precision
 
   public double getPrecision() {
     if (getTotalAlerts() == 0) {
@@ -66,31 +67,35 @@ public class PrecisionRecallEvaluator {
     }
     return 1.0 * getTrueAlerts() / getTotalAlerts();
   }
+
   public double getPrecisionInResponse() {
     if (getTotalResponses() == 0) {
       return Double.NaN;
     }
     return 1.0 * getTrueAlerts() / getTotalResponses();
   }
+
   public double getWeightedPrecision() {
     if (getTotalAlerts() == 0) {
       return Double.NaN;
     }
-    return 1.0 * getTrueAlerts() /
-        (getTotalResponses() + WEIGHT_OF_NULL_LABEL * notifiedNotLabeled);
+    return 1.0 * getTrueAlerts() / (getTotalResponses() + WEIGHT_OF_NULL_LABEL * notifiedNotLabeled);
   }
+
   public double getRecall() {
     if (getTrueAnomalies() == 0) {
-      return  Double.NaN;
+      return Double.NaN;
     }
-    return 1.0 * getTrueAlerts() / (getTrueAnomalies());
+    return 1.0 * getTrueAlerts() / (getTrueAnomalies() + getTrueAnomalyNewTrend());
   }
+
   public double getFalseNegativeRate() {
     if (getTrueAnomalies() == 0) {
-      return  Double.NaN;
+      return Double.NaN;
     }
-    return 1.0 * getUserReportAnomaly() / (getTrueAnomalies());
+    return 1.0 * getUserReportAnomaly() / (getTrueAnomalies() + getTrueAnomalyNewTrend());
   }
+
   public double getResponseRate() {
     return 1.0 * getTotalResponses() / getTotalAlerts();
   }
@@ -98,31 +103,36 @@ public class PrecisionRecallEvaluator {
   public int getTotalResponses() {
     return notifiedFalseAlarm + notifiedTrueAnomaly + notifiedTrueAnomalyNewTrend;
   }
+
   public int getTotalAlerts() {
     return getTotalResponses() + notifiedNotLabeled;
   }
+
+  // number of true anomalies in global set
   public int getTrueAnomalies() {
-    return notifiedTrueAnomaly + notifiedTrueAnomalyNewTrend + userReportTrueAnomaly + userReportTrueAnomalyNewTrend;
+    return notifiedTrueAnomaly + userReportTrueAnomaly;
   }
-  public int getUserReportAnomaly() {
-    return userReportTrueAnomaly + userReportTrueAnomalyNewTrend;
-  }
-  public int getFalseAlarm() {
-    return notifiedFalseAlarm;
-  }
-  public int getTrueAlerts() {
-    return notifiedTrueAnomaly + notifiedTrueAnomalyNewTrend;
-  }
-  public int getNotifiedTrueAnomaly() {
-    return notifiedTrueAnomaly;
-  }
-  public int getNotifiedTrueAnomalyNewTrend() {
+
+  // number of true anomalies new trend in global set
+  public int getTrueAnomalyNewTrend() {
     return notifiedTrueAnomalyNewTrend + userReportTrueAnomalyNewTrend;
   }
 
+  // number of true anomalies and true_new_trend anomalies that "NOTIFIED"
+  public int getTrueAlerts() {
+    return notifiedTrueAnomaly + notifiedTrueAnomalyNewTrend;
+  }
+
+  public int getUserReportAnomaly() {
+    return userReportTrueAnomaly + userReportTrueAnomalyNewTrend;
+  }
+
+  public int getFalseAlarm() {
+    return notifiedFalseAlarm;
+  }
 
   public void init(List<MergedAnomalyResultDTO> anomalies) {
-    if(anomalies == null || anomalies.isEmpty()) {
+    if (anomalies == null || anomalies.isEmpty()) {
       return;
     }
 
@@ -131,18 +141,21 @@ public class PrecisionRecallEvaluator {
     this.notifiedNotLabeled = 0;
     this.notifiedFalseAlarm = 0;
     this.userReportTrueAnomaly = 0;
+    this.userReportTrueAnomalyNewTrend = 0;
 
-    if(anomalies == null || anomalies.isEmpty()) {
+    if (anomalies == null || anomalies.isEmpty()) {
       return;
     }
 
-    for(MergedAnomalyResultDTO anomaly : anomalies) {
+    for (MergedAnomalyResultDTO anomaly : anomalies) {
       AnomalyFeedback feedback = anomaly.getFeedback();
       boolean isLabeledTrueAnomaly = false;
       boolean isLabeledTrueAnomalyNewTrend = false;
-      if(feedback != null && feedback.getFeedbackType() != null && feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY_NEW_TREND)) {
+      if (feedback != null && feedback.getFeedbackType() != null && feedback.getFeedbackType()
+          .equals(AnomalyFeedbackType.ANOMALY_NEW_TREND)) {
         isLabeledTrueAnomalyNewTrend = true;
-      } else if (feedback != null && feedback.getFeedbackType() != null && feedback.getFeedbackType().equals(AnomalyFeedbackType.ANOMALY)) {
+      } else if (feedback != null && feedback.getFeedbackType() != null && feedback.getFeedbackType()
+          .equals(AnomalyFeedbackType.ANOMALY)) {
         isLabeledTrueAnomaly = true;
       }
 
@@ -152,8 +165,8 @@ public class PrecisionRecallEvaluator {
         isNotified = alertFilter.isQualified(anomaly);
       }
 
-      if(isNotified) {
-        if(feedback == null || feedback.getFeedbackType() == null) {
+      if (isNotified) {
+        if (feedback == null || feedback.getFeedbackType() == null) {
           this.notifiedNotLabeled++;
         } else if (isLabeledTrueAnomaly) {
           notifiedTrueAnomaly++;
@@ -163,24 +176,13 @@ public class PrecisionRecallEvaluator {
           notifiedFalseAlarm++;
         }
       } else {
-        if(isLabeledTrueAnomaly) {
+        if (isLabeledTrueAnomaly) {
           userReportTrueAnomaly++;
         } else if (isLabeledTrueAnomalyNewTrend) {
           userReportTrueAnomalyNewTrend++;
         }
       }
     }
-  }
-
-
-
-  /**
-   * Provide feedback summary give a list of merged anomalies
-   * @param anomalies
-   */
-  @Deprecated
-  public void updateFeedbackSummary(List<MergedAnomalyResultDTO> anomalies){
-    init(anomalies);
   }
 
   public Properties toProperties() {
@@ -193,14 +195,14 @@ public class PrecisionRecallEvaluator {
     evals.put(TOTALRESPONSES, getTotalResponses());
     evals.put(TRUEANOMALIES, getTrueAnomalies());
     evals.put(FALSEALARM, getFalseAlarm());
-    evals.put(NEWTREND, getNotifiedTrueAnomalyNewTrend());
+    evals.put(NEWTREND, getTrueAnomalyNewTrend());
     evals.put(USER_REPORT, getUserReportAnomaly());
     return evals;
   }
 
   public static List<String> getPropertyNames() {
-    return Collections.unmodifiableList(
-        new ArrayList<>(Arrays.asList(RESPONSE_RATE, PRECISION, WEIGHTED_PRECISION, RECALL, TOTALALERTS,
-            TOTALRESPONSES, TRUEANOMALIES, FALSEALARM, NEWTREND, USER_REPORT)));
+    return Collections.unmodifiableList(new ArrayList<>(
+        Arrays.asList(RESPONSE_RATE, PRECISION, WEIGHTED_PRECISION, RECALL, TOTALALERTS, TOTALRESPONSES, TRUEANOMALIES,
+            FALSEALARM, NEWTREND, USER_REPORT)));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestPrecisionRecallEvaluator.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestPrecisionRecallEvaluator.java
@@ -4,6 +4,7 @@ import com.linkedin.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.util.ArrayList;
 import java.util.List;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static com.linkedin.thirdeye.constant.AnomalyFeedbackType.*;
@@ -12,50 +13,72 @@ import static org.junit.Assert.*;
 
 public class TestPrecisionRecallEvaluator {
 
-  @Test
-  public void testPrecisionAndRecall() throws Exception{
-    AlertFilter dummyAlertFilter = new DummyAlertFilter();
-    // test data with 1 positive feedback, 1 negative feedback, other NA feedbacks
-    List<MergedAnomalyResultDTO> anomalies = getMockMergedAnomalies(7,8);
-    PrecisionRecallEvaluator evaluator = new PrecisionRecallEvaluator(dummyAlertFilter, anomalies);
-    assertEquals(evaluator.getWeightedPrecision(), 0.1818, 0.0001);
-    assertEquals(evaluator.getRecall(), 1, 0.0001);
-
-    // test data with 1 positive feedback and others are NA feedbacks
-    anomalies = getMockMergedAnomalies(6,-1);
-    evaluator.init(anomalies);
-    assertEquals(evaluator.getWeightedPrecision(), 0.2, 0.0001);
-    assertEquals(evaluator.getRecall(), 1, 0.0001);
-
-    // test data with 0 positive feedback, 1 negative feedback and others are NA feedbacks
-    anomalies = getMockMergedAnomalies(-1,6);
-    evaluator.init(anomalies);
+  @Test(dataProvider = "provideMockAnomalies")
+  public void testSystemPrecisionAndRecall(List<MergedAnomalyResultDTO> anomalyResultDTOS, MergedAnomalyResultDTO notifiedTrueAnomaly,
+      MergedAnomalyResultDTO notifiedFalseAnomaly, MergedAnomalyResultDTO userReportAnomaly) throws Exception {
+    // test anomalies when no feedback, and no user report anomaly
+    PrecisionRecallEvaluator evaluator = new PrecisionRecallEvaluator(anomalyResultDTOS);
+    assertEquals(evaluator.getPrecision(), 0.0, 0.0001);
     assertTrue(Double.isNaN(evaluator.getRecall()));
+
+    // test data with 1 positive feedback
+    anomalyResultDTOS.add(notifiedTrueAnomaly);
+    evaluator.init(anomalyResultDTOS);
+    assertEquals(evaluator.getPrecision(), 0.125, 0.0001);
+    assertEquals(evaluator.getRecall(), 1, 0.00001);
+
+    // test data with 1 positive feedback, 1 false alarm
+    anomalyResultDTOS.add(notifiedFalseAnomaly);
+    evaluator.init(anomalyResultDTOS);
+    assertEquals(evaluator.getPrecision(), 0.1111, 0.0001);
+    assertEquals(evaluator.getRecall(), 1, 0.00001);
+
+    // test data with 1 positive feedback, 1 user report anomaly, 1 false alarm
+    anomalyResultDTOS.add(userReportAnomaly);
+    evaluator.init(anomalyResultDTOS);
+    assertEquals(evaluator.getPrecision(),0.1111, 0.0001);
+    assertEquals(evaluator.getRecall(), 0.5, 0.00001);
   }
 
 
-  private List<MergedAnomalyResultDTO> getMockMergedAnomalies(int posIdx, int negIdx){
+  @Test(dataProvider = "provideMockAnomalies")
+  public void testAlertFilterPrecisionAndRecall(List<MergedAnomalyResultDTO> anomalyResultDTOS, MergedAnomalyResultDTO notifiedTrueAnomaly,
+      MergedAnomalyResultDTO notifiedFalseAnomaly, MergedAnomalyResultDTO userReportAnomaly) throws Exception{
+    // test dummy alert filter's precision and recall
+    // dummy alert filter is sending EVERYTHING out
+    AlertFilter alertFilter = new DummyAlertFilter();
+    anomalyResultDTOS.add(notifiedFalseAnomaly);
+    anomalyResultDTOS.add(notifiedTrueAnomaly);
+    anomalyResultDTOS.add(userReportAnomaly);
+    PrecisionRecallEvaluator evaluator = new PrecisionRecallEvaluator(alertFilter, anomalyResultDTOS);
+    assertEquals(evaluator.getPrecision(),0.2, 0.0001);
+    assertEquals(evaluator.getRecall(), 1, 0.00001);
+  }
+
+
+  @DataProvider(name = "provideMockAnomalies")
+  public Object[][] getMockMergedAnomalies() {
     List<MergedAnomalyResultDTO> anomalyResultDTOS = new ArrayList<>();
-    int[] ws = {1, 1, 2, 3, 4, 4, 5, 6 ,7};
-    double[] severity = {2.0, 4.0, 2.0, 3.0, 1.0, 3.0, 2.0,1.0,3.0};
+    int totalAnomalies = 7;
     AnomalyFeedbackDTO positiveFeedback = new AnomalyFeedbackDTO();
     AnomalyFeedbackDTO negativeFeedback = new AnomalyFeedbackDTO();
     positiveFeedback.setFeedbackType(ANOMALY);
     negativeFeedback.setFeedbackType(NOT_ANOMALY);
-    for(int i = 0; i < ws.length; i++){
+    for (int i = 0; i < totalAnomalies; i++) {
       MergedAnomalyResultDTO anomaly = new MergedAnomalyResultDTO();
-      anomaly.setStartTime(0l);
-      anomaly.setEndTime(ws[i] * 3600 * 1000l);
-      anomaly.setWeight(severity[i]);
-      if(i == posIdx) {
-        anomaly.setFeedback(positiveFeedback);
-      } else if(i == negIdx) {
-        anomaly.setFeedback(negativeFeedback);
-      } else {
-        anomaly.setFeedback(null);
-      }
+      anomaly.setFeedback(null);
+      anomaly.setNotified(true);
       anomalyResultDTOS.add(anomaly);
     }
-    return anomalyResultDTOS;
+    MergedAnomalyResultDTO notifiedTrueAnomaly = new MergedAnomalyResultDTO();
+    notifiedTrueAnomaly.setNotified(true);
+    notifiedTrueAnomaly.setFeedback(positiveFeedback);
+    MergedAnomalyResultDTO notifiedFalseAnomaly = new MergedAnomalyResultDTO();
+    notifiedFalseAnomaly.setNotified(true);
+    notifiedFalseAnomaly.setFeedback(negativeFeedback);
+    MergedAnomalyResultDTO userReportAnomaly = new MergedAnomalyResultDTO();
+    userReportAnomaly.setNotified(false);
+    userReportAnomaly.setFeedback(positiveFeedback);
+    return new Object[][]{{anomalyResultDTOS, notifiedTrueAnomaly, notifiedFalseAnomaly, userReportAnomaly}};
   }
 }


### PR DESCRIPTION
Implement Performance Evaluation when User Report Anomaly
Distinguish two cases of evaluation:
1) Evaluation on Anomaly Detection System. By comparing "notified" anomalies and user labels to get precision, and recall is covering user report anomaly by counting on "not-notified" but label to be true

2) Evaluation on Alert Filter. By comparing alert filter's "isQualified" and anomalies' labels, will get performance statistics for the provided alert filter.

Both of the two cases can be used for "Alert Page" and "Summary Emails"

Enable email report to use Performance Evaluation for Anomaly Detection System (previously was on alert filter)

Unit Tests done:
1) Evaluation on on-going alerting
2) Evaluation on given alert filter 