### PR TITLE
[TE] Add Serializer/Deserializer for TE ResultSet and Create Pinot query proxy 

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -8,17 +8,15 @@ import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAut
 import com.linkedin.thirdeye.dashboard.resources.AnomalyFunctionResource;
 import com.linkedin.thirdeye.dashboard.resources.EmailResource;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
+import com.linkedin.thirdeye.datasource.pinot.resources.PinotDataSourceResource;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import com.linkedin.thirdeye.dashboard.resources.DetectionJobResource;
 import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
-import com.linkedin.thirdeye.anomaly.merge.AnomalyMergeExecutor;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorJobScheduler;
 import com.linkedin.thirdeye.anomaly.task.TaskDriver;
 import com.linkedin.thirdeye.auto.onboard.AutoOnboardService;
@@ -37,10 +35,8 @@ public class ThirdEyeAnomalyApplication
   private DetectionJobScheduler detectionJobScheduler = null;
   private TaskDriver taskDriver = null;
   private MonitorJobScheduler monitorJobScheduler = null;
-//  private AlertJobScheduler alertJobScheduler = null;
   private AlertJobSchedulerV2 alertJobSchedulerV2;
   private AnomalyFunctionFactory anomalyFunctionFactory = null;
-  private AnomalyMergeExecutor anomalyMergeExecutor = null;
   private AutoOnboardService autoOnboardService = null;
   private DataCompletenessScheduler dataCompletenessScheduler = null;
   private AlertFilterFactory alertFilterFactory = null;
@@ -93,20 +89,24 @@ public class ThirdEyeAnomalyApplication
       public void start() throws Exception {
 
         if (config.isWorker()) {
-          anomalyFunctionFactory = new AnomalyFunctionFactory(config.getFunctionConfigPath());
-          alertFilterFactory = new AlertFilterFactory(config.getAlertFilterConfigPath());
-          anomalyClassifierFactory = new AnomalyClassifierFactory(config.getAnomalyClassifierConfigPath());
+          initAnomalyFunctionFactory(config.getFunctionConfigPath());
+          initAlertFilterFactory(config.getAlertFilterConfigPath());
+          initAnomalyClassifierFactory(config.getAnomalyClassifierConfigPath());
 
           taskDriver = new TaskDriver(config, anomalyFunctionFactory, alertFilterFactory, anomalyClassifierFactory);
           taskDriver.start();
         }
         if (config.isScheduler()) {
-          detectionJobScheduler = new DetectionJobScheduler();
-          alertFilterFactory = new AlertFilterFactory(config.getAlertFilterConfigPath());
-          alertFilterAutotuneFactory = new AlertFilterAutotuneFactory(config.getFilterAutotuneConfigPath());
+          initAnomalyFunctionFactory(config.getFunctionConfigPath());
+          initAlertFilterFactory(config.getAlertFilterConfigPath());
+          initAlertFilterAutotuneFactory(config.getFilterAutotuneConfigPath());
+
           emailResource = new EmailResource(config);
+          detectionJobScheduler = new DetectionJobScheduler();
           detectionJobScheduler.start();
-          environment.jersey().register(new DetectionJobResource(detectionJobScheduler, alertFilterFactory, alertFilterAutotuneFactory, emailResource));
+          environment.jersey().register(
+              new DetectionJobResource(detectionJobScheduler, alertFilterFactory, alertFilterAutotuneFactory,
+                  emailResource));
           environment.jersey().register(new AnomalyFunctionResource(config.getFunctionConfigPath()));
         }
         if (config.isMonitor()) {
@@ -117,16 +117,6 @@ public class ThirdEyeAnomalyApplication
           // start alert scheduler v2
           alertJobSchedulerV2 = new AlertJobSchedulerV2();
           alertJobSchedulerV2.start();
-        }
-        if (config.isMerger()) {
-          // anomalyFunctionFactory might have initiated if current machine is also a worker
-          if (anomalyFunctionFactory == null) {
-            anomalyFunctionFactory = new AnomalyFunctionFactory(config.getFunctionConfigPath());
-          }
-          ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-          anomalyMergeExecutor =
-              new AnomalyMergeExecutor(executorService, anomalyFunctionFactory);
-          anomalyMergeExecutor.start();
         }
         if (config.isAutoload()) {
           autoOnboardService = new AutoOnboardService(config);
@@ -139,6 +129,9 @@ public class ThirdEyeAnomalyApplication
         if (config.isClassifier()) {
           classificationJobScheduler = new ClassificationJobScheduler();
           classificationJobScheduler.start();
+        }
+        if (config.isPinotProxy()) {
+          environment.jersey().register(new PinotDataSourceResource());
         }
       }
 
@@ -154,11 +147,7 @@ public class ThirdEyeAnomalyApplication
           monitorJobScheduler.shutdown();
         }
         if (config.isAlert()) {
-          // alertJobScheduler.shutdown();
           alertJobSchedulerV2.shutdown();
-        }
-        if (config.isMerger()) {
-          anomalyMergeExecutor.stop();
         }
         if (config.isAutoload()) {
           autoOnboardService.shutdown();
@@ -169,7 +158,34 @@ public class ThirdEyeAnomalyApplication
         if (config.isClassifier()) {
           classificationJobScheduler.shutdown();
         }
+        if (config.isPinotProxy()) {
+          // Do nothing
+        }
       }
     });
+  }
+
+  private void initAnomalyFunctionFactory(String functoinConfigPath) {
+    if (anomalyFunctionFactory == null) {
+      anomalyFunctionFactory = new AnomalyFunctionFactory(functoinConfigPath);
+    }
+  }
+
+  private void initAlertFilterFactory(String alertFilterConfigPath) {
+    if (alertFilterFactory == null) {
+      alertFilterFactory = new AlertFilterFactory(alertFilterConfigPath);
+    }
+  }
+
+  private void initAnomalyClassifierFactory(String anomalyClassifierConfigPath) {
+    if (anomalyClassifierFactory == null) {
+      anomalyClassifierFactory = new AnomalyClassifierFactory(anomalyClassifierConfigPath);
+    }
+  }
+
+  private void initAlertFilterAutotuneFactory(String filterAutotuneConfigPath) {
+    if (alertFilterAutotuneFactory == null) {
+      alertFilterAutotuneFactory = new AlertFilterAutotuneFactory(filterAutotuneConfigPath);
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyConfiguration.java
@@ -10,10 +10,12 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
   private boolean worker = false;
   private boolean monitor = false;
   private boolean alert = false;
+  @Deprecated
   private boolean merger = false;
   private boolean autoload = false;
   private boolean dataCompleteness = false;
   private boolean classifier = false;
+  private boolean pinotProxy = false;
 
   private long id;
   private String dashboardHost;
@@ -132,6 +134,14 @@ public class ThirdEyeAnomalyConfiguration extends ThirdEyeConfiguration {
 
   public void setClassifier(boolean classifier) {
     this.classifier = classifier;
+  }
+
+  public boolean isPinotProxy() {
+    return pinotProxy;
+  }
+
+  public void setPinotProxy(boolean pinotProxy) {
+    this.pinotProxy = pinotProxy;
   }
 
   public void setSmtpConfiguration(SmtpConfiguration smtpConfiguration) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -2,7 +2,6 @@ package com.linkedin.thirdeye.dashboard.resources;
 
 
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.BaseAlertFilterAutoTune;
-import com.linkedin.thirdeye.detector.email.filter.BaseAlertFilter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotQuery.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotQuery.java
@@ -36,4 +36,13 @@ public class PinotQuery {
     PinotQuery that = (PinotQuery) obj;
     return this.pql.equals(that.pql);
   }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder("PinotQuery{");
+    sb.append("pql='").append(pql).append('\'');
+    sb.append(", tableName='").append(tableName).append('\'');
+    sb.append('}');
+    return sb.toString();
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -445,7 +445,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
             int weight = 0;
             for (int idx = 0; idx < resultSetCount; ++idx) {
               ThirdEyeResultSet resultSet = resultSetGroup.get(idx);
-              weight += (resultSet.getColumnCount() * resultSet.getRowCount());
+              weight += ((resultSet.getColumnCount() + resultSet.getGroupKeyLength()) * resultSet.getRowCount());
             }
             return weight;
           }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resources/PinotDataSourceResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resources/PinotDataSourceResource.java
@@ -11,10 +11,13 @@ import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
 import com.linkedin.thirdeye.datasource.pinot.resultset.ThirdEyeResultSet;
 import com.linkedin.thirdeye.datasource.pinot.resultset.ThirdEyeResultSetGroup;
 import com.linkedin.thirdeye.datasource.pinot.resultset.ThirdEyeResultSetSerializer;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.concurrent.ExecutionException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +33,7 @@ public class PinotDataSourceResource {
     OBJECT_MAPPER = new ObjectMapper();
     OBJECT_MAPPER.registerModule(module);
   }
+  private static final String URL_ENCODING = "UTF-8";
 
   private PinotThirdEyeDataSource pinotDataSource;
 
@@ -44,11 +48,14 @@ public class PinotDataSourceResource {
    */
   @GET
   @Path("/query")
-  public String executePQL(String pql, String tableName) {
+  public String executePQL(@QueryParam("pql") String pql, @QueryParam("tableName") String tableName)
+      throws UnsupportedEncodingException {
     initPinotDataSource();
 
     String resultString;
-    PinotQuery pinotQuery = new PinotQuery(pql, tableName);
+    String decodedPql = URLDecoder.decode(pql, URL_ENCODING);
+    String decodedTableName = URLDecoder.decode(tableName, URL_ENCODING);
+    PinotQuery pinotQuery = new PinotQuery(decodedPql, decodedTableName);
     try {
       ThirdEyeResultSetGroup thirdEyeResultSetGroup = pinotDataSource.executePQL(pinotQuery);
       resultString = OBJECT_MAPPER.writeValueAsString(thirdEyeResultSetGroup);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resources/PinotDataSourceResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resources/PinotDataSourceResource.java
@@ -1,0 +1,77 @@
+package com.linkedin.thirdeye.datasource.pinot.resources;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
+import com.linkedin.thirdeye.datasource.pinot.PinotQuery;
+import com.linkedin.thirdeye.datasource.pinot.PinotThirdEyeDataSource;
+import com.linkedin.thirdeye.datasource.pinot.resultset.ThirdEyeResultSet;
+import com.linkedin.thirdeye.datasource.pinot.resultset.ThirdEyeResultSetGroup;
+import com.linkedin.thirdeye.datasource.pinot.resultset.ThirdEyeResultSetSerializer;
+import java.util.concurrent.ExecutionException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("/pinot-data-source")
+@Produces(MediaType.APPLICATION_JSON)
+public class PinotDataSourceResource {
+  private static final Logger LOG = LoggerFactory.getLogger(PinotDataSourceResource.class);
+  private static final ObjectMapper OBJECT_MAPPER;
+  static {
+    SimpleModule module = new SimpleModule("ThirdEyeResultSetSerializer", new Version(1, 0, 0, null, null, null));
+    module.addSerializer(ThirdEyeResultSet.class, new ThirdEyeResultSetSerializer());
+    OBJECT_MAPPER = new ObjectMapper();
+    OBJECT_MAPPER.registerModule(module);
+  }
+
+  private PinotThirdEyeDataSource pinotDataSource;
+
+  /**
+   * Returns the JSON string of the ThirdEyeResultSetGroup of the given Pinot query.
+   *
+   * @param pql       the given Pinot query.
+   * @param tableName the table name at which the query targets.
+   *
+   * @return the JSON string of the ThirdEyeResultSetGroup of the query; the string could be the exception message if
+   * the query is not executed successfully.
+   */
+  @GET
+  @Path("/query")
+  public String executePQL(String pql, String tableName) {
+    initPinotDataSource();
+
+    String resultString;
+    PinotQuery pinotQuery = new PinotQuery(pql, tableName);
+    try {
+      ThirdEyeResultSetGroup thirdEyeResultSetGroup = pinotDataSource.executePQL(pinotQuery);
+      resultString = OBJECT_MAPPER.writeValueAsString(thirdEyeResultSetGroup);
+    } catch (ExecutionException | JsonProcessingException e) {
+      LOG.error("Failed to execute PQL ({}) due to the exception:", pinotQuery);
+      // TODO: Expand the definition of ThirdEyeResultSetGroup to include a field of error message?
+      resultString = e.toString();
+    }
+
+    return resultString;
+  }
+
+  /**
+   * Initializes the pinot data source if it is still not initialized.
+   */
+  private void initPinotDataSource() {
+    if (pinotDataSource == null) {
+      Preconditions.checkNotNull(ThirdEyeCacheRegistry.getInstance(),
+          "Failed to get Pinot data source because ThirdEye cache registry is not initialized.");
+      pinotDataSource = (PinotThirdEyeDataSource) ThirdEyeCacheRegistry.getInstance().getQueryCache()
+          .getDataSource(PinotThirdEyeDataSource.DATA_SOURCE_NAME);
+      Preconditions
+          .checkNotNull(pinotDataSource, "Failed to get Pinot data source because it is not initialized in ThirdEye.");
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSet.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSet.java
@@ -36,7 +36,7 @@ public class ThirdEyeDataFrameResultSet extends AbstractThirdEyeResultSet {
 
   @Override
   public int getColumnCount() {
-    return dataFrame.getSeries().size();
+    return thirdEyeResultSetMetaData.getMetricColumnNames().size();
   }
 
   @Override
@@ -104,16 +104,12 @@ public class ThirdEyeDataFrameResultSet extends AbstractThirdEyeResultSet {
         new ThirdEyeResultSetMetaData(groupKeyColumnNames, metricColumnNames);
 
     // Build the DataFrame
-    List<String> allColumnNames = thirdEyeResultSetMetaData.getAllColumnNames();
-    List<String> columnNameWithDataType = new ArrayList<>(allColumnNames.size());
-    for (int index = 0; index < allColumnNames.size(); ++index) {
-      if (index < groupByColumnCount) {
-        // Always cast dimension values to STRING type
-        columnNameWithDataType.add(allColumnNames.get(index) + ":STRING");
-      } else {
-        columnNameWithDataType.add(allColumnNames.get(index));
-      }
+    List<String> columnNameWithDataType = new ArrayList<>();
+    //   Always cast dimension values to STRING type
+    for (String groupColumnName : thirdEyeResultSetMetaData.getGroupKeyColumnNames()) {
+      columnNameWithDataType.add(groupColumnName + ":STRING");
     }
+    columnNameWithDataType.addAll(thirdEyeResultSetMetaData.getMetricColumnNames());
     DataFrame.Builder dfBuilder = DataFrame.builder(columnNameWithDataType);
     int rowCount = resultSet.getRowCount();
     int metricColumnCount = resultSet.getColumnCount();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetDeserializer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetDeserializer.java
@@ -1,0 +1,56 @@
+package com.linkedin.thirdeye.datasource.pinot.resultset;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class ThirdEyeResultSetDeserializer extends StdDeserializer<ThirdEyeResultSet> {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public ThirdEyeResultSetDeserializer() {
+    this(null);
+  }
+
+  protected ThirdEyeResultSetDeserializer(Class<?> vc) {
+    super(vc);
+  }
+
+  @Override
+  public ThirdEyeResultSet deserialize(JsonParser parser, DeserializationContext deserializationContext)
+      throws IOException {
+
+    ObjectCodec codec = parser.getCodec();
+    JsonNode rootNode = codec.readTree(parser);
+
+    JsonNode groupColumnNamesNode = rootNode.get(ThirdEyeResultSetSerializer.GROUP_COLUMN_NAMES_FIELD);
+    ArrayList<String> groupColumnNames = OBJECT_MAPPER.treeToValue(groupColumnNamesNode, ArrayList.class);
+
+    JsonNode metricColumnNamesNode = rootNode.get(ThirdEyeResultSetSerializer.METRIC_COLUMN_NAMES_FIELD);
+    ArrayList<String> metricColumnNames = OBJECT_MAPPER.treeToValue(metricColumnNamesNode, ArrayList.class);
+
+    JsonNode rowsNode = rootNode.get(ThirdEyeResultSetSerializer.ROWS_FIELD);
+    ArrayList<ArrayList<String>> rows = OBJECT_MAPPER.treeToValue(rowsNode, ArrayList.class);
+
+    ThirdEyeResultSetMetaData metaData = new ThirdEyeResultSetMetaData(groupColumnNames, metricColumnNames);
+
+    ArrayList<String> columnNamesWithType = new ArrayList<>(groupColumnNames.size());
+    for (String groupColumnName : groupColumnNames) {
+      columnNamesWithType.add(groupColumnName + ":STRING");
+    }
+    columnNamesWithType.addAll(metricColumnNames);
+    DataFrame.Builder dfBuilder = DataFrame.builder(columnNamesWithType);
+    for (ArrayList<String> row : rows) {
+      dfBuilder.append(row.toArray());
+    }
+    DataFrame dataFrame = dfBuilder.build();
+
+    ThirdEyeDataFrameResultSet resultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+    return resultSet;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetGroup.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetGroup.java
@@ -4,8 +4,8 @@ import com.google.common.collect.ImmutableList;
 import com.linkedin.pinot.client.ResultSet;
 import com.linkedin.pinot.client.ResultSetGroup;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 /**
@@ -13,12 +13,12 @@ import org.apache.commons.lang.builder.ToStringBuilder;
  * to Pinot's {@link ResultSet}).
  */
 public class ThirdEyeResultSetGroup {
-  private List<ThirdEyeResultSet> resultSets = Collections.emptyList();
+  private ImmutableList<ThirdEyeResultSet> resultSets = ImmutableList.of();
+
+  public ThirdEyeResultSetGroup() { }
 
   public ThirdEyeResultSetGroup(List<ThirdEyeResultSet> resultSets) {
-    if (resultSets != null) {
-      this.resultSets = ImmutableList.copyOf(resultSets);
-    }
+    this.setResultSets(resultSets);
   }
 
   public int size() {
@@ -27,6 +27,14 @@ public class ThirdEyeResultSetGroup {
 
   public ThirdEyeResultSet get(int idx) {
     return resultSets.get(idx);
+  }
+
+  public void setResultSets(List<ThirdEyeResultSet> resultSets) {
+    if (CollectionUtils.isNotEmpty(resultSets)) {
+      this.resultSets = ImmutableList.copyOf(resultSets);
+    } else {
+      this.resultSets = ImmutableList.of();
+    }
   }
 
   public List<ThirdEyeResultSet> getResultSets() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetSerializer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetSerializer.java
@@ -1,0 +1,59 @@
+package com.linkedin.thirdeye.datasource.pinot.resultset;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ThirdEyeResultSetSerializer extends StdSerializer<ThirdEyeResultSet> {
+  public static final String GROUP_COLUMN_NAMES_FIELD = "groupColumnNames";
+  public static final String METRIC_COLUMN_NAMES_FIELD = "metricColumnNames";
+  public static final String ROWS_FIELD = "rows";
+
+  public ThirdEyeResultSetSerializer() {
+    this(null);
+  }
+
+  public ThirdEyeResultSetSerializer(Class<ThirdEyeResultSet> t) {
+    super(t);
+  }
+
+  @Override
+  public void serialize(ThirdEyeResultSet thirdEyeResultSet, JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider) throws IOException {
+    jsonGenerator.writeStartObject();
+
+    // Metadata: group column names
+    int groupColumnCount = thirdEyeResultSet.getGroupKeyLength();
+    List<String> groupColumnNames = new ArrayList<>(groupColumnCount);
+    for (int idx = 0; idx < groupColumnCount; idx++) {
+      groupColumnNames.add(thirdEyeResultSet.getGroupKeyColumnName(idx));
+    }
+    jsonGenerator.writeObjectField(GROUP_COLUMN_NAMES_FIELD, groupColumnNames);
+    // Metadata: metric column names
+    int metricColumnCount = thirdEyeResultSet.getColumnCount();
+    List<String> metricColumnNames = new ArrayList<>(metricColumnCount);
+    for (int idx = 0; idx < metricColumnCount; idx++) {
+      metricColumnNames.add(thirdEyeResultSet.getColumnName(idx));
+    }
+    jsonGenerator.writeObjectField(METRIC_COLUMN_NAMES_FIELD, metricColumnNames);
+    // Data: data in rows of Strings
+    int rowCount = thirdEyeResultSet.getRowCount();
+    List<String[]> rows = new ArrayList<>();
+    int totalColumnCount = groupColumnCount + metricColumnCount;
+    for (int rowIdx = 0; rowIdx < rowCount; rowIdx++) {
+      String[] newRow = new String[totalColumnCount];
+      rows.add(newRow);
+      for (int columnIdx = 0; columnIdx < groupColumnCount; columnIdx++) {
+        newRow[columnIdx] = thirdEyeResultSet.getGroupKeyColumnValue(rowIdx, columnIdx);
+      }
+      for (int columnIdx = 0; columnIdx < metricColumnCount; columnIdx++) {
+        newRow[columnIdx + groupColumnCount] = thirdEyeResultSet.getString(rowIdx, columnIdx);
+      }
+    }
+    jsonGenerator.writeObjectField(ROWS_FIELD, rows);
+    jsonGenerator.writeEndObject();
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSetTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeDataFrameResultSetTest.java
@@ -48,6 +48,8 @@ public class ThirdEyeDataFrameResultSetTest {
     ThirdEyeDataFrameResultSet expectedDataFrameResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
 
     Assert.assertEquals(actualDataFrameResultSet, expectedDataFrameResultSet);
+    Assert.assertEquals(actualDataFrameResultSet.getGroupKeyLength(), 0);
+    Assert.assertEquals(actualDataFrameResultSet.getColumnCount(), 2);
   }
 
   @Test
@@ -65,6 +67,8 @@ public class ThirdEyeDataFrameResultSetTest {
     ThirdEyeDataFrameResultSet expectedDataFrameResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
 
     Assert.assertEquals(actualDataFrameResultSet, expectedDataFrameResultSet);
+    Assert.assertEquals(actualDataFrameResultSet.getGroupKeyLength(), 0);
+    Assert.assertEquals(actualDataFrameResultSet.getColumnCount(), 1);
   }
 
   @Test
@@ -94,6 +98,8 @@ public class ThirdEyeDataFrameResultSetTest {
     ThirdEyeDataFrameResultSet expectedDataFrameResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
 
     Assert.assertEquals(actualDataFrameResultSet, expectedDataFrameResultSet);
+    Assert.assertEquals(actualDataFrameResultSet.getGroupKeyLength(), 2);
+    Assert.assertEquals(actualDataFrameResultSet.getColumnCount(), 1);
   }
 
   @Test

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetDeserializerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetDeserializerTest.java
@@ -1,0 +1,96 @@
+package com.linkedin.thirdeye.datasource.pinot.resultset;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ThirdEyeResultSetDeserializerTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @BeforeClass
+  public void initObjectMapper() {
+    SimpleModule module = new SimpleModule("ThirdEyeResultSetDeserializer", new Version(1, 0, 0, null, null, null));
+    module.addDeserializer(ThirdEyeResultSet.class, new ThirdEyeResultSetDeserializer());
+    OBJECT_MAPPER.registerModule(module);
+  }
+
+  @Test
+  public void testDeserializeSelectResult() {
+    List<String> columnArray = new ArrayList<>();
+    columnArray.add("col1");
+    columnArray.add("col2");
+
+    DataFrame dataFrame = new DataFrame();
+    dataFrame.addSeries("col1", 0, 10, 20);
+    dataFrame.addSeries("col2", 1, 11, 21);
+    ThirdEyeResultSetMetaData metaData = new ThirdEyeResultSetMetaData(Collections.<String>emptyList(), columnArray);
+    ThirdEyeDataFrameResultSet expectedResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+
+    final String jsonString = "{\"" + ThirdEyeResultSetSerializer.GROUP_COLUMN_NAMES_FIELD + "\":[],\""
+        + ThirdEyeResultSetSerializer.METRIC_COLUMN_NAMES_FIELD + "\":[\"col1\",\"col2\"],\""
+        + ThirdEyeResultSetSerializer.ROWS_FIELD + "\":[[\"0\",\"1\"],[\"10\",\"11\"],[\"20\",\"21\"]]}";
+    ThirdEyeResultSet actualResultSet = fromJsonString(jsonString);
+
+    Assert.assertEquals(actualResultSet, expectedResultSet);
+  }
+
+  @Test
+  public void testDeserializeAggregationResult() {
+    final String functionName = "sum_metric_name";
+    ThirdEyeResultSetMetaData metaData =
+        new ThirdEyeResultSetMetaData(Collections.<String>emptyList(), Collections.singletonList(functionName));
+    DataFrame dataFrame = new DataFrame();
+    dataFrame.addSeries(functionName, 150.33576);
+    ThirdEyeResultSet expectedResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+
+    final String jsonString = "{\"" + ThirdEyeResultSetSerializer.GROUP_COLUMN_NAMES_FIELD + "\":[],\""
+        + ThirdEyeResultSetSerializer.METRIC_COLUMN_NAMES_FIELD + "\":[\"sum_metric_name\"],\""
+        + ThirdEyeResultSetSerializer.ROWS_FIELD + "\":[[\"150.33576\"]]}";
+    ThirdEyeResultSet actualResultSet = fromJsonString(jsonString);
+
+    Assert.assertEquals(actualResultSet, expectedResultSet);
+  }
+
+  @Test
+  public void testDeserializeGroupByResult() {
+    final String functionName = "sum_metric_name";
+
+    List<String> groupByColumnNames = new ArrayList<>();
+    groupByColumnNames.add("country");
+    groupByColumnNames.add("pageName");
+
+    ThirdEyeResultSetMetaData metaData =
+        new ThirdEyeResultSetMetaData(groupByColumnNames, Collections.singletonList(functionName));
+    DataFrame dataFrame = new DataFrame();
+    dataFrame.addSeries("country", "US", "US", "IN", "JP");
+    dataFrame.addSeries("pageName", "page1", "page2", "page3", "page2");
+    dataFrame.addSeries(functionName, 1111, 2222.2, 333.3, 44444.4);
+    ThirdEyeResultSet expectedResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+
+    final String jsonString =
+        "{\"" + ThirdEyeResultSetSerializer.GROUP_COLUMN_NAMES_FIELD + "\":[\"country\",\"pageName\"],\""
+            + ThirdEyeResultSetSerializer.METRIC_COLUMN_NAMES_FIELD + "\":[\"sum_metric_name\"],\""
+            + ThirdEyeResultSetSerializer.ROWS_FIELD
+            + "\":[[\"US\",\"page1\",\"1111.0\"],[\"US\",\"page2\",\"2222.2\"],[\"IN\",\"page3\",\"333.3\"],[\"JP\",\"page2\",\"44444.4\"]]}";
+    ThirdEyeResultSet actualResultSet = fromJsonString(jsonString);
+
+    Assert.assertEquals(actualResultSet, expectedResultSet);
+  }
+
+  private ThirdEyeResultSet fromJsonString(String jsonString) {
+    try {
+      return OBJECT_MAPPER.readValue(jsonString, ThirdEyeResultSet.class);
+    } catch (IOException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetSerializerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/resultset/ThirdEyeResultSetSerializerTest.java
@@ -1,0 +1,99 @@
+package com.linkedin.thirdeye.datasource.pinot.resultset;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ThirdEyeResultSetSerializerTest {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @BeforeClass
+  public void initObjectMapper() {
+    SimpleModule module = new SimpleModule("ThirdEyeResultSetSerializer", new Version(1, 0, 0, null, null, null));
+    module.addSerializer(ThirdEyeResultSet.class, new ThirdEyeResultSetSerializer());
+    OBJECT_MAPPER.registerModule(module);
+  }
+
+  @Test
+  public void testSerializeSelectResult() {
+    List<String> columnArray = new ArrayList<>();
+    columnArray.add("col1");
+    columnArray.add("col2");
+
+    DataFrame dataFrame = new DataFrame();
+    dataFrame.addSeries("col1", 0, 10, 20);
+    dataFrame.addSeries("col2", 1, 11, 21);
+    ThirdEyeResultSetMetaData metaData = new ThirdEyeResultSetMetaData(Collections.<String>emptyList(), columnArray);
+    ThirdEyeResultSet thirdeyeResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+
+    String actualJsonString = toJsonString(thirdeyeResultSet);
+
+    final String expectedJsonString = "{\"" + ThirdEyeResultSetSerializer.GROUP_COLUMN_NAMES_FIELD + "\":[],\""
+        + ThirdEyeResultSetSerializer.METRIC_COLUMN_NAMES_FIELD + "\":[\"col1\",\"col2\"],\""
+        + ThirdEyeResultSetSerializer.ROWS_FIELD + "\":[[\"0\",\"1\"],[\"10\",\"11\"],[\"20\",\"21\"]]}";
+
+    Assert.assertEquals(actualJsonString, expectedJsonString);
+  }
+
+  @Test
+  public void testSerializeAggregationResult() {
+    final String functionName = "sum_metric_name";
+    ThirdEyeResultSetMetaData metaData =
+        new ThirdEyeResultSetMetaData(Collections.<String>emptyList(), Collections.singletonList(functionName));
+    DataFrame dataFrame = new DataFrame();
+    dataFrame.addSeries(functionName, 150.33576);
+    ThirdEyeResultSet thirdeyeResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+
+    String actualJsonString = toJsonString(thirdeyeResultSet);
+
+    final String expectedJsonString = "{\"" + ThirdEyeResultSetSerializer.GROUP_COLUMN_NAMES_FIELD + "\":[],\""
+        + ThirdEyeResultSetSerializer.METRIC_COLUMN_NAMES_FIELD + "\":[\"sum_metric_name\"],\""
+        + ThirdEyeResultSetSerializer.ROWS_FIELD + "\":[[\"150.33576\"]]}";
+
+    Assert.assertEquals(actualJsonString, expectedJsonString);
+  }
+
+  @Test
+  public void testSerializeGroupByResult() {
+    final String functionName = "sum_metric_name";
+
+    List<String> groupByColumnNames = new ArrayList<>();
+    groupByColumnNames.add("country");
+    groupByColumnNames.add("pageName");
+
+    ThirdEyeResultSetMetaData metaData =
+        new ThirdEyeResultSetMetaData(groupByColumnNames, Collections.singletonList(functionName));
+    DataFrame dataFrame = new DataFrame();
+    dataFrame.addSeries("country", "US", "US", "IN", "JP");
+    dataFrame.addSeries("pageName", "page1", "page2", "page3", "page2");
+    dataFrame.addSeries(functionName, 1111, 2222.2, 333.3, 44444.4);
+    ThirdEyeResultSet thirdeyeResultSet = new ThirdEyeDataFrameResultSet(metaData, dataFrame);
+
+    String actualJsonString = toJsonString(thirdeyeResultSet);
+
+    final String expectedJsonString =
+        "{\"" + ThirdEyeResultSetSerializer.GROUP_COLUMN_NAMES_FIELD + "\":[\"country\",\"pageName\"],\""
+            + ThirdEyeResultSetSerializer.METRIC_COLUMN_NAMES_FIELD + "\":[\"sum_metric_name\"],\""
+            + ThirdEyeResultSetSerializer.ROWS_FIELD
+            + "\":[[\"US\",\"page1\",\"1111.0\"],[\"US\",\"page2\",\"2222.2\"],[\"IN\",\"page3\",\"333.3\"],[\"JP\",\"page2\",\"44444.4\"]]}";
+
+    Assert.assertEquals(actualJsonString, expectedJsonString);
+  }
+
+  private String toJsonString(ThirdEyeResultSet dataFrameResultSet) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(dataFrameResultSet);
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
1. Add serializer and deserializer for TE ResultSet.
2. Add Pinot query proxy to ThirdEyeAnomalyApplication. Now a worker could be used as a central portal to Pinot. Thus, other workers or dashboard could leverage the cache on the proxy worker.

Tested with new Unit test and local setup, in which a proxy worker and a dashboard server is started up. The dashboard server could get the cached data from the proxy worker successfully.