### PR TITLE
[TE] Add HTTPS client for Pinot's auto onboard of metrics

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auto/onboard/AutoOnboardPinotDataSource.java
@@ -1,6 +1,9 @@
 package com.linkedin.thirdeye.auto.onboard;
 
 import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,10 +42,15 @@ public class AutoOnboardPinotDataSource extends AutoOnboard {
 
   private AutoOnboardPinotMetricsUtils autoLoadPinotMetricsUtils;
 
-  public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig) {
+  public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig)
+      throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
     super(dataSourceConfig);
-    autoLoadPinotMetricsUtils = new AutoOnboardPinotMetricsUtils(dataSourceConfig);
-    LOG.info("Created {}", AutoOnboardPinotDataSource.class.getName());
+    try {
+      autoLoadPinotMetricsUtils = new AutoOnboardPinotMetricsUtils(dataSourceConfig);
+      LOG.info("Created {}", AutoOnboardPinotDataSource.class.getName());
+    } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+      throw e;
+    }
   }
 
   public AutoOnboardPinotDataSource(DataSourceConfig dataSourceConfig, AutoOnboardPinotMetricsUtils utils) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdeyeDataSourceProperties.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdeyeDataSourceProperties.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.datasource.pinot;
 public enum PinotThirdeyeDataSourceProperties {
   CONTROLLER_HOST("controllerHost"),
   CONTROLLER_PORT("controllerPort"),
+  CONTROLLER_CONNECTION_SCHEME("controllerConnectionScheme"),
   CLUSTER_NAME("clusterName"),
   ZOOKEEPER_URL("zookeeperUrl"),
   TAG("tag"),


### PR DESCRIPTION
Add a HTTPS client for Pinot's auto onboard of metrics. Currently, we assume that ThirdEye and Pinot controller are set up in the same network and thus we uses Accept All policy on the certificate for HTTPS connections (i.e., we assume that middle man's attack doesn't exist for now).

Test for HTTPS client is blocked by Pinot team's progress; HTTP client works as usual.