### PR TITLE
Read all certificates from certification authority file.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpsSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpsSegmentFetcher.java
@@ -21,7 +21,6 @@ import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.math.BigInteger;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -106,9 +105,9 @@ public class HttpsSegmentFetcher extends HttpSegmentFetcher {
       FileInputStream is = new FileInputStream(new File(serverCACertFile));
       KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
       trustStore.load(null);
+      CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE);
       int i = 0;
       while (is.available() > 0) {
-        CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE);
         X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(is);
         _logger.info("Read certificate serial number {} by issuer {} ", cert.getSerialNumber().toString(16), cert.getIssuerDN().toString());
 


### PR DESCRIPTION
We were reading only the first certificate from the certification authority file, which resulted in
some servers not getting recognized by the trust store. We need to read all certificates present
and populate the trust store.