### PR TITLE
[TE] missing import

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-settings/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-settings/component.js
@@ -18,6 +18,7 @@
 
 import Ember from 'ember';
 import moment from 'moment';
+import fetch from 'fetch';
 import { toFilters, toFilterMap, filterPrefix } from '../../../helpers/utils';
 
 // TODO: move this to a utils file (DRYER)


### PR DESCRIPTION
### What's new:
- import `fetch` polyfill instead of using the default chrome `fetch` 