### PR TITLE
Enable Star Tree index when StarTreeIndexSpec specificed during segment generation.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -443,6 +443,10 @@ public class SegmentGeneratorConfig {
 
   public void setStarTreeIndexSpecFile(String starTreeIndexSpecFile) {
     _starTreeIndexSpecFile = starTreeIndexSpecFile;
+
+    // Setting the star tree index spec should automatically enable star tree generation, so that clients
+    // don't have to explicitly set both.
+    _enableStarTreeIndex = true;
   }
 
   public StarTreeIndexSpec getStarTreeIndexSpec() {


### PR DESCRIPTION
Specifying StarTreeIndexSpec during segment generation should imply that
StarTree is being enabled, otherwise clients have to specifically call the
api to enable star tree, even after setting the StarTreeIndexSpec.