### PR TITLE
Add support for long queries for Pinot query console

### DIFF
--- a/pinot-controller/src/main/resources/static/js/init.js
+++ b/pinot-controller/src/main/resources/static/js/init.js
@@ -172,10 +172,15 @@ var HELPERS = {
   },
 
   executeQuery: function(query, traceEnabled, callback) {
-    var url = "/pql?pql=" + encodeURIComponent(query) +"&trace=" + traceEnabled;
+    var url = "/pql";
+    var params = JSON.stringify({
+      "pql": query,
+      "trace": traceEnabled
+    });
     $.ajax({
-      type: 'GET',
+      type: 'POST',
       url: url,
+      data: params,
       contentType: 'application/json; charset=utf-8',
       success: function (text) {
         callback(text);

--- a/pinot-controller/src/main/resources/webapp/js/init.js
+++ b/pinot-controller/src/main/resources/webapp/js/init.js
@@ -105,10 +105,15 @@ var HELPERS = {
   },
 
   executeQuery: function(query, traceEnabled, callback) {
-    var url = "/pql?pql=" + encodeURIComponent(query) +"&trace=" + traceEnabled;
+    var url = "/pql";
+    var params = JSON.stringify({
+      "pql": query,
+      "trace": traceEnabled
+    });
     $.ajax({
-      type: 'GET',
+      type: 'POST',
       url: url,
+      data: params,
       contentType: 'application/json; charset=utf-8',
       success: function (text) {
         callback(text);


### PR DESCRIPTION
Currently, Pinot query console can only process the query
that is shorter than the maximum length of a GET request.
Changed the query console to use PUT request to remove the
limitation for the query length.