### PR TITLE
[MINION] Add SegmentConversionExecutor base class for all minion segment conversion jobs

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/PinotTaskConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/PinotTaskConfig.java
@@ -22,8 +22,8 @@ import org.apache.helix.task.TaskConfig;
 
 
 public class PinotTaskConfig {
-  private static final String TASK_COMMAND_KEY = "TASK_COMMAND";
-  private static final String TASK_ID_KEY = "TASK_ID";
+  public static final String TASK_COMMAND_KEY = "TASK_COMMAND";
+  public static final String TASK_ID_KEY = "TASK_ID";
 
   private final String _taskType;
   private final Map<String, String> _configs;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -257,11 +257,11 @@ public class CommonConstants {
   }
 
   public static class Minion {
-    public static final String MINION_HEADER = "Pinot-Minion-";
     public static final String INSTANCE_PREFIX = "Minion_";
     public static final String INSTANCE_TYPE = "minion";
     public static final String UNTAGGED_INSTANCE = "minion_untagged";
     public static final String METRICS_PREFIX = "pinot.minion.";
+    public static final String HTTP_TASK_TYPE_HEADER_PREFIX = "Pinot-Minion-";
 
     // Config keys
     public static final String METRICS_REGISTRY_REGISTRATION_LISTENERS_KEY = "metricsRegistryRegistrationListeners";

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -430,7 +430,7 @@ public class PinotSegmentUploadRestletResource {
 
     long minionExpectedCrc = -1L;
     boolean isMinionConfigured = offlineTableConfig.getTaskConfig() != null;
-    boolean minionHeaderPresent = headers.getHeaderString(HttpHeaders.USER_AGENT).contains(CommonConstants.Minion.MINION_HEADER);
+    boolean minionHeaderPresent = headers.getHeaderString(HttpHeaders.USER_AGENT).contains(CommonConstants.Minion.HTTP_TASK_TYPE_HEADER_PREFIX);
     boolean metadataRewritten = false;
     if (isMinionConfigured) {
       // Minion configured use case so that we write to zk sparingly

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -199,8 +199,9 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   public static class TestTaskExecutor extends BaseTaskExecutor {
     @Override
     public void executeTask(@Nonnull PinotTaskConfig pinotTaskConfig) {
-      Assert.assertTrue(_minionContext.getDataDir().exists());
-      Assert.assertNotNull(_minionContext.getMinionMetrics());
+      Assert.assertTrue(MINION_CONTEXT.getDataDir().exists());
+      Assert.assertNotNull(MINION_CONTEXT.getMinionMetrics());
+      Assert.assertNotNull(MINION_CONTEXT.getMinionVersion());
 
       Assert.assertTrue(pinotTaskConfig.getTaskType().equals(TestTaskGenerator.TASK_TYPE));
       Map<String, String> configs = pinotTaskConfig.getConfigs();

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionContext.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionContext.java
@@ -17,26 +17,46 @@ package com.linkedin.pinot.minion;
 
 import com.linkedin.pinot.minion.metrics.MinionMetrics;
 import java.io.File;
-import javax.annotation.Nonnull;
 
 
 /**
- * The <code>MinionContext</code> class contains all minion related context.
+ * The <code>MinionContext</code> class is a singleton class which contains all minion related context.
  */
 public class MinionContext {
-  private final File _dataDir;
-  private final MinionMetrics _minionMetrics;
+  private static final MinionContext INSTANCE = new MinionContext();
 
-  public MinionContext(@Nonnull File dataDir, @Nonnull MinionMetrics minionMetrics) {
-    _dataDir = dataDir;
-    _minionMetrics = minionMetrics;
+  private MinionContext() {
   }
+
+  public static MinionContext getInstance() {
+    return INSTANCE;
+  }
+
+  private File _dataDir;
+  private MinionMetrics _minionMetrics;
+  private String _minionVersion;
 
   public File getDataDir() {
     return _dataDir;
   }
 
+  public void setDataDir(File dataDir) {
+    _dataDir = dataDir;
+  }
+
   public MinionMetrics getMinionMetrics() {
     return _minionMetrics;
+  }
+
+  public void setMinionMetrics(MinionMetrics minionMetrics) {
+    _minionMetrics = minionMetrics;
+  }
+
+  public String getMinionVersion() {
+    return _minionVersion;
+  }
+
+  public void setMinionVersion(String minionVersion) {
+    _minionVersion = minionVersion;
   }
 }

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
@@ -85,6 +85,7 @@ public class MinionStarter {
   public void start() throws Exception {
     LOGGER.info("Starting Pinot minion: {}", _instanceId);
     Utils.logVersions();
+    MinionContext minionContext = MinionContext.getInstance();
 
     // Initialize data directory
     LOGGER.info("Initializing data directory");
@@ -93,24 +94,29 @@ public class MinionStarter {
     if (!dataDir.exists()) {
       Preconditions.checkState(dataDir.mkdirs());
     }
+    minionContext.setDataDir(dataDir);
 
     // Initialize metrics
     LOGGER.info("Initializing metrics");
     MetricsHelper.initializeMetrics(_config);
     MetricsRegistry metricsRegistry = new MetricsRegistry();
     MetricsHelper.registerMetricsRegistry(metricsRegistry);
-    MinionMetrics minionMetrics = new MinionMetrics(metricsRegistry);
+    final MinionMetrics minionMetrics = new MinionMetrics(metricsRegistry);
     minionMetrics.initializeGlobalMeters();
+    minionContext.setMinionMetrics(minionMetrics);
+
+    // TODO: set the correct minion version
+    minionContext.setMinionVersion("1.0");
 
     LOGGER.info("initializing segment fetchers for all protocols");
-    SegmentFetcherFactory.initSegmentFetcherFactory(_config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY));
+    SegmentFetcherFactory.initSegmentFetcherFactory(
+        _config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY));
 
     // Join the Helix cluster
     LOGGER.info("Joining the Helix cluster");
-    final MinionContext minionContext = new MinionContext(dataDir, minionMetrics);
     _helixManager.getStateMachineEngine()
         .registerStateModelFactory("Task", new TaskStateModelFactory(_helixManager,
-            new TaskFactoryRegistry(_taskExecutorRegistry, minionContext).getTaskFactoryRegistry()));
+            new TaskFactoryRegistry(_taskExecutorRegistry).getTaskFactoryRegistry()));
     _helixManager.connect();
     _helixAdmin = _helixManager.getClusterManagmentTool();
     addInstanceTagIfNeeded();
@@ -121,7 +127,7 @@ public class MinionStarter {
       @Override
       public ServiceStatus.Status getServiceStatus() {
         // TODO: add health check here
-        minionContext.getMinionMetrics().addMeteredGlobalValue(MinionMeter.HEALTH_CHECK_GOOD_CALLS, 1L);
+        minionMetrics.addMeteredGlobalValue(MinionMeter.HEALTH_CHECK_GOOD_CALLS, 1L);
         return ServiceStatus.Status.GOOD;
       }
     });

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseSegmentConversionExecutor.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.minion.executor;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.config.PinotTaskConfig;
+import com.linkedin.pinot.common.segment.fetcher.SegmentFetcherFactory;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
+import com.linkedin.pinot.core.common.MinionConstants;
+import com.linkedin.pinot.minion.exception.TaskCancelledException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.params.DefaultHttpParams;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Base class which provides a framework for segment conversion tasks.
+ * <p>This class handles segment download and upload.
+ * <p>To extends this base class, override the {@link #convert(PinotTaskConfig, File, File)} method to plug in the logic
+ * to convert the segment.
+ */
+public abstract class BaseSegmentConversionExecutor extends BaseTaskExecutor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseSegmentConversionExecutor.class);
+
+  /**
+   * Convert the segment based on the given {@link PinotTaskConfig}.
+   */
+  protected abstract void convert(@Nonnull PinotTaskConfig pinotTaskConfig, @Nonnull File originalIndexDir,
+      @Nonnull File convertedIndexDir) throws Exception;
+
+  @Override
+  public void executeTask(@Nonnull PinotTaskConfig pinotTaskConfig) throws Exception {
+    String taskType = pinotTaskConfig.getTaskType();
+    Map<String, String> configs = pinotTaskConfig.getConfigs();
+    String tableName = configs.get(MinionConstants.TABLE_NAME_KEY);
+    String segmentName = configs.get(MinionConstants.SEGMENT_NAME_KEY);
+    String downloadURL = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
+    String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
+    String originalSegmentCrc = configs.get(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY);
+
+    LOGGER.info("Start executing {} on table: {}, segment: {} with downloadURL: {}, uploadURL: {}", taskType, tableName,
+        segmentName, downloadURL, uploadURL);
+
+    File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + System.nanoTime());
+    Preconditions.checkState(tempDataDir.mkdirs());
+    try {
+      // Download the tarred segment file
+      File tarredSegmentFile = new File(tempDataDir, "tarredSegmentFile");
+      SegmentFetcherFactory.getSegmentFetcherBasedOnURI(downloadURL)
+          .fetchSegmentToLocal(downloadURL, tarredSegmentFile);
+
+      // Un-tar the segment file
+      File segmentDir = new File(tempDataDir, "segmentDir");
+      TarGzCompressionUtils.unTar(tarredSegmentFile, segmentDir);
+      File[] files = segmentDir.listFiles();
+      Preconditions.checkState(files != null && files.length == 1);
+      File indexDir = files[0];
+
+      // Convert the segment
+      File convertedSegmentDir = new File(tempDataDir, "convertedSegmentDir");
+      Preconditions.checkState(convertedSegmentDir.mkdir());
+      File convertedIndexDir = new File(convertedSegmentDir, segmentName);
+      convert(pinotTaskConfig, indexDir, convertedIndexDir);
+
+      // Tar the converted segment
+      File convertedTarredSegmentDir = new File(tempDataDir, "convertedTarredSegmentDir");
+      Preconditions.checkState(convertedTarredSegmentDir.mkdir());
+      File convertedTarredSegmentFile = new File(
+          TarGzCompressionUtils.createTarGzOfDirectory(convertedIndexDir.getPath(),
+              new File(convertedTarredSegmentDir, segmentName).getPath()));
+
+      // Check whether the task get cancelled before uploading the segment
+      if (_cancelled) {
+        LOGGER.info("{} on table: {}, segment: {} got cancelled", taskType, tableName, segmentName);
+        throw new TaskCancelledException(
+            taskType + " on table: " + tableName + ", segment: " + segmentName + " got cancelled");
+      }
+
+      // Upload the converted tarred segment file with original segment crc and task type encoded in the http headers.
+      // Original segment crc is used to check whether the original segment get refreshed, so that the newer segment
+      // won't get override. We can decide how to handle the segment based on the task type on controller side.
+      // NOTE: even segment is not changed, still need to upload the segment to update the segment ZK metadata so that
+      // segment will not be submitted again
+      Header ifMatchHeader = new Header(HttpHeaders.IF_MATCH, originalSegmentCrc);
+      String minionUserAgentParameter =
+          CommonConstants.Minion.HTTP_TASK_TYPE_HEADER_PREFIX + taskType + "/" + MINION_CONTEXT.getMinionVersion();
+      String defaultUserAgentParameter =
+          DefaultHttpParams.getDefaultParams().getParameter(HttpMethodParams.USER_AGENT).toString();
+      String userAgentParameter = defaultUserAgentParameter + " " + minionUserAgentParameter;
+      Header userAgentHeader = new Header(HttpHeaders.USER_AGENT, userAgentParameter);
+      List<Header> httpHeaders = Arrays.asList(ifMatchHeader, userAgentHeader);
+      FileUploadUtils.sendFile(uploadURL, convertedSegmentDir.getName(),
+          new FileInputStream(convertedTarredSegmentFile), convertedTarredSegmentFile.length(),
+          FileUploadUtils.SendFileMethod.POST, httpHeaders);
+
+      LOGGER.info("Done executing {} on table: {}, segment: {}", taskType, tableName, segmentName);
+    } finally {
+      FileUtils.deleteQuietly(tempDataDir);
+    }
+  }
+}

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseTaskExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseTaskExecutor.java
@@ -15,53 +15,16 @@
  */
 package com.linkedin.pinot.minion.executor;
 
-import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.FileUploadUtils;
 import com.linkedin.pinot.minion.MinionContext;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.Nonnull;
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.params.DefaultHttpParams;
-import org.apache.commons.httpclient.params.HttpParams;
-import org.apache.http.HttpHeaders;
 
 
 public abstract class BaseTaskExecutor implements PinotTaskExecutor {
-  protected MinionContext _minionContext;
+  protected static final MinionContext MINION_CONTEXT = MinionContext.getInstance();
+
   protected boolean _cancelled = false;
-
-  private final String SPACE = " ";
-  // TODO: Get jar version
-  private static final String VERSION = "1.0";
-  private static final String USER_AGENT_PARAM = "http.useragent";
-  private static final String SLASH = "/";
-
-  @Override
-  public void setMinionContext(@Nonnull MinionContext minionContext) {
-    _minionContext = minionContext;
-  }
 
   @Override
   public void cancel() {
     _cancelled = true;
-  }
-
-  @Override
-  public int uploadSegment(String uri, final String fileName, final InputStream inputStream, final long lengthInBytes,
-      FileUploadUtils.SendFileMethod httpMethod, String originalSegmentCrc, String jobType) {
-    List<Header> headers = new ArrayList<>();
-    Header ifMatchHeader = new Header(HttpHeaders.IF_MATCH, originalSegmentCrc);
-    HttpParams httpParams = DefaultHttpParams.getDefaultParams();
-    String userAgentParameter = String.valueOf(httpParams.getParameter(USER_AGENT_PARAM));
-
-    userAgentParameter += SPACE + CommonConstants.Minion.MINION_HEADER + jobType + SLASH + VERSION;
-    Header minionHeader = new Header(HttpHeaders.USER_AGENT, userAgentParameter);
-
-    headers.add(ifMatchHeader);
-    headers.add(minionHeader);
-
-    return FileUploadUtils.sendFile(uri, fileName, inputStream, lengthInBytes, FileUploadUtils.SendFileMethod.POST, headers);
   }
 }

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/ConvertToRawIndexTaskExecutor.java
@@ -15,91 +15,19 @@
  */
 package com.linkedin.pinot.minion.executor;
 
-import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.config.PinotTaskConfig;
-import com.linkedin.pinot.common.segment.fetcher.SegmentFetcherFactory;
-import com.linkedin.pinot.common.utils.FileUploadUtils;
-import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.core.common.MinionConstants;
 import com.linkedin.pinot.core.minion.RawIndexConverter;
-import com.linkedin.pinot.minion.exception.TaskCancelledException;
 import java.io.File;
-import java.io.FileInputStream;
-import java.util.Map;
 import javax.annotation.Nonnull;
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
-public class ConvertToRawIndexTaskExecutor extends BaseTaskExecutor {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToRawIndexTaskExecutor.class);
+public class ConvertToRawIndexTaskExecutor extends BaseSegmentConversionExecutor {
 
   @Override
-  public void executeTask(@Nonnull PinotTaskConfig pinotTaskConfig) {
-    Map<String, String> configs = pinotTaskConfig.getConfigs();
-    String tableName = configs.get(MinionConstants.TABLE_NAME_KEY);
-    String segmentName = configs.get(MinionConstants.SEGMENT_NAME_KEY);
-    String downloadURL = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
-    String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
-    String originalSegmentCrc = configs.get(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY);
-
-    LOGGER.info("Start executing ConvertToRawIndexTask on table: {}, segment: {} with downloadURL: {}, uploadURL: {}",
-        tableName, segmentName, downloadURL, uploadURL);
-
-    File tempDataDir = new File(new File(_minionContext.getDataDir(), MinionConstants.ConvertToRawIndexTask.TASK_TYPE),
-        "tmp-" + System.nanoTime());
-    Preconditions.checkState(tempDataDir.mkdirs());
-    try {
-      // Download the tarred segment file
-      File tarredSegmentFile = new File(tempDataDir, "tarredSegmentFile");
-      SegmentFetcherFactory.getSegmentFetcherBasedOnURI(downloadURL)
-          .fetchSegmentToLocal(downloadURL, tarredSegmentFile);
-
-      // Un-tar the segment file
-      File segmentDir = new File(tempDataDir, "segmentDir");
-      TarGzCompressionUtils.unTar(tarredSegmentFile, segmentDir);
-      File[] files = segmentDir.listFiles();
-      Preconditions.checkState(files != null && files.length == 1);
-      File indexDir = files[0];
-
-      // Convert the segment
-      // NOTE: even no column is converted, still need to upload the segment to update the segment ZK metadata so that
-      // segment will not be submitted again
-      File convertedSegmentDir = new File(tempDataDir, "convertedSegmentDir");
-      Preconditions.checkState(convertedSegmentDir.mkdir());
-      File convertedIndexDir = new File(convertedSegmentDir, segmentName);
-      new RawIndexConverter(indexDir, convertedIndexDir,
-          configs.get(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY)).convert();
-
-      // Tar the converted segment
-      File convertedTarredSegmentDir = new File(tempDataDir, "convertedTarredSegmentDir");
-      Preconditions.checkState(convertedTarredSegmentDir.mkdir());
-      File convertedTarredSegmentFile = new File(TarGzCompressionUtils
-          .createTarGzOfDirectory(convertedIndexDir.getPath(),
-              new File(convertedTarredSegmentDir, segmentName).getPath()));
-
-      // Check whether the task get cancelled before uploading the segment
-      if (_cancelled) {
-        throw new TaskCancelledException(
-            MinionConstants.ConvertToRawIndexTask.TASK_TYPE + " task on table: " + tableName + ", segment: "
-                + segmentName + " has been cancelled");
-      }
-
-      // Upload the converted tarred segment file
-      uploadSegment(uploadURL, convertedTarredSegmentFile.getName(), new FileInputStream(convertedTarredSegmentFile),
-          convertedTarredSegmentFile.length(), FileUploadUtils.SendFileMethod.POST, originalSegmentCrc, "rawIndex");
-
-      LOGGER.info("Done executing ConvertToRawIndexTask on table: {}, segment: {}", tableName, segmentName);
-    } catch (TaskCancelledException e) {
-      LOGGER.info("ConvertToRawIndexTask on table: {}, segment: {} gets cancelled", tableName, segmentName);
-      throw e;
-    } catch (Exception e) {
-      LOGGER.error("Caught exception while executing ConvertToRawIndexTask on table: {}, segment: {}", tableName,
-          segmentName, e);
-      throw new RuntimeException(e);
-    } finally {
-      FileUtils.deleteQuietly(tempDataDir);
-    }
+  protected void convert(@Nonnull PinotTaskConfig pinotTaskConfig, @Nonnull File originalIndexDir,
+      @Nonnull File convertedIndexDir) throws Exception {
+    new RawIndexConverter(originalIndexDir, convertedIndexDir,
+        pinotTaskConfig.getConfigs().get(MinionConstants.ConvertToRawIndexTask.COLUMNS_TO_CONVERT_KEY)).convert();
   }
 }

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/PinotTaskExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/PinotTaskExecutor.java
@@ -28,23 +28,12 @@ import javax.annotation.Nonnull;
 public interface PinotTaskExecutor {
 
   /**
-   * Set the minion context.
-   */
-  void setMinionContext(@Nonnull MinionContext minionContext);
-
-  /**
    * Execute the task based on the given {@link PinotTaskConfig}.
    */
-  void executeTask(@Nonnull PinotTaskConfig pinotTaskConfig);
+  void executeTask(@Nonnull PinotTaskConfig pinotTaskConfig) throws Exception;
 
   /**
    * Try to cancel the task.
    */
   void cancel();
-
-  /**
-   * Try to upload segment with crc
-   */
-  int uploadSegment(String uri, final String fileName, final InputStream inputStream, final long lengthInBytes,
-      FileUploadUtils.SendFileMethod httpMethod, String originalSegmentCrc, String jobType);
 }

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -33,6 +33,8 @@ import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -40,13 +42,16 @@ import org.apache.helix.task.TaskResult;
  * <p>All {@link PinotTaskExecutor} in {@link TaskExecutorRegistry} will automatically be registered.
  */
 public class TaskFactoryRegistry {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TaskFactoryRegistry.class);
+
   private final Map<String, TaskFactory> _taskFactoryRegistry = new HashMap<>();
 
-  public TaskFactoryRegistry(@Nonnull TaskExecutorRegistry taskExecutorRegistry,
-      @Nonnull final MinionContext minionContext) {
+  public TaskFactoryRegistry(@Nonnull TaskExecutorRegistry taskExecutorRegistry) {
     for (final String taskType : taskExecutorRegistry.getAllTaskTypes()) {
       final Class<? extends PinotTaskExecutor> taskExecutorClass = taskExecutorRegistry.getTaskExecutorClass(taskType);
       Preconditions.checkNotNull(taskExecutorClass);
+
+      LOGGER.info("Registering {} with task executor class: {}", taskType, taskExecutorClass.getName());
       TaskFactory taskFactory = new TaskFactory() {
         @Override
         public Task createNewTask(final TaskCallbackContext taskCallbackContext) {
@@ -58,25 +63,37 @@ public class TaskFactoryRegistry {
               @Override
               public TaskResult run() {
                 long startTime = System.nanoTime();
-                _pinotTaskExecutor.setMinionContext(minionContext);
-                MinionMetrics minionMetrics = minionContext.getMinionMetrics();
+                PinotTaskConfig pinotTaskConfig = PinotTaskConfig.fromHelixTaskConfig(_taskConfig);
+                LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),
+                    pinotTaskConfig.getConfigs());
+
+                MinionMetrics minionMetrics = MinionContext.getInstance().getMinionMetrics();
+                minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
                 TaskResult taskResult;
                 try {
-                  minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
-                  _pinotTaskExecutor.executeTask(PinotTaskConfig.fromHelixTaskConfig(_taskConfig));
+                  _pinotTaskExecutor.executeTask(pinotTaskConfig);
                   minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_COMPLETED, 1L);
                   taskResult = new TaskResult(TaskResult.Status.COMPLETED, "Succeeded");
+
+                  long timeSpentInNanos = System.nanoTime() - startTime;
+                  minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_EXECUTION, timeSpentInNanos);
+                  LOGGER.info("Task: {} completed in: {}ms", _taskConfig.getId(), timeSpentInNanos / 1000);
                 } catch (TaskCancelledException e) {
                   taskResult = new TaskResult(TaskResult.Status.CANCELED, e.toString());
                   minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_CANCELLED, 1L);
+
+                  LOGGER.info("Task: {} got cancelled", _taskConfig.getId(), e);
                 } catch (FatalException e) {
                   taskResult = new TaskResult(TaskResult.Status.FATAL_FAILED, e.toString());
                   minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_FATAL_FAILED, 1L);
+
+                  LOGGER.error("Caught fatal exception while executing task: {}", _taskConfig.getId(), e);
                 } catch (Exception e) {
                   taskResult = new TaskResult(TaskResult.Status.FAILED, e.toString());
                   minionMetrics.addMeteredTableValue(taskType, MinionMeter.NUMBER_TASKS_FAILED, 1L);
+
+                  LOGGER.error("Caught exception while executing task: {}", _taskConfig.getId(), e);
                 }
-                minionMetrics.addPhaseTiming(taskType, MinionQueryPhase.TASK_EXECUTION, System.nanoTime() - startTime);
                 return taskResult;
               }
 
@@ -86,6 +103,7 @@ public class TaskFactoryRegistry {
               }
             };
           } catch (Exception e) {
+            LOGGER.error("Caught exception while creating new task", e);
             throw new RuntimeException("Caught exception while creating new task", e);
           }
         }


### PR DESCRIPTION
Minion segment conversion executors should extend this bas class and implement the convert() method.
Made MinionContext a singleton class, so that it's easier to inject classes.