### PR TITLE
Fixed filter-bar bug with reloading new entities

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
@@ -2,7 +2,7 @@
  * Filter Bar Input Component
  * Component for input fields in a filter bar (i.e. dropdown, checkbox)
  * @module components/filter-bar-input
- * @property {string} header        - [required] header of subfilter (i.e. "Holiday", "Deployment")
+ * @property {string} eventType     - [required] type of event of subfilter (i.e. "anomaly", "holiday")
  * @property {object} config        - [required] config file to construct filter bar, passed by parent component,
  *                                  filter-bar
  * @property {string} label         - [required] label of input (i.e. "country", "region")
@@ -61,7 +61,7 @@ export default Ember.Component.extend({
      * @param {Array} selectedValue - selected value in the input
      */
     onSubfilterSelection(selectedValue) {
-      const { label, entities, onSelect, eventType, updateCache, config, header } = this.getProperties('label', 'entities', 'onSelect', 'eventType', 'updateCache', 'config', 'header');
+      const { label, entities, onSelect, eventType, updateCache, config } = this.getProperties('label', 'entities', 'onSelect', 'eventType', 'updateCache', 'config');
       const labelMapping = findLabelMapping(label, config);
 
       this.set('selected', selectedValue);
@@ -82,7 +82,7 @@ export default Ember.Component.extend({
         onSelect(urns);
 
         // Call parent's updateCache() in the filter bar component to update the urns cache
-        updateCache(header, urns);
+        updateCache(eventType, urns);
       }
     }
   }

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
@@ -11,7 +11,6 @@
       <ul class="entity-filter__group-list {{if block.isHidden " entity-filter__group-list--hidden "}}">
         {{#each block.inputs as |filter|}}
           {{filter-bar-input
-            header=block.header
             eventType=block.eventType
             config=config
             label=filter.label


### PR DESCRIPTION
- Bug: when entities are changed by user changing fields like "Comparing By" or "Display Window", the table results don't reload based on these changes.
- Modified urnsCache to have the key be `eventType` instead of `header` (reference in `filterBarConfig` file)