### PR TITLE
[TE] onboarding - reverse proxy for detection-onboarding

### DIFF
--- a/thirdeye/pom.xml
+++ b/thirdeye/pom.xml
@@ -23,6 +23,7 @@
     <dropwizard.version>0.9.2</dropwizard.version>
     <dropwizard-auth.version>0.9.2</dropwizard-auth.version>
     <dropwizard.redirect.bundle.version>1.0.5</dropwizard.redirect.bundle.version>
+    <jetty.version>9.2.13.v20150730</jetty.version>
     <jackson.version>2.8.3</jackson.version>
     <mysql.connector.version>5.1.39</mysql.connector.version>
     <quartz.version>2.2.1</quartz.version>
@@ -157,6 +158,12 @@
         <groupId>io.dropwizard-bundles</groupId>
         <artifactId>dropwizard-redirect-bundle</artifactId>
         <version>${dropwizard.redirect.bundle.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-proxy</artifactId>
+        <version>${jetty.version}</version>
       </dependency>
 
       <!-- jackson -->

--- a/thirdeye/thirdeye-pinot/pom.xml
+++ b/thirdeye/thirdeye-pinot/pom.xml
@@ -123,6 +123,10 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-proxy</artifactId>
+    </dependency>
 
     <!-- dataframe specific -->
     <dependency>

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -70,7 +70,9 @@ import java.util.concurrent.TimeUnit;
 import javax.crypto.spec.SecretKeySpec;
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
+import javax.servlet.ServletRegistration;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.eclipse.jetty.proxy.ProxyServlet;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,6 +153,14 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new AutoOnboardResource(config));
     env.jersey().register(new ConfigResource(DAO_REGISTRY.getConfigDAO()));
     env.jersey().register(new RootCauseSessionResource(DAO_REGISTRY.getRootcauseSessionDAO(), new ObjectMapper()));
+
+    if (config.getOnboardingHost() != null) {
+      LOG.info("Setting up onboarding proxy for '{}'", config.getOnboardingHost());
+      ServletRegistration.Dynamic proxy = env.servlets().addServlet("detection-onboard", ProxyServlet.Transparent.class);
+      proxy.setInitParameter("proxyTo", config.getOnboardingHost());
+      proxy.setInitParameter("prefix", "/detection-onboard");
+      proxy.addMapping("/detection-onboard/*");
+    }
 
     env.getObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardConfiguration.java
@@ -10,6 +10,7 @@ public class ThirdEyeDashboardConfiguration extends ThirdEyeConfiguration {
   AuthConfiguration authConfig;
   RootCauseConfiguration rootCause;
   List<ResourceConfiguration> resourceConfig;
+  String onboardingHost;
 
   public List<ResourceConfiguration> getResourceConfig() {
     return resourceConfig;
@@ -33,5 +34,13 @@ public class ThirdEyeDashboardConfiguration extends ThirdEyeConfiguration {
 
   public void setAuthConfig(AuthConfiguration authConfig) {
     this.authConfig = authConfig;
+  }
+
+  public String getOnboardingHost() {
+    return onboardingHost;
+  }
+
+  public void setOnboardingHost(String onboardingHost) {
+    this.onboardingHost = onboardingHost;
   }
 }


### PR DESCRIPTION
This workaround allows the frontend to connect directly of the detection-onboarding scheduler running on a backend controller via a reverse proxy. This functionality is to be removed as soon as onboarding is integrated fully with the existing task execution infrastructure.