### PR TITLE
[TE] rootcause poc - support special characters in urns

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -250,8 +250,7 @@ export function toFilters(urns) {
   const dimensionFilters = filterPrefix(urns, 'thirdeye:dimension:').map(urn => _.slice(urn.split(':').map(decodeURIComponent), 2, 4));
   const metricFilters = filterPrefix(urns, 'thirdeye:metric:').map(extractTail).map(enc => enc.map(tup => decodeURIComponent(tup).split('='))).reduce(flatten, []);
   const frontendMetricFilters = filterPrefix(urns, 'frontend:metric:').map(extractTail).map(enc => enc.map(tup => decodeURIComponent(tup).split('='))).reduce(flatten, []);
-
-  return [...dimensionFilters, ...metricFilters, ...frontendMetricFilters].sort();
+  return [...new Set([...dimensionFilters, ...metricFilters, ...frontendMetricFilters])].sort();
 }
 
 export function fromFilterMap(filterMap) {

--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -248,9 +248,14 @@ export function toAbsoluteRange(urn, currentRange, baselineCompareMode) {
 export function toFilters(urns) {
   const flatten = (agg, l) => agg.concat(l);
   const dimensionFilters = filterPrefix(urns, 'thirdeye:dimension:').map(urn => _.slice(urn.split(':').map(decodeURIComponent), 2, 4));
-  const metricFilters = filterPrefix(urns, 'thirdeye:metric:').map(extractTail).map(enc => enc.map(tup => decodeURIComponent(tup).split('='))).reduce(flatten, []);
-  const frontendMetricFilters = filterPrefix(urns, 'frontend:metric:').map(extractTail).map(enc => enc.map(tup => decodeURIComponent(tup).split('='))).reduce(flatten, []);
+  const metricFilters = filterPrefix(urns, 'thirdeye:metric:').map(extractTail).map(enc => enc.map(tup => splitFilterFragment(decodeURIComponent(tup)))).reduce(flatten, []);
+  const frontendMetricFilters = filterPrefix(urns, 'frontend:metric:').map(extractTail).map(enc => enc.map(tup => splitFilterFragment(decodeURIComponent(tup)))).reduce(flatten, []);
   return [...new Set([...dimensionFilters, ...metricFilters, ...frontendMetricFilters])].sort();
+}
+
+function splitFilterFragment(fragment) {
+  const parts = fragment.split('=');
+  return [parts[0], _.slice(parts, 1).join('=')];
 }
 
 export function fromFilterMap(filterMap) {

--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -155,7 +155,7 @@ export function appendTail(urn, tail) {
 }
 
 export function appendFilters(urn, filters) {
-  const tail = filters.map(t => `${t[0]}=${t[1]}`);
+  const tail = filters.map(t => encodeURIComponent(`${t[0]}=${t[1]}`));
   return appendTail(urn, tail);
 }
 
@@ -247,10 +247,10 @@ export function toAbsoluteRange(urn, currentRange, baselineCompareMode) {
 
 export function toFilters(urns) {
   const flatten = (agg, l) => agg.concat(l);
+  const dimensionFilters = filterPrefix(urns, 'thirdeye:dimension:').map(urn => _.slice(urn.split(':').map(decodeURIComponent), 2, 4));
+  const metricFilters = filterPrefix(urns, 'thirdeye:metric:').map(extractTail).map(enc => enc.map(tup => decodeURIComponent(tup).split('='))).reduce(flatten, []);
+  const frontendMetricFilters = filterPrefix(urns, 'frontend:metric:').map(extractTail).map(enc => enc.map(tup => decodeURIComponent(tup).split('='))).reduce(flatten, []);
 
-  const dimensionFilters = filterPrefix(urns, 'thirdeye:dimension:').map(urn => _.slice(urn.split(':'), 2, 4));
-  const metricFilters = filterPrefix(urns, 'thirdeye:metric:').map(extractTail).map(enc => enc.map(tup => tup.split('='))).reduce(flatten, []);
-  const frontendMetricFilters = filterPrefix(urns, 'frontend:metric:').map(extractTail).map(enc => enc.map(tup => tup.split('='))).reduce(flatten, []);
   return [...dimensionFilters, ...metricFilters, ...frontendMetricFilters].sort();
 }
 
@@ -293,9 +293,9 @@ export function toColor(urn) {
 
 export function toColorDirection(delta, inverse = false) {
   if (Number.isNaN(delta)) { return 'neutral'; }
-  
+
   if (inverse) { delta *= -1; }
-  
+
   switch(Math.sign(delta)) {
     case -1: return 'negative';
     case 0: return 'neutral';

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -87,7 +87,6 @@ export default Ember.Service.extend({
     const metricId = urn.split(':')[3];
     const metricFilters = toFilters([urn]);
     const filters = toFilterMap(metricFilters);
-
     const filterString = encodeURIComponent(JSON.stringify(filters));
 
     const url = `/aggregation/aggregate?metricIds=${metricId}&ranges=${range[0]}:${range[1]}&filters=${filterString}`;

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -113,7 +113,7 @@ export default Ember.Service.extend({
   },
 
   _makeUrl(framework, context) {
-    const urnString = filterPrefix(context.urns, 'thirdeye:metric:').join(',');
+    const urnString = filterPrefix(context.urns, 'thirdeye:metric:').map(encodeURIComponent).join(',');
     const baselineRange = toBaselineRange(context.anomalyRange, context.compareMode);
     return `/rootcause/query?framework=${framework}` +
       `&anomalyStart=${context.anomalyRange[0]}&anomalyEnd=${context.anomalyRange[1]}` +
@@ -123,7 +123,7 @@ export default Ember.Service.extend({
   },
 
   _makeIdentityUrl(urns) {
-    const urnString = [...urns].join(',');
+    const urnString = [...urns].map(encodeURIComponent).join(',');
     return `/rootcause/raw?framework=identity&urns=${urnString}`;
   },
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntity.java
@@ -51,7 +51,7 @@ public class DimensionEntity extends Entity {
   }
 
   public static DimensionEntity fromDimension(double score, Collection<? extends Entity> related, String name, String value, String type) {
-    return new DimensionEntity(TYPE.formatURN(name, value, type), score, new ArrayList<>(related), name, value, type);
+    return new DimensionEntity(TYPE.formatURN(EntityUtils.encodeURNComponent(name), EntityUtils.encodeURNComponent(value), type), score, new ArrayList<>(related), name, value, type);
   }
 
   public static DimensionEntity fromDimension(double score, String name, String value, String type) {
@@ -69,7 +69,7 @@ public class DimensionEntity extends Entity {
     String[] parts = urn.split(":", 5);
     if(parts.length != 5)
       throw new IllegalArgumentException(String.format("Dimension URN must have 5 parts but has '%d'", parts.length));
-    return fromDimension(score, parts[2], parts[3], parts[4]);
+    return fromDimension(score, EntityUtils.decodeURNComponent(parts[2]), EntityUtils.decodeURNComponent(parts[3]), parts[4]);
   }
 
   public static  Set<DimensionEntity> getContextDimensions(PipelineContext context, String type) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityType.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityType.java
@@ -30,32 +30,29 @@ public final class EntityType {
   }
 
   /**
-   * Returns the parameterized type as string urn. Attaches values in order. Also unwraps the last element
-   * if provided as a Map or Multimap.
+   * Returns the parameterized type as string urn. Attaches values in order. Also unwraps elements
+   * if provided as a Collection.
    *
    * @param values parameters, in order
    * @return formatted urn
    */
   public String formatURN(Object... values) {
-    if (values.length <= 0) {
-      return this.prefix;
+    List<String> tailValues = new ArrayList<>();
+    for (Object value : values) {
+
+      // unwrap collection
+      if (value instanceof Collection) {
+        for (Object v : (Collection<String>) value) {
+          tailValues.add(v.toString());
+        }
+
+      // single item
+      } else {
+        tailValues.add(value.toString());
+      }
     }
 
-    if (values[values.length - 1] instanceof Map) {
-      Map<String, String> tailValues = (Map<String, String>) values[values.length - 1];
-      Object[] headValues = Arrays.copyOf(values, values.length - 1);
-      String tail = tailValues.isEmpty() ? "" :  ":" + makeTail(tailValues.entrySet());
-      return this.prefix + StringUtils.join(headValues, ":") + tail;
-    }
-
-    if (values[values.length - 1] instanceof Multimap) {
-      Multimap<String, String> tailValues = (Multimap<String, String>) values[values.length - 1];
-      Object[] headValues = Arrays.copyOf(values, values.length - 1);
-      String tail = tailValues.isEmpty() ? "" :  ":" + makeTail(tailValues.entries());
-      return this.prefix + StringUtils.join(headValues, ":") + tail;
-    }
-
-    return this.prefix + StringUtils.join(values, ":");
+    return this.prefix + StringUtils.join(tailValues, ":");
   }
 
   public boolean isType(String urn) {
@@ -66,13 +63,4 @@ public final class EntityType {
     return e.getUrn().startsWith(this.prefix);
   }
 
-  private static String makeTail(Collection<Map.Entry<String, String>> entries) {
-    List<String> parts = new ArrayList<>();
-
-    for (Map.Entry<String, String> entry : entries) {
-      parts.add(String.format("%s=%s", entry.getKey(), entry.getValue()));
-    }
-
-    return StringUtils.join(parts, ":");
-  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/EntityUtils.java
@@ -1,9 +1,10 @@
 package com.linkedin.thirdeye.rootcause.impl;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.rootcause.Entity;
 import com.linkedin.thirdeye.rootcause.MaxScoreSet;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -280,5 +281,37 @@ public class EntityUtils {
    */
   public static <T extends Entity> List<T> addRelated(Iterable<T> entities, Entity related) {
     return addRelated(entities, Collections.singletonList(related));
+  }
+
+  /**
+   * Decode URN fragment to original data.
+   * <br/><b>NOTE:</b> almost similar to JavaScript's decodeURIComponent, but may cause issues with '+'
+   *
+   * @param value urn fragment value
+   * @return decoded value
+   */
+  public static String decodeURNComponent(String value) {
+    try {
+      return URLDecoder.decode(value, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // must not happen, utf-8 is part of java spec
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /**
+   * Encode data to URN fragment.
+   * <br/><b>NOTE:</b> almost similar to JavaScript's encodeURIComponent, but may cause issues with '+'
+   *
+   * @param value value
+   * @return encoded urn fragment
+   */
+  public static String encodeURNComponent(String value) {
+    try {
+      return URLEncoder.encode(value, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // must not happen, utf-8 is part of java spec
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricEntity.java
@@ -86,7 +86,7 @@ public class MetricEntity extends Entity {
     Multimap<String, String> filters = TreeMultimap.create();
 
     for(String filterString : filterStrings) {
-      String[] parts = EntityUtils.decodeURNComponent(filterString).split("=");
+      String[] parts = EntityUtils.decodeURNComponent(filterString).split("=", 2);
       if (parts.length != 2) {
         throw new IllegalArgumentException(String.format("Could not parse filter string '%s'", filterString));
       }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntityTest.java
@@ -1,0 +1,35 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DimensionEntityTest {
+  @Test
+  public void testFromDimension() {
+    DimensionEntity e = DimensionEntity.fromDimension(1.0, "myname", "myvalue", "mytype");
+    Assert.assertEquals(e.getUrn(), "thirdeye:dimension:myname:myvalue:mytype");
+  }
+
+  @Test
+  public void testFromDimensionEncode() {
+    DimensionEntity e = DimensionEntity.fromDimension(1.0, "my:name", "my=value", "mytype");
+    Assert.assertEquals(e.getUrn(), "thirdeye:dimension:my%3Aname:my%3Dvalue:mytype");
+  }
+
+  @Test
+  public void testFromURN() {
+    DimensionEntity e = DimensionEntity.fromURN("thirdeye:dimension:myname:myvalue:mytype", 1.0);
+    Assert.assertEquals(e.getName(), "myname");
+    Assert.assertEquals(e.getValue(), "myvalue");
+    Assert.assertEquals(e.getType(), "mytype");
+  }
+
+  @Test
+  public void testFromURNDecode() {
+    DimensionEntity e = DimensionEntity.fromURN("thirdeye:dimension:my%3Aname:my%3Dvalue:mytype", 1.0);
+    Assert.assertEquals(e.getName(), "my:name");
+    Assert.assertEquals(e.getValue(), "my=value");
+    Assert.assertEquals(e.getType(), "mytype");
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MetricEntityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MetricEntityTest.java
@@ -26,6 +26,13 @@ public class MetricEntityTest {
   }
 
   @Test
+  public void testFilterEncoded() {
+    MetricEntity e = MetricEntity.fromURN("thirdeye:metric:12345:key%3Dvalue", 1.0);
+    Assert.assertEquals(e.getFilters().size(), 1);
+    Assert.assertEquals(e.getFilters().get("key").iterator().next(), "value");
+  }
+
+  @Test
   public void testFiltersMultikey() {
     MetricEntity e = MetricEntity.fromURN("thirdeye:metric:12345:key=value:key=other:otherKey=yetAnotherValue", 1.0);
     Assert.assertEquals(e.getFilters().size(), 3);
@@ -54,9 +61,9 @@ public class MetricEntityTest {
 
     Assert.assertEquals(e.getUrn().split(":").length, 6);
     Assert.assertTrue(e.getUrn().startsWith("thirdeye:metric:123"));
-    Assert.assertTrue(e.getUrn().contains(":anotherKey=otherValue"));
-    Assert.assertTrue(e.getUrn().contains(":key=value"));
-    Assert.assertTrue(e.getUrn().contains(":key=otherValue"));
+    Assert.assertTrue(e.getUrn().contains(":anotherKey%3DotherValue"));
+    Assert.assertTrue(e.getUrn().contains(":key%3Dvalue"));
+    Assert.assertTrue(e.getUrn().contains(":key%3DotherValue"));
   }
 
   @Test
@@ -71,13 +78,13 @@ public class MetricEntityTest {
     MetricEntity e = MetricEntity.fromMetric(1.0, 123, filters1);
     Assert.assertEquals(e.getUrn().split(":").length, 5);
     Assert.assertTrue(e.getUrn().startsWith("thirdeye:metric:123"));
-    Assert.assertTrue(e.getUrn().contains(":anotherKey=otherValue"));
-    Assert.assertTrue(e.getUrn().contains(":key=otherValue"));
+    Assert.assertTrue(e.getUrn().contains(":anotherKey%3DotherValue"));
+    Assert.assertTrue(e.getUrn().contains(":key%3DotherValue"));
 
     MetricEntity aug = e.withFilters(filters2);
     Assert.assertEquals(aug.getUrn().split(":").length, 4);
     Assert.assertTrue(aug.getUrn().startsWith("thirdeye:metric:123"));
-    Assert.assertTrue(aug.getUrn().contains(":key=value"));
+    Assert.assertTrue(aug.getUrn().contains(":key%3Dvalue"));
   }
 
   @Test
@@ -90,9 +97,9 @@ public class MetricEntityTest {
     MetricEntity e = MetricEntity.fromMetric(1.0, 123, filters);
     Assert.assertEquals(e.getUrn().split(":").length, 6);
     Assert.assertTrue(e.getUrn().startsWith("thirdeye:metric:123"));
-    Assert.assertTrue(e.getUrn().contains(":anotherKey=otherValue"));
-    Assert.assertTrue(e.getUrn().contains(":key=value"));
-    Assert.assertTrue(e.getUrn().contains(":key=otherValue"));
+    Assert.assertTrue(e.getUrn().contains(":anotherKey%3DotherValue"));
+    Assert.assertTrue(e.getUrn().contains(":key%3Dvalue"));
+    Assert.assertTrue(e.getUrn().contains(":key%3DotherValue"));
 
     MetricEntity drop = e.withoutFilters();
     Assert.assertEquals(drop.getUrn(), "thirdeye:metric:123");

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MetricEntityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MetricEntityTest.java
@@ -33,6 +33,13 @@ public class MetricEntityTest {
   }
 
   @Test
+  public void testFilterEncodedMultipleEquals() {
+    MetricEntity e = MetricEntity.fromURN("thirdeye:metric:12345:key%3Dvalue%3D1", 1.0);
+    Assert.assertEquals(e.getFilters().size(), 1);
+    Assert.assertEquals(e.getFilters().get("key").iterator().next(), "value=1");
+  }
+
+  @Test
   public void testFiltersMultikey() {
     MetricEntity e = MetricEntity.fromURN("thirdeye:metric:12345:key=value:key=other:otherKey=yetAnotherValue", 1.0);
     Assert.assertEquals(e.getFilters().size(), 3);
@@ -43,11 +50,6 @@ public class MetricEntityTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testFiltersShortFail() {
     MetricEntity.fromURN("thirdeye:metric:12345:key:key2=value2", 1.0);
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testFiltersLongFail() {
-    MetricEntity.fromURN("thirdeye:metric:12345:key=value=1", 1.0);
   }
 
   @Test

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MetricMappingPipelineTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/MetricMappingPipelineTest.java
@@ -101,13 +101,13 @@ public class MetricMappingPipelineTest {
     List<MetricEntity> result = getSorted(pipeline.run(context));
 
     Assert.assertEquals(result.size(), 7);
-    assertEquals(result.get(0), "thirdeye:metric:100:L=1:L=2:M=3:N=4:Q=1:Q=2", 1.0);
-    assertEquals(result.get(1), "thirdeye:metric:101:S=one", 0.9);
-    assertEquals(result.get(2), "thirdeye:metric:102:S=one", 0.9);
-    assertEquals(result.get(3), "thirdeye:metric:103:M=3:R=1:R=2", 0.9);
-    assertEquals(result.get(4), "thirdeye:metric:104:M=3", 0.81);
-    assertEquals(result.get(5), "thirdeye:metric:105:M=3:N=4", 0.9);
-    assertEquals(result.get(6), "thirdeye:metric:106:N=4", 0.81);
+    assertEquals(result.get(0), "thirdeye:metric:100:L%3D1:L%3D2:M%3D3:N%3D4:Q%3D1:Q%3D2", 1.0);
+    assertEquals(result.get(1), "thirdeye:metric:101:S%3Done", 0.9);
+    assertEquals(result.get(2), "thirdeye:metric:102:S%3Done", 0.9);
+    assertEquals(result.get(3), "thirdeye:metric:103:M%3D3:R%3D1:R%3D2", 0.9);
+    assertEquals(result.get(4), "thirdeye:metric:104:M%3D3", 0.81);
+    assertEquals(result.get(5), "thirdeye:metric:105:M%3D3:N%3D4", 0.9);
+    assertEquals(result.get(6), "thirdeye:metric:106:N%3D4", 0.81);
   }
 
   private static MetricConfigDTO makeMetric(long id, String dataset) {


### PR DESCRIPTION
People are horrible, so we need support for special characters in urns (with filter tail). Depending on the dataset, filters may take values that are misinterpreted as URN tokens, e.g. "pageId=my:app:/route/subroute?q=text". This PR adds frontend and backend support for URI-encoding URN fragments so that urns can be tokenized safely.