### PR TITLE
[TE] fix legend width and collapsing chart

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -32,25 +32,25 @@
           onSelection=(action "onSelection")
         }}
         <div class="container rootcause-wrapper__chart">
-              {{rootcause-chart-toolbar
-                context=context
-                timeseriesMode=timeseriesMode
-                onContext=(action "onContext")
-                onChart=(action "onChart")
-              }}
-              {{#if isLoadingTimeseries}}
-                <div class="spinner-wrapper spinner-wrapper--card">
-                  {{ember-spinner}}
-                </div>
-              {{/if}}
-              {{rootcause-chart
-                entities=entities
-                selectedUrns=chartSelectedUrns
-                timeseries=timeseries
-                timeseriesMode=timeseriesMode
-                context=context
-                onHover=(action "chartOnHover")
-              }}
+          {{rootcause-chart-toolbar
+            context=context
+            timeseriesMode=timeseriesMode
+            onContext=(action "onContext")
+            onChart=(action "onChart")
+          }}
+          {{#if isLoadingTimeseries}}
+            <div class="spinner-wrapper spinner-wrapper--card">
+              {{ember-spinner}}
+            </div>
+          {{/if}}
+          {{rootcause-chart
+            entities=entities
+            selectedUrns=chartSelectedUrns
+            timeseries=timeseries
+            timeseriesMode=timeseriesMode
+            context=context
+            onHover=(action "chartOnHover")
+          }}
         </div>
       </div>
       <div class="container">

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
@@ -1,3 +1,4 @@
 .rootcause-chart {
   flex-grow: 1;
+  min-height: 400px;
 }

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-legend.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-legend.scss
@@ -1,6 +1,6 @@
 .rootcause-legend {
   flex-basis: 200px;
-  min-width: 200px;
+  min-width: 25%;
   border-right: 1px solid app-shade(black, 0.15);
   overflow: scroll;
   display: flex;
@@ -9,6 +9,10 @@
 
   &__wrapper {
     position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
   }
 
   &__item {


### PR DESCRIPTION
### What's new: 
- added min height to the `rootcause-chart` to avoid collapsing
- increased legend width to be inline with the event filters

### Tests:
Visual sanity check locally 