### PR TITLE
[PINOT-5458] Remove static initialization of classes in SegmentFetcherFactory

### DIFF
--- a/pinot-common/src/test/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactoryTest.java
@@ -21,12 +21,18 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class SegmentFetcherFactoryTest {
+
+  @BeforeTest
+  public void setUp() {
+    SegmentFetcherFactory.getPreloadSegmentFetchers().clear();
+  }
 
   @Test
   public void testInitSegmentFetcherFactory() throws Exception {
@@ -57,7 +63,6 @@ public class SegmentFetcherFactoryTest {
     Assert.assertEquals(((TestSegmentFetcher)SegmentFetcherFactory.getPreloadSegmentFetchers().get("test")).init_called, 1);
     ReplacedFetcher fetcher = (ReplacedFetcher)SegmentFetcherFactory.getPreloadSegmentFetchers().get(replacableProto);
     Assert.assertEquals(fetcher.getInitCalled(), 1);
-    SegmentFetcherFactory.getPreloadSegmentFetchers().clear();
   }
 
   @Test
@@ -70,7 +75,6 @@ public class SegmentFetcherFactoryTest {
     Assert.assertTrue(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("https://") instanceof HttpsSegmentFetcher);
     Assert.assertTrue(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("file://a/asdf/wer/fd/e") instanceof LocalFileSegmentFetcher);
     Assert.assertNull(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("abc:///something"));
-    SegmentFetcherFactory.getPreloadSegmentFetchers().clear();
   }
 
   @Test
@@ -85,7 +89,6 @@ public class SegmentFetcherFactoryTest {
       return;
     }
     Assert.fail();
-    SegmentFetcherFactory.getPreloadSegmentFetchers().clear();
   }
 
   public static class ReplacedFetcher implements SegmentFetcher {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/segment/fetcher/SegmentFetcherFactoryTest.java
@@ -57,26 +57,35 @@ public class SegmentFetcherFactoryTest {
     Assert.assertEquals(((TestSegmentFetcher)SegmentFetcherFactory.getPreloadSegmentFetchers().get("test")).init_called, 1);
     ReplacedFetcher fetcher = (ReplacedFetcher)SegmentFetcherFactory.getPreloadSegmentFetchers().get(replacableProto);
     Assert.assertEquals(fetcher.getInitCalled(), 1);
+    SegmentFetcherFactory.getPreloadSegmentFetchers().clear();
   }
 
   @Test
   public void testGetSegmentFetcherBasedOnURI() throws Exception {
+    Configuration configuration = new PropertiesConfiguration();
+    configuration.addProperty("https.ssl.server.enable-verification", "false");
+    SegmentFetcherFactory.initSegmentFetcherFactory(configuration);
     Assert.assertTrue(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("hdfs:///something/wer") instanceof HdfsSegmentFetcher);
     Assert.assertTrue(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("http://something:wer:") instanceof HttpSegmentFetcher);
     Assert.assertTrue(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("https://") instanceof HttpsSegmentFetcher);
     Assert.assertTrue(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("file://a/asdf/wer/fd/e") instanceof LocalFileSegmentFetcher);
-
     Assert.assertNull(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("abc:///something"));
+    SegmentFetcherFactory.getPreloadSegmentFetchers().clear();
   }
 
   @Test
   public void testGetSegmentFetcherBasedOnURIFailed() throws Exception {
+    Configuration configuration = new PropertiesConfiguration();
+    SegmentFetcherFactory.initSegmentFetcherFactory(configuration);
+    // If HttpsSegmentFetcher is not configured correctly, it fails to initialize.
+    Assert.assertNull(SegmentFetcherFactory.getSegmentFetcherBasedOnURI("https://"));
     try {
       SegmentFetcherFactory.getSegmentFetcherBasedOnURI("");
     } catch (UnsupportedOperationException ex) {
       return;
     }
     Assert.fail();
+    SegmentFetcherFactory.getPreloadSegmentFetchers().clear();
   }
 
   public static class ReplacedFetcher implements SegmentFetcher {


### PR DESCRIPTION
Static initialization of classes in SegmentFetcher factory can have unneeded exception stack trace
when the system starts up. The HttpsSegmentFetcher, for example, will throw (and log) initialization
exceptions, even if it is overridden with some other class. This poses a problem for deployments with
automated exception detection, not to mention unnecessary exception logs confusing the admin when
they have configured a different class.

Removed static initialization in the SegmentFetcherFactory class.

If initSegmentFetcherFactory is not called, then map of protocol to SegmentFetcher is not populated.