### PR TITLE
Added on-heap dictionary support for int/long/float/double data-types.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/column/ColumnIndexContainer.java
@@ -32,6 +32,10 @@ import com.linkedin.pinot.core.segment.index.readers.ImmutableDictionaryReader;
 import com.linkedin.pinot.core.segment.index.readers.IntDictionary;
 import com.linkedin.pinot.core.segment.index.readers.InvertedIndexReader;
 import com.linkedin.pinot.core.segment.index.readers.LongDictionary;
+import com.linkedin.pinot.core.segment.index.readers.OnHeapDoubleDictionary;
+import com.linkedin.pinot.core.segment.index.readers.OnHeapFloatDictionary;
+import com.linkedin.pinot.core.segment.index.readers.OnHeapIntDictionary;
+import com.linkedin.pinot.core.segment.index.readers.OnHeapLongDictionary;
 import com.linkedin.pinot.core.segment.index.readers.OnHeapStringDictionary;
 import com.linkedin.pinot.core.segment.index.readers.StringDictionary;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
@@ -114,24 +118,27 @@ public final class ColumnIndexContainer {
     FieldSpec.DataType dataType = metadata.getDataType();
     if (loadOnHeap) {
       String columnName = metadata.getColumnName();
-      if ((dataType != FieldSpec.DataType.STRING)) {
-        LOGGER.warn("Only support on-heap dictionary for String data type, load off-heap dictionary for column: {}",
-            columnName);
-      } else {
-        LOGGER.info("Loading on-heap dictionary for column: {}", columnName);
-      }
+      LOGGER.info("Loading on-heap dictionary for column: {}", columnName);
     }
 
     int length = metadata.getCardinality();
     switch (dataType) {
       case INT:
-        return new IntDictionary(dictionaryBuffer, length);
+        return (loadOnHeap) ? new OnHeapIntDictionary(dictionaryBuffer, length)
+            : new IntDictionary(dictionaryBuffer, length);
+
       case LONG:
-        return new LongDictionary(dictionaryBuffer, length);
+        return (loadOnHeap) ? new OnHeapLongDictionary(dictionaryBuffer, length)
+            : new LongDictionary(dictionaryBuffer, length);
+
       case FLOAT:
-        return new FloatDictionary(dictionaryBuffer, length);
+        return (loadOnHeap) ? new OnHeapFloatDictionary(dictionaryBuffer, length)
+            : new FloatDictionary(dictionaryBuffer, length);
+
       case DOUBLE:
-        return new DoubleDictionary(dictionaryBuffer, length);
+        return (loadOnHeap) ? new OnHeapDoubleDictionary(dictionaryBuffer, length)
+            : new DoubleDictionary(dictionaryBuffer, length);
+
       case STRING:
         int numBytesPerValue = metadata.getStringColumnMaxLength();
         byte paddingByte = (byte) metadata.getPaddingCharacter();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.index.loader;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.segment.ReadMode;
@@ -149,8 +150,14 @@ public class IndexLoadingConfig {
   /**
    * For tests only.
    */
+  @VisibleForTesting
   public void setInvertedIndexColumns(@Nonnull Set<String> invertedIndexColumns) {
     _invertedIndexColumns = invertedIndexColumns;
+  }
+
+  @VisibleForTesting
+  public void setOnHeapDictionaryColumns(@Nonnull Set<String> onHeapDictionaryColumns) {
+    _onHeapDictionaryColumns = onHeapDictionaryColumns;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapDictionary.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.readers;
+
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+
+
+/**
+ * Abstract base class for all on-heap dictionary implementations.
+ *
+ */
+public abstract class OnHeapDictionary extends ImmutableDictionaryReader {
+
+  protected OnHeapDictionary(PinotDataBuffer dataBuffer, int length, int numBytesPerValue, byte paddingByte) {
+    super(dataBuffer, length, numBytesPerValue, paddingByte);
+  }
+
+  @Override
+  public Object get(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapDoubleDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapDoubleDictionary.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.readers;
+
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import it.unimi.dsi.fastutil.doubles.Double2IntOpenHashMap;
+import java.util.Arrays;
+
+
+/**
+ * Implementation of double dictionary that cache all values on-heap.
+ * <p>This is useful for double columns that:
+ * <ul>
+ *   <li>Have low cardinality double dictionary where memory footprint on-heap is acceptably small</li>
+ *   <li>Is heavily queried</li>
+ * </ul>
+ * <p>This helps avoid creation of double from byte[].
+ */
+public class OnHeapDoubleDictionary extends OnHeapDictionary {
+  private final Double2IntOpenHashMap _valToDictId;
+  private final double[] _dictIdToVal;
+
+  /**
+   * Constructor for the class.
+   * Populates the value <-> mappings.
+   *
+   * @param dataBuffer Pinot data buffer
+   * @param length Length of the dictionary
+   */
+  public OnHeapDoubleDictionary(PinotDataBuffer dataBuffer, int length) {
+    super(dataBuffer, length, V1Constants.Numbers.DOUBLE_SIZE, (byte) 0);
+
+    _valToDictId = new Double2IntOpenHashMap(length);
+    _valToDictId.defaultReturnValue(-1);
+    _dictIdToVal = new double[length];
+
+    for (int dictId = 0; dictId < length; dictId++) {
+      double value = getDouble(dictId);
+      _dictIdToVal[dictId] = value;
+      _valToDictId.put(value, dictId);
+    }
+  }
+
+  @Override
+  public int indexOf(Object rawValue) {
+    double value = getValue(rawValue);
+    return _valToDictId.get(value);
+  }
+
+  private double getValue(Object rawValue) {
+    double value;
+    if (rawValue instanceof String) {
+      value = Double.parseDouble((String) rawValue);
+    } else if (rawValue instanceof Double) {
+      value = (double) rawValue;
+    } else {
+      throw new IllegalArgumentException(
+          "Illegal data type for argument, actual: " + rawValue.getClass().getName() + " expected: "
+              + Double.class.getName());
+    }
+    return value;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
+    int index = indexOf(rawValue);
+    return (index != -1) ? index : Arrays.binarySearch(_dictIdToVal, getValue(rawValue));
+  }
+
+  @Override
+  public Double get(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    return Double.toString(_dictIdToVal[dictId]);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapFloatDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapFloatDictionary.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.readers;
+
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import it.unimi.dsi.fastutil.floats.Float2IntOpenHashMap;
+import java.util.Arrays;
+
+
+/**
+ * Implementation of float dictionary that cache all values on-heap.
+ * <p>This is useful for float columns that:
+ * <ul>
+ *   <li>Have low cardinality float dictionary where memory footprint on-heap is acceptably small</li>
+ *   <li>Is heavily queried</li>
+ * </ul>
+ * <p>This helps avoid creation of float from byte[].
+ */
+public class OnHeapFloatDictionary extends OnHeapDictionary {
+  private final Float2IntOpenHashMap _valToDictId;
+  private final float[] _dictIdToVal;
+
+  /**
+   * Constructor for the class.
+   * Populates the value <-> mappings.
+   *
+   * @param dataBuffer Pinot data buffer
+   * @param length Length of the dictionary
+   */
+  public OnHeapFloatDictionary(PinotDataBuffer dataBuffer, int length) {
+    super(dataBuffer, length, V1Constants.Numbers.FLOAT_SIZE, (byte) 0);
+
+    _valToDictId = new Float2IntOpenHashMap(length);
+    _valToDictId.defaultReturnValue(-1);
+    _dictIdToVal = new float[length];
+
+    for (int dictId = 0; dictId < length; dictId++) {
+      float value = getFloat(dictId);
+      _dictIdToVal[dictId] = value;
+      _valToDictId.put(value, dictId);
+    }
+  }
+
+  @Override
+  public int indexOf(Object rawValue) {
+    float value = getValue(rawValue);
+    return _valToDictId.get(value);
+  }
+
+  private float getValue(Object rawValue) {
+    float value;
+    if (rawValue instanceof String) {
+      value = Float.parseFloat((String) rawValue);
+    } else if (rawValue instanceof Float) {
+      value = (float) rawValue;
+    } else {
+      throw new IllegalArgumentException(
+          "Illegal data type for argument, actual: " + rawValue.getClass().getName() + " expected: "
+              + Float.class.getName());
+    }
+    return value;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
+    int index = indexOf(rawValue);
+    return (index != -1) ? index : Arrays.binarySearch(_dictIdToVal, getValue(rawValue));
+  }
+
+  @Override
+  public Float get(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    return Float.toString(_dictIdToVal[dictId]);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapIntDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapIntDictionary.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.readers;
+
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import java.util.Arrays;
+
+
+/**
+ * Implementation of int dictionary that cache all values on-heap.
+ * <p>This is useful for int columns that:
+ * <ul>
+ *   <li>Have low cardinality int dictionary where memory footprint on-heap is acceptably small</li>
+ *   <li>Is heavily queried</li>
+ * </ul>
+ * <p>This helps avoid creation of int from byte[].
+ */
+public class OnHeapIntDictionary extends OnHeapDictionary {
+  private final Int2IntOpenHashMap _valToDictId;
+  private final int[] _dictIdToVal;
+
+  /**
+   * Constructor for the class.
+   * Populates the value <-> mappings.
+   *
+   * @param dataBuffer Pinot data buffer
+   * @param length Length of the dictionary
+   */
+  public OnHeapIntDictionary(PinotDataBuffer dataBuffer, int length) {
+    super(dataBuffer, length, V1Constants.Numbers.INTEGER_SIZE, (byte) 0);
+
+    _valToDictId = new Int2IntOpenHashMap(length);
+    _valToDictId.defaultReturnValue(-1);
+    _dictIdToVal = new int[length];
+
+    for (int dictId = 0; dictId < length; dictId++) {
+      int value = getInt(dictId);
+      _dictIdToVal[dictId] = value;
+      _valToDictId.put(value, dictId);
+    }
+  }
+
+  @Override
+  public int indexOf(Object rawValue) {
+    int value = getValue(rawValue);
+    return _valToDictId.get(value);
+  }
+
+  private int getValue(Object rawValue) {
+    int value;
+    if (rawValue instanceof String) {
+      value = Integer.parseInt((String) rawValue);
+    } else if (rawValue instanceof Integer) {
+      value = (int) rawValue;
+    } else {
+      throw new IllegalArgumentException(
+          "Illegal data type for argument, actual: " + rawValue.getClass().getName() + " expected: "
+              + Integer.class.getName());
+    }
+    return value;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
+    int index = indexOf(rawValue);
+    return (index != -1) ? index : Arrays.binarySearch(_dictIdToVal, getValue(rawValue));
+  }
+
+  @Override
+  public Integer get(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    return Integer.toString(_dictIdToVal[dictId]);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapLongDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapLongDictionary.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.segment.index.readers;
+
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import java.util.Arrays;
+
+
+/**
+ * Implementation of long dictionary that cache all values on-heap.
+ * <p>This is useful for Long columns that:
+ * <ul>
+ *   <li>Have low cardinality long dictionary where memory footprint on-heap is acceptably small</li>
+ *   <li>Is heavily queried</li>
+ * </ul>
+ * <p>This helps avoid creation of Long from byte[].
+ */
+public class OnHeapLongDictionary extends OnHeapDictionary {
+  private final Long2IntOpenHashMap _valToDictId;
+  private final long[] _dictIdToVal;
+
+  /**
+   * Constructor for the class.
+   * Populates the value <-> mappings.
+   *
+   * @param dataBuffer Pinot data buffer
+   * @param length Length of the dictionary
+   */
+  public OnHeapLongDictionary(PinotDataBuffer dataBuffer, int length) {
+    super(dataBuffer, length, V1Constants.Numbers.LONG_SIZE, (byte) 0);
+
+    _valToDictId = new Long2IntOpenHashMap(length);
+    _valToDictId.defaultReturnValue(-1);
+    _dictIdToVal = new long[length];
+
+    for (int dictId = 0; dictId < length; dictId++) {
+      long value = getLong(dictId);
+      _dictIdToVal[dictId] = value;
+      _valToDictId.put(value, dictId);
+    }
+  }
+
+  @Override
+  public int indexOf(Object rawValue) {
+    long value = getValue(rawValue);
+    return _valToDictId.get(value);
+  }
+
+  private long getValue(Object rawValue) {
+    long value;
+    if (rawValue instanceof String) {
+      value = Long.parseLong((String) rawValue);
+    } else if (rawValue instanceof Long) {
+      value = (Long) rawValue;
+    } else {
+      throw new IllegalArgumentException(
+          "Illegal data type for argument, actual: " + rawValue.getClass().getName() + " expected: "
+              + Long.class.getName());
+    }
+    return value;
+  }
+
+  @Override
+  public int insertionIndexOf(Object rawValue) {
+    int index = indexOf(rawValue);
+    return (index != -1) ? index : Arrays.binarySearch(_dictIdToVal, getValue(rawValue));
+  }
+
+  @Override
+  public Long get(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    return _dictIdToVal[dictId];
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    return Long.toString(_dictIdToVal[dictId]);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapStringDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/OnHeapStringDictionary.java
@@ -19,8 +19,6 @@ import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -32,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * <p>This helps avoid creation of String from byte[], which is expensive as well as creates garbage.
  */
-public class OnHeapStringDictionary extends ImmutableDictionaryReader {
+public class OnHeapStringDictionary extends OnHeapDictionary {
   private final byte _paddingByte;
   private final String[] _unpaddedStrings;
   private final String[] _paddedStrings;
@@ -87,26 +85,6 @@ public class OnHeapStringDictionary extends ImmutableDictionaryReader {
   @Override
   public String get(int dictId) {
     return _unpaddedStrings[dictId];
-  }
-
-  @Override
-  public int getIntValue(int dictId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public long getLongValue(int dictId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public float getFloatValue(int dictId) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public double getDoubleValue(int dictId) {
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/OnHeapDictionariesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/OnHeapDictionariesTest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.segments.v1.creator;
+
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.segment.ReadMode;
+import com.linkedin.pinot.core.common.DataSource;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.readers.FileFormat;
+import com.linkedin.pinot.core.data.readers.GenericRowRecordReader;
+import com.linkedin.pinot.core.indexsegment.IndexSegment;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import com.linkedin.pinot.core.segment.index.loader.IndexLoadingConfig;
+import com.linkedin.pinot.core.segment.index.loader.Loaders;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for On-Heap dictionary implementations.
+ */
+public class OnHeapDictionariesTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OnHeapDictionariesTest.class);
+
+  private static final String SEGMENT_DIR_NAME = System.getProperty("java.io.tmpdir") + File.separator + "onHeapDict";
+  private static final String SEGMENT_NAME = "onHeapDict";
+
+  private static final long RANDOM_SEED = System.nanoTime();
+  private static final int NUM_ROWS = 1;
+  private static final String INT_COLUMN = "intColumn";
+  private static final String LONG_COLUMN = "longColumn";
+  private static final String FLOAT_COLUMN = "floatColumn";
+  private static final String DOUBLE_COLUMN = "doubleColumn";
+  private static final String STRING_COLUMN = "stringColumn";
+
+  private IndexSegment _offHeapSegment;
+  private IndexSegment _onHeapSegment;
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    Schema schema = buildSchema();
+    buildSegment(SEGMENT_DIR_NAME, SEGMENT_NAME, schema);
+
+    IndexLoadingConfig loadingConfig = new IndexLoadingConfig();
+    loadingConfig.setReadMode(ReadMode.mmap);
+    loadingConfig.setSegmentVersion(SegmentVersion.v3);
+    _offHeapSegment = Loaders.IndexSegment.load(new File(SEGMENT_DIR_NAME, SEGMENT_NAME), loadingConfig);
+
+    loadingConfig.setOnHeapDictionaryColumns(new HashSet<>(
+        Arrays.asList(new String[]{INT_COLUMN, LONG_COLUMN, FLOAT_COLUMN, DOUBLE_COLUMN, STRING_COLUMN})));
+
+    _onHeapSegment = Loaders.IndexSegment.load(new File(SEGMENT_DIR_NAME, SEGMENT_NAME), loadingConfig);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(new File(SEGMENT_DIR_NAME));
+  }
+
+  /**
+   * This test compares the on-heap and off-heap loaded dictionaries for the same segment.
+   */
+  @Test
+  public void test() {
+    testColumn(INT_COLUMN);
+    testColumn(LONG_COLUMN);
+    testColumn(FLOAT_COLUMN);
+    testColumn(DOUBLE_COLUMN);
+    testColumn(STRING_COLUMN);
+  }
+
+  private void testColumn(String column) {
+    DataSource onHeapDataSource = _onHeapSegment.getDataSource(column);
+    DataSource offHeapDataSource = _offHeapSegment.getDataSource(column);
+
+    FieldSpec.DataType onHeapDataType = onHeapDataSource.getDataSourceMetadata().getDataType();
+    FieldSpec.DataType offHeapDataType = offHeapDataSource.getDataSourceMetadata().getDataType();
+    Assert.assertEquals(onHeapDataType, offHeapDataType);
+
+    Dictionary onHeapDict = onHeapDataSource.getDictionary();
+    Dictionary offHeapDict = offHeapDataSource.getDictionary();
+
+    Assert.assertEquals(onHeapDict.length(), offHeapDict.length());
+
+    for (int dictId = 0; dictId < onHeapDict.length(); dictId++) {
+      Assert.assertEquals(onHeapDict.get(dictId), offHeapDict.get(dictId));
+      Assert.assertEquals(onHeapDict.getStringValue(dictId), offHeapDict.getStringValue(dictId));
+
+      switch (onHeapDataType) {
+        case INT:
+          Assert.assertEquals(onHeapDict.getIntValue(dictId), offHeapDict.getIntValue(dictId));
+          Assert.assertEquals(onHeapDict.getLongValue(dictId), offHeapDict.getLongValue(dictId));
+          Assert.assertEquals(onHeapDict.getFloatValue(dictId), offHeapDict.getFloatValue(dictId));
+          Assert.assertEquals(onHeapDict.getDoubleValue(dictId), offHeapDict.getDoubleValue(dictId));
+          break;
+
+        case LONG:
+          Assert.assertEquals(onHeapDict.getLongValue(dictId), offHeapDict.getLongValue(dictId));
+          break;
+
+        case FLOAT:
+          Assert.assertEquals(onHeapDict.getFloatValue(dictId), offHeapDict.getFloatValue(dictId));
+          Assert.assertEquals(onHeapDict.getDoubleValue(dictId), offHeapDict.getDoubleValue(dictId));
+          break;
+
+        case DOUBLE:
+          Assert.assertEquals(onHeapDict.getDoubleValue(dictId), offHeapDict.getDoubleValue(dictId));
+          break;
+
+        case STRING:
+          Assert.assertEquals(onHeapDict.getStringValue(dictId), offHeapDict.getStringValue(dictId));
+          break;
+
+        default:
+          throw new RuntimeException("Unexpected data type for dictionary for column: " + column);
+      }
+    }
+  }
+
+  /**
+   * Helper method to build a segment with random data as per the schema.
+   *
+   * @param segmentDirName Name of segment directory
+   * @param segmentName Name of segment
+   * @param schema Schema for segment
+   * @return Schema built for the segment
+   * @throws Exception
+   */
+  private Schema buildSegment(String segmentDirName, String segmentName, Schema schema)
+      throws Exception {
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(schema);
+    config.setOutDir(segmentDirName);
+    config.setFormat(FileFormat.AVRO);
+    config.setSegmentName(segmentName);
+
+    Random random = new Random(RANDOM_SEED);
+
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+
+    for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
+      HashMap<String, Object> map = new HashMap<>();
+
+      map.put(INT_COLUMN, random.nextInt());
+      map.put(LONG_COLUMN, random.nextLong());
+      map.put(FLOAT_COLUMN, random.nextFloat());
+      map.put(DOUBLE_COLUMN, random.nextDouble());
+      map.put(STRING_COLUMN, RandomStringUtils.randomAscii(100));
+
+      GenericRow genericRow = new GenericRow();
+      genericRow.init(map);
+      rows.add(genericRow);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows, schema));
+    driver.build();
+
+    LOGGER.info("Built segment {} at {}", segmentName, segmentDirName);
+    return schema;
+  }
+
+  /**
+   * Helper method to build a schema with provided number of metric columns.
+   *
+   * @return Schema containing the given number of metric columns
+   */
+  private static Schema buildSchema() {
+    Schema schema = new Schema();
+    schema.addField(new DimensionFieldSpec(INT_COLUMN, FieldSpec.DataType.INT, true));
+    schema.addField(new DimensionFieldSpec(LONG_COLUMN, FieldSpec.DataType.LONG, true));
+    schema.addField(new DimensionFieldSpec(FLOAT_COLUMN, FieldSpec.DataType.FLOAT, true));
+    schema.addField(new DimensionFieldSpec(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE, true));
+    schema.addField(new DimensionFieldSpec(STRING_COLUMN, FieldSpec.DataType.STRING, true));
+    return schema;
+  }
+}


### PR DESCRIPTION
For low cardinality columns, it might be more efficient to store the
dictionary directly on-heap, as long as the heap foot-print does not
increase. The advantages are two fold:

1. Provides constant time lookup, as opposed to binary-search.
2. Saves on redundant ser-de of same values from byte-array to
destination data-type over and over again.

Heap usage increases long with cardinality of the item, so it is not
advisable to use this feature where cardinality is medium/large, or can
grow, unless the heap usage is acceptable.