### PR TITLE
Added a descriptive status on ServiceStatus to get an indication of what it is waiting for

### DIFF
--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/ServiceStatusTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/ServiceStatusTest.java
@@ -36,6 +36,10 @@ public class ServiceStatusTest {
     public ServiceStatus.Status getServiceStatus() {
       return ServiceStatus.Status.GOOD;
     }
+    @Override
+    public String getStatusDescription() {
+      return ServiceStatus.STATUS_DESCRIPTION_NONE;
+    }
   };
 
   private static final ServiceStatus.ServiceStatusCallback ALWAYS_STARTING = new ServiceStatus.ServiceStatusCallback() {
@@ -43,12 +47,20 @@ public class ServiceStatusTest {
     public ServiceStatus.Status getServiceStatus() {
       return ServiceStatus.Status.STARTING;
     }
+    @Override
+    public String getStatusDescription() {
+      return ServiceStatus.STATUS_DESCRIPTION_NONE;
+    }
   };
 
   private static final ServiceStatus.ServiceStatusCallback ALWAYS_BAD = new ServiceStatus.ServiceStatusCallback() {
     @Override
     public ServiceStatus.Status getServiceStatus() {
       return ServiceStatus.Status.BAD;
+    }
+    @Override
+    public String getStatusDescription() {
+      return ServiceStatus.STATUS_DESCRIPTION_NONE;
     }
   };
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/ControllerStarter.java
@@ -244,6 +244,7 @@ public class ControllerStarter {
 
     ServiceStatus.setServiceStatusCallback(new ServiceStatus.ServiceStatusCallback() {
       private boolean _isStarted = false;
+      private String _statusDescription = "Helix ZK Not connected";
       @Override
       public ServiceStatus.Status getServiceStatus() {
         if(_isStarted) {
@@ -260,8 +261,13 @@ public class ControllerStarter {
           return ServiceStatus.Status.STARTING;
         } else {
           _isStarted = true;
+          _statusDescription = ServiceStatus.STATUS_DESCRIPTION_NONE;
           return ServiceStatus.Status.GOOD;
         }
+      }
+      @Override
+      public String getStatusDescription() {
+        return _statusDescription;
       }
     });
 

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/MinionStarter.java
@@ -130,6 +130,12 @@ public class MinionStarter {
         minionMetrics.addMeteredGlobalValue(MinionMeter.HEALTH_CHECK_GOOD_CALLS, 1L);
         return ServiceStatus.Status.GOOD;
       }
+
+      @Override
+      public String getStatusDescription() {
+        return ServiceStatus.STATUS_DESCRIPTION_NONE;
+      }
+
     });
 
     LOGGER.info("Pinot minion started");


### PR DESCRIPTION
Often happens that a service is not finished starting up yet because of a specific table or
partition being not available yet. Since we don't log each time we return a STARTING status,
it is good to keep track of what we are waiting for and provide an interface to retrieve it.