### PR TITLE
[TE] frontend - Translate granularity dropdown options to human-readable format

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/template.hbs
@@ -29,7 +29,7 @@
     </span>
   </label>
   {{#power-select
-    selected=granularity
+    selected=selectedOption
     options=granularityOptions
     searchEnabled=false
     triggerId="select-granularity"

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -134,7 +134,7 @@ export default Ember.Controller.extend({
       hoverUrns: new Set(),
       filteredUrns: new Set(),
       activeTab: ROOTCAUSE_TAB_METRICS,
-      timeseriesMode: 'absolute'
+      timeseriesMode: 'split'
     });
 
     Ember.run.later(this, this._onCheckSessionTimer, ROOTCAUSE_SESSION_TIMER_INTERVAL);


### PR DESCRIPTION
- Granularity dropdown values are now grammatically correct
- Default compare by mode is changed to "split"