### PR TITLE
[TE] frontend - Acceptance test for rootcause metric

### DIFF
--- a/thirdeye/thirdeye-frontend/app/mirage/config.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/config.js
@@ -205,4 +205,43 @@ export default function() {
     const hardCodedId = 1234567;
     return hardCodedId;
   });
+
+  /**
+   * Get request for rootcause page
+   */
+  this.get(`/rootcause/raw`, () => {
+    return [ {
+      "urn" : "thirdeye:metric:1",
+      "score" : 1.0,
+      "label" : "thirdeyeKbmi::pageViews",
+      "type" : "metric",
+      "link" : null,
+      "relatedEntities" : [ ],
+      "attributes" : {
+        "inverse" : [ "false" ],
+        "dataset" : [ "thirdeyeKbmi" ],
+        "derived" : [ "false" ],
+        "additive" : [ "true" ]
+      }
+    } ];
+  });
+
+  this.get('/data/autocomplete/filters/metric/1', () => {
+    return {
+      environment: ['prod']
+    };
+  });
+
+  this.get('/data/metric/1', () => {
+    return {
+      "id": 1,
+      "name": "pageViews"
+    };
+  });
+
+  this.get('/data/maxDataTime/metricId/1', () => {
+    return 1;
+  });
+
+  this.passthrough();
 }

--- a/thirdeye/thirdeye-frontend/app/mirage/config.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/config.js
@@ -4,6 +4,7 @@ import entityApplication from 'thirdeye-frontend/mocks/entityApplication';
 import metric from 'thirdeye-frontend/mocks/metric';
 import timeseriesCompare from 'thirdeye-frontend/mocks/timeseriesCompare';
 import { onboardJobStatus, onboardJobCreate } from 'thirdeye-frontend/mocks/detectionOnboard';
+import rootcause from 'thirdeye-frontend/mirage/endpoints/rootcause';
 
 export default function() {
 
@@ -194,54 +195,17 @@ export default function() {
   /**
    * Get request to retrieve an anomaly reports
    */
-  this.get(`/session/:id`, (schema, request) => {
+  this.get(`/session/:id`, () => {
     return {};
   });
 
   /**
    * Post request for saving anomaly reports
    */
-  this.post(`/session`, (schema, request) => {
+  this.post(`/session`, () => {
     const hardCodedId = 1234567;
     return hardCodedId;
   });
 
-  /**
-   * Get request for rootcause page
-   */
-  this.get(`/rootcause/raw`, () => {
-    return [ {
-      "urn" : "thirdeye:metric:1",
-      "score" : 1.0,
-      "label" : "thirdeyeKbmi::pageViews",
-      "type" : "metric",
-      "link" : null,
-      "relatedEntities" : [ ],
-      "attributes" : {
-        "inverse" : [ "false" ],
-        "dataset" : [ "thirdeyeKbmi" ],
-        "derived" : [ "false" ],
-        "additive" : [ "true" ]
-      }
-    } ];
-  });
-
-  this.get('/data/autocomplete/filters/metric/1', () => {
-    return {
-      environment: ['prod']
-    };
-  });
-
-  this.get('/data/metric/1', () => {
-    return {
-      "id": 1,
-      "name": "pageViews"
-    };
-  });
-
-  this.get('/data/maxDataTime/metricId/1', () => {
-    return 1;
-  });
-
-  this.passthrough();
+  rootcause(this);
 }

--- a/thirdeye/thirdeye-frontend/app/mirage/config.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/config.js
@@ -6,6 +6,10 @@ import timeseriesCompare from 'thirdeye-frontend/mocks/timeseriesCompare';
 import { onboardJobStatus, onboardJobCreate } from 'thirdeye-frontend/mocks/detectionOnboard';
 import rootcause from 'thirdeye-frontend/mirage/endpoints/rootcause';
 
+/**
+ * TODO: Group endpoints together and put them in files under the endpoints folder to prevent overloading this file
+ */
+
 export default function() {
 
   this.timing = 1000;      // delay for each request, automatically set to 0 during testing

--- a/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
@@ -1,0 +1,38 @@
+export default function(server) {
+  /**
+   * Get request for rootcause page
+   */
+  server.get(`/rootcause/raw`, () => {
+    return [ {
+      "urn" : "thirdeye:metric:1",
+      "score" : 1.0,
+      "label" : "thirdeyeKbmi::pageViews",
+      "type" : "metric",
+      "link" : null,
+      "relatedEntities" : [ ],
+      "attributes" : {
+        "inverse" : [ "false" ],
+        "dataset" : [ "thirdeyeKbmi" ],
+        "derived" : [ "false" ],
+        "additive" : [ "true" ]
+      }
+    } ];
+  });
+
+  server.get('/data/autocomplete/filters/metric/1', () => {
+    return {
+      environment: ['prod']
+    };
+  });
+
+  server.get('/data/metric/1', () => {
+    return {
+      "id": 1,
+      "name": "pageViews"
+    };
+  });
+
+  server.get('/data/maxDataTime/metricId/1', () => {
+    return 1;
+  });
+}

--- a/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
@@ -1,6 +1,7 @@
 export default function(server) {
   /**
    * Get request for rootcause page
+   * @return {Array}
    */
   server.get(`/rootcause/raw`, () => {
     return [ {
@@ -19,12 +20,18 @@ export default function(server) {
     } ];
   });
 
+  /**
+   * Retrieves the options for autocomplete for 'filter' dropdown
+   */
   server.get('/data/autocomplete/filters/metric/1', () => {
     return {
       environment: ['prod']
     };
   });
 
+  /**
+   * Retrieves information about a metric
+   */
   server.get('/data/metric/1', () => {
     return {
       "id": 1,
@@ -32,7 +39,10 @@ export default function(server) {
     };
   });
 
+  /**
+   * Retrieves timestamp of last element in timeseries
+   */
   server.get('/data/maxDataTime/metricId/1', () => {
-    return 1;
+    return 1517846399998;
   });
 }

--- a/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/endpoints/rootcause.js
@@ -6,13 +6,13 @@ export default function(server) {
     return [ {
       "urn" : "thirdeye:metric:1",
       "score" : 1.0,
-      "label" : "thirdeyeKbmi::pageViews",
+      "label" : "thirdeye::pageViews",
       "type" : "metric",
       "link" : null,
       "relatedEntities" : [ ],
       "attributes" : {
         "inverse" : [ "false" ],
-        "dataset" : [ "thirdeyeKbmi" ],
+        "dataset" : [ "thirdeye" ],
         "derived" : [ "false" ],
         "additive" : [ "true" ]
       }
@@ -28,7 +28,7 @@ export default function(server) {
   server.get('/data/metric/1', () => {
     return {
       "id": 1,
-      "name": "pageViews"
+      "alias": "pageViews"
     };
   });
 

--- a/thirdeye/thirdeye-frontend/app/pods/application/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/application/route.js
@@ -39,9 +39,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
    * @return {undefined}
    */
   afterModel() {
-    // if (config.environment === 'test') {
+    if (config.environment === 'test') {
       this.get('session.session').set('isAuthenticated', true);
-    // }
+    }
   },
 
   /**

--- a/thirdeye/thirdeye-frontend/app/pods/application/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/application/route.js
@@ -39,9 +39,9 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
    * @return {undefined}
    */
   afterModel() {
-    if (config.environment === 'test') {
+    // if (config.environment === 'test') {
       this.get('session.session').set('isAuthenticated', true);
-    }
+    // }
   },
 
   /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
@@ -45,7 +45,6 @@ export default Ember.Component.extend({
         fetch(url)
           .then(res => res.json())
           .then(res => this.set('selectedMetric', res));
-        console.log("selectedMetric: ", this.get('selectedMetric'));
       } else {
         this.set('selectedMetric', null);
       }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
@@ -5,6 +5,8 @@ import { task, timeout } from 'ember-concurrency';
 import _ from 'lodash';
 
 export default Ember.Component.extend({
+  classNames: ['rootcause-select-metric-dimension'],
+
   selectedUrn: null, // ""
 
   onSelection: null, // function (metricUrn)
@@ -43,7 +45,7 @@ export default Ember.Component.extend({
         fetch(url)
           .then(res => res.json())
           .then(res => this.set('selectedMetric', res));
-
+        console.log("selectedMetric: ", this.get('selectedMetric'));
       } else {
         this.set('selectedMetric', null);
       }

--- a/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
@@ -4,6 +4,7 @@ import moduleForAcceptance from 'thirdeye-frontend/tests/helpers/module-for-acce
 const PLACEHOLDER = '.rootcause-placeholder';
 const TABS = '.rootcause-tabs';
 const LABEL = '.rootcause-legend__label';
+const SELECTED_METRIC = '.rootcause-select-metric-dimension';
 
 moduleForAcceptance('Acceptance | rootcause');
 
@@ -37,5 +38,11 @@ in the legend`, async assert => {
     find(LABEL).get(0).innerText,
     'pageViews',
     'metric label is correct'
+  );
+
+  assert.equal(
+    find(SELECTED_METRIC).get(0).innerText,
+    'pageViews',
+    'selected metric is correct'
   );
 });

--- a/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
@@ -3,6 +3,7 @@ import moduleForAcceptance from 'thirdeye-frontend/tests/helpers/module-for-acce
 
 const PLACEHOLDER = '.rootcause-placeholder';
 const TABS = '.rootcause-tabs';
+const LABEL = '.rootcause-legend__label';
 
 moduleForAcceptance('Acceptance | rootcause');
 
@@ -20,5 +21,21 @@ test('empty state of rootcause page should have a placeholder and no tabs', asyn
   assert.notOk(
     find(TABS).get(0),
     'tabs do not exist'
+  );
+});
+
+test(`visiting /rootcause with only a metric provided should have correct metric name selected by default and displayed
+in the legend`, async assert => {
+  await visit('/rootcause?metricId=1');
+
+  assert.equal(
+    currentURL(),
+    '/rootcause?metricId=1',
+    'link is correct');
+
+  assert.equal(
+    find(LABEL).get(0).innerText,
+    'pageViews',
+    'metric label is correct'
   );
 });


### PR DESCRIPTION
- Added test for rootcause page when only a metric is provided
- Created an `app/mirage/endpoints` folder to extract mirage endpoints to group and shorten `mirage/config.js` (inspired by this https://github.com/samselikoff/ember-cli-mirage/issues/1027).
- Removed unnecessary params from mirage endpoints