### PR TITLE
[TE] datasource - timeseries window aggregation with offset

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/component.js
@@ -11,6 +11,7 @@ const granularityMapping = {
   '15 Minutes': '15_MINUTES',
   '1 Hour': '1_HOURS',
   '3 Hours': '3_HOURS',
+  '6 Hours': '6_HOURS',
   '1 Day': '1_DAYS'
 };
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
@@ -3,6 +3,7 @@ import { toAbsoluteRange, toFilters, toFilterMap } from 'thirdeye-frontend/utils
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
+import moment from 'moment';
 
 export default Ember.Service.extend({
   timeseries: null, // {}
@@ -100,10 +101,11 @@ export default Ember.Service.extend({
     const metricId = urn.split(':')[3];
     const metricFilters = toFilters([urn]);
     const filters = toFilterMap(metricFilters);
+    const granularityOffset = moment.tz.zone(moment.tz.guess()).offset(moment()) * 60000;
 
     const filterString = encodeURIComponent(JSON.stringify(filters));
 
-    const url = `/timeseries/query?metricIds=${metricId}&ranges=${range[0]}:${range[1]}&filters=${filterString}&granularity=${context.granularity}`;
+    const url = `/timeseries/query?metricIds=${metricId}&ranges=${range[0]}:${range[1]}&filters=${filterString}&granularity=${context.granularity}&granularityOffset=${granularityOffset}`;
     return fetch(url)
       .then(checkStatus)
       .then(res => this._extractTimeseries(res, urn))

--- a/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
+++ b/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
@@ -115,7 +115,7 @@ export default Helper.extend({
     /** TODO: abstract the js out of the template */
     return htmlSafe(`
       <div class="te-tooltip">
-        <h5 class="te-tooltip__header">${humanTimeStamp} (PDT)</h5>
+        <h5 class="te-tooltip__header">${humanTimeStamp} (local)</h5>
         <div class="te-tooltip__body">
           ${metricUrns.map((urn) => {
             return `

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/DefaultTimeSeriesLoader.java
@@ -34,8 +34,8 @@ public class DefaultTimeSeriesLoader implements TimeSeriesLoader {
    */
   @Override
   public DataFrame load(MetricSlice slice) throws Exception {
-    LOG.info("Loading timeseries for metric id {} time range {}:{} with filters '{}' and granularity {}",
-        slice.getMetricId(), slice.getStart(), slice.getEnd(), slice.getFilters(), slice.getGranularity());
+    LOG.info("Loading timeseries for metric id {} time range {}:{} with filters '{}', granularity {}, and offset: {}",
+        slice.getMetricId(), slice.getStart(), slice.getEnd(), slice.getFilters(), slice.getGranularity(), slice.getGranularityOffset());
 
     TimeSeriesRequestContainer rc = DataFrameUtils.makeTimeSeriesRequestAligned(slice, "ref", this.metricDAO, this.datasetDAO);
     ThirdEyeResponse response = this.cache.getQueryResult(rc.getRequest());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/MetricSlice.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/MetricSlice.java
@@ -9,19 +9,22 @@ import java.util.concurrent.TimeUnit;
 
 public final class MetricSlice {
   public static final TimeGranularity NATIVE_GRANULARITY = new TimeGranularity(0, TimeUnit.MILLISECONDS);
+  public static final long DEFAULT_GRANULARITY_OFFSET = 0;
 
   final long metricId;
   final long start;
   final long end;
   final Multimap<String, String> filters;
   final TimeGranularity granularity;
+  final long granularityOffset;
 
-  MetricSlice(long metricId, long start, long end, Multimap<String, String> filters, TimeGranularity granularity) {
+  MetricSlice(long metricId, long start, long end, Multimap<String, String> filters, TimeGranularity granularity, long granularityOffset) {
     this.metricId = metricId;
     this.start = start;
     this.end = end;
     this.filters = filters;
     this.granularity = granularity;
+    this.granularityOffset = granularityOffset;
   }
 
   public long getMetricId() {
@@ -44,31 +47,47 @@ public final class MetricSlice {
     return granularity;
   }
 
+  public long getGranularityOffset() {
+    return granularityOffset;
+  }
+
+  public MetricSlice withMetricId(long metricId) {
+    return new MetricSlice(metricId, start, end, filters, granularity, granularityOffset);
+  }
+
   public MetricSlice withStart(long start) {
-    return new MetricSlice(metricId, start, end, filters, granularity);
+    return new MetricSlice(metricId, start, end, filters, granularity, granularityOffset);
   }
 
   public MetricSlice withEnd(long end) {
-    return new MetricSlice(metricId, start, end, filters, granularity);
+    return new MetricSlice(metricId, start, end, filters, granularity, granularityOffset);
   }
 
   public MetricSlice withFilters(Multimap<String, String> filters) {
-    return new MetricSlice(metricId, start, end, filters, granularity);
+    return new MetricSlice(metricId, start, end, filters, granularity, granularityOffset);
   }
 
   public MetricSlice withGranularity(TimeGranularity granularity) {
-    return new MetricSlice(metricId, start, end, filters, granularity);
+    return new MetricSlice(metricId, start, end, filters, granularity, granularityOffset);
+  }
+
+  public MetricSlice withGranularityOffset(long granularityOffset) {
+    return new MetricSlice(metricId, start, end, filters, granularity, granularityOffset);
   }
 
   public static MetricSlice from(long metricId, long start, long end) {
-    return new MetricSlice(metricId, start, end, ArrayListMultimap.<String, String>create(), NATIVE_GRANULARITY);
+    return new MetricSlice(metricId, start, end, ArrayListMultimap.<String, String>create(), NATIVE_GRANULARITY, DEFAULT_GRANULARITY_OFFSET);
   }
 
   public static MetricSlice from(long metricId, long start, long end, Multimap<String, String> filters) {
-    return new MetricSlice(metricId, start, end, filters, NATIVE_GRANULARITY);
+    return new MetricSlice(metricId, start, end, filters, NATIVE_GRANULARITY, DEFAULT_GRANULARITY_OFFSET);
   }
 
   public static MetricSlice from(long metricId, long start, long end, Multimap<String, String> filters, TimeGranularity granularity) {
-    return new MetricSlice(metricId, start, end, filters, granularity);
+    return new MetricSlice(metricId, start, end, filters, granularity, DEFAULT_GRANULARITY_OFFSET);
+  }
+
+  public static MetricSlice from(long metricId, long start, long end, Multimap<String, String> filters, TimeGranularity granularity, long granularityOffset) {
+    return new MetricSlice(metricId, start, end, filters, granularity, granularityOffset);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/TimeSeriesRequestContainer.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/TimeSeriesRequestContainer.java
@@ -9,12 +9,14 @@ public class TimeSeriesRequestContainer extends RequestContainer {
   final long start;
   final long end;
   final long interval;
+  final long offset;
 
-  public TimeSeriesRequestContainer(ThirdEyeRequest request, List<MetricExpression> expressions, long start, long end, long interval) {
+  public TimeSeriesRequestContainer(ThirdEyeRequest request, List<MetricExpression> expressions, long start, long end, long interval, long offset) {
     super(request, expressions);
     this.start = start;
     this.end = end;
     this.interval = interval;
+    this.offset = offset;
   }
 
   public long getStart() {
@@ -27,5 +29,9 @@ public class TimeSeriesRequestContainer extends RequestContainer {
 
   public long getInterval() {
     return interval;
+  }
+
+  public long getOffset() {
+    return offset;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/TimeRangeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/TimeRangeUtils.java
@@ -13,6 +13,8 @@ import com.google.common.collect.Range;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeRange;
 import org.joda.time.Hours;
+import org.joda.time.tz.DateTimeZoneBuilder;
+
 
 /**
  * Not to be confused with {@link TimeRange}. This class handles splitting time windows into
@@ -90,7 +92,11 @@ public class TimeRangeUtils {
     int index = -1;
     switch (granularity.getUnit()) {
     case DAYS:
-      Days d = Days.daysBetween(start.toLocalDate(), current.toLocalDate());
+      // HACK: start holds implicit time zone offset
+      int offset = (int) (start.getMillis() - start.withTimeAtStartOfDay().getMillis());
+      DateTimeZone tz = DateTimeZone.forOffsetMillis(offset);
+
+      Days d = Days.daysBetween(start.toDateTime(tz), current.toDateTime(tz));
       index = d.getDays() / granularity.getSize();
       break;
     default:

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -313,7 +313,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
       TimeGranularity dataGranularity = null;
       long startTime = request.getStartTimeInclusive().getMillis();
       DateTimeZone dateTimeZone = Utils.getDataTimeZone(dataset);
-      DateTime startDateTime = new DateTime(startTime, dateTimeZone);
+      DateTime startDateTime = new DateTime(startTime, DateTimeZone.UTC);
       dataGranularity = dataTimeSpec.getDataGranularity();
       boolean isISOFormat = false;
       DateTimeFormatter inputDataDateTimeFormatter = null;
@@ -354,7 +354,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
                 }
                 timeBucket = TimeRangeUtils
                     .computeBucketIndex(request.getGroupByTimeGranularity(), startDateTime,
-                        new DateTime(millis, dateTimeZone));
+                        new DateTime(millis, DateTimeZone.UTC));
                 groupKeyVal = String.valueOf(timeBucket);
               }
               groupKeys[grpKeyIdx] = groupKeyVal;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dashboard/resource/TimeSeriesResourceTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.thirdeye.dashboard.resource;
 
-import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.dashboard.resources.v2.TimeSeriesResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.timeseries.TimeSeriesLoader;
 import com.linkedin.thirdeye.dataframe.DataFrame;
@@ -43,7 +42,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testBasic() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0", RANGE, null, null, null, null);
+        "0", RANGE, null, null, null, null, "0");
 
     Assert.assertEquals(out.size(), 1);
     Assert.assertTrue(out.containsKey(RANGE));
@@ -61,7 +60,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationCumulative() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0", RANGE, null, null, "cumulative", null);
+        "0", RANGE, null, null, "cumulative", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -71,7 +70,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationDifference() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0", RANGE, null, null, "difference", null);
+        "0", RANGE, null, null, "difference", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -81,7 +80,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationFillForward() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0", RANGE, null, null, "fillforward", null);
+        "0", RANGE, null, null, "fillforward", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -91,7 +90,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationFillZero() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0", RANGE, null, null, "fillzero", null);
+        "0", RANGE, null, null, "fillzero", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -101,7 +100,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationChange() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "2", RANGE, null, null, "change", null);
+        "2", RANGE, null, null, "change", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -111,7 +110,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationOffset() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "9", RANGE, null, null, "offset", null);
+        "9", RANGE, null, null, "offset", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -121,7 +120,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationRelative() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "1", RANGE, null, null, "relative", null);
+        "1", RANGE, null, null, "relative", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -131,7 +130,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testTranformationLog() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0", RANGE, null, null, "log", null);
+        "0", RANGE, null, null, "log", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -140,13 +139,13 @@ public class TimeSeriesResourceTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testTranformationChangeNoGranularityFail() throws Exception {
-    this.resource.getTimeSeries("0", RANGE, null, null, "timestamp", null);
+    this.resource.getTimeSeries("0", RANGE, null, null, "timestamp", null, "0");
   }
 
   @Test
   public void testMultiTranformation() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "2", RANGE, null, null, "change,fillforward,cumulative", null);
+        "2", RANGE, null, null, "change,fillforward,cumulative", null, "0");
     Map<String, List<? extends Number>> ts = out.get(RANGE);
 
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 10L, 20L, 30L, 40L, 50L));
@@ -156,7 +155,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testAggregationSingleRange() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0,1", RANGE, null, null, null, "sum");
+        "0,1", RANGE, null, null, null, "sum", "0");
 
     Map<String, List<? extends Number>> ts = out.get("sum");
 
@@ -168,7 +167,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testAggregationMultiRange() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0,1", RANGE + ",20:80", null, null, null, "sum");
+        "0,1", RANGE + ",20:80", null, null, null, "sum", "0");
 
     Map<String, List<? extends Number>> ts = out.get("sum");
 
@@ -179,18 +178,18 @@ public class TimeSeriesResourceTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testAggregationMultiRangeDifferentLengthFail() throws Exception {
-    this.resource.getTimeSeries("0,1", RANGE + ",20:90", null, null, null, "sum");
+    this.resource.getTimeSeries("0,1", RANGE + ",20:90", null, null, null, "sum", "0");
   }
 
   @Test
   public void testNoAggregationMultiRangeDifferentLengthPass() throws Exception {
-    this.resource.getTimeSeries("0,1", RANGE + ",20:90", null, null, null, null);
+    this.resource.getTimeSeries("0,1", RANGE + ",20:90", null, null, null, null, "0");
   }
 
   @Test
   public void testMultiAggregationMultiRange() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0,1", RANGE + ",20:80", null, null, null, "sum,product");
+        "0,1", RANGE + ",20:80", null, null, null, "sum,product", "0");
 
     Map<String, List<? extends Number>> ts = out.get("sum");
     Assert.assertEquals(ts.get(COL_TIME), Arrays.asList(0L, 1L, 2L, 3L, 4L, 5L));
@@ -207,7 +206,7 @@ public class TimeSeriesResourceTest {
   @Test
   public void testMultiTransformationMultiAggregationMultiRange() throws Exception {
     Map<String, Map<String, List<? extends Number>>> out = this.resource.getTimeSeries(
-        "0,1", RANGE + ",20:80", null, null, "fillforward,cumulative", "sum,product");
+        "0,1", RANGE + ",20:80", null, null, "fillforward,cumulative", "sum,product", "0");
 
     // 0: 1d, 0d, -1d, 0d, 1d, null
     // 1: 2d, 1d,  0d, 1d, 2d, null


### PR DESCRIPTION
The existing, legacy pinot data source is unable to partially aggregate time series into windows/buckets that are not aligned with UTC time. Additionally, there is a (rare) condition where data set timezone becomes mingled with the timezone of the request range. This PR addresses the issue in the open-source pinot connector until the data source is re-written from scratch to operate on time stamps instead of bucket indices.

Additionally, this PR enables the frontend to request time series aligned to arbitrary timezone offsets.