### PR TITLE
Let RetryPolicy.attempt() throw AttemptFailureException instead of general Exception

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/AttemptFailureException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/AttemptFailureException.java
@@ -15,13 +15,20 @@
  */
 package com.linkedin.pinot.common.utils.retry;
 
-/**
- * The <code>AttemptsExceededException</code> indicates that the operation did not succeed within maximum number of
- * attempts.
- */
-public class AttemptsExceededException extends AttemptFailureException {
+import java.util.concurrent.Callable;
 
-  public AttemptsExceededException(String message) {
+
+/**
+ * The <code>AttemptFailureException</code> indicates that the {@link RetryPolicy#attempt(Callable)} failed because of
+ * either operation throwing an exception or running out of attempts.
+ */
+public class AttemptFailureException extends Exception {
+
+  public AttemptFailureException(String message) {
     super(message);
+  }
+
+  public AttemptFailureException(Throwable cause) {
+    super(cause);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetriableOperationException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetriableOperationException.java
@@ -16,12 +16,11 @@
 package com.linkedin.pinot.common.utils.retry;
 
 /**
- * The <code>AttemptsExceededException</code> indicates that the operation did not succeed within maximum number of
- * attempts.
+ * The <code>RetriableOperationException</code> indicates that the retriable operation threw an exception.
  */
-public class AttemptsExceededException extends AttemptFailureException {
+public class RetriableOperationException extends AttemptFailureException {
 
-  public AttemptsExceededException(String message) {
-    super(message);
+  public RetriableOperationException(Throwable cause) {
+    super(cause);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/RetryPolicy.java
@@ -28,7 +28,8 @@ public interface RetryPolicy {
    * attempts exhausted.
    *
    * @param operation The operation to attempt, which returns true on success and false on failure.
-   * @throws Exception
+   * @throws AttemptsExceededException
+   * @throws RetriableOperationException
    */
-  void attempt(Callable<Boolean> operation) throws Exception;
+  void attempt(Callable<Boolean> operation) throws AttemptsExceededException, RetriableOperationException;
 }


### PR DESCRIPTION
Added AttemptFailureException with two children exceptions:
- AttemptsExceededException
- RetriableOperationException