### PR TITLE
Make RealtimeIndexOffheapMemoryManager re-usable

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/RealtimeIndexOffHeapMemoryManager.java
@@ -109,6 +109,7 @@ public abstract class RealtimeIndexOffHeapMemoryManager implements Closeable {
     _serverMetrics.addValueToTableGauge(_tableName, ServerGauge.REALTIME_OFFHEAP_MEMORY_USED, -_totalMemBytes);
     doClose();
     _buffers.clear();
+    _totalMemBytes = 0;
   }
 
   public long getTotalMemBytes() {


### PR DESCRIPTION
With this fix, we can re-use the memory manager to allocate and release memory,
useful for estimating memory usage for realtime use cases