### PR TITLE
Clean up Star Tree specific configs in SegmentGenerationConfig.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/StarTreeIndexSpec.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.common.data;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -23,6 +25,7 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.map.ObjectMapper;
 
 
+@SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StarTreeIndexSpec {
   public static final Integer DEFAULT_MAX_LEAF_RECORDS = 100000; // TODO: determine a good number via experiment
@@ -106,5 +109,17 @@ public class StarTreeIndexSpec {
 
   public String toJsonString() throws Exception {
     return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+  }
+
+  /**
+   * Builds and returns StarTreeIndexSpec from specified file.
+   *
+   * @param starTreeIndexSpecFile File containing star tree index spec.
+   * @return StarTreeIndexSpec object de-serialized from the file.
+   * @throws IOException
+   */
+  public static StarTreeIndexSpec fromFile(File starTreeIndexSpecFile)
+      throws IOException {
+    return OBJECT_MAPPER.readValue(starTreeIndexSpecFile, StarTreeIndexSpec.class);
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/minion/BackfillDateTimeColumn.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/minion/BackfillDateTimeColumn.java
@@ -101,7 +101,6 @@ public class BackfillDateTimeColumn {
 
     StarTreeMetadata starTreeMetadata = originalSegmentMetadata.getStarTreeMetadata();
     if (starTreeMetadata != null) {
-      config.setEnableStarTreeIndex(true);
       StarTreeIndexSpec starTreeIndexSpec = new StarTreeIndexSpec();
       starTreeIndexSpec.setDimensionsSplitOrder(starTreeMetadata.getDimensionsSplitOrder());
       starTreeIndexSpec.setMaxLeafRecords((int) starTreeMetadata.getMaxLeafRecords());
@@ -111,7 +110,7 @@ public class BackfillDateTimeColumn {
           .getSkipMaterializationForDimensions()));
       starTreeIndexSpec.setSkipStarNodeCreationForDimensions(Sets.newHashSet(starTreeMetadata
           .getSkipStarNodeCreationForDimensions()));
-      config.setStarTreeIndexSpec(starTreeIndexSpec);
+      config.enableStarTreeIndex(starTreeIndexSpec);
     }
 
     LOGGER.info("Creating segment for {} with config {}", segmentName, config.toString());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -108,8 +108,7 @@ public class RealtimeSegmentConverter {
 
     // Presence of the spec enables star tree generation.
     if (starTreeIndexSpec != null) {
-      genConfig.setEnableStarTreeIndex(true);
-      genConfig.setStarTreeIndexSpec(starTreeIndexSpec);
+      genConfig.enableStarTreeIndex(starTreeIndexSpec);
     }
 
     genConfig.setTimeColumnName(dataSchema.getTimeFieldSpec().getOutgoingTimeColumnName());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -209,7 +209,9 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     if (starTreeIndexSpec == null) {
       starTreeIndexSpec = new StarTreeIndexSpec();
       starTreeIndexSpec.setMaxLeafRecords(StarTreeIndexSpec.DEFAULT_MAX_LEAF_RECORDS);
-      config.setStarTreeIndexSpec(starTreeIndexSpec);
+
+      // Overwrite the null index spec with default one.
+      config.enableStarTreeIndex(starTreeIndexSpec);
     }
     //create star builder config from startreeindexspec. Merge these two in one later.
     StarTreeBuilderConfig starTreeBuilderConfig = new StarTreeBuilderConfig();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/StarTreeIndexTestSegmentHelper.java
@@ -76,8 +76,7 @@ public class StarTreeIndexTestSegmentHelper {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
     StarTreeIndexSpec starTreeIndexSpec = new StarTreeIndexSpec();
     starTreeIndexSpec.setMaxLeafRecords(10);
-    config.setEnableStarTreeIndex(true);
-    config.setStarTreeIndexSpec(starTreeIndexSpec);
+    config.enableStarTreeIndex(starTreeIndexSpec);
     config.setOutDir(segmentDirName);
     config.setFormat(FileFormat.AVRO);
     config.setSegmentName(segmentName);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeMetadata.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/TestStarTreeMetadata.java
@@ -92,8 +92,7 @@ public class TestStarTreeMetadata {
     starTreeIndexSpec.setSkipStarNodeCreationForDimensions(SKIP_STAR_NODE_CREATION_DIMENSTIONS);
     starTreeIndexSpec.setSkipMaterializationForDimensions(SKIP_MATERIALIZATION_DIMENSIONS);
 
-    config.setEnableStarTreeIndex(true);
-    config.setStarTreeIndexSpec(starTreeIndexSpec);
+    config.enableStarTreeIndex(starTreeIndexSpec);
 
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/startree/hll/SegmentWithHllIndexCreateHelper.java
@@ -105,10 +105,9 @@ public class SegmentWithHllIndexCreateHelper {
 
   private void setupStarTreeConfig(SegmentGeneratorConfig segmentGenConfig) {
     // StarTree related
-    segmentGenConfig.setEnableStarTreeIndex(true);
     StarTreeIndexSpec starTreeIndexSpec = new StarTreeIndexSpec();
     starTreeIndexSpec.setMaxLeafRecords(StarTreeIndexSpec.DEFAULT_MAX_LEAF_RECORDS);
-    segmentGenConfig.setStarTreeIndexSpec(starTreeIndexSpec);
+    segmentGenConfig.enableStarTreeIndex(starTreeIndexSpec);
     LOGGER.info("segmentGenConfig Schema (w/o derived fields): ");
     printSchema(segmentGenConfig.getSchema());
   }

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/FastHllQueriesTest.java
@@ -235,7 +235,7 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     if (hasPreGeneratedHllColumns) {
       segmentGeneratorConfig.setHllConfig(new HllConfig(HLL_LOG2M));
     } else {
-      segmentGeneratorConfig.setEnableStarTreeIndex(true);
+      segmentGeneratorConfig.enableStarTreeIndex(null);
       // Intentionally use the non-default suffix
       segmentGeneratorConfig.setHllConfig(
           new HllConfig(HLL_LOG2M, new HashSet<>(Arrays.asList("column17", "column18")), "_HLL"));

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -249,7 +249,9 @@ public class ClusterIntegrationTestUtils {
             // Test segment with space and special character in the file name
             segmentGeneratorConfig.setSegmentNamePostfix(segmentIndex + " %");
 
-            segmentGeneratorConfig.setEnableStarTreeIndex(createStarTreeIndex);
+            if (createStarTreeIndex) {
+              segmentGeneratorConfig.enableStarTreeIndex(null);
+            }
 
             if (rawIndexColumns != null) {
               segmentGeneratorConfig.setRawIndexCreationColumns(rawIndexColumns);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/ColumnarToStarTreeConverter.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/segment/converter/ColumnarToStarTreeConverter.java
@@ -116,14 +116,14 @@ public class ColumnarToStarTreeConverter {
     config.setDataDir(_inputDirName);
     config.setInputFilePath(columnarSegment.getAbsolutePath());
     config.setFormat(FileFormat.PINOT);
-    config.setEnableStarTreeIndex(true);
     config.setOutDir(_outputDirName);
-    config.setStarTreeIndexSpecFile(_starTreeConfigFileName);
     config.setOverwrite(_overwrite);
 
-    // Load the StarTreeSpec object from the config file.
-    StarTreeIndexSpec starTreeIndexSpec = objectMapper.readValue(new File(_starTreeConfigFileName), StarTreeIndexSpec.class);
-    config.setStarTreeIndexSpec(starTreeIndexSpec);
+    StarTreeIndexSpec starTreeIndexSpec = null;
+    if (_starTreeConfigFileName != null) {
+       starTreeIndexSpec = StarTreeIndexSpec.fromFile(new File(_starTreeConfigFileName));
+    }
+    config.enableStarTreeIndex(starTreeIndexSpec);
 
     // Read the segment and table name from the segment's metadata.
     SegmentMetadata metadata = new SegmentMetadataImpl(columnarSegment);


### PR DESCRIPTION
Consolidated the following three api's into one, as there were multiple
occassions where callers would need to call more than one of these api's
to get the same effect, which also caused bugs on a few occassions when
callers missed to call one of the api's. This change helps avoid these
issues.

- setEnableStarTree
- setStarTreeIndexSpec
- setStarTreeIndexSpecFile

The new api setEnableStarTree(StarTreeIndexSpec) takes StarTreeIndexSpec
as input, which can be null as well.