### PR TITLE
[TE] Search page to show notified anomalies / replace using alert filter

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -281,14 +281,7 @@ public class AnomaliesResource {
       @QueryParam("filterOnly") @DefaultValue("false") boolean filterOnly
       ) throws Exception {
 
-    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findByTime(startTime, endTime, false);
-    try {
-      mergedAnomalies = AlertFilterHelper.applyFiltrationRule(mergedAnomalies, alertFilterFactory);
-    } catch (Exception e) {
-      LOG.warn(
-          "Failed to apply alert filters on anomalies in start:{}, end:{}, exception:{}",
-          new DateTime(startTime), new DateTime(endTime), e);
-    }
+    List<MergedAnomalyResultDTO> mergedAnomalies = mergedAnomalyResultDAO.findNotifiedByTime(startTime, endTime, false);
     AnomaliesWrapper
         anomaliesWrapper = constructAnomaliesWrapperFromMergedAnomalies(mergedAnomalies, searchFiltersJSON, pageNumber, filterOnly);
     return anomaliesWrapper;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/MergedAnomalyResultManager.java
@@ -48,6 +48,8 @@ public interface MergedAnomalyResultManager extends AbstractManager<MergedAnomal
 
   List<MergedAnomalyResultDTO> findUnNotifiedByFunctionIdAndIdLesserThanAndEndTimeGreaterThanLastOneDay(long functionId, long anomalyId, boolean loadRawAnomalies);
 
+  List<MergedAnomalyResultDTO> findNotifiedByTime(long startTime, long endTime, boolean loadRawAnomalies);
+
   Map<Long, List<MergedAnomalyResultDTO>> findAnomaliesByMetricIdsAndTimeRange(List<Long> metricIds, long start, long end);
 
   List<MergedAnomalyResultDTO> findAnomaliesByMetricIdAndTimeRange(Long metricId, long start, long end);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/MergedAnomalyResultManagerImpl.java
@@ -252,6 +252,18 @@ public class MergedAnomalyResultManagerImpl extends AbstractManagerImpl<MergedAn
   }
 
   @Override
+  public List<MergedAnomalyResultDTO> findNotifiedByTime(long startTime, long endTime, boolean loadRawAnomalies) {
+    List<MergedAnomalyResultDTO> anomaliesByTime = findByTime(startTime, endTime, loadRawAnomalies);
+    List<MergedAnomalyResultDTO> notifiedAnomalies = new ArrayList<>();
+    for (MergedAnomalyResultDTO anomaly : anomaliesByTime) {
+      if (anomaly.isNotified()) {
+        notifiedAnomalies.add(anomaly);
+      }
+    }
+    return notifiedAnomalies;
+  }
+
+  @Override
   public MergedAnomalyResultDTO findLatestOverlapByFunctionIdDimensions(Long functionId, String dimensions,
       long conflictWindowStart, long conflictWindowEnd, boolean loadRawAnomalies) {
     Map<String, Object> filterParams = new HashMap<>();


### PR DESCRIPTION
Previously on search page, the list of anomalies shown is filtered by latest tuned alert filter. This is misleading since alert filter can be tuned over time and thus the list of anomalies shown on search page can be inconsistent. Here is a fix to make search page extract anomalies that ever "notified" by  the system. 