### PR TITLE
Using preferred protocol and port for realtime segment upload

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpsSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpsSegmentFetcher.java
@@ -18,24 +18,13 @@ package com.linkedin.pinot.common.segment.fetcher;
 
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
+import com.linkedin.pinot.common.utils.ClientSSLContextGenerator;
 import java.util.Collections;
 import java.util.Set;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
 import org.apache.commons.configuration.Configuration;
+
+
 
 
 /*
@@ -77,89 +66,32 @@ public class HttpsSegmentFetcher extends HttpSegmentFetcher {
 
   @Override
   protected void initHttpClient(Configuration configs) {
-    try {
-      TrustManager[] trustManagers = setupTrustManagers(configs);
-      KeyManager[] keyManagers = setupKeyManagers(configs);
+    final String serverCACertFile = configs.getString(CONFIG_OF_SERVER_CA_CERT);
+    final boolean enableServerVerifiction = configs.getBoolean(CONFIG_OF_ENABLE_SERVER_VERIFICATION, true);
+    final String keyStoreFile = configs.getString(CONFIG_OF_CLIENT_PKCS12_FILE);
+    final String keyStorePassword = configs.getString(CONFIG_OF_CLIENT_PKCS12_PASSWORD);
 
-      SSLContext sslContext = SSLContext.getInstance(SECURITY_ALGORITHM);
-      sslContext.init(keyManagers, trustManagers, null);
+    ClientSSLContextGenerator.Builder builder = new ClientSSLContextGenerator.Builder();
+
+    if (enableServerVerifiction) {
+      if (serverCACertFile == null) {
+        throw new RuntimeException("Https server CA Certificate file not configured (" + CONFIG_OF_SERVER_CA_CERT + ")");
+      }
+      builder.withServerCACertFile(serverCACertFile);
+    }
+    if (keyStoreFile == null || keyStorePassword == null) {
+      _logger.info("Either keystore file name ({}) or keystore password ({}) is not configured. Client will not present certificates to server.",
+          CONFIG_OF_CLIENT_PKCS12_FILE, CONFIG_OF_CLIENT_PKCS12_PASSWORD);
+    } else {
+      builder.withKeystoreFile(keyStoreFile).withKeyStorePassword(keyStorePassword);
+    }
+
+    try {
+      SSLContext sslContext = builder.build().generate();
       _httpClient = new FileUploadDownloadClient(sslContext);
     } catch (Exception e) {
       Utils.rethrowException(e);
     }
-  }
-
-  private TrustManager[] setupTrustManagers(Configuration configs)
-      throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
-    // This is the cert authority that validates server's cert, so we need to put it in our
-    // trustStore.
-    final String serverCACertFile = configs.getString(CONFIG_OF_SERVER_CA_CERT);
-    final boolean enableServerVerifiction = configs.getBoolean(CONFIG_OF_ENABLE_SERVER_VERIFICATION, true);
-    final String fileNotConfigured =
-        "Https server CA Certificate file not confugured (" + CONFIG_OF_SERVER_CA_CERT + ")";
-    if (enableServerVerifiction) {
-      if (serverCACertFile == null) {
-        throw new RuntimeException(fileNotConfigured);
-      }
-      _logger.info("Initializing trust store from {}", serverCACertFile);
-      FileInputStream is = new FileInputStream(new File(serverCACertFile));
-      KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-      trustStore.load(null);
-      CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE);
-      int i = 0;
-      while (is.available() > 0) {
-        X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(is);
-        _logger.info("Read certificate serial number {} by issuer {} ", cert.getSerialNumber().toString(16), cert.getIssuerDN().toString());
-
-        String serverKey = "https-server-" + i;
-        trustStore.setCertificateEntry(serverKey, cert);
-        i++;
-      }
-
-      TrustManagerFactory tmf = TrustManagerFactory.getInstance(CERTIFICATE_TYPE);
-      tmf.init(trustStore);
-      _logger.info("Successfully initialized trust store");
-      return tmf.getTrustManagers();
-    }
-    // Server verification disabled. Trust all servers
-    _logger.warn("{}. All servers will be trusted!", fileNotConfigured);
-    TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
-      @Override
-      public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-      }
-
-      @Override
-      public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-      }
-
-      @Override
-      public X509Certificate[] getAcceptedIssuers() {
-        return new X509Certificate[0];
-      }
-    }};
-    return trustAllCerts;
-  }
-
-  private KeyManager[] setupKeyManagers(Configuration configs) {
-    try {
-      KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
-      String keyStoreFile = configs.getString(CONFIG_OF_CLIENT_PKCS12_FILE);
-      String keyStorePassword = configs.getString(CONFIG_OF_CLIENT_PKCS12_PASSWORD);
-      if (keyStoreFile == null || keyStorePassword == null) {
-        _logger.info("Either keystore file name ({}) or keystore password ({}) is not configured. Client will not present certificates to server.",
-            CONFIG_OF_CLIENT_PKCS12_FILE, CONFIG_OF_CLIENT_PKCS12_PASSWORD);
-        return null;
-      }
-      _logger.info("Setting up keystore with file {}", keyStoreFile);
-      keyStore.load(new FileInputStream(new File(keyStoreFile)), keyStorePassword.toCharArray());
-      KeyManagerFactory kmf = KeyManagerFactory.getInstance(KEYMANAGER_FACTORY_ALGORITHM);
-      kmf.init(keyStore, keyStorePassword.toCharArray());
-      _logger.info("Successfully initialized keystore");
-      return kmf.getKeyManagers();
-    } catch (Exception e) {
-      Utils.rethrowException(e);
-    }
-    return null;
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpsSegmentFetcher.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/segment/fetcher/HttpsSegmentFetcher.java
@@ -16,16 +16,12 @@
 
 package com.linkedin.pinot.common.segment.fetcher;
 
-import com.linkedin.pinot.common.Utils;
-import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
 import com.linkedin.pinot.common.utils.ClientSSLContextGenerator;
+import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
 import java.util.Collections;
 import java.util.Set;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.configuration.Configuration;
-
-
-
 
 /*
  * The following links are useful to understand some of the SSL terminology (key store, trust store, algorithms,
@@ -86,12 +82,8 @@ public class HttpsSegmentFetcher extends HttpSegmentFetcher {
       builder.withKeystoreFile(keyStoreFile).withKeyStorePassword(keyStorePassword);
     }
 
-    try {
-      SSLContext sslContext = builder.build().generate();
-      _httpClient = new FileUploadDownloadClient(sslContext);
-    } catch (Exception e) {
-      Utils.rethrowException(e);
-    }
+    SSLContext sslContext = builder.build().generate();
+    _httpClient = new FileUploadDownloadClient(sslContext);
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ClientSSLContextGenerator.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ClientSSLContextGenerator.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.common.utils;
+
+import com.linkedin.pinot.common.Utils;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ClientSSLContextGenerator {
+  private static final String SECURITY_ALGORITHM = "TLS";
+  private static final String CERTIFICATE_TYPE = "X509";
+  private static final String KEYSTORE_TYPE = "PKCS12";
+  private static final String KEYMANAGER_FACTORY_ALGORITHM = "SunX509";
+  private static final Logger _logger = LoggerFactory.getLogger(ClientSSLContextGenerator.class);
+
+  private String _serverCACertFile;
+  private boolean _enableServerVerification;
+  private String _keyStoreFile;
+  private String _keyStorePassword;
+  private boolean _presentClientCerts;
+
+  private ClientSSLContextGenerator() {
+  }
+
+  private void setKeyStoreFile(String keyStoreFile) {
+    _keyStoreFile = keyStoreFile;
+  }
+
+  private void setKeyStorePassword(String keyStorePassword) {
+    _keyStorePassword = keyStorePassword;
+  }
+
+  private void setEnableServerVerification(boolean enableServerVerification) {
+    _enableServerVerification = enableServerVerification;
+  }
+
+  private void setServerCACertFile(String serverCACertFile) {
+    _serverCACertFile = serverCACertFile;
+  }
+
+  private void setPresentClientCerts(boolean presentClientCerts) {
+    _presentClientCerts = presentClientCerts;
+  }
+
+  public SSLContext generate() {
+    SSLContext sslContext = null;
+    try {
+      TrustManager[] trustManagers = setupTrustManagers();
+      KeyManager[] keyManagers = setupKeyManagers();
+
+      sslContext = SSLContext.getInstance(SECURITY_ALGORITHM);
+      sslContext.init(keyManagers, trustManagers, null);
+    } catch (Exception e) {
+      Utils.rethrowException(e);
+    }
+    return sslContext;
+  }
+
+  private TrustManager[] setupTrustManagers()
+      throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+    // This is the cert authority that validates server's cert, so we need to put it in our
+    // trustStore.
+    final String fileNotConfigured = "Https server CA Certificate file not confugured ";
+    if (_enableServerVerification) {
+      _logger.info("Initializing trust store from {}", _serverCACertFile);
+      FileInputStream is = new FileInputStream(new File(_serverCACertFile));
+      KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      trustStore.load(null);
+      CertificateFactory certificateFactory = CertificateFactory.getInstance(CERTIFICATE_TYPE);
+      int i = 0;
+      while (is.available() > 0) {
+        X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(is);
+        _logger.info("Read certificate serial number {} by issuer {} ", cert.getSerialNumber().toString(16), cert.getIssuerDN().toString());
+
+        String serverKey = "https-server-" + i;
+        trustStore.setCertificateEntry(serverKey, cert);
+        i++;
+      }
+
+      TrustManagerFactory tmf = TrustManagerFactory.getInstance(CERTIFICATE_TYPE);
+      tmf.init(trustStore);
+      _logger.info("Successfully initialized trust store");
+      return tmf.getTrustManagers();
+    }
+    // Server verification disabled. Trust all servers
+    _logger.warn("{}. All servers will be trusted!", fileNotConfigured);
+    TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+      }
+    }};
+    return trustAllCerts;
+  }
+
+  private KeyManager[] setupKeyManagers() {
+    if (!_presentClientCerts) {
+      return null;
+    }
+    try {
+      KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+      _logger.info("Setting up keystore with file {}", _keyStoreFile);
+      keyStore.load(new FileInputStream(new File(_keyStoreFile)), _keyStorePassword.toCharArray());
+      KeyManagerFactory kmf = KeyManagerFactory.getInstance(KEYMANAGER_FACTORY_ALGORITHM);
+      kmf.init(keyStore, _keyStorePassword.toCharArray());
+      _logger.info("Successfully initialized keystore");
+      return kmf.getKeyManagers();
+    } catch (Exception e) {
+      Utils.rethrowException(e);
+    }
+    return null;
+  }
+
+  public static class Builder {
+    String _serverCACertFile;
+    String _keyStoreFile;
+    String _keyStorePassword;
+    boolean _enableServerVerification = false;
+    boolean _presentClientCerts = false;
+
+    public Builder() {
+    }
+
+    /**
+     *
+     * @param serverCACertFile is path name of a file containing all the certificates from trusted
+     *                         Certifying Authorities. The client will verify the server's certificate
+     *                         against the CA bundle specified. If this method is not called, or is called
+     *                         with a null argument, then server's certificates will not be verified.
+     * @return
+     */
+    public Builder withServerCACertFile(String serverCACertFile) {
+      if (serverCACertFile != null) {
+        _serverCACertFile = serverCACertFile;
+        _enableServerVerification = true;
+      }
+      return this;
+    }
+
+    /**
+     *
+     * @param keyStoreFile is the path name of a PCKS12 file containing the client certificates to be presented to the
+     *                     server during SSL handshake. If this method is called, then
+     * @return
+     */
+    public Builder withKeystoreFile(String keyStoreFile) {
+      if (keyStoreFile != null) {
+        _keyStoreFile = keyStoreFile;
+        _presentClientCerts = true;
+      }
+      return this;
+    }
+
+    /**
+     *
+     * @param keyStorePassword is the password to open the keyStoreFile.
+     * @return
+     */
+    public Builder withKeyStorePassword(String keyStorePassword) {
+      if (keyStorePassword != null) {
+        _keyStorePassword = keyStorePassword;
+        _presentClientCerts = true;
+      }
+      return this;
+    }
+
+    public ClientSSLContextGenerator build() {
+      if ((_keyStoreFile == null && _keyStorePassword != null) ||
+          (_keyStoreFile != null && _keyStorePassword == null)) {
+        throw new IllegalArgumentException("One of Keystore file or password must be specified");
+      }
+      ClientSSLContextGenerator sslContextGenerator = new ClientSSLContextGenerator();
+      sslContextGenerator.setEnableServerVerification(_enableServerVerification);
+      sslContextGenerator.setKeyStoreFile(_keyStoreFile);
+      sslContextGenerator.setKeyStorePassword(_keyStorePassword);
+      sslContextGenerator.setPresentClientCerts(_presentClientCerts);
+      sslContextGenerator.setServerCACertFile(_serverCACertFile);
+      return sslContextGenerator;
+    }
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -252,6 +252,7 @@ public class CommonConstants {
     public static final String DEFAULT_SEGMENT_LOAD_MAX_RETRY_COUNT = "5";
     public static final String DEFAULT_SEGMENT_LOAD_MIN_RETRY_DELAY_MILLIS = "60000";
     public static final String PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY = "pinot.server.segment.fetcher";
+    public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";
     public static final String DEFAULT_STAR_TREE_FORMAT_VERSION = "OFF_HEAP";
     public static final String DEFAULT_COLUMN_MIN_MAX_VALUE_GENERATOR_MODE = "TIME";
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -231,6 +231,9 @@ public class CommonConstants {
     public static final String CONFIG_OF_ENABLE_SPLIT_COMMIT = "pinot.server.instance.enable.split.commit";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap.direct";
+    // Preferred port and protocol used by the controllers. Used in realtime segment completion protocol
+    public static final String CONFIG_OF_PREFERRED_CONTROLLER_PORT = "pinot.server.preferredControllerPort";
+    public static final String CONFIG_OF_PREFERRED_CONTROLLER_PROTOCOL = "pinot.server.preferredControllerProtocol";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -21,6 +21,8 @@ import org.apache.commons.lang.StringUtils;
 
 public class CommonConstants {
 
+  public static final String PREFIX_OF_SSL_SUBSET = "ssl";
+
   public static class Helix {
     public static final String IS_SHUTDOWN_IN_PROGRESS = "shutdownInProgress";
 
@@ -231,9 +233,6 @@ public class CommonConstants {
     public static final String CONFIG_OF_ENABLE_SPLIT_COMMIT = "pinot.server.instance.enable.split.commit";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap.direct";
-    // Preferred port and protocol used by the controllers. Used in realtime segment completion protocol
-    public static final String CONFIG_OF_PREFERRED_CONTROLLER_PORT = "pinot.server.preferredControllerPort";
-    public static final String CONFIG_OF_PREFERRED_CONTROLLER_PROTOCOL = "pinot.server.preferredControllerProtocol";
 
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String DEFAULT_READ_MODE = "heap";

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
@@ -38,8 +38,7 @@ public class ControllerLeaderLocator {
   private final String _clusterName;
 
   // Co-ordinates of the last known controller leader.
-  private volatile String _controllerLeaderHostPortNotUsed = null;
-  private volatile Pair<String, Integer> _controllerLeaderHostPort = null;
+  private Pair<String, Integer> _controllerLeaderHostPort = null;
 
   // Should we refresh the controller leader co-ordinates?
   private volatile boolean _refresh = true;
@@ -93,7 +92,6 @@ public class ControllerLeaderLocator {
       return _controllerLeaderHostPort;
     } catch (Exception e) {
       LOGGER.warn("Could not locate controller leader, exception", e);
-      _controllerLeaderHostPortNotUsed = null;
       _refresh = true;
       return null;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocator.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.server.realtime;
 
+import com.linkedin.pinot.core.query.utils.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixManager;
@@ -37,7 +38,8 @@ public class ControllerLeaderLocator {
   private final String _clusterName;
 
   // Co-ordinates of the last known controller leader.
-  private volatile String _controllerLeaderHostPort = null;
+  private volatile String _controllerLeaderHostPortNotUsed = null;
+  private volatile Pair<String, Integer> _controllerLeaderHostPort = null;
 
   // Should we refresh the controller leader co-ordinates?
   private volatile boolean _refresh = true;
@@ -73,7 +75,7 @@ public class ControllerLeaderLocator {
    *
    * @return The host:port string of the current controller leader.
    */
-  public synchronized String getControllerLeader() {
+  public synchronized Pair<String, Integer> getControllerLeader() {
     if (!_refresh) {
       return _controllerLeaderHostPort;
     }
@@ -84,12 +86,14 @@ public class ControllerLeaderLocator {
       ZNRecord znRecord = dataAccessor.get("/" + _clusterName + "/CONTROLLER/LEADER", stat, AccessOption.THROW_EXCEPTION_IFNOTEXIST);
       String leader = znRecord.getId();
       int index = leader.lastIndexOf('_');
-      _controllerLeaderHostPort = leader.substring(0, index) + ":" + leader.substring(index + 1);
+      String leaderHost = leader.substring(0, index);
+      int leadePort = Integer.valueOf(leader.substring(index + 1));
+      _controllerLeaderHostPort = new Pair<>(leaderHost, leadePort);
       _refresh = false;
       return _controllerLeaderHostPort;
     } catch (Exception e) {
       LOGGER.warn("Could not locate controller leader, exception", e);
-      _controllerLeaderHostPort = null;
+      _controllerLeaderHostPortNotUsed = null;
       _refresh = true;
       return null;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.server.realtime;
 
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.ClientSSLContextGenerator;
+import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.FileUploadDownloadClient;
 import com.linkedin.pinot.core.query.utils.Pair;
 import java.io.File;
@@ -38,11 +39,8 @@ public class ServerSegmentCompletionProtocolHandler {
   private static final String HTTPS_PROTOCOL = "https";
   private static final String HTTP_PROTOCOL = "http";
 
-  private static final String CONFIG_OF_CONTROLLER_HTTPS_ENABLED = "https.enabled";
-  private static final String CONFIG_OF_CONTROLLER_HTTPS_PORT = "https.controller.port";
-  private static final String CONFIG_OF_HTTPS_CONTROLLER_CACERT = "https.ca-cert";
-  private static final String CONFIG_OF_HTTPS_KEYSTORE_FILE = "https.pkcs12.file";
-  private static final String CONFIG_OF_HTTPS_KEYSTORE_PASSWORD = "https.pkcs12.password";
+  private static final String CONFIG_OF_CONTROLLER_HTTPS_ENABLED = "enabled";
+  private static final String CONFIG_OF_CONTROLLER_HTTPS_PORT = "controller.port";
 
   private static Integer _controllerHttpsPort = null;
 
@@ -50,15 +48,11 @@ public class ServerSegmentCompletionProtocolHandler {
   private final FileUploadDownloadClient _fileUploadDownloadClient;
   private static SSLContext _sslContext;
 
-  public static void init(Configuration config) {
-    if (config.getBoolean(CONFIG_OF_CONTROLLER_HTTPS_ENABLED, false)) {
-      ClientSSLContextGenerator.Builder builder = new ClientSSLContextGenerator.Builder();
-      builder.withServerCACertFile(config.getString(CONFIG_OF_HTTPS_CONTROLLER_CACERT));
-      builder.withKeystoreFile(config.getString(CONFIG_OF_HTTPS_KEYSTORE_FILE));
-      builder.withKeyStorePassword(config.getString(CONFIG_OF_HTTPS_KEYSTORE_PASSWORD));
-
-      _controllerHttpsPort = config.getInt(CONFIG_OF_CONTROLLER_HTTPS_PORT);
-      _sslContext = builder.build().generate();
+  public static void init(Configuration uploaderConfig) {
+    Configuration httpsConfig = uploaderConfig.subset(HTTPS_PROTOCOL);
+    if (httpsConfig.getBoolean(CONFIG_OF_CONTROLLER_HTTPS_ENABLED, false)) {
+      _sslContext = new ClientSSLContextGenerator(httpsConfig.subset(CommonConstants.PREFIX_OF_SSL_SUBSET)).generate();
+      _controllerHttpsPort = httpsConfig.getInt(CONFIG_OF_CONTROLLER_HTTPS_PORT);
     }
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocatorTest.java
@@ -69,7 +69,9 @@ public class ControllerLeaderLocatorTest {
     FakeControllerLeaderLocator.create(helixManager);
     ControllerLeaderLocator controllerLeaderLocator = FakeControllerLeaderLocator.getInstance();
 
-    Assert.assertEquals(controllerLeaderLocator.getControllerLeader(), new Pair<String, Integer>(leaderHost, leaderPort));
+    Pair<String, Integer> expectedLeaderLocation = new Pair<>(leaderHost, leaderPort);
+    Assert.assertEquals(controllerLeaderLocator.getControllerLeader().getFirst(), expectedLeaderLocation.getFirst());
+    Assert.assertEquals(controllerLeaderLocator.getControllerLeader().getSecond(), expectedLeaderLocation.getSecond());
   }
 
   static class FakeControllerLeaderLocator extends ControllerLeaderLocator {

--- a/pinot-core/src/test/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/server/realtime/ControllerLeaderLocatorTest.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.server.realtime;
 
+import com.linkedin.pinot.core.query.utils.Pair;
 import org.apache.helix.BaseDataAccessor;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -55,10 +56,12 @@ public class ControllerLeaderLocatorTest {
     HelixDataAccessor helixDataAccessor = mock(HelixDataAccessor.class);
     BaseDataAccessor<ZNRecord> baseDataAccessor = mock(BaseDataAccessor.class);
     ZNRecord znRecord = mock(ZNRecord.class);
+    final String leaderHost = "host";
+    final int leaderPort = 12345;
 
     when(helixManager.getHelixDataAccessor()).thenReturn(helixDataAccessor);
     when(helixDataAccessor.getBaseDataAccessor()).thenReturn(baseDataAccessor);
-    when(znRecord.getId()).thenReturn("host_port");
+    when(znRecord.getId()).thenReturn(leaderHost + "_" + leaderPort);
     when(baseDataAccessor.get(anyString(), (Stat) any(), anyInt())).thenReturn(znRecord);
     when(helixManager.getClusterName()).thenReturn("myCluster");
 
@@ -66,7 +69,7 @@ public class ControllerLeaderLocatorTest {
     FakeControllerLeaderLocator.create(helixManager);
     ControllerLeaderLocator controllerLeaderLocator = FakeControllerLeaderLocator.getInstance();
 
-    Assert.assertEquals(controllerLeaderLocator.getControllerLeader(), "host:port");
+    Assert.assertEquals(controllerLeaderLocator.getControllerLeader(), new Pair<String, Integer>(leaderHost, leaderPort));
   }
 
   static class FakeControllerLeaderLocator extends ControllerLeaderLocator {

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -114,7 +114,7 @@ public class HelixServerStarter {
     Utils.logVersions();
     ServerConf serverInstanceConfig = DefaultHelixStarterServerConfig.getDefaultHelixServerConfig(_helixServerConfig);
     // Need to do this before we start receiving state transitions.
-    setupSegmentCompletetionProtocolHandler(_helixServerConfig);
+    ServerSegmentCompletionProtocolHandler.init(_helixServerConfig.subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER));
     _serverInstance = new ServerInstance();
     _serverInstance.init(serverInstanceConfig, propertyStore);
     _serverInstance.start();
@@ -194,22 +194,6 @@ public class HelixServerStarter {
         return (long) MmapUtils.getAllocationFailureCount();
       }
     });
-  }
-
-  private void setupSegmentCompletetionProtocolHandler(Configuration config) {
-    if (config.containsKey(CommonConstants.Server.CONFIG_OF_PREFERRED_CONTROLLER_PROTOCOL)) {
-      ServerSegmentCompletionProtocolHandler.setPreferredProtocol(
-          config.getString(CommonConstants.Server.CONFIG_OF_PREFERRED_CONTROLLER_PROTOCOL));
-    }
-    if (config.containsKey(CommonConstants.Server.CONFIG_OF_PREFERRED_CONTROLLER_PORT)) {
-      try {
-        int preferredPort = config.getInt(CommonConstants.Server.CONFIG_OF_PREFERRED_CONTROLLER_PORT);
-        ServerSegmentCompletionProtocolHandler.setPreferredPort(preferredPort);
-      } catch (Exception e) {
-        LOGGER.warn("Discarding controller preferred port configuration : {}",
-            config.getString(CommonConstants.Server.CONFIG_OF_PREFERRED_CONTROLLER_PORT));
-      }
-    }
   }
 
   private void updateInstanceConfigInHelix(int adminApiPort, boolean shuttingDown) {


### PR DESCRIPTION
Separated out the ssl context class so that it can be re-used for realtime segment upload as well.
Added configurations to set preferred controller port and protocol for the server to communicate
with the controller.