### PR TITLE
[TE] Add graceful error handling for pinot data source

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
@@ -31,7 +31,7 @@ import com.linkedin.thirdeye.dashboard.Utils;
  */
 public class PinotDataSourceDimensionFilters {
   private static final Logger LOG = LoggerFactory.getLogger(PinotDataSourceDimensionFilters.class);
-  private static final ExecutorService executorService = Executors.newFixedThreadPool(40);
+  private static final ExecutorService executorService = Executors.newCachedThreadPool();
   private static final int TIME_OUT_SIZE = 60;
   private static final TimeUnit TIME_OUT_UNIT = TimeUnit.SECONDS;
   private final PinotThirdEyeDataSource pinotThirdEyeDataSource;
@@ -90,6 +90,7 @@ public class PinotDataSourceDimensionFilters {
         LOG.error("Execution error when getting filter for Dataset '{}' in Dimension '{}'.", dataset, dimension, e);
       } catch (InterruptedException e) {
         LOG.warn("Execution is interrupted when getting filter for Dataset '{}' in Dimension '{}'.", dataset, dimension, e);
+        break;
       } catch (TimeoutException e) {
         LOG.warn("Time out when getting filter for Dataset '{}' in Dimension '{}'. Time limit: {} {}", dataset, dimension,
             TIME_OUT_SIZE, TIME_OUT_UNIT);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
@@ -14,9 +14,12 @@ import java.util.List;
 import java.util.Map;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +31,9 @@ import com.linkedin.thirdeye.dashboard.Utils;
  */
 public class PinotDataSourceDimensionFilters {
   private static final Logger LOG = LoggerFactory.getLogger(PinotDataSourceDimensionFilters.class);
-  private static final ExecutorService executorService = Executors.newFixedThreadPool(10);
+  private static final ExecutorService executorService = Executors.newFixedThreadPool(40);
+  private static final int TIME_OUT_SIZE = 60;
+  private static final TimeUnit TIME_OUT_UNIT = TimeUnit.SECONDS;
   private final PinotThirdEyeDataSource pinotThirdEyeDataSource;
 
   public PinotDataSourceDimensionFilters(PinotThirdEyeDataSource pinotThirdEyeDataSource) {
@@ -56,8 +61,7 @@ public class PinotDataSourceDimensionFilters {
     return filters;
   }
 
-  private Map<String, List<String>> getFilters(String dataset, List<String> dimensions, DateTime start, DateTime end)
-      throws Exception {
+  private Map<String, List<String>> getFilters(String dataset, List<String> dimensions, DateTime start, DateTime end) {
     DatasetConfigDTO datasetConfig = ThirdEyeUtils.getDatasetConfigFromName(dataset);
     MetricFunction metricFunction =
         new MetricFunction(MetricAggFunction.COUNT, "*", null, dataset, null, datasetConfig);
@@ -79,17 +83,31 @@ public class PinotDataSourceDimensionFilters {
     for (Map.Entry<ThirdEyeRequest, Future<ThirdEyeResponse>> entry : responseFuturesMap.entrySet()) {
       ThirdEyeRequest request = entry.getKey();
       String dimension = request.getGroupBy().get(0);
-      ThirdEyeResponse thirdEyeResponse = entry.getValue().get();
-      int n = thirdEyeResponse.getNumRowsFor(metricFunction);
-
-      List<String> values = new ArrayList<>();
-      for (int i = 0; i < n; i++) {
-        Map<String, String> row = thirdEyeResponse.getRow(metricFunction, i);
-        String dimensionValue = row.get(dimension);
-        values.add(dimensionValue);
+      ThirdEyeResponse thirdEyeResponse = null;
+      try {
+        thirdEyeResponse = entry.getValue().get(TIME_OUT_SIZE, TIME_OUT_UNIT);
+      } catch (ExecutionException e) {
+        LOG.error("Execution error when getting filter for Dataset '{}' in Dimension '{}'.", dataset, dimension, e);
+      } catch (InterruptedException e) {
+        LOG.warn("Execution is interrupted when getting filter for Dataset '{}' in Dimension '{}'.", dataset, dimension, e);
+      } catch (TimeoutException e) {
+        LOG.warn("Time out when getting filter for Dataset '{}' in Dimension '{}'. Time limit: {} {}", dataset, dimension,
+            TIME_OUT_SIZE, TIME_OUT_UNIT);
       }
-      Collections.sort(values);
-      result.put(dimension, values);
+      if (thirdEyeResponse != null) {
+        int n = thirdEyeResponse.getNumRowsFor(metricFunction);
+
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+          Map<String, String> row = thirdEyeResponse.getRow(metricFunction, i);
+          String dimensionValue = row.get(dimension);
+          values.add(dimensionValue);
+        }
+        Collections.sort(values);
+        result.put(dimension, values);
+      } else {
+        result.put(dimension, Collections.<String>emptyList());
+      }
     }
     return result;
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceMaxTime.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceMaxTime.java
@@ -52,7 +52,7 @@ public class PinotDataSourceMaxTime {
       pinotThirdEyeDataSource.refreshPQL(maxTimePinotQuery);
       ThirdEyeResultSetGroup resultSetGroup = pinotThirdEyeDataSource.executePQL(maxTimePinotQuery);
       if (resultSetGroup.size() == 0 || resultSetGroup.get(0).getRowCount() == 0) {
-        LOGGER.warn("resultSetGroup is Empty for collection {} is {}", tableName, resultSetGroup);
+        LOGGER.error("Failed to get latest max time for dataset {} with PQL: {}", tableName, maxTimePinotQuery.getPql());
         this.collectionToPrevMaxDataTimeMap.remove(dataset);
       } else {
         long endTime = new Double(resultSetGroup.get(0).getDouble(0)).longValue();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -246,7 +246,12 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     Preconditions
         .checkNotNull(this.pinotResponseCache, "{} doesn't connect to Pinot or cache is not initialized.", getName());
 
-    return this.pinotResponseCache.get(pinotQuery);
+    try {
+      return this.pinotResponseCache.get(pinotQuery);
+    } catch (ExecutionException e) {
+      LOG.error("Failed to execute PQL: {}", pinotQuery.getPql());
+      throw e;
+    }
   }
 
   /**
@@ -261,9 +266,13 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     Preconditions
         .checkNotNull(this.pinotResponseCache, "{} doesn't connect to Pinot or cache is not initialized.", getName());
 
-    pinotResponseCache.refresh(pinotQuery);
-
-    return pinotResponseCache.get(pinotQuery);
+    try {
+      pinotResponseCache.refresh(pinotQuery);
+      return pinotResponseCache.get(pinotQuery);
+    } catch (ExecutionException e) {
+      LOG.error("Failed to refresh PQL: {}", pinotQuery.getPql());
+      throw e;
+    }
   }
 
   private List<String[]> parseResultSets(ThirdEyeRequest request,


### PR DESCRIPTION
Previously, the method that fetches filter values drops the entire results if it encounters any errors when fetching the filter values for any one of the dimensions of the dataset.

This fix allows the method to return partial results and hence the frontend could still show time series without being blocked.