### PR TITLE
Fix exception when getting group-by column count on empty results

### DIFF
--- a/pinot-api/src/main/java/com/linkedin/pinot/client/GroupByResultSet.java
+++ b/pinot-api/src/main/java/com/linkedin/pinot/client/GroupByResultSet.java
@@ -24,13 +24,11 @@ import org.json.JSONObject;
  * in the query.
  */
 class GroupByResultSet extends AbstractResultSet {
-  private final JSONObject _jsonObject;
   private final JSONArray _groupByResults;
   private final JSONArray _groupByColumns;
   private final String _functionName;
 
   public GroupByResultSet(JSONObject jsonObject) {
-    _jsonObject = jsonObject;
     try {
       _groupByResults = jsonObject.getJSONArray("groupByResult");
       _groupByColumns = jsonObject.getJSONArray("groupByColumns");
@@ -56,11 +54,7 @@ class GroupByResultSet extends AbstractResultSet {
 
   @Override
   public String getColumnName(int columnIndex) {
-    try {
-      return _jsonObject.getString("function");
-    } catch (JSONException e) {
-      throw new PinotClientException(e);
-    }
+    return _functionName;
   }
 
   @Override
@@ -79,11 +73,7 @@ class GroupByResultSet extends AbstractResultSet {
 
   @Override
   public int getGroupKeyLength() {
-    try {
-      return _groupByResults.getJSONObject(0).getJSONArray("group").length();
-    } catch (JSONException e) {
-      throw new PinotClientException(e);
-    }
+    return _groupByColumns.length();
   }
 
   @Override


### PR DESCRIPTION
When getting the group by column count from empty results, an exception is thrown because _groupByResults cannot provide such information. However, the column count should always available since it is meta-data instead of data. Therefore, this PR get this information from _groupByColumns instaed of _groupByResults. 