### PR TITLE
[TE] Self-Serve Onboarding Flow: handling transition to alert page after creation

### DIFF
--- a/thirdeye/thirdeye-frontend/app/helpers/utils.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/utils.js
@@ -612,6 +612,7 @@ export default Ember.Helper.helper({
   metricColors,
   colorMapping,
   eventColorMapping,
+  buildDateEod,
   parseProps,
   postProps,
   toIso,

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -65,7 +65,7 @@ export default Controller.extend({
       sortColumnScoreUp: false,
       sortColumnChangeUp: false,
       sortColumnResolutionUp: false,
-      checkReplayInterval: 60000, // 1min
+      checkReplayInterval: 120000, // 2min
       selectedDimension: 'All Dimensions',
       selectedResolution: 'All Resolutions',
       dateRangeToRender: [30, 10, 5],
@@ -381,7 +381,7 @@ export default Controller.extend({
    * Send a POST request to the report anomaly API (2-step process)
    * http://go/te-ss-alert-flow-api
    * @method reportAnomaly
-   * @param {String} id - The anomaly id
+   * @param {String} id - The alert id
    * @param {Object} data - The input values from 'report new anomaly' modal
    * @return {Promise}
    */

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -65,7 +65,7 @@ export default Controller.extend({
       sortColumnScoreUp: false,
       sortColumnChangeUp: false,
       sortColumnResolutionUp: false,
-      checkReplayInterval: 5000,
+      checkReplayInterval: 60000, // 1min
       selectedDimension: 'All Dimensions',
       selectedResolution: 'All Resolutions',
       dateRangeToRender: [30, 10, 5],
@@ -76,7 +76,7 @@ export default Controller.extend({
     // Start checking for replay to end if an ID was given
     if (this.get('isReplayPending')) {
       Ember.run.later(() => {
-        this.checkReplayStatus(this.get('replayId'));
+        this.set('isReplayPending', false);
       }, this.get('checkReplayInterval'));
     }
   },

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -293,7 +293,7 @@
         {{#if isReplayStatusError}}
           Your alert failed to set up. Please contact <a href="mailto:ask_thirdeye@linkedin.com">ask_thirdeye@linkedin.com</a>
         {{else}}
-          This may take up to a few minutes <br/>We will send you an email when it's done!
+          This may take a while (up to a few minutes) <br/>We will send you an email when it's done!
         {{/if}}
       </p>
     </div>

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -579,64 +579,6 @@ export default Controller.extend({
   },
 
   /**
-   * Replay Flow Step 2 - Replay cloned function
-   * @method callReplayStart
-   * @param {Number} clonedId - id of the cloned function
-   * @param {Object} startTime - replay start time stamp
-   * @param {Object} endTime - replay end time stamp
-   * @return {Ember.RSVP.Promise}
-   */
-  callReplayStart(functionId, startTime, endTime) {
-    const granularity = this.get('graphConfig.granularity').toLowerCase();
-    const speedUp = !(granularity.includes('hour') || granularity.includes('day'));
-    const recipients = this.get('selectedConfigGroup.recipients');
-    const sensitivity = this.get('sensitivityWithDefault');
-    const selectedPattern = this.get('selectedPattern');
-    const pattern = this.optionMap.pattern[selectedPattern];
-
-    const url = `/detection-job/${functionId}/notifyreplaytuning?start=${startTime}` +
-      `&end=${endTime}&speedup=${speedUp}&userDefinedPattern=${pattern}&sensitivity=${sensitivity}` +
-      `&removeAnomaliesInWindow=true&removeAnomaliesInWindow=true&to=${recipients}`;
-
-    return fetch(url, { method: 'post' })
-      .then((res) => checkStatus(res, 'post'))
-      .catch((error) => {
-        this.setProperties({
-          isReplayStatusError: true,
-          isReplayStatusPending: false,
-          bsAlertBannerType: 'danger',
-          replayStatusClass: 'te-form__banner--failure',
-          failureMessage: `The replay sequence has been interrupted. (${error})`
-        });
-      });
-  },
-
-  /**
-   * Sends a request to begin advanced replay for a metric. The replay will fetch new
-   * time-series data based on user-selected sensitivity settings.
-   * @method triggerReplay
-   * @param {Number} newFuncId - the id for the newly created function (alert)
-   * @return {Ember.RSVP.Promise}
-   */
-  triggerReplay(newFuncId) {
-    const replayDateFormat = "YYYY-MM-DDTHH:mm:ss.SSS[Z]";
-    const startTime = buildDateEod(1, 'month').format(replayDateFormat);
-    const endTime = buildDateEod(1, 'day').format(replayDateFormat);
-    const that = this;
-
-    // Set banner to 'pending' state
-    this.setProperties({
-      isReplayStarted: true,
-      isReplayStatusPending: true
-    });
-
-    // Begin triggering of replay sequence
-    this.callReplayStart(newFuncId, startTime, endTime).then((replayId) => {
-      return replayId;
-    })
-  },
-
-  /**
    * Enriches the list of functions by Id, adding the properties we may want to display.
    * We are preparing to display the alerts that belong to the currently selected config group.
    * @method prepareFunctions
@@ -730,10 +672,27 @@ export default Controller.extend({
     'alertGroupNewRecipient',
     'isAlertNameDuplicate',
     'isGroupNameDuplicate',
+    'isProcessingForm',
     function() {
       let isDisabled = false;
-      const requiredFields = this.get('requiredFields');
-      const groupRecipients = this.get('selectedConfigGroup.recipients');
+      const {
+        requiredFields,
+        isProcessingForm,
+        newConfigGroupName,
+        isAlertNameDuplicate,
+        isGroupNameDuplicate,
+        alertGroupNewRecipient,
+        selectedConfigGroup: groupRecipients,
+      } = this.getProperties(
+        'requiredFields',
+        'isProcessingForm',
+        'newConfigGroupName',
+        'isAlertNameDuplicate',
+        'isGroupNameDuplicate',
+        'alertGroupNewRecipient',
+        'selectedConfigGroup'
+      );
+      const hasRecipients = _.has(groupRecipients, 'recipients');
       // Any missing required field values?
       for (var field of requiredFields) {
         if (Ember.isBlank(this.get(field))) {
@@ -741,16 +700,19 @@ export default Controller.extend({
         }
       }
       // Enable submit if either of these field values are present
-      if (Ember.isBlank(this.get('selectedConfigGroup')) && Ember.isBlank(this.get('newConfigGroupName'))) {
+      if (Ember.isBlank(groupRecipients) && Ember.isBlank(newConfigGroupName)) {
         isDisabled = true;
       }
-
       // Duplicate alert Name or group name
-      if (this.get('isAlertNameDuplicate') || this.get('isGroupNameDuplicate')) {
+      if (isAlertNameDuplicate || isGroupNameDuplicate) {
         isDisabled = true;
       }
       // For alert group email recipients, require presence only if group recipients is empty
-      if (Ember.isBlank(this.get('alertGroupNewRecipient')) && !groupRecipients) {
+      if (Ember.isBlank(alertGroupNewRecipient) && !hasRecipients) {
+        isDisabled = true;
+      }
+      // Disable after submit clicked
+      if (isProcessingForm) {
         isDisabled = true;
       }
       return isDisabled;
@@ -1260,12 +1222,11 @@ export default Controller.extend({
 
       // This object contains the data for the new alert function, with default fillers
       const {
+        redirectToAlertPage,
         newAlertProperties: newFunctionObj,
         selectedGroupRecipients: oldEmails,
         alertGroupNewRecipient: newEmails
-      } = this.getProperties('newAlertProperties', 'selectedGroupRecipients', 'alertGroupNewRecipient');
-
-      const redirectToAlertPage = this.get('redirectToAlertPage');
+      } = this.getProperties('redirectToAlertPage', 'newAlertProperties', 'selectedGroupRecipients', 'alertGroupNewRecipient');
       const newEmailsArr = newEmails ? newEmails.replace(/ /g, '').split(',') : [];
       const existingEmailsArr = oldEmails ? oldEmails.replace(/ /g, '').split(',') : [];
       const newRecipientsArr = newEmailsArr.length ? existingEmailsArr.concat(newEmailsArr) : existingEmailsArr;
@@ -1316,53 +1277,28 @@ export default Controller.extend({
             // Display success confirmations including new alert Id and recipients
             this.setProperties({
               selectedGroupRecipients: finalConfigObj.recipients.replace(/,+/g, ', '),
-              isCreateAlertSuccess: true,
               finalFunctionId: newFunctionId
             });
-            // Confirm group creation if not in group edit mode
-            if (!isEditGroupMode) {
-              this.set('isCreateGroupSuccess', true);
-            }
-
             // Display function added to group confirmation
             this.prepareFunctions(finalConfigObj, newFunctionId).then(functionData => {
               this.set('selectedGroupFunctions', functionData);
             });
-
             // Now, disable form
             this.setProperties({
+              newFuncId: newFunctionId,
               isFormDisabled: true,
               isMetricSelected: false,
               isMetricDataInvalid: false
             });
-            this.set('newFuncId', newFunctionId);
+            // Start the replay sequence and transition to Alert Page
             this.send('triggerReplaySequence', newFunctionId);
-/*          return this.triggerReplay(newFunctionId);
-        }).then((replayId) => {
-          debugger;
-          if (!this.get('isReplayStatusError')) {
-            this.setProperties({
-              isReplayStatusSuccess: true,
-              isReplayStatusPending: false,
-              replayStatusClass: 'te-form__banner--success'
-            });
-          }
-
-          // Redirect to onboarding page to trigger wrapper
-          if (redirectToAlertPage) {
-            this.transitionToRoute('manage.alert', this.get('newFuncId'), { queryParams: { replayId }});
-          }*/
         // If Alert Group edit/create fails, remove the orphaned anomaly Id
         }).catch((error) => {
-          console.log('catch 2');
-          debugger;
           this.setAlertCreateErrorState(error);
           this.removeThirdEyeFunction(newFunctionId);
         });
       // Alert creation call has failed
       }).catch((error) => {
-        console.log('catch 3');
-        debugger;
         this.setAlertCreateErrorState(error);
       });
     }

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -1274,22 +1274,6 @@ export default Controller.extend({
         // Finally, save our Alert Config Groupg
         this.saveThirdEyeEntity(finalConfigObj, 'ALERT_CONFIG')
           .then(alertResult => {
-            // Display success confirmations including new alert Id and recipients
-            this.setProperties({
-              selectedGroupRecipients: finalConfigObj.recipients.replace(/,+/g, ', '),
-              finalFunctionId: newFunctionId
-            });
-            // Display function added to group confirmation
-            this.prepareFunctions(finalConfigObj, newFunctionId).then(functionData => {
-              this.set('selectedGroupFunctions', functionData);
-            });
-            // Now, disable form
-            this.setProperties({
-              newFuncId: newFunctionId,
-              isFormDisabled: true,
-              isMetricSelected: false,
-              isMetricDataInvalid: false
-            });
             // Start the replay sequence and transition to Alert Page
             this.send('triggerReplaySequence', newFunctionId);
         // If Alert Group edit/create fails, remove the orphaned anomaly Id

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
@@ -6,23 +6,13 @@
 import Ember from 'ember';
 import fetch from 'fetch';
 import RSVP from 'rsvp';
+import { postProps, checkStatus } from 'thirdeye-frontend/helpers/utils';
 
 export default Ember.Route.extend({
   queryParams: {
     newUx: {
       refreshModel: false,
       replace: true
-    }
-  },
-
-  actions: {
-    /**
-    * Refresh route's model.
-    * @method refreshModel
-    * @return {undefined}
-    */
-    refreshModel() {
-      this.refresh();
     }
   },
 
@@ -53,6 +43,34 @@ export default Ember.Route.extend({
     if (isExiting) {
       controller.clearAll();
     }
-  }
+  },
+
+  actions: {
+    /**
+    * Refresh route's model.
+    * @method refreshModel
+    */
+    refreshModel() {
+      this.refresh();
+    },
+
+    /**
+    * Trigger alert replay sequence after create has finished
+    * @param {Number} alertId - Id of newly created alert function
+    * @method triggerReplaySequence
+    */
+    triggerReplaySequence(alertId) {
+      const replayUrl = this.controller.buildReplayUrl(alertId);
+      fetch(replayUrl, postProps('')).then(checkStatus)
+        .then((replayId) => {
+          this.transitionTo('manage.alert', alertId, { queryParams: { replayId }});
+        })
+        // In the event of failure to trigger, transition anyway, without replay Id
+        // The new API will handle notifying users of job failures.
+        .catch(() => {
+          this.transitionTo('manage.alert', alertId, { queryParams: { replayId: 0 }});
+        });
+    }
+  },
 
 });


### PR DESCRIPTION
This takes care of the transition from alert creation to alert page, after the replay has been triggered. Here we are still using the `/notifyreplaytuning` API to trigger replay. In our next iteration we will be replacing this with the new task handler API `/detection-onboard/create-job`. For now, we are transitioning to the `manage/alert/{id}` route after a 2 min interval.