### PR TITLE
[TE] Self-Serve tuning flow 03: preparing create-alert for new flow

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -4,7 +4,6 @@
  * @exports create
  */
 import fetch from 'fetch';
-import Ember from 'ember';
 import moment from 'moment';
 import _ from 'lodash';
 import Controller from '@ember/controller';
@@ -456,8 +455,10 @@ export default Controller.extend({
     this.fetchAnomalyGraphData(graphConfig).then(metricData => {
       if (!this.isMetricGraphable(metricData)) {
         // Metric has no data. not graphing
-        this.clearAll();
-        this.set('isMetricDataInvalid', true);
+        this.setProperties({
+          isMetricDataInvalid: true,
+          isMetricDataLoading: false
+        });
       } else {
         // Dimensions are selected. Compile, rank, and send them to the graph.
         if(selectedDimension) {
@@ -1063,7 +1064,6 @@ export default Controller.extend({
      * @return {undefined}
      */
     onSelectGranularity(selectedObj) {
-      console.log('newUx: ', this.get('isNewUx'));
       this.setProperties({
         selectedGranularity: selectedObj,
         isMetricDataLoading: true

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -7,10 +7,17 @@ import fetch from 'fetch';
 import Ember from 'ember';
 import moment from 'moment';
 import _ from 'lodash';
-import { checkStatus, buildDateEod } from 'thirdeye-frontend/helpers/utils';
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
+import { checkStatus, buildDateEod } from 'thirdeye-frontend/helpers/utils';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
+  /**
+   * Be ready to receive trigger for loading new ux with redirect to alert page
+   */
+  queryParams: ['newUx'],
+  newUx: null,
 
   /**
    * Initialized alert creation page settings
@@ -54,7 +61,7 @@ export default Ember.Controller.extend({
   /**
    * Change this to activate new alert anomaly page redirect
    */
-  redirectToAlertPage: true,
+  isNewUx: Ember.computed.reads('model.isNewUx'),
 
   /**
    * Component property initial settings
@@ -121,14 +128,76 @@ export default Ember.Controller.extend({
       'Robust (Low)': 'LOW',
       'Medium': 'MEDIUM',
       'Sensitive (High)': 'HIGH'
+    },
+    severity: {
+      'Percentage of Change': 'weight',
+      'Absolute Value of Change': 'deviation'
     }
   },
+
+  /**
+   * Severity display options (power-select) and values
+   * @type {Object}
+   */
+  tuneSeverityOptions: computed(
+    'optionMap.severity',
+    function() {
+      const severityOptions = Object.keys(this.get('optionMap.severity'));
+      return severityOptions;
+    }
+  ),
+
+  /**
+   * Conditionally display '%' based on selected severity option
+   * @type {String}
+   */
+  sensitivityUnits: computed('selectedSeverityOption', function() {
+    const chosenSeverity = this.get('selectedSeverityOption');
+    const isNotPercent = chosenSeverity && chosenSeverity.includes('Absolute');
+    return isNotPercent ? '' : '%';
+  }),
+
+  /**
+   * Builds the new autotune filter from custom tuning options
+   * @type {String}
+   */
+  alertFilterObj: computed(
+    'selectedSeverityOption',
+    'customPercentChange',
+    'customMttdChange',
+    'selectedPattern',
+    function() {
+      const {
+        severity: severityMap,
+        pattern: patternMap
+      } = this.getProperties('optionMap');
+
+      const {
+        selectedPattern,
+        customMttdChange,
+        customPercentChange,
+        selectedSeverityOption: selectedSeverity
+      } = this.getProperties('selectedPattern', 'customMttdChange', 'customPercentChange', 'selectedSeverityOption');
+
+      const mttdVal = Number(customMttdChange).toFixed(2);
+      const severityThresholdVal = (Number(customPercentChange)/100).toFixed(2);
+      const featureString = `window_size_in_hour,${severityMap[selectedSeverity]}`;
+      const mttdString = `window_size_in_hour=${mttdVal};${severityMap[selectedSeverity]}=${severityThresholdVal}`;
+      const patternString = patternMap[selectedPattern] ? `&pattern=${encodeURIComponent(patternMap[selectedPattern])}` : '';
+      const finalStr = `&features=${encodeURIComponent(featureString)}&mttd=${encodeURIComponent(mttdString)}${patternString}`;
+      return {
+        features: featureString,
+        mttd: mttdString,
+        pattern: patternString
+      };
+    }
+  ),
 
   /**
    * All selected dimensions to be loaded into graph
    * @returns {Array}
    */
-  selectedDimensions: Ember.computed(
+  selectedDimensions: computed(
     'topDimensions',
     'topDimensions.@each.isSelected',
     function() {
@@ -140,7 +209,7 @@ export default Ember.Controller.extend({
    * Setting default sensitivity if selectedSensitivity is undefined
    * @returns {String}
    */
-  sensitivityWithDefault: Ember.computed(
+  sensitivityWithDefault: computed(
     'selectedSensitivity',
     'selectedGranularity',
     function() {
@@ -449,7 +518,7 @@ export default Ember.Controller.extend({
           topDimensions = filteredDimensions.sortBy('score').reverse().slice(0, maxSize);
           topDimensionLabels = [...new Set(topDimensions.map(key => key.label.split('=')[1]))];
           // Build the array of subdimension objects for the selected dimension
-          for(let subDimension of topDimensionLabels){
+          for (let subDimension of topDimensionLabels) {
             if (subDimension && dimensionObj[subDimension]) {
               dimensionList.push({
                 name: subDimension,
@@ -577,7 +646,7 @@ export default Ember.Controller.extend({
    * @method isAlertGroupEditModeActive
    * @return {Boolean}
    */
-  isAlertGroupEditModeActive: Ember.computed(
+  isAlertGroupEditModeActive: computed(
     'selectedConfigGroup',
     'newConfigGroupName',
     function() {
@@ -590,7 +659,7 @@ export default Ember.Controller.extend({
    * @method isFilterSelectDisabled
    * @return {Boolean}
    */
-  isFilterSelectDisabled: Ember.computed(
+  isFilterSelectDisabled: computed(
     'filters',
     'isMetricSelected',
     function() {
@@ -603,7 +672,7 @@ export default Ember.Controller.extend({
    * @method isGranularitySelectDisabled
    * @return {Boolean}
    */
-  isGranularitySelectDisabled: Ember.computed(
+  isGranularitySelectDisabled: computed(
     'granularities',
     'isMetricSelected',
     function() {
@@ -617,7 +686,7 @@ export default Ember.Controller.extend({
    * @param {Number} metricId - Id of selected metric to graph
    * @return {Boolean} PreventSubmit
    */
-  isSubmitDisabled: Ember.computed(
+  isSubmitDisabled: computed(
     'selectedMetricOption',
     'selectedPattern',
     'selectedWeeklyEffect',
@@ -697,7 +766,7 @@ export default Ember.Controller.extend({
    * @param {Object} selectedMetricOption - the selected metric's properties
    * @return {Object} New function object
    */
-  newAlertProperties: Ember.computed(
+  newAlertProperties: computed(
     'alertFunctionName',
     'selectedMetricOption',
     'selectedDimension',
@@ -783,7 +852,7 @@ export default Ember.Controller.extend({
    * @param {Object} selectedApplication - user-selected application object
    * @return {Array} activeGroups - filtered list of groups that are active
    */
-  filteredConfigGroups: Ember.computed(
+  filteredConfigGroups: computed(
     'selectedApplication',
     function() {
       const appName = this.get('selectedApplication');
@@ -803,7 +872,7 @@ export default Ember.Controller.extend({
    * @method graphMessageText
    * @return {String} the appropriate graph placeholder text
    */
-  graphMessageText: Ember.computed(
+  graphMessageText: computed(
     'isMetricDataInvalid',
     function() {
       const defaultMsg = 'Once a metric is selected, the metric replay graph will show here';
@@ -817,7 +886,7 @@ export default Ember.Controller.extend({
    * @method graphMailtoLink
    * @return {String} the URI-encoded mailto link
    */
-  graphMailtoLink: Ember.computed(
+  graphMailtoLink: computed(
     'selectedMetricOption',
     function() {
       const selectedMetric = this.get('selectedMetricOption');
@@ -835,7 +904,7 @@ export default Ember.Controller.extend({
    * @method selectedConfigGroupSubtitle
    * @return {String} title of expandable section for selected config group
    */
-  selectedConfigGroupSubtitle: Ember.computed(
+  selectedConfigGroupSubtitle: computed(
     'selectedConfigGroup',
     function () {
       return `Alerts Monitored by: ${this.get('selectedConfigGroup.name')}`;
@@ -989,6 +1058,7 @@ export default Ember.Controller.extend({
      * @return {undefined}
      */
     onSelectGranularity(selectedObj) {
+      console.log('newUx: ', this.get('isNewUx'));
       this.setProperties({
         selectedGranularity: selectedObj,
         isMetricDataLoading: true
@@ -1163,7 +1233,7 @@ export default Ember.Controller.extend({
         alertGroupNewRecipient: newEmails
       } = this.getProperties('newAlertProperties', 'selectedGroupRecipients', 'alertGroupNewRecipient');
 
-      const redirectToAlertPage = this.get('redirectToAlertPage');
+      const redirectToAlertPage = this.get('isNewUx');
       const newEmailsArr = newEmails ? newEmails.replace(/ /g, '').split(',') : [];
       const existingEmailsArr = oldEmails ? oldEmails.replace(/ /g, '').split(',') : [];
       const newRecipientsArr = newEmailsArr.length ? existingEmailsArr.concat(newEmailsArr) : existingEmailsArr;
@@ -1241,7 +1311,9 @@ export default Ember.Controller.extend({
           }
 
           // Redirect to onboarding page to trigger wrapper
-          this.transitionToRoute('manage.alert', this.get('newFuncId'), { queryParams: { replayId }});
+          if (redirectToAlertPage) {
+            this.transitionToRoute('manage.alert', this.get('newFuncId'), { queryParams: { replayId }});
+          }
         // If Alert Group edit/create fails, remove the orphaned anomaly Id
         }).catch((error) => {
           this.setAlertCreateErrorState(error);

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
@@ -8,6 +8,12 @@ import fetch from 'fetch';
 import RSVP from 'rsvp';
 
 export default Ember.Route.extend({
+  queryParams: {
+    newUx: {
+      refreshModel: false,
+      replace: true
+    }
+  },
 
   actions: {
     /**
@@ -25,9 +31,10 @@ export default Ember.Route.extend({
    * @method model
    * @return {Object}
    */
-  model() {
+  model(params, transition) {
     return RSVP.hash({
       // Fetch all alert group configurations
+      isNewUx: transition.queryParams.newUx || false,
       allConfigGroups: fetch('/thirdeye/entity/ALERT_CONFIG').then(res => res.json()),
       allAppNames: fetch('/thirdeye/entity/APPLICATION').then(res => res.json())
     });

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -116,19 +116,21 @@
         {{/if}}
       </div>
     </div>
+
   </fieldset>
 
   <fieldset class="te-form__section row">
     <div class="col-xs-12">
       <legend class="te-form__section-title">Detection Configuration</legend>
     </div>
+
     {{!-- Field: Pattern --}}
-    <div class="col-xs-{{if isNewUx '4' '6'}}">
+    <div class="col-xs-{{if isNewUx '3' '6'}}">
       <label for="select-pattern" class="control-label te-label required">Pattern of Interest *</label>
       {{#power-select
         loadingMessage="Waiting for the server...."
         triggerId="select-pattern"
-        triggerClass="te-form__select {{if isNewUx 'col-xs-4'}}"
+        triggerClass="te-form__select"
         placeholder="Select a Pattern"
         loadingMessage="Please select a metric first"
         options=patternsOfInterest
@@ -143,12 +145,10 @@
       {{/power-select}}
     </div>
 
-    {{!-- Field: Sensitivity --}}
+    {{!-- Field: Sensitivity with mode option --}}
     {{#if isNewUx}}
       <div class="te-form__vertical-block col-xs-12">
-        <label for="select-sensitivity" class="control-label te-label required">
-          Sensitivity (optional)
-        </label>
+        <label for="select-sensitivity" class="control-label te-label required">Sensitivity (optional)</label>
         <div class="te-form__indent-block--custom">
           <span class="te-form__list-label">When</span>
           <div class="te-form__tune-field">
@@ -192,7 +192,7 @@
         </div>
       </div>
     {{else}}
-      <div class="form-group col-xs-6">
+      <div class="col-xs-6">
         <label for="select-sensitivity" class="control-label te-label required">
           Sensitivity (optional)
           <span>
@@ -217,7 +217,6 @@
           required=true
           as |sensitivity|
         }}
-
           {{sensitivity}}
         {{/power-select}}
       </div>

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -5,7 +5,7 @@
     <div class="col-xs-12">
       <legend class="te-form__section-title">Metric Details</legend>
     </div>
-    <div class="form-group col-xs-12 col-sm-8">
+    <div class="col-xs-12 col-sm-8">
       <div class="te-page__right te-page__right--inside">
         {{#link-to "self-serve.import-metric" class="thirdeye-link-secondary thirdeye-link-secondary--inside"}}
           Import a Metric From InGraphs
@@ -34,7 +34,7 @@
       {{/bs-alert}}
     {{/if}}
 
-    <div class="form-group col-xs-6 col-sm-4">
+    <div class="col-xs-6 col-sm-4">
       <label for="select-granularity" class="control-label te-label">Desired Granularity</label>
       {{#power-select
         options=metricGranularityOptions
@@ -51,7 +51,7 @@
       {{/power-select}}
     </div>
 
-    <div class="form-group col-xs-6">
+    <div class="col-xs-6">
       <label for="select-filters" class="control-label te-label required">Filters (optional)</label>
       {{filter-select
         options=filters
@@ -62,7 +62,7 @@
       }}
     </div>
 
-    <div class="form-group col-xs-6">
+    <div class="col-xs-6">
       <label for="select-dimension" class="control-label te-label">Dimension (optional)</label>
       {{#power-select
         classNames="te-input"
@@ -100,7 +100,6 @@
             showLegend=true
             enableZoom=true
             componentId='create-alert'
-            showGraphLegend=showGraphLegend
             showGraphLegend=false
             onSelection=(action "onSelection")
             onPrimaryMetricToggle=(action "onPrimaryMetricToggle")
@@ -119,17 +118,17 @@
     </div>
   </fieldset>
 
-  <fieldset class="te-form__se  ction row">
+  <fieldset class="te-form__section row">
     <div class="col-xs-12">
       <legend class="te-form__section-title">Detection Configuration</legend>
     </div>
     {{!-- Field: Pattern --}}
-    <div class="form-group col-xs-6">
+    <div class="col-xs-{{if isNewUx '4' '6'}}">
       <label for="select-pattern" class="control-label te-label required">Pattern of Interest *</label>
       {{#power-select
         loadingMessage="Waiting for the server...."
         triggerId="select-pattern"
-        triggerClass="te-form__select"
+        triggerClass="te-form__select {{if isNewUx 'col-xs-4'}}"
         placeholder="Select a Pattern"
         loadingMessage="Please select a metric first"
         options=patternsOfInterest
@@ -145,39 +144,88 @@
     </div>
 
     {{!-- Field: Sensitivity --}}
-    <div class="form-group col-xs-6">
-      <label for="select-sensitivity" class="control-label te-label required">
-        Sensitivity (optional)
-        <span>
-          <i class="glyphicon glyphicon-question-sign"></i>
-          {{#tooltip-on-element class="te-tooltip"}}
-            How sensitive do you want your alert to be? "Sensitive" sends emails for most anomalies. "Robust" only sends emails for the strongest anomalies. You can always see the full list of anomalies on ThirdEye.
-          {{/tooltip-on-element}}
-        </span>
-      </label>
-      {{#power-select
-        loadingMessage="Waiting for the server...."
-        triggerId="select-sensitivity"
-        triggerClass="te-form__select"
-        placeholder="Select a sensitivity"
-        loadingMessage="Please select a metric first"
-        options=sensitivityOptions
-        allowClear=true
-        searchEnabled=false
-        selected=selectedSensitivity
-        onchange=(action (mut selectedSensitivity))
-        disabled=(not isMetricSelected)
-        required=true
-        as |sensitivity|
-      }}
+    {{#if isNewUx}}
+      <div class="te-form__vertical-block col-xs-12">
+        <label for="select-sensitivity" class="control-label te-label required">
+          Sensitivity (optional)
+        </label>
+        <div class="te-form__indent-block--custom">
+          <span class="te-form__list-label">When</span>
+          <div class="te-form__tune-field">
+            {{#power-select
+              triggerId="alert-tune-severity"
+              triggerClass="te-form__tune-field"
+              verticalPosition="below"
+              placeholder="Select a severity"
+              options=tuneSeverityOptions
+              searchEnabled=false
+              selected=selectedSeverityOption
+              onchange=(action (mut selectedSeverityOption))
+              disabled=(not isMetricSelected)
+              as |severity|
+            }}
+              {{severity}}
+            {{/power-select}}
+          </div>
+          <span class="te-form__list-label">is >=</span>
+          <div class="te-form__tune-field te-form__tune-field--amount">
+            {{input
+              type="text"
+              id="custom-tune-percent"
+              class="form-control te-input te-input"
+              value=customPercentChange
+              disabled=(not isMetricSelected)
+            }}
+          </div>
+          <span class="te-form__list-label--suffix">{{sensitivityUnits}}, </span>
+          <span class="te-form__list-label">MTTD should be no more than</span>
+          <div class="te-form__tune-field te-form__tune-field--amount">
+            {{input
+              type="text"
+              id="custom-tune-mttd"
+              class="form-control te-input"
+              value=customMttdChange
+              disabled=(not isMetricSelected)
+            }}
+          </div>
+          <span class="te-form__list-label">hours</span>
+        </div>
+      </div>
+    {{else}}
+      <div class="form-group col-xs-6">
+        <label for="select-sensitivity" class="control-label te-label required">
+          Sensitivity (optional)
+          <span>
+            <i class="glyphicon glyphicon-question-sign"></i>
+            {{#tooltip-on-element class="te-tooltip"}}
+              How sensitive do you want your alert to be? "Sensitive" sends emails for most anomalies. "Robust" only sends emails for the strongest anomalies. You can always see the full list of anomalies on ThirdEye.
+            {{/tooltip-on-element}}
+          </span>
+        </label>
+        {{#power-select
+          loadingMessage="Waiting for the server...."
+          triggerId="select-sensitivity"
+          triggerClass="te-form__select"
+          placeholder="Select a sensitivity"
+          loadingMessage="Please select a metric first"
+          options=sensitivityOptions
+          allowClear=true
+          searchEnabled=false
+          selected=selectedSensitivity
+          onchange=(action (mut selectedSensitivity))
+          disabled=(not isMetricSelected)
+          required=true
+          as |sensitivity|
+        }}
 
-        {{sensitivity}}
-      {{/power-select}}
-    </div>
+          {{sensitivity}}
+        {{/power-select}}
+      </div>
+    {{/if}}
 
     {{!-- Field: Weekly Effect --}}
     {{#if (eq selectedGranularity 'DAYS')}}
-      <div class="form-group col-xs-6">
+      <div class="col-xs-6">
         <label for="select-effect" class="control-label te-label required">
           Weekly Seasonality *
           <span>
@@ -212,7 +260,7 @@
     </div>
 
     {{!-- Field: Alert Name --}}
-    <div class="form-group col-xs-12">
+    <div class="col-xs-12">
       <label for="anomaly-form-function-name" class="control-label te-label required">
         Alert Name *
         <div class="te-form__sub-label">Please follow this naming convention: <span class="te-form__sub-label--strong">productName_metricName_dimensionName_other</span></div>
@@ -233,7 +281,7 @@
     </div>
 
     {{!-- Field: App Name --}}
-    <div class="form-group col-xs-12">
+    <div class="col-xs-12">
       <label for="anomaly-form-app-name" class="control-label te-label required">Related Application, Product or Team *</label>
        {{#power-select
           options=allApplicationNames
@@ -253,7 +301,7 @@
     </div>
 
     {{!-- Field: Select Existing Subscription Group --}}
-    <div class="form-group col-sm-6">
+    <div class="col-sm-6">
       <label for="config-group" class="control-label te-label">Add This Alert To An Existing Subscription Group</label>
       {{#power-select
         options=filteredConfigGroups
@@ -273,7 +321,7 @@
       {{/power-select}}
     </div>
     {{!--  Fields for new alert group creation --}}
-    <div class="form-group col-sm-6">
+    <div class="col-sm-6">
       <label for="config-group-new-name" class="control-label te-label"><strong>Or</strong> Provide A New Subscription Group Name</label>
       {{#if isGroupNameDuplicate}}
         <div class="te-form__alert--warning alert-warning">Warning: <strong>{{newConfigGroupName}}</strong> already exists. Please try another name.</div>
@@ -291,7 +339,7 @@
     </div>
     {{!-- Alert Group Metadata --}}
     {{#if selectedConfigGroup}}
-      <div class="form-group col-xs-12">
+      <div class="col-xs-12">
         {{#if selectedGroupFunctions.length}}
           {{#bs-accordion as |acc|}}
             {{#acc.item class="te-form__custom-label" title=selectedConfigGroupSubtitle}}
@@ -310,7 +358,7 @@
       </div>
     {{/if}}
     {{!-- Field: new alert group recipient emails --}}
-    <div class="form-group col-xs-12">
+    <div class="col-xs-12">
       <label for="config-group" class="control-label te-label">
         Add Alert Notification Recipients *
         <div class="te-form__sub-label">Current recipients: <span class="te-form__sub-label--strong">{{if selectedGroupRecipients selectedGroupRecipients "None"}}</span></div>


### PR DESCRIPTION
For Create Alert, we will want to redirect to the Alert Page once its deployed. We will also want to change the way we trigger the alert function creation as well as replay (new API in progress). I added the new computed `alertFilterObj` to build the sensitivity settings for our new auto-tuning API into the filter object.