### PR TITLE
[TE] Implement Onboarding Job and Tasks

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -15,6 +15,7 @@ import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.linkedin.thirdeye.dashboard.resources.DetectionJobResource;
@@ -30,6 +31,9 @@ import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
+
 
 public class ThirdEyeAnomalyApplication
     extends BaseThirdEyeApplication<ThirdEyeAnomalyConfiguration> {
@@ -108,8 +112,7 @@ public class ThirdEyeAnomalyApplication
           detectionJobScheduler = new DetectionJobScheduler();
           detectionJobScheduler.start();
           environment.jersey().register(
-              new DetectionJobResource(detectionJobScheduler, alertFilterFactory, alertFilterAutotuneFactory,
-                  emailResource));
+              new DetectionJobResource(detectionJobScheduler, alertFilterFactory, alertFilterAutotuneFactory));
           environment.jersey().register(new AnomalyFunctionResource(config.getFunctionConfigPath()));
         }
         if (config.isMonitor()) {
@@ -137,9 +140,12 @@ public class ThirdEyeAnomalyApplication
           environment.jersey().register(new PinotDataSourceResource());
         }
         if (config.isDetectionOnboard()) {
+          // TODO: convert ThirdeyeAnomalyConfig to Configuration
+          Configuration systemConfig = DetectionOnboardResource.toSystemConfiguration(config);
+
           detectionOnboardServiceExecutor = new DetectionOnboardServiceExecutor();
           detectionOnboardServiceExecutor.start();
-          environment.jersey().register(new DetectionOnboardResource(detectionOnboardServiceExecutor));
+          environment.jersey().register(new DetectionOnboardResource(detectionOnboardServiceExecutor, systemConfig));
         }
       }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/ThirdEyeAnomalyApplication.java
@@ -140,7 +140,6 @@ public class ThirdEyeAnomalyApplication
           environment.jersey().register(new PinotDataSourceResource());
         }
         if (config.isDetectionOnboard()) {
-          // TODO: convert ThirdeyeAnomalyConfig to Configuration
           Configuration systemConfig = DetectionOnboardResource.toSystemConfiguration(config);
 
           detectionOnboardServiceExecutor = new DetectionOnboardServiceExecutor();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
@@ -28,10 +28,6 @@ public class DetectionOnBoardJobRunner implements Runnable {
   private final int taskTimeOutSize;
   private final TimeUnit taskTimeOutUnit;
 
-  private AnomalyFunctionFactory anomalyFunctionFactory;
-  private AlertFilterFactory alertFilterFactory;
-  private AlertFilterAutotuneFactory alertFilterAutotuneFactory;
-
   public DetectionOnBoardJobRunner(DetectionOnboardJobContext jobContext, List<DetectionOnboardTask> tasks,
       DetectionOnboardJobStatus jobStatus) {
     this(jobContext, tasks, jobStatus, 5, TimeUnit.MINUTES);
@@ -49,18 +45,6 @@ public class DetectionOnBoardJobRunner implements Runnable {
     this.jobStatus = jobStatus;
     this.taskTimeOutSize = taskTimeOutSize;
     this.taskTimeOutUnit = taskTimeOutUnit;
-
-    Configuration configuration = jobContext.getConfiguration();
-    Preconditions.checkNotNull(configuration.getString(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG));
-    Preconditions.checkNotNull(configuration.getString(DefaultDetectionOnboardJob.FUNCTION_CONFIG));
-    Preconditions.checkNotNull(configuration.getString(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG));
-
-    anomalyFunctionFactory = new AnomalyFunctionFactory(configuration
-        .getString(DefaultDetectionOnboardJob.FUNCTION_CONFIG));
-    alertFilterFactory = new AlertFilterFactory(configuration
-        .getString(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG));
-    alertFilterAutotuneFactory = new AlertFilterAutotuneFactory(configuration
-        .getString(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG));
   }
 
   @Override
@@ -77,8 +61,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
       // Construct Task context and configuration
       Configuration taskConfig = jobContext.getConfiguration().subset(task.getTaskName());
       final boolean abortAtFailure = taskConfig.getBoolean("abortAtFailure", true);
-      DetectionOnboardTaskContext taskContext = new DetectionOnboardTaskContext(anomalyFunctionFactory,
-          alertFilterFactory, alertFilterAutotuneFactory);
+      DetectionOnboardTaskContext taskContext = new DetectionOnboardTaskContext();
       taskContext.setConfiguration(taskConfig);
       taskContext.setExecutionContext(jobContext.getExecutionContext());
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
@@ -2,7 +2,11 @@ package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
+import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
+import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -24,6 +28,10 @@ public class DetectionOnBoardJobRunner implements Runnable {
   private final int taskTimeOutSize;
   private final TimeUnit taskTimeOutUnit;
 
+  private AnomalyFunctionFactory anomalyFunctionFactory;
+  private AlertFilterFactory alertFilterFactory;
+  private AlertFilterAutotuneFactory alertFilterAutotuneFactory;
+
   public DetectionOnBoardJobRunner(DetectionOnboardJobContext jobContext, List<DetectionOnboardTask> tasks,
       DetectionOnboardJobStatus jobStatus) {
     this(jobContext, tasks, jobStatus, 5, TimeUnit.MINUTES);
@@ -41,6 +49,18 @@ public class DetectionOnBoardJobRunner implements Runnable {
     this.jobStatus = jobStatus;
     this.taskTimeOutSize = taskTimeOutSize;
     this.taskTimeOutUnit = taskTimeOutUnit;
+
+    Configuration configuration = jobContext.getConfiguration();
+    Preconditions.checkNotNull(configuration.getString(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG));
+    Preconditions.checkNotNull(configuration.getString(DefaultDetectionOnboardJob.FUNCTION_CONFIG));
+    Preconditions.checkNotNull(configuration.getString(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG));
+
+    anomalyFunctionFactory = new AnomalyFunctionFactory(configuration
+        .getString(DefaultDetectionOnboardJob.FUNCTION_CONFIG));
+    alertFilterFactory = new AlertFilterFactory(configuration
+        .getString(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG));
+    alertFilterAutotuneFactory = new AlertFilterAutotuneFactory(configuration
+        .getString(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG));
   }
 
   @Override
@@ -56,8 +76,9 @@ public class DetectionOnBoardJobRunner implements Runnable {
 
       // Construct Task context and configuration
       Configuration taskConfig = jobContext.getConfiguration().subset(task.getTaskName());
-      final boolean abortOnFailure = taskConfig.getBoolean("abortOnFailure", true);
-      DetectionOnboardTaskContext taskContext = new DetectionOnboardTaskContext();
+      final boolean abortAtFailure = taskConfig.getBoolean("abortAtFailure", true);
+      DetectionOnboardTaskContext taskContext = new DetectionOnboardTaskContext(anomalyFunctionFactory,
+          alertFilterFactory, alertFilterAutotuneFactory);
       taskContext.setConfiguration(taskConfig);
       taskContext.setExecutionContext(jobContext.getExecutionContext());
 
@@ -86,7 +107,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
         LOG.error("Encountered unknown error while running job {}.", jobContext.getJobName(), e);
       }
 
-      if (abortOnFailure && !TaskConstants.TaskStatus.COMPLETED.equals(taskStatus.getTaskStatus())) {
+      if (abortAtFailure && !TaskConstants.TaskStatus.COMPLETED.equals(taskStatus.getTaskStatus())) {
         jobStatus.setJobStatus(JobConstants.JobStatus.FAILED);
         LOG.error("Failed to execute job {}.", jobContext.getJobName());
         return;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
@@ -2,11 +2,7 @@ package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
-import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
-import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
-import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
-import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -60,7 +56,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
 
       // Construct Task context and configuration
       Configuration taskConfig = jobContext.getConfiguration().subset(task.getTaskName());
-      final boolean abortAtFailure = taskConfig.getBoolean("abortAtFailure", true);
+      final boolean abortOnFailure = taskConfig.getBoolean("abortAtFailure", true);
       DetectionOnboardTaskContext taskContext = new DetectionOnboardTaskContext();
       taskContext.setConfiguration(taskConfig);
       taskContext.setExecutionContext(jobContext.getExecutionContext());
@@ -90,7 +86,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
         LOG.error("Encountered unknown error while running job {}.", jobContext.getJobName(), e);
       }
 
-      if (abortAtFailure && !TaskConstants.TaskStatus.COMPLETED.equals(taskStatus.getTaskStatus())) {
+      if (abortOnFailure && !TaskConstants.TaskStatus.COMPLETED.equals(taskStatus.getTaskStatus())) {
         jobStatus.setJobStatus(JobConstants.JobStatus.FAILED);
         LOG.error("Failed to execute job {}.", jobContext.getJobName());
         return;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
@@ -18,6 +18,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(DetectionOnBoardJobRunner.class);
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
+  public static final String ABORT_ON_FAILURE= "abortOnFailure";
   private final DetectionOnboardJobContext jobContext;
   private final List<DetectionOnboardTask> tasks;
   private final DetectionOnboardJobStatus jobStatus;
@@ -56,7 +57,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
 
       // Construct Task context and configuration
       Configuration taskConfig = jobContext.getConfiguration().subset(task.getTaskName());
-      final boolean abortOnFailure = taskConfig.getBoolean("abortAtFailure", true);
+      final boolean abortOnFailure = taskConfig.getBoolean(ABORT_ON_FAILURE, true);
       DetectionOnboardTaskContext taskContext = new DetectionOnboardTaskContext();
       taskContext.setConfiguration(taskConfig);
       taskContext.setExecutionContext(jobContext.getExecutionContext());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardJob.java
@@ -1,7 +1,6 @@
 package com.linkedin.thirdeye.anomaly.onboard;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 
 public interface DetectionOnboardJob {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
@@ -3,10 +3,13 @@ package com.linkedin.thirdeye.anomaly.onboard;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
+import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
@@ -15,6 +18,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,9 +31,12 @@ public class DetectionOnboardResource {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private DetectionOnboardService detectionOnboardService;
+  private Configuration systemConfig;
 
-  public DetectionOnboardResource(DetectionOnboardService detectionOnboardService) {
+  public DetectionOnboardResource(DetectionOnboardService detectionOnboardService, Configuration systemConfig) {
     Preconditions.checkNotNull(detectionOnboardService);
+    Preconditions.checkNotNull(systemConfig);
+    this.systemConfig = systemConfig;
     this.detectionOnboardService = detectionOnboardService;
   }
 
@@ -54,6 +62,14 @@ public class DetectionOnboardResource {
     DetectionOnboardJobStatus detectionOnboardingJobStatus;
     try {
       Map<String, String> properties = OBJECT_MAPPER.readValue(jsonPayload, HashMap.class);
+
+      // Put System Configuration into properties
+      Iterator<String> systemConfigKeyIterator = systemConfig.getKeys();
+      while (systemConfigKeyIterator.hasNext()) {
+        String systemConfigKey = systemConfigKeyIterator.next();
+        properties.put(systemConfigKey, systemConfig.getString(systemConfigKey));
+      }
+
       // TODO: Dynamically create different type of Detection Onboard Job?
       long jobId =
           detectionOnboardService.createDetectionOnboardingJob(new DefaultDetectionOnboardJob(jobName, properties));
@@ -101,5 +117,25 @@ public class DetectionOnboardResource {
       LOG.error("Failed to convert job status to a json string.", e);
       return ExceptionUtils.getStackTrace(e);
     }
+  }
+
+  public static Configuration toSystemConfiguration(ThirdEyeAnomalyConfiguration thirdeyeConfigs) {
+    Preconditions.checkNotNull(thirdeyeConfigs);
+    SmtpConfiguration smtpConfiguration = thirdeyeConfigs.getSmtpConfiguration();
+    Preconditions.checkNotNull(smtpConfiguration);
+
+    Map<String, String> systemConfig = new HashMap<>();
+    systemConfig.put(DefaultDetectionOnboardJob.FUNCTION_CONFIG, thirdeyeConfigs.getFunctionConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG, thirdeyeConfigs.getAlertFilterConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG, thirdeyeConfigs.getFilterAutotuneConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.SMTP_HOST, smtpConfiguration.getSmtpHost());
+    systemConfig.put(DefaultDetectionOnboardJob.SMTP_PORT, Integer.toString(smtpConfiguration.getSmtpPort()));
+    systemConfig.put(DefaultDetectionOnboardJob.THIRDEYE_HOST, thirdeyeConfigs.getDashboardHost());
+    systemConfig.put(DefaultDetectionOnboardJob.PHANTON_JS_PATH, thirdeyeConfigs.getPhantomJsPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ROOT_DIR, thirdeyeConfigs.getRootDir());
+    systemConfig.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER, thirdeyeConfigs.getFailureFromAddress());
+    systemConfig.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER, thirdeyeConfigs.getFailureToAddress());
+
+    return new MapConfiguration(systemConfig);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
@@ -125,9 +125,9 @@ public class DetectionOnboardResource {
     Preconditions.checkNotNull(smtpConfiguration);
 
     Map<String, String> systemConfig = new HashMap<>();
-    systemConfig.put(DefaultDetectionOnboardJob.FUNCTION_CONFIG, thirdeyeConfigs.getFunctionConfigPath());
-    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG, thirdeyeConfigs.getAlertFilterConfigPath());
-    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG, thirdeyeConfigs.getFilterAutotuneConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.FUNCTION_FACTORY, thirdeyeConfigs.getFunctionConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY, thirdeyeConfigs.getAlertFilterConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY, thirdeyeConfigs.getFilterAutotuneConfigPath());
     systemConfig.put(DefaultDetectionOnboardJob.SMTP_HOST, smtpConfiguration.getSmtpHost());
     systemConfig.put(DefaultDetectionOnboardJob.SMTP_PORT, Integer.toString(smtpConfiguration.getSmtpPort()));
     systemConfig.put(DefaultDetectionOnboardJob.THIRDEYE_HOST, thirdeyeConfigs.getDashboardHost());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
@@ -124,9 +124,9 @@ public class DetectionOnboardResource {
     Preconditions.checkNotNull(smtpConfiguration);
 
     Map<String, String> systemConfig = new HashMap<>();
-    systemConfig.put(DefaultDetectionOnboardJob.FUNCTION_FACTORY_PATH, thirdeyeConfigs.getFunctionConfigPath());
-    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_PATH, thirdeyeConfigs.getAlertFilterConfigPath());
-    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_PATH, thirdeyeConfigs.getFilterAutotuneConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.FUNCTION_FACTORY_CONFIG_PATH, thirdeyeConfigs.getFunctionConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_CONFIG_PATH, thirdeyeConfigs.getAlertFilterConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH, thirdeyeConfigs.getFilterAutotuneConfigPath());
     systemConfig.put(DefaultDetectionOnboardJob.SMTP_HOST, smtpConfiguration.getSmtpHost());
     systemConfig.put(DefaultDetectionOnboardJob.SMTP_PORT, Integer.toString(smtpConfiguration.getSmtpPort()));
     systemConfig.put(DefaultDetectionOnboardJob.THIRDEYE_DASHBOARD_HOST, thirdeyeConfigs.getDashboardHost());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
@@ -7,7 +7,6 @@ import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
 import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -125,16 +124,16 @@ public class DetectionOnboardResource {
     Preconditions.checkNotNull(smtpConfiguration);
 
     Map<String, String> systemConfig = new HashMap<>();
-    systemConfig.put(DefaultDetectionOnboardJob.FUNCTION_FACTORY, thirdeyeConfigs.getFunctionConfigPath());
-    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY, thirdeyeConfigs.getAlertFilterConfigPath());
-    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY, thirdeyeConfigs.getFilterAutotuneConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.FUNCTION_FACTORY_PATH, thirdeyeConfigs.getFunctionConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_PATH, thirdeyeConfigs.getAlertFilterConfigPath());
+    systemConfig.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_PATH, thirdeyeConfigs.getFilterAutotuneConfigPath());
     systemConfig.put(DefaultDetectionOnboardJob.SMTP_HOST, smtpConfiguration.getSmtpHost());
     systemConfig.put(DefaultDetectionOnboardJob.SMTP_PORT, Integer.toString(smtpConfiguration.getSmtpPort()));
-    systemConfig.put(DefaultDetectionOnboardJob.THIRDEYE_HOST, thirdeyeConfigs.getDashboardHost());
+    systemConfig.put(DefaultDetectionOnboardJob.THIRDEYE_DASHBOARD_HOST, thirdeyeConfigs.getDashboardHost());
     systemConfig.put(DefaultDetectionOnboardJob.PHANTON_JS_PATH, thirdeyeConfigs.getPhantomJsPath());
     systemConfig.put(DefaultDetectionOnboardJob.ROOT_DIR, thirdeyeConfigs.getRootDir());
-    systemConfig.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER, thirdeyeConfigs.getFailureFromAddress());
-    systemConfig.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER, thirdeyeConfigs.getFailureToAddress());
+    systemConfig.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER_ADDRESS, thirdeyeConfigs.getFailureFromAddress());
+    systemConfig.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS, thirdeyeConfigs.getFailureToAddress());
 
     return new MapConfiguration(systemConfig);
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutor.java
@@ -1,8 +1,14 @@
 package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
+import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
+import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -18,6 +24,9 @@ public class DetectionOnboardServiceExecutor implements DetectionOnboardService 
   private ConcurrentHashMap<String, Long> jobNameToId;
   private AtomicLong jobIdCounter = new AtomicLong();
   private ExecutorService executorService;
+
+  public DetectionOnboardServiceExecutor() {
+  }
 
   public void start() {
     detectionOnboardJobStatus = new ConcurrentHashMap<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutor.java
@@ -1,14 +1,8 @@
 package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.linkedin.thirdeye.anomaly.ThirdEyeAnomalyConfiguration;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
-import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
 import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
-import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
-import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
-import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -24,9 +18,6 @@ public class DetectionOnboardServiceExecutor implements DetectionOnboardService 
   private ConcurrentHashMap<String, Long> jobNameToId;
   private AtomicLong jobIdCounter = new AtomicLong();
   private ExecutorService executorService;
-
-  public DetectionOnboardServiceExecutor() {
-  }
 
   public void start() {
     detectionOnboardJobStatus = new ConcurrentHashMap<>();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardTaskContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardTaskContext.java
@@ -2,7 +2,6 @@ package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.google.common.base.Preconditions;
 import java.util.Collections;
-import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardTaskContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardTaskContext.java
@@ -1,30 +1,16 @@
 package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
-import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
-import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
-import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 
 public class DetectionOnboardTaskContext {
-  private AnomalyFunctionFactory anomalyFunctionFactory;
-  private AlertFilterFactory alertFilterFactory;
-  private AlertFilterAutotuneFactory alertFilterAutotuneFactory;
   private Configuration configuration = new MapConfiguration(Collections.emptyMap());
   private DetectionOnboardExecutionContext executionContext = new DetectionOnboardExecutionContext();
 
   public DetectionOnboardTaskContext() {
-  }
-
-  public DetectionOnboardTaskContext(AnomalyFunctionFactory anomalyFunctionFactory,
-      AlertFilterFactory alertFilterFactory, AlertFilterAutotuneFactory alertFilterAutotuneFactory) {
-    this.anomalyFunctionFactory = anomalyFunctionFactory;
-    this.alertFilterFactory = alertFilterFactory;
-    this.alertFilterAutotuneFactory = alertFilterAutotuneFactory;
   }
 
   public Configuration getConfiguration() {
@@ -43,29 +29,5 @@ public class DetectionOnboardTaskContext {
   public void setExecutionContext(DetectionOnboardExecutionContext executionContext) {
     Preconditions.checkNotNull(executionContext);
     this.executionContext = executionContext;
-  }
-
-  public AnomalyFunctionFactory getAnomalyFunctionFactory() {
-    return anomalyFunctionFactory;
-  }
-
-  private void setAnomalyFunctionFactory(AnomalyFunctionFactory anomalyFunctionFactory) {
-    this.anomalyFunctionFactory = anomalyFunctionFactory;
-  }
-
-  public AlertFilterFactory getAlertFilterFactory() {
-    return alertFilterFactory;
-  }
-
-  private void setAlertFilterFactory(AlertFilterFactory alertFilterFactory) {
-    this.alertFilterFactory = alertFilterFactory;
-  }
-
-  public AlertFilterAutotuneFactory getAlertFilterAutotuneFactory() {
-    return alertFilterAutotuneFactory;
-  }
-
-  private void setAlertFilterAutotuneFactory(AlertFilterAutotuneFactory alertFilterAutotuneFactory) {
-    this.alertFilterAutotuneFactory = alertFilterAutotuneFactory;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardTaskContext.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardTaskContext.java
@@ -2,14 +2,30 @@ package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 
 public class DetectionOnboardTaskContext {
+  private AnomalyFunctionFactory anomalyFunctionFactory;
+  private AlertFilterFactory alertFilterFactory;
+  private AlertFilterAutotuneFactory alertFilterAutotuneFactory;
   private Configuration configuration = new MapConfiguration(Collections.emptyMap());
   private DetectionOnboardExecutionContext executionContext = new DetectionOnboardExecutionContext();
+
+  public DetectionOnboardTaskContext() {
+  }
+
+  public DetectionOnboardTaskContext(AnomalyFunctionFactory anomalyFunctionFactory,
+      AlertFilterFactory alertFilterFactory, AlertFilterAutotuneFactory alertFilterAutotuneFactory) {
+    this.anomalyFunctionFactory = anomalyFunctionFactory;
+    this.alertFilterFactory = alertFilterFactory;
+    this.alertFilterAutotuneFactory = alertFilterAutotuneFactory;
+  }
 
   public Configuration getConfiguration() {
     return configuration;
@@ -27,5 +43,29 @@ public class DetectionOnboardTaskContext {
   public void setExecutionContext(DetectionOnboardExecutionContext executionContext) {
     Preconditions.checkNotNull(executionContext);
     this.executionContext = executionContext;
+  }
+
+  public AnomalyFunctionFactory getAnomalyFunctionFactory() {
+    return anomalyFunctionFactory;
+  }
+
+  private void setAnomalyFunctionFactory(AnomalyFunctionFactory anomalyFunctionFactory) {
+    this.anomalyFunctionFactory = anomalyFunctionFactory;
+  }
+
+  public AlertFilterFactory getAlertFilterFactory() {
+    return alertFilterFactory;
+  }
+
+  private void setAlertFilterFactory(AlertFilterFactory alertFilterFactory) {
+    this.alertFilterFactory = alertFilterFactory;
+  }
+
+  public AlertFilterAutotuneFactory getAlertFilterAutotuneFactory() {
+    return alertFilterAutotuneFactory;
+  }
+
+  private void setAlertFilterAutotuneFactory(AlertFilterAutotuneFactory alertFilterAutotuneFactory) {
+    this.alertFilterAutotuneFactory = alertFilterAutotuneFactory;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
@@ -28,7 +28,7 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
 
   public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
   public static final String ALERT_FILTER_AUTOTUNE_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY;
-  public static final String ANOMALY_FUNCTION = DefaultDetectionOnboardJob.ANOMALY_FUNCTION;
+  public static final String ANOMALY_FUNCTION_CONFIG = DefaultDetectionOnboardJob.ANOMALY_FUNCTION_CONFIG;
   public static final String BACKFILL_PERIOD = DefaultDetectionOnboardJob.PERIOD;
   public static final String BACKFILL_START = DefaultDetectionOnboardJob.START;
   public static final String BACKFILL_END = DefaultDetectionOnboardJob.END;
@@ -67,7 +67,8 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
         alertFilterFactory, alertFilterAutotuneFactory);
     MergedAnomalyResultManager mergedAnomalyResultDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
 
-    AnomalyFunctionDTO anomalyFunctionSpec = (AnomalyFunctionDTO) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    AnomalyFunctionDTO anomalyFunctionSpec = (AnomalyFunctionDTO) executionContext.getExecutionResult(
+        ANOMALY_FUNCTION_CONFIG);
     long functionId = anomalyFunctionSpec.getId();
     Period backfillPeriod = Period.parse(taskConfiguration.getString(BACKFILL_PERIOD, DEFAULT_BACKFILL_PERIOD));
     DateTime start = DateTime.parse(taskConfiguration.getString(BACKFILL_START, DateTime.now().toString()));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
@@ -1,0 +1,76 @@
+package com.linkedin.thirdeye.anomaly.onboard.tasks;
+
+import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
+import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
+import com.linkedin.thirdeye.dashboard.resources.DetectionJobResource;
+import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import javax.ws.rs.core.Response;
+import org.apache.commons.configuration.Configuration;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This task takes the output of replay result and tune the alert filter for the given detected anomalies
+ */
+public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask {
+  private static final Logger LOG = LoggerFactory.getLogger(AlertFilterAutoTuneOnboardingTask.class);
+
+  public static final String TASK_NAME = "AlertFilterAutotune";
+
+  public static final String ANOMALY_FUNCTION = DefaultDetectionOnboardJob.ANOMALY_FUNCTION;
+  public static final String BACKFILL_PERIOD = DefaultDetectionOnboardJob.PERIOD;
+  public static final String BACKFILL_START = DefaultDetectionOnboardJob.START;
+  public static final String BACKFILL_END = DefaultDetectionOnboardJob.END;
+  public static final String AUTOTUNE_PATTERN = DefaultDetectionOnboardJob.AUTOTUNE_PATTERN;
+  public static final String AUTOTUNE_SENSITIVITY_LEVEL = DefaultDetectionOnboardJob.AUTOTUNE_SENSITIVITY_LEVEL;
+
+  public static final String DEFAULT_AUTOTUNE_PATTERN = "Up,Down";
+  public static final String DEFAULT_AUTOTUNE_SENSITIVITY_LEVEL = "MEDIUM";
+
+  public static final String DEFAULT_BACKFILL_PERIOD = FunctionReplayOnboardingTask.DEFAULT_BACKFILL_PERIOD;
+
+  public AlertFilterAutoTuneOnboardingTask() {
+    super(TASK_NAME);
+  }
+
+  /**
+   * Executes the task. To fail this task, throw exceptions. The job executor will catch the exception and store
+   * it in the message in the execution status of this task.
+   */
+  @Override
+  public void run() {
+    DetectionJobResource detectionJobResource = new DetectionJobResource(new DetectionJobScheduler(),
+        taskContext.getAlertFilterFactory(), taskContext.getAlertFilterAutotuneFactory());
+    Configuration taskConfiguration = taskContext.getConfiguration();
+    DetectionOnboardExecutionContext executionContext = taskContext.getExecutionContext();
+    MergedAnomalyResultManager mergedAnomalyResultDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
+
+    long functionId = (long) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    Period backfillPeriod = Period.parse(taskConfiguration.getString(BACKFILL_PERIOD, DEFAULT_BACKFILL_PERIOD));
+    DateTime start = DateTime.parse(taskConfiguration.getString(BACKFILL_START, DateTime.now().toString()));
+    DateTime end = DateTime.parse(taskConfiguration.getString(BACKFILL_END, DateTime.now().minus(backfillPeriod).toString()));
+
+    int numReplayedAnomalies = mergedAnomalyResultDAO
+        .findByStartTimeInRangeAndFunctionId(start.getMillis(), end.getMillis(), functionId, false)
+        .size();
+
+    Response initialAutotuneResponse = detectionJobResource.
+        initiateAlertFilterAutoTune(functionId, start.toString(), end.toString(), "AUTOTUNE",
+            taskConfiguration.getString(AUTOTUNE_PATTERN, DEFAULT_AUTOTUNE_PATTERN),
+            taskConfiguration.getString(AUTOTUNE_SENSITIVITY_LEVEL, DEFAULT_AUTOTUNE_SENSITIVITY_LEVEL),
+            "", "");
+
+    if (initialAutotuneResponse.getEntity() != null) {
+      detectionJobResource.updateAlertFilterToFunctionSpecByAutoTuneId(
+          Long.valueOf(initialAutotuneResponse.getEntity().toString()));
+      LOG.info("Initial alert filter applied");
+    } else {
+      LOG.info("AutoTune doesn't applied");
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
@@ -7,6 +7,7 @@ import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.dashboard.resources.DetectionJobResource;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import javax.ws.rs.core.Response;
@@ -66,7 +67,8 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
         alertFilterFactory, alertFilterAutotuneFactory);
     MergedAnomalyResultManager mergedAnomalyResultDAO = DAORegistry.getInstance().getMergedAnomalyResultDAO();
 
-    long functionId = (long) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    AnomalyFunctionDTO anomalyFunctionSpec = (AnomalyFunctionDTO) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    long functionId = anomalyFunctionSpec.getId();
     Period backfillPeriod = Period.parse(taskConfiguration.getString(BACKFILL_PERIOD, DEFAULT_BACKFILL_PERIOD));
     DateTime start = DateTime.parse(taskConfiguration.getString(BACKFILL_START, DateTime.now().toString()));
     DateTime end = DateTime.parse(taskConfiguration.getString(BACKFILL_END, DateTime.now().minus(backfillPeriod).toString()));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DataPreparationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DataPreparationOnboardingTask.java
@@ -17,6 +17,9 @@ public class DataPreparationOnboardingTask extends BaseDetectionOnboardTask {
 
   public static final String TASK_NAME = "DataPreparation";
 
+  public static final String FUNCTION_FACTORY_PATH = DefaultDetectionOnboardJob.FUNCTION_FACTORY_PATH;
+  public static final String ALERT_FILTER_FACTORY_PATH = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_PATH;
+  public static final String ALERT_FILTER_AUTOTUNE_FACTORY_PATH = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_PATH;
   public static final String FUNCTION_FACTORY = DefaultDetectionOnboardJob.FUNCTION_FACTORY;
   public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
   public static final String ALERT_FILTER_AUTOTUNE_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY;
@@ -35,14 +38,16 @@ public class DataPreparationOnboardingTask extends BaseDetectionOnboardTask {
 
     Preconditions.checkNotNull(executionContext);
     Preconditions.checkNotNull(configuration);
-    Preconditions.checkNotNull(configuration.getString(FUNCTION_FACTORY));
-    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_FACTORY));
-    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY));
+    Preconditions.checkNotNull(configuration.getString(FUNCTION_FACTORY_PATH));
+    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_FACTORY_PATH));
+    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY_PATH));
 
-    AnomalyFunctionFactory anomalyFunctionFactory = new AnomalyFunctionFactory(configuration.getString(FUNCTION_FACTORY));
-    AlertFilterFactory alertFilterFactory = new AlertFilterFactory(configuration.getString(ALERT_FILTER_FACTORY));
+    AnomalyFunctionFactory anomalyFunctionFactory =
+        new AnomalyFunctionFactory(configuration.getString(FUNCTION_FACTORY_PATH));
+    AlertFilterFactory alertFilterFactory =
+        new AlertFilterFactory(configuration.getString(ALERT_FILTER_FACTORY_PATH));
     AlertFilterAutotuneFactory alertFilterAutotuneFactory =
-        new AlertFilterAutotuneFactory(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY));
+        new AlertFilterAutotuneFactory(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY_PATH));
 
     Preconditions.checkNotNull(anomalyFunctionFactory);
     Preconditions.checkNotNull(alertFilterFactory);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DataPreparationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DataPreparationOnboardingTask.java
@@ -17,9 +17,9 @@ public class DataPreparationOnboardingTask extends BaseDetectionOnboardTask {
 
   public static final String TASK_NAME = "DataPreparation";
 
-  public static final String FUNCTION_FACTORY_PATH = DefaultDetectionOnboardJob.FUNCTION_FACTORY_PATH;
-  public static final String ALERT_FILTER_FACTORY_PATH = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_PATH;
-  public static final String ALERT_FILTER_AUTOTUNE_FACTORY_PATH = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_PATH;
+  public static final String FUNCTION_FACTORY_CONFIG_PATH = DefaultDetectionOnboardJob.FUNCTION_FACTORY_CONFIG_PATH;
+  public static final String ALERT_FILTER_FACTORY_CONFIG_PATH = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_CONFIG_PATH;
+  public static final String ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH;
   public static final String FUNCTION_FACTORY = DefaultDetectionOnboardJob.FUNCTION_FACTORY;
   public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
   public static final String ALERT_FILTER_AUTOTUNE_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY;
@@ -38,16 +38,16 @@ public class DataPreparationOnboardingTask extends BaseDetectionOnboardTask {
 
     Preconditions.checkNotNull(executionContext);
     Preconditions.checkNotNull(configuration);
-    Preconditions.checkNotNull(configuration.getString(FUNCTION_FACTORY_PATH));
-    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_FACTORY_PATH));
-    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY_PATH));
+    Preconditions.checkNotNull(configuration.getString(FUNCTION_FACTORY_CONFIG_PATH));
+    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_FACTORY_CONFIG_PATH));
+    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH));
 
     AnomalyFunctionFactory anomalyFunctionFactory =
-        new AnomalyFunctionFactory(configuration.getString(FUNCTION_FACTORY_PATH));
+        new AnomalyFunctionFactory(configuration.getString(FUNCTION_FACTORY_CONFIG_PATH));
     AlertFilterFactory alertFilterFactory =
-        new AlertFilterFactory(configuration.getString(ALERT_FILTER_FACTORY_PATH));
+        new AlertFilterFactory(configuration.getString(ALERT_FILTER_FACTORY_CONFIG_PATH));
     AlertFilterAutotuneFactory alertFilterAutotuneFactory =
-        new AlertFilterAutotuneFactory(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY_PATH));
+        new AlertFilterAutotuneFactory(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH));
 
     Preconditions.checkNotNull(anomalyFunctionFactory);
     Preconditions.checkNotNull(alertFilterFactory);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DataPreparationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DataPreparationOnboardingTask.java
@@ -1,0 +1,55 @@
+package com.linkedin.thirdeye.anomaly.onboard.tasks;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTaskContext;
+import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class DataPreparationOnboardingTask extends BaseDetectionOnboardTask {
+  private static final Logger LOG = LoggerFactory.getLogger(DataPreparationOnboardingTask.class);
+
+  public static final String TASK_NAME = "DataPreparation";
+
+  public static final String FUNCTION_FACTORY = DefaultDetectionOnboardJob.FUNCTION_FACTORY;
+  public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
+  public static final String ALERT_FILTER_AUTOTUNE_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY;
+
+  public DataPreparationOnboardingTask(){
+    super(TASK_NAME);
+  }
+
+  @Override
+  public void run(){
+    Preconditions.checkNotNull(getTaskContext());
+
+    DetectionOnboardTaskContext taskContext = getTaskContext();
+    DetectionOnboardExecutionContext executionContext = taskContext.getExecutionContext();
+    Configuration configuration = taskContext.getConfiguration();
+
+    Preconditions.checkNotNull(executionContext);
+    Preconditions.checkNotNull(configuration);
+    Preconditions.checkNotNull(configuration.getString(FUNCTION_FACTORY));
+    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_FACTORY));
+    Preconditions.checkNotNull(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY));
+
+    AnomalyFunctionFactory anomalyFunctionFactory = new AnomalyFunctionFactory(configuration.getString(FUNCTION_FACTORY));
+    AlertFilterFactory alertFilterFactory = new AlertFilterFactory(configuration.getString(ALERT_FILTER_FACTORY));
+    AlertFilterAutotuneFactory alertFilterAutotuneFactory =
+        new AlertFilterAutotuneFactory(configuration.getString(ALERT_FILTER_AUTOTUNE_FACTORY));
+
+    Preconditions.checkNotNull(anomalyFunctionFactory);
+    Preconditions.checkNotNull(alertFilterFactory);
+    Preconditions.checkNotNull(alertFilterAutotuneFactory);
+
+    executionContext.setExecutionResult(FUNCTION_FACTORY, anomalyFunctionFactory);
+    executionContext.setExecutionResult(ALERT_FILTER_FACTORY, alertFilterFactory);
+    executionContext.setExecutionResult(ALERT_FILTER_AUTOTUNE_FACTORY, alertFilterAutotuneFactory);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -21,10 +21,9 @@ import org.apache.commons.configuration.MapConfiguration;
 public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   public static final String ABORT_AT_FAILURE = "abortAtFailure";
 
-  public static final String FUNCTION_CONFIG = "functionConfig";
-  public static final String ALERT_FILTER_CONFIG = "alertFilterConfig";
-  public static final String ALERT_FILTER_AUTOTUNE_CONFIG = "alertFilterAutotuneConfig";
-
+  public static final String FUNCTION_FACTORY = "functionFactory";
+  public static final String ALERT_FILTER_FACTORY = "alertFilterFactory";
+  public static final String ALERT_FILTER_AUTOTUNE_FACTORY = "alertFilterAutotuneFactory";
   public static final String FUNCTION_NAME = "functionName";
   public static final String COLLECTION_NAME = "collection";
   public static final String METRIC_NAME = "metric";
@@ -78,9 +77,9 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
    */
   @Override
   public Configuration getTaskConfiguration() {
-    Preconditions.checkNotNull(this.properties.get(FUNCTION_CONFIG));
-    Preconditions.checkNotNull(this.properties.get(ALERT_FILTER_CONFIG));
-    Preconditions.checkNotNull(this.properties.get(ALERT_FILTER_AUTOTUNE_CONFIG));
+    Preconditions.checkNotNull(this.properties.get(FUNCTION_FACTORY));
+    Preconditions.checkNotNull(this.properties.get(ALERT_FILTER_FACTORY));
+    Preconditions.checkNotNull(this.properties.get(ALERT_FILTER_AUTOTUNE_FACTORY));
     Preconditions.checkNotNull(this.properties.get(FUNCTION_NAME));
     Preconditions.checkNotNull(this.properties.get(COLLECTION_NAME));
     Preconditions.checkNotNull(this.properties.get(METRIC_NAME));
@@ -100,11 +99,12 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
 
     Map<String, String> taskConfigs = new HashMap<>();
 
-    taskConfigs.put(FUNCTION_CONFIG, this.properties.get(FUNCTION_CONFIG));
-    taskConfigs.put(ALERT_FILTER_CONFIG, this.properties.get(ALERT_FILTER_CONFIG));
-    taskConfigs.put(ALERT_FILTER_AUTOTUNE_CONFIG, this.properties.get(ALERT_FILTER_AUTOTUNE_CONFIG));
+    String taskPrefix = DataPreparationOnboardingTask.TASK_NAME + ".";
+    taskConfigs.put(taskPrefix + FUNCTION_FACTORY, this.properties.get(FUNCTION_FACTORY));
+    taskConfigs.put(taskPrefix + ALERT_FILTER_FACTORY, this.properties.get(ALERT_FILTER_FACTORY));
+    taskConfigs.put(taskPrefix + ALERT_FILTER_AUTOTUNE_FACTORY, this.properties.get(ALERT_FILTER_AUTOTUNE_FACTORY));
 
-    String taskPrefix = FunctionCreationOnboardingTask.TASK_NAME + ".";
+    taskPrefix = FunctionCreationOnboardingTask.TASK_NAME + ".";
     taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.TRUE.toString());
     taskConfigs.put(taskPrefix + FUNCTION_NAME, this.properties.get(FUNCTION_NAME));
     taskConfigs.put(taskPrefix + COLLECTION_NAME, this.properties.get(COLLECTION_NAME));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.anomaly.onboard.tasks;
 
 import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardJob;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnBoardJobRunner;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTask;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
@@ -19,7 +20,7 @@ import org.apache.commons.configuration.MapConfiguration;
  * the status-check functionality.
  */
 public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
-  public static final String ABORT_AT_FAILURE = "abortAtFailure";
+  public static final String ABORT_ON_FAILURE = DetectionOnBoardJobRunner.ABORT_ON_FAILURE;
 
   public static final String FUNCTION_FACTORY = "functionFactory";
   public static final String ALERT_FILTER_FACTORY = "alertFilterFactory";
@@ -100,12 +101,13 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
     Map<String, String> taskConfigs = new HashMap<>();
 
     String taskPrefix = DataPreparationOnboardingTask.TASK_NAME + ".";
+    taskConfigs.put(taskPrefix + ABORT_ON_FAILURE, Boolean.TRUE.toString());
     taskConfigs.put(taskPrefix + FUNCTION_FACTORY, this.properties.get(FUNCTION_FACTORY));
     taskConfigs.put(taskPrefix + ALERT_FILTER_FACTORY, this.properties.get(ALERT_FILTER_FACTORY));
     taskConfigs.put(taskPrefix + ALERT_FILTER_AUTOTUNE_FACTORY, this.properties.get(ALERT_FILTER_AUTOTUNE_FACTORY));
 
     taskPrefix = FunctionCreationOnboardingTask.TASK_NAME + ".";
-    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.TRUE.toString());
+    taskConfigs.put(taskPrefix + ABORT_ON_FAILURE, Boolean.TRUE.toString());
     taskConfigs.put(taskPrefix + FUNCTION_NAME, this.properties.get(FUNCTION_NAME));
     taskConfigs.put(taskPrefix + COLLECTION_NAME, this.properties.get(COLLECTION_NAME));
     taskConfigs.put(taskPrefix + METRIC_NAME, this.properties.get(METRIC_NAME));
@@ -161,7 +163,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
     }
 
     taskPrefix = FunctionReplayOnboardingTask.TASK_NAME + ".";
-    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.FALSE.toString());
+    taskConfigs.put(taskPrefix + ABORT_ON_FAILURE, Boolean.FALSE.toString());
     if (this.properties.containsKey(PERIOD)) {
       taskConfigs.put (taskPrefix + PERIOD, this.properties.get(PERIOD));
     }
@@ -182,7 +184,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
     }
 
     taskPrefix = AlertFilterAutoTuneOnboardingTask.TASK_NAME + ".";
-    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.FALSE.toString());
+    taskConfigs.put(taskPrefix + ABORT_ON_FAILURE, Boolean.FALSE.toString());
     if (this.properties.containsKey(PERIOD)) {
       taskConfigs.put (taskPrefix + PERIOD, this.properties.get(PERIOD));
     }
@@ -200,7 +202,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
     }
 
     taskPrefix = NotificationOnboardingTask.TASK_NAME + ".";
-    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.TRUE.toString());
+    taskConfigs.put(taskPrefix + ABORT_ON_FAILURE, Boolean.TRUE.toString());
     if (this.properties.containsKey(START)) {
       taskConfigs.put (taskPrefix + START, this.properties.get(START));
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -24,9 +24,9 @@ import org.apache.commons.configuration.MapConfiguration;
 public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   public static final String ABORT_ON_FAILURE = DetectionOnBoardJobRunner.ABORT_ON_FAILURE;
 
-  public static final String FUNCTION_FACTORY_PATH = "functionFactoryPath";
-  public static final String ALERT_FILTER_FACTORY_PATH = "alertFilterFactoryPath";
-  public static final String ALERT_FILTER_AUTOTUNE_FACTORY_PATH = "alertFilterAutotuneFactoryPath";
+  public static final String FUNCTION_FACTORY_CONFIG_PATH = "functionFactoryConfigPath";
+  public static final String ALERT_FILTER_FACTORY_CONFIG_PATH = "alertFilterFactoryConfigPath";
+  public static final String ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH = "alertFilterAutotuneFactoryConfigPath";
   public static final String FUNCTION_FACTORY = "functionFactory";
   public static final String ALERT_FILTER_FACTORY = "alertFilterFactory";
   public static final String ALERT_FILTER_AUTOTUNE_FACTORY = "alertFilterAutotuneFactory";
@@ -86,9 +86,8 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   @Override
   public Configuration getTaskConfiguration() {
     PropertyCheckUtils.checkNotNull(this.properties,
-        Arrays.asList(FUNCTION_FACTORY_PATH,
-            ALERT_FILTER_AUTOTUNE_FACTORY_PATH,
-            ALERT_FILTER_AUTOTUNE_FACTORY_PATH,
+        Arrays.asList(FUNCTION_FACTORY_CONFIG_PATH, ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH,
+            ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH,
             FUNCTION_NAME,
             COLLECTION_NAME,
             METRIC_NAME,
@@ -113,9 +112,10 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
 
     String taskPrefix = DataPreparationOnboardingTask.TASK_NAME + ".";
     taskConfigs.put(taskPrefix + ABORT_ON_FAILURE, Boolean.TRUE.toString());
-    taskConfigs.put(taskPrefix + FUNCTION_FACTORY_PATH, this.properties.get(FUNCTION_FACTORY_PATH));
-    taskConfigs.put(taskPrefix + ALERT_FILTER_FACTORY_PATH, this.properties.get(ALERT_FILTER_FACTORY_PATH));
-    taskConfigs.put(taskPrefix + ALERT_FILTER_AUTOTUNE_FACTORY_PATH, this.properties.get(ALERT_FILTER_AUTOTUNE_FACTORY_PATH));
+    taskConfigs.put(taskPrefix + FUNCTION_FACTORY_CONFIG_PATH, this.properties.get(FUNCTION_FACTORY_CONFIG_PATH));
+    taskConfigs.put(taskPrefix + ALERT_FILTER_FACTORY_CONFIG_PATH, this.properties.get(ALERT_FILTER_FACTORY_CONFIG_PATH));
+    taskConfigs.put(taskPrefix + ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH, this.properties.get(
+        ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH));
 
     taskPrefix = FunctionCreationOnboardingTask.TASK_NAME + ".";
     taskConfigs.put(taskPrefix + ABORT_ON_FAILURE, Boolean.TRUE.toString());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -50,7 +50,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   public static final String ALERT_FROM = "alertSender";
   public static final String ALERT_TO = "alertRecipients";
   public static final String ALERT_APPLICATION = "application";
-  public static final String ANOMALY_FUNCTION = "anomalyFunciton";
+  public static final String ANOMALY_FUNCTION_CONFIG = "anomalyFuncitonConfig";
   public static final String ALERT_CONFIG = "alertConfig";
   public static final String AUTOTUNE_PATTERN = "pattern";
   public static final String AUTOTUNE_SENSITIVITY_LEVEL = "sensitivity";

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -94,6 +94,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
             METRIC_NAME,
             WINDOW_SIZE,
             WINDOW_UNIT,
+            CRON_EXPRESSION,
             SMTP_HOST,
             SMTP_PORT,
             DEFAULT_ALERT_RECEIVER_ADDRESS,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -225,6 +225,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   @Override
   public List<DetectionOnboardTask> getTasks() {
     List<DetectionOnboardTask> detectionOnboardTasks = new ArrayList<>();
+    detectionOnboardTasks.add(new DataPreparationOnboardingTask());
     detectionOnboardTasks.add(new FunctionCreationOnboardingTask());
     detectionOnboardTasks.add(new FunctionReplayOnboardingTask());
     detectionOnboardTasks.add(new AlertFilterAutoTuneOnboardingTask());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -1,28 +1,232 @@
 package com.linkedin.thirdeye.anomaly.onboard.tasks;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardJob;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTask;
-import java.util.Collections;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 
+
+/**
+ * This job is for self-serve onboarding. During self-serve, a list of tasks needs to be done. Using a wrapper may block
+ * users on browser, and it is hard for them to check onboarding status. This job is sent to back-end scheduler and enable
+ * the status-check functionality.
+ */
 public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
+  public static final String ABORT_AT_FAILURE = "abortAtFailure";
+
+  public static final String FUNCTION_CONFIG = "functionConfig";
+  public static final String ALERT_FILTER_CONFIG = "alertFilterConfig";
+  public static final String ALERT_FILTER_AUTOTUNE_CONFIG = "alertFilterAutotuneConfig";
+
+  public static final String FUNCTION_NAME = "functionName";
+  public static final String COLLECTION_NAME = "collection";
+  public static final String METRIC_NAME = "metric";
+  public static final String EXPLORE_DIMENSION = "exploreDimensions";
+  public static final String FILTERS = "filters";
+  public static final String METRIC_FUNCTION = "metricFunction";
+  public static final String WINDOW_SIZE = "windowSize";
+  public static final String WINDOW_UNIT = "windowUnit";
+  public static final String WINDOW_DELAY = "windowDelay";
+  public static final String WINDOW_DELAY_UNIT = "windowDelayUnit";
+  public static final String DATA_GRANULARITY = "dataGranularity";
+  public static final String FUNCTION_PROPERTIES = "properties";
+  public static final String FUNCTION_IS_ACTIVE = "isActive";
+  public static final String CRON_EXPRESSION = "cron";
+  public static final String ALERT_ID = "alertId";
+  public static final String ALERT_NAME = "alertName";
+  public static final String ALERT_CRON = "alertCron";
+  public static final String ALERT_FROM = "alertSender";
+  public static final String ALERT_TO = "alertRecipients";
+  public static final String ALERT_APPLICATION = "application";
+  public static final String ANOMALY_FUNCTION = "anomalyFunciton";
+  public static final String ALERT_CONFIG = "alertConfig";
+  public static final String AUTOTUNE_PATTERN = "pattern";
+  public static final String AUTOTUNE_SENSITIVITY_LEVEL = "sensitivity";
+  public static final String REMOVE_ANOMALY_IN_WINDOW = "removeAnomaliesInWindow";
+  public static final String PERIOD = "period";
+  public static final String START = "start";
+  public static final String END = "end";
+  public static final String FORCE = "force";
+  public static final String SPEEDUP = "speedup";
+  public static final String SMTP_HOST = "smtpHost";
+  public static final String SMTP_PORT = "smtpPort";
+  public static final String THIRDEYE_HOST = "thirdeyeHost";
+  public static final String DEFAULT_ALERT_SENDER = "alertSender";
+  public static final String DEFAULT_ALERT_RECEIVER = "alertReceiver";
+  public static final String PHANTON_JS_PATH = "phantonJsPath";
+  public static final String ROOT_DIR = "rootDir";
+
+  protected AnomalyFunctionFactory anomalyFunctionFactory;
+  protected AlertFilterFactory alertFilterFactory;
 
   public DefaultDetectionOnboardJob(String jobName, Map<String, String> properties) {
     super(jobName, properties);
   }
 
-  // TODO: Implement this method
+  /**
+   * Return a task configuration with task name as its prefix, e.g. task1.property1
+   * Note that, if a property is used by multiple tasks, the property key is reused for each task,
+   * e.g. task1.property1, task2.property2, and so on
+   * @return a task configuration with task name as the property key prefix
+   */
   @Override
   public Configuration getTaskConfiguration() {
-    return new MapConfiguration(Collections.emptyMap());
+    Preconditions.checkNotNull(this.properties.get(FUNCTION_CONFIG));
+    Preconditions.checkNotNull(this.properties.get(ALERT_FILTER_CONFIG));
+    Preconditions.checkNotNull(this.properties.get(ALERT_FILTER_AUTOTUNE_CONFIG));
+    Preconditions.checkNotNull(this.properties.get(FUNCTION_NAME));
+    Preconditions.checkNotNull(this.properties.get(COLLECTION_NAME));
+    Preconditions.checkNotNull(this.properties.get(METRIC_NAME));
+    Preconditions.checkNotNull(this.properties.get(WINDOW_SIZE));
+    Preconditions.checkNotNull(this.properties.get(WINDOW_UNIT));
+    Preconditions.checkArgument(properties.containsKey(ALERT_ID) || properties.containsKey(ALERT_NAME));
+    if (!properties.containsKey(ALERT_ID)) {
+      Preconditions.checkNotNull(properties.get(ALERT_TO));
+    }
+    Preconditions.checkNotNull(this.properties.get(SMTP_HOST));
+    Preconditions.checkNotNull(this.properties.get(SMTP_PORT));
+    Preconditions.checkNotNull(this.properties.get(DEFAULT_ALERT_RECEIVER));
+    Preconditions.checkNotNull(this.properties.get(DEFAULT_ALERT_SENDER));
+    Preconditions.checkNotNull(this.properties.get(THIRDEYE_HOST));
+    Preconditions.checkNotNull(this.properties.get(PHANTON_JS_PATH));
+    Preconditions.checkNotNull(this.properties.get(ROOT_DIR));
+
+    Map<String, String> taskConfigs = new HashMap<>();
+
+    taskConfigs.put(FUNCTION_CONFIG, this.properties.get(FUNCTION_CONFIG));
+    taskConfigs.put(ALERT_FILTER_CONFIG, this.properties.get(ALERT_FILTER_CONFIG));
+    taskConfigs.put(ALERT_FILTER_AUTOTUNE_CONFIG, this.properties.get(ALERT_FILTER_AUTOTUNE_CONFIG));
+
+    String taskPrefix = FunctionCreationOnboardingTask.TASK_NAME + ".";
+    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.TRUE.toString());
+    taskConfigs.put(taskPrefix + FUNCTION_NAME, this.properties.get(FUNCTION_NAME));
+    taskConfigs.put(taskPrefix + COLLECTION_NAME, this.properties.get(COLLECTION_NAME));
+    taskConfigs.put(taskPrefix + METRIC_NAME, this.properties.get(METRIC_NAME));
+    if (this.properties.containsKey(EXPLORE_DIMENSION)) {
+      taskConfigs.put(taskPrefix + EXPLORE_DIMENSION, this.properties.get(EXPLORE_DIMENSION));
+    }
+    if (this.properties.containsKey(FILTERS)) {
+      taskConfigs.put(taskPrefix + FILTERS, this.properties.get(FILTERS));
+    }
+    if (this.properties.containsKey(METRIC_FUNCTION)) {
+      taskConfigs.put(taskPrefix + METRIC_FUNCTION, this.properties.get(METRIC_FUNCTION));
+    }
+    taskConfigs.put(taskPrefix + WINDOW_SIZE, this.properties.get(WINDOW_SIZE));
+    taskConfigs.put(taskPrefix + WINDOW_UNIT, this.properties.get(WINDOW_UNIT));
+    if (this.properties.containsKey(WINDOW_DELAY)) {
+    taskConfigs.put(taskPrefix + WINDOW_DELAY, this.properties.get(WINDOW_DELAY));
+    }
+    if (this.properties.containsKey(WINDOW_DELAY_UNIT)) {
+    taskConfigs.put(taskPrefix + WINDOW_DELAY_UNIT, this.properties.get(WINDOW_DELAY_UNIT));
+    }
+    if (this.properties.containsKey(DATA_GRANULARITY)) {
+    taskConfigs.put(taskPrefix + DATA_GRANULARITY, this.properties.get(DATA_GRANULARITY));
+    }
+    if (this.properties.containsKey(FUNCTION_PROPERTIES)) {
+    taskConfigs.put(taskPrefix + FUNCTION_PROPERTIES, this.properties.get(FUNCTION_PROPERTIES));
+    }
+    if (this.properties.containsKey(FUNCTION_IS_ACTIVE)) {
+    taskConfigs.put(taskPrefix + FUNCTION_IS_ACTIVE, this.properties.get(FUNCTION_IS_ACTIVE));
+    }
+    if (this.properties.containsKey(CRON_EXPRESSION)) {
+    taskConfigs.put(taskPrefix + CRON_EXPRESSION, this.properties.get(CRON_EXPRESSION));
+    }
+    if (this.properties.containsKey(ALERT_ID)) {
+    taskConfigs.put(taskPrefix + ALERT_ID, this.properties.get(ALERT_ID));
+    }
+    if (this.properties.containsKey(ALERT_NAME)) {
+    taskConfigs.put(taskPrefix + ALERT_NAME, this.properties.get(ALERT_NAME));
+    }
+    if (this.properties.containsKey(ALERT_CRON)) {
+    taskConfigs.put(taskPrefix + ALERT_CRON, this.properties.get(ALERT_CRON));
+    }
+    if (this.properties.containsKey(ALERT_FROM)) {
+    taskConfigs.put(taskPrefix + ALERT_FROM, this.properties.get(ALERT_FROM));
+    }
+    if (this.properties.containsKey(ALERT_TO)) {
+    taskConfigs.put(taskPrefix + ALERT_TO, this.properties.get(ALERT_TO));
+    }
+    if (this.properties.containsKey(ALERT_APPLICATION)) {
+    taskConfigs.put(taskPrefix + ALERT_APPLICATION, this.properties.get(ALERT_APPLICATION));
+    }
+    if (this.properties.containsKey(DEFAULT_ALERT_RECEIVER)) {
+      taskConfigs.put (taskPrefix + DEFAULT_ALERT_RECEIVER, this.properties.get(DEFAULT_ALERT_RECEIVER));
+    }
+
+    taskPrefix = FunctionReplayOnboardingTask.TASK_NAME + ".";
+    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.FALSE.toString());
+    if (this.properties.containsKey(PERIOD)) {
+      taskConfigs.put (taskPrefix + PERIOD, this.properties.get(PERIOD));
+    }
+    if (this.properties.containsKey(START)) {
+      taskConfigs.put (taskPrefix + START, this.properties.get(START));
+    }
+    if (this.properties.containsKey(END)) {
+      taskConfigs.put (taskPrefix + END, this.properties.get(END));
+    }
+    if (this.properties.containsKey(FORCE)) {
+      taskConfigs.put (taskPrefix + FORCE, this.properties.get(FORCE));
+    }
+    if (this.properties.containsKey(SPEEDUP)) {
+      taskConfigs.put (taskPrefix + SPEEDUP, this.properties.get(SPEEDUP));
+    }
+    if (this.properties.containsKey(REMOVE_ANOMALY_IN_WINDOW)) {
+      taskConfigs.put (taskPrefix + REMOVE_ANOMALY_IN_WINDOW, this.properties.get(REMOVE_ANOMALY_IN_WINDOW));
+    }
+
+    taskPrefix = AlertFilterAutoTuneOnboardingTask.TASK_NAME + ".";
+    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.FALSE.toString());
+    if (this.properties.containsKey(PERIOD)) {
+      taskConfigs.put (taskPrefix + PERIOD, this.properties.get(PERIOD));
+    }
+    if (this.properties.containsKey(START)) {
+      taskConfigs.put (taskPrefix + START, this.properties.get(START));
+    }
+    if (this.properties.containsKey(END)) {
+      taskConfigs.put (taskPrefix + END, this.properties.get(END));
+    }
+    if (this.properties.containsKey(AUTOTUNE_PATTERN)) {
+      taskConfigs.put (taskPrefix + AUTOTUNE_PATTERN, this.properties.get(AUTOTUNE_PATTERN));
+    }
+    if (this.properties.containsKey(AUTOTUNE_SENSITIVITY_LEVEL)) {
+      taskConfigs.put (taskPrefix + AUTOTUNE_SENSITIVITY_LEVEL, this.properties.get(AUTOTUNE_SENSITIVITY_LEVEL));
+    }
+
+    taskPrefix = NotificationOnboardingTask.TASK_NAME + ".";
+    taskConfigs.put(taskPrefix + ABORT_AT_FAILURE, Boolean.TRUE.toString());
+    if (this.properties.containsKey(START)) {
+      taskConfigs.put (taskPrefix + START, this.properties.get(START));
+    }
+    if (this.properties.containsKey(END)) {
+      taskConfigs.put (taskPrefix + END, this.properties.get(END));
+    }
+    taskConfigs.put (taskPrefix + THIRDEYE_HOST, this.properties.get(THIRDEYE_HOST));
+    taskConfigs.put (taskPrefix + DEFAULT_ALERT_SENDER, this.properties.get(DEFAULT_ALERT_SENDER));
+    taskConfigs.put (taskPrefix + DEFAULT_ALERT_RECEIVER, this.properties.get(DEFAULT_ALERT_RECEIVER));
+    taskConfigs.put (taskPrefix + PHANTON_JS_PATH, this.properties.get(PHANTON_JS_PATH));
+    taskConfigs.put (taskPrefix + ROOT_DIR, this.properties.get(ROOT_DIR));
+
+    return new MapConfiguration(taskConfigs);
   }
 
-  // TODO: Implement this method
+  /**
+   * Return a list of tasks will be run in the job
+   * @return a list of tasks
+   */
   @Override
   public List<DetectionOnboardTask> getTasks() {
-    return Collections.emptyList();
+    List<DetectionOnboardTask> detectionOnboardTasks = new ArrayList<>();
+    detectionOnboardTasks.add(new FunctionCreationOnboardingTask());
+    detectionOnboardTasks.add(new FunctionReplayOnboardingTask());
+    detectionOnboardTasks.add(new AlertFilterAutoTuneOnboardingTask());
+    detectionOnboardTasks.add(new NotificationOnboardingTask());
+    return detectionOnboardTasks;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -134,40 +134,38 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
     taskConfigs.put(taskPrefix + WINDOW_SIZE, this.properties.get(WINDOW_SIZE));
     taskConfigs.put(taskPrefix + WINDOW_UNIT, this.properties.get(WINDOW_UNIT));
     if (this.properties.containsKey(WINDOW_DELAY)) {
-    taskConfigs.put(taskPrefix + WINDOW_DELAY, this.properties.get(WINDOW_DELAY));
+      taskConfigs.put(taskPrefix + WINDOW_DELAY, this.properties.get(WINDOW_DELAY));
     }
     if (this.properties.containsKey(WINDOW_DELAY_UNIT)) {
-    taskConfigs.put(taskPrefix + WINDOW_DELAY_UNIT, this.properties.get(WINDOW_DELAY_UNIT));
+      taskConfigs.put(taskPrefix + WINDOW_DELAY_UNIT, this.properties.get(WINDOW_DELAY_UNIT));
     }
     if (this.properties.containsKey(DATA_GRANULARITY)) {
-    taskConfigs.put(taskPrefix + DATA_GRANULARITY, this.properties.get(DATA_GRANULARITY));
+      taskConfigs.put(taskPrefix + DATA_GRANULARITY, this.properties.get(DATA_GRANULARITY));
     }
     if (this.properties.containsKey(FUNCTION_PROPERTIES)) {
-    taskConfigs.put(taskPrefix + FUNCTION_PROPERTIES, this.properties.get(FUNCTION_PROPERTIES));
+      taskConfigs.put(taskPrefix + FUNCTION_PROPERTIES, this.properties.get(FUNCTION_PROPERTIES));
     }
     if (this.properties.containsKey(FUNCTION_IS_ACTIVE)) {
-    taskConfigs.put(taskPrefix + FUNCTION_IS_ACTIVE, this.properties.get(FUNCTION_IS_ACTIVE));
+      taskConfigs.put(taskPrefix + FUNCTION_IS_ACTIVE, this.properties.get(FUNCTION_IS_ACTIVE));
     }
-    if (this.properties.containsKey(CRON_EXPRESSION)) {
     taskConfigs.put(taskPrefix + CRON_EXPRESSION, this.properties.get(CRON_EXPRESSION));
-    }
     if (this.properties.containsKey(ALERT_ID)) {
-    taskConfigs.put(taskPrefix + ALERT_ID, this.properties.get(ALERT_ID));
+      taskConfigs.put(taskPrefix + ALERT_ID, this.properties.get(ALERT_ID));
     }
     if (this.properties.containsKey(ALERT_NAME)) {
-    taskConfigs.put(taskPrefix + ALERT_NAME, this.properties.get(ALERT_NAME));
+      taskConfigs.put(taskPrefix + ALERT_NAME, this.properties.get(ALERT_NAME));
     }
     if (this.properties.containsKey(ALERT_CRON)) {
-    taskConfigs.put(taskPrefix + ALERT_CRON, this.properties.get(ALERT_CRON));
+      taskConfigs.put(taskPrefix + ALERT_CRON, this.properties.get(ALERT_CRON));
     }
     if (this.properties.containsKey(ALERT_FROM)) {
-    taskConfigs.put(taskPrefix + ALERT_FROM, this.properties.get(ALERT_FROM));
+      taskConfigs.put(taskPrefix + ALERT_FROM, this.properties.get(ALERT_FROM));
     }
     if (this.properties.containsKey(ALERT_TO)) {
-    taskConfigs.put(taskPrefix + ALERT_TO, this.properties.get(ALERT_TO));
+      taskConfigs.put(taskPrefix + ALERT_TO, this.properties.get(ALERT_TO));
     }
     if (this.properties.containsKey(ALERT_APPLICATION)) {
-    taskConfigs.put(taskPrefix + ALERT_APPLICATION, this.properties.get(ALERT_APPLICATION));
+      taskConfigs.put(taskPrefix + ALERT_APPLICATION, this.properties.get(ALERT_APPLICATION));
     }
     if (this.properties.containsKey(DEFAULT_ALERT_RECEIVER_ADDRESS)) {
       taskConfigs.put (taskPrefix + DEFAULT_ALERT_RECEIVER_ADDRESS, this.properties.get(DEFAULT_ALERT_RECEIVER_ADDRESS));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -63,7 +63,6 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
   public static final String ALERT_APPLICATION = DefaultDetectionOnboardJob.ALERT_APPLICATION;
   public static final String DEFAULT_ALERT_RECEIVER = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS;
 
-  public static final String DEFAULT_CRON_EXPRESSION = "0 0 0 * * ?"; // Everyday
   public static final Boolean DEFAULT_IS_ACTIVE = true;
   public static final String DEFAULT_METRIC_FUNCTION = "SUM";
   public static final String DEFAULT_WINDOW_DELAY = "0";
@@ -106,6 +105,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
     Preconditions.checkNotNull(configuration.getString(FUNCTION_NAME));
     Preconditions.checkNotNull(configuration.getString(COLLECTION_NAME));
     Preconditions.checkNotNull(configuration.getString(METRIC_NAME));
+    Preconditions.checkNotNull(configuration.getString(CRON_EXPRESSION));
     Preconditions.checkNotNull(configuration.getString(WINDOW_SIZE));
     Preconditions.checkNotNull(configuration.getString(WINDOW_UNIT));
     Preconditions.checkNotNull(configuration.getString(PROPERTIES));
@@ -136,7 +136,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
           configuration.getString(METRIC_FUNCTION, DEFAULT_METRIC_FUNCTION),
           getFunctionTypeByTimeGranularity(dataGranularity), configuration.getString(WINDOW_SIZE), configuration.getString(WINDOW_UNIT),
           configuration.getString(WINDOW_DELAY, DEFAULT_WINDOW_DELAY),
-          configuration.getString(CRON_EXPRESSION, DEFAULT_CRON_EXPRESSION), configuration.getString(WINDOW_DELAY_UNIT),
+          configuration.getString(CRON_EXPRESSION), configuration.getString(WINDOW_DELAY_UNIT),
           configuration.getString(EXPLORE_DIMENSION), configuration.getString(FILTERS),
           configuration.getString(DATA_GRANULARITY), configuration.getString(PROPERTIES),
           configuration.getBoolean(IS_ACTIVE, DEFAULT_IS_ACTIVE));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTaskContext;
-import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
 import com.linkedin.thirdeye.dashboard.resources.AnomalyResource;
@@ -60,7 +59,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
   public static final String ALERT_FROM = DefaultDetectionOnboardJob.ALERT_FROM;
   public static final String ALERT_TO = DefaultDetectionOnboardJob.ALERT_TO;
   public static final String ALERT_APPLICATION = DefaultDetectionOnboardJob.ALERT_APPLICATION;
-  public static final String DEFAULT_ALERT_RECEIVER = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER;
+  public static final String DEFAULT_ALERT_RECEIVER = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS;
 
   public static final String DEFAULT_CRON_EXPRESSION = "0 0 0 * * ?"; // Everyday
   public static final Boolean DEFAULT_IS_ACTIVE = true;
@@ -139,7 +138,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
           configuration.getString(EXPLORE_DIMENSION), configuration.getString(FILTERS),
           configuration.getString(DATA_GRANULARITY), configuration.getString(PROPERTIES),
           configuration.getBoolean(IS_ACTIVE, DEFAULT_IS_ACTIVE));
-      if (response.getStatusInfo().equals(Response.Status.OK)) {
+      if (Response.Status.OK.equals(response.getStatusInfo())) {
         long functionId = Long.valueOf(response.getEntity().toString());
         anomalyFunction = anoomalyFunctionDAO.findById(functionId);
         executionContext.setExecutionResult(DefaultDetectionOnboardJob.ANOMALY_FUNCTION, anomalyFunction);
@@ -185,8 +184,8 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
         return "REGRESSION_GAUSSIAN_SCAN";
       case DAYS:
         return "SPLINE_REGRESSION_VANILLA";
-        default:
-          return "WEEK_OVER_WEEK_RULE";
+      default:
+        return "WEEK_OVER_WEEK_RULE";
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTaskContext;
+import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
 import com.linkedin.thirdeye.dashboard.resources.AnomalyResource;
@@ -37,6 +38,8 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
 
   public static final String TASK_NAME = "FunctionAlertCreation";
 
+  public static final String FUNCTION_FACTORY = DefaultDetectionOnboardJob.FUNCTION_FACTORY;
+  public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
   public static final String FUNCTION_NAME = DefaultDetectionOnboardJob.FUNCTION_NAME;
   public static final String COLLECTION_NAME = DefaultDetectionOnboardJob.COLLECTION_NAME;
   public static final String METRIC_NAME = DefaultDetectionOnboardJob.METRIC_NAME;
@@ -87,6 +90,16 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
     DetectionOnboardExecutionContext executionContext = taskContext.getExecutionContext();
     Configuration configuration = taskContext.getConfiguration();
 
+    Preconditions.checkNotNull(executionContext.getExecutionResult(FUNCTION_FACTORY));
+    Preconditions.checkNotNull(executionContext.getExecutionResult(ALERT_FILTER_FACTORY));
+
+    AnomalyFunctionFactory anomalyFunctionFactory = (AnomalyFunctionFactory)
+        executionContext.getExecutionResult(FUNCTION_FACTORY);
+    AlertFilterFactory alertFilterFactory = (AlertFilterFactory) executionContext.getExecutionResult(ALERT_FILTER_FACTORY);
+
+    Preconditions.checkNotNull(anomalyFunctionFactory);
+    Preconditions.checkNotNull(alertFilterFactory);
+
     // Assert if null
     Preconditions.checkNotNull(taskContext);
     Preconditions.checkNotNull(configuration.getString(FUNCTION_NAME));
@@ -98,13 +111,6 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
     if (!configuration.containsKey(ALERT_ID)) {
       Preconditions.checkNotNull(configuration.getString(ALERT_TO));
     }
-
-    Preconditions.checkNotNull(executionContext);
-    AnomalyFunctionFactory anomalyFunctionFactory = taskContext.getAnomalyFunctionFactory();
-    Preconditions.checkNotNull(anomalyFunctionFactory);
-
-    AlertFilterFactory alertFilterFactory = taskContext.getAlertFilterFactory();
-    Preconditions.checkNotNull(alertFilterFactory);
 
     // update datasetConfig
     DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(configuration.getString(COLLECTION_NAME));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -1,0 +1,185 @@
+package com.linkedin.thirdeye.anomaly.onboard.tasks;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTaskContext;
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.api.TimeSpec;
+import com.linkedin.thirdeye.dashboard.resources.AnomalyResource;
+import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
+import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
+import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datalayer.pojo.AlertConfigBean.EmailConfig;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import javax.ws.rs.core.Response;
+import org.apache.commons.configuration.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This task runs the function creation and assign function id to an existing or new alert config
+ * Three steps are included:
+ *  - create a new anomaly function
+ *  - assign the function id to an existing or new alert config
+ */
+public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
+  private static final Logger LOG = LoggerFactory.getLogger(FunctionCreationOnboardingTask.class);
+
+  public static final String TASK_NAME = "FunctionAlertCreation";
+
+  public static final String FUNCTION_NAME = DefaultDetectionOnboardJob.FUNCTION_NAME;
+  public static final String COLLECTION_NAME = DefaultDetectionOnboardJob.COLLECTION_NAME;
+  public static final String METRIC_NAME = DefaultDetectionOnboardJob.METRIC_NAME;
+  public static final String EXPLORE_DIMENSION = DefaultDetectionOnboardJob.EXPLORE_DIMENSION;
+  public static final String FILTERS = DefaultDetectionOnboardJob.FILTERS;
+  public static final String METRIC_FUNCTION = DefaultDetectionOnboardJob.METRIC_FUNCTION;
+  public static final String WINDOW_SIZE = DefaultDetectionOnboardJob.WINDOW_SIZE;
+  public static final String WINDOW_UNIT = DefaultDetectionOnboardJob.WINDOW_UNIT;
+  public static final String WINDOW_DELAY = DefaultDetectionOnboardJob.WINDOW_DELAY;
+  public static final String WINDOW_DELAY_UNIT = DefaultDetectionOnboardJob.WINDOW_DELAY_UNIT;
+  public static final String DATA_GRANULARITY = DefaultDetectionOnboardJob.DATA_GRANULARITY;
+  public static final String PROPERTIES = DefaultDetectionOnboardJob.FUNCTION_PROPERTIES;
+  public static final String IS_ACTIVE = DefaultDetectionOnboardJob.FUNCTION_IS_ACTIVE;
+  public static final String CRON_EXPRESSION = DefaultDetectionOnboardJob.CRON_EXPRESSION;
+  public static final String ALERT_ID = DefaultDetectionOnboardJob.ALERT_ID;
+  public static final String ALERT_NAME = DefaultDetectionOnboardJob.ALERT_NAME;
+  public static final String ALERT_CRON = DefaultDetectionOnboardJob.ALERT_CRON;
+  public static final String ALERT_FROM = DefaultDetectionOnboardJob.ALERT_FROM;
+  public static final String ALERT_TO = DefaultDetectionOnboardJob.ALERT_TO;
+  public static final String ALERT_APPLICATION = DefaultDetectionOnboardJob.ALERT_APPLICATION;
+  public static final String DEFAULT_ALERT_RECEIVER = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER;
+
+  public static final String DEFAULT_CRON_EXPRESSION = "0 0 0 * * ?"; // Everyday
+  public static final Boolean DEFAULT_IS_ACTIVE = true;
+  public static final String DEFAULT_METRIC_FUNCTION = "SUM";
+  public static final String DEFAULT_WINDOW_DELAY = "0";
+  public static final String DEFAULT_ALERT_CRON = "0 0/5 * 1/1 * ? *"; // Every 5 min
+
+  private AnomalyFunctionManager anoomalyFunctionDAO;
+  private AlertConfigManager alertConfigDAO;
+  private DatasetConfigManager datasetConfigDAO;
+
+  public FunctionCreationOnboardingTask() {
+    super(TASK_NAME);
+    DAORegistry daoRegistry = DAORegistry.getInstance();
+    this.alertConfigDAO = daoRegistry.getAlertConfigDAO();
+    this.anoomalyFunctionDAO = daoRegistry.getAnomalyFunctionDAO();
+    this.datasetConfigDAO = daoRegistry.getDatasetConfigDAO();
+  }
+
+  /**
+   * Executes the task. To fail this task, throw exceptions. The job executor will catch the exception and store
+   * it in the message in the execution status of this task.
+   */
+  @Override
+  public void run() {
+    DetectionOnboardTaskContext taskContext = getTaskContext();
+    DetectionOnboardExecutionContext executionContext = taskContext.getExecutionContext();
+    Configuration configuration = taskContext.getConfiguration();
+
+    // Assert if null
+    Preconditions.checkNotNull(taskContext);
+    Preconditions.checkNotNull(configuration.getString(FUNCTION_NAME));
+    Preconditions.checkNotNull(configuration.getString(COLLECTION_NAME));
+    Preconditions.checkNotNull(configuration.getString(METRIC_NAME));
+    Preconditions.checkNotNull(configuration.getString(WINDOW_SIZE));
+    Preconditions.checkNotNull(configuration.getString(WINDOW_UNIT));
+    Preconditions.checkArgument(configuration.containsKey(ALERT_ID) || configuration.containsKey(ALERT_NAME));
+    if (!configuration.containsKey(ALERT_ID)) {
+      Preconditions.checkNotNull(configuration.getString(ALERT_TO));
+    }
+
+    Preconditions.checkNotNull(executionContext);
+    AnomalyFunctionFactory anomalyFunctionFactory = taskContext.getAnomalyFunctionFactory();
+    Preconditions.checkNotNull(anomalyFunctionFactory);
+
+    AlertFilterFactory alertFilterFactory = taskContext.getAlertFilterFactory();
+    Preconditions.checkNotNull(alertFilterFactory);
+
+    // update datasetConfig
+    DatasetConfigDTO datasetConfig = datasetConfigDAO.findByDataset(configuration.getString(COLLECTION_NAME));
+    if (datasetConfig == null) {
+      throw new NoSuchElementException("Cannot find collection: " + configuration.getString(COLLECTION_NAME));
+    }
+    TimeSpec timeSpec = ThirdEyeUtils.getTimeSpecFromDatasetConfig(datasetConfig);
+    TimeGranularity dataGranularity = timeSpec.getDataGranularity();
+    try{
+      dataGranularity = TimeGranularity.fromString(configuration.getString(DATA_GRANULARITY));
+    } catch (Exception e) {
+      LOG.warn("Unable to parse user input data granularity: {}; use default from dataset config", configuration.getString(DATA_GRANULARITY));
+    }
+
+    // create function
+    AnomalyResource anomalyResource = new AnomalyResource(anomalyFunctionFactory, alertFilterFactory);
+    AnomalyFunctionDTO anomalyFunction = null;
+    try {
+      Response response = anomalyResource.createAnomalyFunction(configuration.getString(COLLECTION_NAME),
+          configuration.getString(FUNCTION_NAME), configuration.getString(METRIC_NAME),
+          configuration.getString(METRIC_FUNCTION, DEFAULT_METRIC_FUNCTION),
+          getFunctionTypeByTimeGranularity(dataGranularity), configuration.getString(WINDOW_SIZE), configuration.getString(WINDOW_UNIT),
+          configuration.getString(WINDOW_DELAY, DEFAULT_WINDOW_DELAY),
+          configuration.getString(CRON_EXPRESSION, DEFAULT_CRON_EXPRESSION), configuration.getString(WINDOW_DELAY_UNIT),
+          configuration.getString(EXPLORE_DIMENSION), configuration.getString(FILTERS),
+          configuration.getString(DATA_GRANULARITY), configuration.getString(PROPERTIES),
+          configuration.getBoolean(IS_ACTIVE, DEFAULT_IS_ACTIVE));
+      if (response.getStatusInfo().equals(Response.Status.OK)) {
+        long functionId = Long.valueOf(response.getEntity().toString());
+        anomalyFunction = anoomalyFunctionDAO.findById(functionId);
+        executionContext.setExecutionResult(DefaultDetectionOnboardJob.ANOMALY_FUNCTION, anomalyFunction);
+      } else {
+        throw new UnsupportedOperationException("Get Exception from Anomaly Function Creation End-Point");
+      }
+    } catch (Exception e) {
+      throw new IllegalArgumentException(e);
+    }
+
+    // create alert config
+    AlertConfigDTO alertConfig = null;
+    if (configuration.containsKey(ALERT_ID)) {
+      alertConfig = alertConfigDAO.findById(configuration.getLong(ALERT_ID));
+      EmailConfig emailConfig = alertConfig.getEmailConfig();
+      emailConfig.getFunctionIds().add(anomalyFunction.getId());
+      alertConfigDAO.update(alertConfig);
+    } else {
+      alertConfig = new AlertConfigDTO();
+      EmailConfig emailConfig = new EmailConfig();
+      emailConfig.setFunctionIds(Arrays.asList(anomalyFunction.getId()));
+      alertConfig.setEmailConfig(emailConfig);
+      alertConfig.setName(configuration.getString(ALERT_NAME));
+      String thirdeyeDefaultEmail = configuration.getString(configuration.getString(DEFAULT_ALERT_RECEIVER));
+      alertConfig.setFromAddress(configuration.getString(ALERT_FROM, thirdeyeDefaultEmail));
+      String alertRecipients = thirdeyeDefaultEmail;
+      if (configuration.containsKey(ALERT_TO)) {
+        alertRecipients = alertRecipients + "," + configuration.getString(ALERT_TO);
+      }
+      alertConfig.setApplication(configuration.getString(ALERT_APPLICATION));
+      alertConfig.setRecipients(alertRecipients);
+      alertConfig.setCronExpression(configuration.getString(ALERT_CRON, DEFAULT_ALERT_CRON));
+      alertConfigDAO.save(alertConfig);
+    }
+    executionContext.setExecutionResult(DefaultDetectionOnboardJob.ALERT_CONFIG, alertConfig);
+  }
+
+  protected String getFunctionTypeByTimeGranularity(TimeGranularity timeGranularity) {
+    switch (timeGranularity.getUnit()) {
+      case MINUTES:
+        return "CONFIDENCE_INTERVAL_SIGN_TEST";
+      case HOURS:
+        return "REGRESSION_GAUSSIAN_SCAN";
+      case DAYS:
+        return "SPLINE_REGRESSION_VANILLA";
+        default:
+          return "WEEK_OVER_WEEK_RULE";
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -37,6 +37,8 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
 
   public static final String TASK_NAME = "FunctionAlertCreation";
 
+  public static final String ANOMALY_FUNCTION_CONFIG = DefaultDetectionOnboardJob.ANOMALY_FUNCTION_CONFIG;
+  public static final String ALERT_CONFIG = DefaultDetectionOnboardJob.ALERT_CONFIG;
   public static final String FUNCTION_FACTORY = DefaultDetectionOnboardJob.FUNCTION_FACTORY;
   public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
   public static final String FUNCTION_NAME = DefaultDetectionOnboardJob.FUNCTION_NAME;
@@ -141,7 +143,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       if (Response.Status.OK.equals(response.getStatusInfo())) {
         long functionId = Long.valueOf(response.getEntity().toString());
         anomalyFunction = anoomalyFunctionDAO.findById(functionId);
-        executionContext.setExecutionResult(DefaultDetectionOnboardJob.ANOMALY_FUNCTION, anomalyFunction);
+        executionContext.setExecutionResult(ANOMALY_FUNCTION_CONFIG, anomalyFunction);
       } else {
         throw new UnsupportedOperationException("Get Exception from Anomaly Function Creation End-Point");
       }
@@ -173,7 +175,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       alertConfig.setCronExpression(configuration.getString(ALERT_CRON, DEFAULT_ALERT_CRON));
       alertConfigDAO.save(alertConfig);
     }
-    executionContext.setExecutionResult(DefaultDetectionOnboardJob.ALERT_CONFIG, alertConfig);
+    executionContext.setExecutionResult(ALERT_CONFIG, alertConfig);
   }
 
   protected String getFunctionTypeByTimeGranularity(TimeGranularity timeGranularity) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -107,6 +107,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
     Preconditions.checkNotNull(configuration.getString(METRIC_NAME));
     Preconditions.checkNotNull(configuration.getString(WINDOW_SIZE));
     Preconditions.checkNotNull(configuration.getString(WINDOW_UNIT));
+    Preconditions.checkNotNull(configuration.getString(PROPERTIES));
     Preconditions.checkArgument(configuration.containsKey(ALERT_ID) || configuration.containsKey(ALERT_NAME));
     if (!configuration.containsKey(ALERT_ID)) {
       Preconditions.checkNotNull(configuration.getString(ALERT_TO));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
@@ -23,9 +23,9 @@ import org.joda.time.Period;
 public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
   public static final String TASK_NAME = "FunctionReplay";
 
+  public static final String ANOMALY_FUNCTION_CONFIG = DefaultDetectionOnboardJob.ANOMALY_FUNCTION_CONFIG;
   public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
   public static final String ALERT_FILTER_AUTOTUNE_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY;
-  public static final String ANOMALY_FUNCTION = DefaultDetectionOnboardJob.ANOMALY_FUNCTION;
   public static final String BACKFILL_PERIOD = DefaultDetectionOnboardJob.PERIOD;
   public static final String BACKFILL_START = DefaultDetectionOnboardJob.START;
   public static final String BACKFILL_END = DefaultDetectionOnboardJob.END;
@@ -83,7 +83,7 @@ public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
     detectionJobScheduler = new DetectionJobScheduler();
     DetectionJobResource detectionJobResource = new DetectionJobResource(detectionJobScheduler,
         alertFilterFactory, alertFilterAutotuneFactory);
-    AnomalyFunctionDTO anomalyFunction = (AnomalyFunctionDTO) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    AnomalyFunctionDTO anomalyFunction = (AnomalyFunctionDTO) executionContext.getExecutionResult(ANOMALY_FUNCTION_CONFIG);
     long functionId = anomalyFunction.getId();
     Period backfillPeriod = Period.parse(taskConfiguration.getString(BACKFILL_PERIOD, DEFAULT_BACKFILL_PERIOD));
     DateTime start = DateTime.parse(taskConfiguration.getString(BACKFILL_START, DateTime.now().minus(backfillPeriod).toString()));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
@@ -65,7 +65,7 @@ public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
       }
 
     } catch (Exception e) {
-      throw new UnsupportedOperationException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -102,7 +102,7 @@ public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
           taskConfiguration.getBoolean(BACKFILL_SPEEDUP, DEFAULT_BACKFILL_SPEEDUP),
           taskConfiguration.getBoolean(BACKFILL_REMOVE_ANOMALY_IN_WINDOW, DEFAULT_BACKFILL_REMOVE_ANOMALY_IN_WINDOW));
     } catch (Exception e){
-      throw new UnsupportedOperationException(String.format("Unable to create detection job for %d from %s to %s\n%s",
+      throw new IllegalStateException(String.format("Unable to create detection job for %d from %s to %s\n%s",
           functionId, start.toString(), end.toString(), ExceptionUtils.getStackTrace(e)));
     }
     return response;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
@@ -15,12 +15,15 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * This task performs replay on anomaly functions
  */
 public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
+  private static final Logger LOG = LoggerFactory.getLogger(FunctionReplayOnboardingTask.class);
   public static final String TASK_NAME = "FunctionReplay";
 
   public static final String ANOMALY_FUNCTION_CONFIG = DefaultDetectionOnboardJob.ANOMALY_FUNCTION_CONFIG;
@@ -93,6 +96,7 @@ public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
 
     Response response = null;
     try {
+      LOG.info("Running replay task for {} from {} to {}", anomalyFunction, start, end);
       detectionJobResource.generateAnomaliesInRange(functionId, start.toString(), end.toString(),
           Boolean.toString(taskConfiguration.getBoolean(BACKFILL_FORCE, DEFAULT_BACKFILL_FORCE)),
           taskConfiguration.getBoolean(BACKFILL_SPEEDUP, DEFAULT_BACKFILL_SPEEDUP),

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
@@ -97,7 +97,7 @@ public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
     Response response = null;
     try {
       LOG.info("Running replay task for {} from {} to {}", anomalyFunction, start, end);
-      detectionJobResource.generateAnomaliesInRange(functionId, start.toString(), end.toString(),
+      response = detectionJobResource.generateAnomaliesInRange(functionId, start.toString(), end.toString(),
           Boolean.toString(taskConfiguration.getBoolean(BACKFILL_FORCE, DEFAULT_BACKFILL_FORCE)),
           taskConfiguration.getBoolean(BACKFILL_SPEEDUP, DEFAULT_BACKFILL_SPEEDUP),
           taskConfiguration.getBoolean(BACKFILL_REMOVE_ANOMALY_IN_WINDOW, DEFAULT_BACKFILL_REMOVE_ANOMALY_IN_WINDOW));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionReplayOnboardingTask.java
@@ -1,0 +1,65 @@
+package com.linkedin.thirdeye.anomaly.onboard.tasks;
+
+import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
+import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
+import com.linkedin.thirdeye.dashboard.resources.DetectionJobResource;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import org.apache.commons.configuration.Configuration;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+
+
+/**
+ * This task performs replay on anomaly functions
+ */
+public class FunctionReplayOnboardingTask extends BaseDetectionOnboardTask {
+  public static final String TASK_NAME = "FunctionReplay";
+
+  public static final String ANOMALY_FUNCTION = DefaultDetectionOnboardJob.ANOMALY_FUNCTION;
+  public static final String BACKFILL_PERIOD = DefaultDetectionOnboardJob.PERIOD;
+  public static final String BACKFILL_START = DefaultDetectionOnboardJob.START;
+  public static final String BACKFILL_END = DefaultDetectionOnboardJob.END;
+  public static final String BACKFILL_FORCE = DefaultDetectionOnboardJob.FORCE;
+  public static final String BACKFILL_SPEEDUP = DefaultDetectionOnboardJob.SPEEDUP;
+  public static final String BACKFILL_REMOVE_ANOMALY_IN_WINDOW = DefaultDetectionOnboardJob.REMOVE_ANOMALY_IN_WINDOW;
+
+  public static final String DEFAULT_BACKFILL_PERIOD = "P30D";
+  public static final Boolean DEFAULT_BACKFILL_FORCE = true;
+  public static final Boolean DEFAULT_BACKFILL_SPEEDUP = false;
+  public static final Boolean DEFAULT_BACKFILL_REMOVE_ANOMALY_IN_WINDOW = false;
+
+  public FunctionReplayOnboardingTask() {
+    super(TASK_NAME);
+  }
+
+  /**
+   * Executes the task. To fail this task, throw exceptions. The job executor will catch the exception and store
+   * it in the message in the execution status of this task.
+   */
+  @Override
+  public void run() {
+    DetectionJobResource detectionJobResource = new DetectionJobResource(new DetectionJobScheduler(),
+        taskContext.getAlertFilterFactory(), taskContext.getAlertFilterAutotuneFactory());
+    Configuration taskConfiguration = taskContext.getConfiguration();
+    DetectionOnboardExecutionContext executionContext = taskContext.getExecutionContext();
+
+    AnomalyFunctionDTO anomalyFunction = (AnomalyFunctionDTO) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    long functionId = anomalyFunction.getId();
+    Period backfillPeriod = Period.parse(taskConfiguration.getString(BACKFILL_PERIOD, DEFAULT_BACKFILL_PERIOD));
+    DateTime start = DateTime.parse(taskConfiguration.getString(BACKFILL_START, DateTime.now().toString()));
+    DateTime end = DateTime.parse(taskConfiguration.getString(BACKFILL_END, DateTime.now().minus(backfillPeriod).toString()));
+    executionContext.setExecutionResult(BACKFILL_START, start);
+    executionContext.setExecutionResult(BACKFILL_END, end);
+
+    try {
+      detectionJobResource.generateAnomaliesInRange(functionId, start.toString(), end.toString(),
+          Boolean.toString(taskConfiguration.getBoolean(BACKFILL_FORCE, DEFAULT_BACKFILL_FORCE)),
+          taskConfiguration.getBoolean(BACKFILL_SPEEDUP, DEFAULT_BACKFILL_SPEEDUP),
+          taskConfiguration.getBoolean(BACKFILL_REMOVE_ANOMALY_IN_WINDOW, DEFAULT_BACKFILL_REMOVE_ANOMALY_IN_WINDOW));
+    } catch (Exception e) {
+      throw new UnsupportedOperationException(String.format("Unable to create detection job for %d from %s to %s",
+          functionId, start.toString(), end.toString()));
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
@@ -4,9 +4,11 @@ import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
+import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.dashboard.resources.EmailResource;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import org.apache.commons.configuration.Configuration;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -21,6 +23,7 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
 
   public static final String TASK_NAME = "Notification";
 
+  public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
   public static final String ANOMALY_FUNCTION = DefaultDetectionOnboardJob.ANOMALY_FUNCTION;
   public static final String NOTIFICATION_START = DefaultDetectionOnboardJob.START;
   public static final String NOTIFICATION_END = DefaultDetectionOnboardJob.END;
@@ -45,6 +48,12 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
     Configuration taskConfigs = taskContext.getConfiguration();
     DetectionOnboardExecutionContext executionContext = taskContext.getExecutionContext();
 
+    Preconditions.checkNotNull(executionContext.getExecutionResult(ALERT_FILTER_FACTORY));
+
+    AlertFilterFactory alertFilterFactory = (AlertFilterFactory) executionContext.getExecutionResult(ALERT_FILTER_FACTORY);
+
+    Preconditions.checkNotNull(alertFilterFactory);
+
     Preconditions.checkNotNull(executionContext.getExecutionResult(ANOMALY_FUNCTION));
     Preconditions.checkNotNull(executionContext.getExecutionResult(NOTIFICATION_START));
     Preconditions.checkNotNull(executionContext.getExecutionResult(NOTIFICATION_END));
@@ -66,7 +75,7 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
     SmtpConfiguration smtpConfiguration = new SmtpConfiguration();
     smtpConfiguration.setSmtpHost(taskConfigs.getString(SMTP_HOST));
     smtpConfiguration.setSmtpPort(taskConfigs.getInt(SMTP_PORT));
-    EmailResource emailResource = new EmailResource(smtpConfiguration, taskContext.getAlertFilterFactory(),
+    EmailResource emailResource = new EmailResource(smtpConfiguration, alertFilterFactory,
         taskConfigs.getString(DEFAULT_ALERT_SENDER), taskConfigs.getString(DEFAULT_ALERT_RECEIVER),
         taskConfigs.getString(THIRDEYE_HOST), taskConfigs.getString(PHANTON_JS_PATH), taskConfigs.getString(ROOT_DIR));
     String subject = new StringBuilder(

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
@@ -1,0 +1,81 @@
+package com.linkedin.thirdeye.anomaly.onboard.tasks;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
+import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
+import com.linkedin.thirdeye.dashboard.resources.EmailResource;
+import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import org.apache.commons.configuration.Configuration;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Send out email notifications
+ */
+public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
+  private static final Logger LOG = LoggerFactory.getLogger(NotificationOnboardingTask.class);
+
+  public static final String TASK_NAME = "Notification";
+
+  public static final String ANOMALY_FUNCTION = DefaultDetectionOnboardJob.ANOMALY_FUNCTION;
+  public static final String NOTIFICATION_START = DefaultDetectionOnboardJob.START;
+  public static final String NOTIFICATION_END = DefaultDetectionOnboardJob.END;
+  public static final String SMTP_HOST = DefaultDetectionOnboardJob.SMTP_HOST;
+  public static final String SMTP_PORT = DefaultDetectionOnboardJob.SMTP_PORT;
+  public static final String THIRDEYE_HOST = DefaultDetectionOnboardJob.THIRDEYE_HOST;
+  public static final String DEFAULT_ALERT_SENDER = DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER;
+  public static final String DEFAULT_ALERT_RECEIVER = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER;
+  public static final String PHANTON_JS_PATH = DefaultDetectionOnboardJob.PHANTON_JS_PATH;
+  public static final String ROOT_DIR = DefaultDetectionOnboardJob.ROOT_DIR;
+
+  public NotificationOnboardingTask(){
+    super(TASK_NAME);
+  }
+
+  /**
+   * Executes the task. To fail this task, throw exceptions. The job executor will catch the exception and store
+   * it in the message in the execution status of this task.
+   */
+  @Override
+  public void run() {
+    Configuration taskConfigs = taskContext.getConfiguration();
+    DetectionOnboardExecutionContext executionContext = taskContext.getExecutionContext();
+
+    Preconditions.checkNotNull(executionContext.getExecutionResult(ANOMALY_FUNCTION));
+    Preconditions.checkNotNull(executionContext.getExecutionResult(NOTIFICATION_START));
+    Preconditions.checkNotNull(executionContext.getExecutionResult(NOTIFICATION_END));
+    Preconditions.checkNotNull(taskConfigs.getString(SMTP_HOST));
+    Preconditions.checkNotNull(taskConfigs.getString(SMTP_PORT));
+    Preconditions.checkNotNull(taskConfigs.getString(DEFAULT_ALERT_RECEIVER));
+    Preconditions.checkNotNull(taskConfigs.getString(DEFAULT_ALERT_SENDER));
+    Preconditions.checkNotNull(taskConfigs.getString(THIRDEYE_HOST));
+    Preconditions.checkNotNull(taskConfigs.getString(PHANTON_JS_PATH));
+    Preconditions.checkNotNull(taskConfigs.getString(ROOT_DIR));
+
+    Long functionId = (Long) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    DateTime start = (DateTime) executionContext.getExecutionResult(NOTIFICATION_START);
+    DateTime end = (DateTime) executionContext.getExecutionResult(NOTIFICATION_END);
+
+
+    AlertConfigDTO alertConfig = (AlertConfigDTO) executionContext.getExecutionResult(DefaultDetectionOnboardJob.ALERT_CONFIG);
+
+    SmtpConfiguration smtpConfiguration = new SmtpConfiguration();
+    smtpConfiguration.setSmtpHost(taskConfigs.getString(SMTP_HOST));
+    smtpConfiguration.setSmtpPort(taskConfigs.getInt(SMTP_PORT));
+    EmailResource emailResource = new EmailResource(smtpConfiguration, taskContext.getAlertFilterFactory(),
+        taskConfigs.getString(DEFAULT_ALERT_SENDER), taskConfigs.getString(DEFAULT_ALERT_RECEIVER),
+        taskConfigs.getString(THIRDEYE_HOST), taskConfigs.getString(PHANTON_JS_PATH), taskConfigs.getString(ROOT_DIR));
+    String subject = new StringBuilder(
+        "Replay results for " +
+            DAORegistry.getInstance().getAnomalyFunctionDAO().findById(functionId).getFunctionName() +
+            " is ready for review!").toString();
+    emailResource.generateAndSendAlertForFunctions(start.getMillis(), end.getMillis(), String.valueOf(functionId),
+        alertConfig.getFromAddress(), alertConfig.getRecipients(), subject, false, true,
+        taskConfigs.getString(THIRDEYE_HOST), smtpConfiguration.getSmtpHost(), smtpConfiguration.getSmtpPort(),
+        taskConfigs.getString(PHANTON_JS_PATH));
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.SmtpConfiguration;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
-import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAutotuneFactory;
 import com.linkedin.thirdeye.dashboard.resources.EmailResource;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
@@ -29,9 +28,9 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
   public static final String NOTIFICATION_END = DefaultDetectionOnboardJob.END;
   public static final String SMTP_HOST = DefaultDetectionOnboardJob.SMTP_HOST;
   public static final String SMTP_PORT = DefaultDetectionOnboardJob.SMTP_PORT;
-  public static final String THIRDEYE_HOST = DefaultDetectionOnboardJob.THIRDEYE_HOST;
-  public static final String DEFAULT_ALERT_SENDER = DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER;
-  public static final String DEFAULT_ALERT_RECEIVER = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER;
+  public static final String THIRDEYE_DASHBOARD_HOST = DefaultDetectionOnboardJob.THIRDEYE_DASHBOARD_HOST;
+  public static final String DEFAULT_ALERT_SENDER_ADDRESS = DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER_ADDRESS;
+  public static final String DEFAULT_ALERT_RECEIVER_ADDRESS = DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS;
   public static final String PHANTON_JS_PATH = DefaultDetectionOnboardJob.PHANTON_JS_PATH;
   public static final String ROOT_DIR = DefaultDetectionOnboardJob.ROOT_DIR;
 
@@ -59,9 +58,9 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
     Preconditions.checkNotNull(executionContext.getExecutionResult(NOTIFICATION_END));
     Preconditions.checkNotNull(taskConfigs.getString(SMTP_HOST));
     Preconditions.checkNotNull(taskConfigs.getString(SMTP_PORT));
-    Preconditions.checkNotNull(taskConfigs.getString(DEFAULT_ALERT_RECEIVER));
-    Preconditions.checkNotNull(taskConfigs.getString(DEFAULT_ALERT_SENDER));
-    Preconditions.checkNotNull(taskConfigs.getString(THIRDEYE_HOST));
+    Preconditions.checkNotNull(taskConfigs.getString(DEFAULT_ALERT_RECEIVER_ADDRESS));
+    Preconditions.checkNotNull(taskConfigs.getString(DEFAULT_ALERT_SENDER_ADDRESS));
+    Preconditions.checkNotNull(taskConfigs.getString(THIRDEYE_DASHBOARD_HOST));
     Preconditions.checkNotNull(taskConfigs.getString(PHANTON_JS_PATH));
     Preconditions.checkNotNull(taskConfigs.getString(ROOT_DIR));
 
@@ -76,15 +75,13 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
     smtpConfiguration.setSmtpHost(taskConfigs.getString(SMTP_HOST));
     smtpConfiguration.setSmtpPort(taskConfigs.getInt(SMTP_PORT));
     EmailResource emailResource = new EmailResource(smtpConfiguration, alertFilterFactory,
-        taskConfigs.getString(DEFAULT_ALERT_SENDER), taskConfigs.getString(DEFAULT_ALERT_RECEIVER),
-        taskConfigs.getString(THIRDEYE_HOST), taskConfigs.getString(PHANTON_JS_PATH), taskConfigs.getString(ROOT_DIR));
-    String subject = new StringBuilder(
-        "Replay results for " +
-            DAORegistry.getInstance().getAnomalyFunctionDAO().findById(functionId).getFunctionName() +
-            " is ready for review!").toString();
+        taskConfigs.getString(DEFAULT_ALERT_SENDER_ADDRESS), taskConfigs.getString(DEFAULT_ALERT_RECEIVER_ADDRESS),
+        taskConfigs.getString(THIRDEYE_DASHBOARD_HOST), taskConfigs.getString(PHANTON_JS_PATH), taskConfigs.getString(ROOT_DIR));
+    String subject = String.format("Replay results for %s is ready for review!",
+        DAORegistry.getInstance().getAnomalyFunctionDAO().findById(functionId).getFunctionName());
     emailResource.generateAndSendAlertForFunctions(start.getMillis(), end.getMillis(), String.valueOf(functionId),
         alertConfig.getFromAddress(), alertConfig.getRecipients(), subject, false, true,
-        taskConfigs.getString(THIRDEYE_HOST), smtpConfiguration.getSmtpHost(), smtpConfiguration.getSmtpPort(),
+        taskConfigs.getString(THIRDEYE_DASHBOARD_HOST), smtpConfiguration.getSmtpHost(), smtpConfiguration.getSmtpPort(),
         taskConfigs.getString(PHANTON_JS_PATH));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/NotificationOnboardingTask.java
@@ -22,8 +22,9 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
 
   public static final String TASK_NAME = "Notification";
 
+  public static final String ALERT_CONFIG = DefaultDetectionOnboardJob.ALERT_CONFIG;
   public static final String ALERT_FILTER_FACTORY = DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY;
-  public static final String ANOMALY_FUNCTION = DefaultDetectionOnboardJob.ANOMALY_FUNCTION;
+  public static final String ANOMALY_FUNCTION_CONFIG = DefaultDetectionOnboardJob.ANOMALY_FUNCTION_CONFIG;
   public static final String NOTIFICATION_START = DefaultDetectionOnboardJob.START;
   public static final String NOTIFICATION_END = DefaultDetectionOnboardJob.END;
   public static final String SMTP_HOST = DefaultDetectionOnboardJob.SMTP_HOST;
@@ -53,7 +54,7 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
 
     Preconditions.checkNotNull(alertFilterFactory);
 
-    Preconditions.checkNotNull(executionContext.getExecutionResult(ANOMALY_FUNCTION));
+    Preconditions.checkNotNull(executionContext.getExecutionResult(ANOMALY_FUNCTION_CONFIG));
     Preconditions.checkNotNull(executionContext.getExecutionResult(NOTIFICATION_START));
     Preconditions.checkNotNull(executionContext.getExecutionResult(NOTIFICATION_END));
     Preconditions.checkNotNull(taskConfigs.getString(SMTP_HOST));
@@ -64,12 +65,12 @@ public class NotificationOnboardingTask extends BaseDetectionOnboardTask{
     Preconditions.checkNotNull(taskConfigs.getString(PHANTON_JS_PATH));
     Preconditions.checkNotNull(taskConfigs.getString(ROOT_DIR));
 
-    Long functionId = (Long) executionContext.getExecutionResult(ANOMALY_FUNCTION);
+    Long functionId = (Long) executionContext.getExecutionResult(ANOMALY_FUNCTION_CONFIG);
     DateTime start = (DateTime) executionContext.getExecutionResult(NOTIFICATION_START);
     DateTime end = (DateTime) executionContext.getExecutionResult(NOTIFICATION_END);
 
 
-    AlertConfigDTO alertConfig = (AlertConfigDTO) executionContext.getExecutionResult(DefaultDetectionOnboardJob.ALERT_CONFIG);
+    AlertConfigDTO alertConfig = (AlertConfigDTO) executionContext.getExecutionResult(ALERT_CONFIG);
 
     SmtpConfiguration smtpConfiguration = new SmtpConfiguration();
     smtpConfiguration.setSmtpHost(taskConfigs.getString(SMTP_HOST));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/utils/PropertyCheckUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/utils/PropertyCheckUtils.java
@@ -19,15 +19,13 @@ public class PropertyCheckUtils {
     List<String> missingPropertyKeys = new ArrayList<>();
 
     for (String propertyKey : propertyKeys) {
-      try {
-        Preconditions.checkNotNull(properties.get(propertyKey));
-      } catch (NullPointerException e) {
+      if (properties.get(propertyKey) == null) {
         missingPropertyKeys.add(propertyKey);
       }
     }
 
     if (!missingPropertyKeys.isEmpty()) {
-      throw new NullPointerException("Mising Property Keys: " + missingPropertyKeys);
+      throw new IllegalArgumentException("Mising Property Keys: " + missingPropertyKeys);
     }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/utils/PropertyCheckUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/utils/PropertyCheckUtils.java
@@ -1,0 +1,33 @@
+package com.linkedin.thirdeye.anomaly.onboard.utils;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+public class PropertyCheckUtils {
+  /**
+   * check if the list of property keys exist in the given properties
+   * @param properties
+   * @param propertyKeys
+   */
+  public static void checkNotNull(Map<String, String> properties, List<String> propertyKeys) {
+    Preconditions.checkNotNull(properties);
+    Preconditions.checkNotNull(propertyKeys);
+
+    List<String> missingPropertyKeys = new ArrayList<>();
+
+    for (String propertyKey : propertyKeys) {
+      try {
+        Preconditions.checkNotNull(properties.get(propertyKey));
+      } catch (NullPointerException e) {
+        missingPropertyKeys.add(propertyKey);
+      }
+    }
+
+    if (!missingPropertyKeys.isEmpty()) {
+      throw new NullPointerException("Mising Property Keys: " + missingPropertyKeys);
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -161,7 +161,7 @@ public class ThirdEyeDashboardApplication
      */
     DetectionJobScheduler detectionJobScheduler = new DetectionJobScheduler();
     AlertFilterAutotuneFactory alertFilterAutotuneFactory = new AlertFilterAutotuneFactory(config.getFilterAutotuneConfigPath());
-    env.jersey().register(new DetectionJobResource(detectionJobScheduler, alertFilterFactory, alertFilterAutotuneFactory, emailResource));
+    env.jersey().register(new DetectionJobResource(detectionJobScheduler, alertFilterFactory, alertFilterAutotuneFactory));
 
     try {
       // root cause resource

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -316,10 +316,9 @@ public class AnomalyResource {
 
     if (StringUtils.isEmpty(dataset) || StringUtils.isEmpty(functionName) || StringUtils.isEmpty(metric)
         || StringUtils.isEmpty(windowSize) || StringUtils.isEmpty(windowUnit) || properties == null) {
-      throw new UnsupportedOperationException(
-          "Received null for one of the mandatory params: " + "dataset " + dataset + ", functionName " + functionName
-              + ", metric " + metric + ", windowSize " + windowSize + ", windowUnit " + windowUnit + ", properties"
-              + properties);
+      throw new IllegalArgumentException(String.format("Received nulll or emtpy String for one of the mandatory params: "
+          + "dataset: %s, metric: %s, functionName %s, windowSize: %s, windowUnit: %s, and properties: %s", dataset,
+          metric, functionName, windowSize, windowUnit, properties));
     }
 
     TimeGranularity dataGranularity;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -315,7 +315,7 @@ public class AnomalyResource {
       @NotNull @QueryParam("properties") String properties, @QueryParam("isActive") boolean isActive) throws Exception {
 
     if (StringUtils.isEmpty(dataset) || StringUtils.isEmpty(functionName) || StringUtils.isEmpty(metric)
-        || StringUtils.isEmpty(windowSize) || StringUtils.isEmpty(windowUnit) || StringUtils.isEmpty(properties)) {
+        || StringUtils.isEmpty(windowSize) || StringUtils.isEmpty(windowUnit) || properties == null) {
       throw new UnsupportedOperationException(
           "Received null for one of the mandatory params: " + "dataset " + dataset + ", functionName " + functionName
               + ", metric " + metric + ", windowSize " + windowSize + ", windowUnit " + windowUnit + ", properties"

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
@@ -3,7 +3,6 @@ package com.linkedin.thirdeye.anomaly.onboard;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
@@ -3,6 +3,7 @@ package com.linkedin.thirdeye.anomaly.onboard;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import sun.text.resources.lt.CollationData_lt;
+
 
 public class DetectionOnBoardJobRunnerTest {
   private static final Logger LOG = LoggerFactory.getLogger(DetectionOnBoardJobRunnerTest.class);
@@ -26,7 +29,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "normalJob";
 
-    DetectionOnboardJob onboardJob = new NormalDetectionOnboardJob(jobName, OnboardingTaskTestUtils.getJobProperties());
+    DetectionOnboardJob onboardJob = new NormalDetectionOnboardJob(jobName, Collections.<String, String>emptyMap());
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();
     Configuration configuration = onboardJob.getTaskConfiguration();
     DetectionOnboardJobContext jobContext = new DetectionOnboardJobContext(jobId, jobName, configuration);
@@ -57,7 +60,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "normalJob";
 
-    Map<String, String> properties = OnboardingTaskTestUtils.getJobProperties();
+    Map<String, String> properties = new HashMap<>();
     properties.put("task1.property1", "value11");
     properties.put("task1.property2", "value12");
     properties.put("task2.property1", "value21");
@@ -101,7 +104,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "abortAtTimeOutJob";
 
-    DetectionOnboardJob onboardJob = new TimeOutDetectionOnboardJob(jobName, OnboardingTaskTestUtils.getJobProperties());
+    DetectionOnboardJob onboardJob = new TimeOutDetectionOnboardJob(jobName, Collections.<String, String>emptyMap());
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();
     Configuration configuration = onboardJob.getTaskConfiguration();
     DetectionOnboardJobContext jobContext = new DetectionOnboardJobContext(jobId, jobName, configuration);
@@ -127,7 +130,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "abortOnFailureJob";
 
-    DetectionOnboardJob onboardJob = new HasFailureDetectionOnboardJob(jobName, OnboardingTaskTestUtils.getJobProperties());
+    DetectionOnboardJob onboardJob = new HasFailureDetectionOnboardJob(jobName, Collections.<String, String>emptyMap());
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();
     Configuration configuration = onboardJob.getTaskConfiguration();
     DetectionOnboardJobContext jobContext = new DetectionOnboardJobContext(jobId, jobName, configuration);
@@ -153,8 +156,8 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "continueOnFailureJob";
 
-    Map<String, String> properties = OnboardingTaskTestUtils.getJobProperties();
-    properties.put("faultyTask.abortAtFailure", "false");
+    Map<String, String> properties = new HashMap<>();
+    properties.put("faultyTask." + DetectionOnBoardJobRunner.ABORT_ON_FAILURE, "false");
 
     DetectionOnboardJob onboardJob = new HasFailureDetectionOnboardJob(jobName, properties);
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
@@ -27,7 +27,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "normalJob";
 
-    DetectionOnboardJob onboardJob = new NormalDetectionOnboardJob(jobName, Collections.<String, String>emptyMap());
+    DetectionOnboardJob onboardJob = new NormalDetectionOnboardJob(jobName, OnboardingTaskTestUtils.getJobProperties());
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();
     Configuration configuration = onboardJob.getTaskConfiguration();
     DetectionOnboardJobContext jobContext = new DetectionOnboardJobContext(jobId, jobName, configuration);
@@ -58,7 +58,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "normalJob";
 
-    Map<String, String> properties = new HashMap<>();
+    Map<String, String> properties = OnboardingTaskTestUtils.getJobProperties();
     properties.put("task1.property1", "value11");
     properties.put("task1.property2", "value12");
     properties.put("task2.property1", "value21");
@@ -102,7 +102,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "abortAtTimeOutJob";
 
-    DetectionOnboardJob onboardJob = new TimeOutDetectionOnboardJob(jobName, Collections.<String, String>emptyMap());
+    DetectionOnboardJob onboardJob = new TimeOutDetectionOnboardJob(jobName, OnboardingTaskTestUtils.getJobProperties());
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();
     Configuration configuration = onboardJob.getTaskConfiguration();
     DetectionOnboardJobContext jobContext = new DetectionOnboardJobContext(jobId, jobName, configuration);
@@ -128,7 +128,7 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "abortOnFailureJob";
 
-    DetectionOnboardJob onboardJob = new HasFailureDetectionOnboardJob(jobName, Collections.<String, String>emptyMap());
+    DetectionOnboardJob onboardJob = new HasFailureDetectionOnboardJob(jobName, OnboardingTaskTestUtils.getJobProperties());
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();
     Configuration configuration = onboardJob.getTaskConfiguration();
     DetectionOnboardJobContext jobContext = new DetectionOnboardJobContext(jobId, jobName, configuration);
@@ -154,8 +154,8 @@ public class DetectionOnBoardJobRunnerTest {
     final int jobId = 1;
     final String jobName = "continueOnFailureJob";
 
-    Map<String, String> properties = new HashMap<>();
-    properties.put("faultyTask.abortOnFailure", "false");
+    Map<String, String> properties = OnboardingTaskTestUtils.getJobProperties();
+    properties.put("faultyTask.abortAtFailure", "false");
 
     DetectionOnboardJob onboardJob = new HasFailureDetectionOnboardJob(jobName, properties);
     List<DetectionOnboardTask> tasks = onboardJob.getTasks();

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunnerTest.java
@@ -15,7 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import sun.text.resources.lt.CollationData_lt;
 
 
 public class DetectionOnBoardJobRunnerTest {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResourceTest.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.configuration.MapConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -18,6 +20,7 @@ import org.testng.annotations.Test;
 
 
 public class DetectionOnboardResourceTest {
+  private static final Logger LOG = LoggerFactory.getLogger(DetectionOnboardResourceTest.class);
   public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private DetectionOnboardServiceExecutor executor;
@@ -59,6 +62,7 @@ public class DetectionOnboardResourceTest {
       DetectionOnboardJobStatus onboardJobStatus = OBJECT_MAPPER
           .readValue(detectionOnboardResource.getDetectionOnboardingJobStatus(jobId), DetectionOnboardJobStatus.class);
       JobConstants.JobStatus jobStatus = onboardJobStatus.getJobStatus();
+      LOG.info("Job Status: {}" + jobStatus);
       Assert.assertTrue(
           JobConstants.JobStatus.COMPLETED.equals(jobStatus) || JobConstants.JobStatus.SCHEDULED.equals(jobStatus));
     }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResourceTest.java
@@ -1,10 +1,16 @@
 package com.linkedin.thirdeye.anomaly.onboard;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.job.JobConstants;
+import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
+import com.linkedin.thirdeye.datalayer.bao.DAOTestBase;
+import com.linkedin.thirdeye.datasource.DAORegistry;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.configuration.MapConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -16,23 +22,26 @@ public class DetectionOnboardResourceTest {
 
   private DetectionOnboardServiceExecutor executor;
   private DetectionOnboardResource detectionOnboardResource;
+  private DAOTestBase daoTestBase;
 
   @BeforeClass
   public void initResource() {
+    daoTestBase = DAOTestBase.getInstance();
     executor = new DetectionOnboardServiceExecutor();
     executor.start();
-    detectionOnboardResource = new DetectionOnboardResource(executor);
+    detectionOnboardResource = new DetectionOnboardResource(executor, new MapConfiguration(Collections.emptyMap()));
   }
 
   @AfterClass
   public void shutdownResource() {
     executor.shutdown();
+    daoTestBase.cleanup();
   }
 
 
   @Test
   public void testCreateJob() throws IOException {
-    Map<String, String> properties = Collections.emptyMap();
+    Map<String, String> properties = OnboardingTaskTestUtils.getJobProperties();
 
     String propertiesJson = OBJECT_MAPPER.writeValueAsString(properties);
     String normalJobStatusJson = detectionOnboardResource.createDetectionOnboardingJob("NormalJob", propertiesJson);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutorTest.java
@@ -30,7 +30,7 @@ public class DetectionOnboardServiceExecutorTest {
   @Test
   public void testCreate() throws InterruptedException {
     long jobId = executor.createDetectionOnboardingJob(
-        new DummyDetectionOnboardJob("NormalOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
+        new DummyDetectionOnboardJob("NormalOnboardJob", Collections.<String, String>emptyMap()));
     Thread.sleep(1000);
     JobConstants.JobStatus jobStatus = executor.getDetectionOnboardingJobStatus(jobId).getJobStatus();
     Assert.assertTrue(
@@ -40,13 +40,13 @@ public class DetectionOnboardServiceExecutorTest {
   @Test(dependsOnMethods = "testCreate", expectedExceptions = IllegalArgumentException.class)
   public void testDuplicateJobs() {
     executor.createDetectionOnboardingJob(
-        new DummyDetectionOnboardJob("NormalOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
+        new DummyDetectionOnboardJob("NormalOnboardJob", Collections.<String, String>emptyMap()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testDuplicateTasks() {
     executor.createDetectionOnboardingJob(
-        new DuplicateTaskDetectionOnboardJob("DuplicateTaskOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
+        new DuplicateTaskDetectionOnboardJob("DuplicateTaskOnboardJob", Collections.<String, String>emptyMap()));
   }
 
   @Test(expectedExceptions = RejectedExecutionException.class)
@@ -55,19 +55,19 @@ public class DetectionOnboardServiceExecutorTest {
     executor.start();
     executor.shutdown();
     executor.createDetectionOnboardingJob(
-        new DummyDetectionOnboardJob("NormalOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
+        new DummyDetectionOnboardJob("NormalOnboardJob", Collections.<String, String>emptyMap()));
   }
 
   @Test(expectedExceptions = NullPointerException.class)
   public void testNullTaskList() {
     executor.createDetectionOnboardingJob(
-        new NullTaskListDetectionOnboardJob("NullTaskListJob", OnboardingTaskTestUtils.getJobProperties()));
+        new NullTaskListDetectionOnboardJob("NullTaskListJob", Collections.<String, String>emptyMap()));
   }
 
   @Test(expectedExceptions = NullPointerException.class)
   public void testNullConfiguration() {
     executor.createDetectionOnboardingJob(
-        new NullConfigurationDetectionOnboardJob("NullConfigurationJob", OnboardingTaskTestUtils.getJobProperties()));
+        new NullConfigurationDetectionOnboardJob("NullConfigurationJob", Collections.<String, String>emptyMap()));
   }
 
   static class DummyDetectionOnboardJob extends BaseDetectionOnboardJob {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutorTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardServiceExecutorTest.java
@@ -30,7 +30,7 @@ public class DetectionOnboardServiceExecutorTest {
   @Test
   public void testCreate() throws InterruptedException {
     long jobId = executor.createDetectionOnboardingJob(
-        new DummyDetectionOnboardJob("NormalOnboardJob", Collections.<String, String>emptyMap()));
+        new DummyDetectionOnboardJob("NormalOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
     Thread.sleep(1000);
     JobConstants.JobStatus jobStatus = executor.getDetectionOnboardingJobStatus(jobId).getJobStatus();
     Assert.assertTrue(
@@ -40,13 +40,13 @@ public class DetectionOnboardServiceExecutorTest {
   @Test(dependsOnMethods = "testCreate", expectedExceptions = IllegalArgumentException.class)
   public void testDuplicateJobs() {
     executor.createDetectionOnboardingJob(
-        new DummyDetectionOnboardJob("NormalOnboardJob", Collections.<String, String>emptyMap()));
+        new DummyDetectionOnboardJob("NormalOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testDuplicateTasks() {
     executor.createDetectionOnboardingJob(
-        new DuplicateTaskDetectionOnboardJob("DuplicateTaskOnboardJob", Collections.<String, String>emptyMap()));
+        new DuplicateTaskDetectionOnboardJob("DuplicateTaskOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
   }
 
   @Test(expectedExceptions = RejectedExecutionException.class)
@@ -55,19 +55,19 @@ public class DetectionOnboardServiceExecutorTest {
     executor.start();
     executor.shutdown();
     executor.createDetectionOnboardingJob(
-        new DummyDetectionOnboardJob("NormalOnboardJob", Collections.<String, String>emptyMap()));
+        new DummyDetectionOnboardJob("NormalOnboardJob", OnboardingTaskTestUtils.getJobProperties()));
   }
 
   @Test(expectedExceptions = NullPointerException.class)
   public void testNullTaskList() {
     executor.createDetectionOnboardingJob(
-        new NullTaskListDetectionOnboardJob("NullTaskListJob", Collections.<String, String>emptyMap()));
+        new NullTaskListDetectionOnboardJob("NullTaskListJob", OnboardingTaskTestUtils.getJobProperties()));
   }
 
   @Test(expectedExceptions = NullPointerException.class)
   public void testNullConfiguration() {
     executor.createDetectionOnboardingJob(
-        new NullConfigurationDetectionOnboardJob("NullConfigurationJob", Collections.<String, String>emptyMap()));
+        new NullConfigurationDetectionOnboardJob("NullConfigurationJob", OnboardingTaskTestUtils.getJobProperties()));
   }
 
   static class DummyDetectionOnboardJob extends BaseDetectionOnboardJob {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
@@ -15,9 +15,9 @@ public class OnboardingTaskTestUtils {
   public static Map<String, String> getJobProperties(){
     Map<String, String> properties = new HashMap<>();
     properties.put(
-        DefaultDetectionOnboardJob.FUNCTION_FACTORY, ClassLoader.getSystemResource("sample-functions.properties").getPath());
-    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
-    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
+        DefaultDetectionOnboardJob.FUNCTION_FACTORY_PATH, ClassLoader.getSystemResource("sample-functions.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_PATH, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_PATH, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
     properties.put(DefaultDetectionOnboardJob.FUNCTION_NAME, "Normal Function");
     properties.put(DefaultDetectionOnboardJob.COLLECTION_NAME, "test");
     properties.put(DefaultDetectionOnboardJob.METRIC_NAME, "test");
@@ -28,9 +28,9 @@ public class OnboardingTaskTestUtils {
     properties.put(DefaultDetectionOnboardJob.ALERT_TO, "test@test.com");
     properties.put(DefaultDetectionOnboardJob.SMTP_HOST, "test.com");
     properties.put(DefaultDetectionOnboardJob.SMTP_PORT, "25");
-    properties.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER, "test@test.com");
-    properties.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER, "test@test.com");
-    properties.put(DefaultDetectionOnboardJob.THIRDEYE_HOST, "test.com");
+    properties.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER_ADDRESS, "test@test.com");
+    properties.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER_ADDRESS, "test@test.com");
+    properties.put(DefaultDetectionOnboardJob.THIRDEYE_DASHBOARD_HOST, "test.com");
     properties.put(DefaultDetectionOnboardJob.PHANTON_JS_PATH, "/");
     properties.put(DefaultDetectionOnboardJob.ROOT_DIR, "/");
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
@@ -1,0 +1,35 @@
+package com.linkedin.thirdeye.anomaly.onboard;
+
+import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class OnboardingTaskTestUtils {
+  /**
+   * Generate a default job properties for all onboarding tests
+   * @return a job properties
+   */
+  public static Map<String, String> getJobProperties(){
+    Map<String, String> properties = new HashMap<>();
+    properties.put(
+        DefaultDetectionOnboardJob.FUNCTION_CONFIG, ClassLoader.getSystemResource("sample-functions.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.FUNCTION_NAME, "Normal Function");
+    properties.put(DefaultDetectionOnboardJob.COLLECTION_NAME, "test");
+    properties.put(DefaultDetectionOnboardJob.METRIC_NAME, "test");
+    properties.put(DefaultDetectionOnboardJob.WINDOW_SIZE, "1");
+    properties.put(DefaultDetectionOnboardJob.WINDOW_UNIT, "DAYS");
+    properties.put(DefaultDetectionOnboardJob.ALERT_ID, "1");
+    properties.put(DefaultDetectionOnboardJob.SMTP_HOST, "test.com");
+    properties.put(DefaultDetectionOnboardJob.SMTP_PORT, "25");
+    properties.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER, "test@test.com");
+    properties.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_SENDER, "test@test.com");
+    properties.put(DefaultDetectionOnboardJob.THIRDEYE_HOST, "test.com");
+    properties.put(DefaultDetectionOnboardJob.PHANTON_JS_PATH, "/");
+    properties.put(DefaultDetectionOnboardJob.ROOT_DIR, "/");
+
+    return properties;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
@@ -8,6 +8,9 @@ import org.apache.commons.configuration.MapConfiguration;
 
 
 public class OnboardingTaskTestUtils {
+  public static String TEST_COLLECTION = "test_dataset";
+  public static String TEST_METRIC = "test_metric";
+
   /**
    * Generate a default job properties for all onboarding tests
    * @return a job properties
@@ -19,11 +22,11 @@ public class OnboardingTaskTestUtils {
     properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_PATH, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
     properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_PATH, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
     properties.put(DefaultDetectionOnboardJob.FUNCTION_NAME, "Normal Function");
-    properties.put(DefaultDetectionOnboardJob.COLLECTION_NAME, "test");
-    properties.put(DefaultDetectionOnboardJob.METRIC_NAME, "test");
+    properties.put(DefaultDetectionOnboardJob.COLLECTION_NAME, TEST_COLLECTION);
+    properties.put(DefaultDetectionOnboardJob.METRIC_NAME, TEST_METRIC);
     properties.put(DefaultDetectionOnboardJob.WINDOW_SIZE, "1");
     properties.put(DefaultDetectionOnboardJob.WINDOW_UNIT, "DAYS");
-    properties.put(DefaultDetectionOnboardJob.CRON_EXPRESSION, "0 0/5 * 1/1 * ? *");
+    properties.put(DefaultDetectionOnboardJob.CRON_EXPRESSION, "0 0 0 1/1 * ? *");
     properties.put(DefaultDetectionOnboardJob.FUNCTION_PROPERTIES, "metricTimezone=America/Los_Angeles;");
     properties.put(DefaultDetectionOnboardJob.ALERT_NAME, "Normal Alert");
     properties.put(DefaultDetectionOnboardJob.ALERT_TO, "test@test.com");

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
@@ -13,9 +13,9 @@ public class OnboardingTaskTestUtils {
   public static Map<String, String> getJobProperties(){
     Map<String, String> properties = new HashMap<>();
     properties.put(
-        DefaultDetectionOnboardJob.FUNCTION_CONFIG, ClassLoader.getSystemResource("sample-functions.properties").getPath());
-    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_CONFIG, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
-    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_CONFIG, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
+        DefaultDetectionOnboardJob.FUNCTION_FACTORY, ClassLoader.getSystemResource("sample-functions.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
     properties.put(DefaultDetectionOnboardJob.FUNCTION_NAME, "Normal Function");
     properties.put(DefaultDetectionOnboardJob.COLLECTION_NAME, "test");
     properties.put(DefaultDetectionOnboardJob.METRIC_NAME, "test");

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
@@ -3,6 +3,8 @@ package com.linkedin.thirdeye.anomaly.onboard;
 import com.linkedin.thirdeye.anomaly.onboard.tasks.DefaultDetectionOnboardJob;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.MapConfiguration;
 
 
 public class OnboardingTaskTestUtils {
@@ -21,7 +23,9 @@ public class OnboardingTaskTestUtils {
     properties.put(DefaultDetectionOnboardJob.METRIC_NAME, "test");
     properties.put(DefaultDetectionOnboardJob.WINDOW_SIZE, "1");
     properties.put(DefaultDetectionOnboardJob.WINDOW_UNIT, "DAYS");
-    properties.put(DefaultDetectionOnboardJob.ALERT_ID, "1");
+    properties.put(DefaultDetectionOnboardJob.FUNCTION_PROPERTIES, "");
+    properties.put(DefaultDetectionOnboardJob.ALERT_NAME, "Normal Alert");
+    properties.put(DefaultDetectionOnboardJob.ALERT_TO, "test@test.com");
     properties.put(DefaultDetectionOnboardJob.SMTP_HOST, "test.com");
     properties.put(DefaultDetectionOnboardJob.SMTP_PORT, "25");
     properties.put(DefaultDetectionOnboardJob.DEFAULT_ALERT_RECEIVER, "test@test.com");
@@ -31,5 +35,16 @@ public class OnboardingTaskTestUtils {
     properties.put(DefaultDetectionOnboardJob.ROOT_DIR, "/");
 
     return properties;
+  }
+
+  /**
+   * Return a default task configuration for all onboarding tasks
+   * @return a task context
+   */
+  public static DetectionOnboardTaskContext getDetectionTaskContext() {
+    Configuration configuration = new MapConfiguration(getJobProperties());
+    DetectionOnboardTaskContext detectionOnboardTaskContext = new DetectionOnboardTaskContext();
+    detectionOnboardTaskContext.setConfiguration(configuration);
+    return detectionOnboardTaskContext;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
@@ -18,9 +18,9 @@ public class OnboardingTaskTestUtils {
   public static Map<String, String> getJobProperties(){
     Map<String, String> properties = new HashMap<>();
     properties.put(
-        DefaultDetectionOnboardJob.FUNCTION_FACTORY_PATH, ClassLoader.getSystemResource("sample-functions.properties").getPath());
-    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_PATH, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
-    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_PATH, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
+        DefaultDetectionOnboardJob.FUNCTION_FACTORY_CONFIG_PATH, ClassLoader.getSystemResource("sample-functions.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY_CONFIG_PATH, ClassLoader.getSystemResource("sample-alertfilter.properties").getPath());
+    properties.put(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY_CONFIG_PATH, ClassLoader.getSystemResource("sample-alertfilter-autotune.properties").getPath());
     properties.put(DefaultDetectionOnboardJob.FUNCTION_NAME, "Normal Function");
     properties.put(DefaultDetectionOnboardJob.COLLECTION_NAME, TEST_COLLECTION);
     properties.put(DefaultDetectionOnboardJob.METRIC_NAME, TEST_METRIC);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/OnboardingTaskTestUtils.java
@@ -23,7 +23,8 @@ public class OnboardingTaskTestUtils {
     properties.put(DefaultDetectionOnboardJob.METRIC_NAME, "test");
     properties.put(DefaultDetectionOnboardJob.WINDOW_SIZE, "1");
     properties.put(DefaultDetectionOnboardJob.WINDOW_UNIT, "DAYS");
-    properties.put(DefaultDetectionOnboardJob.FUNCTION_PROPERTIES, "");
+    properties.put(DefaultDetectionOnboardJob.CRON_EXPRESSION, "0 0/5 * 1/1 * ? *");
+    properties.put(DefaultDetectionOnboardJob.FUNCTION_PROPERTIES, "metricTimezone=America/Los_Angeles;");
     properties.put(DefaultDetectionOnboardJob.ALERT_NAME, "Normal Alert");
     properties.put(DefaultDetectionOnboardJob.ALERT_TO, "test@test.com");
     properties.put(DefaultDetectionOnboardJob.SMTP_HOST, "test.com");

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/tasks/TestOnboardingTasks.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/tasks/TestOnboardingTasks.java
@@ -75,35 +75,18 @@ public class TestOnboardingTasks {
   }
 
   @Test(dependsOnMethods = {"testFunctionCreationOnboardingTask"})
-  public void testFunctionReplayOnboardingTask() {
-    final DetectionOnboardTask task = new FunctionReplayOnboardingTask();
+  public void testFunctionReplayOnboardingTask() throws Exception{
+    FunctionReplayOnboardingTask task = new FunctionReplayOnboardingTask();
     task.setTaskContext(context);
-    /*
-    As the replay task has no worker to take the backfill task, so the task will wait infinite time. Here I use a thread
-    to run the task, and terminate the task after that.
-     */
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        task.run();
-      }
-    });
-    thread.start();
-    try {
-      Thread.sleep(TimeUnit.SECONDS.toMillis(2));
-    } catch (InterruptedException e) {
-      // do nothing
-    }
+    task.initDetectionJob();
 
     Assert.assertEquals(1, jobDAO.findAll().size());
-    thread.stop();
   }
 
   @Test(dependsOnMethods = {"testFunctionReplayOnboardingTask"})
-  public void test() {
+  public void testAlertFilterAutoTuneOnboardingTask() {
     final DetectionOnboardTask task = new AlertFilterAutoTuneOnboardingTask();
     task.setTaskContext(context);
     task.run();
-
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/tasks/TestOnboardingTasks.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/tasks/TestOnboardingTasks.java
@@ -76,10 +76,34 @@ public class TestOnboardingTasks {
 
   @Test(dependsOnMethods = {"testFunctionCreationOnboardingTask"})
   public void testFunctionReplayOnboardingTask() {
-    DetectionOnboardTask task = new FunctionReplayOnboardingTask();
+    final DetectionOnboardTask task = new FunctionReplayOnboardingTask();
+    task.setTaskContext(context);
+    /*
+    As the replay task has no worker to take the backfill task, so the task will wait infinite time. Here I use a thread
+    to run the task, and terminate the task after that.
+     */
+    Thread thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        task.run();
+      }
+    });
+    thread.start();
+    try {
+      Thread.sleep(TimeUnit.SECONDS.toMillis(2));
+    } catch (InterruptedException e) {
+      // do nothing
+    }
+
+    Assert.assertEquals(1, jobDAO.findAll().size());
+    thread.stop();
+  }
+
+  @Test(dependsOnMethods = {"testFunctionReplayOnboardingTask"})
+  public void test() {
+    final DetectionOnboardTask task = new AlertFilterAutoTuneOnboardingTask();
     task.setTaskContext(context);
     task.run();
 
-    Assert.assertEquals(1, jobDAO.findAll().size());
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/tasks/TestOnboardingTasks.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/onboard/tasks/TestOnboardingTasks.java
@@ -1,0 +1,85 @@
+package com.linkedin.thirdeye.anomaly.onboard.tasks;
+
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTask;
+import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTaskContext;
+import com.linkedin.thirdeye.anomaly.onboard.OnboardingTaskTestUtils;
+import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
+import com.linkedin.thirdeye.datalayer.bao.DAOTestBase;
+import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.JobManager;
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestOnboardingTasks {
+  private DAOTestBase daoTestBase;
+  private DetectionOnboardTaskContext context;
+  private DatasetConfigManager datasetConfigDAO;
+  private AnomalyFunctionManager anomalyFunctionDAO;
+  private AlertConfigManager alertConfigDAO;
+  private JobManager jobDAO;
+
+  @BeforeClass
+  private void beforeClass(){
+    daoTestBase = DAOTestBase.getInstance();
+    DAORegistry daoRegistry = DAORegistry.getInstance();
+    datasetConfigDAO = daoRegistry.getDatasetConfigDAO();
+    anomalyFunctionDAO = daoRegistry.getAnomalyFunctionDAO();
+    alertConfigDAO = daoRegistry.getAlertConfigDAO();
+    jobDAO = daoRegistry.getJobDAO();
+    context = OnboardingTaskTestUtils.getDetectionTaskContext();
+
+    // Prepare for data
+    DatasetConfigDTO datasetConfig = new DatasetConfigDTO();
+    datasetConfig.setDataset("test");
+    datasetConfig.setTimeColumn("Date");
+    datasetConfig.setTimeUnit(TimeUnit.DAYS);
+    datasetConfig.setTimeDuration(1);
+    datasetConfig.setTimeFormat("SIMPLE_DATE_FORMAT:yyyyMMdd");
+    datasetConfig.setTimezone("US/Pacific");
+    datasetConfigDAO.save(datasetConfig);
+  }
+
+  @AfterClass
+  private void afterClass(){
+    daoTestBase.cleanup();
+  }
+
+  @Test
+  public void testDataPreparationOnboardingTask(){
+    DetectionOnboardTask task = new DataPreparationOnboardingTask();
+    task.setTaskContext(context);
+    task.run();
+
+    DetectionOnboardExecutionContext executionContext = context.getExecutionContext();
+    Assert.assertNotNull(executionContext.getExecutionResult(DefaultDetectionOnboardJob.FUNCTION_FACTORY));
+    Assert.assertNotNull(executionContext.getExecutionResult(DefaultDetectionOnboardJob.ALERT_FILTER_FACTORY));
+    Assert.assertNotNull(executionContext.getExecutionResult(DefaultDetectionOnboardJob.ALERT_FILTER_AUTOTUNE_FACTORY));
+  }
+
+  @Test(dependsOnMethods = {"testDataPreparationOnboardingTask"})
+  public void testFunctionCreationOnboardingTask(){
+    DetectionOnboardTask task = new FunctionCreationOnboardingTask();
+    task.setTaskContext(context);
+    task.run();
+
+    Assert.assertEquals(1, anomalyFunctionDAO.findAll().size());
+    Assert.assertEquals(1, alertConfigDAO.findAll().size());
+  }
+
+  @Test(dependsOnMethods = {"testFunctionCreationOnboardingTask"})
+  public void testFunctionReplayOnboardingTask() {
+    DetectionOnboardTask task = new FunctionReplayOnboardingTask();
+    task.setTaskContext(context);
+    task.run();
+
+    Assert.assertEquals(1, jobDAO.findAll().size());
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/resources/sample-alertfilter-autotune.properties
+++ b/thirdeye/thirdeye-pinot/src/test/resources/sample-alertfilter-autotune.properties
@@ -1,0 +1,1 @@
+DUMMY = com.linkedin.thirdeye.anomalydetection.alertFilterAutotun.DummyAlertFilterAutoTune


### PR DESCRIPTION
Current onboarding tasks are run in a wrapper. This design is hard to manage and is unable to get the task status. With the help of flexible job and tasks by @cyenjung, we are able to implement a onboarding job with multiple tasks, and there is endpoint to retrieve the job status and exceptions. This pr is to implement and replace the current wrapper by the onboarding job.