### PR TITLE
[TE] Self-Serve tuning flow 04: Alert page overview

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/alert-report-modal/template.hbs
@@ -69,42 +69,15 @@
   </fieldset>
 
   <fieldset class="te-form__section row">
-    {{#if isSelectMetricError}}
-      {{#bs-alert type="danger"}}
-        <strong>{{selectMetricErrMsg}}</strong> Unable to fetch data for this metric.
-      {{/bs-alert}}
-    {{/if}}
-
-    <div class="col-xs-12">
-      <div class="te-graph-alert {{if (not isMetricSelected) 'te-graph-alert--pending'}}">
-        {{#if isMetricDataLoading}}
-          <div class="spinner-wrapper--self-serve">{{ember-spinner}}</div>
-        {{/if}}
-        {{#if isMetricSelected}}
-          {{anomaly-graph
-            primaryMetric=selectedMetric
-            selectedDimensions=selectedDimensions
-            dimensions=topDimensions
-            showDimensions=true
-            isLoading=loading
-            showSubchart=true
-            showLegend=true
-            enableZoom=true
-            componentId='create-alert'
-            showGraphLegend=showGraphLegend
-            showGraphLegend=false
-            onSelection=(action "onSelection")
-            onPrimaryMetricToggle=(action "onPrimaryMetricToggle")
-            height=400
-          }}
-        {{else}}
-          <div class="te-graph-alert__content">
-            <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
-            <p class="te-graph-alert__pre-text">{{graphMessageText}}</p>
-          </div>
-        {{/if}}
-      </div>
-    </div>
+    {{self-serve-graph
+      isMetricDataLoading=false
+      isMetricDataInvalid=isMetricDataInvalid
+      isDimensionFetchDone=true
+      isMetricSelected=true
+      metricData=metricData
+      topDimensions=topDimensions
+      componentId='report-anomaly'
+    }}
   </fieldset>
 
   <fieldset class="te-form__section row">

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/component.js
@@ -1,0 +1,80 @@
+/*    {{self-serve-graph
+      isMetricDataLoading=isMetricDataLoading
+      isMetricDataInvalid=isMetricDataInvalid
+      isDimensionFetchDone=isDimensionFetchDone
+      isMetricSelected=isMetricSelected
+      metricData=metricData
+      topDimensions=topDimensions
+      componentId='create-alert'
+    }}*/
+
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+
+isMetricDataLoading: true,
+isMetricDataInvalid: false,
+isDimensionFetchDone: false,
+metricData: {},
+topDimensions: [],
+componentId: '',
+
+graphMessageText: {
+  loading: 'Graph will appear here when data is loaded...',
+  error: 'Could not load graph data for this metric...'
+},
+
+/**
+ * Standard legend settings for graph
+ */
+legendText: {
+  dotted: {
+    text: 'WoW'
+  },
+  solid: {
+    text: 'Observed'
+  }
+},
+
+/**
+ * All selected dimensions to be loaded into graph
+ * @returns {Array}
+ */
+selectedDimensions: computed(
+  'topDimensions',
+  'topDimensions.@each.isSelected',
+  function() {
+    console.log('topDimensions : ', topDimensions);
+    const topDimensions = this.get('topDimensions');
+    return topDimensions ? this.get('topDimensions').filterBy('isSelected') : [];
+  }
+),
+
+didReceiveAttrs() {
+    this._super(...arguments);
+
+
+
+},
+
+actions: {
+    /**
+     * Enable reaction to dimension toggling in graph legend component
+     * @method onSelection
+     * @return {undefined}
+     */
+    onSelection(selectedDimension) {
+      const { isSelected } = selectedDimension;
+      Ember.set(selectedDimension, 'isSelected', !isSelected);
+    },
+
+    /**
+     * Handles the primary metric selection in the alert creation
+     */
+    onPrimaryMetricToggle() {
+      return;
+    }
+}
+
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/component.js
@@ -1,12 +1,25 @@
-/*    {{self-serve-graph
-      isMetricDataLoading=isMetricDataLoading
-      isMetricDataInvalid=isMetricDataInvalid
-      isDimensionFetchDone=isDimensionFetchDone
-      isMetricSelected=isMetricSelected
+/**
+ * Wrapper component for the anomaly-graph component as used in the self-serve flow.
+ * It handles presentation of the graph under various loading and error conditions.
+ * @module components/self-serve-graph
+ * @property {Boolean} isMetricDataLoading  - is primary metric data still loading
+ * @property {Boolean} isMetricDataInvalid  - has the metric data been found to be not graphable
+ * @property {Boolean} isDimensionFetchDone - are we done preparing dimension data
+ * @property {Object} metricData            - primary metric data
+ * @property {Array} topDimensions          - top x dimensions to load aside from primary metric
+ * @property {String} componentId           - id for the graph wrapper element
+ * @example
+    {{self-serve-graph
+      isMetricDataLoading=false
+      isMetricDataInvalid=false
+      isDimensionFetchDone=false
       metricData=metricData
       topDimensions=topDimensions
       componentId='create-alert'
-    }}*/
+    }}
+ * @exports self-serve-graph
+ * @author smcclung
+ */
 
 import Component from '@ember/component';
 import { computed } from '@ember/object';
@@ -45,18 +58,10 @@ selectedDimensions: computed(
   'topDimensions',
   'topDimensions.@each.isSelected',
   function() {
-    console.log('topDimensions : ', topDimensions);
     const topDimensions = this.get('topDimensions');
     return topDimensions ? this.get('topDimensions').filterBy('isSelected') : [];
   }
 ),
-
-didReceiveAttrs() {
-    this._super(...arguments);
-
-
-
-},
 
 actions: {
     /**
@@ -67,13 +72,6 @@ actions: {
     onSelection(selectedDimension) {
       const { isSelected } = selectedDimension;
       Ember.set(selectedDimension, 'isSelected', !isSelected);
-    },
-
-    /**
-     * Handles the primary metric selection in the alert creation
-     */
-    onPrimaryMetricToggle() {
-      return;
     }
 }
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
@@ -4,7 +4,7 @@
       <div class="te-form__super-label">...Displaying top 5 contributing subDimensions for <strong>{{alertDimension}}</strong></div>
     {{/if}}
     {{#if isMetricDataLoading}}
-        <div class="spinner-wrapper--self-serve">{{ember-spinner}}</div>
+      <div class="spinner-wrapper-self-serve">{{ember-spinner}}</div>
       <div class="te-graph-alert__content">
         <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
         <p class="te-graph-alert__pre-text">{{graphMessageText.loading}}</p>
@@ -24,7 +24,6 @@
           componentId=componentId
           showGraphLegend=false
           onSelection=(action "onSelection")
-          onPrimaryMetricToggle=(action "onPrimaryMetricToggle")
         }}
         <div class="te-form__note">
           NOTE: If you find the metric shown above is inconsistent, please email <a class="thirdeye-link-secondary" target="_blank" href="{{graphMailtoLink}}">ask_thirdeye</a>.

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
@@ -1,0 +1,40 @@
+<div class="col-xs-12 te-graph-container">
+  <div class="te-graph-alert {{if (or isMetricDataLoading isMetricDataInvalid) 'te-graph-alert--pending'}}">
+    {{#if isDimensionFetchDone}}
+      <div class="te-form__super-label">...Displaying top 5 contributing subDimensions for <strong>{{alertDimension}}</strong></div>
+    {{/if}}
+    {{#if isMetricDataLoading}}
+        <div class="spinner-wrapper--self-serve">{{ember-spinner}}</div>
+      <div class="te-graph-alert__content">
+        <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
+        <p class="te-graph-alert__pre-text">{{graphMessageText.loading}}</p>
+      </div>
+    {{else}}
+      {{#if (not isMetricDataInvalid)}}
+        {{anomaly-graph
+          primaryMetric=metricData
+          selectedDimensions=selectedDimensions
+          dimensions=topDimensions
+          showDimensions=true
+          isLoading=loading
+          showSubchart=true
+          showLegend=true
+          enableZoom=true
+          legendText=legendText
+          componentId=componentId
+          showGraphLegend=false
+          onSelection=(action "onSelection")
+          onPrimaryMetricToggle=(action "onPrimaryMetricToggle")
+        }}
+        <div class="te-form__note">
+          NOTE: If you find the metric shown above is inconsistent, please email <a class="thirdeye-link-secondary" target="_blank" href="{{graphMailtoLink}}">ask_thirdeye</a>.
+        </div>
+      {{else}}
+        <div class="te-graph-alert__content">
+          <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
+          <p class="te-graph-alert__pre-text">{{graphMessageText.error}}</p>
+        </div>
+      {{/if}}
+    {{/if}}
+  </div>
+</div>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -286,7 +286,7 @@ export default Controller.extend({
   baselineTitle: computed(
     'baselineOptions',
     function() {
-      const activeOpName = this.get('baselineOptions').filter(item => item.isActive).pop().name;
+      const activeOpName = this.get('baselineOptions').filter(item => item.isActive)[0].name;
       const displayName = (activeOpName !== 'Predicted') ? `Current/${activeOpName}` : activeOpName;
       return displayName;
     }

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -9,68 +9,55 @@
             {{range.name}}
             {{#if (eq range.name "Custom")}}
               : {{date-range-picker
-                class="te-pill-selectors__range-picker"
-                timePicker=false
-                timePicker24Hour=true
-                timePickerIncrement=timePickerIncrement
-                maxDate=maxTime
-                start=viewRegionStart
-                end=viewRegionEnd
-                ranges=predefinedRanges
-                showCustomRangeLabel=false
-                format=uiDateFormat
-                serverFormat="YYYY-MM-DD HH:mm"
-                applyAction=(action "onRangeSelection")
-              }}
+                  class="te-pill-selectors__range-picker"
+                  timePicker=false
+                  timePicker24Hour=true
+                  timePickerIncrement=timePickerIncrement
+                  maxDate=maxTime
+                  start=viewRegionStart
+                  end=viewRegionEnd
+                  ranges=predefinedRanges
+                  showCustomRangeLabel=false
+                  format=uiDateFormat
+                  serverFormat="YYYY-MM-DD HH:mm"
+                  applyAction=(action "onRangeSelection")
+                }}
             {{/if}}
           </li>
         {{/each}}
       </ul>
     </div>
 
+    {{#if isPageLoadFailure}}
+      {{#bs-alert type="danger" class="te-form__banner te-form__banner--failure"}}
+        <strong>Error:</strong> Failed to load performance data.
+      {{/bs-alert}}
+    {{/if}}
+
     <div class="te-horizontal-cards te-content-block">
       <h4 class="te-alert-page__subtitle">Alert Performance</h4>
       <a class="te-pill-selectors__side-link" {{action "onClickTuneSensitivity" this}}>Customize sensitivity</a>
       <div class="te-horizontal-cards__container">
         {{!-- Alert anomaly stats cards --}}
-        {{#each anomalyStats as |card|}}
-          <ul class="te-horizontal-cards__card">
-
-            <li class="te-horizontal-cards">
-              <div class="te-horizontal-cards__card-title">{{card.title}}</div>
-              {{#if card.tooltip}}
-                <div class="te-horizontal-cards__card-tooltip">
-                  <span>
-                    <i class="glyphicon glyphicon-question-sign"></i>
-                    {{#tooltip-on-element}}{{card.text}}{{/tooltip-on-element}}
-                  </span>
-                </div>
-              {{else}}
-                <div class="te-horizontal-cards__card-text">{{card.text}}</div>
-              {{/if}}
-            </li>
-
-            <li class="te-horizontal-cards__card-value te-horizontal-cards__card-value--tight">
-              <div class="te-horizontal-cards__val-group">
-                <div class="te-horizontal-cards__card-number">
-                  {{card.value}}
-                  {{#if (and card.units (not-eq card.value "N/A"))}}
-                    <span class="te-horizontal-cards__card-units">{{card.units}}</span>
-                  {{/if}}
-                </div>
-                <div class="te-horizontal-cards__card-subt {{if (eq card.projected "none") "te-horizontal-cards__card-subt--hide"}}">Projected:
-                  <strong>{{card.projected}}</strong>
-                  {{#if (and card.units (not-eq card.projected "N/A"))}}
-                    <span class="te-horizontal-cards__card-units--small">{{card.units}}</span>
-                  {{/if}}
-                </div>
-              </div>
-            </li>
-
-          </ul>
-        {{/each}}
+        {{anomaly-stats-block
+          isTunePreviewActive=isTunePreviewActive
+          displayMode="explore"
+          anomalyStats=anomalyStats
+        }}
       </div>
     </div>
+
+    {{#if isReportSuccess}}
+      {{#bs-alert type="success" class="te-form__banner te-form__banner--success"}}
+        <strong>Success:</strong> We have saved the reported anomaly for alert id <strong>{{alertId}}</strong>
+      {{/bs-alert}}
+    {{/if}}
+
+    {{#if isReportFailure}}
+      {{#bs-alert type="danger" class="te-form__banner te-form__banner--failure"}}
+        <strong>Error:</strong> Failed to save reported anomaly.
+      {{/bs-alert}}
+    {{/if}}
 
     <div class="te-content-block">
       <h4>Anomalies over time ({{filteredAnomalies.length}})</h4>
@@ -78,12 +65,14 @@
 
       <div class="te-pill-selectors">
         {{!-- Dimension selector --}}
-        <div class="te-pill-selectors__range-picker col-md-3">
+        <div class="te-form__select--wider col-md-3">
           {{#power-select
             triggerId="select-dimension"
             triggerClass="te-form__select"
             options=dimensionOptions
             searchEnabled=false
+            matchTriggerWidth=true
+            matchContentWidth=true
             selected=selectedDimension
             onchange=(action "onSelectDimension")
             as |dimension|
@@ -98,6 +87,8 @@
             triggerClass="te-form__select"
             options=resolutionOptions
             searchEnabled=false
+            matchTriggerWidth=true
+            matchContentWidth=true
             selected=selectedResolution
             onchange=(action "onSelectResolution")
             as |resolution|
@@ -107,56 +98,47 @@
         </div>
       </div>
 
-      {{#if openReportModal}}
-        {{#te-modal
-          headerText="Report Undetected Anomaly"
-          cancelButtonText="Cancel"
-          submitButtonText="Report"
-          saveAction=(action "onSave")
-          cancelAction=(action "onCancel")
-        }}
+      {{!-- Missing anomaly modal --}}
+      {{#te-modal
+        headerText="Report Undetected Anomaly"
+        cancelButtonText="Cancel"
+        submitButtonText="Report"
+        saveAction=(action "onSave")
+        cancelAction=(action "onCancel")
+        isShowingModal=openReportModal
+      }}
+        {{#if renderModalContent}}
           {{alert-report-modal
             metricName=alertData.metric
             alertName=alertData.functionName
             dimensionOptions=dimensionOptions
+            showTimePicker=true
             timePickerIncrement=timePickerIncrement
             maxTime=maxTime
             viewRegionStart=viewRegionStart
             viewRegionEnd=viewRegionEnd
             predefinedRanges=predefinedRanges
             uiDateFormat=uiDateFormat
-            graphMessageText=""
+            metricData=metricData
+            topDimensions=topDimensions
+            isMetricDataInvalid=isMetricDataInvalid
             inputAction=(action "onInputMissingAnomaly")
           }}
-        {{/te-modal}}
-      {{/if}}
+        {{else}}
+          {{ember-spinner}}
+        {{/if}}
+      {{/te-modal}}
 
-      {{!-- Alert anomaly graph --}}
-      <div class="te-graph-container col-xs-12">
-        <div class="te-graph-alert {{if (not isGraphReady) 'te-graph-alert--pending'}}">
-          {{#if isMetricDataLoading}}
-            <div class="spinner-wrapper--self-serve">{{ember-spinner}}</div>
-          {{/if}}
-          {{#if isGraphReady}}
-            {{anomaly-graph
-              primaryMetric=metricData
-              isLoading=loading
-              showSubchart=true
-              showLegend=false
-              legendText=legendText
-              enableZoom=true
-              componentId='create-alert'
-              showGraphLegend=false
-              height=400
-            }}
-          {{else}}
-             <div class="te-graph-alert__content">
-              <div class="glyphicon glyphicon-equalizer}} te-graph-alert__icon"></div>
-              <p class="te-graph-alert__pre-text">Loading graph...</p>
-            </div>
-          {{/if}}
-        </div>
-      </div>
+      {{!-- Alert page graph --}}
+      {{self-serve-graph
+        isMetricDataLoading=isMetricDataLoading
+        isMetricDataInvalid=isMetricDataInvalid
+        isDimensionFetchDone=isDimensionFetchDone
+        isMetricSelected=true
+        metricData=metricData
+        topDimensions=topDimensions
+        componentId='alert-page'
+      }}
 
       {{#if filteredAnomalies}}
         {{!-- Baseline type selector --}}
@@ -195,7 +177,7 @@
              </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
-                Current/WoW
+                {{baselineTitle}}
                 <i class="te-anomaly-table__glyph glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
               </a>
              </th>
@@ -215,7 +197,11 @@
             <tr class="te-anomaly-table__row">
                <td class="te-anomaly-table__cell">
                 <ul class="te-anomaly-table__list">
-                  <li class="te-anomaly-table__list--stronger">{{anomaly.startDateStr}}</li>
+                  <li class="te-anomaly-table__list--stronger">
+                    <a target="_blank" class="te-anomaly-table__link" href="/thirdeye#anomalies?anomaliesSearchMode=id&pageNumber=1&anomalyIds={{anomaly.anomalyId}}">
+                      {{anomaly.startDateStr}}
+                    </a>
+                  </li>
                   <li class="te-anomaly-table__list--lighter">{{anomaly.durationStr}}</li>
                 </ul>
                </td>
@@ -312,23 +298,5 @@
       </p>
     </div>
 
-  {{/if}}
-
-  {{#if isReportSuccess}}
-    {{#bs-alert type="success" class="te-form__banner te-form__banner--success"}}
-      <strong>Success:</strong> We have saved the reported anomaly for alert id <strong>{{alertId}}</strong>
-    {{/bs-alert}}
-  {{/if}}
-
-  {{#if isReportFailure}}
-    {{#bs-alert type="danger" class="te-form__banner te-form__banner--failure"}}
-      <strong>Error:</strong> Failed to save reported anomaly.
-    {{/bs-alert}}
-  {{/if}}
-
-  {{#if isPageLoadFailure}}
-    {{#bs-alert type="danger" class="te-form__banner te-form__banner--failure"}}
-      <strong>Error:</strong> Failed to load performance data.
-    {{/bs-alert}}
   {{/if}}
 </div>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -65,7 +65,7 @@
 
       <div class="te-pill-selectors">
         {{!-- Dimension selector --}}
-        <div class="te-form__select--wider col-md-3">
+        <div class="te-form__select te-form__select--wider col-md-3">
           {{#power-select
             triggerId="select-dimension"
             triggerClass="te-form__select"

--- a/thirdeye/thirdeye-frontend/app/styles/components/alert-report-modal.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/alert-report-modal.scss
@@ -10,10 +10,6 @@
   margin-top: 10px
 }
 
-.te-label {
-  margin-top: 5px;
-}
-
 .te-report-title {
   margin: 0;
 }

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -124,6 +124,18 @@ body {
       float: right;
     }
   }
+
+  &__select {
+    float: none;
+
+    &--wider {
+      width: 600px;
+      float: left;
+      margin-left: -15px;
+      display: inline-block;
+      color: app-shade(black, 7);
+    }
+  }
 }
 
 .te-content-block {

--- a/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
@@ -11,12 +11,12 @@ body {
   margin: $te-default-element-spacing;
   height: 250px;
   position: relative;
+}
 
-  &--self-serve {
-    position: absolute;
-    margin-top: 190px;
-    left: 50%;
-  }
+.spinner-wrapper-self-serve {
+  position: absolute;
+  margin: 190px 0 0 0;
+  left: 50%;
 }
 
 .anomaly-title-bar {


### PR DESCRIPTION
For the Alert Page Overview (`manage/alert/{id}/explore` route) this PR includes:
- componentization of graph markup: `self-serve-graph` component
- loading less of the required data pre-page render (deferring non-critical data)
- fix for graph overflow issue in "report anomaly" modal
- catching API errors in model and bubbling them to parent