### PR TITLE
Clean up dependency issues

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -149,7 +149,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka_2.10</artifactId>
-      <version>${kafka.version}</version>
     </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
@@ -181,12 +180,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -148,8 +148,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.8.4</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <!-- End Helix Related Depedency -->

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/TableSizeReaderTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -235,7 +236,7 @@ public class TableSizeReaderTest {
           }
         });
 
-    when(helix.getDataInstanceAdminEndpoints(anySet()))
+    when(helix.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
         .thenAnswer(new Answer<Object>() {
           @Override
           public Object answer(InvocationOnMock invocationOnMock)

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/retention/RetentionManagerTest.java
@@ -49,6 +49,7 @@ import org.apache.helix.model.IdealState;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.json.JSONException;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.Assert;
@@ -106,7 +107,7 @@ public class RetentionManagerTest {
     verify(deletionManager, times(1)).removeAgedDeletedSegments(anyInt());
 
     // Verify that the deleteSegments method is actually called.
-    verify(pinotHelixResourceManager, times(1)).deleteSegments(anyString(), anyList());
+    verify(pinotHelixResourceManager, times(1)).deleteSegments(anyString(), ArgumentMatchers.<String>anyList());
 
     retentionManager.stop();
   }
@@ -202,7 +203,7 @@ public class RetentionManagerTest {
         }
         return null;
       }
-    }).when(resourceManager).deleteSegments(anyString(), anyList());
+    }).when(resourceManager).deleteSegments(anyString(), ArgumentMatchers.<String>anyList());
   }
 
   // This test makes sure that we clean up the segments marked OFFLINE in realtime for more than 7 days
@@ -229,7 +230,7 @@ public class RetentionManagerTest {
     verify(deletionManager, times(1)).removeAgedDeletedSegments(anyInt());
 
     // Verify that the deleteSegments method is actually called.
-    verify(pinotHelixResourceManager, times(1)).deleteSegments(anyString(), anyList());
+    verify(pinotHelixResourceManager, times(1)).deleteSegments(anyString(), ArgumentMatchers.<String>anyList());
 
     retentionManager.stop();
   }

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -120,7 +120,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>com.clearspring.analytics</groupId>
@@ -139,8 +138,7 @@
     <!-- test -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.8.4</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -192,12 +192,10 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.193</version>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-posix</artifactId>
-      <version>3.0.12</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -82,12 +82,10 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>1.8</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -175,8 +175,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.8.4</version>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -60,7 +60,6 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.32</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>
@@ -70,7 +69,6 @@
     <dependency>
       <groupId>org.glassfish.tyrus.bundles</groupId>
       <artifactId>tyrus-standalone-client</artifactId>
-      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -354,11 +354,6 @@
         <version>1.9</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.1.3</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>0.9.1</version>
@@ -643,9 +638,44 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-csv</artifactId>
+        <version>1.0</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>1.4.193</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-posix</artifactId>
+        <version>3.0.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>1.8</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>1.15</version>
+      </dependency>
+      <dependency>
+        <groupId>args4j</groupId>
+        <artifactId>args4j</artifactId>
+        <version>2.32</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.tyrus.bundles</groupId>
+        <artifactId>tyrus-standalone-client</artifactId>
+        <version>1.5</version>
       </dependency>
     </dependencies>
 


### PR DESCRIPTION
Cleaned up various dependency issues:
 - Remove child POM dependency versions, move all version numbers to the
   parent POM
 - Fixed httpclient being specified twice with two different version
   numbers (4.1.3 and 4.2.5)
 - Fixed having multiple versions of mockito in different projects
   (1.8.4 and 2.10.0)