### PR TITLE
Use dictionaryBasedOperator only if dictionary is immutable, hence guaranteeing that it is sorted

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.plan.maker;
 
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
+import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.plan.AggregationGroupByPlanNode;
@@ -34,6 +35,7 @@ import com.linkedin.pinot.core.query.config.QueryExecutorConfig;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -224,7 +226,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     AggregationFunctionType aggFuncType = AggregationFunctionType.valueOf(aggregationInfo.getAggregationType().toUpperCase());
     if (aggFuncType.isOfType(AggregationFunctionType.MAX, AggregationFunctionType.MIN, AggregationFunctionType.MINMAXRANGE)) {
       String column = aggregationInfo.getAggregationParams().get("column");
-      if (indexSegment.getDataSource(column).getDataSourceMetadata().hasDictionary()) {
+      DataSource dataSource = indexSegment.getDataSource(column);
+      if (dataSource.getDataSourceMetadata().hasDictionary() && dataSource.getDictionary().isSorted()) {
         return true;
       }
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionary.java
@@ -27,6 +27,10 @@ public abstract class MutableDictionary extends BaseDictionary {
     return get(dictId).toString();
   }
 
+  public boolean isSorted() {
+    return false;
+  }
+
   public abstract void index(@Nonnull Object rawValue);
 
   public abstract boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare,
@@ -44,4 +48,5 @@ public abstract class MutableDictionary extends BaseDictionary {
   public abstract int getAvgValueSize();
 
   public abstract boolean isEmpty();
+
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/Dictionary.java
@@ -44,6 +44,8 @@ public interface Dictionary extends Closeable {
 
   int length();
 
+  boolean isSorted();
+
   // Batch read APIs
 
   void readIntValues(int[] dictIds, int inStartPos, int length, int[] outValues, int outStartPos);
@@ -55,4 +57,5 @@ public interface Dictionary extends Closeable {
   void readDoubleValues(int[] dictIds, int inStartPos, int length, double[] outValues, int outStartPos);
 
   void readStringValues(int[] dictIds, int inStartPos, int length, String[] outValues, int outStartPos);
+
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReader.java
@@ -56,6 +56,10 @@ public abstract class ImmutableDictionaryReader extends BaseDictionary {
     return _length;
   }
 
+  public boolean isSorted() {
+    return true;
+  }
+
   @Override
   public void close() {
     _valueReader.close();

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -19,6 +19,7 @@ import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.utils.KafkaStarterUtils;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -109,6 +110,41 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
     super.testGeneratedQueriesWithMultiValues();
   }
 
+  /**
+   * In realtime consuming segments, the dictionary is not sorted,
+   * and the dictionary based operator should not be used
+   *
+   * Adding explicit queries to test dictionary based functions,
+   * to ensure the right result is computed, wherein dictionary is not read if it is mutable
+   * @throws Exception
+   */
+  @Test
+  public void testDictionaryBasedQueries() throws Exception {
+
+    // Dictionary columns
+    // int
+    testDictionaryBasedFunctions("NASDelay");
+
+    // long
+    testDictionaryBasedFunctions("AirlineID");
+
+    // double
+    testDictionaryBasedFunctions("ArrDelayMinutes");
+
+    // float
+    testDictionaryBasedFunctions("DepDelayMinutes");
+
+    // Non Dictionary columns
+    // int
+    testDictionaryBasedFunctions("ActualElapsedTime");
+
+    // double
+    testDictionaryBasedFunctions("DepDelay");
+
+    // float
+    testDictionaryBasedFunctions("ArrDelay");
+  }
+
   @Test
   @Override
   public void testQueryExceptions() throws Exception {
@@ -132,5 +168,19 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
     }
     stopZk();
     FileUtils.deleteDirectory(_tempDir);
+  }
+
+  private void testDictionaryBasedFunctions(String column) throws Exception {
+    String pqlQuery;
+    String sqlQuery;
+    pqlQuery = "SELECT MAX(" + column + ") FROM " + getTableName();
+    sqlQuery = "SELECT MAX(" + column + ") FROM " + getTableName();
+    testQuery(pqlQuery, Collections.singletonList(sqlQuery));
+    pqlQuery = "SELECT MIN(" + column + ") FROM " + getTableName();
+    sqlQuery = "SELECT MIN(" + column + ") FROM " + getTableName();
+    testQuery(pqlQuery, Collections.singletonList(sqlQuery));
+    pqlQuery = "SELECT MINMAXRANGE(" + column + ") FROM " + getTableName();
+    sqlQuery = "SELECT MAX(" + column + ")-MIN(" + column + ") FROM " + getTableName();
+    testQuery(pqlQuery, Collections.singletonList(sqlQuery));
   }
 }


### PR DESCRIPTION
In case of realtime consuming segments, the dictionary is unsorted. This results in wrong results for functions which use DictionaryBasedOperator. Introducing an api in Dictionary interface, isSorted(), which will return true if the dictionary is Immutable, and false if it is Mutable