### PR TITLE
[TE] datasource - support timeseries agg functions

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
+import com.linkedin.thirdeye.constant.MetricAggFunction;
 import com.linkedin.thirdeye.dashboard.Utils;
 import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
@@ -26,6 +27,7 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -297,7 +299,8 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     }
 
     int position = 0;
-    LinkedHashMap<String, String[]> dataMap = new LinkedHashMap<>();
+    Map<String, String[]> dataMap = new HashMap<>();
+    Map<String, Integer> countMap = new HashMap<>();
     for (Entry<MetricFunction, List<ThirdEyeResultSet>> entry : metricFunctionToResultSetList.entrySet()) {
 
       MetricFunction metricFunction = entry.getKey();
@@ -366,6 +369,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
             groupKeyBuilder.append(grpKey).append("|");
           }
           String compositeGroupKey = groupKeyBuilder.toString();
+
           String[] rowValues = dataMap.get(compositeGroupKey);
           if (rowValues == null) {
             rowValues = new String[numCols];
@@ -373,9 +377,22 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
             System.arraycopy(groupKeys, 0, rowValues, 0, groupKeys.length);
             dataMap.put(compositeGroupKey, rowValues);
           }
-          rowValues[groupKeys.length + position + i] =
-              String.valueOf(Double.parseDouble(rowValues[groupKeys.length + position + i])
-                  + Double.parseDouble(resultSet.getString(r, 0)));
+
+          if (!countMap.containsKey(compositeGroupKey)) {
+            countMap.put(compositeGroupKey, 0);
+          }
+          final int aggCount = countMap.get(compositeGroupKey);
+
+          // aggregation of multiple values
+          rowValues[groupKeys.length + position + i] = String.valueOf(
+              reduce(
+                  Double.parseDouble(rowValues[groupKeys.length + position + i]),
+                  Double.parseDouble(resultSet.getString(r, 0)),
+                  aggCount,
+                  metricFunction.getFunctionName()
+              ));
+
+          countMap.put(compositeGroupKey, aggCount + 1);
         }
       }
       position ++;
@@ -386,6 +403,20 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
 
   }
 
+  private static double reduce(double aggregate, double value, int count, MetricAggFunction aggFunction) {
+    switch(aggFunction) {
+      case SUM:
+        return aggregate + value;
+      case AVG:
+        return (aggregate + value) / (count + 1);
+      case MAX:
+        return Math.max(aggregate, value);
+      case COUNT:
+        return aggregate + 1;
+      default:
+        throw new IllegalArgumentException(String.format("Unknown aggregation function '%s'", aggFunction));
+    }
+  }
 
   @Override
   public List<String> getDatasets() throws Exception {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -382,6 +382,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
             countMap.put(compositeGroupKey, 0);
           }
           final int aggCount = countMap.get(compositeGroupKey);
+          countMap.put(compositeGroupKey, aggCount + 1);
 
           // aggregation of multiple values
           rowValues[groupKeys.length + position + i] = String.valueOf(
@@ -392,7 +393,6 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
                   metricFunction.getFunctionName()
               ));
 
-          countMap.put(compositeGroupKey, aggCount + 1);
         }
       }
       position ++;
@@ -403,12 +403,12 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
 
   }
 
-  private static double reduce(double aggregate, double value, int count, MetricAggFunction aggFunction) {
+  static double reduce(double aggregate, double value, int prevCount, MetricAggFunction aggFunction) {
     switch(aggFunction) {
       case SUM:
         return aggregate + value;
       case AVG:
-        return (aggregate + value) / (count + 1);
+        return (aggregate * prevCount + value) / (prevCount + 1);
       case MAX:
         return Math.max(aggregate, value);
       case COUNT:

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSourceTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.datasource.pinot;
 
+import com.linkedin.thirdeye.constant.MetricAggFunction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +25,26 @@ public class PinotThirdEyeDataSourceTest {
 
     PinotResponseCacheLoader cacheLoaderInstance = PinotThirdEyeDataSource.getCacheLoaderInstance(properties);
     Assert.assertTrue(PinotControllerResponseCacheLoader.class.equals(cacheLoaderInstance.getClass()));
+  }
+
+  @Test
+  public void testReduceSum() {
+    Assert.assertEquals(PinotThirdEyeDataSource.reduce(10, 3, 4, MetricAggFunction.SUM), 13.0);
+  }
+
+  @Test
+  public void testReduceAvg() {
+    Assert.assertEquals(PinotThirdEyeDataSource.reduce(10, 2, 3, MetricAggFunction.AVG), 8.0);
+  }
+
+  @Test
+  public void testReduceMax() {
+    Assert.assertEquals(PinotThirdEyeDataSource.reduce(10, 3, 12, MetricAggFunction.MAX), 10.0);
+  }
+
+  @Test
+  public void testReduceCount() {
+    Assert.assertEquals(PinotThirdEyeDataSource.reduce(4, 3, 4, MetricAggFunction.COUNT), 5.0);
   }
 
 }


### PR DESCRIPTION
Surprisingly, pinot data source does not support aggregation functions (besides SUM) for time series queries yet. It ignores the setting silently. This PR adds basic support for SUM, MAX, AVG, and COUNT.