### PR TITLE
[TE] allow for more granular timestamp in x axis

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -105,8 +105,7 @@ export default Ember.Component.extend({
           min: analysisRange[0],
           max: analysisRange[1],
           tick: {
-            count: Math.ceil(moment.duration(analysisRange[1] - analysisRange[0]).asDays()),
-            format: '%Y-%m-%d'
+            fit: false
           }
         }
       };


### PR DESCRIPTION
### What's new: 
- removed fixed tick in favor of dynamic ticks. As the user zooms in, the timestamp values should become more and more granular
![screen shot 2018-01-19 at 3 59 30 pm](https://user-images.githubusercontent.com/8664954/35177112-0940ada4-fd32-11e7-9fb2-38806786e6e2.png)
![screen shot 2018-01-19 at 3 59 25 pm](https://user-images.githubusercontent.com/8664954/35177111-092a3a92-fd32-11e7-9d65-8cd4d3783db4.png)
![screen shot 2018-01-19 at 3 59 20 pm](https://user-images.githubusercontent.com/8664954/35177110-09163a7e-fd32-11e7-8d4e-3d7ae82a57a5.png)

