### PR TITLE
[TE] rootcause poc - caching services, controller refactoring

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -48,18 +48,34 @@ export function filterObject(obj, func) {
   return out;
 }
 
+export function toBaselineUrn(urn) {
+  if (!urn.startsWith('thirdeye:metric:')) {
+    throw new Error(`Requires metric urn, but found ${urn}`);
+  }
+  const mid = urn.split(':')[2];
+  return `frontend:baseline:metric:${mid}`;
+}
+
+export function hasPrefix(urn, prefixes) {
+  return !_.isEmpty(makeIterable(prefixes).filter(pre => urn.startsWith(pre)));
+}
+
+export function filterPrefix(urns, prefixes) {
+  return makeIterable(urns).filter(urn => hasPrefix(urn, prefixes));
+}
+
 /**
-   * finds the corresponding labelMapping field given a label in the filterBarConfig
-   * This is only a placeholder since the filterBarConfig is not finalized
-   */
+ * finds the corresponding labelMapping field given a label in the filterBarConfig
+ * This is only a placeholder since the filterBarConfig is not finalized
+ */
 export function findLabelMapping(label, config) {
   let labelMapping = '';
   config.some(filterBlock => filterBlock.inputs.some(input => {
     if (input.label === label) {
-      labelMapping = input.labelMapping;
-    }
-  }));
+    labelMapping = input.labelMapping;
+  }
+}));
   return labelMapping;
 }
 
-export default Ember.Helper.helper({ checkStatus, isIterable, makeIterable, filterObject, findLabelMapping });
+export default Ember.Helper.helper({ checkStatus, isIterable, makeIterable, filterObject, toBaselineUrn, hasPrefix, filterPrefix, findLabelMapping });

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-heatmap/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-heatmap/component.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  aggregates: null, // {}
+  breakdowns: null, // {}
 
   currentUrns: null, // Set
 
@@ -10,35 +10,35 @@ export default Ember.Component.extend({
   currentUrn: null, // ""
 
   current: Ember.computed(
-    'aggregates',
+    'breakdowns',
     'currentUrn',
     function () {
-      const { aggregates, currentUrn } = this.getProperties('aggregates', 'currentUrn');
+      const { breakdowns, currentUrn } = this.getProperties('breakdowns', 'currentUrn');
 
-      const aggregate = aggregates[currentUrn];
+      const breakdown = breakdowns[currentUrn];
 
-      if (!currentUrn || !aggregate) {
+      if (!currentUrn || !breakdown) {
         return {};
       }
-      return aggregate;
+      return breakdown;
     }
   ),
 
   baseline: Ember.computed(
-    'aggregates',
+    'breakdowns',
     'current2baseline',
     'currentUrn',
     function () {
-      const { aggregates, current2baseline, currentUrn } =
-        this.getProperties('aggregates', 'current2baseline', 'currentUrn');
+      const { breakdowns, current2baseline, currentUrn } =
+        this.getProperties('breakdowns', 'current2baseline', 'currentUrn');
 
       const baselineUrn = current2baseline[currentUrn];
-      const aggregate = aggregates[baselineUrn];
+      const breakdown = breakdowns[baselineUrn];
 
-      if (!currentUrn || !baselineUrn || !aggregate) {
+      if (!currentUrn || !baselineUrn || !breakdown) {
         return {};
       }
-      return aggregate;
+      return breakdown;
     }
   )
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { toBaselineUrn, hasPrefix } from '../../../helpers/utils';
 
 export default Ember.Component.extend({
   entities: null, // {}
@@ -17,7 +18,7 @@ export default Ember.Component.extend({
     function () {
       const { entities, selectedUrns } = this.getProperties('entities', 'selectedUrns');
       const labels = {};
-      [...selectedUrns].filter(urn => urn in entities).forEach(urn => labels[urn] = entities[urn].label);
+      [...selectedUrns].filter(urn => hasPrefix(urn, 'thirdeye:')).filter(urn => entities[urn]).forEach(urn => labels[urn] = entities[urn].label);
       return labels;
     }
   ),
@@ -28,14 +29,20 @@ export default Ember.Component.extend({
       if (onVisibility) {
         const state = invisibleUrns.has(urn);
         const updates = { [urn]: state };
+        if (hasPrefix(urn, 'thirdeye:metric:')) {
+          updates[toBaselineUrn(urn)] = state;
+        }
         onVisibility(updates);
       }
     },
-    
+
     removeUrn(urn) {
       const { onSelection } = this.getProperties('onSelection');
       if (onSelection) {
         const updates = { [urn]: false };
+        if (hasPrefix(urn, 'thirdeye:metric:')) {
+          updates[toBaselineUrn(urn)] = false;
+        }
         onSelection(updates);
       }
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -35,7 +35,7 @@ export default Ember.Component.extend({
         onVisibility(updates);
       }
     },
-
+    
     removeUrn(urn) {
       const { onSelection } = this.getProperties('onSelection');
       if (onSelection) {

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { toBaselineUrn, hasPrefix } from '../../../helpers/utils';
 
 export default Ember.Component.extend({
   entities: null, // {}
@@ -24,6 +25,9 @@ export default Ember.Component.extend({
       if (onSelection) {
         const state = !selectedUrns.has(urn);
         const updates = { [urn]: state };
+        if (hasPrefix(urn, 'thirdeye:metric:')) {
+          updates[toBaselineUrn(urn)] = state;
+        }
         onSelection(updates);
       }
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
-import { toBaselineUrn, hasPrefix } from '../../../helpers/utils';
+import { toBaselineUrn, hasPrefix, filterPrefix } from '../../../helpers/utils';
 
 export default Ember.Component.extend({
   entities: null, // {}
+
+  aggregates: null, // {}
 
   selectedUrns: null, // Set
 
@@ -13,9 +15,22 @@ export default Ember.Component.extend({
     function () {
       const { entities } = this.getProperties('entities');
 
-      const labels = {};
-      Object.keys(entities).forEach(urn => labels[urn] = entities[urn].label);
-      return labels;
+      const metricUrns = filterPrefix(Object.keys(entities), ['thirdeye:metric:']);
+      return metricUrns.reduce((agg, urn) => { agg[urn] = entities[urn].label; return agg; }, {});
+    }
+  ),
+
+  changes: Ember.computed(
+    'aggregates',
+    function () {
+      const { aggregates } = this.getProperties('aggregates');
+
+      console.log('rootcauseMetrics: changes: aggregates', aggregates);
+      const metricUrns = filterPrefix(Object.keys(aggregates), ['thirdeye:metric:']);
+
+      return metricUrns
+        .filter(urn => aggregates[toBaselineUrn(urn)])
+        .reduce((agg, urn) => { agg[urn] = aggregates[urn] / aggregates[toBaselineUrn(urn)] - 1; return agg; }, {});
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
@@ -1,6 +1,6 @@
 metrics
 {{#each-in labels as |urn label|}}
-  | <a {{action "toggleSelection" urn}}>{{label}} {{#if set-has-not selectedUrns urn}}(add){{/if}}</a>
+  | <a {{action "toggleSelection" urn}}>{{label}} ({{get changes urn}})</a>
 {{else}}
   No Metrics.
 {{/each-in}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-settings/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-settings/component.js
@@ -72,7 +72,7 @@ export default Ember.Component.extend({
    */
   predefinedAnalysisRanges: {
     'Last 2 days': [
-      moment().subtract(3, 'days').startOf('day'), 
+      moment().subtract(3, 'days').startOf('day'),
       moment().subtract(1, 'days').endOf('day')
     ],
     'Last 7 days': [
@@ -128,11 +128,12 @@ export default Ember.Component.extend({
   }),
 
   _updateFromContext() {
-    const { urns, anomalyRange, baselineRange, analysisRange } = this.get('context');
+    const { urns, anomalyRange, baselineRange, analysisRange, granularity } = this.get('context');
     this.setProperties({ urnString: [...urns].join(','),
       anomalyRangeStart: anomalyRange[0], anomalyRangeEnd: anomalyRange[1],
       baselineRangeStart: baselineRange[0], baselineRangeEnd: baselineRange[1],
-      analysisRangeStart: analysisRange[0], analysisRangeEnd: analysisRange[1]
+      analysisRangeStart: analysisRange[0], analysisRangeEnd: analysisRange[1],
+      granularity
     });
   },
 
@@ -148,15 +149,15 @@ export default Ember.Component.extend({
 
   actions: {
     updateContext() {
-      const { urnString, anomalyRangeStart, anomalyRangeEnd, baselineRangeStart, baselineRangeEnd, analysisRangeStart, analysisRangeEnd } =
-        this.getProperties('urnString', 'anomalyRangeStart', 'anomalyRangeEnd', 'baselineRangeStart', 'baselineRangeEnd', 'analysisRangeStart', 'analysisRangeEnd');
+      const { urnString, anomalyRangeStart, anomalyRangeEnd, baselineRangeStart, baselineRangeEnd, analysisRangeStart, analysisRangeEnd, granularity } =
+        this.getProperties('urnString', 'anomalyRangeStart', 'anomalyRangeEnd', 'baselineRangeStart', 'baselineRangeEnd', 'analysisRangeStart', 'analysisRangeEnd', 'granularity');
       const onChange = this.get('onChange');
       if (onChange != null) {
         const urns = new Set(urnString.split(','));
         const anomalyRange = [parseInt(anomalyRangeStart), parseInt(anomalyRangeEnd)];
         const baselineRange = [parseInt(baselineRangeStart), parseInt(baselineRangeEnd)];
         const analysisRange = [parseInt(analysisRangeStart), parseInt(analysisRangeEnd)];
-        const newContext = { urns, anomalyRange, baselineRange, analysisRange };
+        const newContext = { urns, anomalyRange, baselineRange, analysisRange, granularity };
         onChange(newContext);
       }
     },
@@ -177,7 +178,7 @@ export default Ember.Component.extend({
         anomalyRangeEnd
       });
     },
-    
+
     /**
      * Sets the new display date in ms
      * @method setDisplayDateRange

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -1,0 +1,104 @@
+import Ember from 'ember';
+import checkStatus from 'thirdeye-frontend/helpers/utils';
+import fetch from 'fetch';
+import _ from 'lodash';
+
+export default Ember.Service.extend({
+  aggregates: null, // {}
+
+  context: null, // {}
+
+  pending: null, // Set
+
+  init() {
+    this.setProperties({aggregates: {}, context: {}, pending: {}});
+  },
+
+  request(requestContext, urns) {
+    console.log('rootcauseAggregatesService: request()', requestContext, urns);
+    const { context, aggregates } = this.getProperties('context', 'aggregates');
+
+    const metrics = [...urns].filter(urn => (urn.startsWith('thirdeye:metric:') || urn.startsWith('frontend:baseline:metric:')));
+
+    // TODO eviction on cache size limit
+
+    let missing;
+    let newAggregates;
+    if(!_.isEqual(context.analysisRange, requestContext.analysisRange)) {
+      // new analysis range: evict all, reload
+      missing = metrics;
+      newAggregates = metrics.filter(urn => aggregates[urn]).reduce((agg, urn) => agg[urn] = aggregates[urn], {});
+
+    } else if((context.anomalyRange[0] - context.baselineRange[0]) !=
+      (requestContext.anomalyRange[0] - requestContext.baselineRange[0])) {
+      // new baseline: reload baselines, load missing
+      missing = metrics.filter(urn => !aggregates[urn] || urn.startsWith('frontend:baseline:metric:'));
+      newAggregates = Object.keys(aggregates)
+        .filter(urn => urns.has(urn) || !urn.startsWith('frontend:baseline:metric:'))
+        .reduce((agg, urn) => agg[urn] = aggregates[urn], {});
+
+    } else {
+      // same context: load missing
+      missing = metrics.filter(urn => !aggregates[urn]);
+      newAggregates = aggregates;
+    }
+
+    const newPending = new Set(missing);
+    this.setProperties({ context: _.cloneDeep(requestContext), aggregates: newAggregates, pending: newPending });
+
+    // metrics
+    const metricUrns = missing.filter(urn => urn.startsWith('thirdeye:metric:'));
+    if (!_.isEmpty(metricUrns)) {
+      const metricIdString = metricUrns.map(urn => urn.split(":")[2]).join(',');
+      const metricUrl = `/aggregation/query?metricIds=${metricIdString}&ranges=${requestContext.anomalyRange[0]}:${requestContext.anomalyRange[1]}`;
+
+      fetch(metricUrl)
+        // .then(checkStatus)
+        .then(res => res.json())
+        .then(res => this._extractAggregates(res, (mid) => `thirdeye:metric:${mid}`))
+        .then(incoming => this._complete(requestContext, incoming));
+    }
+
+    // baselines
+    const baselineUrns = missing.filter(urn => urn.startsWith('frontend:baseline:metric:'));
+    if (!_.isEmpty(baselineUrns)) {
+      const baselineIdString = baselineUrns.map(urn => urn.split(":")[3]).join(',');
+      const baselineUrl = `/aggregation/query?metricIds=${baselineIdString}&ranges=${requestContext.baselineRange[0]}:${requestContext.baselineRange[1]}`;
+
+      fetch(baselineUrl)
+         // .then(checkStatus)
+        .then(res => res.json())
+        .then(res => this._extractAggregates(res, (mid) => `frontend:baseline:metric:${mid}`))
+        .then(incoming => this._complete(requestContext, incoming));
+    }
+  },
+
+  _complete(requestContext, incoming) {
+    console.log('rootcauseAggregatesService: _complete()', incoming);
+    const { context, pending, aggregates } = this.getProperties('context', 'pending', 'aggregates');
+
+    // only accept latest result
+    if (!_.isEqual(context, requestContext)) {
+      console.log('rootcauseAggregatesService: received stale result. ignoring.');
+      return;
+    }
+
+    const newPending = new Set([...pending].filter(urn => !incoming[urn]));
+    const newAggregates = Object.assign({}, aggregates, incoming);
+
+    this.setProperties({ aggregates: newAggregates, pending: newPending });
+  },
+
+  _extractAggregates(incoming, urnFunc) {
+    // NOTE: only supports single time range
+    const aggregates = {};
+    Object.keys(incoming).forEach(range => {
+      Object.keys(incoming[range]).forEach(mid => {
+        const aggregate = incoming[range][mid];
+        const urn = urnFunc(mid);
+        aggregates[urn] = aggregate;
+      });
+    });
+    return aggregates;
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -24,13 +24,12 @@ export default Ember.Service.extend({
 
     let missing;
     let newAggregates;
-    if(!_.isEqual(context.analysisRange, requestContext.analysisRange)) {
+    if(!_.isEqual(context.anomalyRange, requestContext.anomalyRange)) {
       // new analysis range: evict all, reload
       missing = metrics;
       newAggregates = metrics.filter(urn => aggregates[urn]).reduce((agg, urn) => agg[urn] = aggregates[urn], {});
 
-    } else if((context.anomalyRange[0] - context.baselineRange[0]) !=
-      (requestContext.anomalyRange[0] - requestContext.baselineRange[0])) {
+    } else if(!_.isEqual(context.baselineRange, requestContext.baselineRange)) {
       // new baseline: reload baselines, load missing
       missing = metrics.filter(urn => !aggregates[urn] || urn.startsWith('frontend:baseline:metric:'));
       newAggregates = Object.keys(aggregates)

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -83,6 +83,11 @@ export default Ember.Service.extend({
       return;
     }
 
+    if (_.isEmpty(incoming)) {
+      console.log('rootcauseAggregatesService: received empty result.');
+      return;
+    }
+
     const newPending = new Set([...pending].filter(urn => !incoming[urn]));
     const newAggregates = Object.assign({}, aggregates, incoming);
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import checkStatus from 'thirdeye-frontend/helpers/utils';
+import { checkStatus, toBaselineUrn } from 'thirdeye-frontend/helpers/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
@@ -85,7 +85,7 @@ export default Ember.Service.extend({
   _augment(incoming) {
     const entities = {};
     Object.keys(incoming).filter(urn => incoming[urn].type == 'metric').forEach(urn => {
-      const baselineUrn = this._makeBaselineUrn(urn);
+      const baselineUrn = toBaselineUrn(urn);
       entities[baselineUrn] = {
         urn: baselineUrn,
         type: 'frontend:baseline:metric',
@@ -108,11 +108,5 @@ export default Ember.Service.extend({
     const entities = {};
     res.forEach(e => entities[e.urn] = e);
     return entities;
-  },
-
-  _makeBaselineUrn(urn) {
-    const mid = urn.split(':')[2];
-    return `frontend:baseline:metric:${mid}`;
   }
-
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -1,0 +1,113 @@
+import Ember from 'ember';
+import checkStatus from 'thirdeye-frontend/helpers/utils';
+import fetch from 'fetch';
+import _ from 'lodash';
+
+export default Ember.Service.extend({
+  entities: null, // {}
+
+  context: null, // {}
+
+  pending: null, // Set
+
+  init() {
+    this._super(...arguments);
+    this.setProperties({ entities: {}, context: {}, pending: new Set() });
+  },
+
+  request(requestContext, selectedUrns) {
+    console.log('rootcauseEntitiesCache: request()', requestContext, selectedUrns);
+    const { context } = this.getProperties('context');
+    if (_.isEqual(context, requestContext)) {
+      return;
+    }
+
+    const frameworks = new Set(['relatedEvents', 'relatedDimensions', 'relatedMetrics']);
+
+    this.setProperties({ context: _.cloneDeep(requestContext), pending: frameworks });
+
+    frameworks.forEach(framework => {
+      const url = this._makeUrl(framework, requestContext);
+      console.log('rootcauseEntitiesCache: request: fetching url', url);
+      fetch(url)
+        // .then(checkStatus) // TODO why doesn't this return parsed json here?
+        .then(res => res.json())
+        .then(this._jsonToEntities)
+        .then(incoming => this._complete(requestContext, selectedUrns, incoming, framework));
+    });
+  },
+
+  _complete(requestContext, selectedUrns, incoming, framework) {
+    console.log('rootcauseEntitiesCache: complete()', requestContext, selectedUrns, incoming, framework);
+
+    // evict unselected
+    const { entities, pending } = this.getProperties('entities', 'pending');
+    const stale = new Set(this._evictionCandidates(entities, framework));
+    const staleSelected = new Set([...stale].filter(urn => selectedUrns.has(urn)));
+    const staleUnselected = new Set([...stale].filter(urn => !selectedUrns.has(urn)));
+
+    // rebuild remaining cache
+    const remaining = {};
+    Object.keys(entities).filter(urn => !staleUnselected.has(urn)).forEach(urn => remaining[urn] = entities[urn]);
+    Object.keys(entities).filter(urn => staleSelected.has(urn)).forEach(urn => remaining[urn].score = -1);
+
+    // augment results
+    const augmenting = this._augment(incoming);
+
+    // merge
+    const newEntities = Object.assign({}, remaining, augmenting, incoming);
+
+    // update pending
+    const newPending = new Set(pending);
+    newPending.delete(framework);
+
+    this.setProperties({ entities: newEntities, pending: newPending });
+  },
+
+  _evictionCandidates(entities, framework) {
+    if (framework == 'relatedEvents') {
+      return Object.keys(entities).filter(urn => entities[urn].type == 'event');
+    }
+    if (framework == 'relatedDimensions') {
+      return Object.keys(entities).filter(urn => entities[urn].type == 'dimension');
+    }
+    if (framework == 'relatedMetrics') {
+      return Object.keys(entities).filter(urn => ['metric', 'frontend:baseline:metric'].includes(entities[urn].type));
+    }
+  },
+
+  _augment(incoming) {
+    const entities = {};
+    Object.keys(incoming).filter(urn => incoming[urn].type == 'metric').forEach(urn => {
+      const baselineUrn = this._makeMetricBaselineUrn(urn);
+      entities[baselineUrn] = {
+        urn: baselineUrn,
+        type: 'frontend:baseline:metric',
+        label: incoming[urn].label + ' (baseline)'
+      };
+    });
+    return entities;
+  },
+
+  _makeUrl(framework, context) {
+    const urnString = [...context.urns].join(',');
+    return `/rootcause/query?framework=${framework}` +
+      `&anomalyStart=${context.anomalyRange[0]}&anomalyEnd=${context.anomalyRange[1]}` +
+      `&baselineStart=${context.baselineRange[0]}&baselineEnd=${context.baselineRange[1]}` +
+      `&analysisStart=${context.analysisRange[0]}&analysisEnd=${context.analysisRange[1]}` +
+      `&urns=${urnString}`;
+  },
+
+  _jsonToEntities(res) {
+    console.log('rootcauseEntitiesCache: _jsonToEntities()', res);
+    const entities = {};
+    res.forEach(e => entities[e.urn] = e);
+    return entities;
+  },
+
+  _makeMetricBaselineUrn(urn) {
+    const mid = urn.split(':')[2];
+    return `frontend:baseline:metric:${mid}`;
+  }
+
+});

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -46,6 +46,11 @@ export default Ember.Service.extend({
       return;
     }
 
+    if (_.isEmpty(incoming)) {
+      console.log('rootcauseEntitiesCache: received empty result.');
+      return;
+    }
+
     // evict unselected
     const { entities, pending } = this.getProperties('entities', 'pending');
     const stale = new Set(this._evictionCandidates(entities, framework));
@@ -105,8 +110,9 @@ export default Ember.Service.extend({
   },
 
   _jsonToEntities(res) {
-    const entities = {};
-    res.forEach(e => entities[e.urn] = e);
-    return entities;
+    if (_.isEmpty(res)) {
+      return {};
+    }
+    return res.reduce((agg, e) => { agg[e.urn] = e; return agg; }, {});
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -28,7 +28,6 @@ export default Ember.Service.extend({
 
     frameworks.forEach(framework => {
       const url = this._makeUrl(framework, requestContext);
-      console.log('rootcauseEntitiesCache: request: fetching url', url);
       fetch(url)
         // .then(checkStatus) // TODO why doesn't this return parsed json here?
         .then(res => res.json())
@@ -99,7 +98,6 @@ export default Ember.Service.extend({
   },
 
   _jsonToEntities(res) {
-    console.log('rootcauseEntitiesCache: _jsonToEntities()', res);
     const entities = {};
     res.forEach(e => entities[e.urn] = e);
     return entities;

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
@@ -1,0 +1,134 @@
+import Ember from 'ember';
+import checkStatus from 'thirdeye-frontend/helpers/utils';
+import fetch from 'fetch';
+import _ from 'lodash';
+
+export default Ember.Service.extend({
+  timeseries: null, // {}
+
+  context: null, // {}
+
+  pending: null, // Set
+
+  init() {
+    this.setProperties({ timeseries: {}, context: {}, pending: new Set() });
+  },
+
+  request(requestContext, urns) {
+    console.log('rootcauseTimeseriesService: request()', requestContext, urns);
+    const { context, timeseries: currTimeseries } = this.getProperties('context', 'timeseries');
+
+    // TODO retain stale timeseries until request completion
+
+    let timeseries = currTimeseries;
+    if(!_.isEqual(context.analysisRange, requestContext.analysisRange)) {
+      // new analysis range: evict all, leave stale copy of requested
+      timeseries = [...urns]
+        .filter(urn => timeseries[urn])
+        .reduce((agg, urn) => agg[urn] = timeseries[urn], {});
+    } else if((context.anomalyRange[0] - context.baselineRange[0]) !=
+              (requestContext.anomalyRange[0] - requestContext.baselineRange[0])) {
+      // new baseline: evict baselines, leave current
+      timeseries = Object.keys(currTimeseries)
+        .filter(urn => !urn.startsWith('frontend:baseline:metric:'))
+        .reduce((agg, urn) => agg[urn] = currTimeseries[urn], {});
+    }
+
+    const missing = [...urns].filter(urn => (urn.startsWith('thirdeye:metric:') || urn.startsWith('frontend:baseline:metric:')) && !timeseries[urn]);
+
+    const newPending = new Set(missing);
+    this.setProperties({ context: _.cloneDeep(requestContext), timeseries, pending: newPending });
+
+    // metrics
+    const metricUrns = missing.filter(urn => urn.startsWith('thirdeye:metric:'));
+    if (!_.isEmpty(metricUrns)) {
+      const metricIdString = metricUrns.map(urn => urn.split(":")[2]).join(',');
+      const metricUrl = `/timeseries/query?metricIds=${metricIdString}&ranges=${requestContext.analysisRange[0]}:${requestContext.analysisRange[1]}&granularity=15_MINUTES&transformations=timestamp`;
+
+      fetch(metricUrl)
+        // .then(checkStatus)
+        .then(res => res.json())
+        .then(this._extractTimeseries)
+        .then(incoming => this._complete(requestContext, incoming));
+    }
+
+    // baselines
+    const baselineOffset = requestContext.anomalyRange[0] - requestContext.baselineRange[0];
+    const baselineAnalysisStart = requestContext.analysisRange[0] - baselineOffset;
+    const baselineAnalysisEnd = requestContext.analysisRange[1] - baselineOffset;
+
+    const baselineUrns = missing.filter(urn => urn.startsWith('frontend:baseline:metric:'));
+    if (!_.isEmpty(baselineUrns)) {
+      const baselineIdString = baselineUrns.map(urn => urn.split(":")[3]).join(',');
+      const baselineUrl = `/timeseries/query?metricIds=${baselineIdString}&ranges=${baselineAnalysisStart}:${baselineAnalysisEnd}&granularity=15_MINUTES&transformations=timestamp`;
+
+      fetch(baselineUrl)
+        // .then(checkStatus)
+        .then(res => res.json())
+        .then(this._extractTimeseries)
+        .then(incoming => this._convertToBaseline(incoming, baselineOffset))
+        .then(incoming => this._complete(requestContext, incoming));
+    }
+  },
+
+  _complete(requestContext, incoming) {
+    console.log('rootcauseTimeseriesService: _complete()', incoming);
+    const { context, pending, timeseries } = this.getProperties('context', 'pending', 'timeseries');
+
+    // only accept latest result
+    if (!_.isEqual(context, requestContext)) {
+      console.log('rootcauseTimeseriesService: received stale result. ignoring.');
+      return;
+    }
+
+    const newPending = new Set([...pending].filter(urn => !incoming[urn]));
+    const newTimeseries = Object.assign({}, timeseries, incoming);
+
+    this.setProperties({ timeseries: newTimeseries, pending: newPending });
+  },
+
+  _extractTimeseries(json) {
+    console.log('rootcauseTimeseriesService: _extractTimeseries()', json);
+    const timeseries = {};
+    Object.keys(json).forEach(range =>
+      Object.keys(json[range]).filter(sid => sid != 'timestamp').forEach(sid => {
+        const urn = `thirdeye:metric:${sid}`;
+        const jrng = json[range];
+        const jval = jrng[sid];
+
+        const timestamps = [];
+        const values = [];
+        jrng.timestamp.forEach((t, i) => {
+          if (jval[i] != null) {
+            timestamps.push(t);
+            values.push(jval[i]);
+          }
+        });
+
+        timeseries[urn] = {
+          timestamps: timestamps,
+          values: values
+        };
+      })
+    );
+    return timeseries;
+  },
+
+  _convertToBaseline(timeseries, offset) {
+    const baseline = {};
+    Object.keys(timeseries).forEach(urn => {
+      const baselineUrn = this._makeBaselineUrn(urn);
+      baseline[baselineUrn] = {
+        values: timeseries[urn].values,
+        timestamps: timeseries[urn].timestamps.map(t => t + offset)
+      };
+    });
+    return baseline;
+  },
+
+  _makeBaselineUrn(urn) {
+    const mid = urn.split(':')[2];
+    return `frontend:baseline:metric:${mid}`;
+  }
+
+});

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
@@ -55,7 +55,7 @@ export default Ember.Service.extend({
     const metricUrns = filterPrefix(missing, 'thirdeye:metric:');
     if (!_.isEmpty(metricUrns)) {
       const metricIdString = metricUrns.map(urn => urn.split(":")[2]).join(',');
-      const metricUrl = `/timeseries/query?metricIds=${metricIdString}&ranges=${requestContext.analysisRange[0]}:${requestContext.analysisRange[1]}&filters=${filtersString}&granularity=${requestContext.granularity}&transformations=timestamp`;
+      const metricUrl = `/timeseries/query?metricIds=${metricIdString}&ranges=${requestContext.analysisRange[0]}:${requestContext.analysisRange[1]}&filters=${filtersString}&granularity=${requestContext.granularity}`;
 
       fetch(metricUrl)
         // .then(checkStatus)
@@ -72,7 +72,7 @@ export default Ember.Service.extend({
     const baselineUrns = filterPrefix(missing, 'frontend:baseline:metric:');
     if (!_.isEmpty(baselineUrns)) {
       const baselineIdString = baselineUrns.map(urn => urn.split(":")[3]).join(',');
-      const baselineUrl = `/timeseries/query?metricIds=${baselineIdString}&ranges=${baselineAnalysisStart}:${baselineAnalysisEnd}&filters=${filtersString}&granularity=${requestContext.granularity}&transformations=timestamp`;
+      const baselineUrl = `/timeseries/query?metricIds=${baselineIdString}&ranges=${baselineAnalysisStart}:${baselineAnalysisEnd}&filters=${filtersString}&granularity=${requestContext.granularity}`;
 
       fetch(baselineUrl)
         // .then(checkStatus)

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -10,6 +10,8 @@ export default Ember.Controller.extend({
 
   aggregatesService: Ember.inject.service("rootcause-aggregates-cache"), // service
 
+  breakdownsService: Ember.inject.service("rootcause-breakdowns-cache"), // service
+
   selectedUrns: null, // Set
 
   filteredUrns: null, // Set
@@ -24,14 +26,16 @@ export default Ember.Controller.extend({
 
   _contextObserver: Ember.observer(
     'context',
+    'entities',
     'selectedUrns',
     'entitiesService',
     'timeseriesService',
     'aggregatesService',
+    'breakdownsService',
     function () {
       console.log('_contextObserver()');
-      const { context, selectedUrns, entitiesService, timeseriesService, aggregatesService } =
-        this.getProperties('context', 'selectedUrns', 'entitiesService', 'timeseriesService', 'aggregatesService');
+      const { context, entities, selectedUrns, entitiesService, timeseriesService, aggregatesService, breakdownsService } =
+        this.getProperties('context', 'entities', 'selectedUrns', 'entitiesService', 'timeseriesService', 'aggregatesService', 'breakdownsService');
 
       if (!context || !selectedUrns) {
         return;
@@ -39,7 +43,10 @@ export default Ember.Controller.extend({
 
       entitiesService.request(context, selectedUrns);
       timeseriesService.request(context, selectedUrns);
-      aggregatesService.request(context, selectedUrns);
+      breakdownsService.request(context, selectedUrns);
+
+      const allUrns = new Set(Object.keys(entities));
+      aggregatesService.request(context, allUrns);
     }
   ),
 
@@ -68,6 +75,14 @@ export default Ember.Controller.extend({
     function () {
       console.log('aggregates()');
       return this.get('aggregatesService.aggregates');
+    }
+  ),
+
+  breakdowns: Ember.computed(
+    'breakdownsService.breakdowns',
+    function () {
+      console.log('breakdowns()');
+      return this.get('breakdownsService.breakdowns');
     }
   ),
 
@@ -135,15 +150,6 @@ export default Ember.Controller.extend({
       const baselineUrns = {};
       filterPrefix(selectedUrns, 'thirdeye:metric:').forEach(urn => baselineUrns[urn] = toBaselineUrn(urn));
       return baselineUrns;
-    }
-  ),
-
-  metricEntities: Ember.computed(
-    'entities',
-    function () {
-      console.log('metricEntities()');
-      const { entities } = this.getProperties('entities');
-      return filterObject(entities, (e) => e.type == 'metric');
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -170,7 +170,7 @@ export default Ember.Controller.extend({
       return this.get('aggregatesService.aggregates').size > 0;
     }
   ),
-  
+
   //
   // Actions
   //

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -1,11 +1,7 @@
 import Ember from 'ember';
-import { makeIterable, filterObject, filterPrefix } from 'thirdeye-frontend/helpers/utils';
+import { makeIterable, filterObject, toBaselineUrn, filterPrefix } from 'thirdeye-frontend/helpers/utils';
 import EVENT_TABLE_COLUMNS from 'thirdeye-frontend/mocks/eventTableColumns';
 import config from 'thirdeye-frontend/mocks/filterBarConfig';
-
-//
-// Controller
-//
 
 export default Ember.Controller.extend({
   entitiesService: Ember.inject.service("rootcause-entities-cache"), // service
@@ -137,7 +133,7 @@ export default Ember.Controller.extend({
     function () {
       const { selectedUrns } = this.getProperties('selectedUrns');
       const baselineUrns = {};
-      filterPrefix(selectedUrns, 'thirdeye:metric:').forEach(urn => baselineUrns[urn] = this._makeBaselineUrn(urn));
+      filterPrefix(selectedUrns, 'thirdeye:metric:').forEach(urn => baselineUrns[urn] = toBaselineUrn(urn));
       return baselineUrns;
     }
   ),
@@ -174,12 +170,7 @@ export default Ember.Controller.extend({
       return this.get('aggregatesService.aggregates').size > 0;
     }
   ),
-
-  _makeBaselineUrn(urn) {
-    const mid = urn.split(':')[2];
-    return `frontend:baseline:metric:${mid}`;
-  },
-
+  
   //
   // Actions
   //

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -4,13 +4,13 @@ import EVENT_TABLE_COLUMNS from 'thirdeye-frontend/mocks/eventTableColumns';
 import config from 'thirdeye-frontend/mocks/filterBarConfig';
 
 export default Ember.Controller.extend({
-  entitiesService: Ember.inject.service("rootcause-entities-cache"), // service
+  entitiesService: Ember.inject.service('rootcause-entities-cache'), // service
 
-  timeseriesService: Ember.inject.service("rootcause-timeseries-cache"), // service
+  timeseriesService: Ember.inject.service('rootcause-timeseries-cache'), // service
 
-  aggregatesService: Ember.inject.service("rootcause-aggregates-cache"), // service
+  aggregatesService: Ember.inject.service('rootcause-aggregates-cache'), // service
 
-  breakdownsService: Ember.inject.service("rootcause-breakdowns-cache"), // service
+  breakdownsService: Ember.inject.service('rootcause-breakdowns-cache'), // service
 
   selectedUrns: null, // Set
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -12,7 +12,10 @@ export default Ember.Route.extend({
 
     // TODO get initial attributes from query params
     controller.setProperties({
-      selectedUrns: new Set(['thirdeye:metric:194592', 'thirdeye:event:holiday:2712391']),
+      selectedUrns: new Set([
+        'thirdeye:metric:194591', 'frontend:baseline:metric:194591',
+        'thirdeye:metric:194592', 'frontend:baseline:metric:194592',
+        'thirdeye:event:holiday:2712391']),
       invisibleUrns: new Set(),
       filteredUrns: new Set(),
       hoverUrns: new Set(),

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -4,6 +4,7 @@ const anomalyRange = [1509044400000, 1509422400000];
 const baselineRange = [1508439600000, 1508817600000];
 const analysisRange = [1508785200000, 1509422400000];
 const urns = new Set(['thirdeye:metric:194591', 'thirdeye:dimension:countryCode:in:provided']);
+const granularity = '30_MINUTES';
 
 export default Ember.Route.extend({
   setupController: function (controller, model) {
@@ -19,7 +20,7 @@ export default Ember.Route.extend({
       invisibleUrns: new Set(),
       filteredUrns: new Set(),
       hoverUrns: new Set(),
-      context: { urns, anomalyRange, baselineRange, analysisRange }
+      context: { urns, anomalyRange, baselineRange, analysisRange, granularity },
     });
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -8,6 +8,7 @@ const urns = new Set(['thirdeye:metric:194591', 'thirdeye:dimension:countryCode:
 export default Ember.Route.extend({
   setupController: function (controller, model) {
     this._super(...arguments);
+    console.log('route: setupController()');
 
     // TODO get initial attributes from query params
     controller.setProperties({

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -71,14 +71,15 @@ urns
 
 <h3>This is the metric tab.</h3>
 {{rootcause-metrics
-  entities=metricEntities
+  entities=entities
+  aggregates=aggregates
   selectedUrns=selectedUrns
   onSelection=(action "onSelection")
 }}
 
 <h3>This is the heatmap.</h3>
 {{rootcause-heatmap
-  aggregates=aggregates
+  breakdowns=breakdowns
   currentUrns=heatmapCurrentUrns
   current2baseline=heatmapCurrent2Baseline
 }}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -1,12 +1,3 @@
-<h3>This is the loading indicator.</h3>
-type
-{{#if isLoadingEntities}}
-  | ENTITIES
-{{/if}}
-{{#if isLoadingTimeseries}}
-  | TIMESERIES
-{{/if}}
-
 <h3>This manipulates the controller state.</h3>
 <a {{action "addSelectedUrns" "thirdeye:metric:17606338"}}>add test metric</a> |
 <a {{action "removeSelectedUrns" "thirdeye:metric:17606338"}}>remove test metric</a> |
@@ -36,6 +27,15 @@ type
   baselineRange=context.baselineRange
   analysisRange=context.analysisRange
   onHover=(action "chartOnHover")}}
+
+<h3>This is the loading indicator.</h3>
+type
+{{#if isLoadingEntities}}
+  | ENTITIES
+{{/if}}
+{{#if isLoadingTimeseries}}
+  | TIMESERIES
+{{/if}}
 
 <h3>This is the hover section.</h3>
 urns

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -18,6 +18,15 @@
   onSelection=(action "onSelection")
 }}
 
+<h3>This is the loading indicator.</h3>
+type
+{{#if isLoadingEntities}}
+  | ENTITIES
+{{/if}}
+{{#if isLoadingTimeseries}}
+  | TIMESERIES
+{{/if}}
+
 <h3>This is the graph.</h3>
 {{rootcause-chart
   entities=entities
@@ -27,15 +36,6 @@
   baselineRange=context.baselineRange
   analysisRange=context.analysisRange
   onHover=(action "chartOnHover")}}
-
-<h3>This is the loading indicator.</h3>
-type
-{{#if isLoadingEntities}}
-  | ENTITIES
-{{/if}}
-{{#if isLoadingTimeseries}}
-  | TIMESERIES
-{{/if}}
 
 <h3>This is the hover section.</h3>
 urns


### PR DESCRIPTION
This PR refactors the RCA poc controller to use caching services for entities, timeseries, and aggregates. The caches provide a declarative request interface and asynchronous resource loading. Also adds a number of utility functions, timeseries filters and granularity support, and cleans up the code base.

* entities caching service

* timeseries caching service

* aggregates caching service

* timeseries filters and granularity support