### PR TITLE
[TE] Append Pinot tables' custom configs to ThirdEye's dataset config

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -21,24 +24,27 @@ import com.linkedin.thirdeye.datasource.DataSourceConfig;
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSourceConfig;
 
 public class AutoOnboardPinotMetricsUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardPinotMetricsUtils.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final org.codehaus.jackson.map.ObjectMapper CODEHAUS_OBJECT_MAPPER =
+      new org.codehaus.jackson.map.ObjectMapper();
+
   private static final String PINOT_TABLES_ENDPOINT = "/tables/";
-  private static final String PINOT_SCHEMA_ENDPOINT = "/schemas/%s";
-  private static final String PINOT_SCHEMA_ENDPOINT_TEMPLATE = "/tables/%s/schema";
+  private static final String PINOT_TABLES_ENDPOINT_TEMPLATE = "/tables/%s";
+  private static final String PINOT_SCHEMA_ENDPOINT_TEMPLATE = "/schemas/%s";
+  private static final String PINOT_TABLE_CONFIG_ENDPOINT_TEMPLATE = "/tables/%s/schema";
   private static final String UTF_8 = "UTF-8";
 
   private CloseableHttpClient pinotControllerClient;
   private HttpHost pinotControllerHost;
 
-  private static final Logger LOG = LoggerFactory.getLogger(AutoOnboardPinotMetricsUtils.class);
-
   public AutoOnboardPinotMetricsUtils(DataSourceConfig dataSourceConfig) {
     PinotThirdEyeDataSourceConfig pinotThirdeyeDataSourceConfig =
         PinotThirdEyeDataSourceConfig.createFromDataSourceConfig(dataSourceConfig);
-      this.pinotControllerClient = HttpClients.createDefault();
-      this.pinotControllerHost = new HttpHost(pinotThirdeyeDataSourceConfig.getControllerHost(),
-          pinotThirdeyeDataSourceConfig.getControllerPort());
+    this.pinotControllerClient = HttpClients.createDefault();
+    this.pinotControllerHost = new HttpHost(pinotThirdeyeDataSourceConfig.getControllerHost(),
+        pinotThirdeyeDataSourceConfig.getControllerPort());
   }
-
 
   public JsonNode getAllTablesFromPinot() throws IOException {
     HttpGet tablesReq = new HttpGet(PINOT_TABLES_ENDPOINT);
@@ -50,7 +56,7 @@ public class AutoOnboardPinotMetricsUtils {
         throw new IllegalStateException(tablesRes.getStatusLine().toString());
       }
       InputStream tablesContent = tablesRes.getEntity().getContent();
-      tables = new ObjectMapper().readTree(tablesContent).get("tables");
+      tables = OBJECT_MAPPER.readTree(tablesContent).get("tables");
     } catch (Exception e) {
       LOG.error("Exception in loading collections", e);
     } finally {
@@ -64,25 +70,27 @@ public class AutoOnboardPinotMetricsUtils {
 
   /**
    * Fetches schema from pinot, from the tables endpoint or schema endpoint
+   *
    * @param dataset
+   *
    * @return
+   *
    * @throws IOException
    */
   public Schema getSchemaFromPinot(String dataset) throws IOException {
-    Schema schema = null;
-    schema = getSchemaFromTableConfig(dataset);
+    Schema schema = getSchemaFromPinotEndpoint(PINOT_TABLE_CONFIG_ENDPOINT_TEMPLATE, dataset);
     if (schema == null) {
-      schema = getSchemaFromSchemaEndpoint(dataset);
+      schema = getSchemaFromPinotEndpoint(PINOT_SCHEMA_ENDPOINT_TEMPLATE, dataset);
     }
     if (schema == null) {
-      schema = getSchemaFromSchemaEndpoint(dataset + "_OFFLINE");
+      schema = getSchemaFromPinotEndpoint(PINOT_SCHEMA_ENDPOINT_TEMPLATE, dataset + "_OFFLINE");
     }
     return schema;
   }
 
-  private Schema getSchemaFromTableConfig(String dataset) throws IOException {
+  private Schema getSchemaFromPinotEndpoint(String endpointTemplate, String dataset) throws IOException {
     Schema schema = null;
-    HttpGet schemaReq = new HttpGet(String.format(PINOT_SCHEMA_ENDPOINT_TEMPLATE, URLEncoder.encode(dataset, UTF_8)));
+    HttpGet schemaReq = new HttpGet(String.format(endpointTemplate, URLEncoder.encode(dataset, UTF_8)));
     LOG.info("Retrieving schema: {}", schemaReq);
     CloseableHttpResponse schemaRes = pinotControllerClient.execute(pinotControllerHost, schemaReq);
     try {
@@ -90,32 +98,9 @@ public class AutoOnboardPinotMetricsUtils {
         LOG.error("Schema {} not found, {}", dataset, schemaRes.getStatusLine().toString());
       } else {
         InputStream schemaContent = schemaRes.getEntity().getContent();
-        schema = new org.codehaus.jackson.map.ObjectMapper().readValue(schemaContent, Schema.class);
+        schema = CODEHAUS_OBJECT_MAPPER.readValue(schemaContent, Schema.class);
       }
 
-    } catch (Exception e) {
-      LOG.error("Exception in retrieving schema collections, skipping {}", dataset);
-    } finally {
-      if (schemaRes.getEntity() != null) {
-        EntityUtils.consume(schemaRes.getEntity());
-      }
-      schemaRes.close();
-    }
-    return schema;
-  }
-
-  private Schema getSchemaFromSchemaEndpoint(String dataset) throws IOException {
-    Schema schema = null;
-    HttpGet schemaReq = new HttpGet(String.format(PINOT_SCHEMA_ENDPOINT, URLEncoder.encode(dataset, UTF_8)));
-    LOG.info("Retrieving schema: {}", schemaReq);
-    CloseableHttpResponse schemaRes = pinotControllerClient.execute(pinotControllerHost, schemaReq);
-    try {
-      if (schemaRes.getStatusLine().getStatusCode() != 200) {
-        LOG.error("Schema {} not found, {}", dataset, schemaRes.getStatusLine().toString());
-      } else {
-        InputStream schemaContent = schemaRes.getEntity().getContent();
-        schema = new org.codehaus.jackson.map.ObjectMapper().readValue(schemaContent, Schema.class);
-      }
     } catch (Exception e) {
       LOG.error("Exception in retrieving schema collections, skipping {}", dataset);
     } finally {
@@ -134,5 +119,57 @@ public class AutoOnboardPinotMetricsUtils {
       isSchemaCorrect = false;
     }
     return isSchemaCorrect;
+  }
+
+  /**
+   * Returns the map of custom configs of the given dataset from the table config on Pinot.
+   *
+   * @param dataset the target dataset
+   *
+   * @return the field, which is a Map of string to string, of custom config on Pinot's table config
+   *
+   * @throws IOException if this method fails to connect to Pinot endpoint.
+   */
+  public Map<String, String> getCustomConfigsFromPinotEndpoint(String dataset) throws IOException {
+    HttpGet request = new HttpGet(String.format(PINOT_TABLES_ENDPOINT_TEMPLATE, dataset));
+    CloseableHttpResponse response = pinotControllerClient.execute(pinotControllerHost, request);
+    LOG.debug("Retrieving datasets' D2 name: {}", request);
+
+    // Retrieve table config
+    JsonNode tables = null;
+    try {
+      if (response.getStatusLine().getStatusCode() != 200) {
+        throw new IllegalStateException(response.getStatusLine().toString());
+      }
+      InputStream tablesContent = response.getEntity().getContent();
+      tables = OBJECT_MAPPER.readTree(tablesContent);
+    } catch (Exception e) {
+      LOG.error("Exception in loading dataset", e);
+    } finally {
+      if (response.getEntity() != null) {
+        EntityUtils.consume(response.getEntity());
+      }
+      response.close();
+    }
+
+    // Parse custom config
+    Map<String, String> customConfigs = Collections.emptyMap();
+    if (tables != null) {
+      JsonNode table = tables.get("REALTIME");
+      if (table == null || table.isNull()) {
+        table = tables.get("OFFLINE");
+      }
+      if (table != null && !table.isNull()) {
+        try {
+          JsonNode jsonNode = table.get("metadata").get("customConfigs");
+          customConfigs = OBJECT_MAPPER.convertValue(jsonNode, HashMap.class);
+        } catch (Exception e) {
+          LOG.error("Failed to get D2 name for dataset: {}. Reason: {}", dataset, e);
+        }
+      } else {
+        LOG.debug("Dataset {} doesn't exists in Pinot.", dataset);
+      }
+    }
+    return customConfigs;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsUtils.java
@@ -133,7 +133,7 @@ public class AutoOnboardPinotMetricsUtils {
   public Map<String, String> getCustomConfigsFromPinotEndpoint(String dataset) throws IOException {
     HttpGet request = new HttpGet(String.format(PINOT_TABLES_ENDPOINT_TEMPLATE, dataset));
     CloseableHttpResponse response = pinotControllerClient.execute(pinotControllerHost, request);
-    LOG.debug("Retrieving datasets' D2 name: {}", request);
+    LOG.debug("Retrieving dataset's custom config: {}", request);
 
     // Retrieve table config
     JsonNode tables = null;
@@ -144,7 +144,7 @@ public class AutoOnboardPinotMetricsUtils {
       InputStream tablesContent = response.getEntity().getContent();
       tables = OBJECT_MAPPER.readTree(tablesContent);
     } catch (Exception e) {
-      LOG.error("Exception in loading dataset", e);
+      LOG.error("Exception in loading dataset {}", dataset, e);
     } finally {
       if (response.getEntity() != null) {
         EntityUtils.consume(response.getEntity());
@@ -164,7 +164,7 @@ public class AutoOnboardPinotMetricsUtils {
           JsonNode jsonNode = table.get("metadata").get("customConfigs");
           customConfigs = OBJECT_MAPPER.convertValue(jsonNode, HashMap.class);
         } catch (Exception e) {
-          LOG.error("Failed to get D2 name for dataset: {}. Reason: {}", dataset, e);
+          LOG.warn("Failed to get custom config for dataset: {}. Reason: {}", dataset, e);
         }
       } else {
         LOG.debug("Dataset {} doesn't exists in Pinot.", dataset);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/ConfigGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/ConfigGenerator.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.auto.onboard;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import com.linkedin.pinot.common.data.MetricFieldSpec;
@@ -20,7 +21,8 @@ public class ConfigGenerator {
 
   private static final String PDT_TIMEZONE = "US/Pacific";
 
-  public static DatasetConfigDTO generateDatasetConfig(String dataset, Schema schema) {
+  public static DatasetConfigDTO generateDatasetConfig(String dataset, Schema schema,
+      Map<String, String> customConfigs) {
     List<String> dimensions = schema.getDimensionNames();
     TimeGranularitySpec timeSpec = schema.getTimeFieldSpec().getOutgoingGranularitySpec();
 
@@ -37,6 +39,7 @@ public class ConfigGenerator {
       datasetConfigDTO.setTimezone(PDT_TIMEZONE);
     }
     datasetConfigDTO.setDataSource(PinotThirdEyeDataSource.DATA_SOURCE_NAME);
+    datasetConfigDTO.setProperties(customConfigs);
     return datasetConfigDTO;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/DatasetConfigBean.java
@@ -7,7 +7,9 @@ import com.linkedin.thirdeye.completeness.checker.Wo4WAvgDataCompletenessAlgorit
 import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -72,6 +74,8 @@ public class DatasetConfigBean extends AbstractBean {
   private String dataCompletenessAlgorithm = DEFAULT_COMPLETENESS_ALGORITHM;
   // expected percentage completeness for dataset to be marked complete
   private double expectedCompleteness = Wo4WAvgDataCompletenessAlgorithm.DEFAULT_EXPECTED_COMPLETENESS;
+
+  private Map<String, String> properties = new HashMap<>();
 
 
   public String getDataset() {
@@ -244,6 +248,14 @@ public class DatasetConfigBean extends AbstractBean {
 
   public void setDataCompletenessAlgorithm(String dataCompletenessAlgorithm) {
     this.dataCompletenessAlgorithm = dataCompletenessAlgorithm;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, String> properties) {
+    this.properties = properties;
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsServiceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotMetricsServiceTest.java
@@ -13,7 +13,9 @@ import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.testng.Assert;
@@ -39,7 +41,10 @@ public class AutoOnboardPinotMetricsServiceTest {
     metricConfigDAO = daoRegistry.getMetricConfigDAO();
     testAutoLoadPinotMetricsService = new AutoOnboardPinotDataSource(null, null);
     schema = Schema.fromInputSteam(ClassLoader.getSystemResourceAsStream("sample-pinot-schema.json"));
-    testAutoLoadPinotMetricsService.addPinotDataset(dataset, schema, null);
+    Map<String, String> pinotCustomConfigs = new HashMap<>();
+    pinotCustomConfigs.put("configKey1", "configValue1");
+    pinotCustomConfigs.put("configKey2", "configValue2");
+    testAutoLoadPinotMetricsService.addPinotDataset(dataset, schema, pinotCustomConfigs, null);
   }
 
   @AfterMethod(alwaysRun = true)
@@ -76,15 +81,21 @@ public class AutoOnboardPinotMetricsServiceTest {
     DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(dataset);
     DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec("newDimension", DataType.STRING, true);
     schema.addField(dimensionFieldSpec);
-    testAutoLoadPinotMetricsService.addPinotDataset(dataset, schema, datasetConfig);
+    Map<String, String> pinotCustomConfigs = new HashMap<>();
+    pinotCustomConfigs.put("configKey1", "configValue1");
+    pinotCustomConfigs.put("configKey2", "configValue2");
+    testAutoLoadPinotMetricsService.addPinotDataset(dataset, schema, new HashMap<>(pinotCustomConfigs), datasetConfig);
     Assert.assertEquals(datasetConfigDAO.findAll().size(), 1);
     DatasetConfigDTO newDatasetConfig1 = datasetConfigDAO.findByDataset(dataset);
     Assert.assertEquals(newDatasetConfig1.getDataset(), dataset);
     Assert.assertEquals(Sets.newHashSet(newDatasetConfig1.getDimensions()), Sets.newHashSet(schema.getDimensionNames()));
+    Assert.assertEquals(newDatasetConfig1.getProperties(), pinotCustomConfigs);
 
     MetricFieldSpec metricFieldSpec = new MetricFieldSpec("newMetric", DataType.LONG);
     schema.addField(metricFieldSpec);
-    testAutoLoadPinotMetricsService.addPinotDataset(dataset, schema, newDatasetConfig1);
+    pinotCustomConfigs.put("configKey3", "configValue3");
+    pinotCustomConfigs.remove("configKey2");
+    testAutoLoadPinotMetricsService.addPinotDataset(dataset, schema, new HashMap<>(pinotCustomConfigs), newDatasetConfig1);
 
     Assert.assertEquals(datasetConfigDAO.findAll().size(), 1);
     List<MetricConfigDTO> metricConfigs = metricConfigDAO.findByDataset(dataset);
@@ -94,6 +105,16 @@ public class AutoOnboardPinotMetricsServiceTest {
     for (MetricConfigDTO metricConfig : metricConfigs) {
       Assert.assertTrue(schemaMetricNames.contains(metricConfig.getName()));
       metricIds.add(metricConfig.getId());
+    }
+
+    // Get the updated dataset config and check custom configs
+    datasetConfig = datasetConfigDAO.findByDataset(dataset);
+    Map<String, String> datasetCustomConfigs = datasetConfig.getProperties();
+    for (Map.Entry<String, String> pinotCustomCnofig : pinotCustomConfigs.entrySet()) {
+      String configKey = pinotCustomCnofig.getKey();
+      String configValue = pinotCustomCnofig.getValue();
+      Assert.assertTrue(datasetCustomConfigs.containsKey(configKey));
+      Assert.assertEquals(datasetCustomConfigs.get(configKey), configValue);
     }
   }
 }


### PR DESCRIPTION
Pinot stores addition configurations in table configs. Those configuration could provide the information regarding LinkedIn's Restli endpoint. In this PR, we start to import those configuration to provide more features for ThirdEye's Pinot client.

Test on local setups and new unit tests.