### PR TITLE
Re-factor: Code re-factor to separate out realtime specific references from fixed-byte readers/writers.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -40,7 +40,7 @@ import com.linkedin.pinot.core.data.extractors.FieldExtractorFactory;
 import com.linkedin.pinot.core.data.extractors.PlainFieldExtractor;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.realtime.converter.RealtimeSegmentConverter;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentConfig;
 import com.linkedin.pinot.core.realtime.impl.RealtimeSegmentImpl;
@@ -196,7 +196,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final String _sortedColumn;
   private Logger segmentLogger = LOGGER;
   private final String _tableStreamName;
-  private final RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private final PinotDataBufferMemoryManager _memoryManager;
   private AtomicLong _lastUpdatedRawDocuments = new AtomicLong(0);
   private final String _instanceId;
   private final ServerSegmentCompletionProtocolHandler _protocolHandler;
@@ -657,7 +657,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
 
     SegmentCompletionProtocol.Response commitEndResponse =  _protocolHandler.segmentCommitEnd(_currentOffset,
-        _segmentNameStr, segmentCommitUploadResponse.getSegmentLocation(), _memoryManager.getTotalMemBytes());
+        _segmentNameStr, segmentCommitUploadResponse.getSegmentLocation(), _memoryManager.getTotalAllocatedBytes());
     if (!commitEndResponse.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS))  {
       segmentLogger.warn("CommitEnd failed  with response {}", commitEndResponse.toJsonString());
       return SegmentCompletionProtocol.RESP_FAILED;
@@ -690,7 +690,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   protected SegmentCompletionProtocol.Response postSegmentCommitMsg(File segmentTarFile) {
     SegmentCompletionProtocol.Response response = _protocolHandler.segmentCommit(_currentOffset, _segmentNameStr,
-        _memoryManager.getTotalMemBytes(), segmentTarFile);
+        _memoryManager.getTotalAllocatedBytes(), segmentTarFile);
     if (!response.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS)) {
       segmentLogger.warn("Commit failed  with response {}", response.toJsonString());
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -18,13 +18,13 @@ package com.linkedin.pinot.core.data.manager.realtime;
 
 import com.linkedin.pinot.common.metrics.ServerMetrics;
 import com.linkedin.pinot.core.data.manager.offline.SegmentDataManager;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
 
 
 public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
-  protected static RealtimeIndexOffHeapMemoryManager getMemoryManager(String consumerDir, String segmentName,
+  protected static PinotDataBufferMemoryManager getMemoryManager(String consumerDir, String segmentName,
       boolean offHeap, boolean directOffHeap, ServerMetrics serverMetrics) {
     if (offHeap && !directOffHeap) {
       return new MmapMemoryManager(consumerDir, segmentName, serverMetrics);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/PinotDataBufferMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/PinotDataBufferMemoryManager.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.io.readerwriter;
+
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import java.io.Closeable;
+
+
+/**
+ * Interface for memory manager that allocates/manages PinotDataBuffer.
+ * At the moment, this is far from a memory manager, and is just an allocator.
+ */
+public interface PinotDataBufferMemoryManager extends Closeable {
+
+  /**
+   * Allocates and returns a PinotDataBuffer of specified size.
+   *
+   * @param size Size of the data buffer to be allocated.
+   * @param allocationContext Context for allocation.
+   * @return Allocated data buffer.
+   */
+  PinotDataBuffer allocate(long size, String allocationContext);
+
+  /**
+   * Returns total size of memory allocated in bytes.
+   *
+   * @return Total memory size in bytes.
+   */
+  long getTotalAllocatedBytes();
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/DirectMemoryManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/DirectMemoryManager.java
@@ -41,15 +41,14 @@ public class DirectMemoryManager extends RealtimeIndexOffHeapMemoryManager {
   /**
    *
    * @param size size of memory
-   * @param columnName Name of the column for which memory is being allocated
+   * @param allocationContext String describing context of allocation (typically segment:column name).
    * @return PinotDataBuffer via direct allocation
    *
    * @see {@link RealtimeIndexOffHeapMemoryManager#allocate(long, String)}
    */
   @Override
-  protected PinotDataBuffer allocateInternal(long size, String columnName) {
-    PinotDataBuffer buffer = PinotDataBuffer.allocateDirect(size, getSegmentName() + "." + columnName);
-    return buffer;
+  protected PinotDataBuffer allocateInternal(long size, String allocationContext) {
+    return PinotDataBuffer.allocateDirect(size, allocationContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentConfig.java
@@ -18,7 +18,7 @@ package com.linkedin.pinot.core.realtime.impl;
 import com.linkedin.pinot.common.config.SegmentPartitionConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import java.util.Set;
 
 
@@ -32,14 +32,14 @@ public class RealtimeSegmentConfig {
   private final Set<String> _invertedIndexColumns;
   private final RealtimeSegmentZKMetadata _realtimeSegmentZKMetadata;
   private final boolean _offHeap;
-  private final RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private final PinotDataBufferMemoryManager _memoryManager;
   private final RealtimeSegmentStatsHistory _statsHistory;
   private final SegmentPartitionConfig _segmentPartitionConfig;
 
   private RealtimeSegmentConfig(String segmentName, String streamName, Schema schema, int capacity,
       int avgNumMultiValues, Set<String> noDictionaryColumns, Set<String> invertedIndexColumns,
       RealtimeSegmentZKMetadata realtimeSegmentZKMetadata, boolean offHeap,
-      RealtimeIndexOffHeapMemoryManager memoryManager, RealtimeSegmentStatsHistory statsHistory,
+      PinotDataBufferMemoryManager memoryManager, RealtimeSegmentStatsHistory statsHistory,
       SegmentPartitionConfig segmentPartitionConfig) {
     _segmentName = segmentName;
     _streamName = streamName;
@@ -91,7 +91,7 @@ public class RealtimeSegmentConfig {
     return _offHeap;
   }
 
-  public RealtimeIndexOffHeapMemoryManager getMemoryManager() {
+  public PinotDataBufferMemoryManager getMemoryManager() {
     return _memoryManager;
   }
 
@@ -113,7 +113,7 @@ public class RealtimeSegmentConfig {
     private Set<String> _invertedIndexColumns;
     private RealtimeSegmentZKMetadata _realtimeSegmentZKMetadata;
     private boolean _offHeap;
-    private RealtimeIndexOffHeapMemoryManager _memoryManager;
+    private PinotDataBufferMemoryManager _memoryManager;
     private RealtimeSegmentStatsHistory _statsHistory;
     private SegmentPartitionConfig _segmentPartitionConfig;
 
@@ -165,7 +165,7 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
-    public Builder setMemoryManager(RealtimeIndexOffHeapMemoryManager memoryManager) {
+    public Builder setMemoryManager(PinotDataBufferMemoryManager memoryManager) {
       _memoryManager = memoryManager;
       return this;
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.IOException;
@@ -30,12 +30,12 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public DoubleOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, RealtimeIndexOffHeapMemoryManager memoryManager,
-      String columnName) {
-    super(estimatedCardinality, maxOverflowSize, memoryManager, columnName);
+  public DoubleOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, PinotDataBufferMemoryManager memoryManager,
+      String allocationContext) {
+    super(estimatedCardinality, maxOverflowSize, memoryManager, allocationContext);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.DOUBLE_SIZE,
-        memoryManager, columnName);
+        memoryManager, allocationContext);
   }
 
   public Object get(int dictionaryId) {
@@ -112,6 +112,7 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Nonnull
   @Override
+  @SuppressWarnings("Duplicates")
   public double[] getSortedValues() {
     int numValues = length();
     double[] sortedValues = new double[numValues];
@@ -151,7 +152,7 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public double getDoubleValue(int dictId) {
-    return (Double)get(dictId);
+    return (Double) get(dictId);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.IOException;
@@ -30,12 +30,12 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public FloatOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, RealtimeIndexOffHeapMemoryManager memoryManager,
-      String columnName) {
-    super(estimatedCardinality, maxOverflowSize, memoryManager, columnName);
+  public FloatOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, PinotDataBufferMemoryManager memoryManager,
+      String allocationContext) {
+    super(estimatedCardinality, maxOverflowSize, memoryManager, allocationContext);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.FLOAT_SIZE,
-        memoryManager, columnName);
+        memoryManager, allocationContext);
   }
 
   public Object get(int dictionaryId) {
@@ -112,6 +112,7 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   @Nonnull
   @Override
+  @SuppressWarnings("Duplicates")
   public float[] getSortedValues() {
     int numValues = length();
     float[] sortedValues = new float[numValues];

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.IOException;
@@ -30,12 +30,12 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public IntOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, RealtimeIndexOffHeapMemoryManager memoryManager,
-      String columnName) {
-    super(estimatedCardinality, maxOverflowSize, memoryManager, columnName);
+  public IntOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowSize, PinotDataBufferMemoryManager memoryManager,
+      String allocationContext) {
+    super(estimatedCardinality, maxOverflowSize, memoryManager, allocationContext);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.INTEGER_SIZE,
-        memoryManager, columnName);
+        memoryManager, allocationContext);
   }
 
   public Object get(int dictionaryId) {
@@ -112,6 +112,7 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   @Nonnull
   @Override
+  @SuppressWarnings("Duplicates")
   public int[] getSortedValues() {
     int numValues = length();
     int[] sortedValues = new int[numValues];

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import java.io.IOException;
@@ -30,12 +30,12 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   private final FixedByteSingleColumnSingleValueReaderWriter _dictIdToValue;
 
-  public LongOffHeapMutableDictionary(int estimatedCardinality, int overflowSize, RealtimeIndexOffHeapMemoryManager memoryManager,
-      String columnName) {
-    super(estimatedCardinality, overflowSize, memoryManager, columnName);
+  public LongOffHeapMutableDictionary(int estimatedCardinality, int overflowSize, PinotDataBufferMemoryManager memoryManager,
+      String allocationContext) {
+    super(estimatedCardinality, overflowSize, memoryManager, allocationContext);
     final int initialEntryCount = nearestPowerOf2(estimatedCardinality);
     _dictIdToValue = new FixedByteSingleColumnSingleValueReaderWriter(initialEntryCount, V1Constants.Numbers.LONG_SIZE,
-        memoryManager, columnName);
+        memoryManager, allocationContext);
   }
 
   public Object get(int dictionaryId) {
@@ -112,6 +112,7 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
   @Nonnull
   @Override
+  @SuppressWarnings("Duplicates")
   public long[] getSortedValues() {
     int numValues = length();
     long[] sortedValues = new long[numValues];

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryFactory.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 
 
 public class MutableDictionaryFactory {
@@ -24,21 +24,21 @@ public class MutableDictionaryFactory {
   }
 
   public static MutableDictionary getMutableDictionary(FieldSpec.DataType dataType, boolean isOffHeapAllocation,
-      RealtimeIndexOffHeapMemoryManager memoryManager, int avgStringLen, int cardinality, String columnName) {
+      PinotDataBufferMemoryManager memoryManager, int avgStringLen, int cardinality, String allocationContext) {
     if (isOffHeapAllocation) {
       // OnHeap allocation
-      int maxOverflowSize = cardinality/10;
+      int maxOverflowSize = cardinality / 10;
       switch (dataType) {
         case INT:
-          return new IntOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+          return new IntOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, allocationContext);
         case LONG:
-          return new LongOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+          return new LongOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, allocationContext);
         case FLOAT:
-          return new FloatOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+          return new FloatOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, allocationContext);
         case DOUBLE:
-          return new DoubleOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName);
+          return new DoubleOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, allocationContext);
         case STRING:
-          return new StringOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, columnName,
+          return new StringOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, allocationContext,
               avgStringLen);
         default:
           throw new UnsupportedOperationException();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -32,9 +32,9 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   private String _max = null;
 
   public StringOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize,
-      RealtimeIndexOffHeapMemoryManager memoryManager, String columnName, int avgStringLen) {
-    super(estimatedCardinality, maxOverflowHashSize, memoryManager, columnName);
-    _byteStore = new MutableOffHeapByteArrayStore(memoryManager, columnName, estimatedCardinality, avgStringLen);
+      PinotDataBufferMemoryManager memoryManager, String allocationContext, int avgStringLen) {
+    super(estimatedCardinality, maxOverflowHashSize, memoryManager, allocationContext);
+    _byteStore = new MutableOffHeapByteArrayStore(memoryManager, allocationContext, estimatedCardinality, avgStringLen);
   }
 
   @Override
@@ -56,14 +56,14 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   public void index(@Nonnull Object rawValue) {
     if (rawValue instanceof String) {
       // Single value
-      byte[] serializedValue =  ((String)rawValue).getBytes(UTF_8);
+      byte[] serializedValue =  ((String) rawValue).getBytes(UTF_8);
       indexValue(rawValue, serializedValue);
       updateMinMax((String) rawValue);
     } else {
       // Multi value
       Object[] values = (Object[]) rawValue;
       for (Object value : values) {
-        byte[] serializedValue =  ((String)value).getBytes(UTF_8);
+        byte[] serializedValue =  ((String) value).getBytes(UTF_8);
         indexValue(value, serializedValue);
         updateMinMax((String) value);
       }
@@ -159,6 +159,6 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public int getAvgValueSize() {
-    return (int)_byteStore.getAvgValueSize();
+    return (int) _byteStore.getAvgValueSize();
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/RealtimeNoDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/RealtimeNoDictionaryTest.java
@@ -18,7 +18,7 @@ package com.linkedin.pinot.core.common;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.operator.BaseOperator;
@@ -44,7 +44,7 @@ public class RealtimeNoDictionaryTest {
   private double[] _doubleVals = new double[NUM_ROWS];
   private Random _random;
 
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {
@@ -56,6 +56,7 @@ public class RealtimeNoDictionaryTest {
     _memoryManager.close();
   }
 
+  @SuppressWarnings("Duplicates")
   private DataFetcher makeDataFetcher(long seed) {
     FieldSpec intSpec = new MetricFieldSpec(INT_COL_NAME, FieldSpec.DataType.INT);
     FieldSpec longSpec = new MetricFieldSpec(LONG_COL_NAME, FieldSpec.DataType.LONG);
@@ -265,7 +266,7 @@ public class RealtimeNoDictionaryTest {
       double[] doubleValues = new double[NUM_ROWS];
       dataFetcher.fetchDoubleValues(DOUBLE_COL_NAME, docIds, startIndex, numDocIds, doubleValues, valStart);
       for (int i = 0; i < numDocIds; i++) {
-        Assert.assertEquals(doubleValues[valStart + i], (double)_doubleVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
+        Assert.assertEquals(doubleValues[valStart + i], _doubleVals[docIds[startIndex + i]], " for row " + docIds[startIndex+i]);
       }
 
     } catch (Throwable t) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerFileCleanupTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerFileCleanupTest.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.pinot.core.indexsegment.utils;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
 import java.io.File;
 import org.apache.commons.io.FileUtils;
@@ -50,14 +50,14 @@ public class MmapMemoryManagerFileCleanupTest {
     final String someColumn = "column";
     final long firstAlloc = 20;
     final long allocAfterRestart = 200;
-    RealtimeIndexOffHeapMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    PinotDataBufferMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
     memoryManager.allocate(firstAlloc, someColumn);
     // Now, if the host restarts, we will have a file left behind for the same consuming segment.
     // and we should not see any exception.
     memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
     memoryManager.allocate(allocAfterRestart, someColumn);
     // We should not see the first allocation in the total.
-    Assert.assertEquals(memoryManager.getTotalMemBytes(), allocAfterRestart);
+    Assert.assertEquals(memoryManager.getTotalAllocatedBytes(), allocAfterRestart);
     memoryManager.close();
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MmapMemoryManagerTest.java
@@ -17,7 +17,7 @@
 package com.linkedin.pinot.core.indexsegment.utils;
 
 import com.linkedin.pinot.common.utils.MmapUtils;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
 import java.io.File;
@@ -54,7 +54,7 @@ public class MmapMemoryManagerTest {
   @Test
   public void testLargeBlocks() throws Exception {
     final String segmentName = "someSegment";
-    RealtimeIndexOffHeapMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    PinotDataBufferMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
     final long s1 = 2 * MmapMemoryManager.getDefaultFileLength();
     final long s2 = 1000;
     final String col1 = "col1";
@@ -104,7 +104,7 @@ public class MmapMemoryManagerTest {
   @Test
   public void testSmallBlocksForSameColumn() throws Exception {
     final String segmentName = "someSegment";
-    RealtimeIndexOffHeapMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    PinotDataBufferMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
     final long s1 = 500;
     final long s2 = 1000;
     final String col1 = "col1";
@@ -138,7 +138,7 @@ public class MmapMemoryManagerTest {
   @Test
   public void testCornerConditions() throws Exception {
     final String segmentName = "someSegment";
-    RealtimeIndexOffHeapMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
+    PinotDataBufferMemoryManager memoryManager = new MmapMemoryManager(_tmpDir, segmentName);
     final long s1 = MmapMemoryManager.getDefaultFileLength() - 1;
     final long s2 = 1;
     final long s3 = 100*1024*1024;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/MutableOffHeapByteArrayStoreTest.java
@@ -16,11 +16,11 @@
 
 package com.linkedin.pinot.core.indexsegment.utils;
 
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import java.util.Arrays;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.MutableOffHeapByteArrayStore;
 import junit.framework.Assert;
@@ -28,7 +28,7 @@ import junit.framework.Assert;
 
 public class MutableOffHeapByteArrayStoreTest {
 
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/OffHeapStringStoreTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/indexsegment/utils/OffHeapStringStoreTest.java
@@ -16,19 +16,19 @@
 
 package com.linkedin.pinot.core.indexsegment.utils;
 
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.OffHeapStringStore;
 
 
 public class OffHeapStringStoreTest {
   private static Random RANDOM = new Random();
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/operator/docvaliterators/RealtimeSingleValueIteratorTest.java
@@ -16,7 +16,7 @@
 
 package com.linkedin.pinot.core.operator.docvaliterators;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
@@ -40,7 +40,7 @@ public class RealtimeSingleValueIteratorTest {
   FixedByteSingleColumnSingleValueReaderWriter _longReader;
   FixedByteSingleColumnSingleValueReaderWriter _floatReader;
   FixedByteSingleColumnSingleValueReaderWriter _doubleReader;
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeNoDictionaryColStatsTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/converter/stats/RealtimeNoDictionaryColStatsTest.java
@@ -18,7 +18,7 @@ package com.linkedin.pinot.core.realtime.converter.stats;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import com.linkedin.pinot.core.segment.index.data.source.ColumnDataSource;
@@ -47,7 +47,7 @@ public class RealtimeNoDictionaryColStatsTest {
   private float _floatMaxVal;
   private double _doubleMinVal;
   private double _doubleMaxVal;
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MultiValueDictionaryTest.java
@@ -15,12 +15,12 @@
  */
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 
@@ -28,7 +28,7 @@ import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 public class MultiValueDictionaryTest {
   private static final int NROWS = 1000;
   private static final int MAX_N_VALUES = 1000;
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/dictionary/MutableDictionaryTest.java
@@ -16,7 +16,7 @@
 package com.linkedin.pinot.core.realtime.impl.dictionary;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class MutableDictionaryTest {
   private static final Random RANDOM = new Random(RANDOM_SEED);
 
   private final ExecutorService _executorService = Executors.newFixedThreadPool(NUM_READERS + 1);
-  private final RealtimeIndexOffHeapMemoryManager _memoryManager =
+  private final PinotDataBufferMemoryManager _memoryManager =
       new DirectMemoryManager(MutableDictionaryTest.class.getName());
 
   @Test

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.index.readerwriter;
 
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
@@ -23,13 +24,12 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 
 
 public class FixedByteSingleColumnMultiValueReaderWriterTest {
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {
@@ -156,11 +156,8 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     final int avgMultiValueCount = r.nextInt(maxNumberOfMultiValuesPerRow) + 1;
     final int rowCountPerChunk = r.nextInt(rows) + 1;
 
-    FixedByteSingleColumnMultiValueReaderWriter readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, avgMultiValueCount,
-            rowCountPerChunk, columnSize, _memoryManager, "ReaderWriter");
-
-    return readerWriter;
+    return new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, avgMultiValueCount,
+        rowCountPerChunk, columnSize, _memoryManager, "ReaderWriter");
   }
 
   private int sizeForType(FieldSpec.DataType type) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnSingleValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnSingleValueReaderWriterTest.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.index.readerwriter;
 
-import com.linkedin.pinot.core.io.readerwriter.RealtimeIndexOffHeapMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
 import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnSingleValueReaderWriter;
 import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import java.io.IOException;
@@ -28,7 +28,7 @@ import org.testng.annotations.Test;
 
 
 public class FixedByteSingleColumnSingleValueReaderWriterTest {
-  private RealtimeIndexOffHeapMemoryManager _memoryManager;
+  private PinotDataBufferMemoryManager _memoryManager;
 
   @BeforeClass
   public void setUp() {


### PR DESCRIPTION
1. Created an interface PinotDataBufferMemoryManager, that is now passed
to fixed-byte readers/writers.

2. Eliminated segmentName being stored in memory manager. Instead, now
callers allocating memory pass an allocationContext
(segmentName:columnName), that is used for logging within memory
manager. RealtimeOffHeapMemoryManager still has dependency on segment
name, that is harder to remove, and will explode this PR, therefore not
addressed.

3. Fixed code-style for all touched files.