### PR TITLE
[TE] Onboarding tasks: initial trigger auto-tune with pattern only, anomaly severity score

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
@@ -93,7 +93,7 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
             taskConfiguration.getString(AUTOTUNE_FEATURES), taskConfiguration.getString(AUTOTUNE_MTTD),
             taskConfiguration.getString(AUTOTUNE_PATTERN, DEFAULT_AUTOTUNE_PATTERN),
             taskConfiguration.getString(AUTOTUNE_PATTERN_ONLY,
-                String.valueOf(Strings.isNullOrEmpty(taskConfiguration.getString(AUTOTUNE_MTTD)))));
+                Boolean.toString(Strings.isNullOrEmpty(taskConfiguration.getString(AUTOTUNE_MTTD)))));
 
     if (autotuneResponse.getEntity() != null) {
       List<Long> autotuneIds;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
@@ -83,8 +83,8 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
     AnomalyFunctionDTO anomalyFunctionSpec =
         (AnomalyFunctionDTO) executionContext.getExecutionResult(ANOMALY_FUNCTION_CONFIG);
     long functionId = anomalyFunctionSpec.getId();
-    DateTime start = (DateTime) executionContext.getExecutionResult(BACKFILL_START);
-    DateTime end = (DateTime) executionContext.getExecutionResult(BACKFILL_END);
+    DateTime start = ((DateTime) executionContext.getExecutionResult(BACKFILL_START)).minusDays(1);
+    DateTime end = ((DateTime) executionContext.getExecutionResult(BACKFILL_END)).plusDays(1);
 
     Response autotuneResponse = detectionJobResource.
         tuneAlertFilter(Long.toString(functionId), start.toString(), end.toString(),

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/AlertFilterAutoTuneOnboardingTask.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.anomaly.onboard.tasks;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
@@ -8,6 +9,7 @@ import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.AlertFilterAut
 import com.linkedin.thirdeye.dashboard.resources.DetectionJobResource;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.util.StringUtils;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import java.io.IOException;
@@ -19,6 +21,8 @@ import org.joda.time.DateTime;
 import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.linkedin.thirdeye.dataframe.StringSeries.*;
 
 
 /**
@@ -38,6 +42,7 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
   public static final String BACKFILL_END = DefaultDetectionOnboardJob.END;
   public static final String AUTOTUNE_PATTERN = DefaultDetectionOnboardJob.AUTOTUNE_PATTERN;
   public static final String AUTOTUNE_TYPE = DefaultDetectionOnboardJob.AUTOTUNE_TYPE;
+  public static final String AUTOTUNE_PATTERN_ONLY = DefaultDetectionOnboardJob.AUTOTUNE_PATTERN_ONLY;
   public static final String AUTOTUNE_FEATURES = DefaultDetectionOnboardJob.AUTOTUNE_FEATURES;
   public static final String AUTOTUNE_MTTD = DefaultDetectionOnboardJob.AUTOTUNE_MTTD;
   public static final String HOLIDAY_STARTS = DefaultDetectionOnboardJob.HOLIDAY_STARTS;
@@ -64,18 +69,19 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
     Preconditions.checkNotNull(executionContext.getExecutionResult(ALERT_FILTER_FACTORY));
     Preconditions.checkNotNull(executionContext.getExecutionResult(ALERT_FILTER_AUTOTUNE_FACTORY));
 
-    AlertFilterFactory alertFilterFactory = (AlertFilterFactory) executionContext.getExecutionResult(ALERT_FILTER_FACTORY);
-    AlertFilterAutotuneFactory alertFilterAutotuneFactory = (AlertFilterAutotuneFactory)
-        executionContext.getExecutionResult(ALERT_FILTER_AUTOTUNE_FACTORY);
+    AlertFilterFactory alertFilterFactory =
+        (AlertFilterFactory) executionContext.getExecutionResult(ALERT_FILTER_FACTORY);
+    AlertFilterAutotuneFactory alertFilterAutotuneFactory =
+        (AlertFilterAutotuneFactory) executionContext.getExecutionResult(ALERT_FILTER_AUTOTUNE_FACTORY);
 
     Preconditions.checkNotNull(alertFilterFactory);
     Preconditions.checkNotNull(alertFilterAutotuneFactory);
 
-    DetectionJobResource detectionJobResource = new DetectionJobResource(new DetectionJobScheduler(),
-        alertFilterFactory, alertFilterAutotuneFactory);
+    DetectionJobResource detectionJobResource =
+        new DetectionJobResource(new DetectionJobScheduler(), alertFilterFactory, alertFilterAutotuneFactory);
 
-    AnomalyFunctionDTO anomalyFunctionSpec = (AnomalyFunctionDTO) executionContext.getExecutionResult(
-        ANOMALY_FUNCTION_CONFIG);
+    AnomalyFunctionDTO anomalyFunctionSpec =
+        (AnomalyFunctionDTO) executionContext.getExecutionResult(ANOMALY_FUNCTION_CONFIG);
     long functionId = anomalyFunctionSpec.getId();
     DateTime start = (DateTime) executionContext.getExecutionResult(BACKFILL_START);
     DateTime end = (DateTime) executionContext.getExecutionResult(BACKFILL_END);
@@ -84,16 +90,18 @@ public class AlertFilterAutoTuneOnboardingTask extends BaseDetectionOnboardTask 
         tuneAlertFilter(Long.toString(functionId), start.toString(), end.toString(),
             taskConfiguration.getString(AUTOTUNE_TYPE, DEFAULT_AUTOTUNE_TYPE),
             taskConfiguration.getString(HOLIDAY_STARTS, ""), taskConfiguration.getString(HOLIDAY_ENDS, ""),
-            taskConfiguration.getString(AUTOTUNE_FEATURES),
-            taskConfiguration.getString(AUTOTUNE_MTTD),
-            taskConfiguration.getString(AUTOTUNE_PATTERN, DEFAULT_AUTOTUNE_PATTERN));
+            taskConfiguration.getString(AUTOTUNE_FEATURES), taskConfiguration.getString(AUTOTUNE_MTTD),
+            taskConfiguration.getString(AUTOTUNE_PATTERN, DEFAULT_AUTOTUNE_PATTERN),
+            taskConfiguration.getString(AUTOTUNE_PATTERN_ONLY,
+                String.valueOf(Strings.isNullOrEmpty(taskConfiguration.getString(AUTOTUNE_MTTD)))));
 
     if (autotuneResponse.getEntity() != null) {
       List<Long> autotuneIds;
       try {
         autotuneIds = OBJECT_MAPPER.readValue(autotuneResponse.getEntity().toString(), List.class);
       } catch (IOException e) {
-        throw new IllegalStateException("Unable to parse autotune response: " + autotuneResponse.getEntity().toString(), e);
+        throw new IllegalStateException("Unable to parse autotune response: " + autotuneResponse.getEntity().toString(),
+            e);
       }
       for (int i = 0; i < autotuneIds.size(); i++) {
         detectionJobResource.updateAlertFilterToFunctionSpecByAutoTuneId(((Number) autotuneIds.get(i)).longValue());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -58,6 +58,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   public static final String ALERT_CONFIG = "alertConfig";
   public static final String AUTOTUNE_PATTERN = DetectionJobResource.AUTOTUNE_PATTERN_KEY;
   public static final String AUTOTUNE_TYPE = "autoTuneType";
+  public static final String AUTOTUNE_PATTERN_ONLY = DetectionJobResource.AUTOTUNE_PATTERN_ONLY;
   public static final String AUTOTUNE_FEATURES = DetectionJobResource.AUTOTUNE_FEATURE_KEY;
   public static final String AUTOTUNE_MTTD = DetectionJobResource.AUTOTUNE_MTTD_KEY;
   public static final String HOLIDAY_STARTS = "holidayStarts";

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -38,8 +38,10 @@ import com.linkedin.thirdeye.datalayer.dto.RawAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
+import com.linkedin.thirdeye.detector.email.filter.AlertFilter;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 import com.linkedin.thirdeye.detector.email.filter.BaseAlertFilter;
+import com.linkedin.thirdeye.detector.email.filter.DummyAlertFilter;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
@@ -221,8 +223,11 @@ public class AnomalyResource {
   @Path("/anomalies/score/{anomaly_merged_result_id}")
   public double getAnomalyScore(@NotNull @PathParam("anomaly_merged_result_id") long mergedAnomalyId) {
     MergedAnomalyResultDTO mergedAnomaly = anomalyMergedResultDAO.findById(mergedAnomalyId);
-    AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(mergedAnomaly.getFunctionId());
-    BaseAlertFilter alertFilter = alertFilterFactory.fromSpec(anomalyFunctionSpec.getAlertFilter());
+    BaseAlertFilter alertFilter = new DummyAlertFilter();
+    if (mergedAnomaly != null) {
+      AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(mergedAnomaly.getFunctionId());
+      alertFilter = alertFilterFactory.fromSpec(anomalyFunctionSpec.getAlertFilter());
+    }
     return alertFilter.getProbability(mergedAnomaly);
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -39,6 +39,7 @@ import com.linkedin.thirdeye.datalayer.pojo.MetricConfigBean;
 import com.linkedin.thirdeye.datasource.DAORegistry;
 import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
+import com.linkedin.thirdeye.detector.email.filter.BaseAlertFilter;
 import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
@@ -213,6 +214,16 @@ public class AnomalyResource {
     }
 
     return anomalyResults;
+  }
+
+  // Get anomaly score
+  @GET
+  @Path("/anomalies/score/{anomaly_merged_result_id}")
+  public double getAnomalyScore(@NotNull @PathParam("anomaly_merged_result_id") long mergedAnomalyId) {
+    MergedAnomalyResultDTO mergedAnomaly = anomalyMergedResultDAO.findById(mergedAnomalyId);
+    AnomalyFunctionDTO anomalyFunctionSpec = anomalyFunctionDAO.findById(mergedAnomaly.getFunctionId());
+    BaseAlertFilter alertFilter = alertFilterFactory.fromSpec(anomalyFunctionSpec.getAlertFilter());
+    return alertFilter.getProbability(mergedAnomaly);
   }
 
   //View raw anomalies for collection

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -84,7 +84,7 @@ public class DetectionJobResource {
   public static final String AUTOTUNE_FEATURE_KEY = "features";
   public static final String AUTOTUNE_PATTERN_KEY = "pattern";
   public static final String AUTOTUNE_MTTD_KEY = "mttd";
-  private static final String COMMA_SEPARATOR = ",";
+  public static final String AUTOTUNE_PATTERN_ONLY = "tunePatternOnly";
   private static final String SIGN_TEST_WINDOW_SIZE = "signTestWindowSize";
 
   /**
@@ -606,7 +606,8 @@ public class DetectionJobResource {
       @QueryParam("end") String endTimeIso, @QueryParam("autoTuneType") @DefaultValue("AUTOTUNE") String autoTuneType,
       @QueryParam("holidayStarts") @DefaultValue("") String holidayStarts,
       @QueryParam("holidayEnds") @DefaultValue("") String holidayEnds, @QueryParam("tuningFeatures") String features,
-      @QueryParam("mttd") String mttd, @QueryParam("pattern") String pattern) {
+      @QueryParam("mttd") String mttd, @QueryParam("pattern") String pattern,
+      @QueryParam("tunePatternOnly") String tunePatternOnly) {
 
     long startTime = ISODateTimeFormat.dateTimeParser().parseDateTime(startTimeIso).getMillis();
     long endTime = ISODateTimeFormat.dateTimeParser().parseDateTime(endTimeIso).getMillis();
@@ -660,6 +661,14 @@ public class DetectionJobResource {
       String previousMttd = autotuneProperties.getProperty(AUTOTUNE_MTTD_KEY);
       LOG.info("The previous mttd for autotune is {}; now changed to {}", previousMttd, mttd);
       autotuneProperties.setProperty(AUTOTUNE_MTTD_KEY, mttd);
+      autotuneConfig.setTuningProps(autotuneProperties);
+    }
+
+    // if specified "tunePatternOnly"
+    if (StringUtils.isNotBlank(tunePatternOnly)) {
+      String previousTunePatternOnly = autotuneProperties.getProperty(AUTOTUNE_PATTERN_ONLY);
+      LOG.info("The previous tunePatternOnly for autotune is {}; now changed to {}", previousTunePatternOnly, tunePatternOnly);
+      autotuneProperties.setProperty(AUTOTUNE_PATTERN_ONLY, tunePatternOnly);
       autotuneConfig.setTuningProps(autotuneProperties);
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/BaseAlertFilter.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.detector.email.filter;
 
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Properties;
@@ -90,5 +91,14 @@ public abstract class BaseAlertFilter implements AlertFilter {
    */
   public double getAlertFilterMTTD (double severity) {
     return 0.0;
+  }
+
+  /**
+   * get probability score given anomalyResult based on current alert filter
+   * @param anomalyResult Merged anomaly result
+   * @return probability to be true anomaly
+   */
+  public double getProbability (MergedAnomalyResultDTO anomalyResult) {
+    return Double.NaN;
   }
 }


### PR DESCRIPTION
Currently when onboarding metrics with different granularity are using auto-tune. Based on the launch of alert page tuning, we move tuning sensitivity to "tuning page". When onboarding, we only tune "pattern" only to avoid potential alert delay. If users specifies "mttd" during onboarding process, then auto-tuning is triggered via "mttd" constraints as well. 
Within this pr, we also expose anomaly severity score by passing the anomaly probability 