### PR TITLE
Let RetryPolicy throw exception when number of attempts exhausted

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpSegmentFetcher.java
@@ -19,7 +19,6 @@ import com.linkedin.pinot.common.exception.HttpErrorStatusException;
 import com.linkedin.pinot.common.exception.PermanentDownloadException;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
-import com.linkedin.pinot.common.utils.retry.RetryPolicy;
 import java.io.File;
 import java.net.URI;
 import java.util.concurrent.Callable;
@@ -50,26 +49,27 @@ public class HttpSegmentFetcher implements SegmentFetcher {
 
   @Override
   public void fetchSegmentToLocal(final String uri, final File tempFile) throws Exception {
-    RetryPolicy policy = RetryPolicies.exponentialBackoffRetryPolicy(_retryCount, _retryWaitMs, 5);
-    policy.attempt(new Callable<Boolean>() {
+    RetryPolicies.exponentialBackoffRetryPolicy(_retryCount, _retryWaitMs, 5).attempt(new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
         try {
           int statusCode = _httpClient.downloadFile(new URI(uri), tempFile);
-          _logger.info("Downloaded file from {} to {}; Length of downloaded file: {}; Response status code: {}", uri,
+          _logger.info("Downloaded file from: {} to: {}; Length of downloaded file: {}; Response status code: {}", uri,
               tempFile, tempFile.length(), statusCode);
           return true;
         } catch (HttpErrorStatusException e) {
           int statusCode = e.getStatusCode();
           if (statusCode >= 500) {
-            _logger.error("Failed to download file from {}, might retry", uri, e);
+            // Temporary exception
+            _logger.warn("Caught temporary exception while downloading file from: {}, will retry", uri, e);
             return false;
           } else {
-            _logger.error("Failed to download file from {}, won't retry", uri, e);
+            // Permanent exception
+            _logger.error("Caught permanent exception while downloading file from: {}, won't retry", uri, e);
             throw new PermanentDownloadException(e.getMessage());
           }
         } catch (Exception e) {
-          _logger.error("Failed to download file from {}, might retry", uri, e);
+          _logger.warn("Caught temporary exception while downloading file from: {}, will retry", uri, e);
           return false;
         }
       }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -70,67 +70,67 @@ public class HelixHelper {
    */
   public static void updateIdealState(final HelixManager helixManager, final String resourceName,
       final Function<IdealState, IdealState> updater, RetryPolicy policy) {
-    boolean successful = policy.attempt(new Callable<Boolean>() {
-      @Override
-      public Boolean call() {
-        HelixDataAccessor dataAccessor = helixManager.getHelixDataAccessor();
-        PropertyKey propertyKey = dataAccessor.keyBuilder().idealStates(resourceName);
+    try {
+      policy.attempt(new Callable<Boolean>() {
+        @Override
+        public Boolean call() {
+          HelixDataAccessor dataAccessor = helixManager.getHelixDataAccessor();
+          PropertyKey propertyKey = dataAccessor.keyBuilder().idealStates(resourceName);
 
-        // Create an updated version of the ideal state
-        IdealState idealState = dataAccessor.getProperty(propertyKey);
-        PropertyKey key = dataAccessor.keyBuilder().idealStates(resourceName);
-        String path = key.getPath();
-        // Make a copy of the the idealState above to pass it to the updater, instead of querying again,
-        // as the state my change between the queries.
-        ZNRecordSerializer znRecordSerializer = new ZNRecordSerializer();
-        IdealState idealStateCopy = new IdealState(
-            (ZNRecord) znRecordSerializer.deserialize(znRecordSerializer.serialize(idealState.getRecord())));
-        IdealState updatedIdealState;
-
-        try {
-          updatedIdealState = updater.apply(idealStateCopy);
-        } catch (Exception e) {
-          LOGGER.error("Caught exception while updating ideal state", e);
-          return false;
-        }
-
-        // If there are changes to apply, apply them
-        if (!EqualityUtils.isEqual(idealState, updatedIdealState) && updatedIdealState != null) {
-          BaseDataAccessor<ZNRecord> baseDataAccessor = dataAccessor.getBaseDataAccessor();
-          boolean success;
-
-          // If the ideal state is large enough, enable compression
-          if (MAX_PARTITION_COUNT_IN_UNCOMPRESSED_IDEAL_STATE < updatedIdealState.getPartitionSet().size()) {
-            updatedIdealState.getRecord().setBooleanField("enableCompression", true);
-          }
+          // Create an updated version of the ideal state
+          IdealState idealState = dataAccessor.getProperty(propertyKey);
+          PropertyKey key = dataAccessor.keyBuilder().idealStates(resourceName);
+          String path = key.getPath();
+          // Make a copy of the the idealState above to pass it to the updater, instead of querying again,
+          // as the state my change between the queries.
+          ZNRecordSerializer znRecordSerializer = new ZNRecordSerializer();
+          IdealState idealStateCopy = new IdealState(
+              (ZNRecord) znRecordSerializer.deserialize(znRecordSerializer.serialize(idealState.getRecord())));
+          IdealState updatedIdealState;
 
           try {
-            success =
-                baseDataAccessor.set(path, updatedIdealState.getRecord(), idealState.getRecord().getVersion(),
-                    AccessOption.PERSISTENT);
+            updatedIdealState = updater.apply(idealStateCopy);
           } catch (Exception e) {
-            boolean idealStateIsCompressed = updatedIdealState.getRecord().getBooleanField("enableCompression", false);
-
-            LOGGER.warn("Caught exception while updating ideal state for resource {} (compressed={}), retrying.",
-                resourceName, idealStateIsCompressed, e);
+            LOGGER.error("Caught exception while updating ideal state", e);
             return false;
           }
 
-          if (success) {
-            return true;
+          // If there are changes to apply, apply them
+          if (!EqualityUtils.isEqual(idealState, updatedIdealState) && updatedIdealState != null) {
+            BaseDataAccessor<ZNRecord> baseDataAccessor = dataAccessor.getBaseDataAccessor();
+            boolean success;
+
+            // If the ideal state is large enough, enable compression
+            if (MAX_PARTITION_COUNT_IN_UNCOMPRESSED_IDEAL_STATE < updatedIdealState.getPartitionSet().size()) {
+              updatedIdealState.getRecord().setBooleanField("enableCompression", true);
+            }
+
+            try {
+              success =
+                  baseDataAccessor.set(path, updatedIdealState.getRecord(), idealState.getRecord().getVersion(),
+                      AccessOption.PERSISTENT);
+            } catch (Exception e) {
+              boolean idealStateIsCompressed = updatedIdealState.getRecord().getBooleanField("enableCompression", false);
+
+              LOGGER.warn("Caught exception while updating ideal state for resource {} (compressed={}), retrying.",
+                  resourceName, idealStateIsCompressed, e);
+              return false;
+            }
+
+            if (success) {
+              return true;
+            } else {
+              LOGGER.warn("Failed to update ideal state for resource {}, retrying.", resourceName);
+              return false;
+            }
           } else {
-            LOGGER.warn("Failed to update ideal state for resource {}, retrying.", resourceName);
-            return false;
+            LOGGER.warn("Idempotent or null ideal state update for resource {}, skipping update.", resourceName);
+            return true;
           }
-        } else {
-          LOGGER.warn("Idempotent or null ideal state update for resource {}, skipping update.", resourceName);
-          return true;
         }
-      }
-    });
-
-    if (!successful) {
-      throw new RuntimeException("Failed to update ideal state for resource " + resourceName);
+      });
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception while updating ideal state for resource: " + resourceName, e);
     }
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/AttemptsExceededException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/AttemptsExceededException.java
@@ -16,16 +16,12 @@
 package com.linkedin.pinot.common.utils.retry;
 
 /**
- * Retry policy without delay between attempts.
+ * The <code>AttemptsExceededException</code> indicates that the operation does not succeed within maximum number of
+ * attempts.
  */
-public class NoDelayRetryPolicy extends BaseRetryPolicy {
+public class AttemptsExceededException extends Exception {
 
-  public NoDelayRetryPolicy(int maxNumAttempts) {
-    super(maxNumAttempts);
-  }
-
-  @Override
-  protected long getNextDelayMs() {
-    return 0L;
+  public AttemptsExceededException(String message) {
+    super(message);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/BaseRetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/BaseRetryPolicy.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils.retry;
+
+import java.util.concurrent.Callable;
+
+
+public abstract class BaseRetryPolicy implements RetryPolicy {
+  private final int _maxNumAttempts;
+
+  protected BaseRetryPolicy(int maxNumAttempts) {
+    _maxNumAttempts = maxNumAttempts;
+  }
+
+  /**
+   * Get the delay in milliseconds before the next attempt.
+   *
+   * @return Delay in milliseconds
+   */
+  protected abstract long getNextDelayMs();
+
+  @Override
+  public void attempt(Callable<Boolean> operation) throws Exception {
+    int numAttempts = 0;
+    while (numAttempts < _maxNumAttempts) {
+      if (operation.call()) {
+        // Succeeded
+        return;
+      } else {
+        // Failed
+        numAttempts++;
+        Thread.sleep(getNextDelayMs());
+      }
+    }
+    throw new AttemptsExceededException("Operation failed after " + _maxNumAttempts + " attempts");
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/ExponentialBackoffRetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/ExponentialBackoffRetryPolicy.java
@@ -15,55 +15,30 @@
  */
 package com.linkedin.pinot.common.utils.retry;
 
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.linkedin.pinot.common.Utils;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 
 
 /**
- * Exponential backoff retry policy, see {@link RetryPolicies#exponentialBackoffRetryPolicy(int, long, float)}.
- *
- * @author jfim
+ * Retry policy with exponential backoff delay between attempts.
+ * <p>The delay between the i<sup>th</sup> and (i + 1)<sup>th</sup> attempts is between delayScaleFactor<sup>i - 1</sup>
+ * * initialDelayMs and delayScaleFactor<sup>i</sup> * initialDelayMs.
  */
-public class ExponentialBackoffRetryPolicy implements RetryPolicy {
-  private final int _maximumAttemptCount;
-  private final long _minimumMilliseconds;
-  private final float _retryScaleFactor;
+public class ExponentialBackoffRetryPolicy extends BaseRetryPolicy {
+  private final ThreadLocalRandom _random = ThreadLocalRandom.current();
+  private final double _delayScaleFactor;
+  private long _minDelayMs;
 
-  public ExponentialBackoffRetryPolicy(int maximumAttemptCount, long minimumMilliseconds, float retryScaleFactor) {
-    _maximumAttemptCount = maximumAttemptCount;
-    _minimumMilliseconds = minimumMilliseconds;
-    _retryScaleFactor = retryScaleFactor;
+  public ExponentialBackoffRetryPolicy(int maxNumAttempts, long initialDelayMs, double delayScaleFactor) {
+    super(maxNumAttempts);
+    _delayScaleFactor = delayScaleFactor;
+    _minDelayMs = initialDelayMs;
   }
 
   @Override
-  public boolean attempt(Callable<Boolean> operation) {
-    try {
-      ThreadLocalRandom random = ThreadLocalRandom.current();
-      int remainingAttempts = _maximumAttemptCount - 1;
-      long minimumSleepTime = _minimumMilliseconds;
-      long maximumSleepTime = (long) (minimumSleepTime * _retryScaleFactor);
-
-      boolean result = operation.call();
-
-      while ((!result) && (0 < remainingAttempts)) {
-        long sleepTime = random.nextLong(minimumSleepTime, maximumSleepTime);
-
-        Uninterruptibles.sleepUninterruptibly(sleepTime, TimeUnit.MILLISECONDS);
-
-        result = operation.call();
-
-        remainingAttempts--;
-        minimumSleepTime *= _retryScaleFactor;
-        maximumSleepTime *= _retryScaleFactor;
-      }
-
-      return result;
-    } catch (Exception e) {
-      Utils.rethrowException(e);
-      return false;
-    }
+  protected long getNextDelayMs() {
+    long maxDelayMs = (long) (_minDelayMs * _delayScaleFactor);
+    long nextDelayMs = _random.nextLong(_minDelayMs, maxDelayMs);
+    _minDelayMs = maxDelayMs;
+    return nextDelayMs;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/FixedDelayRetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/FixedDelayRetryPolicy.java
@@ -15,41 +15,19 @@
  */
 package com.linkedin.pinot.common.utils.retry;
 
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.linkedin.pinot.common.Utils;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
-
-
 /**
- * Fixed delay retry policy, see {@link RetryPolicies#fixedDelayRetryPolicy(int, long)}.
+ * Delay policy with fixed delay between attempts.
  */
-public class FixedDelayRetryPolicy implements RetryPolicy {
-  public FixedDelayRetryPolicy(int attemptCount, long sleepTimeMillis) {
-    _attemptCount = attemptCount;
-    _sleepTimeMillis = sleepTimeMillis;
+public class FixedDelayRetryPolicy extends BaseRetryPolicy {
+  private final long _delayMs;
+
+  public FixedDelayRetryPolicy(int maxNumAttempts, long delayMs) {
+    super(maxNumAttempts);
+    _delayMs = delayMs;
   }
 
-  private int _attemptCount;
-  private long _sleepTimeMillis;
-
   @Override
-  public boolean attempt(Callable<Boolean> operation) {
-    try {
-      int remainingAttempts = _attemptCount - 1;
-      boolean result = operation.call();
-
-      while (!result && 0 < remainingAttempts) {
-        Uninterruptibles.sleepUninterruptibly(_sleepTimeMillis, TimeUnit.MILLISECONDS);
-
-        result = operation.call();
-        remainingAttempts--;
-      }
-
-      return result;
-    } catch (Exception e) {
-      Utils.rethrowException(e);
-      return false;
-    }
+  protected long getNextDelayMs() {
+    return _delayMs;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicies.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicies.java
@@ -23,45 +23,36 @@ public class RetryPolicies {
   }
 
   /**
-   * Returns an exponential backoff retry policy. The time between attempts for the <em>i</em><sup>th</sup> retry is
-   * between retryScaleFactor<sup>i - 1</sup> * minimumDelayMillis and retryScaleFactor<sup>i</sup> * minimumDelayMillis.
+   * Creates an {@link ExponentialBackoffRetryPolicy}.
    *
-   * @param maximumAttemptCount The maximum number of attempts to try
-   * @param minimumDelayMillis The minimum of milliseconds between tries
-   * @param retryScaleFactor The factor used for exponential scaling.
+   * @param maxNumAttempts The maximum number of attempts to try
+   * @param initialDelayMs The initial delay in milliseconds between attempts
+   * @param delayScaleFactor The factor used for exponential scaling of delay
    * @return The retry policy
    */
-  public static ExponentialBackoffRetryPolicy exponentialBackoffRetryPolicy(
-      int maximumAttemptCount,
-      long minimumDelayMillis,
-      float retryScaleFactor
-  ) {
-    return new ExponentialBackoffRetryPolicy(maximumAttemptCount, minimumDelayMillis, retryScaleFactor);
+  public static ExponentialBackoffRetryPolicy exponentialBackoffRetryPolicy(int maxNumAttempts, long initialDelayMs,
+      double delayScaleFactor) {
+    return new ExponentialBackoffRetryPolicy(maxNumAttempts, initialDelayMs, delayScaleFactor);
   }
 
   /**
-   * Returns a fixed delay retry policy, where the time between attempts is the same between each attempt.
+   * Creates a {@link FixedDelayRetryPolicy}.
    *
-   * @param maximumAttemptCount The maximum number of attempts to try
-   * @param delayMillis The time to wait between tries, in milliseconds
+   * @param maxNumAttempts The maximum number of attempts to try
+   * @param delayMs The delay in milliseconds between attempts
    * @return The retry policy
    */
-  public static FixedDelayRetryPolicy fixedDelayRetryPolicy(
-      int maximumAttemptCount,
-      long delayMillis
-  ) {
-    return new FixedDelayRetryPolicy(maximumAttemptCount, delayMillis);
+  public static FixedDelayRetryPolicy fixedDelayRetryPolicy(int maxNumAttempts, long delayMs) {
+    return new FixedDelayRetryPolicy(maxNumAttempts, delayMs);
   }
 
   /**
-   * Returns a no delay retry policy, where operations are retried without waiting.
+   * Creates a {@link NoDelayRetryPolicy}.
    *
-   * @param maximumAttemptCount The maximum number of attempts to try
+   * @param maxNumAttempts The maximum number of attempts to try
    * @return The retry policy
    */
-  public static NoDelayRetryPolicy noDelayRetryPolicy(
-      int maximumAttemptCount
-  ) {
-    return new NoDelayRetryPolicy(maximumAttemptCount);
+  public static NoDelayRetryPolicy noDelayRetryPolicy(int maxNumAttempts) {
+    return new NoDelayRetryPolicy(maxNumAttempts);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicy.java
@@ -22,12 +22,13 @@ import java.util.concurrent.Callable;
  * Retry policy, encapsulating the logic needed to retry an operation until it succeeds.
  */
 public interface RetryPolicy {
+
   /**
-   * Attempts to do the operation until it succeeds, aborting if an exception is thrown by the operation.
+   * Attempts to do the operation until it succeeds, aborting if an exception is thrown by the operation or number of
+   * attempts exhausted.
    *
    * @param operation The operation to attempt, which returns true on success and false on failure.
-   * @return true if the operation succeeded or false if the operation did not succeed within the retries specified by
-   * this retry policy
+   * @throws Exception
    */
-  boolean attempt(Callable<Boolean> operation);
+  void attempt(Callable<Boolean> operation) throws Exception;
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2078,27 +2078,29 @@ public class PinotHelixResourceManager {
    */
   public PinotResourceManagerResponse dropInstance(final String instanceName) {
     // Delete '/INSTANCES/<server_name>'
-    final String instancePath = "/" + _helixClusterName + "/INSTANCES/" + instanceName;
-    boolean successfulInstanceRemove = DEFAULT_RETRY_POLICY.attempt(new Callable<Boolean>() {
-      @Override
-      public Boolean call()
-          throws Exception {
-        return _helixDataAccessor.getBaseDataAccessor().remove(instancePath, AccessOption.PERSISTENT);
-      }
-    });
-    if (!successfulInstanceRemove) {
+    try {
+      final String instancePath = "/" + _helixClusterName + "/INSTANCES/" + instanceName;
+      DEFAULT_RETRY_POLICY.attempt(new Callable<Boolean>() {
+        @Override
+        public Boolean call()
+            throws Exception {
+          return _helixDataAccessor.getBaseDataAccessor().remove(instancePath, AccessOption.PERSISTENT);
+        }
+      });
+    } catch (Exception e) {
       return new PinotResourceManagerResponse("Failed to erase /INSTANCES/" + instanceName, false);
     }
 
     // Delete '/CONFIGS/PARTICIPANT/<server_name>'
-    boolean successfulConfigRemove = DEFAULT_RETRY_POLICY.attempt(new Callable<Boolean>() {
-      @Override
-      public Boolean call() throws Exception {
-        PropertyKey instanceKey = _keyBuilder.instanceConfig(instanceName);
-        return _helixDataAccessor.removeProperty(instanceKey);
-      }
-    });
-    if (!successfulConfigRemove) {
+    try {
+      DEFAULT_RETRY_POLICY.attempt(new Callable<Boolean>() {
+        @Override
+        public Boolean call() throws Exception {
+          PropertyKey instanceKey = _keyBuilder.instanceConfig(instanceName);
+          return _helixDataAccessor.removeProperty(instanceKey);
+        }
+      });
+    } catch (Exception e) {
       return new PinotResourceManagerResponse("Failed to erase /CONFIGS/PARTICIPANT/" + instanceName
           + " Make sure to erase /CONFIGS/PARTICIPANT/" + instanceName  + " manually since /INSTANCES/" + instanceName
           + " has already been removed.", false);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/kafka/KafkaAvroMessageDecoder.java
@@ -213,16 +213,9 @@ public class KafkaAvroMessageDecoder implements KafkaMessageDecoder<byte[]> {
 
   private org.apache.avro.Schema fetchSchema(String reference) throws Exception {
     SchemaFetcher schemaFetcher = new SchemaFetcher(makeRandomUrl(reference));
-
-    boolean successful = RetryPolicies.exponentialBackoffRetryPolicy(MAXIMUM_SCHEMA_FETCH_RETRY_COUNT,
+    RetryPolicies.exponentialBackoffRetryPolicy(MAXIMUM_SCHEMA_FETCH_RETRY_COUNT,
         MINIMUM_SCHEMA_FETCH_RETRY_TIME_MILLIS, SCHEMA_FETCH_RETRY_EXPONENTIAL_BACKOFF_FACTOR).attempt(schemaFetcher);
-
-    if (successful) {
-      return schemaFetcher.getSchema();
-    } else {
-      throw new RuntimeException(
-          "Failed to fetch schema from " + reference + " after " + MAXIMUM_SCHEMA_FETCH_RETRY_COUNT + "retries");
-    }
+    return schemaFetcher.getSchema();
   }
 
   /**

--- a/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseSegmentConversionExecutor.java
+++ b/pinot-minion/src/main/java/com/linkedin/pinot/minion/executor/BaseSegmentConversionExecutor.java
@@ -148,7 +148,7 @@ public abstract class BaseSegmentConversionExecutor extends BaseTaskExecutor {
           RetryPolicies.exponentialBackoffRetryPolicy(maxNumAttempts, initialRetryDelayMs, retryScaleFactor);
 
       try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
-        if (!retryPolicy.attempt(new Callable<Boolean>() {
+        retryPolicy.attempt(new Callable<Boolean>() {
           @Override
           public Boolean call() throws Exception {
             try {
@@ -171,9 +171,7 @@ public abstract class BaseSegmentConversionExecutor extends BaseTaskExecutor {
               return false;
             }
           }
-        })) {
-          throw new RuntimeException("Failed to upload segment: " + segmentName);
-        }
+        });
       }
 
       LOGGER.info("Done executing {} on table: {}, segment: {}", taskType, tableName, segmentName);


### PR DESCRIPTION
Remove the return value from attempt() so it either succeeds or throws exception
Add AttemptsExceededException to indicates number of attempts exhausted

The reason for this change is to prevent using RetryPolicy without checking the return value which might cause silent failure.