### PR TITLE
Fixed the flaky test for StringPredicateEvaluator

### DIFF
--- a/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
@@ -225,7 +225,7 @@ public class NoDictionaryInPredicateEvaluatorTest {
     Set<String> valueSet = new HashSet<>();
 
     for (int i = 0; i < 100; i++) {
-      stringValues[i] = RandomStringUtils.random(MAX_STRING_LENGTH);
+      stringValues[i] = RandomStringUtils.random(MAX_STRING_LENGTH).replace("\t", "");
       valueSet.add(stringValues[i]);
     }
 


### PR DESCRIPTION
Because we join and split with double tab delimiter, the integration test
becomes flaky when the random string generator generates a tab in the beginning
or the end of the string or generates two tabs in a row.