### PR TITLE
[TE] rootcause entity attributes for holidays, anomalies, metrics

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseEntityFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseEntityFormatter.java
@@ -16,7 +16,7 @@ public abstract class RootCauseEntityFormatter {
   public static RootCauseEntity makeRootCauseEntity(Entity entity, String type, String label, String link) {
     RootCauseEntity out = new RootCauseEntity();
     out.setUrn(entity.getUrn());
-    out.setScore(Math.round(entity.getScore() * 1000) / 1000.0);
+    out.setScore(entity.getScore());
     out.setType(type);
     out.setLabel(label);
     out.setLink(link);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseEventEntityFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseEventEntityFormatter.java
@@ -31,7 +31,7 @@ public abstract class RootCauseEventEntityFormatter extends RootCauseEntityForma
   public static RootCauseEventEntity makeRootCauseEventEntity(EventEntity entity, String label, String link, long start, long end, String details) {
     RootCauseEventEntity out = new RootCauseEventEntity();
     out.setUrn(entity.getUrn());
-    out.setScore(Math.round(entity.getScore() * 1000) / 1000.0);
+    out.setScore(entity.getScore());
     out.setType("event");
     out.setLabel(label);
     out.setLink(link);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/RootCauseEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/RootCauseEntity.java
@@ -1,7 +1,11 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.pojo;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class RootCauseEntity {
@@ -11,6 +15,7 @@ public class RootCauseEntity {
   String type;
   String link;
   List<RootCauseEntity> relatedEntities = new ArrayList<>();
+  Multimap<String, String> attributes = ArrayListMultimap.create();
 
   public RootCauseEntity() {
     // left blank
@@ -74,5 +79,17 @@ public class RootCauseEntity {
 
   public void addRelatedEntity(RootCauseEntity e) {
     this.relatedEntities.add(e);
+  }
+
+  public Multimap<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Multimap<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+  public void putAttribute(String key, String value) {
+    this.attributes.put(key, value);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/AnomalyEventFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/AnomalyEventFormatter.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.rootcause;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseEventEntityFormatter;
 import com.linkedin.thirdeye.dashboard.resources.v2.pojo.RootCauseEventEntity;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
@@ -16,6 +18,9 @@ import org.apache.commons.lang.StringUtils;
 
 
 public class AnomalyEventFormatter extends RootCauseEventEntityFormatter {
+  public static final String ATTR_DATASET = "dataset";
+  public static final String ATTR_METRIC = "dataset";
+
   @Override
   public boolean applies(EventEntity entity) {
     return entity instanceof AnomalyEventEntity;
@@ -28,14 +33,22 @@ public class AnomalyEventFormatter extends RootCauseEventEntityFormatter {
     MergedAnomalyResultDTO dto = e.getDto();
     AnomalyFunctionDTO func = dto.getFunction();
 
+    Multimap<String, String> attributes = ArrayListMultimap.create();
+    attributes.put(ATTR_DATASET, dto.getCollection());
+    attributes.put(ATTR_METRIC, dto.getMetric());
+
     List<String> dimensions = new ArrayList<>();
     for (Map.Entry<String, String> entry : dto.getDimensions().entrySet()) {
-      dimensions.add(entry.getKey() + ":" + entry.getValue().toUpperCase());
+      dimensions.add(entry.getKey() + ":" + entry.getValue());
+      attributes.put(entry.getKey(), entry.getValue());
     }
 
     String label = String.format("%s (%s)", func.getFunctionName(), StringUtils.join(dimensions, ", "));
     String link = String.format("thirdeye#investigate?anomalyId=%d", dto.getId());
 
-    return makeRootCauseEventEntity(entity, label, link, dto.getStartTime(), dto.getEndTime(), null);
+    RootCauseEventEntity out = makeRootCauseEventEntity(entity, label, link, dto.getStartTime(), dto.getEndTime(), null);
+    out.setAttributes(attributes);
+
+    return out;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/HolidayEventFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/HolidayEventFormatter.java
@@ -1,16 +1,15 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.rootcause;
 
-import com.google.common.base.Joiner;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseEventEntityFormatter;
 import com.linkedin.thirdeye.dashboard.resources.v2.pojo.RootCauseEventEntity;
 import com.linkedin.thirdeye.datalayer.dto.EventDTO;
-import com.linkedin.thirdeye.rootcause.impl.DimensionEntity;
 import com.linkedin.thirdeye.rootcause.impl.EventEntity;
 import com.linkedin.thirdeye.rootcause.impl.HolidayEventEntity;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang.StringUtils;
 
 
 public class HolidayEventFormatter extends RootCauseEventEntityFormatter {
@@ -24,20 +23,24 @@ public class HolidayEventFormatter extends RootCauseEventEntityFormatter {
     HolidayEventEntity holidayEvent = (HolidayEventEntity) entity;
     EventDTO eventDto = holidayEvent.getDto();
 
+    Multimap<String, String> attributes = ArrayListMultimap.create();
+
     StringBuilder dimensions = new StringBuilder();
-    List<DimensionEntity> relatedDimensionEntities = new ArrayList<>();
     for(Map.Entry<String, List<String>> entry : eventDto.getTargetDimensionMap().entrySet()) {
       String dimName = entry.getKey();
-      dimensions.append(" (" + dimName + ":");
-      dimensions.append(Joiner.on(",").join(entry.getValue()) + ")");
-      for(String dimValue : entry.getValue()) {
-        DimensionEntity de = DimensionEntity.fromDimension(entity.getScore(), dimName, dimValue, DimensionEntity.TYPE_GENERATED);
-        relatedDimensionEntities.add(de);
-      }
+      dimensions.append(String.format(" (%s:", dimName));
+      dimensions.append(StringUtils.join(entry.getValue(), ","));
+      dimensions.append(")");
+
+      attributes.putAll(dimName, entry.getValue());
     }
 
     String label = String.format("%s %s", eventDto.getName(), dimensions.toString());
     String link =  String.format("https://www.google.com/search?q=%s", eventDto.getName());
-    return makeRootCauseEventEntity(entity, label, link, eventDto.getStartTime(), eventDto.getEndTime(), "");
+
+    RootCauseEventEntity out = makeRootCauseEventEntity(entity, label, link, eventDto.getStartTime(), eventDto.getEndTime(), "");
+    out.setAttributes(attributes);
+
+    return out;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/MetricEntityFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/MetricEntityFormatter.java
@@ -1,5 +1,7 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.rootcause;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseEntityFormatter;
 import com.linkedin.thirdeye.dashboard.resources.v2.pojo.RootCauseEntity;
 import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
@@ -11,6 +13,8 @@ import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
 
 public class MetricEntityFormatter extends RootCauseEntityFormatter {
   public static final String TYPE_METRIC = "metric";
+
+  public static final String ATTR_DATASET = "dataset";
 
   private final MetricConfigManager metricDAO;
 
@@ -32,8 +36,15 @@ public class MetricEntityFormatter extends RootCauseEntityFormatter {
     MetricEntity e = (MetricEntity) entity;
 
     MetricConfigDTO dto = this.metricDAO.findById(e.getId());
+
+    Multimap<String, String> attributes = ArrayListMultimap.create();
+    attributes.put(ATTR_DATASET, dto.getDataset());
+
     String label = String.format("%s::%s", dto.getDataset(), dto.getName());
 
-    return makeRootCauseEntity(entity, TYPE_METRIC, label, null);
+    RootCauseEntity out = makeRootCauseEntity(entity, TYPE_METRIC, label, null);
+    out.setAttributes(attributes);
+
+    return out;
   }
 }


### PR DESCRIPTION
This PR adds entity-specific, filterable "attributes" to rootcause entities returned from RCA endpoints. This allows frontend filtering in addition to backend RCA searches. The attributes are injected by the respective entity formatters.