### PR TITLE
[TE] rootcause poc - time-based session modification check

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -46,6 +46,8 @@ export const eventColorMapping = {
   anomaly: 'teal'
 };
 
+export const dateFormatFull = 'ddd, MMM D YYYY, h:mm a';
+
 /**
  * The Promise returned from fetch() won't reject on HTTP error status even if the response is an HTTP 404 or 500.
  * This helps us define a custom response handler.
@@ -594,5 +596,6 @@ export default Ember.Helper.helper({
   eventColorMapping,
   parseProps,
   postProps,
-  toIso
+  toIso,
+  dateFormatFull
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/component.js
@@ -1,36 +1,104 @@
 import Component from '@ember/component';
-import { getProperties, computed } from '@ember/object';
+import { get, getProperties, computed } from '@ember/object';
+import { dateFormatFull } from 'thirdeye-frontend/helpers/utils';
 
 export default Component.extend({
   classNames: ['rootcause-header'],
-  sessionId: null, // 0
-
-  sessionName: null, // ""
-
-  sessionText: null, // ""
-
-  sessionModified: null, // true
-
-  onSave: null, // func(sessionName, sessionText)
-
-  onCopy: null, // func(sessionName, sessionText)
 
   /**
-   * Toggles the comment textarea
+   * Rootcause session identifier
+   * @type {Int}
    */
-  showComment: computed.bool('sessionText'),
+  sessionId: null,
+
+  /**
+   * Rootcause session title
+   * @type {string}
+   */
+  sessionName: null,
+
+  /**
+   * Rootcause session comments
+   * @Type {string}
+   */
+  sessionText: null,
+
+  /**
+   * Rootcause session dirty flag
+   * @type {boolean}
+   */
+  sessionModified: null,
+
+  /**
+   * Rootcause session last updated timestamp
+   * @type {Int}
+   */
+  sessionUpdatedTime: null,
+
+  /**
+   * Rootcause session last updated author
+   * @type {string}
+   */
+  sessionUpdatedBy: null,
+
+  /**
+   * "Save" button callback
+   * @type {function}
+   */
+  onSave: null, // func()
+
+  /**
+   * "Copy" button callback
+   * @type {function}
+   */
+  onCopy: null, // func()
+
+  /**
+   * Text edit callback
+   * @type {function}
+   */
+  onChange: null, // func(sessionName, sessionText)
+
+  /**
+   * Toggle for the comment textarea
+   * @type {boolean}
+   */
+  isCommentEditMode: computed.bool('sessionText'),
+
+  /**
+   * Toggle for editing the session title
+   * @type {boolean}
+   */
+  isTitleEditMode: false,
+
+  /**
+   * Formatted session last updated time
+   * @type {string}
+   */
+  sessionUpdatedTimeFormatted: computed('sessionUpdatedTime', function () {
+    return moment(get(this, 'sessionUpdatedTime')).format(dateFormatFull);
+  }),
 
   actions: {
+    /**
+     * "Save" button action
+     */
     onSave() {
       const { onSave } = getProperties(this, 'onSave');
       onSave();
     },
 
+    /**
+     * "Copy" button action (currently disabled)
+     */
     onCopy() {
       const { onCopy } = getProperties(this, 'onCopy');
       onCopy();
     },
 
+    /**
+     * Edit action on changing session title or comments
+     */
     onChange() {
       const {
         sessionName,

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/template.hbs
@@ -31,10 +31,10 @@
     </div>
     <div class="col-xs-10">
       {{#if sessionId}}
-        <p class="rootcause-header__last-updated-info">Last edited by {{sessionUpdatedBy}} on {{sessionUpdatedTime}}</p>
+        <p class="rootcause-header__last-updated-info">Last saved by {{sessionUpdatedBy}} on {{sessionUpdatedTimeFormatted}}</p>
       {{/if}}
-      {{#unless showComment}}
-        <a class="thirdeye-link" {{action (mut showComment) true}}>
+      {{#unless isCommentEditMode}}
+        <a class="thirdeye-link" {{action (mut isCommentEditMode) true}}>
           <span><i class="glyphicon glyphicon-plus"></i></span>
           <span>New comment</span>
           {{#tooltip-on-element class="te-tooltip"}} Add a comment {{/tooltip-on-element}}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-session-datasource/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-session-datasource/service.js
@@ -1,0 +1,17 @@
+import Service from '@ember/service';
+import fetch from 'fetch';
+import { checkStatus } from 'thirdeye-frontend/helpers/utils';
+
+export default Service.extend({
+  loadAsync(sessionId) {
+    if (!sessionId) { return; }
+
+    return fetch(`/session/${sessionId}`).then(checkStatus);
+  },
+
+  saveAsync(session) {
+    const jsonString = JSON.stringify(session);
+
+    return fetch(`/session/`, { method: 'POST', body: jsonString }).then(checkStatus);
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -3,7 +3,7 @@ import RSVP from 'rsvp';
 import fetch from 'fetch';
 import moment from 'moment';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { toCurrentUrn, toBaselineUrn, filterPrefix, appendFilters, toFilters, checkStatus } from 'thirdeye-frontend/helpers/utils';
+import { toCurrentUrn, toBaselineUrn, filterPrefix, appendFilters, toFilters, checkStatus, dateFormatFull } from 'thirdeye-frontend/helpers/utils';
 import _ from 'lodash';
 
 const queryParamsConfig = {
@@ -152,8 +152,6 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     const anomalyRange = [anomalyRangeStart, anomalyRangeEnd];
     const analysisRange = [analysisRangeStart, analysisRangeEnd];
 
-    const dateFormat = 'ddd, MMM D YYYY, h:mm a';
-
     // default blank context
     let context = {
       urns: new Set(),
@@ -165,7 +163,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     };
 
     let selectedUrns = new Set();
-    let sessionName = 'New Investigation (' + moment().format(dateFormat) + ')';
+    let sessionName = 'New Investigation (' + moment().format(dateFormatFull) + ')';
     let sessionText = '';
     let sessionUpdatedBy = '';
     let sessionUpdatedTime = '';
@@ -217,7 +215,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         };
 
         selectedUrns = new Set([...metricUrns, ...metricUrns.map(toCurrentUrn), ...metricUrns.map(toBaselineUrn), anomalyUrn]);
-        sessionName = 'New Investigation of #' + anomalyId + ' (' + moment().format(dateFormat) + ')';
+        sessionName = 'New Investigation of #' + anomalyId + ' (' + moment().format(dateFormatFull) + ')';
 
       } else {
         routeErrors.add(`Could not find anomalyId ${anomalyId}`);
@@ -241,7 +239,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         sessionName = name;
         sessionText = text;
         sessionUpdatedBy = updatedBy;
-        sessionUpdatedTime = moment(updated).format(dateFormat);
+        sessionUpdatedTime = updated;
         sessionModified = false;
 
       } else {

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -5,6 +5,12 @@
   </div>
 {{/if}}
 
+{{#if sessionUpdateWarning}}
+  <div class="rootcause-alert alert alert-warning fade in">
+    {{sessionUpdateWarning}}
+  </div>
+{{/if}}
+
 {{rootcause-header
   sessionId=sessionId
   sessionName=sessionName

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -1,7 +1,7 @@
 {{#if hasErrorsRoute}}
   <div class="rootcause-alert alert alert-danger alert-dismissable fade in">
     <a class="close" data-dismiss="alert" {{action "clearErrors" "route"}}>&times;</a>
-    Error initializing analysis:{{#each routeErrors as |e|}} <strong>{{e}}</strong>{{/each}}
+    Error:{{#each routeErrors as |e|}} <strong>{{e}}</strong>{{/each}}
   </div>
 {{/if}}
 


### PR DESCRIPTION
Adding a basic time-based check for session modification in the background by another user. It polls in large intervals (5min) and displays a warning if modification is detected. This isn't bullet-proof yet and users can still override existing sessions with stale data.

![image](https://user-images.githubusercontent.com/25439965/35298823-2b37ac10-0038-11e8-9278-837236aedc60.png)
