### PR TITLE
Remove the API open() and close() in Operator

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/Operator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/Operator.java
@@ -19,21 +19,15 @@ import com.linkedin.pinot.core.operator.ExecutionStatistics;
 
 
 public interface Operator<T extends Block> {
-  /*
-   * allows the operator to set up/initialize processing
-   */
-  boolean open();
 
   /**
-   * Get the next non empty block, if there are additional predicates the
-   * operator is responsible to apply the predicate and return the block that
-   * has atleast one doc that satisfies the predicate
-   *
-   * @return
+   * Get the next {@link Block}.
+   * <p>For filter operator and operators above projection phase (aggregation, selection, combine etc.), method should
+   * only be called once, and will return a non-null block.
+   * <p>For operators in projection phase (docIdSet, projection, transformExpression), method can be called multiple
+   * times, and will return non-empty block or null if no more documents available</p>
    */
   T nextBlock();
-
-  boolean close();
 
   ExecutionStatistics getExecutionStatistics();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BReusableFilteredDocIdSetOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/BReusableFilteredDocIdSetOperator.java
@@ -59,12 +59,6 @@ public class BReusableFilteredDocIdSetOperator extends BaseOperator<DocIdSetBloc
   }
 
   @Override
-  public boolean open() {
-    _filterOperator.open();
-    return true;
-  }
-
-  @Override
   protected DocIdSetBlock getNextBlock() {
     // Handle limit 0 clause safely.
     // For limit 0, _docIdArray will be zero sized
@@ -95,12 +89,6 @@ public class BReusableFilteredDocIdSetOperator extends BaseOperator<DocIdSetBloc
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    _filterOperator.close();
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineGroupByOperator.java
@@ -90,20 +90,6 @@ public class MCombineGroupByOperator extends BaseOperator<IntermediateResultsBlo
 
   /**
    * {@inheritDoc}
-   * Calls 'open' on all the underlying operators.
-   *
-   * @return
-   */
-  @Override
-  public boolean open() {
-    for (Operator operator : _operators) {
-      operator.open();
-    }
-    return true;
-  }
-
-  /**
-   * {@inheritDoc}
    * Builds and returns a block containing result of combine:
    * - Group-by blocks from underlying operators are merged.
    * - Merged results are sorted and trimmed (for 'TOP N').
@@ -256,13 +242,5 @@ public class MCombineGroupByOperator extends BaseOperator<IntermediateResultsBlo
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    for (Operator operator : _operators) {
-      operator.close();
-    }
-    return true;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MCombineOperator.java
@@ -69,14 +69,6 @@ public class MCombineOperator extends BaseOperator<IntermediateResultsBlock> {
   }
 
   @Override
-  public boolean open() {
-    for (Operator op : _operators) {
-      op.open();
-    }
-    return true;
-  }
-
-  @Override
   protected IntermediateResultsBlock getNextBlock() {
     final long startTime = System.currentTimeMillis();
     final long queryEndTime = System.currentTimeMillis() + _timeOutMs;
@@ -202,13 +194,5 @@ public class MCombineOperator extends BaseOperator<IntermediateResultsBlock> {
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    for (Operator op : _operators) {
-      op.close();
-    }
-    return true;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MProjectionOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/MProjectionOperator.java
@@ -48,24 +48,6 @@ public class MProjectionOperator extends BaseOperator<ProjectionBlock> {
   }
 
   @Override
-  public boolean open() {
-    for (final String column : _columnToDataSourceMap.keySet()) {
-      _columnToDataSourceMap.get(column).open();
-    }
-    _docIdSetOperator.open();
-    return true;
-  }
-
-  @Override
-  public boolean close() {
-    for (final String column : _columnToDataSourceMap.keySet()) {
-      _columnToDataSourceMap.get(column).close();
-    }
-    _docIdSetOperator.close();
-    return true;
-  }
-
-  @Override
   protected ProjectionBlock getNextBlock() {
     DocIdSetBlock docIdSetBlock = _docIdSetOperator.nextBlock();
     if (docIdSetBlock == null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/UResultOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/UResultOperator.java
@@ -34,12 +34,6 @@ public class UResultOperator extends BaseOperator<InstanceResponseBlock> {
   }
 
   @Override
-  public boolean open() {
-    _operator.open();
-    return true;
-  }
-
-  @Override
   protected InstanceResponseBlock getNextBlock() {
     return new InstanceResponseBlock(_operator.nextBlock());
   }
@@ -47,11 +41,5 @@ public class UResultOperator extends BaseOperator<InstanceResponseBlock> {
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    _operator.close();
-    return true;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/AndOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/AndOperator.java
@@ -35,14 +35,6 @@ public class AndOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    for (Operator operator : operators) {
-      operator.open();
-    }
-    return true;
-  }
-
-  @Override
   protected BaseFilterBlock getNextBlock() {
     List<FilterBlockDocIdSet> blockDocIdSets = new ArrayList<FilterBlockDocIdSet>();
     for (Operator operator : operators) {
@@ -62,14 +54,6 @@ public class AndOperator extends BaseFilterOperator {
       }
     }
     return false;
-  }
-
-  @Override
-  public boolean close() {
-    for (Operator operator : operators) {
-      operator.close();
-    }
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BitmapBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/BitmapBasedFilterOperator.java
@@ -58,11 +58,6 @@ public class BitmapBasedFilterOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    return _dataSource.open();
-  }
-
-  @Override
   protected BaseFilterBlock getNextBlock() {
     if (_bitmaps != null) {
       return new BitmapBlock(_bitmaps, _startDocId, _endDocId, _exclusive);
@@ -94,11 +89,6 @@ public class BitmapBasedFilterOperator extends BaseFilterOperator {
   @Override
   public boolean isResultEmpty() {
     return _predicateEvaluator != null && _predicateEvaluator.isAlwaysFalse();
-  }
-
-  @Override
-  public boolean close() {
-    return _dataSource.close();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/EmptyFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/EmptyFilterOperator.java
@@ -34,22 +34,12 @@ public final class EmptyFilterOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    return true;
-  }
-
-  @Override
   protected BaseFilterBlock getNextBlock() {
     return EmptyFilterBlock.getInstance();
   }
 
   @Override
   public boolean isResultEmpty() {
-    return true;
-  }
-
-  @Override
-  public boolean close() {
     return true;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/MatchEntireSegmentOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/MatchEntireSegmentOperator.java
@@ -28,16 +28,6 @@ public class MatchEntireSegmentOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    return true;
-  }
-
-  @Override
-  public boolean close() {
-    return true;
-  }
-
-  @Override
   protected BaseFilterBlock getNextBlock() {
     return new MatchEntireSegmentDocIdSetBlock(_totalDocs);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/OrOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/OrOperator.java
@@ -35,14 +35,6 @@ public class OrOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    for (Operator operator : operators) {
-      operator.open();
-    }
-    return true;
-  }
-
-  @Override
   protected BaseFilterBlock getNextBlock() {
     List<FilterBlockDocIdSet> blockDocIdSets = new ArrayList<>();
     for (Operator operator : operators) {
@@ -60,14 +52,6 @@ public class OrOperator extends BaseFilterOperator {
       if (!operator.isResultEmpty()) {
         return false;
       }
-    }
-    return true;
-  }
-
-  @Override
-  public boolean close() {
-    for (Operator operator : operators) {
-      operator.close();
     }
     return true;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -47,11 +47,6 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    return _dataSource.open();
-  }
-
-  @Override
   protected BaseFilterBlock getNextBlock() {
     DataSourceMetadata dataSourceMetadata = _dataSource.getDataSourceMetadata();
     FilterBlockDocIdSet docIdSet;
@@ -74,11 +69,6 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
   @Override
   public boolean isResultEmpty() {
     return _predicateEvaluator.isAlwaysFalse();
-  }
-
-  @Override
-  public boolean close() {
-    return _dataSource.close();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/SortedInvertedIndexBasedFilterOperator.java
@@ -49,11 +49,6 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    return _dataSource.open();
-  }
-
-  @Override
   protected BaseFilterBlock getNextBlock() {
     SortedIndexReader invertedIndex = (SortedIndexReader) _dataSource.getInvertedIndex();
     List<IntPair> pairs = new ArrayList<>();
@@ -158,11 +153,6 @@ public class SortedInvertedIndexBasedFilterOperator extends BaseFilterOperator {
   @Override
   public boolean isResultEmpty() {
     return _predicateEvaluator.isAlwaysFalse();
-  }
-
-  @Override
-  public boolean close() {
-    return _dataSource.close();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/StarTreeIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/StarTreeIndexBasedFilterOperator.java
@@ -192,11 +192,6 @@ public class StarTreeIndexBasedFilterOperator extends BaseFilterOperator {
   }
 
   @Override
-  public boolean open() {
-    return true;
-  }
-
-  @Override
   public BaseFilterBlock getNextBlock() {
     if (_resultEmpty) {
       return EmptyFilterBlock.getInstance();
@@ -215,11 +210,6 @@ public class StarTreeIndexBasedFilterOperator extends BaseFilterOperator {
   @Override
   public boolean isResultEmpty() {
     return _resultEmpty;
-  }
-
-  @Override
-  public boolean close() {
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationGroupByOperator.java
@@ -53,12 +53,6 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
   }
 
   @Override
-  public boolean open() {
-    _transformOperator.open();
-    return true;
-  }
-
-  @Override
   protected IntermediateResultsBlock getNextBlock() {
     int numDocsScanned = 0;
 
@@ -88,12 +82,6 @@ public class AggregationGroupByOperator extends BaseOperator<IntermediateResults
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    _transformOperator.close();
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/AggregationOperator.java
@@ -45,12 +45,6 @@ public class AggregationOperator extends BaseOperator<IntermediateResultsBlock> 
   }
 
   @Override
-  public boolean open() {
-    _transformOperator.open();
-    return true;
-  }
-
-  @Override
   protected IntermediateResultsBlock getNextBlock() {
     int numDocsScanned = 0;
 
@@ -78,12 +72,6 @@ public class AggregationOperator extends BaseOperator<IntermediateResultsBlock> 
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    _transformOperator.close();
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOnlyOperator.java
@@ -63,12 +63,6 @@ public class MSelectionOnlyOperator extends BaseOperator<IntermediateResultsBloc
   }
 
   @Override
-  public boolean open() {
-    _projectionOperator.open();
-    return true;
-  }
-
-  @Override
   protected IntermediateResultsBlock getNextBlock() {
     int numDocsScanned = 0;
 
@@ -104,12 +98,6 @@ public class MSelectionOnlyOperator extends BaseOperator<IntermediateResultsBloc
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    _projectionOperator.close();
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MSelectionOrderByOperator.java
@@ -76,12 +76,6 @@ public class MSelectionOrderByOperator extends BaseOperator<IntermediateResultsB
   }
 
   @Override
-  public boolean open() {
-    _projectionOperator.open();
-    return true;
-  }
-
-  @Override
   protected IntermediateResultsBlock getNextBlock() {
     int numDocsScanned = 0;
 
@@ -109,12 +103,6 @@ public class MSelectionOrderByOperator extends BaseOperator<IntermediateResultsB
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    _projectionOperator.close();
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
@@ -58,14 +58,6 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
   }
 
   @Override
-  public boolean open() {
-    for (BaseOperator operator : _dataSourceMap.values()) {
-      operator.open();
-    }
-    return true;
-  }
-
-  @Override
   protected IntermediateResultsBlock getNextBlock() {
     int numAggregationFunctions = _aggregationFunctionContexts.length;
     List<Object> aggregationResults = new ArrayList<>(numAggregationFunctions);
@@ -102,14 +94,6 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
-  }
-
-  @Override
-  public boolean close() {
-    for (BaseOperator operator : _dataSourceMap.values()) {
-      operator.close();
-    }
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformExpressionOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformExpressionOperator.java
@@ -69,16 +69,6 @@ public class TransformExpressionOperator extends BaseOperator<TransformBlock> {
   }
 
   @Override
-  public boolean open() {
-    return _projectionOperator.open();
-  }
-
-  @Override
-  public boolean close() {
-    return _projectionOperator.close();
-  }
-
-  @Override
   public ExecutionStatistics getExecutionStatistics() {
     return _projectionOperator.getExecutionStatistics();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/GlobalPlanImplV0.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/GlobalPlanImplV0.java
@@ -27,45 +27,29 @@ import org.slf4j.LoggerFactory;
  *
  *
  */
-public class GlobalPlanImplV0 extends Plan {
+public class GlobalPlanImplV0 implements Plan {
   private static final Logger LOGGER = LoggerFactory.getLogger(GlobalPlanImplV0.class);
 
-  private InstanceResponsePlanNode _rootNode;
-  private DataTable _instanceResponseDataTable;
+  private final InstanceResponsePlanNode _instanceResponsePlanNode;
 
-  public GlobalPlanImplV0(InstanceResponsePlanNode rootNode) {
-    _rootNode = rootNode;
+  public GlobalPlanImplV0(InstanceResponsePlanNode instanceResponsePlanNode) {
+    _instanceResponsePlanNode = instanceResponsePlanNode;
+  }
+
+  @Override
+  public DataTable execute() {
+    long startTime = System.currentTimeMillis();
+    UResultOperator uResultOperator = _instanceResponsePlanNode.run();
+    long endTime1 = System.currentTimeMillis();
+    LOGGER.debug("InstanceResponsePlanNode.run() took: {}ms", endTime1 - startTime);
+    InstanceResponseBlock instanceResponseBlock = uResultOperator.nextBlock();
+    long endTime2 = System.currentTimeMillis();
+    LOGGER.debug("UResultOperator.nextBlock() took: {}ms", endTime2 - endTime1);
+    return instanceResponseBlock.getInstanceResponseDataTable();
   }
 
   @Override
   public void print() {
-    _rootNode.showTree("");
-  }
-
-  @Override
-  public PlanNode getRoot() {
-    return _rootNode;
-  }
-
-  @Override
-  public void execute() {
-    long startTime = System.currentTimeMillis();
-    PlanNode root = getRoot();
-    UResultOperator operator = (UResultOperator) root.run();
-    try {
-      long endTime1 = System.currentTimeMillis();
-      LOGGER.debug("InstanceResponsePlanNode.run took:{}", (endTime1 - startTime));
-      InstanceResponseBlock instanceResponseBlock = (InstanceResponseBlock) operator.nextBlock();
-      long endTime2 = System.currentTimeMillis();
-      LOGGER.debug("UResultOperator took :{}", (endTime2 - endTime1));
-      _instanceResponseDataTable = instanceResponseBlock.getInstanceResponseDataTable();
-    } finally {
-      operator.close();
-    }
-  }
-
-  @Override
-  public DataTable getInstanceResponse() {
-    return _instanceResponseDataTable;
+    _instanceResponsePlanNode.showTree("");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/InstanceResponsePlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/InstanceResponsePlanNode.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.plan;
 
-import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.operator.UResultOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +33,7 @@ public class InstanceResponsePlanNode implements PlanNode {
   }
 
   @Override
-  public Operator run() {
+  public UResultOperator run() {
     long start = System.currentTimeMillis();
     UResultOperator uResultOperator = new UResultOperator(_combinePlanNode.run());
     long end = System.currentTimeMillis();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/Plan.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/Plan.java
@@ -18,18 +18,18 @@ package com.linkedin.pinot.core.plan;
 import com.linkedin.pinot.common.utils.DataTable;
 
 
-public abstract class Plan {
-
-  public abstract void print();
+/**
+ * Instance level query plan.
+ */
+public interface Plan {
 
   /**
-   * Root node of the plan
-   *
-   * @return
+   * Execute the query plan and get the instance response.
    */
-  public abstract PlanNode getRoot();
+  DataTable execute();
 
-  public abstract void execute();
-
-  public abstract DataTable getInstanceResponse();
+  /**
+   * Print the query plan (for debugging only).
+   */
+  void print();
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -140,10 +140,9 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
         }
 
         TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
-        globalQueryPlan.execute();
+        dataTable = globalQueryPlan.execute();
         planExecTimer.stopAndRecord();
 
-        dataTable = globalQueryPlan.getInstanceResponse();
         // Update the total docs in the metadata based on un-pruned segments.
         dataTable.getMetadata().put(DataTable.TOTAL_DOCS_METADATA_KEY, Long.toString(totalRawDocs));
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSource.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/data/source/ColumnDataSource.java
@@ -151,14 +151,4 @@ public final class ColumnDataSource extends DataSource {
   public String getOperatorName() {
     return _operatorName;
   }
-
-  @Override
-  public boolean open() {
-    return true;
-  }
-
-  @Override
-  public boolean close() {
-    return true;
-  }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/SumStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/SumStarTreeIndexTest.java
@@ -69,7 +69,6 @@ public class SumStarTreeIndexTest extends BaseStarTreeIndexTest {
 
   @Override
   protected Map<List<Integer>, List<Double>> compute(Operator filterOperator) {
-    filterOperator.open();
     BlockDocIdIterator docIdIterator = filterOperator.nextBlock().getBlockDocIdSet().iterator();
 
     Map<List<Integer>, List<Double>> results = new HashMap<>();
@@ -96,7 +95,6 @@ public class SumStarTreeIndexTest extends BaseStarTreeIndexTest {
         sums.set(i, sums.get(i) + _metricDictionaries[i].getDoubleValue(dictId));
       }
     }
-    filterOperator.close();
 
     return results;
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllStarTreeIndexTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/HllStarTreeIndexTest.java
@@ -84,7 +84,6 @@ public class HllStarTreeIndexTest extends BaseStarTreeIndexTest {
 
   @Override
   protected Map<List<Integer>, List<Double>> compute(Operator filterOperator) throws Exception {
-    filterOperator.open();
     BlockDocIdIterator docIdIterator = filterOperator.nextBlock().getBlockDocIdSet().iterator();
 
     Map<List<Integer>, List<HyperLogLog>> intermediateResults = new HashMap<>();
@@ -113,7 +112,6 @@ public class HllStarTreeIndexTest extends BaseStarTreeIndexTest {
         hyperLogLogs.set(i, hyperLogLog);
       }
     }
-    filterOperator.close();
 
     // Compute the final result
     Map<List<Integer>, List<Double>> finalResults = new HashMap<>();

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/AndOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/AndOperatorTest.java
@@ -38,12 +38,10 @@ public class AndOperatorTest {
     operators.add(FilterOperatorTestUtils.makeFilterOperator(docIds2));
     AndOperator andOperator = new AndOperator(operators);
 
-    andOperator.open();
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 3);
     Assert.assertEquals(iterator.next(), 28);
     Assert.assertEquals(iterator.next(), Constants.EOF);
-    andOperator.close();
   }
 
   @Test
@@ -58,12 +56,10 @@ public class AndOperatorTest {
     operators.add(FilterOperatorTestUtils.makeFilterOperator(docIds3));
     AndOperator andOperator = new AndOperator(operators);
 
-    andOperator.open();
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 3);
     Assert.assertEquals(iterator.next(), 6);
     Assert.assertEquals(iterator.next(), Constants.EOF);
-    andOperator.close();
   }
 
   @Test
@@ -82,12 +78,10 @@ public class AndOperatorTest {
     operators.add(FilterOperatorTestUtils.makeFilterOperator(docIds3));
     AndOperator andOperator = new AndOperator(operators);
 
-    andOperator.open();
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 3);
     Assert.assertEquals(iterator.next(), 6);
     Assert.assertEquals(iterator.next(), Constants.EOF);
-    andOperator.close();
   }
 
   @Test
@@ -106,13 +100,11 @@ public class AndOperatorTest {
     operators.add(FilterOperatorTestUtils.makeFilterOperator(docIds1));
     AndOperator andOperator = new AndOperator(operators);
 
-    andOperator.open();
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 2);
     Assert.assertEquals(iterator.next(), 3);
     Assert.assertEquals(iterator.next(), 6);
     Assert.assertEquals(iterator.next(), 28);
     Assert.assertEquals(iterator.next(), Constants.EOF);
-    andOperator.close();
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/FilterOperatorTestUtils.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/FilterOperatorTestUtils.java
@@ -85,16 +85,6 @@ public class FilterOperatorTestUtils {
       public String getOperatorName() {
         return null;
       }
-
-      @Override
-      public boolean open() {
-        return true;
-      }
-
-      @Override
-      public boolean close() {
-        return true;
-      }
     };
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/OrOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/operator/filter/OrOperatorTest.java
@@ -45,13 +45,11 @@ public class OrOperatorTest {
     operators.add(FilterOperatorTestUtils.makeFilterOperator(docIds2));
     OrOperator orOperator = new OrOperator(operators);
 
-    orOperator.open();
     BlockDocIdIterator iterator = orOperator.nextBlock().getBlockDocIdSet().iterator();
     int docId;
     while ((docId = iterator.next()) != Constants.EOF) {
       Assert.assertEquals(docId, expectedIterator.next().intValue());
     }
-    orOperator.close();
   }
 
   @Test
@@ -71,13 +69,11 @@ public class OrOperatorTest {
     operators.add(FilterOperatorTestUtils.makeFilterOperator(docIds3));
     OrOperator orOperator = new OrOperator(operators);
 
-    orOperator.open();
     BlockDocIdIterator iterator = orOperator.nextBlock().getBlockDocIdSet().iterator();
     int docId;
     while ((docId = iterator.next()) != Constants.EOF) {
       Assert.assertEquals(docId, expectedIterator.next().intValue());
     }
-    orOperator.close();
   }
 
   @Test
@@ -101,12 +97,10 @@ public class OrOperatorTest {
     operators.add(FilterOperatorTestUtils.makeFilterOperator(docIds3));
     OrOperator orOperator = new OrOperator(operators);
 
-    orOperator.open();
     BlockDocIdIterator iterator = orOperator.nextBlock().getBlockDocIdSet().iterator();
     int docId;
     while ((docId = iterator.next()) != Constants.EOF) {
       Assert.assertEquals(docId, expectedIterator.next().intValue());
     }
-    orOperator.close();
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/BaseQueriesTest.java
@@ -84,8 +84,7 @@ public abstract class BaseQueriesTest {
 
     // Server side.
     Plan plan = PLAN_MAKER.makeInterSegmentPlan(getSegmentDataManagers(), brokerRequest, EXECUTOR_SERVICE, 10_000);
-    plan.execute();
-    DataTable instanceResponse = plan.getInstanceResponse();
+    DataTable instanceResponse = plan.execute();
 
     // Broker side.
     BrokerReduceService brokerReduceService = new BrokerReduceService();

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/transform/TransformExpressionOperatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/transform/TransformExpressionOperatorTest.java
@@ -133,12 +133,9 @@ public class TransformExpressionOperatorTest {
 
     TransformExpressionOperator transformOperator =
         new TransformExpressionOperator(projectionOperator, expressionTrees);
-    transformOperator.open();
     TransformBlock transformBlock = transformOperator.nextBlock();
     BlockValSet blockValueSet = transformBlock.getBlockValueSet(expression);
-    double[] actual = blockValueSet.getDoubleValuesSV();
-    transformOperator.close();
-    return actual;
+    return blockValueSet.getDoubleValuesSV();
   }
 
   /**

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/FilterOperatorBenchmark.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/FilterOperatorBenchmark.java
@@ -126,7 +126,6 @@ public class FilterOperatorBenchmark {
       start = System.currentTimeMillis();
       FilterPlanNode planNode = new FilterPlanNode(indexSegmentImpl, brokerRequest);
       Operator filterOperator = planNode.run();
-      filterOperator.open();
       Block block = filterOperator.nextBlock();
       BlockDocIdSet filteredDocIdSet = block.getBlockDocIdSet();
       BlockDocIdIterator iterator = filteredDocIdSet.iterator();
@@ -152,7 +151,6 @@ public class FilterOperatorBenchmark {
 
       end = System.currentTimeMillis();
       timesSpent[id] = (end - start);
-      filterOperator.close();
       totalDocsMatched.addAndGet(matchedCount);
       return null;
     }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/SegmentDumpTool.java
@@ -70,7 +70,6 @@ public class SegmentDumpTool {
 
     for (String columnName : columnNames) {
       DataSource dataSource = indexSegment.getDataSource(columnName);
-      dataSource.open();
       Block block = dataSource.nextBlock();
       BlockValSet blockValSet = block.getBlockValueSet();
       BlockSingleValIterator itr = (BlockSingleValIterator) blockValSet.iterator();

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/StarTreeIndexViewer.java
@@ -100,7 +100,6 @@ public class StarTreeIndexViewer {
 
     for (String columnName : metadata.getAllColumns()) {
       DataSource dataSource = indexSegment.getDataSource(columnName);
-      dataSource.open();
       Block block = dataSource.nextBlock();
       BlockValSet blockValSet = block.getBlockValueSet();
       BlockSingleValIterator itr = (BlockSingleValIterator) blockValSet.iterator();


### PR DESCRIPTION
We decide to remove these 2 APIs for the following reasons:
1. Currently we never call open() in the query execution path, but call close() in finally, which breaks the contract.
2. All open() and close() call are no-ops in all operators, and the return value are ignored.
3. For readability purpose.
4. No potential needs for these 2 APIs. Resource managing should be handled in constructor or nextBlock().
5. If in the future we need an API to release resource (maybe we want to bring things off-heap), make the class Closeable.

Also simplified the APIs in the Plan.