### PR TITLE
Enable support for splitting predicate values for NOT-IN clause.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/BaseInPredicate.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/BaseInPredicate.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.common.predicate;
+
+import com.linkedin.pinot.core.common.Predicate;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Abstract base class for IN and NOT IN predicates.
+ */
+public abstract class BaseInPredicate extends Predicate {
+  public static final String DELIMITER = "\t\t";
+
+  public BaseInPredicate(String lhs, Type predicateType, List<String> rhs) {
+    super(lhs, predicateType, rhs);
+  }
+
+  @Override
+  public String toString() {
+    List<String> rhs = getRhs();
+    return "Predicate: type: " + getType() + ", left : " + getLhs() + ", right : " + Arrays.toString(
+        rhs.toArray(new String[rhs.size()])) + "\n";
+  }
+
+  public String[] getValues() {
+    /* To maintain backward compatibility, we always split if number of values is one. We do not support
+       case where DELIMITER is a sub-string of value.
+     */
+    List<String> values = getRhs();
+    return (values.size() == 1) ? values.get(0).split(DELIMITER) : values.toArray(new String[values.size()]);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/InPredicate.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/InPredicate.java
@@ -15,32 +15,20 @@
  */
 package com.linkedin.pinot.core.common.predicate;
 
-import java.util.Arrays;
 import java.util.List;
 
-import com.linkedin.pinot.core.common.Predicate;
 
+/**
+ * This class implements the IN predicate.
+ */
+public class InPredicate extends BaseInPredicate {
 
-public class InPredicate extends Predicate {
-  public static final String DELIMITER = "\t\t";
-
+  /**
+   * Constructor for the class
+   * @param lhs LHS for the IN predicate (column name)
+   * @param rhs RHS for the IN predicate (list of values)
+   */
   public InPredicate(String lhs, List<String> rhs) {
     super(lhs, Type.IN, rhs);
   }
-
-  @Override
-  public String toString() {
-    List<String> rhs = getRhs();
-    return "Predicate: type: " + getType() + ", left : " + getLhs() + ", right : "
-        + Arrays.toString(rhs.toArray(new String[rhs.size()])) + "\n";
-  }
-
-  public String[] getInRange() {
-    /* To maintain backward compatibility, we always split if number of values is one. We do not support
-       case where DELIMITER is a sub-string of value.
-     */
-    List<String> values = getRhs();
-    return (values.size() == 1) ? values.get(0).split(DELIMITER) : values.toArray(new String[values.size()]);
-  }
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/NotInPredicate.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/NotInPredicate.java
@@ -15,25 +15,20 @@
  */
 package com.linkedin.pinot.core.common.predicate;
 
-import java.util.Arrays;
 import java.util.List;
 
-import com.linkedin.pinot.core.common.Predicate;
 
+/**
+ * This class implements the IN predicate.
+ */
+public class NotInPredicate extends BaseInPredicate {
 
-public class NotInPredicate extends Predicate {
-
+  /**
+   * Constructor for the class
+   * @param lhs LHS for the NOT-IN predicate (column name)
+   * @param rhs RHS for the NOT-IN predicate (list of values)
+   */
   public NotInPredicate(String lhs, List<String> rhs) {
     super(lhs, Type.NOT_IN, rhs);
-  }
-
-  @Override
-  public String toString() {
-    return "Predicate: type: " + getType() + ", left : " + getLhs() + ", right : "
-        + Arrays.toString(getRhs().toArray(new String[0])) + "\n";
-  }
-
-  public String[] getNotInRange() {
-    return getRhs().get(0).split("\t\t");
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -81,7 +81,7 @@ public class InPredicateEvaluatorFactory {
     int[] _matchingDictIds;
 
     DictionaryBasedInPredicateEvaluator(InPredicate inPredicate, Dictionary dictionary) {
-      String[] values = inPredicate.getInRange();
+      String[] values = inPredicate.getValues();
       _matchingDictIdSet = new IntOpenHashSet();
       for (String value : values) {
         int dictId = dictionary.indexOf(value);
@@ -119,7 +119,7 @@ public class InPredicateEvaluatorFactory {
     final IntSet _matchingValues;
 
     IntRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
-      String[] values = inPredicate.getInRange();
+      String[] values = inPredicate.getValues();
       _matchingValues = new IntOpenHashSet(values.length);
       for (String value : values) {
         _matchingValues.add(Integer.parseInt(value));
@@ -141,7 +141,7 @@ public class InPredicateEvaluatorFactory {
     final LongSet _matchingValues;
 
     LongRawValueBasedInPredicateEvaluator(InPredicate predicate) {
-      String[] values = predicate.getInRange();
+      String[] values = predicate.getValues();
       _matchingValues = new LongOpenHashSet(values.length);
       for (String value : values) {
         _matchingValues.add(Long.parseLong(value));
@@ -163,7 +163,7 @@ public class InPredicateEvaluatorFactory {
     final FloatSet _matchingValues;
 
     FloatRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
-      String[] values = inPredicate.getInRange();
+      String[] values = inPredicate.getValues();
       _matchingValues = new FloatOpenHashSet(values.length);
       for (String value : values) {
         _matchingValues.add(Float.parseFloat(value));
@@ -185,7 +185,7 @@ public class InPredicateEvaluatorFactory {
     final DoubleSet _matchingValues;
 
     DoubleRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
-      String[] values = inPredicate.getInRange();
+      String[] values = inPredicate.getValues();
       _matchingValues = new DoubleOpenHashSet(values.length);
       for (String value : values) {
         _matchingValues.add(Double.parseDouble(value));
@@ -207,7 +207,7 @@ public class InPredicateEvaluatorFactory {
     final Set<String> _matchingValues;
 
     StringRawValueBasedInPredicateEvaluator(InPredicate inPredicate) {
-      String[] values = inPredicate.getInRange();
+      String[] values = inPredicate.getValues();
       _matchingValues = new HashSet<>(values.length);
       Collections.addAll(_matchingValues, values);
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -83,7 +83,7 @@ public class NotInPredicateEvaluatorFactory {
     int[] _nonMatchingDictIds;
 
     DictionaryBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, Dictionary dictionary) {
-      String[] values = notInPredicate.getNotInRange();
+      String[] values = notInPredicate.getValues();
       _nonMatchingDictIdSet = new IntOpenHashSet(values.length);
       for (String value : values) {
         int dictId = dictionary.indexOf(value);
@@ -137,7 +137,7 @@ public class NotInPredicateEvaluatorFactory {
     final IntSet _nonMatchingValues;
 
     IntRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
-      String[] values = notInPredicate.getNotInRange();
+      String[] values = notInPredicate.getValues();
       _nonMatchingValues = new IntOpenHashSet(values.length);
       for (String value : values) {
         _nonMatchingValues.add(Integer.parseInt(value));
@@ -159,7 +159,7 @@ public class NotInPredicateEvaluatorFactory {
     final LongSet _nonMatchingValues;
 
     LongRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
-      String[] values = notInPredicate.getNotInRange();
+      String[] values = notInPredicate.getValues();
       _nonMatchingValues = new LongOpenHashSet(values.length);
       for (String value : values) {
         _nonMatchingValues.add(Long.parseLong(value));
@@ -181,7 +181,7 @@ public class NotInPredicateEvaluatorFactory {
     final FloatSet _nonMatchingValues;
 
     FloatRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
-      String[] values = notInPredicate.getNotInRange();
+      String[] values = notInPredicate.getValues();
       _nonMatchingValues = new FloatOpenHashSet(values.length);
       for (String value : values) {
         _nonMatchingValues.add(Float.parseFloat(value));
@@ -203,7 +203,7 @@ public class NotInPredicateEvaluatorFactory {
     final DoubleSet _nonMatchingValues;
 
     DoubleRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
-      String[] values = notInPredicate.getNotInRange();
+      String[] values = notInPredicate.getValues();
       _nonMatchingValues = new DoubleOpenHashSet(values.length);
       for (String value : values) {
         _nonMatchingValues.add(Double.parseDouble(value));
@@ -225,7 +225,7 @@ public class NotInPredicateEvaluatorFactory {
     final Set<String> _nonMatchingValues;
 
     StringRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate) {
-      String[] values = notInPredicate.getNotInRange();
+      String[] values = notInPredicate.getValues();
       _nonMatchingValues = new HashSet<>(values.length);
       Collections.addAll(_nonMatchingValues, values);
     }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/InPredicateTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/InPredicateTest.java
@@ -17,10 +17,10 @@ package com.linkedin.pinot.core.predicate;
 
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.utils.EqualityUtils;
-import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.request.FilterQueryTree;
 import com.linkedin.pinot.common.utils.request.RequestUtils;
 import com.linkedin.pinot.core.common.Predicate;
+import com.linkedin.pinot.core.common.predicate.BaseInPredicate;
 import com.linkedin.pinot.core.common.predicate.InPredicate;
 import com.linkedin.pinot.pql.parsers.Pql2Compiler;
 import java.util.Arrays;
@@ -42,8 +42,18 @@ public class InPredicateTest {
    */
   @Test
   public void testSplitInClause() {
-    Pql2Compiler compiler = new Pql2Compiler();
     String query = "select * from foo where values in ('abc', 'xyz', '123')";
+    testSplit(query);
+  }
+
+  @Test
+  public void testSplitNotInClause() {
+    String query = "select * from foo where values not in ('abc', 'xyz', '123')";
+    testSplit(query);
+  }
+
+  private void testSplit(String query) {
+    Pql2Compiler compiler = new Pql2Compiler();
 
     String[] expectedValues = new String[]{"abc", "xyz", "123"};
     Arrays.sort(expectedValues); /* InPredicateAstNode sorts the predicate values. */
@@ -51,8 +61,8 @@ public class InPredicateTest {
     /* Test split case */
     BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query, true /*splitInClause*/);
     FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
-    InPredicate predicate = (InPredicate) Predicate.newPredicate(filterQueryTree);
-    String[] actualValues = predicate.getInRange();
+    BaseInPredicate predicate = (BaseInPredicate) Predicate.newPredicate(filterQueryTree);
+    String[] actualValues = predicate.getValues();
     Arrays.sort(actualValues);
 
     Assert.assertEquals(actualValues, expectedValues);
@@ -61,8 +71,8 @@ public class InPredicateTest {
     /* Test join case */
     brokerRequest = compiler.compileToBrokerRequest(query, false /*splitInClause*/);
     filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
-    predicate = (InPredicate) Predicate.newPredicate(filterQueryTree);
-    actualValues = predicate.getInRange();
+    predicate = (BaseInPredicate) Predicate.newPredicate(filterQueryTree);
+    actualValues = predicate.getValues();
     Arrays.sort(actualValues);
 
     Assert.assertEquals(actualValues, expectedValues);


### PR DESCRIPTION
Support for splitting predicate values (not joining using '\t\t') is
only enabled for IN clause. And to make this feature always on, we need
to first enable it for NOT-IN clause as well, so server side can be
backward compatible and recognize both splitted and joined predicate
values. Once that is done, we can enable the feature by default.

1. Added support in NOT-IN predicate to handle both joined as well as
splitted predicate values.

2. Extracted out a base class to move common code for IN and NOT-IN.
Renamed 'getInRange' to getValues() so it can be moved to base class as
well.

3. Updated test to cover the NOT-IN case.

Once server side is available to handle both cases, will file another PR
to enable always splitting the values.