### PR TITLE
[TE] filter bar small tweaks

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
@@ -1,10 +1,14 @@
 <div class="filter-bar">
   {{#each filterBlocks as |block|}}
     <section class="filter-bar__group">
-      <h5 class="filter-bar__group-title {{if block.isHidden "" "filter-bar__group-title--active "}}">
-        <div class="filter-bar__group-circle filter-bar__group-circle--{{block.color}}"></div>
-        {{block.header}}
-        <a class="filter-bar__group-toggle" {{action 'selectEventType' block.eventType}}>
+      <h5 class="filter-bar__group-title {{if block.isHidden "" "filter-bar__group-title--active "}}" {{action 'selectEventType' block.eventType}}>
+        <div class="filter-bar__indicator">
+          <span class="entity-indicator entity-indicator--{{block.color}}"></span>
+        </div>
+        <div class="filter-bar__header">
+          <span>{{block.header}}</span>
+        </div>
+        <a class="filter-bar__group-toggle">
           <i class="glyphicon {{if block.isHidden " glyphicon-menu-up " "glyphicon-menu-down "}}"></i>
         </a>
       </h5>

--- a/thirdeye/thirdeye-frontend/app/styles/components/filter-bar.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/filter-bar.scss
@@ -1,28 +1,47 @@
 .filter-bar {
-
   background-color: white;
   border: 1px solid $te-grey--border;
+  color: app-shade(black, 0.85);
 
   &__group {
-    border-top: 1px solid $te-grey--border;
+    &:not(:first-of-type) {
+      border-top: 1px solid $te-grey--border;
+    }
   }
-
+  
   &__group-title {
     padding: 15px $te-default-element-spacing;
     margin-top: 0px;
     margin-bottom: 0px;
     font-size: 16px;
     border-left: 3px solid transparent;
-
+    display:flex;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    cursor: pointer;
+    
     &--active {
-      border-left: 3px solid $te-blue-6;
-      font-weight: bold;
+      border-left: 3px solid $te-blue-5;
+      font-weight: 600;
     }
+  }
+
+  &__indicator {
+    display: flex;
+    align-items: center;
+  }
+
+  &__header {
+    flex-grow: 1;
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
 
   &__group-toggle {
-    float: right;
+    margin-left: 4px;
     color: app-shade(black, 3);
     font-weight: 300;
   }
@@ -49,7 +68,6 @@ $colors:
 "green" $te-green,
 "pink" $te-pink;
 
-.filter-bar__group-circle,
 .entity-indicator {
   display: inline-block;
   margin-right: 10px;


### PR DESCRIPTION
### What's new: 
- removed  `filter-bar__group-circle` in favor or `.entity-indicator`
- changed layout of the filter bar to flex box which allows for text ellipsis
- small css tweak (colors, font weight, cursor)
- fix alignment between filter bar groups and the active one 

### Screenshots: 
<img width="297" alt="screen shot 2017-12-07 at 6 05 09 pm" src="https://user-images.githubusercontent.com/8664954/33748090-751b31d0-db7b-11e7-92d1-e2eb78bc1d35.png">
<img width="194" alt="screen shot 2017-12-07 at 6 05 52 pm" src="https://user-images.githubusercontent.com/8664954/33748091-752f1b96-db7b-11e7-983b-10d37efa40bf.png">

