### PR TITLE
[TE] Alert performance by application

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -315,6 +315,7 @@ export function postProps(postData) {
 export default Ember.Helper.helper({
   checkStatus,
   pluralizeTime,
+  buildDateEod,
   isIterable,
   makeIterable,
   filterObject,

--- a/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/component.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  classNames: ['performance-tooltip']
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/component.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-  classNames: ['performance-tooltip']
+  classNames: ['te-performance-tooltip']
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/template.hbs
@@ -2,13 +2,13 @@
   <a class="te-anomaly-table__link" href="#">
     {{if viewTotals data.tot data.avg}}
       {{#tooltip-on-element}}
-        {{category}} for <span class="te-perf-tooltip__title">{{data.name}}</span><br>
-        <ul class="te-perf-tooltip__list">
-          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Total: </span>{{data.tot}}</li>
-          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Avg: </span>{{data.avg}}</li>
-          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Min: </span>{{data.min}}</li>
-          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Max: </span>{{data.max}}</li>
-          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Standard deviation: </span>{{data.std}}</li>
+        {{category}} for <span class="te-performance-tooltip__title">{{data.name}}</span><br>
+        <ul class="te-performance-tooltip__list">
+          <li class="te-performance-tooltip__item"><span class="te-performance-tooltip__category">Total: </span>{{data.tot}}</li>
+          <li class="te-performance-tooltip__item"><span class="te-performance-tooltip__category">Avg: </span>{{data.avg}}</li>
+          <li class="te-performance-tooltip__item"><span class="te-performance-tooltip__category">Min: </span>{{data.min}}</li>
+          <li class="te-performance-tooltip__item"><span class="te-performance-tooltip__category">Max: </span>{{data.max}}</li>
+          <li class="te-performance-tooltip__item"><span class="te-performance-tooltip__category">Standard deviation: </span>{{data.std}}</li>
         </ul>
       {{/tooltip-on-element}}
   </a>

--- a/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/performance-tooltip/template.hbs
@@ -1,0 +1,17 @@
+{{#if (not-eq data.tot 0)}}
+  <a class="te-anomaly-table__link" href="#">
+    {{if viewTotals data.tot data.avg}}
+      {{#tooltip-on-element}}
+        {{category}} for <span class="te-perf-tooltip__title">{{data.name}}</span><br>
+        <ul class="te-perf-tooltip__list">
+          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Total: </span>{{data.tot}}</li>
+          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Avg: </span>{{data.avg}}</li>
+          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Min: </span>{{data.min}}</li>
+          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Max: </span>{{data.max}}</li>
+          <li class="te-perf-tooltip__item"><span class="te-perf-tooltip__category">Standard deviation: </span>{{data.std}}</li>
+        </ul>
+      {{/tooltip-on-element}}
+  </a>
+{{else}}
+  {{if viewTotals data.tot data.avg}}
+{{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
@@ -1,0 +1,76 @@
+/**
+ * Controller for Alert Details Page: Tune Sensitivity Tab
+ * @module manage/alert/tune
+ * @exports manage/alert/tune
+ */
+import fetch from 'fetch';
+import Ember from 'ember';
+import _ from 'lodash';
+import { checkStatus, buildDateEod } from 'thirdeye-frontend/helpers/utils';
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+
+  /**
+   * Mapping anomaly table column names to corresponding prop keys
+   */
+  sortMap: {
+    name: 'name',
+    alert: 'alerts',
+    anomaly: 'data.totalAlerts',
+    user: 'data.userReportAnomaly',
+    responses: 'data.totalResponses',
+    resrate: 'data.responseRate',
+    precision: 'data.precision'
+  },
+
+  /**
+   * List of applications to render as rows, with filtering applied
+   */
+  applications: Ember.computed(
+    'perfDataByApplication',
+    'selectedSortMode',
+    'viewTotals',
+    'sortMap',
+    function() {
+      const sortMap = this.get('sortMap');
+      const selectedSortMode = this.get('selectedSortMode');
+      const sortMapChild = this.get('viewTotals') ? '.tot' : '.avg';
+      const keysWithChildren = ['anomaly', 'user', 'responses'];
+      let allApps = this.get('perfDataByApplication');
+      let fullSortKey = '';
+      let applySortType = true;
+
+      if (selectedSortMode) {
+        let [ sortKey, sortDir ] = selectedSortMode.split(':');
+        applySortType = keysWithChildren.includes(sortKey);
+        fullSortKey = applySortType ? sortMap[sortKey] + sortMapChild : sortMap[sortKey];
+
+        if (sortDir === 'up') {
+          allApps = _.sortBy(allApps, fullSortKey);
+        } else {
+          allApps = _.sortBy(allApps, fullSortKey).reverse();
+        }
+      }
+
+      return allApps;
+    }
+  ),
+
+  actions: {
+    /**
+     * Handle sorting for each sortable table column
+     * @param {String} sortKey  - stringified start date
+     */
+    toggleSortDirection(sortKey) {
+      const propName = 'sortColumn' + sortKey.capitalize() + 'Up' || '';
+
+      this.toggleProperty(propName);
+      if (this.get(propName)) {
+        this.set('selectedSortMode', sortKey + ':up');
+      } else {
+        this.set('selectedSortMode', sortKey + ':down');
+      }
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
@@ -6,28 +6,33 @@
 import fetch from 'fetch';
 import Ember from 'ember';
 import _ from 'lodash';
+import { computed } from '@ember/object';
 import { checkStatus, buildDateEod } from 'thirdeye-frontend/helpers/utils';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
 
   /**
-   * Mapping anomaly table column names to corresponding prop keys
+   * Active class appendage of 'view totals' link
+   * @type {String}
    */
-  sortMap: {
-    name: 'name',
-    alert: 'alerts',
-    anomaly: 'data.totalAlerts',
-    user: 'data.userReportAnomaly',
-    responses: 'data.totalResponses',
-    resrate: 'data.responseRate',
-    precision: 'data.precision'
-  },
+  viewTotalsState: computed('viewTotals', function() {
+    return this.get('viewTotals') ? 'active' : 'inactive';
+  }),
+
+  /**
+   * Active class appendage of 'view average' link
+   * @type {String}
+   */
+  viewAvgState: computed('viewTotals', function() {
+    return !this.get('viewTotals') ? 'active' : 'inactive';
+  }),
 
   /**
    * List of applications to render as rows, with filtering applied
+   * @type {Array}
    */
-  applications: Ember.computed(
+  applications: computed(
     'perfDataByApplication',
     'selectedSortMode',
     'viewTotals',
@@ -63,14 +68,13 @@ export default Controller.extend({
      * @param {String} sortKey  - stringified start date
      */
     toggleSortDirection(sortKey) {
+      const sortMenu = this.get('sortMenuGlyph');
       const propName = 'sortColumn' + sortKey.capitalize() + 'Up' || '';
-
+      let direction = '';
       this.toggleProperty(propName);
-      if (this.get(propName)) {
-        this.set('selectedSortMode', sortKey + ':up');
-      } else {
-        this.set('selectedSortMode', sortKey + ':down');
-      }
+      direction  = this.get(propName) ? 'up' : 'down';
+      Ember.set(sortMenu, sortKey, direction);
+      this.set('selectedSortMode', `${sortKey}:${direction}`);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -8,6 +8,9 @@ import fetch from 'fetch';
 import RSVP from 'rsvp';
 import { checkStatus, pluralizeTime, buildDateEod, parseProps, postProps } from 'thirdeye-frontend/helpers/utils';
 
+/**
+ * If true, this reduces the list of alerts per app to 2 for a quick demo.
+ */
 const demoMode = false;
 
 /**
@@ -156,6 +159,7 @@ export default Ember.Route.extend({
     const availableGroups = Array.from(new Set(model.richFunctionObjects.map(alertObj => alertObj.name)));
     const roundable = ['totalAlerts', 'totalResponses', 'falseAlarm', 'newTrend', 'trueAnomalies', 'userReportAnomaly'];
     let newGroupArr = [];
+    let count = 0;
 
     // Filter down to functions belonging to our active application groups
     availableGroups.forEach((group) => {
@@ -167,6 +171,7 @@ export default Ember.Route.extend({
 
       // Get array of keys from first record
       let metricKeys = Object.keys(groupData[0].data);
+      count++;
 
       // Look at each anomaly's perf object keys. For our "roundable" fields, get derived data
       metricKeys.forEach((key) => {
@@ -197,7 +202,7 @@ export default Ember.Route.extend({
       avgData['precision'] = avgData['precision'] ? calculateRate(avgData['totalAlerts'], avgData['trueAnomalies']) : 'N/A';
 
       newGroupArr.push({
-        name: group,
+        name: demoMode ? `group ${count}` : group,
         data: avgData,
         alerts: groupData.length
       });

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
@@ -1,121 +1,128 @@
-<div class="manage-alert-tune">
+{{#if isDataLoading}}
+  <div class="te-alert-page-pending">
+    <img src="assets/images/te-alert-{{if isDataLoadingError "error" "pending"}}.png" class="te-alert-page-pending__image {{if isDataLoadingError "te-alert-page-pending__image--error"}}" alt="alertData.Setup is Processing">
+    <h2 class="te-alert-page-pending__title">{{if isDataLoadingError "Oops, something went wrong." "Aggregating anomaly performance data..."}}</h2>
+    {{#if (not isDataLoadingError)}}<div class="te-alert-page-pending__loader"></div>{{/if}}
+    <p class="te-alert-page-pending__text">
+      {{#if isDataLoadingError}}
+        The performance data cannot be retrieved.
+      {{else}}
+        Fetching all app-related anomaly data for all alerts may take up to a minute. <br/>Hang in there!
+      {{/if}}
+    </p>
+  </div>
+{{else}}
+  <div class="manage-alert-tune">
+    <div class="te-content-block">
+      <h4 class="te-alert-page__subtitle">Alert Performance by Application Group</h4>
+      <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{viewTotalsState}}" {{action (toggle "viewTotals" this)}}>View total values</a>
+      <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{viewAvgState}}" {{action (toggle "viewTotals" this)}}>View average values</a>
+      {{!-- Alert anomaly table --}}
+      <table class="te-anomaly-table te-anomaly-table--performance">
+        <thead>
+          <tr class="te-anomaly-table__row te-anomaly-table__head">
+           <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "name"}}>
+                Appp
+                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.name}}"></i>
+              </a>
+             </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "alert"}}>
+                Alerts
+                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.alert}}"></i>
+              </a>
+             </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "anomaly"}}>
+                Anomalies
+                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.anomaly}}"></i>
+              </a>
+             </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "user"}}>
+                User-rep
+                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.user}}"></i>
+              </a>
+            </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "responses"}}>
+                Responses
+                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.responses}}"></i>
+              </a>
+             </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resrate"}}>
+                Response rate
+                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.resrate}}"></i>
+              </a>
+            </th>
+             <th class="te-anomaly-table__cell-head">
+              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "precision"}}>
+                Precision
+                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.precision}}"></i>
+              </a>
+            </th>
+          </tr>
+        </thead>
 
-  <div class="te-content-block">
-    <h4 class="te-alert-page__subtitle">Alert Performance by Application Group</h4>
-
-    <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{if viewTotals "active" "inactive"}}" {{action (toggle "viewTotals" this)}}>
-      View total values
-    </a>
-    <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{if viewTotals "inactive" "active"}}" {{action (toggle "viewTotals" this)}}>
-      View average values
-    </a>
-
-    {{!-- Alert anomaly table --}}
-    <table class="te-anomaly-table te-anomaly-table--performance">
-      <thead>
-        <tr class="te-anomaly-table__row te-anomaly-table__head">
-         <th class="te-anomaly-table__cell-head">
-            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "name"}}>
-              Appp
-              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnNameUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-            </a>
-           </th>
-           <th class="te-anomaly-table__cell-head">
-            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "alert"}}>
-              Total Alerts
-              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnAlertUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-            </a>
-           </th>
-           <th class="te-anomaly-table__cell-head">
-            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "anomaly"}}>
-              Anomalies
-              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnAnomalyUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-            </a>
-           </th>
-           <th class="te-anomaly-table__cell-head">
-            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "user"}}>
-              User-reported
-              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnUserUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-            </a>
-          </th>
-           <th class="te-anomaly-table__cell-head">
-            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "responses"}}>
-              Responses
-              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnRespUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-            </a>
-           </th>
-           <th class="te-anomaly-table__cell-head">
-            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resrate"}}>
-              Response rate
-              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnResrateUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-            </a>
-          </th>
-           <th class="te-anomaly-table__cell-head">
-            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "precision"}}>
-              Precision
-              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnPrecisionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-            </a>
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        {{#each applications as |app|}}
-          <tr class="te-anomaly-table__row">
-            <td class="te-anomaly-table__cell te-anomaly-table__list--stronger">{{app.name}}</td>
-            <td class="te-anomaly-table__cell">{{app.alerts}}</td>
-            <td class="te-anomaly-table__cell">
-              {{performance-tooltip
-                data=app.data.totalAlerts
-                category="Anomalies"
-                viewTotals=viewTotals
-              }}
-            </td>
-            <td class="te-anomaly-table__cell">
-              {{performance-tooltip
-                data=app.data.userReportAnomaly
-                category="User reported anomalies"
-                viewTotals=viewTotals
-              }}
-            </td>
-            <td class="te-anomaly-table__cell">
-              <div class="performance-metric">
+        <tbody>
+          {{#each applications as |app|}}
+            <tr class="te-anomaly-table__row">
+              <td class="te-anomaly-table__cell te-anomaly-table__list--stronger">{{app.name}}</td>
+              <td class="te-anomaly-table__cell">{{app.alerts}}</td>
+              <td class="te-anomaly-table__cell">
                 {{performance-tooltip
-                 data=app.data.totalResponses
-                 category="Total Responses"
-                 viewTotals=viewTotals
+                  data=app.data.totalAlerts
+                  category="Anomalies"
+                  viewTotals=viewTotals
                 }}
-              </div>
-              <div class="performance-metric__subset">
-                ( True: {{performance-tooltip
-                       data=app.data.trueAnomalies
-                       category="True anomalies"
+              </td>
+              <td class="te-anomaly-table__cell">
+                {{performance-tooltip
+                  data=app.data.userReportAnomaly
+                  category="User reported anomalies"
+                  viewTotals=viewTotals
+                }}
+              </td>
+              <td class="te-anomaly-table__cell">
+                <div class="te-performance-metric">
+                  {{performance-tooltip
+                   data=app.data.totalResponses
+                   category="Total Responses"
+                   viewTotals=viewTotals
+                  }}
+                </div>
+                <div class="te-performance-metric__subset">
+                  ( T: {{performance-tooltip
+                         data=app.data.trueAnomalies
+                         category="True anomalies"
+                         viewTotals=viewTotals
+                       }} |
+                  F: {{performance-tooltip
+                       data=app.data.falseAlarm
+                       category="False anomalies"
                        viewTotals=viewTotals
                      }} |
-                False: {{performance-tooltip
-                     data=app.data.falseAlarm
-                     category="False anomalies"
-                     viewTotals=viewTotals
-                   }} |
-                New: {{performance-tooltip
-                     data=app.data.newTrend
-                     category="New trend anomalies"
-                     viewTotals=viewTotals
-                   }} )
-            </div>
-            </td>
-            <td class="te-anomaly-table__cell">
-              {{app.data.responseRate}}
-              <span class="te-anomaly-table__list--smaller">%</span>
-            </td>
-            <td class="te-anomaly-table__cell">
-              {{app.data.precision}}
-              <span class="te-anomaly-table__list--smaller">%</span>
-            </td>
-          </tr>
-        {{/each}}
-      </tbody>
-    </table>
-
+                  N: {{performance-tooltip
+                       data=app.data.newTrend
+                       category="New trend anomalies"
+                       viewTotals=viewTotals
+                     }} )
+              </div>
+              </td>
+              <td class="te-anomaly-table__cell">
+                {{app.data.responseRate}}
+                <span class="te-anomaly-table__list--smaller">%</span>
+              </td>
+              <td class="te-anomaly-table__cell">
+                {{app.data.precision}}
+                <span class="te-anomaly-table__list--smaller">%</span>
+              </td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
+{{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
@@ -1,0 +1,121 @@
+<div class="manage-alert-tune">
+
+  <div class="te-content-block">
+    <h4 class="te-alert-page__subtitle">Alert Performance by Application Group</h4>
+
+    <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{if viewTotals "active" "inactive"}}" {{action (toggle "viewTotals" this)}}>
+      View total values
+    </a>
+    <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{if viewTotals "inactive" "active"}}" {{action (toggle "viewTotals" this)}}>
+      View average values
+    </a>
+
+    {{!-- Alert anomaly table --}}
+    <table class="te-anomaly-table te-anomaly-table--performance">
+      <thead>
+        <tr class="te-anomaly-table__row te-anomaly-table__head">
+         <th class="te-anomaly-table__cell-head">
+            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "name"}}>
+              Appp
+              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnNameUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+            </a>
+           </th>
+           <th class="te-anomaly-table__cell-head">
+            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "alert"}}>
+              Total Alerts
+              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnAlertUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+            </a>
+           </th>
+           <th class="te-anomaly-table__cell-head">
+            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "anomaly"}}>
+              Anomalies
+              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnAnomalyUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+            </a>
+           </th>
+           <th class="te-anomaly-table__cell-head">
+            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "user"}}>
+              User-reported
+              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnUserUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+            </a>
+          </th>
+           <th class="te-anomaly-table__cell-head">
+            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "responses"}}>
+              Responses
+              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnRespUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+            </a>
+           </th>
+           <th class="te-anomaly-table__cell-head">
+            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resrate"}}>
+              Response rate
+              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnResrateUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+            </a>
+          </th>
+           <th class="te-anomaly-table__cell-head">
+            <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "precision"}}>
+              Precision
+              <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon {{if sortColumnPrecisionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+            </a>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        {{#each applications as |app|}}
+          <tr class="te-anomaly-table__row">
+            <td class="te-anomaly-table__cell te-anomaly-table__list--stronger">{{app.name}}</td>
+            <td class="te-anomaly-table__cell">{{app.alerts}}</td>
+            <td class="te-anomaly-table__cell">
+              {{performance-tooltip
+                data=app.data.totalAlerts
+                category="Anomalies"
+                viewTotals=viewTotals
+              }}
+            </td>
+            <td class="te-anomaly-table__cell">
+              {{performance-tooltip
+                data=app.data.userReportAnomaly
+                category="User reported anomalies"
+                viewTotals=viewTotals
+              }}
+            </td>
+            <td class="te-anomaly-table__cell">
+              <div class="performance-metric">
+                {{performance-tooltip
+                 data=app.data.totalResponses
+                 category="Total Responses"
+                 viewTotals=viewTotals
+                }}
+              </div>
+              <div class="performance-metric__subset">
+                ( True: {{performance-tooltip
+                       data=app.data.trueAnomalies
+                       category="True anomalies"
+                       viewTotals=viewTotals
+                     }} |
+                False: {{performance-tooltip
+                     data=app.data.falseAlarm
+                     category="False anomalies"
+                     viewTotals=viewTotals
+                   }} |
+                New: {{performance-tooltip
+                     data=app.data.newTrend
+                     category="New trend anomalies"
+                     viewTotals=viewTotals
+                   }} )
+            </div>
+            </td>
+            <td class="te-anomaly-table__cell">
+              {{app.data.responseRate}}
+              <span class="te-anomaly-table__list--smaller">%</span>
+            </td>
+            <td class="te-anomaly-table__cell">
+              {{app.data.precision}}
+              <span class="te-anomaly-table__list--smaller">%</span>
+            </td>
+          </tr>
+        {{/each}}
+      </tbody>
+    </table>
+
+  </div>
+</div>

--- a/thirdeye/thirdeye-frontend/app/router.js
+++ b/thirdeye/thirdeye-frontend/app/router.js
@@ -19,6 +19,7 @@ Router.map(function() {
     });
     this.route('alerts', function() {
       this.route('edit', { path: '/:alertId' });
+      this.route('performance');
     });
   });
 

--- a/thirdeye/thirdeye-frontend/app/styles/app.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/app.scss
@@ -57,6 +57,7 @@ body {
 @import 'ember-power-select/themes/bootstrap';
 @import "ember-power-select";
 @import "pods/manage/alerts";
+@import "pods/manage/alerts-performance";
 @import "pods/self-serve/create-alert";
 @import "pods/self-serve/import-metric";
 @import 'pods/rca';

--- a/thirdeye/thirdeye-frontend/app/styles/pods/manage/alerts-performance.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/pods/manage/alerts-performance.scss
@@ -1,0 +1,35 @@
+.te-performance-tooltip {
+  display: inline-block;
+
+  &__title {
+    text-transform: uppercase;
+  }
+  &__list {
+    padding-left: 0;
+    margin-top: 5px;
+    max-width: 400px;
+  }
+  &__item {
+    list-style: none;
+  }
+  &__category {
+    color: app-shade(white, 5);
+    padding-right: 7px;
+  }
+}
+
+.te-performance-metric {
+  width: 20px;
+  text-align: right;
+  display: inline-block;
+
+  &__subset {
+    display: inline-block;
+    color: app-shade(black, 6);
+    padding-left: 5px;
+
+    &--null {
+      color: app-shade(black, 4);
+    }
+  }
+}

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -227,24 +227,6 @@ body {
   }
 }
 
-.te-perf-tooltip {
-  &__title {
-    text-transform: uppercase;
-  }
-  &__list {
-    padding-left: 0;
-    margin-top: 5px;
-    max-width: 400px;
-  }
-  &__item {
-    list-style: none;
-  }
-  &__category {
-    color: app-shade(white, 5);
-    padding-right: 7px;
-  }
-}
-
 .te-horizontal-cards {
   &__container {
     display: flex;
@@ -300,7 +282,7 @@ body {
 }
 
 .te-anomaly-table {
-  width: 97%;
+  width: 100%;
   margin-top: 12px;
   border: 1px solid app-shade(black, 1);
 
@@ -602,26 +584,6 @@ body {
 
     &:first-child {
       margin-left: 0;
-    }
-  }
-}
-
-.performance-tooltip {
-  display: inline-block;
-}
-
-.performance-metric {
-  width: 20px;
-  text-align: right;
-  display: inline-block;
-
-  &__subset {
-    display: inline-block;
-    color: app-shade(black, 6);
-    padding-left: 5px;
-
-    &--null {
-      color: app-shade(black, 4);
     }
   }
 }

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -201,11 +201,47 @@ body {
     font-weight: 600;
     letter-spacing: .03em;
     float: right;
-    margin-top: -15px;
+    margin: -15px 10px 0 0;
+    cursor: pointer;
 
     &--high {
       margin-top: -30px;
     }
+
+    &--low {
+      margin-top: -5px;
+    }
+
+    &--active {
+      border-bottom: 1px dashed;
+    }
+
+    &--inactive {
+      color: app-shade(black, 3);
+    }
+
+    &:hover {
+      color: $te-link-blue;
+      text-decoration: none;
+    }
+  }
+}
+
+.te-perf-tooltip {
+  &__title {
+    text-transform: uppercase;
+  }
+  &__list {
+    padding-left: 0;
+    margin-top: 5px;
+    max-width: 400px;
+  }
+  &__item {
+    list-style: none;
+  }
+  &__category {
+    color: app-shade(white, 5);
+    padding-right: 7px;
   }
 }
 
@@ -252,6 +288,10 @@ body {
 
   &__card-tooltip {
     font-size: 15px;
+
+    &--small {
+      font-size: 11px;
+    }
   }
 }
 
@@ -315,7 +355,8 @@ body {
     }
 
     &--smaller {
-      font-size: 13px;
+      font-size: 12px;
+      margin-left: -2px;
     }
   }
 
@@ -344,6 +385,15 @@ body {
       font-size: 20px;
       margin: 14px 0 0 -26px;
     }
+
+    &--small {
+      font-size: 11px;
+      margin-left: 0px;
+    }
+  }
+
+  &--performance {
+    margin-top: 30px;
   }
 
 }
@@ -552,6 +602,26 @@ body {
 
     &:first-child {
       margin-left: 0;
+    }
+  }
+}
+
+.performance-tooltip {
+  display: inline-block;
+}
+
+.performance-metric {
+  width: 20px;
+  text-align: right;
+  display: inline-block;
+
+  &__subset {
+    display: inline-block;
+    color: app-shade(black, 6);
+    padding-left: 5px;
+
+    &--null {
+      color: app-shade(black, 4);
     }
   }
 }


### PR DESCRIPTION
Builds a sortable performance table aggregating alert performance by application.

<img width="1150" alt="screen shot 2018-01-04 at 2 19 21 am" src="https://user-images.githubusercontent.com/11814420/34555121-c2c02e4c-f0f5-11e7-9a16-eaf6a381417d.png">

Final commit: addressed suggestions below + moved logic out of `afterModel` hook into `setupController` to implement a loading banner.