### PR TITLE
[TE] rootcause poc - session storage

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
@@ -44,7 +44,7 @@ export default Ember.Component.extend({
       const { labelMapping, attributesMap, eventType } = this.getProperties('labelMapping', 'attributesMap', 'eventType');
       let inputValues = [];
       if (attributesMap && attributesMap[eventType] && labelMapping) {
-        inputValues = Array.from(attributesMap[eventType][labelMapping]);
+        inputValues = Array.from(attributesMap[eventType][labelMapping] || []);
       }
       return inputValues;
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -47,7 +47,7 @@ export default Ember.Component.extend({
     'validUrns',
     function () {
       const { entities, validUrns } = this.getProperties('entities', 'validUrns');
-      return validUrns.filter(urn => entities[urn]).reduce((agg, urn) => { agg[urn] = entities[urn].color; return agg; }, {});
+      return validUrns.filter(urn => entities[stripTail(urn)]).reduce((agg, urn) => { agg[urn] = entities[stripTail(urn)].color; return agg; }, {});
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { toCurrentUrn, toBaselineUrn, hasPrefix, filterPrefix } from '../../../helpers/utils';
+import { toCurrentUrn, toBaselineUrn, hasPrefix, filterPrefix } from 'thirdeye-frontend/helpers/utils';
 
 const ROOTCAUSE_METRICS_SORT_PROPERTY_METRIC = 'metric';
 const ROOTCAUSE_METRICS_SORT_PROPERTY_DATASET = 'dataset';

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-settings/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-settings/component.js
@@ -19,7 +19,8 @@
 import Ember from 'ember';
 import moment from 'moment';
 import fetch from 'fetch';
-import { toFilters, toFilterMap, filterPrefix } from '../../../helpers/utils';
+import { toFilters, toFilterMap, filterPrefix } from 'thirdeye-frontend/helpers/utils';
+import _ from 'lodash'
 
 // TODO: move this to a utils file (DRYER)
 const _filterToUrn = (filters) => {
@@ -191,7 +192,7 @@ export default Ember.Component.extend({
     const otherUrns = this.get('otherUrns');
     const metricUrns = filterPrefix(otherUrns, 'thirdeye:metric:');
 
-    if (!metricUrns) { return null; }
+    if (_.isEmpty(metricUrns)) { return null; }
 
     return metricUrns[0];
   }),
@@ -206,7 +207,7 @@ export default Ember.Component.extend({
     const otherUrns = this.get('otherUrns');
     const metricUrns = filterPrefix(otherUrns, 'thirdeye:metric:');
 
-    if (!metricUrns) { return {}; }
+    if (_.isEmpty(metricUrns)) { return {}; }
 
     const id = metricUrns[0].split(':')[2];
     return fetch(`/data/autocomplete/filters/metric/${id}`)
@@ -371,7 +372,7 @@ export default Ember.Component.extend({
 
       const nonMetricUrns = [...otherUrns].filter(urn => !urn.startsWith('thirdeye:metric:'));
       const newOtherUrns = [...nonMetricUrns, ...selected];
-      
+
       this.set('otherUrns', newOtherUrns);
       this.send('updateContext');
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-tooltip/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-tooltip/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { filterPrefix, toBaselineUrn, toCurrentUrn, toMetricLabel } from 'thirdeye-frontend/helpers/utils';
+import { filterPrefix, toBaselineUrn, toCurrentUrn, toMetricLabel, stripTail } from 'thirdeye-frontend/helpers/utils';
 
 export default Component.extend({
   entities: null, // {}
@@ -74,7 +74,7 @@ export default Component.extend({
       const { entities, hoverUrns } = this.getProperties('entities', 'hoverUrns');
 
       return filterPrefix(hoverUrns, ['thirdeye:metric:', 'thirdeye:event:']).reduce((agg, urn) => {
-        agg[urn] = entities[urn].color;
+        agg[urn] = entities[stripTail(urn)].color;
         return agg;
       }, {});
     }

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -21,7 +21,7 @@ export default Ember.Service.extend({
     const { context, entities, nativeUrns } = this.getProperties('context', 'entities', 'nativeUrns');
 
     // special case: urn identity
-    const requestNativeUrns = new Set(filterPrefix(urns, 'thirdeye:metric:'));
+    const requestNativeUrns = new Set(filterPrefix(urns, ['thirdeye:metric:', 'thirdeye:event:anomaly:']));
     if (!_.isEqual(nativeUrns, requestNativeUrns)) {
       this.setProperties({ nativeUrns: requestNativeUrns });
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -97,7 +97,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
   },
 
   afterModel(model, transition) {
-    const maxTime = moment().valueOf();
+    const maxTime = moment().startOf('hour').valueOf();
 
     const defaultParams = {
       filters: JSON.stringify({}),

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -10,7 +10,8 @@
   {{/if}}
 
   <div class="row">
-    {{!-- TODO: delete <p> tags before release --}}
+    {{!-- TODO: replace with loading spinner --}}
+    {{#if isLoading}}
     <p>loading
       {{#if isLoadingEntities}}
         | ENTITIES
@@ -25,16 +26,18 @@
         | BREAKDOWNS
       {{/if}}
     </p>
+  {{/if}}
 
-    <p>testing | <a {{action "loadtestSelectedUrns"}}>select all entities (loadtest)</a></p>
-
-    <p>sharing | <a {{action "onShare"}}>save</a>
-      {{#if shareId}}
-        | {{#link-to "rootcause" (query-params shareId=shareId)}}{{shareId}}{{/link-to}}
+    <p>session | <a {{action "onSessionSave"}}>save</a> | <a {{action "onSessionSaveCopy"}}>save copy</a>
+      {{#if sessionId}}
+        | {{#link-to "rootcause" (query-params sessionId=sessionId)}}{{sessionId}}{{/link-to}}
       {{/if}}
     </p>
 
-    <h2 class="te-title te-title--rootcause">Root Cause Analysis</h2>
+    <h2 class="te-title te-title--rootcause">{{sessionName}} [edit?]</h2>
+
+    <p>{{#if sessionId}}(Session {{sessionId}}) {{/if}}{{sessionText}} [edit?]</p>
+
     {{rootcause-settings
       context=context
       config=settingsConfig
@@ -46,21 +49,21 @@
   <div class="row">
     <div class="card-container card-container--box-shadow">
       <div class="card-container__header">
-          <div class="card-container__subnav">
-            <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "events") "thirdeye-link--active"}}" {{action (mut activeTab) "events"}}>
-              Events Correlation
-            </a>
-          </div>
-          <div class="card-container__subnav">
-            <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "dimensions") "thirdeye-link--active"}}" {{action (mut activeTab) "dimensions"}}>
-              Dimensions Analysis
-            </a>
-          </div>
-          <div class="card-container__subnav">
-            <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "metrics") "thirdeye-link--active"}}" {{action (mut activeTab) "metrics"}}>
-              Metrics Correlation
-            </a>
-          </div>
+        <div class="card-container__subnav">
+          <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "dimensions") "thirdeye-link--active"}}" {{action (mut activeTab) "dimensions"}}>
+            Dimensions
+          </a>
+        </div>
+        <div class="card-container__subnav">
+          <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "metrics") "thirdeye-link--active"}}" {{action (mut activeTab) "metrics"}}>
+            Metrics
+          </a>
+        </div>
+        <div class="card-container__subnav">
+          <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "events") "thirdeye-link--active"}}" {{action (mut activeTab) "events"}}>
+            Events
+          </a>
+        </div>
       </div>
       <div class="card-container__body">
         <div class="row">

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -40,6 +40,7 @@ import com.linkedin.thirdeye.dashboard.resources.v2.DataResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.EventResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseEntityFormatter;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseResource;
+import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseSessionResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.TimeSeriesResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.aggregation.DefaultAggregationLoader;
 import com.linkedin.thirdeye.dashboard.resources.v2.rootcause.DefaultEntityFormatter;
@@ -149,6 +150,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new OnboardDatasetMetricResource());
     env.jersey().register(new AutoOnboardResource(config));
     env.jersey().register(new ConfigResource(DAO_REGISTRY.getConfigDAO()));
+    env.jersey().register(new RootCauseSessionResource(DAO_REGISTRY.getRootcauseSessionDAO(), new ObjectMapper()));
 
     env.getObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseResource.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -170,8 +169,8 @@ public class RootCauseResource {
    * <br/><b>(1) comma-delimited:</b> {@code "urns=thirdeye:metric:123,thirdeye:metric:124"}
    * <br/><b>(2) multi-param</b> {@code "urns=thirdeye:metric:123&urns=thirdeye:metric:124"}
    *
-   * @param urns
-   * @return
+   * @param urns urns param
+   * @return list of urns
    */
   private static List<String> parseUrnsParam(List<String> urns) {
     if(urns.size() != 1)

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseSessionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseSessionResource.java
@@ -1,0 +1,122 @@
+package com.linkedin.thirdeye.dashboard.resources.v2;
+
+import com.linkedin.thirdeye.datalayer.bao.RootcauseSessionManager;
+import com.linkedin.thirdeye.datalayer.dto.RootcauseSessionDTO;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+
+
+@Path(value = "/session")
+@Produces(MediaType.APPLICATION_JSON)
+public class RootCauseSessionResource {
+  private final RootcauseSessionManager sessionDAO;
+  private final ObjectMapper mapper;
+
+  public RootCauseSessionResource(RootcauseSessionManager sessionDAO, ObjectMapper mapper) {
+    this.sessionDAO = sessionDAO;
+    this.mapper = mapper;
+  }
+
+  @GET
+  @Path("/{sessionId}")
+  public RootcauseSessionDTO getSession(@PathParam("sessionId") Long sessionId) {
+    if (sessionId == null) {
+      throw new IllegalArgumentException("Must provide sessionId");
+    }
+
+    RootcauseSessionDTO session = this.sessionDAO.findById(sessionId);
+
+    if (session == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve session id %d", sessionId));
+    }
+
+    return session;
+  }
+
+  @POST
+  @Path("/")
+  public Long postSession(
+      String jsonString) throws IOException {
+    RootcauseSessionDTO session = this.mapper.readValue(jsonString, new TypeReference<RootcauseSessionDTO>() {});
+
+    return this.sessionDAO.save(session);
+  }
+
+  @GET
+  @Path("/query")
+  public List<RootcauseSessionDTO> getSession(
+      @QueryParam("id") String idsString,
+      @QueryParam("name") String namesString,
+      @QueryParam("owner") String ownersString,
+      @QueryParam("previousId") String previousIdsString,
+      @QueryParam("anomalyRangeStart") Long anomalyRangeStart,
+      @QueryParam("anomalyRangeEnd") Long anomalyRangeEnd,
+      @QueryParam("createdRangeStart") Long createdRangeStart,
+      @QueryParam("createdRangeEnd") Long createdRangeEnd) {
+
+    List<Predicate> predicates = new ArrayList<>();
+
+    if (!StringUtils.isBlank(idsString)) {
+      predicates.add(Predicate.IN("base_id", split(idsString)));
+    }
+
+    if (!StringUtils.isBlank(namesString)) {
+      predicates.add(Predicate.IN("name", split(namesString)));
+    }
+
+    if (!StringUtils.isBlank(ownersString)) {
+      predicates.add(Predicate.IN("owner", split(ownersString)));
+    }
+
+    if (!StringUtils.isBlank(previousIdsString)) {
+      predicates.add(Predicate.IN("previousId", split(previousIdsString)));
+    }
+
+    if (anomalyRangeStart != null) {
+      predicates.add(Predicate.GT("anomalyRangeEnd", anomalyRangeStart));
+    }
+
+    if (anomalyRangeEnd != null) {
+      predicates.add(Predicate.LT("anomalyRangeStart", anomalyRangeEnd));
+    }
+
+    if (createdRangeStart != null) {
+      predicates.add(Predicate.GE("created", createdRangeStart));
+    }
+
+    if (createdRangeEnd != null) {
+      predicates.add(Predicate.LT("created", createdRangeEnd));
+    }
+
+    if (predicates.isEmpty()) {
+      throw new IllegalArgumentException("Must provide at least one property");
+    }
+
+    return this.sessionDAO.findByPredicate(Predicate.AND(predicates.toArray(new Predicate[predicates.size()])));
+  }
+
+  private static String[] split(String str) {
+    List<String> args = new ArrayList<>(Arrays.asList(str.split(",")));
+    Iterator<String> itStr = args.iterator();
+    while (itStr.hasNext()) {
+      if (itStr.next().length() <= 0) {
+        itStr.remove();
+      }
+    }
+    return args.toArray(new String[args.size()]);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseSessionResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseSessionResource.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.dashboard.resources.v2;
 
+import com.linkedin.thirdeye.auth.ThirdEyeAuthFilter;
 import com.linkedin.thirdeye.datalayer.bao.RootcauseSessionManager;
 import com.linkedin.thirdeye.datalayer.dto.RootcauseSessionDTO;
 import com.linkedin.thirdeye.datalayer.util.Predicate;
@@ -18,6 +19,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
+import org.joda.time.DateTime;
 
 
 @Path(value = "/session")
@@ -52,6 +54,11 @@ public class RootCauseSessionResource {
   public Long postSession(
       String jsonString) throws IOException {
     RootcauseSessionDTO session = this.mapper.readValue(jsonString, new TypeReference<RootcauseSessionDTO>() {});
+
+    if (session.getId() == null) {
+      session.setCreated(DateTime.now().getMillis());
+      session.setOwner(ThirdEyeAuthFilter.getCurrentPrincipal().getName());
+    }
 
     return this.sessionDAO.save(session);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/RootcauseSessionManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/RootcauseSessionManager.java
@@ -9,9 +9,7 @@ public interface RootcauseSessionManager extends AbstractManager<RootcauseSessio
   List<RootcauseSessionDTO> findByName(String name);
   List<RootcauseSessionDTO> findByNameLike(Set<String> nameFragments);
   List<RootcauseSessionDTO> findByOwner(String owner);
-  List<RootcauseSessionDTO> findByOwnerLike(Set<String> ownerFragments);
   List<RootcauseSessionDTO> findByAnomalyRange(long start, long end);
-  List<RootcauseSessionDTO> findByBaselineRange(long start, long end);
   List<RootcauseSessionDTO> findByCreatedRange(long start, long end);
   List<RootcauseSessionDTO> findByPreviousId(long id);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/RootcauseSessionManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/RootcauseSessionManager.java
@@ -1,0 +1,17 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import com.linkedin.thirdeye.datalayer.dto.RootcauseSessionDTO;
+import java.util.List;
+import java.util.Set;
+
+
+public interface RootcauseSessionManager extends AbstractManager<RootcauseSessionDTO> {
+  List<RootcauseSessionDTO> findByName(String name);
+  List<RootcauseSessionDTO> findByNameLike(Set<String> nameFragments);
+  List<RootcauseSessionDTO> findByOwner(String owner);
+  List<RootcauseSessionDTO> findByOwnerLike(Set<String> ownerFragments);
+  List<RootcauseSessionDTO> findByAnomalyRange(long start, long end);
+  List<RootcauseSessionDTO> findByBaselineRange(long start, long end);
+  List<RootcauseSessionDTO> findByCreatedRange(long start, long end);
+  List<RootcauseSessionDTO> findByPreviousId(long id);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RootcauseSessionManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RootcauseSessionManagerImpl.java
@@ -23,9 +23,6 @@ public class RootcauseSessionManagerImpl extends AbstractManagerImpl<RootcauseSe
   private static final String FIND_BY_NAME_LIKE_TEMPLATE = "name LIKE :name__%d";
   private static final String FIND_BY_NAME_LIKE_KEY = "name__%d";
 
-  private static final String FIND_BY_CREATED_BY_LIKE_TEMPLATE = "owner LIKE :owner__%d";
-  private static final String FIND_BY_CREATED_BY_LIKE_KEY = "owner__%d";
-
   public RootcauseSessionManagerImpl() {
     super(RootcauseSessionDTO.class, RootcauseSessionBean.class);
   }
@@ -56,18 +53,8 @@ public class RootcauseSessionManagerImpl extends AbstractManagerImpl<RootcauseSe
   }
 
   @Override
-  public List<RootcauseSessionDTO> findByOwnerLike(Set<String> createdByFragments) {
-    return findByLike(createdByFragments, FIND_BY_CREATED_BY_LIKE_TEMPLATE, FIND_BY_CREATED_BY_LIKE_KEY);
-  }
-
-  @Override
   public List<RootcauseSessionDTO> findByAnomalyRange(long start, long end) {
     return findByPredicate(Predicate.AND(Predicate.GT("anomalyRangeEnd", start), Predicate.LT("anomalyRangeStart", end)));
-  }
-
-  @Override
-  public List<RootcauseSessionDTO> findByBaselineRange(long start, long end) {
-    return findByPredicate(Predicate.AND(Predicate.GT("baselineRangeEnd", start), Predicate.LT("baselineRangeStart", end)));
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RootcauseSessionManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RootcauseSessionManagerImpl.java
@@ -1,0 +1,110 @@
+package com.linkedin.thirdeye.datalayer.bao.jdbc;
+
+import com.google.inject.Singleton;
+import com.linkedin.thirdeye.datalayer.bao.RootcauseSessionManager;
+import com.linkedin.thirdeye.datalayer.dto.RootcauseSessionDTO;
+import com.linkedin.thirdeye.datalayer.pojo.AbstractBean;
+import com.linkedin.thirdeye.datalayer.pojo.RootcauseSessionBean;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+
+
+@Singleton
+public class RootcauseSessionManagerImpl extends AbstractManagerImpl<RootcauseSessionDTO> implements RootcauseSessionManager {
+  private static final String FIND_BY_LIKE_TEMPLATE = "WHERE %s";
+  private static final String FIND_BY_LIKE_JOINER = " AND ";
+  private static final String FIND_BY_LIKE_VALUE = "%%%s%%";
+
+  private static final String FIND_BY_NAME_LIKE_TEMPLATE = "name LIKE :name__%d";
+  private static final String FIND_BY_NAME_LIKE_KEY = "name__%d";
+
+  private static final String FIND_BY_CREATED_BY_LIKE_TEMPLATE = "owner LIKE :owner__%d";
+  private static final String FIND_BY_CREATED_BY_LIKE_KEY = "owner__%d";
+
+  public RootcauseSessionManagerImpl() {
+    super(RootcauseSessionDTO.class, RootcauseSessionBean.class);
+  }
+
+  @Override
+  public int update(RootcauseSessionDTO entity) {
+    throw new IllegalArgumentException("RootcauseSessionBeans are immutable");
+  }
+
+  @Override
+  public int update(RootcauseSessionDTO entity, Predicate predicate) {
+    throw new IllegalArgumentException("RootcauseSessionBeans are immutable");
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByName(String name) {
+    return findByPredicate(Predicate.EQ("name", name));
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByNameLike(Set<String> nameFragments) {
+    return findByLike(nameFragments, FIND_BY_NAME_LIKE_TEMPLATE, FIND_BY_NAME_LIKE_KEY);
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByOwner(String owner) {
+    return findByPredicate(Predicate.EQ("owner", owner));
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByOwnerLike(Set<String> createdByFragments) {
+    return findByLike(createdByFragments, FIND_BY_CREATED_BY_LIKE_TEMPLATE, FIND_BY_CREATED_BY_LIKE_KEY);
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByAnomalyRange(long start, long end) {
+    return findByPredicate(Predicate.AND(Predicate.GT("anomalyRangeEnd", start), Predicate.LT("anomalyRangeStart", end)));
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByBaselineRange(long start, long end) {
+    return findByPredicate(Predicate.AND(Predicate.GT("baselineRangeEnd", start), Predicate.LT("baselineRangeStart", end)));
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByCreatedRange(long start, long end) {
+    return findByPredicate(Predicate.AND(Predicate.GE("created", start), Predicate.LT("created", end)));
+  }
+
+  @Override
+  public List<RootcauseSessionDTO> findByPreviousId(long id) {
+    return findByPredicate(Predicate.EQ("previousId", id));
+  }
+
+  private List<RootcauseSessionDTO> findByLike(Set<String> fragments, String template, String key) {
+    return findByLike(fragments, template, key, RootcauseSessionDTO.class, RootcauseSessionBean.class);
+  }
+
+  private <B extends AbstractBean, D> List<D> findByLike(Set<String> fragments, String template, String key,
+      Class<D> dtoClass, Class<B> beanClass) {
+    List<String> conditions = new ArrayList<>();
+    Map<String, Object> params = new HashMap<>();
+
+    int i = 0;
+    for (String fragment : fragments) {
+      conditions.add(String.format(template, i));
+      params.put(String.format(key, i), String.format(FIND_BY_LIKE_VALUE, fragment));
+      i++;
+    }
+
+    String query = String.format(FIND_BY_LIKE_TEMPLATE, StringUtils.join(conditions, FIND_BY_LIKE_JOINER));
+
+    List<B> beans = genericPojoDao.executeParameterizedSQL(query, params, beanClass);
+
+    List<D> dtos = new ArrayList<>();
+    for (B bean : beans) {
+      dtos.add(MODEL_MAPPER.map(bean, dtoClass));
+    }
+
+    return dtos;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RootcauseSessionManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/RootcauseSessionManagerImpl.java
@@ -28,16 +28,6 @@ public class RootcauseSessionManagerImpl extends AbstractManagerImpl<RootcauseSe
   }
 
   @Override
-  public int update(RootcauseSessionDTO entity) {
-    throw new IllegalArgumentException("RootcauseSessionBeans are immutable");
-  }
-
-  @Override
-  public int update(RootcauseSessionDTO entity, Predicate predicate) {
-    throw new IllegalArgumentException("RootcauseSessionBeans are immutable");
-  }
-
-  @Override
   public List<RootcauseSessionDTO> findByName(String name) {
     return findByPredicate(Predicate.EQ("name", name));
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -30,6 +30,7 @@ import com.linkedin.thirdeye.datalayer.entity.MetricConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.OnboardDatasetMetricIndex;
 import com.linkedin.thirdeye.datalayer.entity.OverrideConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.RawAnomalyResultIndex;
+import com.linkedin.thirdeye.datalayer.entity.RootcauseSessionIndex;
 import com.linkedin.thirdeye.datalayer.entity.TaskIndex;
 import com.linkedin.thirdeye.datalayer.pojo.AbstractBean;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
@@ -52,6 +53,7 @@ import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.OnboardDatasetMetricBean;
 import com.linkedin.thirdeye.datalayer.pojo.OverrideConfigBean;
 import com.linkedin.thirdeye.datalayer.pojo.RawAnomalyResultBean;
+import com.linkedin.thirdeye.datalayer.pojo.RootcauseSessionBean;
 import com.linkedin.thirdeye.datalayer.pojo.TaskBean;
 import com.linkedin.thirdeye.datalayer.util.GenericResultSetMapper;
 import com.linkedin.thirdeye.datalayer.util.Predicate;
@@ -126,6 +128,8 @@ public class GenericPojoDao {
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, ApplicationIndex.class));
     pojoInfoMap.put(AlertSnapshotBean.class,
         newPojoInfo(DEFAULT_BASE_TABLE_NAME, AlertSnapshotIndex.class));
+    pojoInfoMap.put(RootcauseSessionBean.class,
+        newPojoInfo(DEFAULT_BASE_TABLE_NAME, RootcauseSessionIndex.class));
   }
 
   private static PojoInfo newPojoInfo(String baseTableName,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/RootcauseSessionDTO.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dto/RootcauseSessionDTO.java
@@ -1,0 +1,8 @@
+package com.linkedin.thirdeye.datalayer.dto;
+
+import com.linkedin.thirdeye.datalayer.pojo.RootcauseSessionBean;
+
+
+public class RootcauseSessionDTO extends RootcauseSessionBean {
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/RootcauseSessionIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/RootcauseSessionIndex.java
@@ -6,8 +6,6 @@ public class RootcauseSessionIndex extends AbstractIndexEntity {
   private Long previousId;
   private Long anomalyRangeStart;
   private Long anomalyRangeEnd;
-  private Long baselineRangeStart;
-  private Long baselineRangeEnd;
   private Long created;
 
   public String getName() {
@@ -48,22 +46,6 @@ public class RootcauseSessionIndex extends AbstractIndexEntity {
 
   public void setAnomalyRangeEnd(Long anomalyRangeEnd) {
     this.anomalyRangeEnd = anomalyRangeEnd;
-  }
-
-  public Long getBaselineRangeStart() {
-    return baselineRangeStart;
-  }
-
-  public void setBaselineRangeStart(Long baselineRangeStart) {
-    this.baselineRangeStart = baselineRangeStart;
-  }
-
-  public Long getBaselineRangeEnd() {
-    return baselineRangeEnd;
-  }
-
-  public void setBaselineRangeEnd(Long baselineRangeEnd) {
-    this.baselineRangeEnd = baselineRangeEnd;
   }
 
   public Long getCreated() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/RootcauseSessionIndex.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/entity/RootcauseSessionIndex.java
@@ -1,0 +1,76 @@
+package com.linkedin.thirdeye.datalayer.entity;
+
+public class RootcauseSessionIndex extends AbstractIndexEntity {
+  private String name;
+  private String owner;
+  private Long previousId;
+  private Long anomalyRangeStart;
+  private Long anomalyRangeEnd;
+  private Long baselineRangeStart;
+  private Long baselineRangeEnd;
+  private Long created;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public Long getPreviousId() {
+    return previousId;
+  }
+
+  public void setPreviousId(Long previousId) {
+    this.previousId = previousId;
+  }
+
+  public Long getAnomalyRangeStart() {
+    return anomalyRangeStart;
+  }
+
+  public void setAnomalyRangeStart(Long anomalyRangeStart) {
+    this.anomalyRangeStart = anomalyRangeStart;
+  }
+
+  public Long getAnomalyRangeEnd() {
+    return anomalyRangeEnd;
+  }
+
+  public void setAnomalyRangeEnd(Long anomalyRangeEnd) {
+    this.anomalyRangeEnd = anomalyRangeEnd;
+  }
+
+  public Long getBaselineRangeStart() {
+    return baselineRangeStart;
+  }
+
+  public void setBaselineRangeStart(Long baselineRangeStart) {
+    this.baselineRangeStart = baselineRangeStart;
+  }
+
+  public Long getBaselineRangeEnd() {
+    return baselineRangeEnd;
+  }
+
+  public void setBaselineRangeEnd(Long baselineRangeEnd) {
+    this.baselineRangeEnd = baselineRangeEnd;
+  }
+
+  public Long getCreated() {
+    return created;
+  }
+
+  public void setCreated(Long created) {
+    this.created = created;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.datalayer.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Objects;
+import java.util.Set;
 
 
 /**
@@ -21,6 +22,9 @@ public class RootcauseSessionBean extends AbstractBean {
   private Long analysisRangeStart;
   private Long analysisRangeEnd;
   private Long created;
+  private Long sessionVersion;
+  private Set<String> contextUrns;
+  private Set<String> selectedUrns;
 
   public String getName() {
     return name;
@@ -110,6 +114,30 @@ public class RootcauseSessionBean extends AbstractBean {
     this.created = created;
   }
 
+  public Long getSessionVersion() {
+    return sessionVersion;
+  }
+
+  public void setSessionVersion(Long sessionVersion) {
+    this.sessionVersion = sessionVersion;
+  }
+
+  public Set<String> getContextUrns() {
+    return contextUrns;
+  }
+
+  public void setContextUrns(Set<String> contextUrns) {
+    this.contextUrns = contextUrns;
+  }
+
+  public Set<String> getSelectedUrns() {
+    return selectedUrns;
+  }
+
+  public void setSelectedUrns(Set<String> selectedUrns) {
+    this.selectedUrns = selectedUrns;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -124,12 +152,13 @@ public class RootcauseSessionBean extends AbstractBean {
         && Objects.equals(previousId, that.previousId) && Objects.equals(anomalyRangeStart, that.anomalyRangeStart)
         && Objects.equals(anomalyRangeEnd, that.anomalyRangeEnd) && Objects.equals(analysisRangeStart,
         that.analysisRangeStart) && Objects.equals(analysisRangeEnd, that.analysisRangeEnd) && Objects.equals(created,
-        that.created);
+        that.created) && Objects.equals(sessionVersion, that.sessionVersion) && Objects.equals(contextUrns,
+        that.contextUrns) && Objects.equals(selectedUrns, that.selectedUrns);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(name, text, owner, compareMode, granularity, previousId, anomalyRangeStart, anomalyRangeEnd,
-        analysisRangeStart, analysisRangeEnd, created);
+        analysisRangeStart, analysisRangeEnd, created, sessionVersion, contextUrns, selectedUrns);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
@@ -22,7 +22,6 @@ public class RootcauseSessionBean extends AbstractBean {
   private Long analysisRangeStart;
   private Long analysisRangeEnd;
   private Long created;
-  private Long sessionVersion;
   private Set<String> contextUrns;
   private Set<String> selectedUrns;
 
@@ -114,14 +113,6 @@ public class RootcauseSessionBean extends AbstractBean {
     this.created = created;
   }
 
-  public Long getSessionVersion() {
-    return sessionVersion;
-  }
-
-  public void setSessionVersion(Long sessionVersion) {
-    this.sessionVersion = sessionVersion;
-  }
-
   public Set<String> getContextUrns() {
     return contextUrns;
   }
@@ -152,13 +143,13 @@ public class RootcauseSessionBean extends AbstractBean {
         && Objects.equals(previousId, that.previousId) && Objects.equals(anomalyRangeStart, that.anomalyRangeStart)
         && Objects.equals(anomalyRangeEnd, that.anomalyRangeEnd) && Objects.equals(analysisRangeStart,
         that.analysisRangeStart) && Objects.equals(analysisRangeEnd, that.analysisRangeEnd) && Objects.equals(created,
-        that.created) && Objects.equals(sessionVersion, that.sessionVersion) && Objects.equals(contextUrns,
+        that.created) && Objects.equals(contextUrns,
         that.contextUrns) && Objects.equals(selectedUrns, that.selectedUrns);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(name, text, owner, compareMode, granularity, previousId, anomalyRangeStart, anomalyRangeEnd,
-        analysisRangeStart, analysisRangeEnd, created, sessionVersion, contextUrns, selectedUrns);
+        analysisRangeStart, analysisRangeEnd, created, contextUrns, selectedUrns);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
@@ -13,11 +13,13 @@ public class RootcauseSessionBean extends AbstractBean {
   private String name;
   private String text;
   private String owner;
+  private String compareMode;
+  private String granularity;
   private Long previousId;
   private Long anomalyRangeStart;
   private Long anomalyRangeEnd;
-  private Long baselineRangeStart;
-  private Long baselineRangeEnd;
+  private Long analysisRangeStart;
+  private Long analysisRangeEnd;
   private Long created;
 
   public String getName() {
@@ -44,6 +46,22 @@ public class RootcauseSessionBean extends AbstractBean {
     this.owner = owner;
   }
 
+  public String getCompareMode() {
+    return compareMode;
+  }
+
+  public void setCompareMode(String compareMode) {
+    this.compareMode = compareMode;
+  }
+
+  public String getGranularity() {
+    return granularity;
+  }
+
+  public void setGranularity(String granularity) {
+    this.granularity = granularity;
+  }
+
   public Long getPreviousId() {
     return previousId;
   }
@@ -68,20 +86,20 @@ public class RootcauseSessionBean extends AbstractBean {
     this.anomalyRangeEnd = anomalyRangeEnd;
   }
 
-  public Long getBaselineRangeStart() {
-    return baselineRangeStart;
+  public Long getAnalysisRangeStart() {
+    return analysisRangeStart;
   }
 
-  public void setBaselineRangeStart(Long baselineRangeStart) {
-    this.baselineRangeStart = baselineRangeStart;
+  public void setAnalysisRangeStart(Long analysisRangeStart) {
+    this.analysisRangeStart = analysisRangeStart;
   }
 
-  public Long getBaselineRangeEnd() {
-    return baselineRangeEnd;
+  public Long getAnalysisRangeEnd() {
+    return analysisRangeEnd;
   }
 
-  public void setBaselineRangeEnd(Long baselineRangeEnd) {
-    this.baselineRangeEnd = baselineRangeEnd;
+  public void setAnalysisRangeEnd(Long analysisRangeEnd) {
+    this.analysisRangeEnd = analysisRangeEnd;
   }
 
   public Long getCreated() {
@@ -102,15 +120,16 @@ public class RootcauseSessionBean extends AbstractBean {
     }
     RootcauseSessionBean that = (RootcauseSessionBean) o;
     return Objects.equals(name, that.name) && Objects.equals(text, that.text) && Objects.equals(owner, that.owner)
+        && Objects.equals(compareMode, that.compareMode) && Objects.equals(granularity, that.granularity)
         && Objects.equals(previousId, that.previousId) && Objects.equals(anomalyRangeStart, that.anomalyRangeStart)
-        && Objects.equals(anomalyRangeEnd, that.anomalyRangeEnd) && Objects.equals(baselineRangeStart,
-        that.baselineRangeStart) && Objects.equals(baselineRangeEnd, that.baselineRangeEnd) && Objects.equals(created,
+        && Objects.equals(anomalyRangeEnd, that.anomalyRangeEnd) && Objects.equals(analysisRangeStart,
+        that.analysisRangeStart) && Objects.equals(analysisRangeEnd, that.analysisRangeEnd) && Objects.equals(created,
         that.created);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, text, owner, previousId, anomalyRangeStart, anomalyRangeEnd, baselineRangeStart,
-        baselineRangeEnd, created);
+    return Objects.hash(name, text, owner, compareMode, granularity, previousId, anomalyRangeStart, anomalyRangeEnd,
+        analysisRangeStart, analysisRangeEnd, created);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
@@ -5,8 +5,8 @@ import java.util.Objects;
 
 
 /**
- * RootcauseSessionBean holds information for stored rootcause investigation reports. Each session is immutable once
- * stored. Any modifications are stored in a new session with a backpointer to the previous version.
+ * RootcauseSessionBean holds information for stored rootcause investigation reports. Supports backpointers to previous
+ * versions.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RootcauseSessionBean extends AbstractBean {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/RootcauseSessionBean.java
@@ -1,0 +1,116 @@
+package com.linkedin.thirdeye.datalayer.pojo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Objects;
+
+
+/**
+ * RootcauseSessionBean holds information for stored rootcause investigation reports. Each session is immutable once
+ * stored. Any modifications are stored in a new session with a backpointer to the previous version.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RootcauseSessionBean extends AbstractBean {
+  private String name;
+  private String text;
+  private String owner;
+  private Long previousId;
+  private Long anomalyRangeStart;
+  private Long anomalyRangeEnd;
+  private Long baselineRangeStart;
+  private Long baselineRangeEnd;
+  private Long created;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public Long getPreviousId() {
+    return previousId;
+  }
+
+  public void setPreviousId(Long previousId) {
+    this.previousId = previousId;
+  }
+
+  public Long getAnomalyRangeStart() {
+    return anomalyRangeStart;
+  }
+
+  public void setAnomalyRangeStart(Long anomalyRangeStart) {
+    this.anomalyRangeStart = anomalyRangeStart;
+  }
+
+  public Long getAnomalyRangeEnd() {
+    return anomalyRangeEnd;
+  }
+
+  public void setAnomalyRangeEnd(Long anomalyRangeEnd) {
+    this.anomalyRangeEnd = anomalyRangeEnd;
+  }
+
+  public Long getBaselineRangeStart() {
+    return baselineRangeStart;
+  }
+
+  public void setBaselineRangeStart(Long baselineRangeStart) {
+    this.baselineRangeStart = baselineRangeStart;
+  }
+
+  public Long getBaselineRangeEnd() {
+    return baselineRangeEnd;
+  }
+
+  public void setBaselineRangeEnd(Long baselineRangeEnd) {
+    this.baselineRangeEnd = baselineRangeEnd;
+  }
+
+  public Long getCreated() {
+    return created;
+  }
+
+  public void setCreated(Long created) {
+    this.created = created;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RootcauseSessionBean)) {
+      return false;
+    }
+    RootcauseSessionBean that = (RootcauseSessionBean) o;
+    return Objects.equals(name, that.name) && Objects.equals(text, that.text) && Objects.equals(owner, that.owner)
+        && Objects.equals(previousId, that.previousId) && Objects.equals(anomalyRangeStart, that.anomalyRangeStart)
+        && Objects.equals(anomalyRangeEnd, that.anomalyRangeEnd) && Objects.equals(baselineRangeStart,
+        that.baselineRangeStart) && Objects.equals(baselineRangeEnd, that.baselineRangeEnd) && Objects.equals(created,
+        that.created);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, text, owner, previousId, anomalyRangeStart, anomalyRangeEnd, baselineRangeStart,
+        baselineRangeEnd, created);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/DaoProviderUtil.java
@@ -1,43 +1,39 @@
 package com.linkedin.thirdeye.datalayer.util;
 
-import com.linkedin.thirdeye.datalayer.entity.AlertConfigIndex;
-import com.linkedin.thirdeye.datalayer.entity.AlertSnapshotIndex;
-import com.linkedin.thirdeye.datalayer.entity.ApplicationIndex;
-import com.linkedin.thirdeye.datalayer.entity.ClassificationConfigIndex;
-import com.linkedin.thirdeye.datalayer.entity.ConfigIndex;
-import com.linkedin.thirdeye.datalayer.entity.EventIndex;
-import com.linkedin.thirdeye.datalayer.entity.AutotuneConfigIndex;
-import com.linkedin.thirdeye.datalayer.entity.GroupedAnomalyResultsIndex;
-import com.linkedin.thirdeye.datalayer.entity.OverrideConfigIndex;
-
-import io.dropwizard.configuration.ConfigurationFactory;
-import io.dropwizard.jackson.Jackson;
-
-import java.io.File;
-import java.sql.Connection;
-
-import javax.validation.Validation;
-
-import org.apache.tomcat.jdbc.pool.DataSource;
-
 import com.google.common.base.CaseFormat;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AbstractManagerImpl;
 import com.linkedin.thirdeye.datalayer.dto.AbstractDTO;
+import com.linkedin.thirdeye.datalayer.entity.AlertConfigIndex;
+import com.linkedin.thirdeye.datalayer.entity.AlertSnapshotIndex;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFeedbackIndex;
 import com.linkedin.thirdeye.datalayer.entity.AnomalyFunctionIndex;
+import com.linkedin.thirdeye.datalayer.entity.ApplicationIndex;
+import com.linkedin.thirdeye.datalayer.entity.AutotuneConfigIndex;
+import com.linkedin.thirdeye.datalayer.entity.ClassificationConfigIndex;
+import com.linkedin.thirdeye.datalayer.entity.ConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DataCompletenessConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DatasetConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.DetectionStatusIndex;
 import com.linkedin.thirdeye.datalayer.entity.EntityToEntityMappingIndex;
+import com.linkedin.thirdeye.datalayer.entity.EventIndex;
 import com.linkedin.thirdeye.datalayer.entity.GenericJsonEntity;
+import com.linkedin.thirdeye.datalayer.entity.GroupedAnomalyResultsIndex;
 import com.linkedin.thirdeye.datalayer.entity.JobIndex;
 import com.linkedin.thirdeye.datalayer.entity.MergedAnomalyResultIndex;
 import com.linkedin.thirdeye.datalayer.entity.MetricConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.OnboardDatasetMetricIndex;
+import com.linkedin.thirdeye.datalayer.entity.OverrideConfigIndex;
 import com.linkedin.thirdeye.datalayer.entity.RawAnomalyResultIndex;
+import com.linkedin.thirdeye.datalayer.entity.RootcauseSessionIndex;
 import com.linkedin.thirdeye.datalayer.entity.TaskIndex;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import java.io.File;
+import java.sql.Connection;
+import javax.validation.Validation;
+import org.apache.tomcat.jdbc.pool.DataSource;
 
 public abstract class DaoProviderUtil {
 
@@ -146,6 +142,8 @@ public abstract class DaoProviderUtil {
             convertCamelCaseToUnderscore(ApplicationIndex.class.getSimpleName()));
         entityMappingHolder.register(conn, AlertSnapshotIndex.class,
             convertCamelCaseToUnderscore(AlertSnapshotIndex.class.getSimpleName()));
+        entityMappingHolder.register(conn, RootcauseSessionIndex.class,
+            convertCamelCaseToUnderscore(RootcauseSessionIndex.class.getSimpleName()));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DAORegistry.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/DAORegistry.java
@@ -19,6 +19,7 @@ import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.OnboardDatasetMetricManager;
 import com.linkedin.thirdeye.datalayer.bao.OverrideConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.RawAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.bao.RootcauseSessionManager;
 import com.linkedin.thirdeye.datalayer.bao.TaskManager;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.AlertSnapshotManagerImpl;
@@ -39,6 +40,7 @@ import com.linkedin.thirdeye.datalayer.bao.jdbc.MetricConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.OnboardDatasetMetricManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.OverrideConfigManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.RawAnomalyResultManagerImpl;
+import com.linkedin.thirdeye.datalayer.bao.jdbc.RootcauseSessionManagerImpl;
 import com.linkedin.thirdeye.datalayer.bao.jdbc.TaskManagerImpl;
 import com.linkedin.thirdeye.datalayer.util.DaoProviderUtil;
 
@@ -157,5 +159,9 @@ public class DAORegistry {
 
   public AlertSnapshotManager getAlertSnapshotDAO() {
     return DaoProviderUtil.getInstance(AlertSnapshotManagerImpl.class);
+  }
+
+  public RootcauseSessionManager getRootcauseSessionDAO() {
+    return DaoProviderUtil.getInstance(RootcauseSessionManagerImpl.class);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
@@ -304,18 +304,20 @@ public class DaoTestUtils {
     return anomaly;
   }
 
-  public static RootcauseSessionDTO getTestRootcauseSessionResult(long start, long end, long baselineOffset, long created,
-      String name, String owner, String text, Long previousId) {
+  public static RootcauseSessionDTO getTestRootcauseSessionResult(long start, long end, long created,
+      String name, String owner, String text, String granularity, String compareMode, Long previousId) {
     RootcauseSessionDTO session = new RootcauseSessionDTO();
     session.setAnomalyRangeStart(start);
     session.setAnomalyRangeEnd(end);
-    session.setBaselineRangeStart(start - baselineOffset);
-    session.setBaselineRangeEnd(end - baselineOffset);
+    session.setAnalysisRangeStart(start - 100);
+    session.setAnalysisRangeEnd(end + 100);
     session.setName(name);
     session.setOwner(owner);
     session.setText(text);
     session.setPreviousId(previousId);
     session.setCreated(created);
+    session.setGranularity(granularity);
+    session.setCompareMode(compareMode);
     return session;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
@@ -30,6 +30,7 @@ import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.OnboardDatasetMetricDTO;
 import com.linkedin.thirdeye.datalayer.dto.OverrideConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.dto.RootcauseSessionDTO;
 import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean;
 import com.linkedin.thirdeye.detector.email.filter.AlphaBetaAlertFilter;
 import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
@@ -301,5 +302,20 @@ public class DaoTestUtils {
     anomaly.setCreatedTime(createdTime);
 
     return anomaly;
+  }
+
+  public static RootcauseSessionDTO getTestRootcauseSessionResult(long start, long end, long baselineOffset, long created,
+      String name, String owner, String text, Long previousId) {
+    RootcauseSessionDTO session = new RootcauseSessionDTO();
+    session.setAnomalyRangeStart(start);
+    session.setAnomalyRangeEnd(end);
+    session.setBaselineRangeStart(start - baselineOffset);
+    session.setBaselineRangeEnd(end - baselineOffset);
+    session.setName(name);
+    session.setOwner(owner);
+    session.setText(text);
+    session.setPreviousId(previousId);
+    session.setCreated(created);
+    return session;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestRootcauseSessionManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestRootcauseSessionManager.java
@@ -48,12 +48,14 @@ public class TestRootcauseSessionManager {
     RootcauseSessionDTO session = this.sessionDAO.findById(id);
     Assert.assertEquals(session.getAnomalyRangeStart(), (Long) 1000L);
     Assert.assertEquals(session.getAnomalyRangeEnd(), (Long) 1100L);
-    Assert.assertEquals(session.getBaselineRangeStart(), (Long) 500L);
-    Assert.assertEquals(session.getBaselineRangeEnd(), (Long) 600L);
+    Assert.assertEquals(session.getAnalysisRangeStart(), (Long) 900L);
+    Assert.assertEquals(session.getAnalysisRangeEnd(), (Long) 1200L);
     Assert.assertEquals(session.getCreated(), (Long) 1500L);
     Assert.assertEquals(session.getName(), "myname");
     Assert.assertEquals(session.getOwner(), "myowner");
     Assert.assertEquals(session.getText(), "mytext");
+    Assert.assertEquals(session.getGranularity(), "mygranularity");
+    Assert.assertEquals(session.getCompareMode(), "mycomparemode");
     Assert.assertEquals(session.getPreviousId(), (Long) 12345L);
   }
 
@@ -105,23 +107,6 @@ public class TestRootcauseSessionManager {
   }
 
   @Test
-  public void testFindSessionByOwnerLike() {
-    this.sessionDAO.save(makeOwner("XYZ"));
-    this.sessionDAO.save(makeOwner("YWX"));
-    this.sessionDAO.save(makeOwner("YX"));
-
-    List<RootcauseSessionDTO> sessionsWX = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("W", "X")));
-    List<RootcauseSessionDTO> sessionsXY = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("X", "Y")));
-    List<RootcauseSessionDTO> sessionsYZ = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("Y", "Z")));
-    List<RootcauseSessionDTO> sessionsWXYZ = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("W", "X", "Y", "Z")));
-
-    Assert.assertEquals(sessionsWX.size(), 1);
-    Assert.assertEquals(sessionsXY.size(), 3);
-    Assert.assertEquals(sessionsYZ.size(), 1);
-    Assert.assertEquals(sessionsWXYZ.size(), 0);
-  }
-
-  @Test
   public void testFindByCreatedRange() {
     this.sessionDAO.save(makeCreated(800));
     this.sessionDAO.save(makeCreated(900));
@@ -152,21 +137,6 @@ public class TestRootcauseSessionManager {
   }
 
   @Test
-  public void testFindByBaselineRange() {
-    this.sessionDAO.save(makeBaseline(1000, 1200));
-    this.sessionDAO.save(makeBaseline(1100, 1150));
-    this.sessionDAO.save(makeBaseline(1150, 1300));
-
-    List<RootcauseSessionDTO> sessionsBefore = this.sessionDAO.findByBaselineRange(0, 1000);
-    List<RootcauseSessionDTO> sessionsMid = this.sessionDAO.findByBaselineRange(1000, 1100);
-    List<RootcauseSessionDTO> sessionsEnd = this.sessionDAO.findByBaselineRange(1100, 1175);
-
-    Assert.assertEquals(sessionsBefore.size(), 0);
-    Assert.assertEquals(sessionsMid.size(), 1);
-    Assert.assertEquals(sessionsEnd.size(), 3);
-  }
-
-  @Test
   public void testFindByPreviousId() {
     this.sessionDAO.save(makePrevious(0));
     this.sessionDAO.save(makePrevious(1));
@@ -185,7 +155,8 @@ public class TestRootcauseSessionManager {
   }
 
   private static RootcauseSessionDTO makeDefault() {
-    return DaoTestUtils.getTestRootcauseSessionResult(1000, 1100, 500, 1500, "myname", "myowner", "mytext", 12345L);
+    return DaoTestUtils.getTestRootcauseSessionResult(1000, 1100, 1500, "myname", "myowner",
+        "mytext", "mygranularity", "mycomparemode", 12345L);
   }
 
   private static RootcauseSessionDTO makeName(String name) {
@@ -210,13 +181,6 @@ public class TestRootcauseSessionManager {
     RootcauseSessionDTO session = makeDefault();
     session.setAnomalyRangeStart(start);
     session.setAnomalyRangeEnd(end);
-    return session;
-  }
-
-  private static RootcauseSessionDTO makeBaseline(long start, long end) {
-    RootcauseSessionDTO session = makeDefault();
-    session.setBaselineRangeStart(start);
-    session.setBaselineRangeEnd(end);
     return session;
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestRootcauseSessionManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestRootcauseSessionManager.java
@@ -34,11 +34,17 @@ public class TestRootcauseSessionManager {
     this.sessionDAO.save(makeDefault());
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
+  @Test
   public void testUpdateSession() throws Exception {
     RootcauseSessionDTO session = makeDefault();
     this.sessionDAO.save(session);
+
+    session.setName("mynewname");
     this.sessionDAO.save(session);
+
+    RootcauseSessionDTO read = this.sessionDAO.findById(session.getId());
+
+    Assert.assertEquals(read.getName(), "mynewname");
   }
 
   @Test

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestRootcauseSessionManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestRootcauseSessionManager.java
@@ -1,0 +1,228 @@
+package com.linkedin.thirdeye.datalayer.bao;
+
+import com.linkedin.thirdeye.datalayer.DaoTestUtils;
+import com.linkedin.thirdeye.datalayer.dto.RootcauseSessionDTO;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TestRootcauseSessionManager {
+
+  private DAOTestBase testDAOProvider;
+  private RootcauseSessionManager sessionDAO;
+
+  @BeforeMethod
+  void beforeMethod() {
+    testDAOProvider = DAOTestBase.getInstance();
+    DAORegistry daoRegistry = DAORegistry.getInstance();
+    sessionDAO = daoRegistry.getRootcauseSessionDAO();
+  }
+
+  @AfterMethod(alwaysRun = true)
+  void afterMethod() {
+    testDAOProvider.cleanup();
+  }
+
+  @Test
+  public void testCreateSession() {
+    this.sessionDAO.save(makeDefault());
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testUpdateSession() throws Exception {
+    RootcauseSessionDTO session = makeDefault();
+    this.sessionDAO.save(session);
+    this.sessionDAO.save(session);
+  }
+
+  @Test
+  public void testFindSessionById() {
+    Long id = this.sessionDAO.save(makeDefault());
+
+    RootcauseSessionDTO session = this.sessionDAO.findById(id);
+    Assert.assertEquals(session.getAnomalyRangeStart(), (Long) 1000L);
+    Assert.assertEquals(session.getAnomalyRangeEnd(), (Long) 1100L);
+    Assert.assertEquals(session.getBaselineRangeStart(), (Long) 500L);
+    Assert.assertEquals(session.getBaselineRangeEnd(), (Long) 600L);
+    Assert.assertEquals(session.getCreated(), (Long) 1500L);
+    Assert.assertEquals(session.getName(), "myname");
+    Assert.assertEquals(session.getOwner(), "myowner");
+    Assert.assertEquals(session.getText(), "mytext");
+    Assert.assertEquals(session.getPreviousId(), (Long) 12345L);
+  }
+
+  @Test
+  public void testFindSessionByName() {
+    this.sessionDAO.save(makeName("A"));
+    this.sessionDAO.save(makeName("B"));
+    this.sessionDAO.save(makeName("A"));
+
+    List<RootcauseSessionDTO> sessionsA = this.sessionDAO.findByName("A");
+    List<RootcauseSessionDTO> sessionsB = this.sessionDAO.findByName("B");
+    List<RootcauseSessionDTO> sessionsC = this.sessionDAO.findByName("C");
+
+    Assert.assertEquals(sessionsA.size(), 2);
+    Assert.assertEquals(sessionsB.size(), 1);
+    Assert.assertEquals(sessionsC.size(), 0);
+  }
+
+  @Test
+  public void testFindSessionByNameLike() {
+    this.sessionDAO.save(makeName("ABC"));
+    this.sessionDAO.save(makeName("BDC"));
+    this.sessionDAO.save(makeName("CB"));
+
+    List<RootcauseSessionDTO> sessionsAB = this.sessionDAO.findByNameLike(new HashSet<>(Arrays.asList("A", "B")));
+    List<RootcauseSessionDTO> sessionsBC = this.sessionDAO.findByNameLike(new HashSet<>(Arrays.asList("B", "C")));
+    List<RootcauseSessionDTO> sessionsCD = this.sessionDAO.findByNameLike(new HashSet<>(Arrays.asList("C", "D")));
+    List<RootcauseSessionDTO> sessionsABCD = this.sessionDAO.findByNameLike(new HashSet<>(Arrays.asList("A", "B", "C", "D")));
+
+    Assert.assertEquals(sessionsAB.size(), 1);
+    Assert.assertEquals(sessionsBC.size(), 3);
+    Assert.assertEquals(sessionsCD.size(), 1);
+    Assert.assertEquals(sessionsABCD.size(), 0);
+  }
+
+  @Test
+  public void testFindSessionByOwner() {
+    this.sessionDAO.save(makeOwner("X"));
+    this.sessionDAO.save(makeOwner("Y"));
+    this.sessionDAO.save(makeOwner("Y"));
+
+    List<RootcauseSessionDTO> sessionsX = this.sessionDAO.findByOwner("X");
+    List<RootcauseSessionDTO> sessionsY = this.sessionDAO.findByOwner("Y");
+    List<RootcauseSessionDTO> sessionsZ = this.sessionDAO.findByOwner("Z");
+
+    Assert.assertEquals(sessionsX.size(), 1);
+    Assert.assertEquals(sessionsY.size(), 2);
+    Assert.assertEquals(sessionsZ.size(), 0);
+  }
+
+  @Test
+  public void testFindSessionByOwnerLike() {
+    this.sessionDAO.save(makeOwner("XYZ"));
+    this.sessionDAO.save(makeOwner("YWX"));
+    this.sessionDAO.save(makeOwner("YX"));
+
+    List<RootcauseSessionDTO> sessionsWX = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("W", "X")));
+    List<RootcauseSessionDTO> sessionsXY = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("X", "Y")));
+    List<RootcauseSessionDTO> sessionsYZ = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("Y", "Z")));
+    List<RootcauseSessionDTO> sessionsWXYZ = this.sessionDAO.findByOwnerLike(new HashSet<>(Arrays.asList("W", "X", "Y", "Z")));
+
+    Assert.assertEquals(sessionsWX.size(), 1);
+    Assert.assertEquals(sessionsXY.size(), 3);
+    Assert.assertEquals(sessionsYZ.size(), 1);
+    Assert.assertEquals(sessionsWXYZ.size(), 0);
+  }
+
+  @Test
+  public void testFindByCreatedRange() {
+    this.sessionDAO.save(makeCreated(800));
+    this.sessionDAO.save(makeCreated(900));
+    this.sessionDAO.save(makeCreated(1000));
+
+    List<RootcauseSessionDTO> sessionsBefore = this.sessionDAO.findByCreatedRange(700, 800);
+    List<RootcauseSessionDTO> sessionsMid = this.sessionDAO.findByCreatedRange(800, 1000);
+    List<RootcauseSessionDTO> sessionsEnd = this.sessionDAO.findByCreatedRange(1000, 1500);
+
+    Assert.assertEquals(sessionsBefore.size(), 0);
+    Assert.assertEquals(sessionsMid.size(), 2);
+    Assert.assertEquals(sessionsEnd.size(), 1);
+  }
+
+  @Test
+  public void testFindByAnomalyRange() {
+    this.sessionDAO.save(makeAnomaly(1000, 1200));
+    this.sessionDAO.save(makeAnomaly(1100, 1150));
+    this.sessionDAO.save(makeAnomaly(1150, 1300));
+
+    List<RootcauseSessionDTO> sessionsBefore = this.sessionDAO.findByAnomalyRange(0, 1000);
+    List<RootcauseSessionDTO> sessionsMid = this.sessionDAO.findByAnomalyRange(1000, 1100);
+    List<RootcauseSessionDTO> sessionsEnd = this.sessionDAO.findByAnomalyRange(1100, 1175);
+
+    Assert.assertEquals(sessionsBefore.size(), 0);
+    Assert.assertEquals(sessionsMid.size(), 1);
+    Assert.assertEquals(sessionsEnd.size(), 3);
+  }
+
+  @Test
+  public void testFindByBaselineRange() {
+    this.sessionDAO.save(makeBaseline(1000, 1200));
+    this.sessionDAO.save(makeBaseline(1100, 1150));
+    this.sessionDAO.save(makeBaseline(1150, 1300));
+
+    List<RootcauseSessionDTO> sessionsBefore = this.sessionDAO.findByBaselineRange(0, 1000);
+    List<RootcauseSessionDTO> sessionsMid = this.sessionDAO.findByBaselineRange(1000, 1100);
+    List<RootcauseSessionDTO> sessionsEnd = this.sessionDAO.findByBaselineRange(1100, 1175);
+
+    Assert.assertEquals(sessionsBefore.size(), 0);
+    Assert.assertEquals(sessionsMid.size(), 1);
+    Assert.assertEquals(sessionsEnd.size(), 3);
+  }
+
+  @Test
+  public void testFindByPreviousId() {
+    this.sessionDAO.save(makePrevious(0));
+    this.sessionDAO.save(makePrevious(1));
+    this.sessionDAO.save(makePrevious(1));
+    this.sessionDAO.save(makePrevious(2));
+
+    List<RootcauseSessionDTO> sessions0 = this.sessionDAO.findByPreviousId(0);
+    List<RootcauseSessionDTO> sessions1 = this.sessionDAO.findByPreviousId(1);
+    List<RootcauseSessionDTO> sessions2 = this.sessionDAO.findByPreviousId(2);
+    List<RootcauseSessionDTO> sessions3 = this.sessionDAO.findByPreviousId(3);
+
+    Assert.assertEquals(sessions0.size(), 1);
+    Assert.assertEquals(sessions1.size(), 2);
+    Assert.assertEquals(sessions2.size(), 1);
+    Assert.assertEquals(sessions3.size(), 0);
+  }
+
+  private static RootcauseSessionDTO makeDefault() {
+    return DaoTestUtils.getTestRootcauseSessionResult(1000, 1100, 500, 1500, "myname", "myowner", "mytext", 12345L);
+  }
+
+  private static RootcauseSessionDTO makeName(String name) {
+    RootcauseSessionDTO session = makeDefault();
+    session.setName(name);
+    return session;
+  }
+
+  private static RootcauseSessionDTO makeOwner(String owner) {
+    RootcauseSessionDTO session = makeDefault();
+    session.setOwner(owner);
+    return session;
+  }
+
+  private static RootcauseSessionDTO makeCreated(long created) {
+    RootcauseSessionDTO session = makeDefault();
+    session.setCreated(created);
+    return session;
+  }
+
+  private static RootcauseSessionDTO makeAnomaly(long start, long end) {
+    RootcauseSessionDTO session = makeDefault();
+    session.setAnomalyRangeStart(start);
+    session.setAnomalyRangeEnd(end);
+    return session;
+  }
+
+  private static RootcauseSessionDTO makeBaseline(long start, long end) {
+    RootcauseSessionDTO session = makeDefault();
+    session.setBaselineRangeStart(start);
+    session.setBaselineRangeEnd(end);
+    return session;
+  }
+
+  private static RootcauseSessionDTO makePrevious(long previousId) {
+    RootcauseSessionDTO session = makeDefault();
+    session.setPreviousId(previousId);
+    return session;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -328,3 +328,26 @@ create table if not exists alert_snapshot_index (
     update_time timestamp default current_timestamp,
     version int(10)
 ) ENGINE=InnoDB;
+
+create table if not exists rootcause_session_index (
+    base_id bigint(20) not null,
+    create_time timestamp,
+    update_time timestamp default current_timestamp,
+    name varchar(256),
+    owner varchar(32),
+    previousId bigint(20),
+    anomaly_range_start bigint(8),
+    anomaly_range_end bigint(8),
+    baseline_range_start bigint(8),
+    baseline_range_end bigint(8),
+    created bigint(8),
+    version int(10)
+) ENGINE=InnoDB;
+create index rootcause_session_name_idx on rootcause_session_index(name);
+create index rootcause_session_owner_idx on rootcause_session_index(owner);
+create index rootcause_session_previousId_idx on rootcause_session_index(previousId);
+create index rootcause_session_anomaly_range_start_idx on rootcause_session_index(anomaly_range_start);
+create index rootcause_session_anomaly_range_end_idx on rootcause_session_index(anomaly_range_end);
+create index rootcause_session_baseline_range_start_idx on rootcause_session_index(baseline_range_start);
+create index rootcause_session_baseline_range_end_idx on rootcause_session_index(baseline_range_end);
+create index rootcause_session_created_idx on rootcause_session_index(created);

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -338,8 +338,6 @@ create table if not exists rootcause_session_index (
     previousId bigint(20),
     anomaly_range_start bigint(8),
     anomaly_range_end bigint(8),
-    baseline_range_start bigint(8),
-    baseline_range_end bigint(8),
     created bigint(8),
     version int(10)
 ) ENGINE=InnoDB;
@@ -348,6 +346,4 @@ create index rootcause_session_owner_idx on rootcause_session_index(owner);
 create index rootcause_session_previousId_idx on rootcause_session_index(previousId);
 create index rootcause_session_anomaly_range_start_idx on rootcause_session_index(anomaly_range_start);
 create index rootcause_session_anomaly_range_end_idx on rootcause_session_index(anomaly_range_end);
-create index rootcause_session_baseline_range_start_idx on rootcause_session_index(baseline_range_start);
-create index rootcause_session_baseline_range_end_idx on rootcause_session_index(baseline_range_end);
 create index rootcause_session_created_idx on rootcause_session_index(created);

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/drop-tables.sql
@@ -22,4 +22,5 @@ DROP TABLE IF EXISTS onboard_dataset_metric_index;
 DROP TABLE IF EXISTS config_index;
 DROP TABLE IF EXISTS application_index;
 DROP TABLE IF EXISTS alert_snapshot_index;
+DROP TABLE IF EXISTS rootcause_session_index;
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Add structured RCA session storage to frontend and backend. Most notably adds support for custom naming and custom text per session and enables the backend to introspect and search the contents of RCA sessions.

* rootcause session bean, DAO, and tests

* rootcause session endpoint with predicate search and partial updates

* frontend integration with rootcause session backend (replaces "share")

* various frontend bugfixes for smaller issues encountered during testing