### PR TITLE
[TE] frontend - Fixed bug with filter bar on init

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -4,13 +4,15 @@
  * @module components/filter-bar
  * @property {object[]} config            - [required] array of objects (config file) passed in from the route that sets
  *                                          up the filter bar sub-filters
- * @property {number} maxStrLen           - number of characters for filter name truncation
+ * @property {object[]} filterBlock       - [required] array of objects constructed from config to render filter bar
+ * @property {number} maxStrLen           - [optional] number of characters for filter name truncation
  * @property {array}  onFilterSelection   - [required] closure action to bubble to controller on filter selection change
  *
  * @example
  * {{filter-bar
  *   config=filterBarConfig
  *   filterBlocks=filterBlocks
+ *   entities=entities
  *   maxStrLen=25
  *   onSelectFilter=(action "onFilterSelection")}}
  *
@@ -18,8 +20,6 @@
  */
 import Ember from 'ember';
 import _ from 'lodash';
-
-const { setProperties } = Ember;
 
 export default Ember.Component.extend({
 
@@ -41,57 +41,7 @@ export default Ember.Component.extend({
   urnsCache: {},
 
   /**
-   * Overwrite the init function
-   * Initializes values of the filter blocks
-   * Example of a filter block:
-   * {
-   *  filtersArray: [
-   *    {
-   *      isActive: false,
-   *      name: 'country',
-   *      id: 'country'
-   *    }
-   *  ],
-   *  header: 'holiday',
-   *  isHidden: true,
-   *  inputs: [
-   *    {
-   *      label: 'country',
-   *      type: 'dropdown
-   *    }
-   *  ]
-   * }
-   */
-  init() {
-    this._super(...arguments);
-    // Fetch the config file to create sub-filters
-    const filterBlocks = _.cloneDeep(this.get('config'));
-
-    // Set up filter block object
-    filterBlocks.forEach((block, index) => {
-      // Show first sub-filter by default but hide the rest
-      let isHidden = Boolean(index);
-      let filtersArray = [];
-
-      // Generate a name and id for each one based on provided filter keys
-      block.inputs.forEach((filter) => {
-        filtersArray.push({
-          isActive: false,
-          name: filter.label,
-          id: filter.label.dasherize()
-        });
-      });
-
-      // Now add new initialized props to block item
-      setProperties(block, {
-        filtersArray,
-        isHidden
-      });
-    });
-  },
-
-  /**
-   * observer on entities to set default event type when entities is loaded
+   * Observer on entities to set default event type when new entities are loaded
    * @type {undefined}
    */
   entitiesObserver: Ember.observer(

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
@@ -1,6 +1,6 @@
 {{!-- TODO: Create separate styling for filter-bar component --}}
 <div class="entity-filter filter-bar">
-  {{#each config as |block|}}
+  {{#each filterBlocks as |block|}}
     <section class="entity-filter__group">
       <h5 class="entity-filter__group-title">
         {{block.header}}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -3,6 +3,7 @@ import { filterObject, filterPrefix, toBaselineUrn, toCurrentUrn } from 'thirdey
 import EVENT_TABLE_COLUMNS from 'thirdeye-frontend/mocks/eventTableColumns';
 import config from 'thirdeye-frontend/mocks/filterBarConfig';
 import CryptoJS from 'cryptojs';
+const { setProperties } = Ember;
 
 const ROOTCAUSE_TAB_DIMENSIONS = "dimensions";
 const ROOTCAUSE_TAB_METRICS = "metrics";
@@ -214,6 +215,60 @@ export default Ember.Controller.extend({
     'breakdownsService.pending',
     function () {
       return this.get('breakdownsService.pending').size > 0;
+    }
+  ),
+
+  /**
+   * Constructs filter blocks based on the filter bar config to render the filter bar
+   * Example of a filter block:
+   * {
+   *  filtersArray: [
+   *    {
+   *      isActive: false,
+   *      name: 'country',
+   *      id: 'country'
+   *    }
+   *  ],
+   *  header: 'holiday',
+   *  isHidden: true,
+   *  inputs: [
+   *    {
+   *      label: 'country',
+   *      type: 'dropdown
+   *    }
+   *  ]
+   * }
+   * @type {Object[]} - array of filter block objects
+   */
+  filterBlocks: Ember.computed(
+    'config',
+    function() {
+      this._super(...arguments);
+      // Fetch the config file to create sub-filters
+      const filterBlocks = config;
+
+      // Set up filter block object
+      filterBlocks.forEach((block, index) => {
+        // Show first sub-filter by default but hide the rest
+        let isHidden = Boolean(index);
+        let filtersArray = [];
+
+        // Generate a name and id for each one based on provided filter keys
+        block.inputs.forEach((filter) => {
+          filtersArray.push({
+            isActive: false,
+            name: filter.label,
+            id: filter.label.dasherize()
+          });
+        });
+
+        // Now add new initialized props to block item
+        setProperties(block, {
+          filtersArray,
+          isHidden
+        });
+      });
+      return filterBlocks;
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -120,7 +120,7 @@
                 <div class="col-xs-3">
                   {{filter-bar
                     config=filterConfig
-                    activeTab=selectedTab
+                    filterBlocks=filterBlocks
                     entities=eventFilterEntities
                     onSelect=(action "onFilter")}}
                 </div>


### PR DESCRIPTION
- Moved creation of `filterBlocks` to rootcause's controller to pass to the `filter-bar` template, so the default block will be selected when different tabs are selected that doesn't affect changes to `entities` (`Events Correlation`, `Dimensions Analysis`). 