### PR TITLE
[TE] Fix issue when parsing empty GroupByResultSets

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSet.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSet.java
@@ -1,7 +1,6 @@
 package com.linkedin.thirdeye.datasource.pinot.resultset;
 
 import com.google.common.base.Preconditions;
-import com.linkedin.pinot.client.PinotClientException;
 import com.linkedin.pinot.client.ResultSet;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import java.util.ArrayList;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSet.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSet.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datasource.pinot.resultset;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.client.PinotClientException;
 import com.linkedin.pinot.client.ResultSet;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import java.util.ArrayList;
@@ -78,7 +79,22 @@ public class ThirdEyeDataFrameResultSet extends AbstractThirdEyeResultSet {
   public static ThirdEyeDataFrameResultSet fromPinotResultSet(ResultSet resultSet) {
     // Build the meta data of this result set
     List<String> groupKeyColumnNames = new ArrayList<>();
-    for (int groupKeyColumnIdx = 0; groupKeyColumnIdx < resultSet.getGroupKeyLength(); groupKeyColumnIdx++) {
+    int groupByColumnCount = 0;
+    try {
+      groupByColumnCount = resultSet.getGroupKeyLength();
+    } catch (Exception e) {
+      // Only happens when result set is GroupByResultSet type and contains empty result.
+      // In this case, we have to use brutal force to count the number of group by columns.
+      while (true) {
+        try {
+          resultSet.getGroupKeyColumnName(groupByColumnCount);
+          ++groupByColumnCount;
+        } catch (Exception breakSignal) {
+          break;
+        }
+      }
+    }
+    for (int groupKeyColumnIdx = 0; groupKeyColumnIdx < groupByColumnCount; groupKeyColumnIdx++) {
       groupKeyColumnNames.add(resultSet.getGroupKeyColumnName(groupKeyColumnIdx));
     }
     List<String> metricColumnNames = new ArrayList<>();
@@ -91,7 +107,6 @@ public class ThirdEyeDataFrameResultSet extends AbstractThirdEyeResultSet {
     // Build the DataFrame
     DataFrame.Builder dfBuilder = DataFrame.builder(thirdEyeResultSetMetaData.getAllColumnNames());
     int rowCount = resultSet.getRowCount();
-    int groupByColumnCount = resultSet.getGroupKeyLength();
     int metricColumnCount = resultSet.getColumnCount();
     int totalColumnCount = groupByColumnCount + metricColumnCount;
     // Dump the values in ResultSet to the DataFrame

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSetTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSetTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSetTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSetTest.java
@@ -1,12 +1,15 @@
 package com.linkedin.thirdeye.datasource.pinot.resultset;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.client.PinotClientException;
 import com.linkedin.pinot.client.ResultSet;
 import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.ObjectSeries;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -64,7 +67,8 @@ public class ThirdEyeDataFrameResultSetTest {
     Assert.assertEquals(actualDataFrameResultSet, expectedDataFrameResultSet);
   }
 
-  @Test public void testFromPinotSingleGroupByResultSet() {
+  @Test
+  public void testFromPinotSingleGroupByResultSet() {
     final String functionName = "sum_metric_name";
 
     List<String> groupByColumnNames = new ArrayList<>();
@@ -92,6 +96,31 @@ public class ThirdEyeDataFrameResultSetTest {
     Assert.assertEquals(actualDataFrameResultSet, expectedDataFrameResultSet);
   }
 
+  @Test
+  public void testFromEmptyPinotSingleGroupByResultSet() {
+    final String functionName = "sum_metric_name";
+
+    List<String> groupByColumnNames = new ArrayList<>();
+    groupByColumnNames.add("country");
+    groupByColumnNames.add("pageName");
+
+    List<MockedSingleGroupByResultSet.GroupByRowResult> resultArray = new ArrayList<>();
+
+    ResultSet singleGroupByResultSet = new MockedSingleGroupByResultSet(groupByColumnNames, functionName, resultArray);
+    ThirdEyeDataFrameResultSet actualDataFrameResultSet =
+        ThirdEyeDataFrameResultSet.fromPinotResultSet(singleGroupByResultSet);
+
+    ThirdEyeResultSetMetaData metaData =
+        new ThirdEyeResultSetMetaData(groupByColumnNames, Collections.singletonList(functionName));
+    DataFrame dataFrame = new DataFrame();
+    dataFrame.addSeries("country", ObjectSeries.builder().build());
+    dataFrame.addSeries("pageName", ObjectSeries.builder().build());
+    dataFrame.addSeries(functionName, ObjectSeries.builder().build());
+    ThirdEyeDataFrameResultSet expectedDataFrameResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+
+    Assert.assertEquals(actualDataFrameResultSet, expectedDataFrameResultSet);
+  }
+
   private static class MockedSingleGroupByResultSet extends MockedAbstractResultSet {
     List<String> groupByColumnNames = Collections.emptyList();
     String functionName;
@@ -108,34 +137,48 @@ public class ThirdEyeDataFrameResultSetTest {
       this.resultArray = resultArray;
     }
 
-    @Override public int getRowCount() {
+    @Override
+    public int getRowCount() {
       return resultArray.size();
     }
 
-    @Override public int getColumnCount() {
+    @Override
+    public int getColumnCount() {
       return 1;
     }
 
-    @Override public String getColumnName(int i) {
+    @Override
+    public String getColumnName(int i) {
       return functionName;
     }
 
-    @Override public String getString(int rowIdx, int columnIdx) {
+    @Override
+    public String getString(int rowIdx, int columnIdx) {
       if (columnIdx != 0) {
         throw new IllegalArgumentException("Column index has to be 0 for single group by result.");
       }
       return resultArray.get(rowIdx).value;
     }
 
-    @Override public int getGroupKeyLength() {
-      return groupByColumnNames.size();
+    @Override
+    public int getGroupKeyLength() {
+      // This method mimics the behavior of GroupByResultSet in Pinot, which throw exceptions when the result array
+      // is empty.
+      try {
+        return resultArray.get(0).groupByColumnValues.size();
+      } catch (Exception e) {
+        throw new PinotClientException(
+            "For some reason, Pinot decides to throw exception when the result is empty.");
+      }
     }
 
-    @Override public String getGroupKeyColumnName(int i) {
+    @Override
+    public String getGroupKeyColumnName(int i) {
       return groupByColumnNames.get(i);
     }
 
-    @Override public String getGroupKeyString(int rowIdx, int columnIdx) {
+    @Override
+    public String getGroupKeyString(int rowIdx, int columnIdx) {
       return resultArray.get(rowIdx).groupByColumnValues.get(columnIdx);
     }
 


### PR DESCRIPTION
Problem:
When parsing a GroupByResultSet, the parser needs to know the number of group by columns. In Pinot code, the meta-data is retrieved from data (i.e., the result). If the result is empty, then an exception is thrown. Consequently, we are not able to know how many group by columns the result should have. 

The above issue may bring new issues when we try to join two group by results. If one group by result has data and the other does not. Then we cannot join then because the latter one does not have column names.

Fix:
This work-around handles the exception when the result is empty and uses brutal force to retrieve the meta-data. The permanent fix should happen in Pinot code.