### PR TITLE
Minimize window in which two controllers can update metadata for LLC segment commit

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -561,8 +561,9 @@ public class PinotLLCRealtimeSegmentManager {
     File fileToMoveTo = new File(tableDir, segmentName);
 
     if (!isConnected() || !isLeader()) {
-      LOGGER.warn("Lost leadership while committing segment file {}, {} for table {}", segmentName, segmentLocation,
-          tableName);
+      // We can potentially log a different value than what we saw ....
+      LOGGER.warn("Lost leadership while committing segment file {}, {} for table {}: isLeader={}, isConnected={}",
+          segmentName, segmentLocation, tableName, isLeader(), isConnected());
       return false;
     }
 
@@ -661,8 +662,9 @@ public class PinotLLCRealtimeSegmentManager {
     records.add(newZnRecord);
 
     if (!isConnected() || !isLeader()) {
-      LOGGER.warn("Lost leadership while committing segment metadata for{} for table {}", committingSegmentNameStr,
-          rawTableName);
+      // We can potentially log a different value than what we saw ....
+      LOGGER.warn("Lost leadership while committing segment metadata for{} for table {}: isLeader={}, isConnected={}",
+          committingSegmentNameStr, rawTableName, isLeader(), isConnected());
       return false;
     }
     /*

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -153,7 +153,7 @@ public class SegmentCompletionManager {
    * that it currently has (i.e. next offset that it will consume, if it continues to consume).
    */
   public SegmentCompletionProtocol.Response segmentConsumed(SegmentCompletionProtocol.Request.Params reqParams) {
-    if (!_helixManager.isLeader()) {
+    if (!_helixManager.isLeader() || !_helixManager.isConnected()) {
       return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String segmentNameStr = reqParams.getSegmentName();
@@ -189,7 +189,7 @@ public class SegmentCompletionManager {
    * incoming segment).
    */
   public SegmentCompletionProtocol.Response segmentCommitStart(final SegmentCompletionProtocol.Request.Params reqParams) {
-    if (!_helixManager.isLeader()) {
+    if (!_helixManager.isLeader() || !_helixManager.isConnected()) {
       return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String segmentNameStr = reqParams.getSegmentName();
@@ -212,7 +212,7 @@ public class SegmentCompletionManager {
   }
 
   public SegmentCompletionProtocol.Response extendBuildTime(final SegmentCompletionProtocol.Request.Params reqParams) {
-    if (!_helixManager.isLeader()) {
+    if (!_helixManager.isLeader() || !_helixManager.isConnected()) {
       return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String segmentNameStr = reqParams.getSegmentName();
@@ -242,7 +242,7 @@ public class SegmentCompletionManager {
    * @return
    */
   public SegmentCompletionProtocol.Response segmentStoppedConsuming(SegmentCompletionProtocol.Request.Params reqParams) {
-    if (!_helixManager.isLeader()) {
+    if (!_helixManager.isLeader() || !_helixManager.isConnected()) {
       return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String segmentNameStr = reqParams.getSegmentName();
@@ -277,7 +277,7 @@ public class SegmentCompletionManager {
    */
   public SegmentCompletionProtocol.Response segmentCommitEnd(SegmentCompletionProtocol.Request.Params reqParams, boolean success, boolean isSplitCommit) {
     String segmentLocation = reqParams.getSegmentLocation();
-    if (!_helixManager.isLeader()) {
+    if (!_helixManager.isLeader() || !_helixManager.isConnected()) {
       return SegmentCompletionProtocol.RESP_NOT_LEADER;
     }
     final String segmentNameStr = reqParams.getSegmentName();


### PR DESCRIPTION
It is possible that the leader controller undergoes heavy GC after accepging the
segment commit request from a server. In this case, the leader could lose zk connection
for a while and wait to regain connection in order to test leadership.  During this time
another controller could gain leadership and commit the metadata, with a slightly different
kafka offset, and create a new segment. Meanwhile, the former leader, without knowing that it
has lost leadership, could go ahead and commit another new realtime segment, which could
have a different name than the segment committed by the new leader!

We minimize the window of this happening by checking one more time right before we commit
metadata.

Also, we check for leadership as well as zk connectivity instead of just leadership check.

Added unit tests