### PR TITLE
Modify murmur function to always use UTF-8 bytes

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/MurmurPartitionFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/partition/MurmurPartitionFunction.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.core.data.partition;
 
 import com.google.common.base.Preconditions;
 import org.apache.kafka.common.utils.Utils;
+import java.nio.charset.Charset;
 
 
 /**
@@ -31,6 +32,7 @@ import org.apache.kafka.common.utils.Utils;
  */
 public class MurmurPartitionFunction implements PartitionFunction {
   private static final String NAME = "Murmur";
+  private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
   private final int _numPartitions;
 
   /**
@@ -45,7 +47,7 @@ public class MurmurPartitionFunction implements PartitionFunction {
   @Override
   public int getPartition(Object valueIn) {
     String value = (valueIn instanceof String) ? (String) valueIn : valueIn.toString();
-    return (Utils.murmur2((value).getBytes()) & 0x7fffffff) % _numPartitions;
+    return (Utils.murmur2((value).getBytes(UTF8_CHARSET)) & 0x7fffffff) % _numPartitions;
   }
 
   @Override


### PR DESCRIPTION
Murmur partition function picks up the default charset, which can be different 
based on the system environment. This forces murmur partition function to use
UTF-8 bytes.