### PR TITLE
[TE] rootcause poc - offset data loading and metrics table display

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -148,6 +148,10 @@ export function toBaselineUrn(urn) {
   return metricUrnHelper('frontend:metric:baseline:', urn);
 }
 
+export function toOffsetUrn(urn, compareMode) {
+  return metricUrnHelper(`frontend:metric:${compareMode}:`, urn);
+}
+
 export function toMetricUrn(urn) {
   return metricUrnHelper('thirdeye:metric:', urn);
 }
@@ -189,18 +193,37 @@ export function filterPrefix(urns, prefixes) {
   return makeIterable(urns).filter(urn => hasPrefix(urn, prefixes));
 }
 
-export function toBaselineRange(anomalyRange, compareMode) {
+export function toBaselineRange(currentRange, compareMode) {
   const offset = {
-    WoW: 1,
-    Wo2W: 2,
-    Wo3W: 3,
-    Wo4W: 4
-  }[compareMode];
+    current: 0,
+    wow: 1,
+    wo1w: 1,
+    wo2w: 2,
+    wo3w: 3,
+    wo4w: 4
+  }[compareMode.toLowerCase()];
 
-  const start = moment(anomalyRange[0]).subtract(offset, 'weeks').valueOf();
-  const end = moment(anomalyRange[1]).subtract(offset, 'weeks').valueOf();
+  if (offset === 0) {
+    return currentRange;
+  }
+
+  const start = moment(currentRange[0]).subtract(offset, 'weeks').valueOf();
+  const end = moment(currentRange[1]).subtract(offset, 'weeks').valueOf();
 
   return [start, end];
+}
+
+export function toAbsoluteRange(urn, currentRange, baselineCompareMode) {
+  if (!urn.startsWith('frontend:metric:')) {
+    return currentRange;
+  }
+
+  let compareMode = urn.split(':')[2];
+  if (compareMode === 'baseline') {
+    compareMode = baselineCompareMode;
+  }
+
+  return toBaselineRange(currentRange, compareMode);
 }
 
 export function toFilters(urns) {
@@ -318,12 +341,14 @@ export default Ember.Helper.helper({
   toCurrentUrn,
   toBaselineUrn,
   toMetricUrn,
+  toOffsetUrn,
   stripTail,
   extractTail,
   appendTail,
   hasPrefix,
   filterPrefix,
   toBaselineRange,
+  toAbsoluteRange,
   toFilters,
   toFilterMap,
   findLabelMapping,

--- a/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import _ from 'lodash';
 
 export default Component.extend({
   /**
@@ -17,11 +16,37 @@ export default Component.extend({
     }, {
       propertyName: 'score',
       title: 'Anomalous Score',
+      disableFiltering: true,
       className: 'rootcause-metric__table__column'
     }, {
-      template: 'custom/metrics-table-changes',
-      propertyName: 'change',
-      title: 'Changes',
+      propertyName: 'changeFormatted',
+      sortedBy: 'change',
+      title: 'baseline',
+      disableFiltering: true,
+      className: 'rootcause-metric__table__column'
+    }, {
+      propertyName: 'change1wFormatted',
+      sortedBy: 'change1w',
+      title: 'WoW',
+      disableFiltering: true,
+      className: 'rootcause-metric__table__column'
+    }, {
+      propertyName: 'change2wFormatted',
+      sortedBy: 'change2w',
+      title: 'Wo2W',
+      disableFiltering: true,
+      className: 'rootcause-metric__table__column'
+    }, {
+      propertyName: 'change3wFormatted',
+      sortedBy: 'change3w',
+      title: 'Wo3W',
+      disableFiltering: true,
+      className: 'rootcause-metric__table__column'
+    }, {
+      propertyName: 'change4wFormatted',
+      sortedBy: 'change4w',
+      title: 'Wo4W',
+      disableFiltering: true,
       className: 'rootcause-metric__table__column'
     }
   ],
@@ -35,20 +60,29 @@ export default Component.extend({
     'urns',
     'metrics',
     'scores',
-    'changesFormatted',
+    'changesOffset',
+    'changesOffsetFormatted',
     function() {
       let arr = [];
-      const properties = ['urns', 'metrics', 'scores', 'changesFormatted', 'selectedUrns'];
-      const { urns, metrics, scores, changesFormatted, selectedUrns } = this.getProperties(...properties);
-      const urnsClone = _.cloneDeep(urns);
+      const { urns, metrics, scores, changesOffset, changesOffsetFormatted, selectedUrns } =
+        this.getProperties('urns', 'metrics', 'scores', 'changesOffset', 'changesOffsetFormatted', 'selectedUrns');
 
-      urnsClone.forEach(urn => {
+      urns.forEach(urn => {
         arr.push({
           urn,
           isSelected: selectedUrns.has(urn),
           metric: metrics[urn],
           score: scores[urn],
-          change: changesFormatted[urn]
+          change: changesOffset['baseline'][urn],
+          change1w: changesOffset['wo1w'][urn],
+          change2w: changesOffset['wo2w'][urn],
+          change3w: changesOffset['wo3w'][urn],
+          change4w: changesOffset['wo4w'][urn],
+          changeFormatted: changesOffsetFormatted['baseline'][urn],
+          change1wFormatted: changesOffsetFormatted['wo1w'][urn],
+          change2wFormatted: changesOffsetFormatted['wo2w'][urn],
+          change3wFormatted: changesOffsetFormatted['wo3w'][urn],
+          change4wFormatted: changesOffsetFormatted['wo4w'][urn]
         });
       });
       return arr;

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -105,7 +105,7 @@ export default Ember.Component.extend({
     'aggregates',
     function () {
       const { entities, aggregates } = this.getProperties('entities', 'aggregates'); // poll observer
-      return this._changesOffset('baseline');
+      return this._computeChangesForOffset('baseline');
     }
   ),
 
@@ -113,7 +113,7 @@ export default Ember.Component.extend({
     'changes',
     function () {
       const { changes } = this.getProperties('changes');
-      return this._changesFormatted(changes);
+      return this._formatChanges(changes);
     }
   ),
 
@@ -125,7 +125,7 @@ export default Ember.Component.extend({
 
       const offsets = ['wo1w', 'wo2w', 'wo3w', 'wo4w', 'baseline'];
       const dict = {}
-      offsets.forEach(offset => dict[offset] = this._changesOffset(offset));
+      offsets.forEach(offset => dict[offset] = this._computeChangesForOffset(offset));
 
       return dict;
     }
@@ -137,7 +137,7 @@ export default Ember.Component.extend({
       const { changesOffset } = this.getProperties('changesOffset');
 
       const dict = {};
-      Object.keys(changesOffset).forEach(offset => dict[offset] = this._changesFormatted(changesOffset[offset]));
+      Object.keys(changesOffset).forEach(offset => dict[offset] = this._formatChanges(changesOffset[offset]));
 
       return dict;
     }
@@ -155,7 +155,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  _changesOffset(offset) {
+  _computeChangesForOffset(offset) {
     const { entities, aggregates } = this.getProperties('entities', 'aggregates');
     return filterPrefix(Object.keys(entities), ['thirdeye:metric:'])
       .reduce((agg, urn) => {
@@ -164,7 +164,7 @@ export default Ember.Component.extend({
     }, {});
   },
 
-  _changesFormatted(changes) {
+  _formatChanges(changes) {
     return Object.keys(changes).reduce((agg, urn) => {
       const value = changes[urn];
       if (Number.isNaN(value)) {

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -38,6 +38,9 @@ export default Ember.Component.extend({
     this.setProperties({ sortProperty: ROOTCAUSE_METRICS_SORT_PROPERTY_CHANGE, sortMode: ROOTCAUSE_METRICS_SORT_MODE_ASC });
   },
 
+  /**
+   * List of metric urns, sorted by sortMode.
+   */
   urns: Ember.computed(
     'entities',
     'metrics',
@@ -76,6 +79,9 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Metric labels, keyed by urn
+   */
   metrics: Ember.computed(
     'entities',
     function () {
@@ -88,6 +94,9 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Dataset labels, keyed by metric urn
+   */
   datasets: Ember.computed(
     'entities',
     function () {
@@ -100,6 +109,9 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Change values from baseline to current time range, keyed by metric urn
+   */
   changes: Ember.computed(
     'entities',
     'aggregates',
@@ -109,6 +121,9 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Formatted change strings for 'changes'
+   */
   changesFormatted: Ember.computed(
     'changes',
     function () {
@@ -117,6 +132,9 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Change values from multiple offsets to current time range, keyed by offset, then by metric urn
+   */
   changesOffset: Ember.computed(
     'entities',
     'aggregates',
@@ -131,6 +149,9 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Formatted change strings for 'changesOffset'
+   */
   changesOffsetFormatted: Ember.computed(
     'changesOffset',
     function () {
@@ -143,6 +164,9 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Anomalyity scores, keyed by metric urn
+   */
   scores: Ember.computed(
     'entities',
     function () {
@@ -155,6 +179,12 @@ export default Ember.Component.extend({
     }
   ),
 
+  /**
+   * Compute changes from a given offset to the current time range, as a fraction.
+   *
+   * @param {String} offset time range offset, e.g. 'baseline', 'wow', 'wo2w', ...
+   * @returns {Object} change values, keyed by metric urn
+   */
   _computeChangesForOffset(offset) {
     const { entities, aggregates } = this.getProperties('entities', 'aggregates');
     return filterPrefix(Object.keys(entities), ['thirdeye:metric:'])
@@ -164,6 +194,12 @@ export default Ember.Component.extend({
     }, {});
   },
 
+  /**
+   * Format changes dict with sign and decimals and gracefully handle outliers
+   *
+   * @param {Object} changes change values, keyed by metric urn
+   * @returns {Object} formatted change strings
+   */
   _formatChanges(changes) {
     return Object.keys(changes).reduce((agg, urn) => {
       const value = changes[urn];

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
@@ -41,6 +41,7 @@
     urns=urns
     metrics=metrics
     scores=scores
-    changesFormatted=changesFormatted
+    changesOffset=changesOffset
+    changesOffsetFormatted=changesOffsetFormatted
     toggleSelection=(action "toggleSelection")}}
 {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { checkStatus, toBaselineRange, toFilters, toFilterMap } from 'thirdeye-frontend/helpers/utils';
+import { checkStatus, toAbsoluteRange, toFilters, toFilterMap } from 'thirdeye-frontend/helpers/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
@@ -51,13 +51,10 @@ export default Ember.Service.extend({
     }
 
     // metrics
-    const metricUrns = missing.filter(urn => urn.startsWith('frontend:metric:current:'));
-    metricUrns.forEach(urn => this._fetchSlice(urn, requestContext.anomalyRange, requestContext));
-
-    // baselines
-    const baselineRange = toBaselineRange(requestContext.anomalyRange, requestContext.compareMode);
-    const baselineUrns = missing.filter(urn => urn.startsWith('frontend:metric:baseline:'));
-    baselineUrns.forEach(urn => this._fetchSlice(urn, baselineRange, requestContext));
+    missing.forEach(urn => {
+      const range = toAbsoluteRange(urn, requestContext.anomalyRange, requestContext.compareMode);
+      return this._fetchSlice(urn, range, requestContext)
+    });
   },
 
   _complete(requestContext, incoming) {

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-breakdowns-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-breakdowns-cache/service.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { checkStatus, toBaselineRange, toFilters, toFilterMap } from 'thirdeye-frontend/helpers/utils';
+import { checkStatus, toAbsoluteRange, toFilters, toFilterMap } from 'thirdeye-frontend/helpers/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
@@ -51,13 +51,10 @@ export default Ember.Service.extend({
     }
 
     // metrics
-    const metricUrns = missing.filter(urn => urn.startsWith('frontend:metric:current:'));
-    metricUrns.forEach(urn => this._fetchSlice(urn, requestContext.anomalyRange, requestContext));
-
-    // baselines
-    const baselineRange = toBaselineRange(requestContext.anomalyRange, requestContext.compareMode);
-    const baselineUrns = missing.filter(urn => urn.startsWith('frontend:metric:baseline:'));
-    baselineUrns.forEach(urn => this._fetchSlice(urn, baselineRange, requestContext));
+    missing.forEach(urn => {
+      const range = toAbsoluteRange(urn, requestContext.anomalyRange, requestContext.compareMode);
+      return this._fetchSlice(urn, range, requestContext)
+    });
   },
 
   _complete(requestContext, incoming) {

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { filterObject, filterPrefix, toBaselineUrn, toCurrentUrn, toColor, checkStatus, toFilters, appendFilters } from 'thirdeye-frontend/helpers/utils';
+import { filterObject, filterPrefix, toBaselineUrn, toCurrentUrn, toOffsetUrn, toColor, checkStatus, toFilters, appendFilters } from 'thirdeye-frontend/helpers/utils';
 import EVENT_TABLE_COLUMNS from 'thirdeye-frontend/mocks/eventTableColumns';
 import config from 'thirdeye-frontend/mocks/filterBarConfig';
 import _ from 'lodash';
@@ -113,7 +113,11 @@ export default Ember.Controller.extend({
         const metricUrns = new Set(filterPrefix(Object.keys(entities), 'thirdeye:metric:'));
         const currentUrns = [...metricUrns].map(toCurrentUrn);
         const baselineUrns = [...metricUrns].map(toBaselineUrn);
-        aggregatesService.request(context, new Set(currentUrns.concat(baselineUrns)));
+
+        const offsets = ['wo1w', 'wo2w', 'wo3w', 'wo4w'];
+        const offsetUrns = [...metricUrns].map(urn => [].concat(offsets.map(offset => toOffsetUrn(urn, offset)))).reduce((agg, l) => agg.concat(l), []);
+
+        aggregatesService.request(context, new Set([...currentUrns, ...baselineUrns, ...offsetUrns]));
       }
     }
   ),

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -104,8 +104,8 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
       granularity: '1_HOURS',
       anomalyRangeStart:  moment(maxTime).subtract(3, 'hours').valueOf(),
       anomalyRangeEnd: moment(maxTime).valueOf(),
-      analysisRangeStart: moment(maxTime).endOf('day').subtract(1, 'week').valueOf(),
-      analysisRangeEnd: moment(maxTime).endOf('day').valueOf(),
+      analysisRangeStart: moment(maxTime).endOf('day').subtract(1, 'week').valueOf() + 1,
+      analysisRangeEnd: moment(maxTime).endOf('day').valueOf() + 1,
       compareMode: 'WoW'
     };
     let { queryParams } = transition;


### PR DESCRIPTION
* adds support for loading "frontend:metric:wo1w:12345" entities (and similar)

* fetches and displays basic data in metrics table for baseline, 1w, 2w, 3w, and 4w offsets

* fixes off-by-one error for display range

![metrics table](https://user-images.githubusercontent.com/25439965/34851424-cb323518-f6de-11e7-892a-50ec3f3ed9cf.png)
