### PR TITLE
[TE] update all thirdeye to the newest module API

### DIFF
--- a/thirdeye/thirdeye-frontend/app/actions/metrics.js
+++ b/thirdeye/thirdeye-frontend/app/actions/metrics.js
@@ -1,6 +1,6 @@
+import { hash } from 'rsvp';
 import { type } from './utils';
 import fetch from 'fetch';
-import Ember from 'ember';
 import moment from 'moment';
 import _ from 'lodash';
 import {
@@ -229,7 +229,7 @@ function fetchRelatedMetricData() {
       return hash;
     }, {});
 
-    return Ember.RSVP.hash(promiseHash)
+    return hash(promiseHash)
       .then((metrics) => {
         const filteredMetrics = _.pickBy(metrics, filterMetric);
 

--- a/thirdeye/thirdeye-frontend/app/actions/primary-metric.js
+++ b/thirdeye/thirdeye-frontend/app/actions/primary-metric.js
@@ -1,6 +1,6 @@
+import { hash } from 'rsvp';
 import { type } from './utils';
 import fetch from 'fetch';
-import Ember from 'ember';
 import moment from 'moment';
 import { COMPARE_MODE_MAPPING } from './constants';
 
@@ -171,7 +171,7 @@ function fetchRelatedMetricData() {
       return hash;
     }, {});
 
-    return Ember.RSVP.hash(promiseHash)
+    return hash(promiseHash)
       .then(res => dispatch(loadRelatedMetricsData(res)))
       .catch(() => {
         dispatch(requestFail());

--- a/thirdeye/thirdeye-frontend/app/app.js
+++ b/thirdeye/thirdeye-frontend/app/app.js
@@ -1,11 +1,11 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let App;
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/thirdeye/thirdeye-frontend/app/authenticators/custom-ldap.js
+++ b/thirdeye/thirdeye-frontend/app/authenticators/custom-ldap.js
@@ -1,11 +1,11 @@
+import { inject as service } from '@ember/service';
 import Base from 'ember-simple-auth/authenticators/base';
 import fetch from 'fetch';
-import Ember from 'ember';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import RSVP from 'rsvp';
 
 export default Base.extend({
-  session: Ember.inject.service(),
+  session: service(),
   /**
    * Implements Base authenticator's authenticate method.
    * @param {Object}  credentials containing username and password

--- a/thirdeye/thirdeye-frontend/app/helpers/color-delta.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/color-delta.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 import { toColorDirection } from 'thirdeye-frontend/utils/rca-utils';
 
 /**
@@ -13,4 +13,4 @@ export function colorDelta([value = 'N/A', inverse = false]) {
   return toColorDirection(value, inverse);
 }
 
-export default Ember.Helper.helper(colorDelta);
+export default helper(colorDelta);

--- a/thirdeye/thirdeye-frontend/app/helpers/compute-color.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/compute-color.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 /**
  * Template helper that computes the background color
@@ -16,4 +16,4 @@ export function computeColor([value = 0]) {
   }
 }
 
-export default Ember.Helper.helper(computeColor);
+export default helper(computeColor);

--- a/thirdeye/thirdeye-frontend/app/helpers/compute-text-color.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/compute-text-color.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 /**
  * Template helper that computes the text color
@@ -16,4 +16,4 @@ export function computeTextColor([value = 0]) {
   }
 }
 
-export default Ember.Helper.helper(computeTextColor);
+export default helper(computeTextColor);

--- a/thirdeye/thirdeye-frontend/app/helpers/get-safe.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/get-safe.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 /**
  * Returns the value referred to by key in dict. Avoids resolving dot-syntax as done by the builtin
@@ -13,5 +13,5 @@ export function getSafe([dict, key]) {
   return dict[key];
 }
 
-export default Ember.Helper.helper(getSafe);
+export default helper(getSafe);
 

--- a/thirdeye/thirdeye-frontend/app/helpers/set-has-not.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/set-has-not.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 /**
  * Returns true if the set does not contain the value
@@ -10,4 +10,4 @@ export function setHasNot([set = new Set(), value = null]) {
   return !set.has(value);
 }
 
-export default Ember.Helper.helper(setHasNot);
+export default helper(setHasNot);

--- a/thirdeye/thirdeye-frontend/app/helpers/set-has.js
+++ b/thirdeye/thirdeye-frontend/app/helpers/set-has.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 export function setHas([set, value]) {
   if (!set) { return; }
   return set.has && set.has(value);
 }
 
-export default Ember.Helper.helper(setHas);
+export default helper(setHas);
 

--- a/thirdeye/thirdeye-frontend/app/pods/application/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/application/controller.js
@@ -3,11 +3,14 @@
  * @module  application
  * @exports application
  */
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
 
-export default Ember.Controller.extend({
-  showNavbar: Ember.computed.alias('model'),
-  session: Ember.inject.service(),
+import { alias } from '@ember/object/computed';
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  showNavbar: alias('model'),
+  session: service(),
 
   /**
    * Global navbar items

--- a/thirdeye/thirdeye-frontend/app/pods/application/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/application/route.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 import fetch from 'fetch';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import config from 'thirdeye-frontend/config/environment';
 
-export default Ember.Route.extend(ApplicationRouteMixin, {
-  moment: Ember.inject.service(),
-  session: Ember.inject.service(),
+export default Route.extend(ApplicationRouteMixin, {
+  moment: service(),
+  session: service(),
 
   beforeModel() {
     // calling this._super to trigger ember-simple-auth's hook

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-graph/component.js
@@ -1,4 +1,7 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import { set, computed } from '@ember/object';
+import { later } from '@ember/runloop';
+import Component from '@ember/component';
 import moment from 'moment';
 import d3 from 'd3';
 import { eventWeightMapping } from 'thirdeye-frontend/actions/constants';
@@ -20,7 +23,7 @@ const COLOR_MAPPING = {
   light_pink: '#FF91CF'
 };
 
-export default Ember.Component.extend({
+export default Component.extend({
   init() {
     this._super(...arguments);
 
@@ -209,7 +212,7 @@ export default Ember.Component.extend({
   didRender(){
     this._super(...arguments);
 
-    Ember.run.later(() => {
+    later(() => {
       this.buildSliderButton();
       // hiding this feature until fully fleshed out
       // this.buildAnomalyRegionSlider();
@@ -245,7 +248,7 @@ export default Ember.Component.extend({
 
     // This check is necessary so that it is only set once
     if (primaryMetric.isSelected === undefined) {
-      Ember.set(primaryMetric, 'isSelected', true);
+      set(primaryMetric, 'isSelected', true);
     }
 
     const data = [
@@ -316,22 +319,22 @@ export default Ember.Component.extend({
   padding: null,
 
   // dd for primary metric
-  primaryMetricId: Ember.computed('componentId', function() {
+  primaryMetricId: computed('componentId', function() {
     return this.get('componentId') + '-primary-metric-';
   }),
 
   // id for related metrics
-  relatedMetricId: Ember.computed('componentId', function() {
+  relatedMetricId: computed('componentId', function() {
     return this.get('componentId') + '-related-metric-';
   }),
 
   // id for dimension
-  dimensionId:  Ember.computed('componentId', function() {
+  dimensionId:  computed('componentId', function() {
     return this.get('componentId') + '-dimension-';
   }),
 
   // filtered events for graph
-  holidayEvents: Ember.computed('events', function() {
+  holidayEvents: computed('events', function() {
     return this.get('events');
     // const events = this.get('events');
     // const hiddenEvents = [];
@@ -340,7 +343,7 @@ export default Ember.Component.extend({
     // });
   }),
 
-  holidayEventsColumn: Ember.computed(
+  holidayEventsColumn: computed(
     'holidayEvents',
     function() {
       const events = this.get('holidayEvents');
@@ -361,7 +364,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  holidayEventsDatesColumn: Ember.computed(
+  holidayEventsDatesColumn: computed(
     'holidayEvents',
     function() {
       const holidays = this.get('holidayEvents');
@@ -382,7 +385,7 @@ export default Ember.Component.extend({
   /**
    * Graph Legend config
    */
-  legend: Ember.computed('showGraphLegend', function() {
+  legend: computed('showGraphLegend', function() {
     const showGraphLegend = this.get('showGraphLegend');
     return {
       position: 'inset',
@@ -393,7 +396,7 @@ export default Ember.Component.extend({
   /**
    * Graph Zoom config
    */
-  zoom: Ember.computed(
+  zoom: computed(
     'onSubchartChange',
     'enableZoom',
     function() {
@@ -409,7 +412,7 @@ export default Ember.Component.extend({
   /**
    * Graph Point Config
    */
-  point: Ember.computed(
+  point: computed(
     'showGraphLegend',
     function() {
       return {
@@ -429,7 +432,7 @@ export default Ember.Component.extend({
   /**
    * Graph axis config
    */
-  axis: Ember.computed(
+  axis: computed(
     'chartDates',
     'primaryMetric',
     'subchartStart',
@@ -491,7 +494,7 @@ export default Ember.Component.extend({
   /**
    * Graph Subchart Config
    */
-  subchart: Ember.computed(
+  subchart: computed(
     'showLegend',
     'showSubchart',
     'showGraphLegend',
@@ -535,7 +538,7 @@ export default Ember.Component.extend({
   /**
    * Graph Height Config
    */
-  size: Ember.computed(
+  size: computed(
     'showLegend',
     'height',
     function() {
@@ -550,7 +553,7 @@ export default Ember.Component.extend({
   /**
    * Data massages primary Metric into a Column
    */
-  primaryMetricColumn: Ember.computed(
+  primaryMetricColumn: computed(
     'primaryMetric',
     'primaryMetric.isSelected',
     function() {
@@ -574,7 +577,7 @@ export default Ember.Component.extend({
   /**
    * Data massages relatedMetrics into Columns
    */
-  selectedMetricsColumn: Ember.computed(
+  selectedMetricsColumn: computed(
     'selectedMetrics',
     'selectedMetrics.@each',
     function() {
@@ -595,7 +598,7 @@ export default Ember.Component.extend({
   /**
    * Data massages dimensions into Columns
    */
-  selectedDimensionsColumn: Ember.computed(
+  selectedDimensionsColumn: computed(
     'selectedDimensions',
     function() {
       const columns = [];
@@ -612,7 +615,7 @@ export default Ember.Component.extend({
   /**
    * Derives x axis from the primary metric
    */
-  chartDates: Ember.computed(
+  chartDates: computed(
     'primaryMetric.timeBucketsCurrent',
     function() {
       return ['date', ...this.get('primaryMetric.timeBucketsCurrent')];
@@ -622,7 +625,7 @@ export default Ember.Component.extend({
   /**
    * Aggregates data for chart
    */
-  data: Ember.computed(
+  data: computed(
     'primaryMetricColumn',
     'selectedMetricsColumn',
     'selectedDimensionsColumn',
@@ -696,7 +699,7 @@ export default Ember.Component.extend({
    * Data massages Primary Metric's region
    * and assigns color class
    */
-  primaryRegions: Ember.computed('primaryMetric', function() {
+  primaryRegions: computed('primaryMetric', function() {
     const primaryMetric = this.get('primaryMetric') || {};
     const {
       regions,
@@ -722,7 +725,7 @@ export default Ember.Component.extend({
   /**
    * Data massages the main anomaly region
    */
-  anomalyRegion: Ember.computed(
+  anomalyRegion: computed(
     'analysisStart',
     'analysisEnd',
     function() {
@@ -749,7 +752,7 @@ export default Ember.Component.extend({
    * Data massages Primary Metric's region
    * and assigns color class
    */
-  relatedRegions: Ember.computed(
+  relatedRegions: computed(
     'selectedMetrics',
     'selectedMetrics.@each',
     function() {
@@ -811,7 +814,7 @@ export default Ember.Component.extend({
   /**
    * Aggregates chart regions
    */
-  regions: Ember.computed(
+  regions: computed(
     'primaryRegions',
     'relatedRegions',
     'anomalyRegion',
@@ -854,8 +857,8 @@ export default Ember.Component.extend({
      * Scrolls to the appropriate tab on click
      */
     scrollToSection() {
-      Ember.run.later(() => {
-        Ember.$('#root-cause-analysis').get(0).scrollIntoView();
+      later(() => {
+        $('#root-cause-analysis').get(0).scrollIntoView();
       });
     }
   }

--- a/thirdeye/thirdeye-frontend/app/pods/components/anomaly-id/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/anomaly-id/component.js
@@ -3,9 +3,11 @@
  * @module components/anomaly-id
  * @exports anomaly-id
  */
-import Ember from 'ember';
+import { computed } from '@ember/object';
 
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
   /**
    * Component's tag name
    */
@@ -22,7 +24,7 @@ export default Ember.Component.extend({
    * @method anomalyChangeRate
    * @return {Number} - total % change from baseline
    */
-  anomalyChangeRate: Ember.computed('anomaly.current', 'anomaly.baseline', function() {
+  anomalyChangeRate: computed('anomaly.current', 'anomaly.baseline', function() {
     const currentValue = this.get('anomaly.current') || 0;
     const baselineValue = this.get('anomaly.baseline') || 0;
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/containers/anomaly-container/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/containers/anomaly-container/component.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { connect } from 'ember-redux';
 import { Actions } from 'thirdeye-frontend/actions/anomaly';
 
@@ -34,5 +34,5 @@ function actions(dispatch) {
   };
 }
 
-export default connect(select, actions)(Ember.Component.extend({
+export default connect(select, actions)(Component.extend({
 }));

--- a/thirdeye/thirdeye-frontend/app/pods/components/containers/dimensions-container/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/containers/dimensions-container/component.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { connect } from 'ember-redux';
 
 
@@ -53,6 +53,6 @@ function actions() {
   return {};
 }
 
-export default connect(select, actions)(Ember.Component.extend({
+export default connect(select, actions)(Component.extend({
 }));
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/containers/events-table-container/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/containers/events-table-container/component.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { connect } from 'ember-redux';
 
 function select(store) {
@@ -33,5 +33,5 @@ function actions() {
   return {};
 }
 
-export default connect(select, actions)(Ember.Component.extend({
+export default connect(select, actions)(Component.extend({
 }));

--- a/thirdeye/thirdeye-frontend/app/pods/components/containers/metrics-container/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/containers/metrics-container/component.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { connect } from 'ember-redux';
 import _ from 'lodash';
 
@@ -50,5 +50,5 @@ function actions() {
   return {};
 }
 
-export default connect(select, actions)(Ember.Component.extend({
+export default connect(select, actions)(Component.extend({
 }));

--- a/thirdeye/thirdeye-frontend/app/pods/components/containers/primary-metric-container/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/containers/primary-metric-container/component.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { connect } from 'ember-redux';
 import { Actions } from 'thirdeye-frontend/actions/primary-metric';
 import _ from 'lodash';
@@ -146,5 +146,5 @@ function actions(dispatch) {
   };
 }
 
-export default connect(select, actions)(Ember.Component.extend({
+export default connect(select, actions)(Component.extend({
 }));

--- a/thirdeye/thirdeye-frontend/app/pods/components/contribution-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/contribution-table/component.js
@@ -1,4 +1,7 @@
-import Ember from 'ember';
+import { isArray } from '@ember/array';
+import { computed } from '@ember/object';
+import { later } from '@ember/runloop';
+import Component from '@ember/component';
 import _ from 'lodash';
 
 const GRANULARITY_MAPPING = {
@@ -34,7 +37,7 @@ const filterRow = (rows, startIndex, endIndex) => {
   return newRows;
 };
 
-export default Ember.Component.extend({
+export default Component.extend({
   metrics: null,
   showDetails: false,
   granularity: 'DAYS',
@@ -50,7 +53,7 @@ export default Ember.Component.extend({
   didRender(...args) {
     this._super(args);
 
-    Ember.run.later(() => {
+    later(() => {
       this.attrs.stopLoading();
     });
   },
@@ -58,7 +61,7 @@ export default Ember.Component.extend({
   /**
    * Determines the date format based on granularity
    */
-  dateFormat: Ember.computed('granularity', function() {
+  dateFormat: computed('granularity', function() {
     const granularity = this.get('granularity');
     return GRANULARITY_MAPPING[granularity];
   }),
@@ -66,28 +69,28 @@ export default Ember.Component.extend({
   /**
    * Contribution data of the primary metric
    */
-  primaryMetricRows: Ember.computed('primaryMetric', function() {
+  primaryMetricRows: computed('primaryMetric', function() {
     const metrics = this.get('primaryMetric');
 
-    return Ember.isArray(metrics) ? [...metrics] : [Object.assign({}, metrics)];
+    return isArray(metrics) ? [...metrics] : [Object.assign({}, metrics)];
   }),
 
   /**
    * Contribution data of the related metrics
    */
-  relatedMetricRows: Ember.computed('relatedMetrics', function() {
+  relatedMetricRows: computed('relatedMetrics', function() {
     const metrics = this.get('relatedMetrics');
 
-    return Ember.isArray(metrics) ? [...metrics] : [Object.assign({}, metrics)];
+    return isArray(metrics) ? [...metrics] : [Object.assign({}, metrics)];
   }),
 
   /**
    * Contribution data of the dimension
    */
-  dimensionRows: Ember.computed('dimensions', function() {
+  dimensionRows: computed('dimensions', function() {
     const dimensions = this.get('dimensions');
 
-    return Ember.isArray(dimensions) ? [...dimensions] : [Object.assign({}, dimensions)];
+    return isArray(dimensions) ? [...dimensions] : [Object.assign({}, dimensions)];
   }),
 
   /**
@@ -96,7 +99,7 @@ export default Ember.Component.extend({
    * @param {Number} start Start date in unix ms
    * @return {Number} The start Index
    */
-  startIndex: Ember.computed('dates', 'start', function() {
+  startIndex: computed('dates', 'start', function() {
     const dates = this.get('dates');
     const start = this.get('start');
 
@@ -114,7 +117,7 @@ export default Ember.Component.extend({
    * @param {Number} end end date in unix ms
    * @return {Number} The end Index
    */
-  endIndex: Ember.computed('dates', 'end', function() {
+  endIndex: computed('dates', 'end', function() {
     const dates = this.get('dates');
     const end = this.get('end');
 
@@ -129,7 +132,7 @@ export default Ember.Component.extend({
   /**
    * Filters the date to return only those in range
    */
-  filteredDates: Ember.computed(
+  filteredDates: computed(
     'startIndex',
     'endIndex',
     'dates',
@@ -145,7 +148,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  filteredPrimaryMetricRows: Ember.computed(
+  filteredPrimaryMetricRows: computed(
     'startIndex',
     'endIndex',
     'primaryMetricRows',
@@ -159,7 +162,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  filteredRelatedMetricRows: Ember.computed(
+  filteredRelatedMetricRows: computed(
     'startIndex',
     'endIndex',
     'relatedMetricRows',
@@ -173,7 +176,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  filteredDimensionRows: Ember.computed(
+  filteredDimensionRows: computed(
     'startIndex',
     'endIndex',
     'dimensionRows',

--- a/thirdeye/thirdeye-frontend/app/pods/components/dimension-heatmap/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/dimension-heatmap/component.js
@@ -1,16 +1,19 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import Component from '@ember/component';
 import d3 from 'd3';
 
-export default Ember.Component.extend({
+export default Component.extend({
   heatMapData: {},
-  dimensions: Ember.computed.alias('heatMapData.dimensions'),
-  metricName: Ember.computed.alias('heatMapData.metrics.firstObject'),
-  inverseMetric:Ember.computed.alias('heatMapData.inverseMetric'),
+  dimensions: alias('heatMapData.dimensions'),
+  metricName: alias('heatMapData.metrics.firstObject'),
+  inverseMetric:alias('heatMapData.inverseMetric'),
   classNames: ['dimension-heatmap'],
   heatmapMode: 'Change in Contribution',
 
   // Copy pasted code from all Thirdeye UI
-  treeMapData: Ember.computed(
+  treeMapData: computed(
     'dimensions',
     'dimensions.@each',
     'heatMapData',
@@ -116,8 +119,8 @@ export default Ember.Component.extend({
       var data = treeMapData[i];
       var dimension = dimensions[i];
       var dimensionPlaceHolderId = '#' + dimension + '-heatmap-placeholder';
-      var height = Ember.$(dimensionPlaceHolderId).height();
-      var width = Ember.$(dimensionPlaceHolderId).width();
+      var height = $(dimensionPlaceHolderId).height();
+      var width = $(dimensionPlaceHolderId).width();
       var treeMap = d3.layout.treemap().size([ width, height ]).sort(function(a, b) {
         return a.value - b.value;
       });

--- a/thirdeye/thirdeye-frontend/app/pods/components/dimension-summary/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/dimension-summary/component.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['dimension-summary card-container card-container--padded']
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/entity-filter/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/entity-filter/component.js
@@ -16,10 +16,13 @@
  * @exports entity-filter
  */
 
-import Ember from 'ember';
+import { set } from '@ember/object';
+
+import { isPresent } from '@ember/utils';
+import Component from '@ember/component';
 import _ from 'lodash';
 
-export default Ember.Component.extend({
+export default Component.extend({
   /**
    * Overwrite the init function
    * @param {Object} args - Attributes for this component
@@ -35,7 +38,7 @@ export default Ember.Component.extend({
       let filterKeys = [];
 
       // Dedupe and remove null or empty values
-      filterKeys = Array.from(new Set(block.filterKeys.filter(value => Ember.isPresent(value))));
+      filterKeys = Array.from(new Set(block.filterKeys.filter(value => isPresent(value))));
       // Generate a name and Id for each one based on provided filter keys
       filterKeys.forEach((filter) => {
         filtersArray.push({
@@ -69,7 +72,7 @@ export default Ember.Component.extend({
      */
     onFilterSelection(category, filterObj) {
       // Note: toggleProperty will not be able to find 'filterObj', as it is not an observed property
-      Ember.set(filterObj, 'isActive', !filterObj.isActive);
+      set(filterObj, 'isActive', !filterObj.isActive);
 
       if (filterObj.isActive) {
         this.get('alertFilters').push({ category, filter: filterObj.name, isActive: filterObj.isActive });
@@ -89,7 +92,7 @@ export default Ember.Component.extend({
      */
     toggleDisplay(clickedBlock) {
       // Note: toggleProperty will not be able to find 'filterBlocks', as it is not an observed property
-      Ember.set(clickedBlock, 'isHidden', !clickedBlock.isHidden);
+      set(clickedBlock, 'isHidden', !clickedBlock.isHidden);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/events-header/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/events-header/component.js
@@ -1,6 +1,8 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   events: [],
   onTabChange: null,
 
@@ -11,7 +13,7 @@ export default Ember.Component.extend({
   /**
    * Holiday Events
    */
-  holidays: Ember.computed(
+  holidays: computed(
     'events.@each',
     function() {
       return this.get('events')
@@ -22,7 +24,7 @@ export default Ember.Component.extend({
   /**
    * GCN events
    */
-  gcn: Ember.computed(
+  gcn: computed(
     'events.@each',
     function() {
       return this.get('events')
@@ -33,7 +35,7 @@ export default Ember.Component.extend({
   /**
    * anomaly events
    */
-  anomaly: Ember.computed(
+  anomaly: computed(
     'events.@each',
     function() {
       return this.get('events')
@@ -45,7 +47,7 @@ export default Ember.Component.extend({
   /**
    * Informed events
    */
-  informed: Ember.computed(
+  informed: computed(
     'events.@each',
     function() {
       return this.get('events')
@@ -57,7 +59,7 @@ export default Ember.Component.extend({
   /**
    * Lix events
    */
-  lix: Ember.computed(
+  lix: computed(
     'events.@each',
     function() {
       return this.get('events')
@@ -68,12 +70,12 @@ export default Ember.Component.extend({
   /**
    * Count of events
    */
-  allCount: Ember.computed.alias('events.length'),
-  holidayCount: Ember.computed.alias('holidays.length'),
-  gcnCount: Ember.computed.alias('gcn.length'),
-  informedCount: Ember.computed.alias('informed.length'),
-  lixCount: Ember.computed.alias('lix.length'),
-  anomalyCount: Ember.computed.alias('anomaly.length'),
+  allCount: alias('events.length'),
+  holidayCount: alias('holidays.length'),
+  gcnCount: alias('gcn.length'),
+  informedCount: alias('informed.length'),
+  lixCount: alias('lix.length'),
+  anomalyCount: alias('anomaly.length'),
 
   actions: {
     // Handles tab change on click

--- a/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/events-table/component.js
@@ -1,6 +1,8 @@
-import Ember from 'ember';
+import { later } from '@ember/runloop';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   events: [],
   selectedTab: 'all',
 
@@ -10,7 +12,7 @@ export default Ember.Component.extend({
   /**
    * Returns event based on the selected tab
    */
-  filteredEvents: Ember.computed(
+  filteredEvents: computed(
     'eventsInRange.@each.type',
     'selectedTab',
     function() {
@@ -28,7 +30,7 @@ export default Ember.Component.extend({
   /**
    * Returns events in a range
    */
-  eventsInRange: Ember.computed(
+  eventsInRange: computed(
     'events',
     'start',
     'end',
@@ -51,7 +53,7 @@ export default Ember.Component.extend({
 
   // Require to display a loader for long rendering
   didUpdateAttrs(...args) {
-    Ember.run.later(() => {
+    later(() => {
       this._super(args);
     });
   },

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar-input/component.js
@@ -21,9 +21,11 @@
  *
  * @exports filter-bar
  */
-import Ember from 'ember';
+import { computed } from '@ember/object';
 
-export default Ember.Component.extend({
+import Component from '@ember/component';
+
+export default Component.extend({
 
   /**
    * @type Array
@@ -35,7 +37,7 @@ export default Ember.Component.extend({
    * options to populate dropdown (required by power-select addon)
    * @type {Array}
    */
-  options: Ember.computed(
+  options: computed(
     'labelMapping',
     'attributesMap',
     'eventType',

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -16,7 +16,14 @@
  * @exports filter-bar
  */
 import Component from "@ember/component";
-import { get, set, setProperties, computed, getProperties, observer } from "@ember/object";
+import {
+  get,
+  set,
+  setProperties,
+  computed,
+  getProperties,
+  observer
+} from "@ember/object";
 import _ from 'lodash';
 
 export default Component.extend({

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-select/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-select/component.js
@@ -13,7 +13,9 @@
  * @author yyuen
  */
 
-import Ember from 'ember';
+import { computed } from '@ember/object';
+
+import Component from '@ember/component';
 import { task, timeout } from 'ember-concurrency';
 
 /**
@@ -114,7 +116,7 @@ const getSearchResults = (filterOptions, filterToMatch, maxNum) => {
 };
 
 
-export default Ember.Component.extend({
+export default Component.extend({
   // Maximum filters by filter group
   maxNumFilters: 25,
 
@@ -138,14 +140,14 @@ export default Ember.Component.extend({
    * Takes the filters and massage them for the power-select grouping api
    * Currently not showing the whole list because of performance issues
    */
-  filterOptions: Ember.computed('options', function() {
+  filterOptions: computed('options', function() {
     const filters = this.get('options') || {};
 
     return buildFilterOptions(filters);
   }),
 
   // Selected Filters Serializer
-  selectedFilters: Ember.computed('selected', {
+  selectedFilters: computed('selected', {
     get() {
       const filters = JSON.parse(this.get('selected'));
 
@@ -160,7 +162,7 @@ export default Ember.Component.extend({
   }),
 
   // Initial filter View (subset of FilterOptions)
-  viewFilterOptions: Ember.computed(
+  viewFilterOptions: computed(
     'filterOptions.@each',
     'maxNumFilters',
     function() {

--- a/thirdeye/thirdeye-frontend/app/pods/components/heatmap-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/heatmap-chart/component.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import Component from '@ember/component';
+import { get } from '@ember/object';
 import d3 from 'd3';
-
-const { get } = Ember;
 
 // TODO: move to utils file
 const getBackgroundColor = function (factor = 0, inverse = false) {
@@ -26,7 +26,7 @@ const getTextColor = function (factor = 0, inverse = false) {
   return opacity < 0.5 ? '#000000' : '#ffffff';
 };
 
-export default Ember.Component.extend({
+export default Component.extend({
   cells: null, // {}
 
   /**
@@ -86,7 +86,7 @@ export default Ember.Component.extend({
           });
         });
 
-      const domElem = Ember.$(dimensionPlaceHolderId);
+      const domElem = $(dimensionPlaceHolderId);
       const height = domElem.height();
       const width = domElem.width();
       const treeMap = d3.layout.treemap()

--- a/thirdeye/thirdeye-frontend/app/pods/components/login-form/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/login-form/component.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['nacho-login-form'],
   username: null,
   password: null,

--- a/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
@@ -1,6 +1,11 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { makeSortable, toMetricLabel, toColorDirection, isInverse } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  makeSortable,
+  toMetricLabel,
+  toColorDirection,
+  isInverse
+} from 'thirdeye-frontend/utils/rca-utils';
 import { humanizeScore } from 'thirdeye-frontend/utils/utils';
 
 export default Component.extend({

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
@@ -1,7 +1,18 @@
 import Component from "@ember/component";
-import { computed, setProperties, getProperties, get } from '@ember/object';
+import {
+  computed,
+  setProperties,
+  getProperties,
+  get
+} from '@ember/object';
 import moment from 'moment';
-import { filterPrefix, toOffsetUrn, toColorDirection, isInverse, toMetricLabel } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  filterPrefix,
+  toOffsetUrn,
+  toColorDirection,
+  isInverse,
+  toMetricLabel
+} from 'thirdeye-frontend/utils/rca-utils';
 import { humanizeChange } from 'thirdeye-frontend/utils/utils';
 import { equal, reads } from '@ember/object/computed';
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart-toolbar/component.js
@@ -1,6 +1,12 @@
 import Component from '@ember/component';
 import moment from 'moment';
-import { computed, get, set, getProperties, setProperties } from '@ember/object';
+import {
+  computed,
+  get,
+  set,
+  getProperties,
+  setProperties
+} from '@ember/object';
 import translate from 'thirdeye-frontend/utils/translate';
 
 /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -1,8 +1,16 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import moment from 'moment';
 import d3 from 'd3';
 import buildTooltip from 'thirdeye-frontend/utils/build-tooltip';
-import { toBaselineUrn, toMetricUrn, filterPrefix, hasPrefix, toMetricLabel, colorMapping } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  toBaselineUrn,
+  toMetricUrn,
+  filterPrefix,
+  hasPrefix,
+  toMetricLabel,
+  colorMapping
+} from 'thirdeye-frontend/utils/rca-utils';
 
 const TIMESERIES_MODE_ABSOLUTE = 'absolute';
 const TIMESERIES_MODE_RELATIVE = 'relative';
@@ -11,7 +19,7 @@ const TIMESERIES_MODE_SPLIT = 'split';
 
 const EVENT_MIN_GAP = 60000;
 
-export default Ember.Component.extend({
+export default Component.extend({
   entities: null, // {}
 
   selectedUrns: null, // Set
@@ -36,7 +44,7 @@ export default Ember.Component.extend({
    * Translate an urn into a chart id
    * @returns {String|null}
    */
-  focusedId: Ember.computed('focusedUrn', function() {
+  focusedId: computed('focusedUrn', function() {
     const urn = this.get('focusedUrn');
 
     return this._urnToChartId(urn);
@@ -69,7 +77,7 @@ export default Ember.Component.extend({
     height: 200
   },
 
-  tooltip: Ember.computed(
+  tooltip: computed(
     'onHover',
     function () {
       return {
@@ -96,7 +104,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  axis: Ember.computed(
+  axis: computed(
     'context',
     function () {
       const { context } = this.getProperties('context');
@@ -131,7 +139,7 @@ export default Ember.Component.extend({
   /**
    * Array of displayable urns in timeseries chart (events, metrics, metric refs)
    */
-  displayableUrns: Ember.computed(
+  displayableUrns: computed(
     'entities',
     'timeseries',
     'selectedUrns',
@@ -148,7 +156,7 @@ export default Ember.Component.extend({
   /**
    * Transformed data series as ingested by timeseries-chart
    */
-  series: Ember.computed(
+  series: computed(
     'entities',
     'timeseries',
     'context',
@@ -177,7 +185,7 @@ export default Ember.Component.extend({
   /**
    * Dictionary of transformed data series for split view, keyed by metric ref urn.
    */
-  splitSeries: Ember.computed(
+  splitSeries: computed(
     'entities',
     'timeseries',
     'context',
@@ -214,7 +222,7 @@ export default Ember.Component.extend({
   /**
    * Array of urns for split view. One per metric ref urn.
    */
-  splitUrns: Ember.computed(
+  splitUrns: computed(
     'entities',
     'displayableUrns',
     'timeseriesMode',
@@ -236,7 +244,7 @@ export default Ember.Component.extend({
   /**
    * Dictionary of chart labels for split view, keyed by metric ref urn.
    */
-  splitLabels: Ember.computed(
+  splitLabels: computed(
     'entities',
     'displayableUrns',
     'timeseriesMode',
@@ -259,7 +267,7 @@ export default Ember.Component.extend({
   /**
    * Split view indicator
    */
-  isSplit: Ember.computed(
+  isSplit: computed(
     'timeseriesMode',
     function () {
       return this.get('timeseriesMode') == TIMESERIES_MODE_SPLIT;
@@ -298,7 +306,7 @@ export default Ember.Component.extend({
   /**
    * Dictionary for the min and mix timestamps of events and timeseries for hover bounds checking
    */
-  _hoverBounds: Ember.computed(
+  _hoverBounds: computed(
     'entities',
     'timeseries',
     'displayableUrns',
@@ -318,7 +326,7 @@ export default Ember.Component.extend({
   /**
    * Dictionary of y-values for event entities. Laid out by a swimlane algorithm purely for display purposes
    */
-  _eventValues: Ember.computed(
+  _eventValues: computed(
     'entities',
     'displayableUrns',
     function () {

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-data-indicator/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-data-indicator/component.js
@@ -1,5 +1,9 @@
 import Component from '@ember/component';
-import { computed, setProperties, getProperties } from '@ember/object';
+import {
+  computed,
+  setProperties,
+  getProperties
+} from '@ember/object';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import moment from 'moment';
 import fetch from 'fetch';

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-header/component.js
@@ -1,3 +1,4 @@
+import { bool } from '@ember/object/computed';
 import Component from '@ember/component';
 import { get, getProperties, computed } from '@ember/object';
 import { dateFormatFull } from 'thirdeye-frontend/utils/rca-utils';
@@ -70,7 +71,7 @@ export default Component.extend({
    * Toggle for the comment textarea
    * @type {boolean}
    */
-  isCommentEditMode: computed.bool('sessionText'),
+  isCommentEditMode: bool('sessionText'),
 
   /**
    * whether to enable saving

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-heatmap/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-heatmap/component.js
@@ -1,6 +1,12 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import { getProperties, computed } from '@ember/object';
-import { toCurrentUrn, toBaselineUrn, appendFilters, isInverse, isAdditive } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  toCurrentUrn,
+  toBaselineUrn,
+  appendFilters,
+  isInverse,
+  isAdditive
+} from 'thirdeye-frontend/utils/rca-utils';
 import { humanizeChange } from 'thirdeye-frontend/utils/utils';
 import _ from 'lodash';
 
@@ -23,7 +29,7 @@ const ROOTCAUSE_MODE_MAPPING = {
   'Contribution to Overall Change': ROOTCAUSE_ROLLUP_MODE_CONTRIBUTION_TO_DIFF
 };
 
-export default Ember.Component.extend({
+export default Component.extend({
   //
   // external
   //
@@ -70,7 +76,7 @@ export default Ember.Component.extend({
     return modeMapping[selectedMode];
   }),
 
-  current: Ember.computed(
+  current: computed(
     'breakdowns',
     'selectedUrn',
     function () {
@@ -89,7 +95,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  baseline: Ember.computed(
+  baseline: computed(
     'breakdowns',
     'selectedUrn',
     function () {
@@ -108,7 +114,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  hasCurrent: Ember.computed(
+  hasCurrent: computed(
     'current',
     'isLoadingBreakdowns',
     function () {
@@ -117,7 +123,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  hasBaseline: Ember.computed(
+  hasBaseline: computed(
     'baseline',
     'isLoadingBreakdowns',
     function () {
@@ -126,7 +132,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  isInverse: Ember.computed(
+  isInverse: computed(
     'selectedUrn',
     'entities',
     function () {
@@ -135,7 +141,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  isAdditive: Ember.computed(
+  isAdditive: computed(
     'selectedUrn',
     'entities',
     function () {
@@ -149,7 +155,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  _dataRollup: Ember.computed(
+  _dataRollup: computed(
     'current',
     'baseline',
     'rollupRange',
@@ -195,7 +201,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  cells: Ember.computed(
+  cells: computed(
     '_dataRollup',
     'mode',
     'isInverse',

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -1,7 +1,15 @@
-import Ember from 'ember';
-import { toCurrentUrn, toBaselineUrn, filterPrefix, hasPrefix, toMetricLabel, toEventLabel } from 'thirdeye-frontend/utils/rca-utils';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import {
+  toCurrentUrn,
+  toBaselineUrn,
+  filterPrefix,
+  hasPrefix,
+  toMetricLabel,
+  toEventLabel
+} from 'thirdeye-frontend/utils/rca-utils';
 
-export default Ember.Component.extend({
+export default Component.extend({
   entities: null, // {}
 
   selectedUrns: null, // Set
@@ -14,7 +22,7 @@ export default Ember.Component.extend({
 
   classNames: ['rootcause-legend'],
 
-  validUrns: Ember.computed(
+  validUrns: computed(
     'entities',
     'selectedUrns',
     function () {
@@ -23,7 +31,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  metrics: Ember.computed(
+  metrics: computed(
     'entities',
     'validUrns',
     function () {
@@ -41,7 +49,7 @@ export default Ember.Component.extend({
    * a Mapping of event Types to a mapping of urns
    * @type {Objectgit sta}
    */
-  events: Ember.computed(
+  events: computed(
     'entities',
     'validUrns',
     function () {
@@ -59,7 +67,7 @@ export default Ember.Component.extend({
     }
   ),
 
-  colors: Ember.computed(
+  colors: computed(
     'entities',
     'validUrns',
     function () {
@@ -73,14 +81,14 @@ export default Ember.Component.extend({
     }
   ),
 
-  hasMetrics: Ember.computed(
+  hasMetrics: computed(
     'metrics',
     function () {
       return Object.keys(this.get('metrics')).length > 0;
     }
   ),
 
-  hasEvents: Ember.computed(
+  hasEvents: computed(
     'events',
     function () {
       return Object.keys(this.get('events')).length > 0;

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -1,6 +1,17 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import _ from 'lodash';
-import { toCurrentUrn, toBaselineUrn, toOffsetUrn, hasPrefix, filterPrefix, toMetricLabel, makeSortable, isInverse, toColorDirection } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  toCurrentUrn,
+  toBaselineUrn,
+  toOffsetUrn,
+  hasPrefix,
+  filterPrefix,
+  toMetricLabel,
+  makeSortable,
+  isInverse,
+  toColorDirection
+} from 'thirdeye-frontend/utils/rca-utils';
 import { humanizeChange } from 'thirdeye-frontend/utils/utils';
 
 const ROOTCAUSE_METRICS_SORT_PROPERTY_METRIC = 'metric';
@@ -11,7 +22,7 @@ const ROOTCAUSE_METRICS_SORT_PROPERTY_SCORE = 'score';
 const ROOTCAUSE_METRICS_OUTPUT_MODE_ASC = 'asc';
 const ROOTCAUSE_METRICS_OUTPUT_MODE_DESC = 'desc';
 
-export default Ember.Component.extend({
+export default Component.extend({
   //
   // external properties
   //
@@ -78,7 +89,7 @@ export default Ember.Component.extend({
    * List of metric urns, sorted by sortProperty and ordered by outputMode.
    * @type {Array}
    */
-  urns: Ember.computed(
+  urns: computed(
     'entities',
     'metrics',
     'datasets',
@@ -154,7 +165,7 @@ export default Ember.Component.extend({
    * Metric labels, keyed by urn
    * @type {Object}
    */
-  metrics: Ember.computed(
+  metrics: computed(
     'entities',
     function () {
       const { entities } = this.getProperties('entities');
@@ -170,7 +181,7 @@ export default Ember.Component.extend({
    * Dataset labels, keyed by metric urn
    * @type {Object}
    */
-  datasets: Ember.computed(
+  datasets: computed(
     'entities',
     function () {
       const { entities } = this.getProperties('entities');
@@ -186,7 +197,7 @@ export default Ember.Component.extend({
    * Change values from baseline to current time range, keyed by metric urn
    * @type {Object}
    */
-  changes: Ember.computed(
+  changes: computed(
     'entities',
     'aggregates',
     function () {
@@ -199,7 +210,7 @@ export default Ember.Component.extend({
    * Formatted change strings for 'changes'
    * @type {Object}
    */
-  changesFormatted: Ember.computed(
+  changesFormatted: computed(
     'changes',
     function () {
       const { changes } = this.getProperties('changes');
@@ -211,7 +222,7 @@ export default Ember.Component.extend({
    * Change values from multiple offsets to current time range, keyed by offset, then by metric urn
    * @type {Object}
    */
-  changesOffset: Ember.computed(
+  changesOffset: computed(
     'entities',
     'aggregates',
     function () {
@@ -229,7 +240,7 @@ export default Ember.Component.extend({
    * Formatted change strings for 'changesOffset'
    * @type {Object}
    */
-  changesOffsetFormatted: Ember.computed(
+  changesOffsetFormatted: computed(
     'changesOffset',
     function () {
       const { changesOffset } = this.getProperties('changesOffset');
@@ -245,7 +256,7 @@ export default Ember.Component.extend({
    * Trend direction label (positive, neutral, negative) for change values
    * @type {Object}
    */
-  directions: Ember.computed(
+  directions: computed(
     'entities',
     'changes',
     function () {
@@ -271,7 +282,7 @@ export default Ember.Component.extend({
    *  ]
    * }
    */
-  links: Ember.computed(
+  links: computed(
     'urns',
     function() {
       const { urns, entities } = this.getProperties('urns', 'entities');

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import moment from 'moment';
 
 /**
@@ -8,7 +9,7 @@ import moment from 'moment';
  */
 const serverDateFormat = 'YYYY-MM-DD HH:mm';
 
-export default Ember.Component.extend({
+export default Component.extend({
   range: null, // [0, 0]
 
   compareMode: null, // ""
@@ -29,25 +30,25 @@ export default Ember.Component.extend({
     'Wo4W'
   ],
 
-  maxDateFormatted: Ember.computed({
+  maxDateFormatted: computed({
     get() {
       return moment().startOf('hour').add(1, 'hours').format(serverDateFormat);
     }
   }),
 
-  startFormatted: Ember.computed('range', {
+  startFormatted: computed('range', {
     get() {
       return moment(this.get('range')[0]).format(serverDateFormat);
     }
   }),
 
-  endFormatted: Ember.computed('range', {
+  endFormatted: computed('range', {
     get() {
       return moment(this.get('range')[1]).format(serverDateFormat);
     }
   }),
 
-  compareModeFormatted: Ember.computed('compareMode', {
+  compareModeFormatted: computed('compareMode', {
     get() {
       return this.get('compareMode');
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/component.js
@@ -1,10 +1,20 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import fetch from 'fetch';
-import { filterPrefix, toFilters, stripTail, toFilterMap, appendFilters, fromFilterMap, toBaselineUrn, toCurrentUrn } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  filterPrefix,
+  toFilters,
+  stripTail,
+  toFilterMap,
+  appendFilters,
+  fromFilterMap,
+  toBaselineUrn,
+  toCurrentUrn
+} from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import _ from 'lodash';
 
-export default Ember.Component.extend({
+export default Component.extend({
   selectedUrn: null,
 
   onSelection: null,
@@ -45,7 +55,7 @@ export default Ember.Component.extend({
     this.setProperties({ baseUrn, filterMap });
   },
 
-  filters: Ember.computed('filterMap', {
+  filters: computed('filterMap', {
     get() {
       const { filterMap } = this.getProperties('filterMap');
       return JSON.stringify(filterMap);

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
+import Component from '@ember/component';
 import fetch from 'fetch';
 import { toBaselineUrn, toCurrentUrn } from 'thirdeye-frontend/utils/rca-utils';
 import { task, timeout } from 'ember-concurrency';
 import _ from 'lodash';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['rootcause-select-metric-dimension'],
 
   selectedUrn: null, // ""

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-table/component.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 import _ from 'lodash';
 import moment from 'moment';
 import { toEventLabel } from 'thirdeye-frontend/utils/rca-utils';
 
-export default Ember.Component.extend({
+export default Component.extend({
   columns: null, // []
 
   entities: null, // {}
@@ -17,7 +18,7 @@ export default Ember.Component.extend({
    * Sets the 'isSelected' property to respond to table selection
    * @type {Object} - object with keys as urns and values as entities
    */
-  records: Ember.computed(
+  records: computed(
     'entities',
     'selectedUrns',
     function () {
@@ -34,7 +35,7 @@ export default Ember.Component.extend({
    * Add human readable date properties to the list of values
    * @type {Array[Objects]} - array of entities
    */
-  data: Ember.computed(
+  data: computed(
     'records',
     function () {
       let values = Object.values(this.get('records'));
@@ -61,7 +62,7 @@ export default Ember.Component.extend({
    * Keeps track of items that are selected in the table
    * @type {Array}
    */
-  preselectedItems: Ember.computed(
+  preselectedItems: computed(
     'records',
     'selectedUrns',
     function () {

--- a/thirdeye/thirdeye-frontend/app/pods/components/te-navbar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/te-navbar/component.js
@@ -3,10 +3,10 @@
  * @module  components/te-navbar
  * @exports anomaly-navbar
  */
-import Ember from 'ember';
+import Component from '@ember/component';
 import config from '../../../config/environment';
 
-export default Ember.Component.extend({
+export default Component.extend({
 
   /**
    * Component's tag name

--- a/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { debounce } from '@ember/runloop';
+import Component from '@ember/component';
 import c3 from 'c3';
 import d3 from 'd3';
 import _ from 'lodash';
 import moment from 'moment';
 
-export default Ember.Component.extend({
+export default Component.extend({
   tagName: 'div',
   classNames: ['timeseries-chart'],
 
@@ -203,7 +204,7 @@ export default Ember.Component.extend({
     this._updateFocusedEntity();
 
     if (!_.isEqual(series, cache)) {
-      Ember.run.debounce(this, this._updateChart, 300);
+      debounce(this, this._updateChart, 300);
     }
   },
 

--- a/thirdeye/thirdeye-frontend/app/pods/example/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/example/controller.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   splitView: false,
   actions: {
     onToggleSplitView() {

--- a/thirdeye/thirdeye-frontend/app/pods/example/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/example/route.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 // import fetch from 'fetch';
 import { Actions as AnomalyActions } from 'thirdeye-frontend/actions/anomaly';
 
-export default Ember.Route.extend({
-  redux: Ember.inject.service(),
+export default Route.extend({
+  redux: service(),
 
   model(params) {
     const { id } = params;

--- a/thirdeye/thirdeye-frontend/app/pods/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/index/route.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/thirdeye/thirdeye-frontend/app/pods/login/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/login/controller.js
@@ -1,8 +1,9 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   errorMessage: null,
-  session: Ember.inject.service(),
+  session: service(),
   queryParams: ['fromUrl'],
   fromUrl: null,
 

--- a/thirdeye/thirdeye-frontend/app/pods/logout/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/logout/route.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 /**
@@ -6,8 +7,8 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
  * This is necessary because we need to have access to this from
  * the old (non-Ember) UI
  */
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  session: Ember.inject.service(),
+export default Route.extend(AuthenticatedRouteMixin, {
+  session: service(),
 
   routeIfAlreadyAuthenticated: 'rca',
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/controller.js
@@ -3,6 +3,8 @@
  * @module manage/alert/edit
  * @exports manage/alert/edit
  */
+import { reads, or } from '@ember/object/computed';
+
 import _ from 'lodash';
 import RSVP from 'rsvp';
 import fetch from 'fetch';
@@ -59,7 +61,7 @@ export default Controller.extend({
    * The config group that the current alert belongs to
    * @type {Object}
    */
-  originalConfigGroup: computed.reads('model.originalConfigGroup'),
+  originalConfigGroup: reads('model.originalConfigGroup'),
 
   /**
    * Returns the list of existing config groups and updates it if a new one is added.
@@ -200,7 +202,7 @@ export default Controller.extend({
    * @method isSubmitDisabled
    * @return {Boolean} show/hide submit
    */
-  isSubmitDisabled: computed.or('{isEmptyEmail,isEmailError,isDuplicateEmail,isProcessingForm}'),
+  isSubmitDisabled: or('{isEmptyEmail,isEmailError,isDuplicateEmail,isProcessingForm}'),
 
   /**
    * Fetches an alert function record by name.

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -4,16 +4,29 @@
  * @exports manage/alert/explore
  */
 import _ from 'lodash';
-import Ember from 'ember';
 import fetch from 'fetch';
 import moment from 'moment';
 import { later } from "@ember/runloop";
 import { isPresent } from "@ember/utils";
 import Controller from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
-import { computed, set, get, setProperties } from '@ember/object';
-import { checkStatus, postProps, buildDateEod } from 'thirdeye-frontend/utils/utils';
-import { buildAnomalyStats, extractSeverity, setDuration } from 'thirdeye-frontend/utils/manage-alert-utils';
+import {
+  computed,
+  set,
+  get,
+  setProperties,
+  getWithDefault
+} from '@ember/object';
+import {
+  checkStatus,
+  postProps,
+  buildDateEod
+} from 'thirdeye-frontend/utils/utils';
+import {
+  buildAnomalyStats,
+  extractSeverity,
+  setDuration
+} from 'thirdeye-frontend/utils/manage-alert-utils';
 
 export default Controller.extend({
   /**
@@ -219,7 +232,7 @@ export default Controller.extend({
         alertEvalMetrics,
         defaultSeverity
       } = this.getProperties('alertData', 'alertEvalMetrics', 'defaultSeverity');
-      const features = Ember.getWithDefault(alertData, 'alertFilter.features', null);
+      const features = getWithDefault(alertData, 'alertFilter.features', null);
       const severityUnit = features && features.split(',')[1] !== 'deviation' ? '%' : '';
       const mttdWeight = Number(extractSeverity(alertData, defaultSeverity)) * 100;
       const statsCards = [

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -11,7 +11,15 @@ import { later } from "@ember/runloop";
 import { set, get, setProperties } from '@ember/object';
 import { isPresent } from "@ember/utils";
 import { checkStatus, buildDateEod, toIso } from 'thirdeye-frontend/utils/utils';
-import { enhanceAnomalies, toIdGroups, setUpTimeRangeOptions, getTopDimensions, buildMetricDataUrl, extractSeverity, getDuration } from 'thirdeye-frontend/utils/manage-alert-utils';
+import {
+  enhanceAnomalies,
+  toIdGroups,
+  setUpTimeRangeOptions,
+  getTopDimensions,
+  buildMetricDataUrl,
+  extractSeverity,
+  getDuration
+} from 'thirdeye-frontend/utils/manage-alert-utils';
 
 /**
  * Shorthand for setting date defaults

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -10,8 +10,19 @@ import moment from 'moment';
 import Route from '@ember/routing/route';
 import { isPresent } from "@ember/utils";
 import { later } from "@ember/runloop";
-import { checkStatus, postProps, buildDateEod, toIso } from 'thirdeye-frontend/utils/utils';
-import { enhanceAnomalies, setUpTimeRangeOptions, toIdGroups, extractSeverity, getDuration } from 'thirdeye-frontend/utils/manage-alert-utils';
+import {
+  checkStatus,
+  postProps,
+  buildDateEod,
+  toIso
+} from 'thirdeye-frontend/utils/utils';
+import {
+  enhanceAnomalies,
+  setUpTimeRangeOptions,
+  toIdGroups,
+  extractSeverity,
+  getDuration
+} from 'thirdeye-frontend/utils/manage-alert-utils';
 
 /**
  * Basic alert page defaults

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/edit/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/edit/route.js
@@ -1,11 +1,15 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import moment from 'moment';
 import fetch from 'fetch';
 import RSVP from 'rsvp';
 import _ from 'lodash';
-import { checkStatus, buildDateEod, parseProps } from 'thirdeye-frontend/utils/utils';
+import {
+  checkStatus,
+  buildDateEod,
+  parseProps
+} from 'thirdeye-frontend/utils/utils';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model(params) {
     const { alertId: id } = params;
     if (!id) { return; }

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -3,13 +3,15 @@
  * @module manage/alerts/controller
  * @exports alerts controller
  */
-import Ember from 'ember';
+import { computed, set } from '@ember/object';
+
+import Controller from '@ember/controller';
 import fetch from 'fetch';
 import _ from 'lodash';
 import { task, timeout } from 'ember-concurrency';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: ['selectedSearchMode', 'alertId', 'testMode'],
   /**
    * Alerts Search Mode options
@@ -56,7 +58,7 @@ export default Ember.Controller.extend({
   pageSize: 10,
 
   // Number of pages to display
-  paginationSize: Ember.computed(
+  paginationSize: computed(
     'pagesNum',
     'pageSize',
     function() {
@@ -68,7 +70,7 @@ export default Ember.Controller.extend({
   ),
 
   // Total Number of pages to display
-  pagesNum: Ember.computed(
+  pagesNum: computed(
     'selectedAlerts.length',
     'pageSize',
     function() {
@@ -79,7 +81,7 @@ export default Ember.Controller.extend({
   ),
 
   // Groups array for search filter 'search by Subscriber Groups'
-  subscriberGroupNames: Ember.computed('model.subscriberGroups', function() {
+  subscriberGroupNames: computed('model.subscriberGroups', function() {
     const groupNames = this.get('model.subscriberGroups');
 
     return groupNames
@@ -90,7 +92,7 @@ export default Ember.Controller.extend({
   }),
 
   // App names array for search filter 'search by Application'
-  applicationNames: Ember.computed('model.applications', function() {
+  applicationNames: computed('model.applications', function() {
     const appNames = this.get('model.applications');
 
     return appNames
@@ -99,7 +101,7 @@ export default Ember.Controller.extend({
   }),
 
   // creates the page Array for view
-  viewPages: Ember.computed(
+  viewPages: computed(
     'pages',
     'currentPage',
     'paginationSize',
@@ -121,7 +123,7 @@ export default Ember.Controller.extend({
   ),
 
   // alerts with pagination
-  paginatedSelectedAlerts: Ember.computed(
+  paginatedSelectedAlerts: computed(
     'selectedAlerts.@each',
     'pageSize',
     'currentPage',
@@ -163,8 +165,8 @@ export default Ember.Controller.extend({
             return alert.id === id;
           });
           if (foundAlert) {
-            Ember.set(foundAlert, 'application', config.application);
-            Ember.set(foundAlert, 'group', config.name);
+            set(foundAlert, 'application', config.application);
+            set(foundAlert, 'group', config.name);
           }
         }
       }

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
+import { hash } from 'rsvp';
+import Route from '@ember/routing/route';
 import fetch from 'fetch';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
-    return Ember.RSVP.hash({
+    return hash({
       alerts: fetch('/thirdeye/entity/ANOMALY_FUNCTION').then(res => res.json()),
       subscriberGroups: fetch('/thirdeye/entity/ALERT_CONFIG').then(res => res.json()),
       applications: fetch('/thirdeye/entity/APPLICATION').then(res => res.json())

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
@@ -1,11 +1,5 @@
-/**
- * Controller for Alert Details Page: Tune Sensitivity Tab
- * @module manage/alert/tune
- * @exports manage/alert/tune
- */
-import Ember from 'ember';
 import _ from 'lodash';
-import { computed } from '@ember/object';
+import { computed, set } from '@ember/object';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
@@ -71,7 +65,7 @@ export default Controller.extend({
       let direction = '';
       this.toggleProperty(propName);
       direction  = this.get(propName) ? 'up' : 'down';
-      Ember.set(sortMenu, sortKey, direction);
+      set(sortMenu, sortKey, direction);
       this.set('selectedSortMode', `${sortKey}:${direction}`);
     }
   }

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -3,9 +3,12 @@
  * @module self-serve/create/route
  * @exports alert create model
  */
-import Ember from 'ember';
+import { getWithDefault } from '@ember/object';
+
+import { isPresent } from '@ember/utils';
+import Route from '@ember/routing/route';
 import fetch from 'fetch';
-import RSVP from 'rsvp';
+import RSVP, { hash, allSettled } from 'rsvp';
 import { checkStatus, buildDateEod } from 'thirdeye-frontend/utils/utils';
 
 /**
@@ -45,10 +48,10 @@ const fetchAppAnomalies = (alertList) => {
       name,
       data: fetch(`/detection-job/eval/filter/${alert.id}?${tuneParams}`).then(checkStatus)
     };
-    alertPromises.push(Ember.RSVP.hash(getAlertPerfHash));
+    alertPromises.push(hash(getAlertPerfHash));
   });
 
-  return Ember.RSVP.allSettled(alertPromises);
+  return allSettled(alertPromises);
 };
 
 /**
@@ -131,7 +134,7 @@ const calculateRate = (anomalies, subset) => {
   return Number(percentage.toFixed());
 };
 
-export default Ember.Route.extend({
+export default Route.extend({
 
   actions: {
     /**
@@ -161,7 +164,7 @@ export default Ember.Route.extend({
     this._super(model);
 
     const activeGroups = model.configGroups.filterBy('active');
-    const groupsWithAppName = activeGroups.filter(group => Ember.isPresent(group.application));
+    const groupsWithAppName = activeGroups.filter(group => isPresent(group.application));
     const groupsWithAlertId = groupsWithAppName.filter(group => group.emailConfig.functionIds.length > 0);
     const idsByApplication = fillAppBuckets(model.applications, groupsWithAlertId);
     Object.assign(model, { idsByApplication });
@@ -198,7 +201,7 @@ export default Ember.Route.extend({
 
           // Get array of keys from first record
           let metricKeys = Object.keys(groupData[0].data);
-          let getTotalValue = (key) => Ember.getWithDefault(avgData, key, 0);
+          let getTotalValue = (key) => getWithDefault(avgData, key, 0);
           count++;
 
           // Look at each anomaly's perf object keys. For our "roundable" fields, get derived data

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/route.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/controller.js
@@ -1,8 +1,10 @@
-import Ember from 'ember';
+import { computed } from '@ember/object';
+import { oneWay } from '@ember/object/computed';
+import Controller from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
 
-export default Ember.Controller.extend({
-  primaryMetric: Ember.computed.oneWay('model'),
+export default Controller.extend({
+  primaryMetric: oneWay('model'),
   mostRecentSearch: null,
 
   /**
@@ -29,7 +31,7 @@ export default Ember.Controller.extend({
       .then(res => res.json());
   }),
 
-  placeholder: Ember.computed(function() {
+  placeholder: computed(function() {
     'Search for a Metric';
   }),
 

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/controller.js
@@ -1,9 +1,12 @@
-import Ember from 'ember';
+import { once, debounce } from '@ember/runloop';
+import { computed } from '@ember/object';
+import { reads } from '@ember/object/computed';
+import Controller from '@ember/controller';
 import moment from 'moment';
 
 const serverDateFormat = 'YYYY-MM-DD HH:mm';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: [
     'granularity',
     'filters',
@@ -15,13 +18,13 @@ export default Ember.Controller.extend({
     'analysisStart',
     'analysisEnd'
   ],
-  granularities: Ember.computed.reads('model.granularities'),
+  granularities: reads('model.granularities'),
   noMatchesMessage: '',
   filters: null,
   compareMode: null,
   compareModeOptions: ['WoW', 'Wo2W', 'Wo3W', 'Wo4W'],
   mostRecentTask: null,
-  metricFilters: Ember.computed.reads('model.metricFilters'),
+  metricFilters: reads('model.metricFilters'),
   subchartStart: 0,
   subchartEnd: 0,
   predefinedRanges: {},
@@ -31,7 +34,7 @@ export default Ember.Controller.extend({
    * Upper bound (end) for date range
    * @type {String}
    */
-  maxTime: Ember.computed(
+  maxTime: computed(
     'model.maxTime',
     'granularity',
     function() {
@@ -50,7 +53,7 @@ export default Ember.Controller.extend({
    * Indicates the date format to be used based on granularity
    * @type {String}
    */
-  uiDateFormat: Ember.computed('granularity', function() {
+  uiDateFormat: computed('granularity', function() {
     const granularity = this.get('granularity');
 
     switch(granularity) {
@@ -67,7 +70,7 @@ export default Ember.Controller.extend({
    * Indicates the allowed date range picker increment based on granularity
    * @type {Number}
    */
-  timePickerIncrement: Ember.computed('granularity', function() {
+  timePickerIncrement: computed('granularity', function() {
     const granularity = this.get('granularity');
 
     switch(granularity) {
@@ -84,14 +87,14 @@ export default Ember.Controller.extend({
    * Determines if the date range picker should show time selection
    * @type {Boolean}
    */
-  showTimePicker: Ember.computed('granularity', function() {
+  showTimePicker: computed('granularity', function() {
     const granularity = this.get('granularity');
 
     return granularity !== 'DAYS';
   }),
 
   // converts analysisStart from unix ms to serverDateFormat
-  anomalyRegionStart: Ember.computed('analysisStart', {
+  anomalyRegionStart: computed('analysisStart', {
     get() {
       const start = this.get('analysisStart');
 
@@ -110,7 +113,7 @@ export default Ember.Controller.extend({
   }),
 
   // converts analysisEnd from unix ms to serverDateFormat
-  anomalyRegionEnd: Ember.computed('analysisEnd', {
+  anomalyRegionEnd: computed('analysisEnd', {
     get() {
       const end = this.get('analysisEnd');
 
@@ -127,7 +130,7 @@ export default Ember.Controller.extend({
   }),
 
   // converts startDate from unix ms to serverDateFormat
-  viewRegionStart: Ember.computed(
+  viewRegionStart: computed(
     'startDate',
     {
       get() {
@@ -148,7 +151,7 @@ export default Ember.Controller.extend({
         }
 
         this.set('startDate', start);
-        Ember.run.once(this, this.get('actions.resetAnalysisDates'));
+        once(this, this.get('actions.resetAnalysisDates'));
 
         return moment(value).format(serverDateFormat);
       }
@@ -156,7 +159,7 @@ export default Ember.Controller.extend({
   ),
 
   // converts endDate from unix ms to serverDateFormat
-  viewRegionEnd: Ember.computed(
+  viewRegionEnd: computed(
     'endDate',
     {
       get() {
@@ -175,7 +178,7 @@ export default Ember.Controller.extend({
           this.set('shouldReset', true);
         }
         this.set('endDate', newEnd);
-        Ember.run.once(this, this.get('actions.resetAnalysisDates'));
+        once(this, this.get('actions.resetAnalysisDates'));
 
         return moment(value).format(serverDateFormat);
       }
@@ -183,14 +186,14 @@ export default Ember.Controller.extend({
   ),
 
   // min date for the anomaly region
-  minDate: Ember.computed('startDate', function() {
+  minDate: computed('startDate', function() {
     const start = this.get('startDate');
 
     return moment(+start).format(serverDateFormat);
   }),
 
   // max date for the anomaly region
-  maxDate: Ember.computed(
+  maxDate: computed(
     'endDate',
     'granularity',
     function() {
@@ -209,7 +212,7 @@ export default Ember.Controller.extend({
     }
   ),
 
-  uiGranularity: Ember.computed(
+  uiGranularity: computed(
     'granularity',
     'model.maxTime',
     'startDate', {
@@ -301,7 +304,7 @@ export default Ember.Controller.extend({
      * Handles subchart date change (debounced)
      */
     setDateParams([start, end]) {
-      Ember.run.debounce(this, this.get('actions.setNewDate'), { start, end }, 2000);
+      debounce(this, this.get('actions.setNewDate'), { start, end }, 2000);
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/controller.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
+import { debounce, later } from '@ember/runloop';
+import Controller from '@ember/controller';
 import moment from 'moment';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: ['dimension'],
   dimension: 'All',
 
@@ -50,7 +51,7 @@ export default Ember.Controller.extend({
      */
     setDateParams([start, end]) {
       this.set('tableIsLoading', true);
-      Ember.run.debounce(this, this.get('actions.setNewDate'), { start, end }, 500);
+      debounce(this, this.get('actions.setNewDate'), { start, end }, 500);
     },
 
     /**
@@ -60,7 +61,7 @@ export default Ember.Controller.extend({
     onTabChange(tab) {
       const currentTab = this.get('selectedTab');
       if (currentTab !== tab) {
-        Ember.run.later(() => {
+        later(() => {
           this.setProperties({
             selectedTab: tab
           });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/heatmap/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/heatmap/controller.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   // default heatmap Mode
   heatmapMode: 'Change in Contribution',
   dateFormat: 'MMM D, YYYY hh:mm a',

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/heatmap/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/heatmap/route.js
@@ -1,8 +1,10 @@
-import Ember from 'ember';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import { Actions } from 'thirdeye-frontend/actions/dimensions';
 
-export default Ember.Route.extend({
-  redux: Ember.inject.service(),
+export default Route.extend({
+  redux: service(),
   model(params, transition) {
     const redux = this.get('redux');
     const { metricId } = transition.params['rca.details'];
@@ -39,7 +41,7 @@ export default Ember.Route.extend({
         start = start || oldParams.analysisStart;
         end = end || oldParams.analysisEnd;
 
-        Ember.run.later(() => {
+        later(() => {
           redux.dispatch(Actions.fetchHeatMapData(
             Number(start),
             Number(end)

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/dimensions/route.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
+import { later } from '@ember/runloop';
+import Route from '@ember/routing/route';
 
 import { Actions } from 'thirdeye-frontend/actions/dimensions';
 import { inject as service } from '@ember/service';
 
-export default Ember.Route.extend({
+export default Route.extend({
   redux: service(),
 
   // queryParam unique to the dimension route
@@ -41,7 +42,7 @@ export default Ember.Route.extend({
       Number(end)
     ));
 
-    Ember.run.later(() => {
+    later(() => {
       redux.dispatch(Actions.updateDimension(dimension)).then(() => {
         redux.dispatch(Actions.fetchDimensions(metricId));
       });
@@ -89,7 +90,7 @@ export default Ember.Route.extend({
           start = start || oldParams.analysisStart;
           end = end || oldParams.analysisEnd;
 
-          Ember.run.later(() => {
+          later(() => {
             redux.dispatch(Actions.updateDates(
               Number(start),
               Number(end)
@@ -115,7 +116,7 @@ export default Ember.Route.extend({
           shouldReload = true;
         }
         if (shouldReload) {
-          Ember.run.later(() => {
+          later(() => {
             redux.dispatch(Actions.loaded());
           });
           shouldReload = false;

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/events/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/events/controller.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
+import { debounce } from '@ember/runloop';
+import Controller from '@ember/controller';
 import moment from 'moment';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   eventStart: 0,
   eventEnd: 0,
   displayStart: 0,
@@ -25,7 +26,7 @@ export default Ember.Controller.extend({
      * Handles subchart date change (debounced)
      */
     setDateParams([start, end]) {
-      Ember.run.debounce(this, this.get('actions.setNewDate'), { start, end }, 500);
+      debounce(this, this.get('actions.setNewDate'), { start, end }, 500);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/events/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/events/route.js
@@ -1,8 +1,10 @@
-import Ember from 'ember';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import { Actions } from 'thirdeye-frontend/actions/events';
 
-export default Ember.Route.extend({
-  redux: Ember.inject.service(),
+export default Route.extend({
+  redux: service(),
 
   /**
    * Massages Query Params from URL and dispatch redux actions
@@ -63,7 +65,7 @@ export default Ember.Route.extend({
           start = start || oldParams.analysisStart;
           end = end || oldParams.analysisEnd;
 
-          Ember.run.later(() => {
+          later(() => {
             redux.dispatch(Actions.updateDates(
               Number(start),
               Number(end)
@@ -85,7 +87,7 @@ export default Ember.Route.extend({
           });
         }
 
-        Ember.run.later(() => {
+        later(() => {
           redux.dispatch(Actions.loaded());
         });
       }

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/controller.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
+import { later } from '@ember/runloop';
+import Controller, { inject as controller } from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
 import moment from 'moment';
 
-export default Ember.Controller.extend({
-  detailsController: Ember.inject.controller('rca/details'),
+export default Controller.extend({
+  detailsController: controller('rca/details'),
   splitView: false,
   selectedTab: 'change',
 
@@ -27,7 +28,7 @@ export default Ember.Controller.extend({
     let startDate = moment(start).valueOf();
     let endDate = moment(end).valueOf();
 
-    Ember.run.later(() => {
+    later(() => {
       this.setProperties({
         analysisStart: startDate,
         analysisEnd: endDate
@@ -62,7 +63,7 @@ export default Ember.Controller.extend({
       if (currentTab !== tab) {
         this.set('loading', true);
 
-        Ember.run.later(() => {
+        later(() => {
           this.setProperties({
             selectedTab: tab
           });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/route.js
@@ -1,9 +1,11 @@
-import Ember from 'ember';
+import { later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import moment from 'moment';
 import { Actions } from 'thirdeye-frontend/actions/metrics';
 
-export default Ember.Route.extend({
-  redux: Ember.inject.service(),
+export default Route.extend({
+  redux: service(),
 
   model(params, transition) {
     const { metricId } = transition.params['rca.details'];
@@ -87,7 +89,7 @@ export default Ember.Route.extend({
           start = start || oldParams.analysisStart;
           end = end || oldParams.analysisEnd;
 
-          Ember.run.later(() => {
+          later(() => {
             redux.dispatch(Actions.updateDates(
               Number(start),
               Number(end)
@@ -111,7 +113,7 @@ export default Ember.Route.extend({
           controller.set('analysisEnd', Number(end));
         }
 
-        Ember.run.later(() => {
+        later(() => {
           redux.dispatch(Actions.loaded());
         });
       }

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/route.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import moment from 'moment';
 import fetch from 'fetch';
@@ -18,7 +19,7 @@ const replaceConfig = {
   replace: true
 };
 
-export default Ember.Route.extend({
+export default Route.extend({
   // queryParams for rca
   queryParams: {
     startDate: queryParamsConfig,
@@ -32,7 +33,7 @@ export default Ember.Route.extend({
     displayEnd: replaceConfig
   },
 
-  redux: Ember.inject.service(),
+  redux: service(),
 
   // resets all redux stores' state
   beforeModel(transition) {

--- a/thirdeye/thirdeye-frontend/app/pods/rca/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/route.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import fetch from 'fetch';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
+export default Route.extend(AuthenticatedRouteMixin, {
 
   model(params, transition) {
     const {

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -1,10 +1,14 @@
-import Ember from 'ember';
-import { toAbsoluteRange, toFilters, toFilterMap } from 'thirdeye-frontend/utils/rca-utils';
+import Service from '@ember/service';
+import {
+  toAbsoluteRange,
+  toFilters,
+  toFilterMap
+} from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
-export default Ember.Service.extend({
+export default Service.extend({
   aggregates: null, // {}
 
   context: null, // {}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-breakdowns-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-breakdowns-cache/service.js
@@ -1,10 +1,14 @@
-import Ember from 'ember';
-import { toAbsoluteRange, toFilters, toFilterMap } from 'thirdeye-frontend/utils/rca-utils';
+import Service from '@ember/service';
+import {
+  toAbsoluteRange,
+  toFilters,
+  toFilterMap
+} from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
-export default Ember.Service.extend({
+export default Service.extend({
   breakdowns: null, // {}
 
   context: null, // {}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -1,10 +1,16 @@
-import Ember from 'ember';
-import { filterObject, filterPrefix, toBaselineRange, toColor, trimTimeRanges } from 'thirdeye-frontend/utils/rca-utils';
+import Service from '@ember/service';
+import {
+  filterObject,
+  filterPrefix,
+  toBaselineRange,
+  toColor,
+  trimTimeRanges
+} from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
-export default Ember.Service.extend({
+export default Service.extend({
   entities: null, // {}
 
   context: null, // {}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-scores-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-scores-cache/service.js
@@ -1,10 +1,14 @@
-import Ember from 'ember';
-import { trimTimeRanges, filterPrefix, toBaselineRange } from 'thirdeye-frontend/utils/rca-utils';
+import Service from '@ember/service';
+import {
+  trimTimeRanges,
+  filterPrefix,
+  toBaselineRange
+} from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
-export default Ember.Service.extend({
+export default Service.extend({
   scores: null, // {}
 
   context: null, // {}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
@@ -1,10 +1,14 @@
-import Ember from 'ember';
-import { toAbsoluteRange, toFilters, toFilterMap } from 'thirdeye-frontend/utils/rca-utils';
+import Service from '@ember/service';
+import {
+  toAbsoluteRange,
+  toFilters,
+  toFilterMap
+} from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
 import _ from 'lodash';
 
-export default Ember.Service.extend({
+export default Service.extend({
   timeseries: null, // {}
 
   context: null, // {}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -310,7 +310,7 @@ export default Controller.extend({
    * Setup observer for context and default selection
    * May run multiple times while entities are loading.
    */
-  _setupObserver: Ember.observer(
+  _setupObserver: observer(
     'context',
     'entities',
     'scores',

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -1,5 +1,18 @@
-import Ember from 'ember';
-import { filterObject, filterPrefix, toBaselineUrn, toCurrentUrn, toOffsetUrn, toFilters, appendFilters, dateFormatFull } from 'thirdeye-frontend/utils/rca-utils';
+import { observer, computed } from '@ember/object';
+import { later, debounce } from '@ember/runloop';
+import { reads, gt, or } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+import {
+  filterObject,
+  filterPrefix,
+  toBaselineUrn,
+  toCurrentUrn,
+  toOffsetUrn,
+  toFilters,
+  appendFilters,
+  dateFormatFull
+} from 'thirdeye-frontend/utils/rca-utils';
 import EVENT_TABLE_COLUMNS from 'thirdeye-frontend/mocks/eventTableColumns';
 import filterBarConfig from 'thirdeye-frontend/mocks/filterBarConfig';
 import fetch from 'fetch';
@@ -30,7 +43,7 @@ const ROOTCAUSE_SESSION_PERMISSIONS_READ_WRITE = 'READ_WRITE';
 
 // TODO: Update module import to comply by new Ember standards
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   queryParams: [
     'metricId',
     'anomalyId',
@@ -56,29 +69,24 @@ export default Ember.Controller.extend({
   //
   // services
   //
-  authService: Ember.inject.service('session'),
+  authService: service('session'),
 
-  entitiesService: Ember.inject.service('rootcause-entities-cache'),
+  entitiesService: service('rootcause-entities-cache'),
 
-  timeseriesService: Ember.inject.service('rootcause-timeseries-cache'),
+  timeseriesService: service('rootcause-timeseries-cache'),
 
-  aggregatesService: Ember.inject.service('rootcause-aggregates-cache'),
+  aggregatesService: service('rootcause-aggregates-cache'),
 
-  breakdownsService: Ember.inject.service('rootcause-breakdowns-cache'),
+  breakdownsService: service('rootcause-breakdowns-cache'),
 
-  scoresService: Ember.inject.service('rootcause-scores-cache'),
+  scoresService: service('rootcause-scores-cache'),
 
-  sessionService: Ember.inject.service('rootcause-session-datasource'),
+  sessionService: service('rootcause-session-datasource'),
 
   //
   // user details
   //
-
-  /**
-   * Active user name
-   * @type {string}
-   */
-  username: Ember.computed.reads('authService.data.authenticated.name'),
+  username: reads('authService.data.authenticated.name'),
 
   //
   // user selection
@@ -212,7 +220,7 @@ export default Ember.Controller.extend({
 
     // This is a flag for the acceptance test for rootcause to prevent it from timing out because of this run loop
     if (config.environment !== 'test') {
-      Ember.run.later(this, this._onCheckSessionTimer, ROOTCAUSE_SESSION_TIMER_INTERVAL);
+      later(this, this._onCheckSessionTimer, ROOTCAUSE_SESSION_TIMER_INTERVAL);
     }
   },
 
@@ -238,7 +246,7 @@ export default Ember.Controller.extend({
    * scores:       entity scores as computed by backend pipelines (e.g. metric anomality score)
    *               (typically displayed in metrics table)
    */
-  _contextObserver: Ember.observer(
+  _contextObserver: observer(
     'context',
     'entities',
     'selectedUrns',
@@ -337,32 +345,32 @@ export default Ember.Controller.extend({
   /**
    * Subscribed entities cache
    */
-  entities: Ember.computed.reads('entitiesService.entities'),
+  entities: reads('entitiesService.entities'),
 
   /**
    * Subscribed timeseries cache
    */
-  timeseries: Ember.computed.reads('timeseriesService.timeseries'),
+  timeseries: reads('timeseriesService.timeseries'),
 
   /**
    * Subscribed aggregates cache
    */
-  aggregates: Ember.computed.reads('aggregatesService.aggregates'),
+  aggregates: reads('aggregatesService.aggregates'),
 
   /**
    * Subscribed breakdowns cache
    */
-  breakdowns: Ember.computed.reads('breakdownsService.breakdowns'),
+  breakdowns: reads('breakdownsService.breakdowns'),
 
   /**
    * Subscribed scores cache
    */
-  scores: Ember.computed.reads('scoresService.scores'),
+  scores: reads('scoresService.scores'),
 
   /**
    * Primary metric urn for rootcause search
    */
-  metricUrn: Ember.computed(
+  metricUrn: computed(
     'context',
     function () {
       const { context } = this.getProperties('context');
@@ -377,7 +385,7 @@ export default Ember.Controller.extend({
   /**
    * Visible series and events in timeseries chart
    */
-  chartSelectedUrns: Ember.computed(
+  chartSelectedUrns: computed(
     'entities',
     'selectedUrns',
     'invisibleUrns',
@@ -395,7 +403,7 @@ export default Ember.Controller.extend({
   /**
    * (Event) entities for event table as filtered by the side bar
    */
-  eventTableEntities: Ember.computed(
+  eventTableEntities: computed(
     'entities',
     'filteredUrns',
     function () {
@@ -412,7 +420,7 @@ export default Ember.Controller.extend({
   /**
    * (Event) entities for filtering in the side bar
    */
-  eventFilterEntities: Ember.computed(
+  eventFilterEntities: computed(
     'entities',
     function () {
       const { entities } = this.getProperties('entities');
@@ -423,7 +431,7 @@ export default Ember.Controller.extend({
   /**
    * Visible entities for tooltip
    */
-  tooltipEntities: Ember.computed(
+  tooltipEntities: computed(
     'entities',
     'invisibleUrns',
     'hoverUrns',
@@ -437,34 +445,34 @@ export default Ember.Controller.extend({
   //
   // loading indicators
   //
-  isLoadingEntities: Ember.computed.gt('entitiesService.pending.size', 0),
+  isLoadingEntities: gt('entitiesService.pending.size', 0),
 
-  isLoadingTimeseries: Ember.computed.gt('timeseriesService.pending.size', 0),
+  isLoadingTimeseries: gt('timeseriesService.pending.size', 0),
 
-  isLoadingAggregates: Ember.computed.gt('aggregatesService.pending.size', 0),
+  isLoadingAggregates: gt('aggregatesService.pending.size', 0),
 
-  isLoadingBreakdowns: Ember.computed.gt('breakdownsService.pending.size', 0),
+  isLoadingBreakdowns: gt('breakdownsService.pending.size', 0),
 
-  isLoadingScores: Ember.computed.gt('scoresService.pending.size', 0),
+  isLoadingScores: gt('scoresService.pending.size', 0),
 
-  loadingFrameworks: Ember.computed.reads('entitiesService.pending'),
+  loadingFrameworks: reads('entitiesService.pending'),
 
   //
   // error indicators
   //
-  hasErrorsRoute: Ember.computed.gt('routeErrors.size', 0),
+  hasErrorsRoute: gt('routeErrors.size', 0),
 
-  hasErrorsEntities: Ember.computed.gt('entitiesService.errors.size', 0),
+  hasErrorsEntities: gt('entitiesService.errors.size', 0),
 
-  hasErrorsTimeseries: Ember.computed.gt('timeseriesService.errors.size', 0),
+  hasErrorsTimeseries: gt('timeseriesService.errors.size', 0),
 
-  hasErrorsAggregates: Ember.computed.gt('aggregatesService.errors.size', 0),
+  hasErrorsAggregates: gt('aggregatesService.errors.size', 0),
 
-  hasErrorsBreakdowns: Ember.computed.gt('breakdownsService.errors.size', 0),
+  hasErrorsBreakdowns: gt('breakdownsService.errors.size', 0),
 
-  hasErrorsScores: Ember.computed.gt('scoresService.errors.size', 0),
+  hasErrorsScores: gt('scoresService.errors.size', 0),
 
-  hasServiceErrors: Ember.computed.or(
+  hasServiceErrors: or(
     'hasErrorsEntities',
     'hasErrorsTimeseries',
     'hasErrorsAggregates',
@@ -475,7 +483,7 @@ export default Ember.Controller.extend({
   //
   // session handling
   //
-  sessionCanSave: Ember.computed(
+  sessionCanSave: computed(
     'sessionPermissions',
     'sessionOwner',
     'username',
@@ -490,7 +498,7 @@ export default Ember.Controller.extend({
     }
   ),
 
-  sessionCanCopy: Ember.computed(
+  sessionCanCopy: computed(
     'sessionId',
     'sessionPermissions',
     'sessionOwner',
@@ -591,7 +599,7 @@ export default Ember.Controller.extend({
     // debounce: do not run if destroyed
     if (this.isDestroyed) { return; }
 
-    Ember.run.debounce(this, this._onCheckSessionTimer, ROOTCAUSE_SESSION_TIMER_INTERVAL);
+    debounce(this, this._onCheckSessionTimer, ROOTCAUSE_SESSION_TIMER_INTERVAL);
 
     if (!sessionId) { return; }
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -1,9 +1,15 @@
-import Ember from 'ember';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import fetch from 'fetch';
 import moment from 'moment';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { toCurrentUrn, toBaselineUrn, filterPrefix, dateFormatFull } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  toCurrentUrn,
+  toBaselineUrn,
+  filterPrefix,
+  dateFormatFull
+} from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import _ from 'lodash';
 
@@ -49,8 +55,8 @@ const toAnalysisOffset = (granularity) => {
   return UNIT_MAPPING[granularity[1]] || -1;
 };
 
-export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  authService: Ember.inject.service('session'),
+export default Route.extend(AuthenticatedRouteMixin, {
+  authService: service('session'),
 
   queryParams: {
     metricId: {

--- a/thirdeye/thirdeye-frontend/app/pods/screenshot/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/screenshot/controller.js
@@ -1,7 +1,9 @@
-import Ember from 'ember';
+import { alias } from '@ember/object/computed';
+import { computed } from '@ember/object';
+import Controller from '@ember/controller';
 import moment from 'moment';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   // Default Legend text and color
   legendText: {
     dotted: {
@@ -23,7 +25,7 @@ export default Ember.Controller.extend({
   },
 
   // Displaying points for screenshot for n < 100
-  point: Ember.computed('anomaly.dates', function() {
+  point: computed('anomaly.dates', function() {
     const datesCount = this.get('anomaly.dates.length');
     return {
       show: datesCount <= 100
@@ -31,15 +33,15 @@ export default Ember.Controller.extend({
   }),
 
   // Primary Anomaly details
-  anomaly: Ember.computed.alias('model.anomalyDetailsList.firstObject'),
+  anomaly: alias('model.anomalyDetailsList.firstObject'),
 
   // Name of the metric for legend
-  metricName: Ember.computed.alias('anomaly.metric'),
+  metricName: alias('anomaly.metric'),
 
   /** Data Massaging the anomaly for the graph component
    * @returns {Object}
    */
-  primaryMetric: Ember.computed(
+  primaryMetric: computed(
     'anomaly',
     'metricName',
     function() {
@@ -63,21 +65,21 @@ export default Ember.Controller.extend({
    * Formats dates into ms unix
    * @returns {Array}
    */
-  dates: Ember.computed('anomaly.dates.@each', function() {
+  dates: computed('anomaly.dates.@each', function() {
     const dates = this.getWithDefault('anomaly.dates', []);
     const unixDates = dates.map((date) => moment(date).valueOf());
 
     return ['date', ...unixDates];
   }),
 
-  current: Ember.computed.alias('anomaly.currentValues'),
-  expected: Ember.computed.alias('anomaly.baselineValues'),
+  current: alias('anomaly.currentValues'),
+  expected: alias('anomaly.baselineValues'),
 
   /**
    * Data Massages current and expected values for the graph component
    * @returns {Array}
    */
-  columns: Ember.computed(
+  columns: computed(
     'current',
     'expected',
     'metricName',

--- a/thirdeye/thirdeye-frontend/app/pods/screenshot/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/screenshot/route.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
 import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Ember.Route.extend(UnauthenticatedRouteMixin, {
+export default Route.extend(UnauthenticatedRouteMixin, {
   model(params) {
     const { anomalyId: id} = params;
     const url = `/anomalies/search/anomalyIds/1/1/1?anomalyIds=${id}&functionName=`;

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -3,15 +3,25 @@
  * @module self-serve/create/controller
  * @exports create
  */
+import { reads } from '@ember/object/computed';
+
 import RSVP from "rsvp";
 import _ from 'lodash';
 import fetch from 'fetch';
 import Controller from '@ember/controller';
 import { computed, set } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
-import { isPresent, isEmpty, isNone, isBlank } from "@ember/utils";
+import {
+  isPresent,
+  isEmpty,
+  isNone,
+  isBlank
+} from "@ember/utils";
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
-import { buildMetricDataUrl, getTopDimensions } from 'thirdeye-frontend/utils/manage-alert-utils';
+import {
+  buildMetricDataUrl,
+  getTopDimensions
+} from 'thirdeye-frontend/utils/manage-alert-utils';
 
 export default Controller.extend({
 
@@ -196,12 +206,12 @@ export default Controller.extend({
   /**
    * Application name field options loaded from our model.
    */
-  allApplicationNames: computed.reads('model.allAppNames'),
+  allApplicationNames: reads('model.allAppNames'),
 
   /**
    * The list of all existing alert configuration groups.
    */
-  allAlertsConfigGroups: computed.reads('model.allConfigGroups'),
+  allAlertsConfigGroups: reads('model.allConfigGroups'),
 
   /**
    * Handler for search by function name - using ember concurrency (task)

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/import-metric/controller.js
@@ -3,11 +3,15 @@
  * @module self-serve/create/import-metric
  * @exports import-metric
  */
-import Ember from 'ember';
+import { and } from '@ember/object/computed';
+
+import { isPresent } from '@ember/utils';
+import { computed } from '@ember/object';
+import Controller from '@ember/controller';
 import fetch from 'fetch';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   /**
    * Import Defaults
    */
@@ -25,7 +29,7 @@ export default Ember.Controller.extend({
    * @method isSubmitDisabled
    * @return {Boolean} isDisabled
    */
-  isSubmitDisabled: Ember.computed(
+  isSubmitDisabled: computed(
     'importExistingDashboardName',
     'importCustomNewDataset',
     'importCustomNewMetric',
@@ -39,14 +43,14 @@ export default Ember.Controller.extend({
       const newMetricField = this.get('importCustomNewMetric');
       const newRrdField = this.get('importCustomNewRrd');
       // If existing dashboard field is filled, release submit button.
-      if (Ember.isPresent(existingNameField) && !isExistingNameError) {
+      if (isPresent(existingNameField) && !isExistingNameError) {
         isDisabled = false;
       }
       // If any of the 'import custom' fields are filled, assume user will go the RRD import route. Disable submit.
-      if (Ember.isPresent(newNameField) || Ember.isPresent(newRrdField) || Ember.isPresent(newMetricField)) {
+      if (isPresent(newNameField) || isPresent(newRrdField) || isPresent(newMetricField)) {
         isDisabled = true;
         // Enable submit if all required RRD fields are present
-        if (Ember.isPresent(newNameField) && Ember.isPresent(newRrdField) && Ember.isPresent(newMetricField)) {
+        if (isPresent(newNameField) && isPresent(newRrdField) && isPresent(newMetricField)) {
           isDisabled = false;
         }
       }
@@ -59,7 +63,7 @@ export default Ember.Controller.extend({
    * @method isExistingDashboardNameFieldDisabled
    * @return {Boolean} isExistingDashFieldDisabled
    */
-  isExistingDashFieldDisabled: Ember.computed(
+  isExistingDashFieldDisabled: computed(
     'importExistingDashboardName',
     'importCustomNewDataset',
     'importCustomNewMetric',
@@ -70,7 +74,7 @@ export default Ember.Controller.extend({
       const name = this.get('importCustomNewDataset');
       const metric = this.get('importCustomNewMetric');
       const isSubmitted = this.get('isSubmitDone');
-      return Ember.isPresent(rrd) || Ember.isPresent(name) || Ember.isPresent(metric) || isSubmitted;
+      return isPresent(rrd) || isPresent(name) || isPresent(metric) || isSubmitted;
     }
   ),
 
@@ -79,7 +83,7 @@ export default Ember.Controller.extend({
    * @method isFormDisabled
    * @return {Boolean} isFormDisabled
    */
-  isFormDisabled: Ember.computed.and('isExistingDashFieldDisabled', 'isCustomDashFieldDisabled'),
+  isFormDisabled: and('isExistingDashFieldDisabled', 'isCustomDashFieldDisabled'),
 
   /**
    * Validates whether the entered dashboard name exists in inGraphs

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/route.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin);
+export default Route.extend(AuthenticatedRouteMixin);

--- a/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
+++ b/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
@@ -1,6 +1,14 @@
 import Helper from '@ember/component/helper';
 import { htmlSafe } from '@ember/string';
-import { filterPrefix, toBaselineUrn, toCurrentUrn, toMetricLabel, toEventLabel, toColorDirection, isInverse } from 'thirdeye-frontend/utils/rca-utils';
+import {
+  filterPrefix,
+  toBaselineUrn,
+  toCurrentUrn,
+  toMetricLabel,
+  toEventLabel,
+  toColorDirection,
+  isInverse
+} from 'thirdeye-frontend/utils/rca-utils';
 import { humanizeChange, humanizeFloat } from 'thirdeye-frontend/utils/utils';
 import moment from 'moment';
 import d3 from 'd3';

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { getWithDefault } from '@ember/object';
 import _ from 'lodash';
 import moment from 'moment';
 import { isPresent } from "@ember/utils";
@@ -77,7 +77,7 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
 
     // We want to display only non-zero duration values in our table
     const noZeroDurationArr = _.remove(durationArr, function(item) {
-      return Ember.isPresent(item);
+      return isPresent(item);
     });
 
     // Set 'not reviewed' label
@@ -314,7 +314,7 @@ export function getDuration() {
  * @return {undefined}
  */
 export function extractSeverity(alertData, defaultSeverity) {
-  const alertFilterSeverity = Ember.getWithDefault(alertData, 'alertFilter.mttd', null);
+  const alertFilterSeverity = getWithDefault(alertData, 'alertFilter.mttd', null);
   const parsedSeverity = alertFilterSeverity ? alertFilterSeverity.split(';')[1].split('=') : null;
   const isSeverityNumeric = parsedSeverity && !isNaN(parsedSeverity[1]);
   const finalSeverity = isSeverityNumeric ? parsedSeverity[1] : defaultSeverity;

--- a/thirdeye/thirdeye-frontend/app/utils/utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/utils.js
@@ -1,5 +1,5 @@
+import { isNone } from '@ember/utils';
 import moment from 'moment';
-import Ember from 'ember';
 
 /**
  * The Promise returned from fetch() won't reject on HTTP error status even if the response is an HTTP 404 or 500.
@@ -32,7 +32,7 @@ export function checkStatus(response, mode = 'get', recoverBlank = false) {
  * Formatter for the human-readable floating point numbers numbers
  */
 export function humanizeFloat(f) {
-  if (Ember.isNone(f) || Number.isNaN(f)) { return '-'; }
+  if (isNone(f) || Number.isNaN(f)) { return '-'; }
   const fixed = Math.max(3 - Math.max(Math.floor(Math.log10(f)) + 1, 0), 0);
   return f.toFixed(fixed);
 }
@@ -41,7 +41,7 @@ export function humanizeFloat(f) {
  * Formatter for the human-readable change values in percent with 1 decimal
  */
 export function humanizeChange(f) {
-  if (Ember.isNone(f) || Number.isNaN(f)) { return '-'; }
+  if (isNone(f) || Number.isNaN(f)) { return '-'; }
   return `${f > 0 ? '+' : ''}${(Math.round(f * 1000) / 10.0).toFixed(1)}%`;
 }
 
@@ -49,7 +49,7 @@ export function humanizeChange(f) {
  * Formatter for human-readable entity scores with 2 decimals
  */
 export function humanizeScore(f) {
-  if (Ember.isNone(f) || Number.isNaN(f)) { return '-'; }
+  if (isNone(f) || Number.isNaN(f)) { return '-'; }
   return f.toFixed(2);
 }
 


### PR DESCRIPTION
### What's new: 
Updating all import to use ember's latest module API
https://www.emberjs.com/blog/2017/10/11/ember-2-16-released.html#toc_ember-js

### Next step:
Remove usage of legacy ember-cli-shim

### Sanity Test (visual):
@ttbach @newsummit So far all tests are passing and clicking through the app didn't reveal breakage. 
- [x] legacy RCA
- [x] new RCA
- [x] manage alerts
- [x] create alerts
- [x] edit alert (Couldn't test as feature is hidden)