### PR TITLE
[TE] Add try-and-catch block to protect the initialization of cache loader.

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -111,7 +111,16 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     } else {
       cacheLoaderClassName = PinotControllerResponseCacheLoader.class.getName();
     }
-    Constructor<?> constructor = Class.forName(cacheLoaderClassName).getConstructor();
+    LOG.info("Constructing cache loader: {}", cacheLoaderClassName);
+    Class<?> aClass = null;
+    try {
+      aClass = Class.forName(cacheLoaderClassName);
+    } catch (Throwable throwable) {
+      LOG.error("Failed to initiate cache loader: {}; reason:", cacheLoaderClassName, throwable);
+      aClass = PinotControllerResponseCacheLoader.class;
+    }
+    LOG.info("Initiating cache loader: {}", aClass.getName());
+    Constructor<?> constructor = aClass.getConstructor();
     PinotResponseCacheLoader pinotResponseCacheLoader = (PinotResponseCacheLoader) constructor.newInstance();
     return pinotResponseCacheLoader;
   }


### PR DESCRIPTION
Add protections when initializing Pinot cache loader. It falls back to the default class: PinotControllerResponseCacheLoader, if the external cache loader is unable to be initialized.