### PR TITLE
Fix the flakiness in ConvertToRawIndexMinionClusterIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/ConvertToRawIndexMinionClusterIntegrationTest.java
@@ -115,50 +115,53 @@ public class ConvertToRawIndexMinionClusterIntegrationTest extends HybridCluster
     TestUtils.waitForCondition(new Function<Void, Boolean>() {
       @Override
       public Boolean apply(@Nullable Void aVoid) {
-        try {
-          // Check task state
-          for (TaskState taskState : _helixTaskResourceManager.getTaskStates(
-              MinionConstants.ConvertToRawIndexTask.TASK_TYPE).values()) {
-            if (taskState != TaskState.COMPLETED) {
-              return false;
-            }
+        // Check task state
+        for (TaskState taskState : _helixTaskResourceManager.getTaskStates(
+            MinionConstants.ConvertToRawIndexTask.TASK_TYPE).values()) {
+          if (taskState != TaskState.COMPLETED) {
+            return false;
+          }
+        }
+
+        // Check segment ZK metadata
+        for (OfflineSegmentZKMetadata offlineSegmentZKMetadata : _helixResourceManager.getOfflineSegmentMetadata(
+            offlineTableName)) {
+          Map<String, String> customMap = offlineSegmentZKMetadata.getCustomMap();
+          if (customMap == null || customMap.size() != 1 || !customMap.containsKey(
+              MinionConstants.ConvertToRawIndexTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX)) {
+            return false;
+          }
+        }
+
+        // Check segment metadata
+        File[] indexDirs = tableDataDir.listFiles();
+        Assert.assertNotNull(indexDirs);
+        for (File indexDir : indexDirs) {
+          SegmentMetadata segmentMetadata;
+
+          // Segment metadata file might not exist if the segment is refreshing
+          try {
+            segmentMetadata = new SegmentMetadataImpl(indexDir);
+          } catch (Exception e) {
+            return false;
           }
 
-          // Check segment ZK metadata
-          for (OfflineSegmentZKMetadata offlineSegmentZKMetadata : _helixResourceManager.getOfflineSegmentMetadata(
-              offlineTableName)) {
-            Map<String, String> customMap = offlineSegmentZKMetadata.getCustomMap();
-            if (customMap == null || customMap.size() != 1 || !customMap.containsKey(
-                MinionConstants.ConvertToRawIndexTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX)) {
-              return false;
-            }
-          }
-
-          // Check segment metadata
-          File[] indexDirs = tableDataDir.listFiles();
-          Assert.assertNotNull(indexDirs);
-          for (File indexDir : indexDirs) {
-            SegmentMetadata segmentMetadata = new SegmentMetadataImpl(indexDir);
-
-            // The columns in COLUMNS_TO_CONVERT should have raw index
-            List<String> rawIndexColumns = Arrays.asList(StringUtils.split(COLUMNS_TO_CONVERT, ','));
-            for (String columnName : segmentMetadata.getSchema().getColumnNames()) {
-              if (rawIndexColumns.contains(columnName)) {
-                if (segmentMetadata.hasDictionary(columnName)) {
-                  return false;
-                }
-              } else {
-                if (!segmentMetadata.hasDictionary(columnName)) {
-                  return false;
-                }
+          // The columns in COLUMNS_TO_CONVERT should have raw index
+          List<String> rawIndexColumns = Arrays.asList(StringUtils.split(COLUMNS_TO_CONVERT, ','));
+          for (String columnName : segmentMetadata.getSchema().getColumnNames()) {
+            if (rawIndexColumns.contains(columnName)) {
+              if (segmentMetadata.hasDictionary(columnName)) {
+                return false;
+              }
+            } else {
+              if (!segmentMetadata.hasDictionary(columnName)) {
+                return false;
               }
             }
           }
-
-          return true;
-        } catch (Exception e) {
-          throw new RuntimeException(e);
         }
+
+        return true;
       }
     }, 600_000L, "Failed to get all tasks COMPLETED and new segments refreshed");
   }


### PR DESCRIPTION
While refreshing the segment, segment metadata file might not exist, which might cause test failure.