### PR TITLE
[TE] Fix null pointer exception occurs in data report

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/alert/util/EmailHelper.java
@@ -157,6 +157,7 @@ public abstract class EmailHelper {
 
     Period baselinePeriod = getBaselinePeriod(compareMode);
     ContributorViewRequest request = new ContributorViewRequest();
+    request.setCollection(collection);
 
     List<MetricExpression> metricExpressions =
         Utils.convertToMetricExpressions(metric, metricAggFunction, collection);


### PR DESCRIPTION
The request of collection is accidentally removed in one of previous PRs. This PR puts it back.

Tested on local alerter.