### PR TITLE
[TE] Self-Serve Onboarding 02: enhancements

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -325,6 +325,7 @@ export default Controller.extend({
       checkReplayInterval
     } = this.getProperties('alertId', 'functionName', 'requestCanContinue', 'checkReplayInterval');
     const br = `\r\n`;
+    const replayStatusArr = ['completed', 'timeout'];
     const subject = 'TE Self-Serve Create Alert Issue';
     const intro = `TE Team, please look into a replay error for...${br}${br}`;
     const mailtoString = `mailto:ask_thirdeye@linkedin.com?subject=${encodeURIComponent(subject)}&body=`;
@@ -339,8 +340,9 @@ export default Controller.extend({
         const replayStatus = replayStatusObj ? replayStatusObj.taskStatus.toLowerCase() : '';
         const bodyString = `${intro}jobId: ${jobId}${br}alertId: ${alertId}${br}functionName: ${functionName}${br}${br}error: ${replayErr}`;
 
-        if (replayStatus === 'completed') {
+        if (replayStatusArr.includes(replayStatus)) {
           this.set('isReplayPending', false);
+          this.send('refreshModel');
           this.transitionToRoute('manage.alert', alertId, { queryParams: { jobId: null }});
         } else if (replayStatus === 'failed') {
           this.setProperties({

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -439,6 +439,12 @@ export default Route.extend({
   },
 
   actions: {
+    /**
+    * Refresh route's model.
+    */
+    refreshModel() {
+      this.refresh();
+    },
 
     /**
      * Handle any errors occurring in model/afterModel in parent route

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
@@ -23,8 +23,8 @@ export default Route.extend({
   beforeModel(transition) {
     const id = transition.params['manage.alert'].alertId;
     const { jobId, functionName } = transition.queryParams;
-    const durationDefault = '1m';
-    const startDateDefault = buildDateEod(1, 'month').valueOf();
+    const durationDefault = '3m';
+    const startDateDefault = buildDateEod(3, 'month').valueOf();
     const endDateDefault = buildDateEod(1, 'day');
 
     // Enter default 'explore' route with defaults loaded in URI

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -4,12 +4,13 @@
  * @exports alerts controller
  */
 import Ember from 'ember';
-import { task, timeout } from 'ember-concurrency';
 import fetch from 'fetch';
 import _ from 'lodash';
+import { task, timeout } from 'ember-concurrency';
+import { checkStatus } from 'thirdeye-frontend/utils/utils';
 
 export default Ember.Controller.extend({
-  queryParams: ['selectedSearchMode', 'alertId'],
+  queryParams: ['selectedSearchMode', 'alertId', 'testMode'],
   /**
    * Alerts Search Mode options
    */
@@ -24,6 +25,11 @@ export default Ember.Controller.extend({
    * True when results appear
    */
   resultsActive: false,
+
+  /**
+   * Used to surface newer features pre-launch
+   */
+  testMode: null,
 
   /**
    * Default Search Mode
@@ -250,6 +256,7 @@ export default Ember.Controller.extend({
 
     /**
      * Send a DELETE request to the function delete endpoint.
+     * TODO: Include DELETE postProps in common util function
      * @method removeThirdEyeFunction
      * @param {Number} functionId - The id of the alert to remove
      * @return {Promise}
@@ -260,8 +267,8 @@ export default Ember.Controller.extend({
         headers: { 'content-type': 'text/plain' }
       };
       const url = '/dashboard/anomaly-function?id=' + functionId;
-      fetch(url, postProps).then(checkStatus).then((result) => {
-        this.transitionToRoute('manage.alerts');
+      fetch(url, postProps).then(checkStatus).then(() => {
+        this.send('refreshModel');
       });
     },
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -248,6 +248,23 @@ export default Ember.Controller.extend({
       }
     },
 
+    /**
+     * Send a DELETE request to the function delete endpoint.
+     * @method removeThirdEyeFunction
+     * @param {Number} functionId - The id of the alert to remove
+     * @return {Promise}
+     */
+    removeThirdEyeFunction(functionId) {
+      const postProps = {
+        method: 'delete',
+        headers: { 'content-type': 'text/plain' }
+      };
+      const url = '/dashboard/anomaly-function?id=' + functionId;
+      fetch(url, postProps).then(checkStatus).then((result) => {
+        this.transitionToRoute('manage.alerts');
+      });
+    },
+
     // Handles UI mode change
     onSearchModeChange(mode) {
       if (mode === 'All Alerts') {

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -50,5 +50,15 @@ export default Ember.Route.extend({
         resultsActive: true
       });
     }
+  },
+
+  actions: {
+    /**
+    * Refresh route's model.
+    * @method refreshModel
+    */
+    refreshModel() {
+      this.refresh();
+    }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
@@ -122,14 +122,23 @@
                 <span class="te-search-results__tag te-search-results__tag--list {{if alert.isActive "te-search-results__tag--active"}}">
                   {{if alert.isActive "Active" "Inactive"}}
                 </span>
-                {{!-- TODO: add {{#link-to "manage.alert.explore" alert.id}} when ready for new edit/tune flow --}}
-                <span title={{alert.functionName}}>{{alert.functionName}}</span>
+                {{#if testMode}}
+                  {{#link-to "manage.alert.explore" alert.id}}
+                    <span title={{alert.functionName}}>{{alert.functionName}}</span>
+                  {{/link-to}}
+                {{else}}
+                  <span title={{alert.functionName}}>{{alert.functionName}}</span>
+                {{/if}}
               </div>
             </div>
-            {{!-- TODO: remove this when enabling new edit/tune flow --}}
-            <div class="te-search-results__edit-button">
-              {{#link-to "manage.alerts.edit" alert.id}}<span class="glyphicon glyphicon-pencil"></span>{{/link-to}}
-            </div>
+            {{!-- TODO: remove delete option when enabling new edit/tune flow --}}
+              <div class="te-search-results__edit-button">
+                {{#if testMode}}
+                  <a href="#" {{action "removeThirdEyeFunction" alert.id}}><span class="glyphicon glyphicon-trash"></span></a>
+                {{else}}
+                  {{#link-to "manage.alerts.edit" alert.id}}<span class="glyphicon glyphicon-pencil"></span>{{/link-to}}
+                {{/if}}
+              </div>
           </div>
           <ul class="te-search-results__list te-search-results__list--details-block row">
             <div class="col-xs-12 col-sm-5">

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
@@ -7,7 +7,7 @@ import fetch from 'fetch';
 import RSVP from 'rsvp';
 import _ from 'lodash';
 import moment from 'moment';
-import { isArray } from "@ember/array"
+import { isArray } from "@ember/array";
 import Route from '@ember/routing/route';
 import { task, timeout } from 'ember-concurrency';
 import { postProps, checkStatus } from 'thirdeye-frontend/utils/utils';
@@ -23,7 +23,6 @@ export default Route.extend({
    */
   model(params, transition) {
     return RSVP.hash({
-      // Fetch all alert group configurations
       allConfigGroups: fetch('/thirdeye/entity/ALERT_CONFIG').then(res => res.json()),
       allAppNames: fetch('/thirdeye/entity/APPLICATION').then(res => res.json())
     });
@@ -53,7 +52,8 @@ export default Route.extend({
    * @return {undefined}
    */
   jumpToAlertPage(alertId, jobId, functionName) {
-    this.transitionTo('manage.alert', alertId, { queryParams: { jobId, functionName }});
+    const queryParams = { jobId, functionName };
+    this.transitionTo('manage.alert', alertId, { queryParams });
   },
 
   /**

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -83,7 +83,11 @@
     <div class="col-xs-12">
       <div class="te-graph-alert {{if (not isMetricSelected) 'te-graph-alert--pending'}}">
         {{#if (or isFetchingDimensions isDimensionFetchDone)}}
-          <div class="te-form__super-label">...{{if isDimensionFetchDone 'Displaying' 'Loading'}} top 5 contributing subDimensions for <strong>{{selectedDimension}}</strong></div>
+          {{#if isDimensionError}}
+            <div class="te-form__super-label">... error loading subDimensions for <strong>{{selectedDimension}}</strong></div>
+          {{else}}
+            <div class="te-form__super-label">...{{if isDimensionFetchDone 'Displaying' 'Loading'}} top 5 contributing subDimensions for <strong>{{selectedDimension}}</strong></div>
+          {{/if}}
         {{/if}}
         {{#if isMetricDataLoading}}
           <div class="spinner-wrapper--self-serve">{{ember-spinner}}</div>


### PR DESCRIPTION
- Allowing transition to Alert Page even if replay returns "timeout"
- Refreshing the model once replay is done (to fetch fresh anomaly data)
- Changing default time span for alert page to 3 months to sync with tuning range
- Adding alert deletion method in search page to be used once we have proper access to admin permissions
- For fetching dimension data in Create Alert, only reloading graph if we have new data
- Fix for onboarding: prevent sending null for alertRecipients

In second commit:
- Adding temporary URL query param for testing and alert clean-up