### PR TITLE
[TE] Self-Serve Onboarding 03: enhancements

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/application/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/application/controller.js
@@ -29,7 +29,7 @@ export default Ember.Controller.extend({
     {
       className: 'manage',
       link: 'manage.alerts',
-      title: 'Manage'
+      title: 'Manage Alerts'
     }
   ]
 });

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -330,6 +330,7 @@ export default Controller.extend({
       checkReplayInterval
     } = this.getProperties('alertId', 'functionName', 'replayStartTime', 'requestCanContinue', 'checkReplayInterval');
     const br = `\r\n`;
+    const replayStatusList = ['completed', 'failed'];
     const subject = 'TE Self-Serve Create Alert Issue';
     const intro = `TE Team, please look into a replay error for...${br}${br}`;
     const mailtoString = `mailto:ask_thirdeye@linkedin.com?subject=${encodeURIComponent(subject)}&body=`;
@@ -344,16 +345,12 @@ export default Controller.extend({
         const replayErr = replayStatusObj ? replayStatusObj.message : 'N/A';
         const replayStatus = replayStatusObj ? replayStatusObj.taskStatus.toLowerCase() : '';
         const bodyString = `${intro}jobId: ${jobId}${br}alertId: ${alertId}${br}functionName: ${functionName}${br}${br}error: ${replayErr}`;
+        const replayErrorMailtoStr = mailtoString + encodeURIComponent(bodyString);
 
-        if (replayStatus === 'completed' || isReplayTimeUp) {
+        if (replayStatusList.includes(replayStatus) || isReplayTimeUp) {
           this.set('isReplayPending', false);
           this.send('refreshModel');
           this.transitionToRoute('manage.alert', alertId, { queryParams: { jobId: null }});
-        } else if (replayStatus === 'failed') {
-          this.setProperties({
-            isReplayStatusError: true,
-            replayErrorMailtoStr: mailtoString + encodeURIComponent(bodyString)
-          });
         } else if (requestCanContinue) {
           later(() => {
             this.checkReplayStatus(jobId);

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -330,7 +330,7 @@ export default Controller.extend({
       checkReplayInterval
     } = this.getProperties('alertId', 'functionName', 'replayStartTime', 'requestCanContinue', 'checkReplayInterval');
     const br = `\r\n`;
-    const replayStatusList = ['completed', 'failed'];
+    const replayStatusList = ['completed', 'failed', 'timeout'];
     const subject = 'TE Self-Serve Create Alert Issue';
     const intro = `TE Team, please look into a replay error for...${br}${br}`;
     const mailtoString = `mailto:ask_thirdeye@linkedin.com?subject=${encodeURIComponent(subject)}&body=`;

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -81,6 +81,7 @@ export default Controller.extend({
 
     // Start checking for replay to end if a jobId is present
     if (this.get('isReplayPending')) {
+      this.set('replayStartTime', moment());
       this.checkReplayStatus(this.get('jobId'));
     }
   },
@@ -234,8 +235,11 @@ export default Controller.extend({
     'alertEvalMetrics',
     'alertEvalMetrics.projected',
     function() {
-      const evalMetrics = this.get('alertEvalMetrics');
-      return buildAnomalyStats(evalMetrics, 'explore');
+      const {
+        alertEvalMetrics,
+        defaultSeverity
+      } = this.getProperties('alertEvalMetrics', 'defaultSeverity');
+      return buildAnomalyStats(alertEvalMetrics, 'explore', defaultSeverity);
     }
   ),
 
@@ -321,14 +325,15 @@ export default Controller.extend({
     const {
       alertId,
       functionName,
+      replayStartTime,
       requestCanContinue,
       checkReplayInterval
-    } = this.getProperties('alertId', 'functionName', 'requestCanContinue', 'checkReplayInterval');
+    } = this.getProperties('alertId', 'functionName', 'replayStartTime', 'requestCanContinue', 'checkReplayInterval');
     const br = `\r\n`;
-    const replayStatusArr = ['completed', 'timeout'];
     const subject = 'TE Self-Serve Create Alert Issue';
     const intro = `TE Team, please look into a replay error for...${br}${br}`;
     const mailtoString = `mailto:ask_thirdeye@linkedin.com?subject=${encodeURIComponent(subject)}&body=`;
+    let isReplayTimeUp = Number(moment.duration(moment().diff(replayStartTime)).asSeconds().toFixed(0)) > 60;
 
     // In replay status check, continue to display "pending" banner unless we have known success or failure.
     fetch(checkStatusUrl).then(checkStatus)
@@ -340,7 +345,7 @@ export default Controller.extend({
         const replayStatus = replayStatusObj ? replayStatusObj.taskStatus.toLowerCase() : '';
         const bodyString = `${intro}jobId: ${jobId}${br}alertId: ${alertId}${br}functionName: ${functionName}${br}${br}error: ${replayErr}`;
 
-        if (replayStatusArr.includes(replayStatus)) {
+        if (replayStatus === 'completed' || isReplayTimeUp) {
           this.set('isReplayPending', false);
           this.send('refreshModel');
           this.transitionToRoute('manage.alert', alertId, { queryParams: { jobId: null }});

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -249,7 +249,7 @@ export default Route.extend({
       exploreDimensions
     };
 
-    // Load endpoints for projected metrics
+    // Load endpoints for projected metrics. TODO: consolidate into CP if duplicating this logic
     const qsParams = `start=${baseStart.utc().format(dateFormat)}&end=${baseEnd.utc().format(dateFormat)}&useNotified=true`;
     const dateParams = `start=${toIso(startDate)}&end=${toIso(endDate)}`;
     const anomalyDataUrl = `/anomalies/search/anomalyIds/${startStamp}/${endStamp}/1?anomalyIds=`;

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -19,6 +19,7 @@ const dateFormat = 'YYYY-MM-DD';
 /**
  * Basic alert page defaults
  */
+const defaultSeverity = 30;
 const paginationDefault = 10;
 const durationDefault = '1m';
 const metricDataColor = 'blue';
@@ -41,10 +42,6 @@ const anomalyResponseObj = [
   { name: 'False alarm',
     value: 'NOT_ANOMALY',
     status: 'False Alarm'
-  },
-  { name: 'I don\'t know',
-    value: 'NO_FEEDBACK',
-    status: 'Not Resolved'
   },
   { name: 'Confirmed - New Trend',
     value: 'ANOMALY_NEW_TREND',
@@ -179,12 +176,10 @@ export default Route.extend({
     } = transition.queryParams;
 
     // Prepare endpoints for eval, mttd, projected metrics calls
-    const tuneParams = `start=${toIso(startDate)}&end=${toIso(endDate)}`;
-    const tuneUrl = `/detection-job/autotune/filter/${id}?${tuneParams}`;
-    const evalUrl = `/detection-job/eval/filter/${id}?${tuneParams}`;
-    const mttdUrl = `/detection-job/eval/mttd/${id}`;
+    const dateParams = `start=${toIso(startDate)}&end=${toIso(endDate)}`;
+    const evalUrl = `/detection-job/eval/filter/${id}?${dateParams}`;
+    const mttdUrl = `/detection-job/eval/mttd/${id}?severity=${defaultSeverity/100}`;
     const performancePromiseHash = {
-      autotuneId: fetch(tuneUrl, postProps('')).then(checkStatus),
       current: fetch(`${evalUrl}&isProjected=FALSE`).then(checkStatus),
       projected: fetch(`${evalUrl}&isProjected=TRUE`).then(checkStatus),
       mttd: fetch(mttdUrl).then(checkStatus)
@@ -201,7 +196,7 @@ export default Route.extend({
           duration,
           startDate,
           endDate,
-          tuneParams,
+          dateParams,
           alertEvalMetrics
         };
       })
@@ -256,14 +251,13 @@ export default Route.extend({
 
     // Load endpoints for projected metrics
     const qsParams = `start=${baseStart.utc().format(dateFormat)}&end=${baseEnd.utc().format(dateFormat)}&useNotified=true`;
-    const tuneParams = `start=${toIso(startDate)}&end=${toIso(endDate)}`;
+    const dateParams = `start=${toIso(startDate)}&end=${toIso(endDate)}`;
     const anomalyDataUrl = `/anomalies/search/anomalyIds/${startStamp}/${endStamp}/1?anomalyIds=`;
-    const projectedMttdUrl = `/detection-job/eval/projected/mttd/${alertEvalMetrics.autotuneId}`;
     const metricsUrl = `/data/autocomplete/metric?name=${dataset}::${metricName}`;
     const anomaliesUrl = `/dashboard/anomaly-function/${alertId}/anomalies?${qsParams}`;
 
     const anomalyPromiseHash = {
-      projectedMttd: fetch(projectedMttdUrl).then(checkStatus),
+      projectedMttd: 0, // In overview mode, no projected MTTD value is needed
       metricsByName: fetch(metricsUrl).then(checkStatus),
       anomalyIds: fetch(anomaliesUrl).then(checkStatus)
     };
@@ -339,6 +333,7 @@ export default Route.extend({
       jobId,
       functionName,
       alertId: id,
+      defaultSeverity,
       isMetricDataInvalid: false,
       anomalyDataUrl,
       baselineOptions,

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -63,40 +63,42 @@
       <h4>Anomalies over time ({{filteredAnomalies.length}})</h4>
       <a class="te-pill-selectors__side-link te-pill-selectors__side-link--high" {{action "onClickReportAnomaly" this}}>Report missing anomaly</a>
 
-      <div class="te-pill-selectors">
-        {{!-- Dimension selector --}}
-        <div class="te-form__select te-form__select--wider col-md-3">
-          {{#power-select
-            triggerId="select-dimension"
-            triggerClass="te-form__select"
-            options=dimensionOptions
-            searchEnabled=false
-            matchTriggerWidth=true
-            matchContentWidth=true
-            selected=selectedDimension
-            onchange=(action "onSelectDimension")
-            as |dimension|
-          }}
-            {{dimension}}
-          {{/power-select}}
+      {{#if filteredAnomalies}}
+        <div class="te-pill-selectors">
+          {{!-- Dimension selector --}}
+          <div class="te-form__select te-form__select--wider col-md-3">
+            {{#power-select
+              triggerId="select-dimension"
+              triggerClass="te-form__select"
+              options=dimensionOptions
+              searchEnabled=false
+              matchTriggerWidth=true
+              matchContentWidth=true
+              selected=selectedDimension
+              onchange=(action "onSelectDimension")
+              as |dimension|
+            }}
+              {{dimension}}
+            {{/power-select}}
+          </div>
+          {{!-- Resolution selector --}}
+          <div class="te-pill-selectors__range-picker col-md-3">
+            {{#power-select
+              triggerId="select-resolution"
+              triggerClass="te-form__select"
+              options=resolutionOptions
+              searchEnabled=false
+              matchTriggerWidth=true
+              matchContentWidth=true
+              selected=selectedResolution
+              onchange=(action "onSelectResolution")
+              as |resolution|
+            }}
+              {{resolution}}
+            {{/power-select}}
+          </div>
         </div>
-        {{!-- Resolution selector --}}
-        <div class="te-pill-selectors__range-picker col-md-3">
-          {{#power-select
-            triggerId="select-resolution"
-            triggerClass="te-form__select"
-            options=resolutionOptions
-            searchEnabled=false
-            matchTriggerWidth=true
-            matchContentWidth=true
-            selected=selectedResolution
-            onchange=(action "onSelectResolution")
-            as |resolution|
-          }}
-            {{resolution}}
-          {{/power-select}}
-        </div>
-      </div>
+      {{/if}}
 
       {{!-- Missing anomaly modal --}}
       {{#te-modal
@@ -152,45 +154,40 @@
             {{/each}}
           </ul>
         </div>
-
-      {{else}}
-        No anomalies to show.
       {{/if}}
 
       {{!-- Alert anomaly table --}}
       <table class="te-anomaly-table">
         {{#if filteredAnomalies}}
-        <thead>
-          <tr class="te-anomaly-table__row te-anomaly-table__head">
-             <th class="te-anomaly-table__cell-head">
-              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
-                Start/Duration (PDT)
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-              </a>
+          <thead>
+            <tr class="te-anomaly-table__row te-anomaly-table__head">
+               <th class="te-anomaly-table__cell-head">
+                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
+                  Start/Duration (PDT)
+                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                </a>
+               </th>
+               <th class="te-anomaly-table__cell-head">Dimensions</th>
+               <th class="te-anomaly-table__cell-head">
+                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
+                  Severity Score
+                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                </a>
+               </th>
+               <th class="te-anomaly-table__cell-head">
+                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
+                  {{baselineTitle}}
+                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                </a>
+               </th>
+               <th class="te-anomaly-table__cell-head">
+                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
+                  Resolution
+                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                </a>
              </th>
-             <th class="te-anomaly-table__cell-head">Dimensions</th>
-             <th class="te-anomaly-table__cell-head">
-              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
-                Severity Score
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-              </a>
-             </th>
-             <th class="te-anomaly-table__cell-head">
-              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
-                {{baselineTitle}}
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-              </a>
-             </th>
-             <th class="te-anomaly-table__cell-head">
-              <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
-                Resolution
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-              </a>
-           </th>
-          </tr>
-        </thead>
-        {{else}}
-          No anomalies to show.
+            </tr>
+          </thead>
         {{/if}}
         <tbody>
           {{#each paginatedFilteredAnomalies as |anomaly|}}
@@ -232,17 +229,21 @@
                     <i class="te-anomaly-table__glyph--status glyphicon glyphicon-remove-circle"></i>
                   {{/if}}
 
-                  {{#power-select
-                    triggerId=anomaly.anomalyId
-                    triggerClass="te-anomaly-table__select"
-                    options=responseOptions
-                    searchEnabled=false
-                    selected=anomaly.anomalyFeedback
-                    onchange=(action "onChangeAnomalyResponse" anomaly)
-                    as |response|
-                  }}
-                    {{response}}
-                  {{/power-select}}
+                  {{#if anomaly.isUserReported}}
+                    <span class="te-anomaly-table__text">User Reported</span>
+                  {{else}}
+                    {{#power-select
+                      triggerId=anomaly.anomalyId
+                      triggerClass="te-anomaly-table__select"
+                      options=responseOptions
+                      searchEnabled=false
+                      selected=anomaly.anomalyFeedback
+                      onchange=(action "onChangeAnomalyResponse" anomaly)
+                      as |response|
+                    }}
+                      {{response}}
+                    {{/power-select}}
+                  {{/if}}
 
                   <a target="_blank" class="te-anomaly-table__link" href="/thirdeye#anomalies?anomaliesSearchMode=id&pageNumber=1&anomalyIds={{anomaly.anomalyId}}">investigate</a>
                </td>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -164,26 +164,26 @@
                <th class="te-anomaly-table__cell-head">
                 <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
                   Start/Duration (PDT)
-                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
                 </a>
                </th>
                <th class="te-anomaly-table__cell-head">Dimensions</th>
                <th class="te-anomaly-table__cell-head">
                 <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
                   Severity Score
-                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
                 </a>
                </th>
                <th class="te-anomaly-table__cell-head">
                 <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
                   {{baselineTitle}}
-                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
                 </a>
                </th>
                <th class="te-anomaly-table__cell-head">
                 <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
                   Resolution
-                  <i class="te-anomaly-table__glyph glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
                 </a>
              </th>
             </tr>
@@ -222,11 +222,11 @@
                </td>
                <td class="te-anomaly-table__cell">
                   {{#if anomaly.showResponseSaved}}
-                    <i class="te-anomaly-table__glyph--status glyphicon glyphicon-ok-circle"></i>
+                    <i class="te-anomaly-table__icon--status glyphicon glyphicon-ok-circle"></i>
                   {{/if}}
 
                   {{#if anomaly.showResponseFailed}}
-                    <i class="te-anomaly-table__glyph--status glyphicon glyphicon-remove-circle"></i>
+                    <i class="te-anomaly-table__icon--status glyphicon glyphicon-remove-circle"></i>
                   {{/if}}
 
                   {{#if anomaly.isUserReported}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
@@ -193,26 +193,26 @@
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
                 Start/Duration (PDT)
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
               </a>
              </th>
              <th class="te-anomaly-table__cell-head">Dimensions</th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
                 Severity Score
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
               </a>
              </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
                 Current/WoW
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
               </a>
              </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
                 Resolution
-                <i class="te-anomaly-table__glyph glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                <i class="te-anomaly-table__icon glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
               </a>
            </th>
           </tr>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/edit/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/edit/route.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import fetch from 'fetch';
 import moment from 'moment';
+import fetch from 'fetch';
 import RSVP from 'rsvp';
 import _ from 'lodash';
 import { checkStatus, buildDateEod, parseProps } from 'thirdeye-frontend/utils/utils';

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -4,6 +4,7 @@
  * @exports alert create model
  */
 import Ember from 'ember';
+import fetch from 'fetch';
 import RSVP from 'rsvp';
 import { checkStatus, buildDateEod } from 'thirdeye-frontend/utils/utils';
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
@@ -24,43 +24,43 @@
            <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "name"}}>
                 Appp
-                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.name}}"></i>
+                <i class="te-anomaly-table__icon te-anomaly-table__icon--small glyphicon glyphicon-menu-{{sortMenuGlyph.name}}"></i>
               </a>
              </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "alert"}}>
                 Alerts
-                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.alert}}"></i>
+                <i class="te-anomaly-table__icon te-anomaly-table__icon--small glyphicon glyphicon-menu-{{sortMenuGlyph.alert}}"></i>
               </a>
              </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "anomaly"}}>
                 Anomalies
-                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.anomaly}}"></i>
+                <i class="te-anomaly-table__icon te-anomaly-table__icon--small glyphicon glyphicon-menu-{{sortMenuGlyph.anomaly}}"></i>
               </a>
              </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "user"}}>
                 User-rep
-                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.user}}"></i>
+                <i class="te-anomaly-table__icon te-anomaly-table__icon--small glyphicon glyphicon-menu-{{sortMenuGlyph.user}}"></i>
               </a>
             </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "responses"}}>
                 Responses
-                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.responses}}"></i>
+                <i class="te-anomaly-table__icon te-anomaly-table__icon--small glyphicon glyphicon-menu-{{sortMenuGlyph.responses}}"></i>
               </a>
              </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resrate"}}>
                 Response rate
-                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.resrate}}"></i>
+                <i class="te-anomaly-table__icon te-anomaly-table__icon--small glyphicon glyphicon-menu-{{sortMenuGlyph.resrate}}"></i>
               </a>
             </th>
              <th class="te-anomaly-table__cell-head">
               <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "precision"}}>
                 Precision
-                <i class="te-anomaly-table__glyph te-anomaly-table__glyph--small glyphicon glyphicon-menu-{{sortMenuGlyph.precision}}"></i>
+                <i class="te-anomaly-table__icon te-anomaly-table__icon--small glyphicon glyphicon-menu-{{sortMenuGlyph.precision}}"></i>
               </a>
             </th>
           </tr>

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -893,6 +893,7 @@ export default Controller.extend({
 
     /**
      * When a metric is selected, fetch its props, and send them to the graph builder
+     * TODO: if 'hash.dimensions' is not needed, lets refactor the RSVP object instead of renaming
      * @method onSelectMetric
      * @param {Object} selectedObj - The selected metric
      * @return {undefined}
@@ -906,12 +907,12 @@ export default Controller.extend({
       });
       this.fetchMetricData(selectedObj.id)
         .then((hash) => {
-          this.setProperties(hash);
-          this.setProperties({
-            metricGranularityOptions: hash.granularities,
+          Object.assign(hash, {
             originalDimensions: hash.dimensions,
+            metricGranularityOptions: hash.granularities,
             alertFunctionName: this.get('functionNamePrimer')
           });
+          this.setProperties(hash);
           this.triggerGraphFromMetric(selectedObj);
         })
         .catch((err) => {

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -39,6 +39,7 @@ export default Controller.extend({
   isProcessingForm: false,
   isEmailError: false,
   isDuplicateEmail: false,
+  isAlertNameUserModified: false,
   showGraphLegend: false,
   redirectToAlertPage: true,
   metricGranularityOptions: [],
@@ -622,6 +623,24 @@ export default Controller.extend({
   },
 
   /**
+   * Auto-generate the alert name until the user directly edits it
+   * @method modifyAlertFunctionName
+   * @return {undefined}
+   */
+  modifyAlertFunctionName() {
+    const {
+      functionNamePrimer,
+      isAlertNameUserModified,
+    } = this.getProperties('functionNamePrimer', 'isAlertNameUserModified');
+    // If user has not yet edited the alert name, continue to auto-generate it.
+    if (!isAlertNameUserModified) {
+      this.set('alertFunctionName', functionNamePrimer);
+    }
+    // Each time we modify the name, we validate it as well to ensure no duplicates exist.
+    this.send('validateAlertName', this.get('alertFunctionName'));
+  },
+
+  /**
    * Filter all existing alert groups down to only those that are active and belong to the
    * currently selected application team.
    * @method filteredConfigGroups
@@ -640,6 +659,39 @@ export default Controller.extend({
       } else {
         return activeGroups;
       }
+    }
+  ),
+
+  /**
+   * Generate alert name primer based on user selections
+   * @type {String}
+   */
+  functionNamePrimer: computed(
+    'selectedPattern',
+    'selectedDimension',
+    'selectedGranularity',
+    'selectedApplication',
+    'selectedMetricOption',
+    function() {
+      const {
+        selectedPattern,
+        selectedDimension,
+        selectedGranularity,
+        selectedApplication,
+        selectedMetricOption
+      } = this.getProperties(
+        'selectedPattern',
+        'selectedDimension',
+        'selectedGranularity',
+        'selectedApplication',
+        'selectedMetricOption'
+      );
+      const pattern = selectedPattern ? `${selectedPattern.camelize()}_` : '';
+      const dimension = selectedDimension ? `${selectedDimension.camelize()}_` : '';
+      const granularity = selectedGranularity ? selectedGranularity.toLowerCase().camelize() : '';
+      const app = selectedApplication ? `${selectedApplication.camelize()}_` : 'applicationName_';
+      const metric = selectedMetricOption ? `${selectedMetricOption.name.camelize()}_` : 'metricName_';
+      return `${app}${metric}${dimension}${pattern}${granularity}`;
     }
   ),
 
@@ -761,7 +813,7 @@ export default Controller.extend({
 
       // Add filters property if present
       if (selectedFilters.length > 2) {
-        Object.assign(newAlertObj, { filters: selectedFilters });
+        Object.assign(newAlertObj, { filters: encodeURIComponent(selectedFilters) });
       }
 
       // Add dimensions if present
@@ -857,7 +909,8 @@ export default Controller.extend({
           this.setProperties(hash);
           this.setProperties({
             metricGranularityOptions: hash.granularities,
-            originalDimensions: hash.dimensions
+            originalDimensions: hash.dimensions,
+            alertFunctionName: this.get('functionNamePrimer')
           });
           this.triggerGraphFromMetric(selectedObj);
         })
@@ -926,6 +979,7 @@ export default Controller.extend({
           isMetricDataLoading: true,
           isFetchingDimensions: true
         });
+        this.modifyAlertFunctionName();
         this.triggerGraphFromMetric(this.get('selectedMetricOption'));
       }
     },
@@ -941,7 +995,19 @@ export default Controller.extend({
         selectedGranularity: selectedObj,
         isMetricDataLoading: true
       });
+      this.modifyAlertFunctionName();
       this.triggerGraphFromMetric(this.get('selectedMetricOption'));
+    },
+
+    /**
+     * Set selected pattern and trigger auto-generation of Alert Name
+     * @method onSelectPattern
+     * @param {Object} selectedOption - The selected pattern option
+     * @return {undefined}
+     */
+    onSelectPattern(selectedOption) {
+      this.set('selectedPattern', selectedOption);
+      this.modifyAlertFunctionName();
     },
 
     /**
@@ -955,6 +1021,7 @@ export default Controller.extend({
         selectedAppName: selectedObj,
         selectedApplication: selectedObj.application
       });
+      this.modifyAlertFunctionName();
     },
 
     /**
@@ -981,9 +1048,11 @@ export default Controller.extend({
      * Make sure alert name does not already exist in the system
      * @method validateAlertName
      * @param {String} name - The new alert name
+     * @param {Boolean} userModified - Up to this moment, is the new name auto-generated, or user modified?
+     * If user-modified, we will stop modifying it dynamically (via 'isAlertNameUserModified')
      * @return {undefined}
      */
-    validateAlertName(name) {
+    validateAlertName(name, userModified = false) {
       let isDuplicateName = false;
       this.fetchAnomalyByName(name).then(anomaly => {
         for (var resultObj of anomaly) {
@@ -991,7 +1060,12 @@ export default Controller.extend({
             isDuplicateName = true;
           }
         }
-        this.set('isAlertNameDuplicate', isDuplicateName);
+      // If the user edits the alert name, we want to stop auto-generating it.
+      if (userModified) {
+        this.set('isAlertNameUserModified', true);
+      }
+      // Either add or clear the "is duplicate name" banner
+      this.set('isAlertNameDuplicate', isDuplicateName);
       });
     },
 

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -769,6 +769,11 @@ export default Controller.extend({
         Object.assign(newAlertObj, { exploreDimensions: selectedDimension });
       }
 
+      // Add speedup prop for minutely metrics
+      if (selectedGranularity.toLowerCase().includes('minute')) {
+        Object.assign(newAlertObj, { speedup: true });
+      }
+
       return {
         jobName,
         payload: JSON.stringify(newAlertObj)
@@ -877,7 +882,6 @@ export default Controller.extend({
       const filterNames = Object.keys(JSON.parse(selectedFilters));
       let isSelectedDimensionEqualToSelectedFilter = false;
 
-      this.set('graphConfig.filters', selectedFilters);
       // Remove selected filters from dimension options only if filter has single entity
       for (var key of filterNames) {
         if (selectedFilterObj[key].length === 1) {

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
@@ -73,7 +73,7 @@ export default Route.extend({
       .then((jobStatus) => {
         const createStatusObj = _.has(jobStatus, 'taskStatuses') ? jobStatus.taskStatuses.find(status => status.taskName === 'FunctionAlertCreation') : null;
         const isCreateComplete = createStatusObj ? createStatusObj.taskStatus.toLowerCase() === 'completed' : false;
-        let continuePolling = Number(moment.duration(moment().diff(onboardStartTime)).asSeconds().toFixed(0)) > 10;
+        let continuePolling = Number(moment.duration(moment().diff(onboardStartTime)).asSeconds().toFixed(0)) > 20;
 
         if (isCreateComplete) {
           // alert function is created. Redirect to alert page.

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -139,7 +139,7 @@
         options=patternsOfInterest
         searchEnabled=false
         selected=selectedPattern
-        onchange=(action (mut selectedPattern))
+        onchange=(action "onSelectPattern")
         disabled=(not isMetricSelected)
         required=true
         as |name|
@@ -246,8 +246,7 @@
         class="form-control te-input"
         placeholder="Add a descriptive alert name"
         value=alertFunctionName
-        focus-out="validateAlertName"
-        key-up="validateAlertName"
+        key-up=(action "validateAlertName" alertFunctionName true)
         disabled=(not isMetricSelected)
       }}
     </div>

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -515,6 +515,7 @@ body {
     list-style: none;
     margin-left: -39px;
     margin-bottom: 0;
+    max-width: 230px;
 
     &--lighter {
       font-size: 12px;
@@ -552,7 +553,7 @@ body {
     font-size: 15px;
   }
 
-  &__glyph {
+  &__icon {
     font-size: 14px;
     margin-left: 5px;
 

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -472,6 +472,10 @@ body {
     overflow-y: scroll;
   }
 
+  &__text {
+    margin-right: 30px;
+  }
+
   &__head {
     line-height: 40px;
   }

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -108,7 +108,7 @@ export function enhanceAnomalies(rawAnomalies) {
     newAnomalies.push(anomaly);
   });
 
-  return newAnomalies;
+  return newAnomalies.sortBy('anomalyStart');
 }
 
 /**

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -261,8 +261,13 @@ export function buildAnomalyStats(alertEvalMetrics, mode, severity = '30', isPer
   ];
 
   if (mode === 'explore') {
+    // Hide MTTD projected metric
+    const mttdObj = anomalyStats.find(stat => stat.key === 'mttd');
+    if (mttdObj) {
+      mttdObj.hideProjected = true;
+    }
+    // Append response rate metric
     anomalyStats.splice(1, 0, responseRateObj);
-    anomalyStats.find(stat => stat.key === 'mttd').hideProjected = true;
   }
 
   anomalyStats.forEach((stat) => {

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -81,13 +81,14 @@ export function enhanceAnomalies(rawAnomalies) {
     Object.assign(anomaly, {
       changeRate,
       shownChangeRate: changeRate,
+      isUserReported: anomaly.anomalyResultSource === 'USER_LABELED_ANOMALY',
       startDateStr: moment(anomaly.anomalyStart).format('MMM D, hh:mm A'),
       durationStr: noZeroDurationArr.join(', '),
       severityScore: (anomaly.current/anomaly.baseline - 1).toFixed(2),
       shownCurrent: anomaly.current,
       shownBaseline: anomaly.baseline,
       showResponseSaved: false,
-      shorResponseFailed: false
+      showResponseFailed: false
     });
 
     // Create a list of all available dimensions for toggling. Also massage dimension property.
@@ -261,6 +262,7 @@ export function buildAnomalyStats(alertEvalMetrics, mode, severity = '30', isPer
 
   if (mode === 'explore') {
     anomalyStats.splice(1, 0, responseRateObj);
+    anomalyStats.find(stat => stat.key === 'mttd').hideProjected = true;
   }
 
   anomalyStats.forEach((stat) => {
@@ -276,6 +278,8 @@ export function buildAnomalyStats(alertEvalMetrics, mode, severity = '30', isPer
     stat.showDirectionIcon = isFinite(origData) && isFinite(newData) && origData !== newData;
     stat.direction = stat.showDirectionIcon && origData > newData ? 'bottom' : 'top';
   });
+
+
 
   return anomalyStats;
 }

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/thirdeye.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/thirdeye.ftl
@@ -202,7 +202,7 @@
                     <a class="te-nav__dropdown-item" href="https://iwww.corp.linkedin.com/wiki/cf/display/PRT/ThirdEye+Help+Page" target="_blank">Help page</a>
                     <a class="te-nav__dropdown-item" href="app/#/logout">Logout</a>
                   </div>
-                </div> 
+                </div>
               </div>
 
               <!--- <div class="thirdeye-nav__oldui">


### PR DESCRIPTION
Taking care of pre-launch enhancements for Self Serve Onboarding/Tuning:
- Making sure we are using the async replay call for transition with 1min timeout
- Ensure user-reported status is properly read
- Anomaly resolution types select options
- Add "speedup":"true" for minute creation
- Add severity = 0.3 when displaying mttd on alert page
- Remove "projected MTTD" in alert page

In second commit `acf81b83b68121efacce1cf597968f6d04e56692`:
- Properly populating alert filters when on-boarding metrics with filters
- Adding computed property to auto-generate the Alert Name
- Fixing fetch error in `manage.alerts.performance`

In third commit `75fcf63313404fe2724b1e49cd0ed9539210ccf6`:
- Adding `timeout` to list of replay responses to ignore
- Sorting anomaly list by start date