### PR TITLE
[TE] Add email recipients when an alert group exists

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/BaseEmailContentFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/alert/content/BaseEmailContentFormatter.java
@@ -15,6 +15,7 @@ import com.linkedin.thirdeye.anomaly.events.EventDataProviderManager;
 import com.linkedin.thirdeye.anomaly.events.EventFilter;
 import com.linkedin.thirdeye.anomaly.events.EventType;
 import com.linkedin.thirdeye.anomaly.events.HolidayEventProvider;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyFeedback;
 import com.linkedin.thirdeye.anomalydetection.context.AnomalyResult;
 import com.linkedin.thirdeye.api.DimensionMap;
@@ -54,7 +55,6 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.mail.HtmlEmail;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -90,8 +90,6 @@ public abstract class BaseEmailContentFormatter implements EmailContentFormatter
   public static final String DEFAULT_TIME_ZONE = "America/Los_Angeles";
   public static final String DEFAULT_EVENT_CRAWL_OFFSET = "P2D";
 
-  public static Pattern EMAIL_REGEX_PATTERN = Pattern.compile(
-      "\\b[\\w.%-]+@[-.\\w]+\\.[A-Za-z]{2,4}\\b", Pattern.CASE_INSENSITIVE);
   public static final String EVENT_FILTER_COUNTRY = "countryCode";
 
   protected DateTimeZone dateTimeZone;
@@ -260,7 +258,7 @@ public abstract class BaseEmailContentFormatter implements EmailContentFormatter
       String alertEmailHtml = new String(baos.toByteArray(), AlertTaskRunnerV2.CHARSET);
 
       emailEntity.setFrom(fromEmail);
-      emailEntity.setTo(getValidEmailAddresses(emailRecipients));
+      emailEntity.setTo(EmailUtils.getValidEmailAddresses(emailRecipients));
       emailEntity.setSubject(subject);
       email.setHtmlMsg(alertEmailHtml);
       emailEntity.setContent(email);
@@ -268,41 +266,6 @@ public abstract class BaseEmailContentFormatter implements EmailContentFormatter
       Throwables.propagate(e);
     }
     return emailEntity;
-  }
-
-  /**
-   * Return a list of valid email addresses
-   * @param emails
-   * @return
-   */
-  public static String getValidEmailAddresses(String emails) {
-    StringBuilder emailAddressBuilder = new StringBuilder();
-    List<String> invalidEmailAddresses = new ArrayList<>();
-    if (StringUtils.isBlank(emails)) {
-      return null;
-    } else {
-      String[] emailArr = emails.split(",");
-      for (String email : emailArr) {
-        if (isValidEmailAddress(email)) {
-          emailAddressBuilder.append(email + ",");
-        } else {
-          invalidEmailAddresses.add(email);
-        }
-      }
-    }
-    if (invalidEmailAddresses.size() > 0) {
-      LOG.warn("Found invalid email addresses, please verify the email addresses: {}", invalidEmailAddresses);
-    }
-    return emailAddressBuilder.deleteCharAt(emailAddressBuilder.length() - 1).toString();
-  }
-
-  /**
-   * Check if given email is a valid email
-   * @param email
-   * @return
-   */
-  public static boolean isValidEmailAddress(String email) {
-    return EMAIL_REGEX_PATTERN.matcher(email).matches();
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -220,6 +220,15 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       alertConfig = alertConfigDAO.findById(configuration.getLong(ALERT_ID));
       EmailConfig emailConfig = alertConfig.getEmailConfig();
       emailConfig.getFunctionIds().add(anomalyFunction.getId());
+
+      // Add recipients to existing alert group
+      String recipients = configuration.getString(ALERT_TO);
+      if (StringUtils.isNotBlank(recipients)) {
+        if (StringUtils.isNotBlank(alertConfig.getRecipients())) {
+          recipients = recipients + "," + alertConfig.getRecipients();
+        }
+        alertConfig.setRecipients(recipients);
+      }
       alertConfigDAO.update(alertConfig);
     } else {
       alertConfig = new AlertConfigDTO();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.anomaly.onboard.BaseDetectionOnboardTask;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardExecutionContext;
 import com.linkedin.thirdeye.anomaly.onboard.DetectionOnboardTaskContext;
+import com.linkedin.thirdeye.anomaly.utils.EmailUtils;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.api.TimeSpec;
 import com.linkedin.thirdeye.dashboard.resources.AnomalyResource;
@@ -227,6 +228,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
         if (StringUtils.isNotBlank(alertConfig.getRecipients())) {
           recipients = recipients + "," + alertConfig.getRecipients();
         }
+        recipients = EmailUtils.getValidEmailAddresses(recipients);
         alertConfig.setRecipients(recipients);
       }
       alertConfigDAO.update(alertConfig);
@@ -242,6 +244,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       if (configuration.containsKey(ALERT_TO)) {
         alertRecipients = alertRecipients + "," + configuration.getString(ALERT_TO);
       }
+      alertRecipients = EmailUtils.getValidEmailAddresses(alertRecipients);
       alertConfig.setApplication(configuration.getString(ALERT_APPLICATION));
       alertConfig.setRecipients(alertRecipients);
       alertConfig.setCronExpression(configuration.getString(ALERT_CRON, DEFAULT_ALERT_CRON));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/EmailUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/utils/EmailUtils.java
@@ -1,0 +1,53 @@
+package com.linkedin.thirdeye.anomaly.utils;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class EmailUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(EmailUtils.class);
+  public static Pattern EMAIL_REGEX_PATTERN = Pattern.compile(
+      "\\b[\\w.%-]+@[-.\\w]+\\.[A-Za-z]{2,4}\\b", Pattern.CASE_INSENSITIVE);
+  /**
+   * Check if given email is a valid email
+   * @param email
+   * @return
+   */
+  public static boolean isValidEmailAddress(String email) {
+    return EMAIL_REGEX_PATTERN.matcher(email).matches();
+  }
+
+  /**
+   * Return a list of valid email addresses
+   * @param emails
+   * @return
+   */
+  public static String getValidEmailAddresses(String emails) {
+    List<String> emailAddressList= new ArrayList<>();
+    Set<String> addedEmailAddresses = new HashSet<>();
+    List<String> invalidEmailAddresses = new ArrayList<>();
+    if (StringUtils.isBlank(emails)) {
+      return null;
+    } else {
+      String[] emailArr = emails.split(",");
+      for (String email : emailArr) {
+        if (isValidEmailAddress(email) && !addedEmailAddresses.contains(email)) {
+          emailAddressList.add(email);
+          addedEmailAddresses.add(email);
+        } else {
+          invalidEmailAddresses.add(email);
+        }
+      }
+    }
+    if (invalidEmailAddresses.size() > 0) {
+      LOG.warn("Found invalid email addresses, please verify the email addresses: {}", invalidEmailAddresses);
+    }
+    return StringUtils.join(emailAddressList, ",");
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/utils/TestEmailUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/utils/TestEmailUtils.java
@@ -1,0 +1,22 @@
+package com.linkedin.thirdeye.anomaly.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestEmailUtils {
+  @Test
+  public void testIsValidEmailAddress() {
+    Assert.assertTrue(EmailUtils.isValidEmailAddress("abc@cba.abc"));
+    Assert.assertFalse(EmailUtils.isValidEmailAddress("abc"));
+  }
+
+
+  @Test
+  public void testGetValidEmailAddresses() {
+    String emailAddresses = "abc@cba.abc,bcd@dcb.bcd";
+    Assert.assertEquals(EmailUtils.getValidEmailAddresses(emailAddresses), emailAddresses);
+    Assert.assertEquals(EmailUtils.getValidEmailAddresses(emailAddresses + ",abc"), emailAddresses);
+    Assert.assertEquals(EmailUtils.getValidEmailAddresses(emailAddresses + ",abc@cba.abc"), emailAddresses);
+  }
+}


### PR DESCRIPTION
In current pipeline, the new assigned email recipients are missed when updating an existing alerts. This pr is to fix this bug. 