### PR TITLE
[TE] frontend - ttbach/remove edit button on rootcause page

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/component.js
@@ -73,12 +73,6 @@ export default Component.extend({
   isCommentEditMode: computed.bool('sessionText'),
 
   /**
-   * Toggle for editing the session title
-   * @type {boolean}
-   */
-  isTitleEditMode: false,
-
-  /**
    * whether to enable saving
    * @type {boolean}
    */

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/template.hbs
@@ -1,12 +1,11 @@
 <div class="container">
   <div class="row">
-    <div class="col-xs-10">
+    <div class="col-xs-11">
       {{textarea-autosize
         placeholder="Enter investigation title ..."
         value=sessionName
-        cols=50
+        cols=85
         rows=1
-        maxlen=80
         class="rootcause-header__major rootcause-header--textarea"
         key-press="onChange"}}
     </div>

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/template.hbs
@@ -1,30 +1,14 @@
 <div class="container">
   <div class="row">
     <div class="col-xs-10">
-      {{#unless isTitleEditMode}}
-        <div class="rootcause-header__title">
-          <h3 class="rootcause-header__major">
-            {{sessionName}}
-          </h3>
-          <a class="thirdeye-link thirdeye-link--vertical-centered" {{action (mut isTitleEditMode) true}}>
-            <span>
-              <i class="glyphicon glyphicon-pencil"></i>
-            </span>
-            {{#tooltip-on-element class="te-tooltip"}}
-              Edit title
-            {{/tooltip-on-element}}
-          </a>
-        </div>
-      {{else}}
-        {{textarea-autosize
-          placeholder="Enter investigation title ..."
-          value=sessionName
-          cols=50
-          rows=1
-          maxlen=80
-          class="rootcause-header__major rootcause-header--textarea"
-          key-press="onChange"}}
-      {{/unless}}
+      {{textarea-autosize
+        placeholder="Enter investigation title ..."
+        value=sessionName
+        cols=50
+        rows=1
+        maxlen=80
+        class="rootcause-header__major rootcause-header--textarea"
+        key-press="onChange"}}
     </div>
     {{#if canSave}}
       <div class="rootcause-header__menu">


### PR DESCRIPTION
- Removed edit pencil icon on rootcause page, so it behaves like google doc

![edit-title](https://user-images.githubusercontent.com/6884406/36004514-f1a13978-0ce7-11e8-8b11-69df0db49e5e.gif)
