### PR TITLE
Add broker meter to track result's group by size

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/BrokerMeter.java
@@ -78,7 +78,9 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   LLC_QUERY_COUNT("queries", false),
   HLC_QUERY_COUNT("queries", false),
 
-  ROUTING_TABLE_REBUILD_FAILURES("failures", false);
+  ROUTING_TABLE_REBUILD_FAILURES("failures", false),
+
+  GROUP_BY_SIZE("queries", false);
 
   private final String brokerMeterName;
   private final String unit;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -203,6 +203,12 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
           setGroupByHavingResults(brokerResponseNative, aggregationFunctions, aggregationFunctionSelectStatus,
               brokerRequest.getGroupBy(), dataTableMap, brokerRequest.getHavingFilterQuery(),
               brokerRequest.getHavingFilterSubQueryMap());
+          if (brokerMetrics != null && (!brokerResponseNative.getAggregationResults().isEmpty())) {
+            // We emit the group by size when the result isn't empty. All the sizes among group by results should be the same.
+            // Thus, we can just choose the size of 1st group by result.
+            brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.GROUP_BY_SIZE,
+                brokerResponseNative.getAggregationResults().get(0).getGroupByResult().size());
+          }
         }
       }
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -204,8 +204,8 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
               brokerRequest.getGroupBy(), dataTableMap, brokerRequest.getHavingFilterQuery(),
               brokerRequest.getHavingFilterSubQueryMap());
           if (brokerMetrics != null && (!brokerResponseNative.getAggregationResults().isEmpty())) {
-            // We emit the group by size when the result isn't empty. All the sizes among group by results should be the same.
-            // Thus, we can just choose the size of 1st group by result.
+            // We emit the group by size when the result isn't empty. All the sizes among group-by results should be the same.
+            // Thus, we can just emit the one from the 1st result.
             brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.GROUP_BY_SIZE,
                 brokerResponseNative.getAggregationResults().get(0).getGroupByResult().size());
           }


### PR DESCRIPTION
This PR adds broker meter to keep track of group by size from the result.