### PR TITLE
[TE] Self-Serve tuning flow 01: associated components/utils

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/manage-alert-utils.js
@@ -4,18 +4,17 @@ import moment from 'moment';
 /**
  * Handles types and defaults returned from eval/projected endpoints
  * @param {Number|String} metric - number or string like 'NaN', 'Infinity'
- * @param {Boolean} allowDecimal - should this metric be shown as whole number?
+ * @param {Boolean} isPercentage - shall we treat this as a % or a whole number?
  * @returns {Object}
  */
-export function formatEvalMetric(metric, allowDecimal = false) {
-  let shown = 'N/A';
-  if (!isNaN(metric)) {
-    if (allowDecimal) {
-      shown = (Number(metric) === 1 || Number(metric) === 0)
-        ? metric * 100
-        : (metric * 100).toFixed(1);
+export function formatEvalMetric(metric, isPercentage = false) {
+  const isWhole = Number(metric) % 1 === 0;
+  let shown = (metric === 'Infinity') ? metric : 'N/A';
+  if (isFinite(metric)) {
+    if (isPercentage) {
+      shown = isWhole ? metric * 100 : (metric * 100).toFixed(1);
     } else {
-      shown = metric;
+      shown = isWhole ? metric : metric.toFixed(1);
     }
   }
   return shown;
@@ -52,12 +51,12 @@ export function toIdGroups(anomalyIds, bucketSize = 10) {
  */
 export function enhanceAnomalies(rawAnomalies) {
   const newAnomalies = [];
-  const anomaliesPresent = rawAnomalies.length ;
+  const anomaliesPresent = rawAnomalies && rawAnomalies.length;
   // De-dupe raw anomalies, extract only the good stuff (anomalyDetailsList)
   const anomalies = anomaliesPresent ? [].concat(...rawAnomalies.map(data => data.anomalyDetailsList)) : [];
 
   // Loop over all anomalies to configure display settings
-  for (var anomaly of anomalies) {
+  anomalies.forEach((anomaly) => {
     let dimensionList = [];
     const startMoment = moment(anomaly.anomalyStart);
     const endMoment = moment(anomaly.anomalyEnd);
@@ -97,20 +96,30 @@ export function enhanceAnomalies(rawAnomalies) {
     // Create a list of all available dimensions for toggling. Also massage dimension property.
     if (anomaly.anomalyFunctionDimension) {
       let dimensionObj = JSON.parse(anomaly.anomalyFunctionDimension);
+      let dimensionStrArr = [];
       for (let dimension of Object.keys(dimensionObj)) {
         let dimensionKey = dimension.dasherize();
         let dimensionVal = dimensionObj[dimension].join(',');
         dimensionList.push({ dimensionKey, dimensionVal });
+        dimensionStrArr.push(`${dimensionKey}:${dimensionVal}`);
       }
-      Object.assign(anomaly, { dimensionList });
+      let dimensionString = dimensionStrArr.join(' & ');
+      Object.assign(anomaly, { dimensionList, dimensionString });
     }
 
     newAnomalies.push(anomaly);
-  }
+  });
 
   return newAnomalies;
 }
 
+/**
+ * Generates time range options for selection in the self-serve UI
+ * @method setUpTimeRangeOptions
+ * @param {Array} datesKeys - array of keys used to generate time ranges
+ * @param {String} duration - the selected time span that is default
+ * @return {Array}
+ */
 export function setUpTimeRangeOptions(datesKeys, duration) {
   const newRangeArr = [];
 
@@ -161,19 +170,65 @@ export function evalObj() {
 }
 
 /**
+ * If a dimension has been selected, the metric data object will contain subdimensions.
+ * This method calls for dimension ranking by metric, filters for the selected dimension,
+ * and returns a sorted list of graph-ready dimension objects.
+ * @method getTopDimensions
+ * @param {Object} dimensionObj - the object containing available subdimension for current metric
+ * @param {Array} scoredDimensions - array of dimensions scored by relevance
+ * @param {String} selectedDimension - the user-selected dimension to graph
+ * @return {RSVP Promise}
+ */
+export function getTopDimensions(dimensionObj = {}, scoredDimensions, selectedDimension) {
+  const maxSize = 5;
+  const colors = ['orange', 'teal', 'purple', 'red', 'green', 'pink'];
+  let dimensionList = [];
+  let colorIndex = 0;
+
+  if (selectedDimension) {
+    const filteredDimensions =  _.filter(scoredDimensions, (dimension) => {
+      return dimension.label.split('=')[0] === selectedDimension;
+    });
+    const topDimensions = filteredDimensions.sortBy('score').reverse().slice(0, maxSize);
+    const topDimensionLabels = [...new Set(topDimensions.map(key => key.label.split('=')[1]))];
+
+    // Build the array of subdimension objects for the selected dimension
+    topDimensionLabels.forEach((subDimension) => {
+      if (dimensionObj[subDimension] && subDimension !== '') {
+        dimensionList.push({
+          name: subDimension,
+          metricName: subDimension,
+          color: colors[colorIndex],
+          baselineValues: dimensionObj[subDimension].baselineValues,
+          currentValues: dimensionObj[subDimension].currentValues
+        });
+        colorIndex++;
+      }
+    });
+  }
+
+  // Return sorted list of dimension objects
+  return dimensionList;
+}
+
+/**
  * Data needed to render the stats 'cards' above the anomaly graph for a given alert
  * @param {Object} alertEvalMetrics - contains the alert's performance data
  * @param {String} mode - the originating route
+ * @param {String} severity - the severity threshold entered
+ * @param {Boolean} isPercent - suffix associated with the selected severity mode
  * @returns {Array}
  */
-export function buildAnomalyStats(alertEvalMetrics, mode) {
+export function buildAnomalyStats(alertEvalMetrics, mode, severity = '30', isPercent = true) {
   const tooltip = false;
+  const severityUnit = isPercent ? '%' : '';
 
   const responseRateObj = {
     title: 'Response Rate',
     key: 'responseRate',
     units: '%',
     tooltip,
+    hideProjected: true,
     text: '% of anomalies that are reviewed.'
   };
 
@@ -182,7 +237,7 @@ export function buildAnomalyStats(alertEvalMetrics, mode) {
       title: 'Number of anomalies',
       key: 'totalAlerts',
       text: 'Estimated average number of anomalies',
-      tooltip
+      tooltip,
     },
     {
       title: 'Precision',
@@ -199,11 +254,11 @@ export function buildAnomalyStats(alertEvalMetrics, mode) {
       text: 'Among all anomalies that happened, the % of them detected by the system.'
     },
     {
-      title: 'MTTD for >30% change',
+      title: `MTTD for > ${severity}${severityUnit} change`,
       key: 'mttd',
-      units: 'hours',
+      units: 'hrs',
       tooltip,
-      text: 'Minimum time to detect for anomalies with > 30% change'
+      text: `Minimum time to detect for anomalies with > ${severity}${severityUnit} change`
     }
   ];
 
@@ -212,16 +267,17 @@ export function buildAnomalyStats(alertEvalMetrics, mode) {
   }
 
   anomalyStats.forEach((stat) => {
-    let origData = alertEvalMetrics.evalData[stat.key];
+    let origData = alertEvalMetrics.current[stat.key];
     let newData = alertEvalMetrics.projected[stat.key];
-    stat.value = formatEvalMetric(origData);
-    stat.projected = formatEvalMetric(newData);
-    if (stat.units) {
-      stat.valueUnits = isNaN(origData) ? null : stat.units;
-      stat.projectedUnits = isNaN(newData) ? null : stat.units;
-      stat.showDirectionIcon = !isNaN(origData) && !isNaN(newData) && origData !== newData;
-      stat.direction = stat.showDirectionIcon && origData > newData ? 'bottom' : 'top';
-    }
+    let isPercentageMetric = stat.units === '%';
+    let isTotal = stat.key === 'totalAlerts';
+    stat.showProjected = mode === 'explore';
+    stat.value = isTotal ? origData : formatEvalMetric(origData, isPercentageMetric);
+    stat.projected = isTotal ? newData : formatEvalMetric(newData, isPercentageMetric);
+    stat.valueUnits = isFinite(origData) ? stat.units : null;
+    stat.projectedUnits = isFinite(newData) ? stat.units : null;
+    stat.showDirectionIcon = isFinite(origData) && isFinite(newData) && origData !== newData;
+    stat.direction = stat.showDirectionIcon && origData > newData ? 'bottom' : 'top';
   });
 
   return anomalyStats;
@@ -232,6 +288,7 @@ export default helper(
   toIdGroups,
   pluralizeTime,
   enhanceAnomalies,
+  getTopDimensions,
   setUpTimeRangeOptions,
   buildAnomalyStats,
   evalObj

--- a/thirdeye/thirdeye-frontend/app/helpers/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/manage-alert-utils.js
@@ -8,16 +8,12 @@ import moment from 'moment';
  * @returns {Object}
  */
 export function formatEvalMetric(metric, isPercentage = false) {
-  const isWhole = Number(metric) % 1 === 0;
+  const isWhole = Number.isInteger(Number(metric));
   let shown = (metric === 'Infinity') ? metric : 'N/A';
-  if (isFinite(metric)) {
-    if (isPercentage) {
-      shown = isWhole ? metric * 100 : (metric * 100).toFixed(1);
-    } else {
-      shown = isWhole ? metric : metric.toFixed(1);
-    }
-  }
-  return shown;
+  const multiplier = isPercentage ? 100 : 1;
+  const convertedNum = metric * multiplier;
+  const formattedNum = isWhole ? convertedNum : convertedNum.toFixed(1);
+  return isFinite(metric) ? formattedNum : shown;
 }
 
 /**
@@ -237,7 +233,7 @@ export function buildAnomalyStats(alertEvalMetrics, mode, severity = '30', isPer
       title: 'Number of anomalies',
       key: 'totalAlerts',
       text: 'Estimated average number of anomalies',
-      tooltip,
+      tooltip
     },
     {
       title: 'Precision',

--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -580,7 +580,6 @@ export default Ember.Helper.helper({
   metricColors,
   colorMapping,
   eventColorMapping,
-  buildDateEod,
   parseProps,
   postProps,
   toIso

--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/component.js
@@ -29,19 +29,22 @@
  * @author smcclung
  */
 
-import Ember from 'ember';
-import _ from 'lodash';
+import moment from 'moment';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
 
-export default Ember.Component.extend({
+export default Component.extend({
   containerClassNames: 'alert-report-modal',
   isNewTrend: false,
+  showTimePicker: true,
+  timePickerIncrement: 30,
 
   /**
    * Collects all input data for the post request
    * @method reportAnomalyPayload
    * @return {Object} Post data
    */
-  reportAnomalyPayload: Ember.computed(
+  reportAnomalyPayload: computed(
     'isNewTrend',
     'anomalyComments',
     'selectedDimension',
@@ -50,8 +53,8 @@ export default Ember.Component.extend({
     'anomalyLinks',
     function() {
       const postObj = {
-        startTime: this.get('viewAnomalyStart'),
-        endTime: this.get('viewAnomalyEnd'),
+        startTime: moment(this.get('viewAnomalyStart')).utc().valueOf(),
+        endTime: moment(this.get('viewAnomalyEnd')).utc().valueOf(),
         feedbackType: this.get('isNewTrend') ? 'ANOMALY_NEW_TREND' : 'ANOMALY',
         dimension: this.get('selectedDimension') || null,
         comment: this.get('anomalyComments') || null,

--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
@@ -55,7 +55,6 @@
         id="date-picker"
         parentEl=".te-modal"
         timePicker=showTimePicker
-        timePicker24Hour=true
         timePickerIncrement=timePickerIncrement
         maxDate=maxTime
         start=viewAnomalyStart

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-stats-block/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-stats-block/component.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  classNames: ['te-horizontal-cards__container']
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-stats-block/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-stats-block/template.hbs
@@ -1,0 +1,53 @@
+{{#each anomalyStats as |card|}}
+  <ul class="te-horizontal-cards__card">
+
+    <li class="te-horizontal-cards">
+      <div class="te-horizontal-cards__card-title">{{card.title}}</div>
+      {{#if card.tooltip}}
+        <div class="te-horizontal-cards__card-tooltip">
+          <span>
+            <i class="glyphicon glyphicon-question-sign"></i>
+            {{#tooltip-on-element}}{{card.text}}{{/tooltip-on-element}}
+          </span>
+        </div>
+      {{else}}
+        <div class="te-horizontal-cards__card-text">{{card.text}}</div>
+      {{/if}}
+    </li>
+
+    <li class="te-horizontal-cards__card-value">
+      <div class="te-horizontal-cards__val-group">
+        {{#if isTunePreviewActive}}
+          <div class="te-horizontal-cards__card-subt">Current</div>
+        {{/if}}
+        <div class="te-horizontal-cards__card-number">
+          {{card.value}}
+          {{#if card.valueUnits}}
+            <span class="te-horizontal-cards__card-units">{{card.valueUnits}}</span>
+          {{/if}}
+        </div>
+        {{#if card.showProjected}}
+          <div class="te-horizontal-cards__card-subt {{if card.hideProjected "te-horizontal-cards--hidden"}}">Projected: <span class="te-horizontal-cards__card-subt--stronger">{{card.projected}}{{if card.projectedUnits card.projectedUnits}}</span></div>
+        {{/if}}
+      </div>
+      {{#if isTunePreviewActive}}
+        <div class="te-horizontal-cards__val-group">
+          <i class="te-horizontal-cards__val-glyph--middle glyphicon glyphicon-menu-right"></i>
+        </div>
+        <div class="te-horizontal-cards__val-group">
+          <div class="te-horizontal-cards__card-subt">New</div>
+          <div class="te-horizontal-cards__card-number">
+            {{#if card.showDirectionIcon}}
+              <i class="te-horizontal-cards__val-glyph--right glyphicon glyphicon-triangle-{{card.direction}}"></i>
+            {{/if}}
+            {{card.projected}}
+            {{#if card.projectedUnits}}
+              <span class="te-horizontal-cards__card-units">{{card.projectedUnits}}</span>
+            {{/if}}
+          </div>
+        </div>
+      {{/if}}
+    </li>
+
+  </ul>
+{{/each}}


### PR DESCRIPTION
This includes changes to helper functions (utils) used across Self-Serve as well as supporting components:
- alert-report-modal (report missing anomaly)
- anomaly-stats-block (area where performance metrics are displayed)

<img width="1139" alt="screen shot 2018-01-15 at 6 15 21 pm" src="https://user-images.githubusercontent.com/11814420/35126375-fd3f0120-fc61-11e7-98c3-a547efb0f252.png">
