### PR TITLE
[TE] rootcause poc - position tweak for comparison settings

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/template.hbs
@@ -1,37 +1,48 @@
-<div class="col-xs-2">
-  {{date-range-picker
-    class="te-range-picker"
-    start=analysisRangeStart
-    end=analysisRangeEnd
-    maxDate=analysisRangeMax
-    ranges=analysisRangePredefined
-    showCustomRangeLabel=false
-    format="MMM D"
-    serverFormat="YYYY-MM-DD HH:mm"
-    applyAction=(action "onAnalysisRange")
-  }}
-</div>
-<div class="col-xs-2">
-  {{#power-select
-    selected=granularity
-    options=granularityOptions
-    searchEnabled=false
-    triggerId="select-granularity"
-    onchange=(action "onGranularity")
-    as |granularity|
-  }}
-    {{granularity}}
-  {{/power-select}}
-</div>
-<div class="col-xs-2">
-  {{#power-select
-    selected=timeseriesMode
-    options=timeseriesModeOptions
-    searchEnabled=false
-    triggerId="select-timeseries-mode"
-    onchange=(action "onTimeseriesMode")
-    as |mode|
-  }}
-    {{mode}}
-  {{/power-select}}
+<div class="row">
+  <div class="col-xs-2">
+    Time-series
+    <span>
+      <i class="glyphicon glyphicon-question-sign"></i>
+      {{#tooltip-on-element}}
+        These settings affect only the display of time-series. To change the comparison region and mode, use the "comparison" settings below.
+      {{/tooltip-on-element}}
+    </span>
+  </div>
+  <div class="col-xs-4">
+    {{date-range-picker
+      class="te-range-picker"
+      start=analysisRangeStart
+      end=analysisRangeEnd
+      maxDate=analysisRangeMax
+      ranges=analysisRangePredefined
+      showCustomRangeLabel=false
+      format="MMM D"
+      serverFormat="YYYY-MM-DD HH:mm"
+      applyAction=(action "onAnalysisRange")
+    }}
+  </div>
+  <div class="col-xs-2">
+    {{#power-select
+      selected=granularity
+      options=granularityOptions
+      searchEnabled=false
+      triggerId="select-granularity"
+      onchange=(action "onGranularity")
+      as |granularity|
+    }}
+      {{granularity}}
+    {{/power-select}}
+  </div>
+  <div class="col-xs-2">
+    {{#power-select
+      selected=timeseriesMode
+      options=timeseriesModeOptions
+      searchEnabled=false
+      triggerId="select-timeseries-mode"
+      onchange=(action "onTimeseriesMode")
+      as |mode|
+    }}
+      {{mode}}
+    {{/power-select}}
+  </div>
 </div>

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/template.hbs
@@ -1,7 +1,7 @@
 {{#if isSplit}}
   {{#each splitUrns as |urn|}}
-    <div>
-      <h4>{{get-safe splitLabels urn}}</h4>
+    <div class="row">
+      <h4 class="rootcause-chart--split__header">{{get-safe splitLabels urn}}</h4>
       {{timeseries-chart
         series=(get splitSeries urn)
         tooltip=tooltip
@@ -13,11 +13,13 @@
     </div>
   {{/each}}
 {{else}}
-  {{timeseries-chart
-    series=series
-    tooltip=tooltip
-    legend=legend
-    axis=axis
-    subchart=subchart
-  }}
+  <div class="row">
+    {{timeseries-chart
+      series=series
+      tooltip=tooltip
+      legend=legend
+      axis=axis
+      subchart=subchart
+    }}
+  </div>
 {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/template.hbs
@@ -1,28 +1,39 @@
-<div class="col-xs-4">
-  {{date-range-picker
-    class="te-range-picker"
-    timePicker=true
-    timePicker24Hour=true
-    timePickerIncrement=5
-    start=startFormatted
-    end=endFormatted
-    maxDate=maxDateFormatted
-    ranges=rangeOptions
-    showCustomRangeLabel=false
-    format="MMM D, hh:mm a"
-    serverFormat="YYYY-MM-DD HH:mm"
-    applyAction=(action "onRange")
-  }}
-</div>
-<div class="col-xs-2">
-  {{#power-select
-    selected=compareModeFormatted
-    options=compareModeOptions
-    searchEnabled=false
-    triggerId="select-compare-mode"
-    onchange=(action "onCompareMode")
-  as |mode|
-  }}
-    {{mode}}
-  {{/power-select}}
+<div class="row">
+  <div class="col-xs-2">
+    Comparison
+    <span>
+      <i class="glyphicon glyphicon-question-sign"></i>
+      {{#tooltip-on-element}}
+        Typically, this is your anomaly region. It's highlighted in orange in the graph above. It also affects the data in the views below.
+      {{/tooltip-on-element}}
+    </span>
+  </div>
+  <div class="col-xs-4">
+    {{date-range-picker
+      class="te-range-picker"
+      timePicker=true
+      timePicker24Hour=true
+      timePickerIncrement=5
+      start=startFormatted
+      end=endFormatted
+      maxDate=maxDateFormatted
+      ranges=rangeOptions
+      showCustomRangeLabel=false
+      format="MMM D, hh:mm a"
+      serverFormat="YYYY-MM-DD HH:mm"
+      applyAction=(action "onRange")
+    }}
+  </div>
+  <div class="col-xs-2">
+    {{#power-select
+      selected=compareModeFormatted
+      options=compareModeOptions
+      searchEnabled=false
+      triggerId="select-compare-mode"
+      onchange=(action "onCompareMode")
+    as |mode|
+    }}
+      {{mode}}
+    {{/power-select}}
+  </div>
 </div>

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -51,19 +51,6 @@
             context=context
             onHover=(action "chartOnHover")
           }}
-        </div>
-      </div>
-      <div class="container">
-        <div class="row">
-          <div class="col-xs-2">
-            Comparison settings
-            <span>
-              <i class="glyphicon glyphicon-question-sign"></i>
-              {{#tooltip-on-element}}
-                Typically, this is your anomaly region. It's highlighted in orange in the graph above. It also affects the data in views below.
-              {{/tooltip-on-element}}
-            </span>
-          </div>
           {{rootcause-select-comparison-range
             range=context.anomalyRange
             compareMode=context.compareMode

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
@@ -1,4 +1,8 @@
 .rootcause-chart {
   flex-grow: 1;
   min-height: 400px;
+
+  &--split__header {
+    padding-left: 16px;
+  }
 }


### PR DESCRIPTION
the comparison settings used to be positioned below the legend but were not adjusted accordingly. This PR moves it below the chart as a toolbar.

![image](https://user-images.githubusercontent.com/25439965/34186643-da8b1836-e4e1-11e7-87c7-76112102eeec.png)
