### PR TITLE
Ttbach/search filter component

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
@@ -62,6 +62,7 @@ export default Ember.Component.extend({
     onSubfilterSelection(selectedValue) {
       const { label, entities, onSelect, header, updateCache } = this.getProperties('label', 'entities', 'onSelect', 'header', 'updateCache');
       const labelMapping = findLabelMapping(label, this.get('config'));
+      debugger;
 
       this.set('selected', selectedValue);
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
@@ -42,11 +42,11 @@ export default Ember.Component.extend({
     'label',
     'attributesMap',
     function() {
-      const { label, attributesMap, config, header } = this.getProperties('label', 'attributesMap', 'config', 'header');
+      const { label, attributesMap, config, eventType } = this.getProperties('label', 'attributesMap', 'config', 'eventType');
       const labelMapping = findLabelMapping(label, config);
       let inputValues = '';
       if (!_.isEmpty(attributesMap) && labelMapping) {
-        inputValues = Array.from(attributesMap[header.toLowerCase()][labelMapping]);
+        inputValues = Array.from(attributesMap[eventType.toLowerCase()][labelMapping]);
       }
 
       return inputValues;
@@ -60,31 +60,18 @@ export default Ember.Component.extend({
      * @param {Array} selectedValue - selected value in the input
      */
     onSubfilterSelection(selectedValue) {
-      const { label, entities, onSelect, header, updateCache } = this.getProperties('label', 'entities', 'onSelect', 'header', 'updateCache');
+      const { label, filterUrns, eventType } = this.getProperties('label', 'filterUrns', 'eventType');
       const labelMapping = findLabelMapping(label, this.get('config'));
-      debugger;
 
+      // Saves the selected values in UI
       this.set('selected', selectedValue);
 
-      if (onSelect) {
-        let urns;
-        // If there are no filters, show all entities under that event type
-        if (!selectedValue.length) {
-          urns = Object.keys(entities).filter(urn => entities[urn].type == 'event'
-                                                    && entities[urn].eventType == header.toLowerCase());
-        } else {
-          urns = Object.keys(entities).filter(urn => {
-            if (entities[urn].attributes[labelMapping]) {
-              return selectedValue.some(value => entities[urn].attributes[labelMapping].includes(value));
-            }
-          });
-        }
-        // Call parent's onSelect() in the route controller to filter entities based on a list of urns
-        onSelect(urns);
+      const subFilter = {
+        key: labelMapping,
+        value: selectedValue
+      };
 
-        // Call parent's updateCache() in the filter bar component to update the urns cache
-        updateCache(header, urns);
-      }
+      filterUrns(eventType, subFilter);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -165,6 +165,7 @@ export default Ember.Component.extend({
   actions: {
 
     /**
+     * Filters results in the events table depending on a selected event type in the filter block
      * Expands/collapses a filter block
      * @method filterByEvent
      * @param {Object} clickedBlock - selected filter block object
@@ -185,7 +186,7 @@ export default Ember.Component.extend({
 
       /*
       * If results were already previously filtered for this filter block (i.e. "Holiday", "Deployment"),
-      * call onSelect on the cached urns
+      * call onSelect on the cached urns.
       */
       if (cachedHeader) {
         onSelect(cachedHeader);
@@ -194,7 +195,9 @@ export default Ember.Component.extend({
       else {
         const urns = Object.keys(entities).filter(urn => entities[urn].type == 'event'
                                                   && entities[urn].eventType == clickedBlock.eventType);
-        this.urnsCache[clickedBlock.header] = urns;
+        if (urns.length) {
+          this.urnsCache[clickedBlock.header] = urns;
+        }
         onSelect(urns);
       }
     },

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -28,17 +28,6 @@ export default Ember.Component.extend({
   options: ['All', 'None'],
 
   /**
-   * Cache for urns, filtered by search criteria
-   * @type {Object}
-   * @example
-   * {
-   *  Holiday: {urns1, urns2},
-   *  Region: {urns3, urns4}
-   * }
-   */
-  urnsCache: {},
-
-  /**
    * Overwrite the init function
    * Initializes values of the filter blocks
    * Example of a filter block:
@@ -171,8 +160,7 @@ export default Ember.Component.extend({
      * @param {Object} clickedBlock - selected filter block object
      */
     selectEventType(clickedBlock) {
-      const { entities, onSelect } = this.getProperties('entities', 'onSelect');
-      const cachedHeader = this.urnsCache[clickedBlock.header];
+      const filterUrns = this.get('filterUrns');
       let filterBlocks = this.get('config');
 
       // Hide all other blocks when one is clicked
@@ -184,22 +172,8 @@ export default Ember.Component.extend({
       // Show clickedBlock
       Ember.set(clickedBlock, 'isHidden', !clickedBlock.isHidden);
 
-      /*
-      * If results were already previously filtered for this filter block (i.e. "Holiday", "Deployment"),
-      * call onSelect on the cached urns.
-      */
-      if (cachedHeader) {
-        onSelect(cachedHeader);
-      }
-      // If this is the first time results are computed, cache them
-      else {
-        const urns = Object.keys(entities).filter(urn => entities[urn].type == 'event'
-                                                  && entities[urn].eventType == clickedBlock.eventType);
-        if (urns.length) {
-          this.urnsCache[clickedBlock.header] = urns;
-        }
-        onSelect(urns);
-      }
+      // Calls parent to filter urns by event type
+      filterUrns(clickedBlock.eventType);
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -28,6 +28,13 @@ export default Ember.Component.extend({
   options: ['All', 'None'],
 
   /**
+   * Currently active event type
+   * This is used for the rca-filter-search-bar
+   * @type {String}
+   */
+  activeEventType: '',
+
+  /**
    * Overwrite the init function
    * Initializes values of the filter blocks
    * Example of a filter block:
@@ -174,16 +181,9 @@ export default Ember.Component.extend({
 
       // Calls parent to filter urns by event type
       filterUrns(clickedBlock.eventType);
-    },
 
-    /**
-     * Bubbled up action, called by the child component, filter-bar-input component, to update the urns cache
-     * @method updateCache
-     * @param {String} header - name of filter block (i.e. "Holiday", "Deployment")
-     * @param {Array} urns - list of urns that are filtered based on subfilters (i.e. country, region)
-     */
-    updateCache(header, urns) {
-      this.urnsCache[header] = urns;
+      // Update the currently active block
+      this.set('activeEventType', clickedBlock.eventType);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -60,6 +60,7 @@ export default Ember.Component.extend({
     this._super(...arguments);
     // Fetch the config file to create sub-filters
     const filterBlocks = this.get('config');
+    debugger;
 
     // Set up filter block object
     filterBlocks.forEach((block, index) => {

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -60,7 +60,6 @@ export default Ember.Component.extend({
     this._super(...arguments);
     // Fetch the config file to create sub-filters
     const filterBlocks = this.get('config');
-    debugger;
 
     // Set up filter block object
     filterBlocks.forEach((block, index) => {
@@ -78,7 +77,8 @@ export default Ember.Component.extend({
       });
 
       // Now add new initialized props to block item
-      Object.assign(block, { filtersArray, isHidden });
+      Ember.set(block, 'filtersArray', filtersArray);
+      Ember.set(block, 'isHidden', isHidden);
     });
   },
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
@@ -1,5 +1,9 @@
 {{!-- TODO: Create separate styling for filter-bar component --}}
 <div class="entity-filter filter-bar">
+  {{rca-filter-search-bar
+    activeEventType=activeEventType
+    filterUrns=filterUrns}}
+
   {{#each config as |block|}}
     <section class="entity-filter__group">
       <h5 class="entity-filter__group-title">
@@ -17,8 +21,7 @@
             type=filter.type
             attributesMap=attributesMap
             entities=entities
-            filterUrns=filterUrns
-            updateCache=(action 'updateCache')}}
+            filterUrns=filterUrns}}
         {{/each}}
       </ul>
     </section>

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
@@ -11,13 +11,13 @@
       <ul class="entity-filter__group-list {{if block.isHidden " entity-filter__group-list--hidden "}}">
         {{#each block.inputs as |filter|}}
           {{filter-bar-input
-            header=block.header
+            eventType=block.eventType
             config=config
             label=filter.label
             type=filter.type
             attributesMap=attributesMap
             entities=entities
-            onSelect=onSelect
+            filterUrns=filterUrns
             updateCache=(action 'updateCache')}}
         {{/each}}
       </ul>

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
@@ -1,9 +1,9 @@
 {{!-- TODO: Create separate styling for filter-bar component --}}
-<div class="entity-filter filter-bar">
-  {{rca-filter-search-bar
-    activeEventType=activeEventType
-    filterUrns=filterUrns}}
+{{rca-filter-search-bar
+  activeEventType=activeEventType
+  filterUrns=filterUrns}}
 
+<div class="entity-filter filter-bar">
   {{#each config as |block|}}
     <section class="entity-filter__group">
       <h5 class="entity-filter__group-title">

--- a/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/component.js
@@ -15,11 +15,9 @@ export default Ember.Component.extend({
      * @method filterResults
      */
     filterResults() {
-      const { entities, onSelect } = this.getProperties('entities', 'onSelect');
+      const { activeEventType, filterUrns, value } = this.getProperties('activeEventType', 'filterUrns', 'value');
       this.set('value', this.get('value'));
-      debugger;
-      const urns = Object.keys(entities).filter(urn => entities[urn].label.includes(this.value.toLowerCase()));
-      onSelect(urns);
+      filterUrns(activeEventType, null, value);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/component.js
@@ -2,12 +2,21 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 
+  /**
+   * Value of the input
+   * @type {String}
+   */
   value: '',
 
   actions: {
+
+    /**
+     * Filters the results in the events table based on user input in the search bar
+     * @method filterResults
+     */
     filterResults() {
-      this.set('value', this.get('value'));
       const { entities, onSelect } = this.getProperties('entities', 'onSelect');
+      this.set('value', this.get('value'));
       debugger;
       const urns = Object.keys(entities).filter(urn => entities[urn].label.includes(this.value.toLowerCase()));
       onSelect(urns);

--- a/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/component.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  value: '',
+
+  actions: {
+    filterResults() {
+      this.set('value', this.get('value'));
+      const { entities, onSelect } = this.getProperties('entities', 'onSelect');
+      debugger;
+      const urns = Object.keys(entities).filter(urn => entities[urn].label.includes(this.value.toLowerCase()));
+      onSelect(urns);
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/template.hbs
@@ -2,5 +2,4 @@
 {{input
   value=value
   placeholder="Filter the results in the table"
-  key-up=(action "filterResults")
-  change=(action "filterResults")}}
+  key-up=(action "filterResults")}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/template.hbs
@@ -2,4 +2,5 @@
 {{input
   value=value
   placeholder="Filter the results in the table"
-  key-up=(action "filterResults")}}
+  key-up=(action "filterResults")
+  filterUrns=filterUrns}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rca-filter-search-bar/template.hbs
@@ -1,0 +1,6 @@
+<p>SEARCH BAR</p>
+{{input
+  value=value
+  placeholder="Filter the results in the table"
+  key-up=(action "filterResults")
+  change=(action "filterResults")}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-table/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-table/template.hbs
@@ -1,3 +1,7 @@
+{{rca-filter-search-bar
+  entities=entities
+  onSelect=onSelect}}
+
 {{models-table
   data=data
   columns=columns

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-table/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-table/template.hbs
@@ -1,7 +1,3 @@
-{{rca-filter-search-bar
-  entities=entities
-  onSelect=onSelect}}
-
 {{models-table
   data=data
   columns=columns

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -397,7 +397,7 @@ export default Ember.Controller.extend({
       }
 
       // Reset filtered urns
-      this.send('filterOnSelect', urns);
+      this.send('onFilter', urns);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -362,17 +362,23 @@ export default Ember.Controller.extend({
       let urns;
       const cachedEvent = this.urnsCache[eventType];
       const filtersCache = this.filtersCache;
+      const entities = this.get('eventFilterEntities');
 
       this.send('updateFiltersCache', eventType, subFilter, text);
 
       if (!_.isEmpty(cachedEvent) && !subFilter) {
         urns = cachedEvent;
+        if (text) {
+          urns = urns.filter(urn => entities[urn].label.includes(text ? text.toLowerCase() : ''));
+        }
       } else {
-        const entities = this.get('eventFilterEntities');
-        urns = Object.keys(entities).filter(urn => entities[urn].eventType == eventType);
-
         const subFilters = filtersCache[eventType].subFilters;
 
+        // Filter by event type
+        urns = Object.keys(entities).filter(urn => entities[urn].eventType == eventType
+                                                  && entities[urn].label.includes(text ? text.toLowerCase() : ''));
+
+        // Filter by subfilters
         if (!_.isEmpty(subFilters)) {
           urns = urns.filter(urn => {
             let labels = Object.keys(subFilters);
@@ -389,22 +395,6 @@ export default Ember.Controller.extend({
           });
         }
 
-                                      //     // if (entities[urn].attributes[labelMapping]) {
-                                      //     //   return Object.keys(subFilters).filter(filter => {
-                                      //     //     return subFilters[filter]
-                                      //     //             .some(value => entities[urn].attributes[labelMapping]
-                                      //     //               .includes(value));
-                                      //     //   });
-                                      //     // }
-                                      //   }
-                                      // });
-                                      // // Filter by input from filter search bar
-                                      // .filter(urn => {
-                                      //   const filterText = filtersCache[eventType].filterText;
-                                      //   if (filterText) {
-                                      //     return entities[urn].label.includes(filterText);
-                                      //   }
-                                      // });
       }
 
       this.send('filterOnSelect', urns);

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -139,7 +139,6 @@ export default Ember.Controller.extend({
     function () {
       console.log('eventTableEntities()');
       const { entities, filteredUrns } = this.getProperties('entities', 'filteredUrns');
-      console.log("EVENT TABLE ENTITIES: ", filterObject(entities, (e) => filteredUrns.has(e.urn)));
       return filterObject(entities, (e) => filteredUrns.has(e.urn));
     }
   ),
@@ -152,7 +151,6 @@ export default Ember.Controller.extend({
       console.log('eventFilterEntities()');
       const { entities } = this.getProperties('entities');
       console.log("printing entities: ", entities);
-      console.log("EVENT FILTER ENTITIES: ", filterObject(entities, (e) => e.type == 'event'));
       return filterObject(entities, (e) => e.type == 'event');
     }
   ),
@@ -322,7 +320,7 @@ export default Ember.Controller.extend({
      * @param {Object} subFilter - representation of subfilter and its values (i.e. {key: "country", value: ["US"]})
      */
     updateFiltersCache(eventType, subFilter) {
-      // Initialize object assignments in the cache
+      // Initialize objects before assignment in the cache
       if (!this.filtersCache[eventType]) {
         this.filtersCache[eventType] = {};
       }
@@ -361,6 +359,7 @@ export default Ember.Controller.extend({
       const filtersCache = this.filtersCache;
       const entities = this.get('eventFilterEntities');
 
+      // Updates the filters cache with new filters
       this.send('updateFiltersCache', eventType, subFilter);
 
       // If the event is cached and there are no new subfilters selected
@@ -399,7 +398,6 @@ export default Ember.Controller.extend({
 
       // Reset filtered urns
       this.send('filterOnSelect', urns);
-
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -65,9 +65,10 @@
     <div class="col-xs-3">
       {{filter-bar
         config=config
+        urnsCache=urnsCache
         activeTab=selectedTab
         entities=eventFilterEntities
-        onSelect=(action "filterOnSelect")}}
+        filterUrns=(action "filterUrns")}}
     </div>
     <div class="col-xs-8">
       {{rootcause-table

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -64,16 +64,17 @@
   <div class="row">
     <div class="col-xs-3">
       {{filter-bar
-        config=filterConfig
+        config=config
         activeTab=selectedTab
         entities=eventFilterEntities
-        onSelect=(action "onFilter")}}
+        onSelect=(action "filterOnSelect")}}
     </div>
     <div class="col-xs-8">
       {{rootcause-table
         entities=eventTableEntities
         columns=eventTableColumns
         selectedUrns=selectedUrns
+        onSelect=(action "filterOnSelect")
         onSelection=(action "onSelection")
       }}
     </div>

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -75,7 +75,7 @@
         entities=eventTableEntities
         columns=eventTableColumns
         selectedUrns=selectedUrns
-        onSelect=(action "filterOnSelect")
+        filterUrns=(action "filterUrns")
         onSelection=(action "onSelection")
       }}
     </div>

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -63,8 +63,9 @@
   <h3>Events</h3>
   <div class="row">
     <div class="col-xs-3">
+      Filter Bar
       {{filter-bar
-        config=config
+        config=filterConfig
         urnsCache=urnsCache
         activeTab=selectedTab
         entities=eventFilterEntities

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/rca-filter-search-bar/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/rca-filter-search-bar/component-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('rca-filter-search-bar', 'Integration | Component | rca filter search bar', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{rca-filter-search-bar}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#rca-filter-search-bar}}
+      template block text
+    {{/rca-filter-search-bar}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
- Created search filter bar component to filter results in the events table
- Moved caching to rootcause controller (filters cache and urns cache)
- Moved filtering logic from child component to rootcause controller. TLDR; This is because in order for search filter bar to work, it needed a reference to all the filters that were selected from both the `filter-bar` and the `filter-bar-input`. For more explanation, see below:
- Before, I had the logic for filtering entities by event type in `filter-bar` and filtering by subfilters (i.e. country) in the `filter-bar-input`, both of which compute the urns and send an action with urns up to the controller that resets the `filteredUrns` and changes how entities are displayed. However, since the `filter-search-bar` needs to know what filters were previously applied (for event type and subfilters), I thought a better way to do this is to have the controller keep track of all filters and process the filtering logic in the controller, so the sub-filtering-components (filter-bar, filter-bar-input, and search-filter-bar) just need to worry about calling an action that bubbles up to update the filters.
- Minor bug: switching between tabs don't clear the input text in the `search-filter-bar`. For example, if i type "abc" into the search bar when I'm on the `Holiday` tab, it filters the `Holiday` events' labels by "abc." However, when I switch to the `Anomalies` tab, the search bar still has "abc", but does not filter the results based on "abc". Otherwise, it functions.

<img width="1223" alt="screen shot 2017-11-16 at 11 05 05 pm" src="https://user-images.githubusercontent.com/6884406/32928937-c1ab36bc-cb22-11e7-9992-7341a0dfeb5c.png">
