### PR TITLE
Refactor FileUploadUtils to use HttpClient 4.5.3

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/exception/HttpErrorStatusException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/exception/HttpErrorStatusException.java
@@ -15,19 +15,15 @@
  */
 package com.linkedin.pinot.common.exception;
 
-/**
- * Custom exception thrown to escape from retries.
- */
-public class PermanentPushFailureException extends RuntimeException {
-  public PermanentPushFailureException(String message) {
+public class HttpErrorStatusException extends Exception {
+  private final int _statusCode;
+
+  public HttpErrorStatusException(String message, int statusCode) {
     super(message);
+    _statusCode = statusCode;
   }
 
-  public PermanentPushFailureException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public PermanentPushFailureException(Throwable cause) {
-    super(cause);
+  public int getStatusCode() {
+    return _statusCode;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/exception/PermanentDownloadException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/exception/PermanentDownloadException.java
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.linkedin.pinot.common.exception;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-
 public class PermanentDownloadException extends RuntimeException {
-  public static Logger LOGGER = LoggerFactory.getLogger(PermanentDownloadException.class);
 
-  public  PermanentDownloadException(String errorMsg) {
-    super(errorMsg);
+  public PermanentDownloadException(String message) {
+    super(message);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -255,6 +255,8 @@ public class CommonConstants {
 
   public static class Controller {
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.controller.segment.fetcher";
+    public static final String HOST_HTTP_HEADER = "Pinot-Controller-Host";
+    public static final String VERSION_HTTP_HEADER = "Pinot-Controller-Version";
   }
 
   public static class Minion {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileDownloadUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileDownloadUtils.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.exception.HttpErrorStatusException;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+
+public class FileDownloadUtils {
+  private FileDownloadUtils() {
+  }
+
+  private static final CloseableHttpClient HTTP_CLIENT = HttpClientBuilder.create().build();
+
+  /**
+   * Download a file with uri.
+   * @param fileUri Uri of the file.
+   * @param dest File destination.
+   * @return Response status code
+   * @throws Exception
+   */
+  public static int downloadFile(String fileUri, File dest) throws Exception {
+    HttpUriRequest request = RequestBuilder.get(fileUri).setVersion(HttpVersion.HTTP_1_1).build();
+    try (CloseableHttpResponse response = HTTP_CLIENT.execute(request)) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode >= 400) {
+        throw new HttpErrorStatusException(getErrorMessage(fileUri, response), statusCode);
+      }
+
+      HttpEntity entity = response.getEntity();
+      long contentLength = entity.getContentLength();
+      try (InputStream inputStream = response.getEntity().getContent();
+          OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(dest))) {
+        IOUtils.copyLarge(inputStream, outputStream);
+      }
+      long fileLength = dest.length();
+      Preconditions.checkState(fileLength == contentLength,
+          String.format("File length: %d does not match content length: %d", fileLength, contentLength));
+
+      return statusCode;
+    }
+  }
+
+  private static String getErrorMessage(String fileUri, CloseableHttpResponse response) {
+    String controllerHost = null;
+    String controllerVersion = null;
+    if (response.containsHeader(CommonConstants.Controller.HOST_HTTP_HEADER)) {
+      controllerHost = response.getFirstHeader(CommonConstants.Controller.HOST_HTTP_HEADER).getValue();
+      controllerVersion = response.getFirstHeader(CommonConstants.Controller.VERSION_HTTP_HEADER).getValue();
+    }
+    StatusLine statusLine = response.getStatusLine();
+    String errorMessage = String.format("Got error status code: %d with reason: %s while downloading file with uri: %s",
+        statusLine.getStatusCode(), statusLine.getReasonPhrase(), fileUri);
+    if (controllerHost != null) {
+      errorMessage =
+          String.format("%s from controller: %s, version: %s", errorMessage, controllerHost, controllerVersion);
+    }
+    return errorMessage;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/serde/SerDe.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/serde/SerDe.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.serde;
 
-import org.apache.http.annotation.NotThreadSafe;
+import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentUploadRestletResource.java
@@ -28,9 +28,9 @@ import com.linkedin.pinot.common.segment.fetcher.SegmentFetcher;
 import com.linkedin.pinot.common.segment.fetcher.SegmentFetcherFactory;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.FileUploadUtils;
+import com.linkedin.pinot.common.utils.PinotMinionUserAgentHeader;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
-import com.linkedin.pinot.common.utils.PinotMinionUserAgentHeader;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.time.TimeUtils;
 import com.linkedin.pinot.controller.ControllerConf;
@@ -285,7 +285,7 @@ public class PinotSegmentUploadRestletResource {
       tempSegmentDir.deleteOnExit();
 
       // Get upload type
-      List<String> uploadTypes = headers.getRequestHeader(FileUploadUtils.UPLOAD_TYPE);
+      List<String> uploadTypes = headers.getRequestHeader(FileUploadUtils.CustomHeaders.UPLOAD_TYPE);
       FileUploadUtils.FileUploadType uploadType = FileUploadUtils.FileUploadType.getDefaultUploadType();
       if (uploadTypes != null && uploadTypes.size() > 0) {
         String uploadTypeStr = uploadTypes.get(0);
@@ -574,10 +574,11 @@ public class PinotSegmentUploadRestletResource {
     return ControllerConf.constructDownloadUrl(tableName, segmentName, provider.getVip());
   }
 
-  private String getDownloadUri(FileUploadUtils.FileUploadType uploadType, HttpHeaders headers, String segmentJsonStr) throws Exception {
+  private String getDownloadUri(FileUploadUtils.FileUploadType uploadType, HttpHeaders headers, String segmentJsonStr)
+      throws Exception {
     switch (uploadType) {
       case URI:
-        return headers.getRequestHeader(FileUploadUtils.DOWNLOAD_URI).get(0);
+        return headers.getRequestHeader(FileUploadUtils.CustomHeaders.DOWNLOAD_URI).get(0);
       case JSON:
         // Get segmentJsonStr
         JSONTokener tokener = new JSONTokener(segmentJsonStr);

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -17,6 +17,8 @@
 
 package com.linkedin.pinot.server.realtime;
 
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -36,7 +38,6 @@ import org.apache.commons.httpclient.methods.multipart.PartSource;
 import org.apache.commons.httpclient.params.HttpMethodParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 
 
 /**
@@ -160,8 +161,8 @@ public class ServerSegmentCompletionProtocolHandler {
     try {
       int responseCode = httpClient.executeMethod(postMethod);
       // TODO Pick these up from constants defined in a common place.
-      Header controllerHostNameHdr =  postMethod.getResponseHeader("Pinot-Controller-Host");
-      Header controllerVersionHdr = postMethod.getResponseHeader("Pinot-Controller-Version");
+      Header controllerHostNameHdr =  postMethod.getResponseHeader(CommonConstants.Controller.HOST_HTTP_HEADER);
+      Header controllerVersionHdr = postMethod.getResponseHeader(CommonConstants.Controller.VERSION_HTTP_HEADER);
 
       if (responseCode >= 300) {
         LOGGER.error("Bad controller response code {} for {} from {}, version {}", responseCode, request,

--- a/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentUriPushJob.java
+++ b/pinot-hadoop/src/main/java/com/linkedin/pinot/hadoop/job/SegmentUriPushJob.java
@@ -15,8 +15,8 @@
  */
 package com.linkedin.pinot.hadoop.job;
 
+import com.linkedin.pinot.common.utils.FileUploadUtils;
 import java.util.Properties;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileStatus;
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.pinot.common.utils.FileUploadUtils;
 
 public class SegmentUriPushJob extends Configured {
 
@@ -33,7 +32,7 @@ public class SegmentUriPushJob extends Configured {
   private String _pushUriSuffix;
   private String _segmentPath;
   private String[] _hosts;
-  private String _port;
+  private int _port;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentUriPushJob.class);
 
@@ -43,8 +42,7 @@ public class SegmentUriPushJob extends Configured {
     _pushUriSuffix = properties.getProperty("uri.suffix", "");
     _segmentPath = properties.getProperty("path.to.output") + "/";
     _hosts = properties.getProperty("push.to.hosts").split(",");
-    _port = properties.getProperty("push.to.port");
-
+    _port = Integer.parseInt(properties.getProperty("push.to.port"));
   }
 
   public void run() throws Exception {
@@ -59,7 +57,6 @@ public class SegmentUriPushJob extends Configured {
         pushOneTarFile(fs, fileStatus.getPath());
       }
     }
-
   }
 
   public void pushDir(FileSystem fs, Path path) throws Exception {
@@ -81,7 +78,8 @@ public class SegmentUriPushJob extends Configured {
     }
     for (String host : _hosts) {
       String uri = String.format("%s%s%s", _pushUriPrefix, path.toUri().getRawPath(), _pushUriSuffix);
-      LOGGER.info("******** Upoading file: {} to Host: {} and Port: {} with download uri: {} *******", fileName, host, _port, uri);
+      LOGGER.info("******** Upoading file: {} to Host: {} and Port: {} with download uri: {} *******", fileName, host,
+          _port, uri);
       try {
         int responseCode = FileUploadUtils.sendSegmentUri(host, _port, uri);
         LOGGER.info("Response code: {}", responseCode);
@@ -92,5 +90,4 @@ public class SegmentUriPushJob extends Configured {
       }
     }
   }
-
 }

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ClusterTest.java
@@ -40,7 +40,6 @@ import com.linkedin.pinot.minion.executor.PinotTaskExecutor;
 import com.linkedin.pinot.server.starter.helix.DefaultHelixStarterServerConfig;
 import com.linkedin.pinot.server.starter.helix.HelixServerStarter;
 import java.io.File;
-import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -202,13 +201,11 @@ public abstract class ClusterTest extends ControllerTest {
   }
 
   protected void addSchema(File schemaFile, String schemaName) throws Exception {
-    FileUploadUtils.sendFile(LOCAL_HOST, Integer.toString(_controllerPort), "schemas", schemaName,
-        new FileInputStream(schemaFile), schemaFile.length(), FileUploadUtils.SendFileMethod.POST);
+    FileUploadUtils.addSchema(LOCAL_HOST, _controllerPort, schemaName, schemaFile);
   }
 
   protected void updateSchema(File schemaFile, String schemaName) throws Exception {
-    FileUploadUtils.sendFile(LOCAL_HOST, Integer.toString(_controllerPort), "schemas/" + schemaName, schemaName,
-        new FileInputStream(schemaFile), schemaFile.length(), FileUploadUtils.SendFileMethod.PUT);
+    FileUploadUtils.updateSchema(LOCAL_HOST, _controllerPort, schemaName, schemaFile);
   }
 
   /**
@@ -216,13 +213,12 @@ public abstract class ClusterTest extends ControllerTest {
    *
    * @param segmentDir Segment directory
    */
-  protected void uploadSegments(@Nonnull File segmentDir) {
+  protected void uploadSegments(@Nonnull File segmentDir) throws Exception {
     String[] segmentNames = segmentDir.list();
     Assert.assertNotNull(segmentNames);
     for (String segmentName : segmentNames) {
       File segmentFile = new File(segmentDir, segmentName);
-      FileUploadUtils.sendSegmentFile(LOCAL_HOST, Integer.toString(_controllerPort), segmentName, segmentFile,
-          segmentFile.length());
+      FileUploadUtils.uploadSegment(LOCAL_HOST, _controllerPort, segmentName, segmentFile);
     }
   }
 

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AddSchemaCommand.java
@@ -15,18 +15,15 @@
  */
 package com.linkedin.pinot.tools.admin.command;
 
-import com.linkedin.pinot.tools.Command;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-
-import org.kohsuke.args4j.Option;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.FileUploadUtils;
 import com.linkedin.pinot.common.utils.NetUtil;
+import com.linkedin.pinot.tools.Command;
+import java.io.File;
+import java.io.FileNotFoundException;
+import org.kohsuke.args4j.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class AddSchemaCommand extends AbstractBaseAdminCommand implements Command {
@@ -116,8 +113,7 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
 
     Schema s = Schema.fromFile(schemaFile);
 
-    FileUploadUtils.sendFile(_controllerHost, _controllerPort, "schemas", s.getSchemaName(), new FileInputStream(
-        schemaFile), schemaFile.length(), FileUploadUtils.SendFileMethod.POST);
+    FileUploadUtils.addSchema(_controllerHost, Integer.parseInt(_controllerPort), s.getSchemaName(), schemaFile);
 
     return true;
   }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -20,7 +20,6 @@ import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
 import com.linkedin.pinot.tools.Command;
 import java.io.File;
-import java.io.FileInputStream;
 import org.apache.commons.io.FileUtils;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
@@ -120,9 +119,7 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
         }
 
         LOGGER.info("Uploading segment {}", tgzFile.getName());
-        FileUploadUtils
-            .sendSegmentFile(_controllerHost, _controllerPort, tgzFile.getName(), tgzFile,
-                tgzFile.length());
+        FileUploadUtils.uploadSegment(_controllerHost, Integer.parseInt(_controllerPort), tgzFile.getName(), tgzFile);
       }
     } catch (Exception e) {
       LOGGER.error("Exception caught while uploading segment {}", _segmentDir, e);

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -289,8 +289,7 @@ public class PerfBenchmarkDriver {
     Preconditions.checkNotNull(indexFiles);
     for (File indexFile : indexFiles) {
       LOGGER.info("Uploading index segment: {}", indexFile.getAbsolutePath());
-      FileUploadUtils.sendSegmentFile(_controllerHost, String.valueOf(_controllerPort), indexFile.getName(),
-          indexFile, indexFile.length());
+      FileUploadUtils.uploadSegment(_controllerHost, _controllerPort, indexFile.getName(), indexFile);
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -180,17 +180,17 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpmime</artifactId>
-        <version>4.2.5</version>
+        <version>4.5.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.2.5</version>
+        <version>4.5.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.2.5</version>
+        <version>4.4.6</version>
       </dependency>
       <dependency>
         <groupId>com.linkedin.pinot</groupId>

--- a/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/push/SegmentPushPhase.java
+++ b/thirdeye/thirdeye-hadoop/src/main/java/com/linkedin/thirdeye/hadoop/push/SegmentPushPhase.java
@@ -131,7 +131,7 @@ public class SegmentPushPhase  extends Configured {
         }
         LOGGER.info("******** Uploading file: {} to Host: {} and Port: {} *******", fileName, host, port);
         try {
-          int responseCode = FileUploadUtils.sendSegmentFile(host, port, fileName, inputStream, length);
+          int responseCode = FileUploadUtils.uploadSegment(host, Integer.parseInt(port), fileName, inputStream);
           LOGGER.info("Response code: {}", responseCode);
 
           if (uploadSuccess == true && responseCode != 200) {


### PR DESCRIPTION
1. Make file upload from local and HDFS use the same HttpClient
2. Add optional headers and parameters into upload segment request
3. Remove the retry logic from FileUploadUtils, client should handle retry based on the response status code
4. Add exception class HttpErrorStatusException to pass both error message and status code
5. Move the file download logic into a new class FileDownloadUtils