### PR TITLE
[TE] add holiday mode to email scheduling

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
@@ -151,11 +151,6 @@ public abstract class EmailHelper {
     return handler.process(request);
   }
 
-  public static ContributorViewResponse getContributorDataForDataReport(String collection, String metric, List<String> dimensions)
-      throws Exception {
-    return getContributorDataForDataReport(collection, metric, dimensions, AlertConfigBean.COMPARE_MODE.WoW, 2 * 36_00_000, false); // add 2 hours delay
-  }
-
   public static long getBaselineOffset(AlertConfigBean.COMPARE_MODE compareMode) {
     switch (compareMode) {
     case Wo2W:

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertJobSchedulerV2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/v2/AlertJobSchedulerV2.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang.StringUtils;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
 import org.quartz.JobBuilder;
@@ -125,8 +126,12 @@ public class AlertJobSchedulerV2 implements JobScheduler, Runnable {
     if (isActive) {
       if (isScheduled) {
         String cronInDatabase = alertConfig.getCronExpression();
-        List<Trigger> triggers =
-            (List<Trigger>) quartzScheduler.getTriggersOfJob(JobKey.jobKey(jobKey));
+        if (!StringUtils.isBlank(alertConfig.getHolidayCronExpression())) {
+          LOG.info("Using holiday mode for alert config id '{}' with expression '{}'", id, alertConfig.getHolidayCronExpression());
+          cronInDatabase = alertConfig.getHolidayCronExpression();
+        }
+
+        List<Trigger> triggers = (List<Trigger>) quartzScheduler.getTriggersOfJob(JobKey.jobKey(jobKey));
         CronTrigger cronTrigger = (CronTrigger) triggers.get(0);
         String cronInSchedule = cronTrigger.getCronExpression();
         // cron expression has been updated, restart this job

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
@@ -15,6 +15,7 @@ public class AlertConfigBean extends AbstractBean {
   String name;
   String application;
   String cronExpression;
+  String holidayCronExpression;
   boolean active;
   AnomalyFeedConfig anomalyFeedConfig;
   EmailConfig emailConfig;
@@ -62,6 +63,14 @@ public class AlertConfigBean extends AbstractBean {
 
   public void setAnomalyFeedConfig(AnomalyFeedConfig anomalyFeedConfig) {
     this.anomalyFeedConfig = anomalyFeedConfig;
+  }
+
+  public String getHolidayCronExpression() {
+    return holidayCronExpression;
+  }
+
+  public void setHolidayCronExpression(String holidayCronExpression) {
+    this.holidayCronExpression = holidayCronExpression;
   }
 
   public EmailConfig getEmailConfig() {
@@ -229,6 +238,7 @@ public class AlertConfigBean extends AbstractBean {
     public boolean isEnabled() {
       return enabled;
     }
+
     public void setEnabled(boolean enabled) {
       this.enabled = enabled;
     }


### PR DESCRIPTION
Add a holidayCronExpression to alert configs that may override the primary cron schedule if set. This allows temporary changes to alert schedules without permanently overriding existing configurations.