### PR TITLE
Rebalancer for tables with replica group segment assignment

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -97,7 +97,7 @@ public class PinotTableRestletResource {
   @Path("/tables")
   @ApiOperation(value = "Adds a table", notes = "Adds a table")
   public SuccessResponse addTable(String tableConfigStr) throws Exception {
-      // TODO introduce a table config ctor with json string.
+    // TODO introduce a table config ctor with json string.
     TableConfig tableConfig;
     String tableName;
     try {
@@ -128,8 +128,7 @@ public class PinotTableRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables")
   @ApiOperation(value = "Lists all tables in cluster", notes = "Lists all tables in cluster")
-  public String listTableConfigs(
-  ) {
+  public String listTableConfigs() {
     try {
       List<String> rawTables = _pinotHelixResourceManager.getAllRawTables();
       Collections.sort(rawTables);
@@ -146,14 +145,15 @@ public class PinotTableRestletResource {
     try {
       JSONObject ret = new JSONObject();
 
-      if ((tableTypeStr == null || CommonConstants.Helix.TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr)) && _pinotHelixResourceManager.hasOfflineTable(
-          tableName)) {
+      if ((tableTypeStr == null || CommonConstants.Helix.TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr))
+          && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
         TableConfig tableConfig = _pinotHelixResourceManager.getOfflineTableConfig(tableName);
         Preconditions.checkNotNull(tableConfig);
         ret.put(CommonConstants.Helix.TableType.OFFLINE.name(), TableConfig.toJSONConfig(tableConfig));
       }
 
-      if ((tableTypeStr == null || CommonConstants.Helix.TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr)) && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
+      if ((tableTypeStr == null || CommonConstants.Helix.TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr))
+          && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
         TableConfig tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableName);
         Preconditions.checkNotNull(tableConfig);
         ret.put(CommonConstants.Helix.TableType.REALTIME.name(), TableConfig.toJSONConfig(tableConfig));
@@ -167,15 +167,13 @@ public class PinotTableRestletResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}")
-  @ApiOperation(value = "Get/Enable/Disable/Drop a table",
-      notes = "Get/Enable/Disable/Drop a table. If table name is the only parameter specified " +
-          ", the tableconfig will be printed"
-  )
+  @ApiOperation(value = "Get/Enable/Disable/Drop a table", notes =
+      "Get/Enable/Disable/Drop a table. If table name is the only parameter specified "
+          + ", the tableconfig will be printed")
   public String alterTableStateOrListTableConfig(
       @ApiParam(value = "Name of the table", required = false) @PathParam("tableName") String tableName,
       @ApiParam(value = "enable|disable|drop", required = false) @QueryParam("state") String stateStr,
-      @ApiParam(value = "realtime|offline", required = false) @QueryParam("type") String tableTypeStr
-  ) {
+      @ApiParam(value = "realtime|offline", required = false) @QueryParam("type") String tableTypeStr) {
     try {
       if (tableName == null) {
         List<String> rawTables = _pinotHelixResourceManager.getAllRawTables();
@@ -192,7 +190,8 @@ public class PinotTableRestletResource {
       JSONArray ret = new JSONArray();
       boolean tableExists = false;
 
-      if ((tableTypeStr == null || CommonConstants.Helix.TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr)) && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
+      if ((tableTypeStr == null || CommonConstants.Helix.TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr))
+          && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
         String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
         JSONObject offline = new JSONObject();
         tableExists = true;
@@ -202,8 +201,8 @@ public class PinotTableRestletResource {
         ret.put(offline);
       }
 
-      if ((tableTypeStr == null || CommonConstants.Helix.TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr)) && _pinotHelixResourceManager
-          .hasRealtimeTable(tableName)) {
+      if ((tableTypeStr == null || CommonConstants.Helix.TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr))
+          && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
         String realTimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
         JSONObject realTime = new JSONObject();
         tableExists = true;
@@ -215,12 +214,12 @@ public class PinotTableRestletResource {
       if (tableExists) {
         return ret.toString();
       } else {
-        throw new ControllerApplicationException(LOGGER, "Table '" + tableName + "' does not exist", Response.Status.BAD_REQUEST);
+        throw new ControllerApplicationException(LOGGER, "Table '" + tableName + "' does not exist",
+            Response.Status.BAD_REQUEST);
       }
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }
-
   }
 
   @DELETE
@@ -229,8 +228,7 @@ public class PinotTableRestletResource {
   @ApiOperation(value = "Deletes a table", notes = "Deletes a table")
   public SuccessResponse deleteTable(
       @ApiParam(value = "Name of the table to delete", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "realtime|offline", required = false) @QueryParam("type") String tableTypeStr
-  ) {
+      @ApiParam(value = "realtime|offline", required = false) @QueryParam("type") String tableTypeStr) {
     List<String> tablesDeleted = new LinkedList<>();
     try {
       if (tableTypeStr == null || tableTypeStr.equalsIgnoreCase(CommonConstants.Helix.TableType.OFFLINE.name())) {
@@ -253,8 +251,7 @@ public class PinotTableRestletResource {
   @ApiOperation(value = "Updates table config for a table", notes = "Updates table config for a table")
   public SuccessResponse updateTableConfig(
       @ApiParam(value = "Name of the table to update", required = true) @PathParam("tableName") String tableName,
-      String tableConfigStr
-  ) throws Exception {
+      String tableConfigStr) throws Exception {
     TableConfig tableConfig;
     try {
       JSONObject tableConfigJson = new JSONObject(tableConfigStr);
@@ -275,11 +272,13 @@ public class PinotTableRestletResource {
 
       if (tableType == CommonConstants.Helix.TableType.OFFLINE) {
         if (!_pinotHelixResourceManager.hasOfflineTable(tableName)) {
-          throw new ControllerApplicationException(LOGGER, "Table " + tableName + " does not exist", Response.Status.BAD_REQUEST);
+          throw new ControllerApplicationException(LOGGER, "Table " + tableName + " does not exist",
+              Response.Status.BAD_REQUEST);
         }
       } else {
         if (!_pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-          throw new ControllerApplicationException(LOGGER, "Table " + tableName + " does not exist", Response.Status.NOT_FOUND);
+          throw new ControllerApplicationException(LOGGER, "Table " + tableName + " does not exist",
+              Response.Status.NOT_FOUND);
         }
       }
 
@@ -300,17 +299,19 @@ public class PinotTableRestletResource {
   @POST
   @Path("/tables/validate")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Validate table config for a table",
-      notes = "This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
+  @ApiOperation(value = "Validate table config for a table", notes =
+      "This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
           + " This allows us to validate table config before apply.")
-  public String checkTableConfig (String tableConfigStr) throws Exception {
+  public String checkTableConfig(String tableConfigStr) throws Exception {
     try {
       JSONObject tableConfigValidateStr = new JSONObject();
       TableConfig tableConfig = TableConfig.fromJSONConfig(new JSONObject(tableConfigStr));
       if (tableConfig.getTableType() == CommonConstants.Helix.TableType.OFFLINE) {
-        tableConfigValidateStr.put(CommonConstants.Helix.TableType.OFFLINE.name(), TableConfig.toJSONConfig(tableConfig));
+        tableConfigValidateStr.put(CommonConstants.Helix.TableType.OFFLINE.name(),
+            TableConfig.toJSONConfig(tableConfig));
       } else {
-        tableConfigValidateStr.put(CommonConstants.Helix.TableType.REALTIME.name(), TableConfig.toJSONConfig(tableConfig));
+        tableConfigValidateStr.put(CommonConstants.Helix.TableType.REALTIME.name(),
+            TableConfig.toJSONConfig(tableConfig));
       }
       return tableConfigValidateStr.toString();
     } catch (Exception e) {
@@ -393,11 +394,10 @@ public class PinotTableRestletResource {
   public String rebalance(
       @ApiParam(value = "Name of the table to rebalance") @Nonnull @PathParam("tableName") String tableName,
       @ApiParam(value = "offline|realtime") @Nonnull @QueryParam("type") String tableType,
-      @ApiParam(value = "true|false") @Nonnull @QueryParam("dryrun") Boolean dryRun,
+      @ApiParam(value = "true|false") @Nonnull @DefaultValue("true") @QueryParam("dryrun") Boolean dryRun,
       @ApiParam(value = "true|false") @DefaultValue("false") @QueryParam("includeConsuming") Boolean includeConsuming) {
 
-    if (tableType != null
-        && !EnumUtils.isValidEnum(CommonConstants.Helix.TableType.class, tableType.toUpperCase())) {
+    if (tableType != null && !EnumUtils.isValidEnum(CommonConstants.Helix.TableType.class, tableType.toUpperCase())) {
       throw new ControllerApplicationException(LOGGER, "Illegal table type " + tableType, Response.Status.BAD_REQUEST);
     }
 
@@ -405,7 +405,7 @@ public class PinotTableRestletResource {
     rebalanceUserConfig.addProperty(RebalanceUserConfigConstants.DRYRUN, dryRun);
     rebalanceUserConfig.addProperty(RebalanceUserConfigConstants.INCLUDE_CONSUMING, includeConsuming);
 
-    JSONObject jsonObject = null;
+    JSONObject jsonObject;
     try {
       jsonObject = _pinotHelixResourceManager.rebalanceTable(tableName,
           CommonConstants.Helix.TableType.valueOf(tableType.toUpperCase()), rebalanceUserConfig);
@@ -417,5 +417,4 @@ public class PinotTableRestletResource {
     return jsonObject.toString();
 
   }
-
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
@@ -42,26 +42,25 @@ public class ControllerRequestBuilderUtil {
   }
 
   public static void addFakeBrokerInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances)
-      throws Exception {
+      int numInstances) throws Exception {
     addFakeBrokerInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, false);
   }
 
   public static void addFakeBrokerInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances, boolean isSingleTenant)
-      throws Exception {
+      int numInstances, boolean isSingleTenant) throws Exception {
     for (int i = 0; i < numInstances; ++i) {
       final String brokerId = "Broker_localhost_" + i;
       final HelixManager helixZkManager =
           HelixManagerFactory.getZKHelixManager(helixClusterName, brokerId, InstanceType.PARTICIPANT, zkServer);
       final StateMachineEngine stateMachineEngine = helixZkManager.getStateMachineEngine();
       final StateModelFactory<?> stateModelFactory = new EmptyBrokerOnlineOfflineStateModelFactory();
-      stateMachineEngine
-          .registerStateModelFactory(EmptyBrokerOnlineOfflineStateModelFactory.getStateModelDef(), stateModelFactory);
+      stateMachineEngine.registerStateModelFactory(EmptyBrokerOnlineOfflineStateModelFactory.getStateModelDef(),
+          stateModelFactory);
       helixZkManager.connect();
       if (isSingleTenant) {
-        helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, brokerId,
-            ControllerTenantNameBuilder.getBrokerTenantNameForTenant(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
+        helixZkManager.getClusterManagmentTool()
+            .addInstanceTag(helixClusterName, brokerId, ControllerTenantNameBuilder.getBrokerTenantNameForTenant(
+                ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
       } else {
         helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, brokerId, UNTAGGED_BROKER_INSTANCE);
       }
@@ -69,62 +68,82 @@ public class ControllerRequestBuilderUtil {
   }
 
   public static void addFakeDataInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances)
-      throws Exception {
-    addFakeDataInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, false, 8097);
+      int numInstances) throws Exception {
+    addFakeDataInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, false,
+        CommonConstants.Server.DEFAULT_ADMIN_API_PORT);
   }
 
   public static void addFakeDataInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances, boolean isSingleTenant)
-      throws Exception {
-    addFakeDataInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, isSingleTenant, 8097);
+      int numInstances, boolean isSingleTenant) throws Exception {
+    addFakeDataInstancesToAutoJoinHelixCluster(helixClusterName, zkServer, numInstances, isSingleTenant,
+        CommonConstants.Server.DEFAULT_ADMIN_API_PORT);
   }
 
   public static void addFakeDataInstancesToAutoJoinHelixCluster(String helixClusterName, String zkServer,
-      int numInstances, boolean isSingleTenant, int adminPort)
-      throws Exception {
+      int numInstances, boolean isSingleTenant, int adminPort) throws Exception {
 
     for (int i = 0; i < numInstances; ++i) {
       final String instanceId = "Server_localhost_" + i;
-
-      final HelixManager helixZkManager =
-          HelixManagerFactory.getZKHelixManager(helixClusterName, instanceId, InstanceType.PARTICIPANT, zkServer);
-      final StateMachineEngine stateMachineEngine = helixZkManager.getStateMachineEngine();
-      final StateModelFactory<?> stateModelFactory = new EmptySegmentOnlineOfflineStateModelFactory();
-      stateMachineEngine
-          .registerStateModelFactory(EmptySegmentOnlineOfflineStateModelFactory.getStateModelDef(), stateModelFactory);
-      helixZkManager.connect();
-      if (isSingleTenant) {
-        helixZkManager.getClusterManagmentTool()
-            .addInstanceTag(helixClusterName, instanceId,
-                TableNameBuilder.OFFLINE.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
-        helixZkManager.getClusterManagmentTool()
-            .addInstanceTag(helixClusterName, instanceId,
-                TableNameBuilder.REALTIME.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
-      } else {
-        helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId, UNTAGGED_SERVER_INSTANCE);
-      }
-      HelixConfigScope scope =
-          new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.PARTICIPANT, helixClusterName)
-              .forParticipant(instanceId).build();
-      Map<String, String> props = new HashMap<>();
-      props.put(CommonConstants.Helix.Instance.ADMIN_PORT_KEY, String.valueOf(adminPort + i));
-      helixZkManager.getClusterManagmentTool().setConfig(scope, props);
+      addFakeDataInstanceToAutoJoinHelixCluster(helixClusterName, zkServer, instanceId, isSingleTenant, adminPort + i);
     }
+  }
+
+  public static void addFakeDataInstanceToAutoJoinHelixCluster(String helixClusterName, String zkServer,
+      String instanceId) throws Exception {
+    addFakeDataInstanceToAutoJoinHelixCluster(helixClusterName, zkServer, instanceId, false,
+        CommonConstants.Server.DEFAULT_ADMIN_API_PORT);
+  }
+
+  public static void addFakeDataInstanceToAutoJoinHelixCluster(String helixClusterName, String zkServer,
+      String instanceId, boolean isSingleTenant) throws Exception {
+    addFakeDataInstanceToAutoJoinHelixCluster(helixClusterName, zkServer, instanceId, isSingleTenant,
+        CommonConstants.Server.DEFAULT_ADMIN_API_PORT);
+  }
+
+  public static void addFakeDataInstanceToAutoJoinHelixCluster(String helixClusterName, String zkServer,
+      String instanceId, boolean isSingleTenant, int adminPort) throws Exception {
+    final HelixManager helixZkManager =
+        HelixManagerFactory.getZKHelixManager(helixClusterName, instanceId, InstanceType.PARTICIPANT, zkServer);
+    final StateMachineEngine stateMachineEngine = helixZkManager.getStateMachineEngine();
+    final StateModelFactory<?> stateModelFactory = new EmptySegmentOnlineOfflineStateModelFactory();
+    stateMachineEngine.registerStateModelFactory(EmptySegmentOnlineOfflineStateModelFactory.getStateModelDef(),
+        stateModelFactory);
+    helixZkManager.connect();
+    if (isSingleTenant) {
+      helixZkManager.getClusterManagmentTool()
+          .addInstanceTag(helixClusterName, instanceId,
+              TableNameBuilder.OFFLINE.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
+      helixZkManager.getClusterManagmentTool()
+          .addInstanceTag(helixClusterName, instanceId,
+              TableNameBuilder.REALTIME.tableNameWithType(ControllerTenantNameBuilder.DEFAULT_TENANT_NAME));
+    } else {
+      helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId, UNTAGGED_SERVER_INSTANCE);
+    }
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.PARTICIPANT, helixClusterName).forParticipant(
+            instanceId).build();
+    Map<String, String> props = new HashMap<>();
+    props.put(CommonConstants.Helix.Instance.ADMIN_PORT_KEY, String.valueOf(adminPort));
+    helixZkManager.getClusterManagmentTool().setConfig(scope, props);
   }
 
   public static JSONObject buildBrokerTenantCreateRequestJSON(String tenantName, int numberOfInstances)
       throws JSONException {
-    Tenant tenant = new TenantBuilder(tenantName).setRole(TenantRole.BROKER).setTotalInstances(numberOfInstances)
-        .setOfflineInstances(0).setRealtimeInstances(0).build();
+    Tenant tenant = new TenantBuilder(tenantName).setRole(TenantRole.BROKER)
+        .setTotalInstances(numberOfInstances)
+        .setOfflineInstances(0)
+        .setRealtimeInstances(0)
+        .build();
     return tenant.toJSON();
   }
 
   public static JSONObject buildServerTenantCreateRequestJSON(String tenantName, int numberOfInstances,
-      int offlineInstances, int realtimeInstances)
-      throws JSONException {
-    Tenant tenant = new TenantBuilder(tenantName).setRole(TenantRole.SERVER).setTotalInstances(numberOfInstances)
-        .setOfflineInstances(offlineInstances).setRealtimeInstances(realtimeInstances).build();
+      int offlineInstances, int realtimeInstances) throws JSONException {
+    Tenant tenant = new TenantBuilder(tenantName).setRole(TenantRole.SERVER)
+        .setTotalInstances(numberOfInstances)
+        .setOfflineInstances(offlineInstances)
+        .setRealtimeInstances(realtimeInstances)
+        .build();
     return tenant.toJSON();
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2070,16 +2070,15 @@ public class PinotHelixResourceManager {
 
     JSONObject jsonObject = new JSONObject();
     try {
-    RebalanceSegmentStrategy rebalanceSegmentsStrategy =
-        RebalanceSegmentStrategyFactory.getInstance().getRebalanceSegmentsStrategy(tableConfig);
-    PartitionAssignment newPartitionAssignment =
-        rebalanceSegmentsStrategy.rebalancePartitionAssignment(idealState, tableConfig, rebalanceUserConfig);
-    IdealState newIdealState = rebalanceSegmentsStrategy.rebalanceIdealState(idealState, tableConfig,
-        rebalanceUserConfig, newPartitionAssignment);
+      RebalanceSegmentStrategy rebalanceSegmentsStrategy =
+          RebalanceSegmentStrategyFactory.getInstance().getRebalanceSegmentsStrategy(tableConfig);
+      PartitionAssignment newPartitionAssignment =
+          rebalanceSegmentsStrategy.rebalancePartitionAssignment(idealState, tableConfig, rebalanceUserConfig);
+      IdealState newIdealState = rebalanceSegmentsStrategy.rebalanceIdealState(idealState, tableConfig,
+          rebalanceUserConfig, newPartitionAssignment);
 
-
-      jsonObject.put("partitionAssignment", newPartitionAssignment);
-      jsonObject.put("idealState", newIdealState);
+      jsonObject.put("partitionAssignment", newPartitionAssignment.getPartitionToInstances());
+      jsonObject.put("idealState", newIdealState.getRecord().getMapFields());
     } catch (JSONException e) {
       LOGGER.error("Exception in constructing json response for rebalance table {}", tableNameWithType, e);
       throw e;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategy.java
@@ -47,5 +47,5 @@ public interface RebalanceSegmentStrategy {
    * @return rebalanced ideal state
    */
   IdealState rebalanceIdealState(IdealState idealState, TableConfig tableConfig, Configuration rebalanceUserConfig,
-      PartitionAssignment newPartitionAssignment);
+      PartitionAssignment newPartitionAssignment) throws InvalidConfigException;
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategyFactory.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceSegmentStrategyFactory.java
@@ -17,6 +17,8 @@
 package com.linkedin.pinot.controller.helix.core.rebalance;
 
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategy;
+import com.linkedin.pinot.controller.helix.core.sharding.SegmentAssignmentStrategyEnum;
 import org.apache.helix.HelixManager;
 
 
@@ -48,9 +50,13 @@ public class RebalanceSegmentStrategyFactory {
   }
 
   public RebalanceSegmentStrategy getRebalanceSegmentsStrategy(TableConfig tableConfig) {
-
-    // TODO: based on table config pick the right Rebalancer
-    return new DefaultRebalanceSegmentStrategy(_helixManager);
+    // If we use replica group segment assignment strategy, we pick the replica group rebalancer
+    String segmentAssignmentStrategy = tableConfig.getValidationConfig().getSegmentAssignmentStrategy();
+    switch (SegmentAssignmentStrategyEnum.valueOf(segmentAssignmentStrategy)) {
+      case ReplicaGroupSegmentAssignmentStrategy:
+        return new ReplicaGroupRebalanceSegmentStrategy(_helixManager);
+      default:
+        return new DefaultRebalanceSegmentStrategy(_helixManager);
+    }
   }
-
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceUserConfigConstants.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/RebalanceUserConfigConstants.java
@@ -24,4 +24,7 @@ public class RebalanceUserConfigConstants {
   public static final String DRYRUN = "dryRun";
   /** Whether consuming segments should also be rebalanced or not */
   public static final String INCLUDE_CONSUMING = "includeConsuming";
+
+  public static final boolean DEFAULT_DRY_RUN = true;
+  public static final boolean DEFAULT_INCLUDE_CONSUMING = false;
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceSegmentStrategy.java
@@ -1,0 +1,539 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.rebalance;
+
+import com.google.common.base.Function;
+import com.linkedin.pinot.common.config.OfflineTagConfig;
+import com.linkedin.pinot.common.config.ReplicaGroupStrategyConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.exception.InvalidConfigException;
+import com.linkedin.pinot.common.partition.PartitionAssignment;
+import com.linkedin.pinot.common.partition.ReplicaGroupPartitionAssignment;
+import com.linkedin.pinot.common.partition.ReplicaGroupPartitionAssignmentGenerator;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.helix.HelixHelper;
+import com.linkedin.pinot.common.utils.retry.RetryPolicies;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Replica group aware rebalance segment strategy.
+ */
+public class ReplicaGroupRebalanceSegmentStrategy implements RebalanceSegmentStrategy {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupRebalanceSegmentStrategy.class);
+
+  private HelixManager _helixManager;
+  private HelixAdmin _helixAdmin;
+  private String _helixClusterName;
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  public ReplicaGroupRebalanceSegmentStrategy(HelixManager helixManager) {
+    _helixManager = helixManager;
+    _helixAdmin = helixManager.getClusterManagmentTool();
+    _helixClusterName = helixManager.getClusterName();
+    _propertyStore = helixManager.getHelixPropertyStore();
+  }
+
+  /**
+   * Rebalance partition assignment for replica group tables.
+   * @param idealState old ideal state
+   * @param tableConfig table config of table tor rebalance
+   * @param rebalanceUserConfig custom user configs for specific rebalance strategies
+   * @return a rebalanced replica group partition assignment
+   */
+  @Override
+  public PartitionAssignment rebalancePartitionAssignment(IdealState idealState, TableConfig tableConfig,
+      Configuration rebalanceUserConfig) throws InvalidConfigException {
+    // Currently, only offline table is supported
+    if (tableConfig.getTableType() == CommonConstants.Helix.TableType.REALTIME) {
+      throw new InvalidConfigException("Realtime table is not supported by replica group rebalancer");
+    }
+
+    String tableNameWithType = tableConfig.getTableName();
+    LOGGER.info("Rebalancing replica group partition assignment for table {}", tableNameWithType);
+
+    ReplicaGroupPartitionAssignmentGenerator partitionAssignmentGenerator =
+        new ReplicaGroupPartitionAssignmentGenerator(_propertyStore);
+
+    // Compute new replica group partition assignment
+    ReplicaGroupPartitionAssignment newPartitionAssignment =
+        computeNewReplicaGroupMapping(tableConfig, partitionAssignmentGenerator);
+
+    boolean dryRun = rebalanceUserConfig.getBoolean(RebalanceUserConfigConstants.DRYRUN,
+        RebalanceUserConfigConstants.DEFAULT_DRY_RUN);
+    if (!dryRun) {
+      LOGGER.info("Updating replica group partition assignment for table {}", tableNameWithType);
+      partitionAssignmentGenerator.writeReplicaGroupPartitionAssignment(newPartitionAssignment);
+    } else {
+      LOGGER.info("Dry run. Skip writing replica group partition assignment to property store");
+    }
+
+    return newPartitionAssignment;
+  }
+
+  /**
+   * Rebalance the segments for replica group tables.
+   * @param idealState old ideal state
+   * @param tableConfig table config of table tor rebalance
+   * @param rebalanceUserConfig custom user configs for specific rebalance strategies
+   * @param newPartitionAssignment new rebalaned partition assignments as part of the resource rebalance
+   * @return a rebalanced idealstate
+   */
+  @Override
+  public IdealState rebalanceIdealState(IdealState idealState, TableConfig tableConfig,
+      Configuration rebalanceUserConfig, PartitionAssignment newPartitionAssignment) throws InvalidConfigException {
+    // Currently, only offline table is supported
+    if (tableConfig.getTableType() == CommonConstants.Helix.TableType.REALTIME) {
+      throw new InvalidConfigException("Realtime table is not supported by replica group rebalancer");
+    }
+    ReplicaGroupPartitionAssignment newReplicaGroupPartitionAssignment =
+        (ReplicaGroupPartitionAssignment) newPartitionAssignment;
+    String tableNameWithType = tableConfig.getTableName();
+
+    // update if not dryRun
+    boolean dryRun = rebalanceUserConfig.getBoolean(RebalanceUserConfigConstants.DRYRUN,
+        RebalanceUserConfigConstants.DEFAULT_DRY_RUN);
+    IdealState newIdealState;
+    if (!dryRun) {
+      LOGGER.info("Updating ideal state for table {}", tableNameWithType);
+      newIdealState = rebalanceSegmentsAndUpdateIdealState(tableConfig, newReplicaGroupPartitionAssignment);
+    } else {
+      newIdealState = rebalanceSegments(idealState, tableConfig, newReplicaGroupPartitionAssignment);
+      LOGGER.info("Dry run. Skip writing ideal state");
+    }
+
+    return newIdealState;
+  }
+
+  /**
+   * Compute the new replica group mapping based on the new configurations
+   * @param tableConfig a talbe config
+   * @param partitionAssignmentGenerator partition assignment generator
+   * @return new replica group partition assignment
+   */
+  private ReplicaGroupPartitionAssignment computeNewReplicaGroupMapping(TableConfig tableConfig,
+      ReplicaGroupPartitionAssignmentGenerator partitionAssignmentGenerator) throws InvalidConfigException {
+    ReplicaGroupStrategyConfig replicaGroupConfig = tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
+
+    // If no replica group config is available in table config, we cannot perform the rebalance algorithm
+    if (replicaGroupConfig == null) {
+      throw new InvalidConfigException("This table is not using replica group segment assignment");
+    }
+
+    // Currently, only table level replica group rebalance is supported
+    if (replicaGroupConfig.getPartitionColumn() != null) {
+      throw new InvalidConfigException("Partition level replica group rebalance is not supported");
+    }
+
+    // Fetch the information required for computing new replica group partition assignment
+    int targetNumInstancesPerPartition = replicaGroupConfig.getNumInstancesPerPartition();
+    int targetNumReplicaGroup = tableConfig.getValidationConfig().getReplicationNumber();
+
+    OfflineTagConfig offlineTagConfig = new OfflineTagConfig(tableConfig, _helixManager);
+    List<String> serverInstances =
+        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, offlineTagConfig.getOfflineServerTag());
+
+    // Perform the basic validation
+    if (targetNumReplicaGroup <= 0 || targetNumInstancesPerPartition <= 0
+        || targetNumReplicaGroup * targetNumInstancesPerPartition > serverInstances.size()) {
+      throw new InvalidConfigException(
+          "Invalid input config (numReplicaGroup: " + targetNumReplicaGroup + ", " + "numInstancesPerPartition: "
+              + targetNumInstancesPerPartition + ", numServers: " + serverInstances.size() + ")");
+    }
+
+    // Check that the partition assignment exists
+    String tableNameWithType = tableConfig.getTableName();
+    ReplicaGroupPartitionAssignment oldReplicaGroupPartitionAssignment =
+        partitionAssignmentGenerator.getReplicaGroupPartitionAssignment(tableNameWithType);
+    if (oldReplicaGroupPartitionAssignment == null) {
+      throw new InvalidConfigException(
+          "Replica group partition assignment does not exist for " + tableNameWithType);
+    }
+
+    // Fetch the previous replica group configurations
+    List<String> oldServerInstances = oldReplicaGroupPartitionAssignment.getAllInstances();
+    int oldNumReplicaGroup = oldReplicaGroupPartitionAssignment.getNumReplicaGroups();
+    int oldNumInstancesPerPartition = oldServerInstances.size() / oldNumReplicaGroup;
+
+    // Compute added and removed servers
+    List<String> addedServers = new ArrayList<>(serverInstances);
+    addedServers.removeAll(oldServerInstances);
+    List<String> removedServers = new ArrayList<>(oldServerInstances);
+    removedServers.removeAll(serverInstances);
+
+    // Create the new replica group partition assignment
+    ReplicaGroupPartitionAssignment newReplicaGroupPartitionAssignment =
+        new ReplicaGroupPartitionAssignment(oldReplicaGroupPartitionAssignment.getTableName());
+
+    // In case of replacement, create the removed to added server mapping
+    Map<String, String> oldToNewServerMapping = new HashMap<>();
+    if (addedServers.size() == removedServers.size()) {
+      for (int i = 0; i < addedServers.size(); i++) {
+        oldToNewServerMapping.put(removedServers.get(i), addedServers.get(i));
+      }
+    }
+
+    // Compute rebalance type
+    ReplicaGroupRebalanceType rebalanceType =
+        computeRebalanceType(oldNumInstancesPerPartition, oldNumReplicaGroup, targetNumReplicaGroup,
+            targetNumInstancesPerPartition, addedServers, removedServers);
+    LOGGER.info("Replica group rebalance type: " + rebalanceType);
+
+    // For now, we don't support the rebalance for partition level replica group so "numPartitions" will always be 1.
+    for (int partitionId = 0; partitionId < oldReplicaGroupPartitionAssignment.getNumPartitions(); partitionId++) {
+      int currentNewReplicaGroupId = 0;
+      for (int groupId = 0; groupId < oldNumReplicaGroup; groupId++) {
+        List<String> oldReplicaGroup =
+            oldReplicaGroupPartitionAssignment.getInstancesfromReplicaGroup(partitionId, groupId);
+        List<String> newReplicaGroup = new ArrayList<>();
+        boolean removeGroup = false;
+
+        // Based on the rebalance type, compute the new replica group partition assignment accordingly
+        switch (rebalanceType) {
+          case REPLACE:
+            // Swap the removed server with the added one.
+            for (String oldServer : oldReplicaGroup) {
+              if (!oldToNewServerMapping.containsKey(oldServer)) {
+                newReplicaGroup.add(oldServer);
+              } else {
+                newReplicaGroup.add(oldToNewServerMapping.get(oldServer));
+              }
+            }
+            break;
+          case ADD_SERVER:
+            newReplicaGroup.addAll(oldReplicaGroup);
+            // Assign new servers to the replica group
+            for (int serverIndex = 0; serverIndex < addedServers.size(); serverIndex++) {
+              if (serverIndex % targetNumReplicaGroup == groupId) {
+                newReplicaGroup.add(addedServers.get(serverIndex));
+              }
+            }
+            break;
+          case REMOVE_SERVER:
+            // Only add the servers that are not in the removed list
+            newReplicaGroup.addAll(oldReplicaGroup);
+            newReplicaGroup.removeAll(removedServers);
+            break;
+          case ADD_REPLICA_GROUP:
+            // Add all servers for original replica groups and add new replica groups later
+            newReplicaGroup.addAll(oldReplicaGroup);
+            break;
+          case REMOVE_REPLICA_GROUP:
+            newReplicaGroup.addAll(oldReplicaGroup);
+            // mark the group if this is the replica group that needs to be removed
+            if (removedServers.containsAll(oldReplicaGroup)) {
+              removeGroup = true;
+            }
+            break;
+          default:
+            String errorMessage =
+                "Not supported replica group rebalance operation. Need to check server tags and replica group config to"
+                    + " make sure only one maintenance step is asked. ( oldNumInstancesPerPatition: "
+                    + oldNumInstancesPerPartition + ", targetNumInstancesPerPartition: "
+                    + targetNumInstancesPerPartition + ", oldNumReplicaGroup: " + oldNumReplicaGroup
+                    + ", targetNumReplicaGroup: " + targetNumReplicaGroup + ", numAddedServers: " + addedServers.size()
+                    + ", numRemovedServers: " + removedServers.size() + " )";
+            LOGGER.info(errorMessage);
+            throw new InvalidConfigException(errorMessage);
+        }
+        if (!removeGroup) {
+          LOGGER.info("Setting new replica group ( partitionId: " + partitionId + ", replicaGroupId: " + groupId
+              + ", server list: " + StringUtils.join(",", newReplicaGroup));
+          newReplicaGroupPartitionAssignment.setInstancesToReplicaGroup(partitionId, currentNewReplicaGroupId++, newReplicaGroup);
+        }
+      }
+
+      // Adding new replica groups if needed
+      int index = 0;
+      for (int newGroupId = currentNewReplicaGroupId; newGroupId < targetNumReplicaGroup; newGroupId++) {
+        List<String> newReplicaGroup = new ArrayList<>();
+        while (newReplicaGroup.size() < targetNumInstancesPerPartition) {
+          newReplicaGroup.add(addedServers.get(index));
+          index++;
+        }
+        newReplicaGroupPartitionAssignment.setInstancesToReplicaGroup(partitionId, newGroupId, newReplicaGroup);
+      }
+    }
+
+    return newReplicaGroupPartitionAssignment;
+  }
+
+  /**
+   * Given the list of added/removed servers and the old and new replica group configurations, compute the
+   * type of update (e.g. replace server, add servers to each replica group, add replica groups..)
+   *
+   * @return the update type
+   */
+  private ReplicaGroupRebalanceType computeRebalanceType(int oldNumInstancesPerPartition, int oldNumReplicaGroup,
+      int targetNumReplicaGroup, int targetNumInstancesPerPartition, List<String> addedServers,
+      List<String> removedServers) {
+    boolean sameNumInstancesPerPartition = oldNumInstancesPerPartition == targetNumInstancesPerPartition;
+    boolean sameNumReplicaGroup = oldNumReplicaGroup == targetNumReplicaGroup;
+    boolean isAddedServersSizeZero = addedServers.size() == 0;
+    boolean isRemovedServersSizeZero = removedServers.size() == 0;
+
+    if (sameNumInstancesPerPartition && sameNumReplicaGroup && addedServers.size() == removedServers.size()) {
+      return ReplicaGroupRebalanceType.REPLACE;
+    } else if (sameNumInstancesPerPartition) {
+      if (oldNumReplicaGroup < targetNumReplicaGroup && !isAddedServersSizeZero && isRemovedServersSizeZero
+          && addedServers.size() % targetNumInstancesPerPartition == 0) {
+        return ReplicaGroupRebalanceType.ADD_REPLICA_GROUP;
+      } else if (oldNumReplicaGroup > targetNumReplicaGroup && isAddedServersSizeZero && !isRemovedServersSizeZero
+          && removedServers.size() % targetNumInstancesPerPartition == 0) {
+        return ReplicaGroupRebalanceType.REMOVE_REPLICA_GROUP;
+      }
+    } else if (sameNumReplicaGroup) {
+      if (oldNumInstancesPerPartition < targetNumInstancesPerPartition && isRemovedServersSizeZero
+          && !isAddedServersSizeZero && addedServers.size() % targetNumReplicaGroup == 0) {
+        return ReplicaGroupRebalanceType.ADD_SERVER;
+      } else if (oldNumInstancesPerPartition > targetNumInstancesPerPartition && !isRemovedServersSizeZero
+          && isAddedServersSizeZero && removedServers.size() % targetNumReplicaGroup == 0) {
+        return ReplicaGroupRebalanceType.REMOVE_SERVER;
+      }
+    }
+    return ReplicaGroupRebalanceType.UNSUPPORTED;
+  }
+
+  /**
+   * Modifies in-memory idealstate to rebalance segments for table with replica-group based segment assignment
+   * @param idealState old idealstate
+   * @param tableConfig a table config
+   * @param replicaGroupPartitionAssignment a replica group partition assignment
+   * @return a rebalanced idealstate
+   */
+  private IdealState rebalanceSegments(IdealState idealState, TableConfig tableConfig,
+      ReplicaGroupPartitionAssignment replicaGroupPartitionAssignment) {
+
+    Map<String, Map<String, String>> segmentToServerMapping = idealState.getRecord().getMapFields();
+    Map<String, LinkedList<String>> serverToSegments = buildServerToSegmentMapping(segmentToServerMapping);
+
+    List<String> oldServerInstances = new ArrayList<>(serverToSegments.keySet());
+    List<String> serverInstances = replicaGroupPartitionAssignment.getAllInstances();
+
+    // Compute added and removed servers
+    List<String> addedServers = new ArrayList<>(serverInstances);
+    addedServers.removeAll(oldServerInstances);
+    List<String> removedServers = new ArrayList<>(oldServerInstances);
+    removedServers.removeAll(serverInstances);
+
+    // Add servers to the mapping
+    for (String server : addedServers) {
+      serverToSegments.put(server, new LinkedList<String>());
+    }
+
+    // Remove servers from the mapping
+    for (String server : removedServers) {
+      serverToSegments.remove(server);
+    }
+
+    // Check if rebalance can cause the data inconsistency
+    Set<String> segmentsToCover = segmentToServerMapping.keySet();
+    Set<String> coveredSegments = new HashSet<>();
+    for (Map.Entry<String, LinkedList<String>> entry : serverToSegments.entrySet()) {
+      coveredSegments.addAll(entry.getValue());
+    }
+
+    coveredSegments.removeAll(segmentsToCover);
+    if (!coveredSegments.isEmpty()) {
+      LOGGER.warn("Some segments may temporarily be unavailable during the rebalance. "
+          + "This may cause incorrect answer for the query.");
+    }
+
+    // Fetch replica group configs
+    ReplicaGroupStrategyConfig replicaGroupConfig = tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
+    boolean mirrorAssignment = replicaGroupConfig.getMirrorAssignmentAcrossReplicaGroups();
+    int numPartitions = replicaGroupPartitionAssignment.getNumPartitions();
+    int numReplicaGroups = replicaGroupPartitionAssignment.getNumReplicaGroups();
+
+    // For now, we don't support for rebalancing partition level replica group so "numPartitions" will be 1.
+    for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
+      List<String> referenceReplicaGroup = new ArrayList<>();
+      for (int replicaId = 0; replicaId < numReplicaGroups; replicaId++) {
+        List<String> serversInReplicaGroup =
+            replicaGroupPartitionAssignment.getInstancesfromReplicaGroup(partitionId, replicaId);
+        if (replicaId == 0) {
+          // We need to keep the first replica group in case of mirroring.
+          referenceReplicaGroup.addAll(serversInReplicaGroup);
+        } else if (mirrorAssignment) {
+          // Copy the segment assignment from the reference replica group
+          for (int i = 0; i < serversInReplicaGroup.size(); i++) {
+            serverToSegments.put(serversInReplicaGroup.get(i), serverToSegments.get(referenceReplicaGroup.get(i)));
+          }
+          continue;
+        }
+
+        // Uniformly distribute the segments among servers in a replica group
+        rebalanceReplicaGroup(serversInReplicaGroup, serverToSegments, segmentsToCover);
+      }
+    }
+
+    // Update Idealstate with rebalanced segment assignment
+    Map<String, Map<String, String>> serverToSegmentsMapping = buildSegmentToServerMapping(serverToSegments);
+    for (Map.Entry<String, Map<String, String>> entry : serverToSegmentsMapping.entrySet()) {
+      idealState.setInstanceStateMap(entry.getKey(), entry.getValue());
+    }
+    idealState.setReplicas(Integer.toString(numReplicaGroups));
+
+    return idealState;
+  }
+
+  /**
+   * Rebalances segments and updates the idealstate in Helix
+   * @param tableConfig a table config
+   * @param replicaGroupPartitionAssignment a replica group partition assignment
+   * @return a rebalanced idealstate
+   */
+  private IdealState rebalanceSegmentsAndUpdateIdealState(final TableConfig tableConfig,
+      final ReplicaGroupPartitionAssignment replicaGroupPartitionAssignment) {
+    final Function<IdealState, IdealState> updaterFunction = new Function<IdealState, IdealState>() {
+      @Nullable
+      @Override
+      public IdealState apply(@Nullable IdealState idealState) {
+        return rebalanceSegments(idealState, tableConfig, replicaGroupPartitionAssignment);
+      }
+    };
+    HelixHelper.updateIdealState(_helixManager, tableConfig.getTableName(), updaterFunction,
+        RetryPolicies.exponentialBackoffRetryPolicy(5, 1000, 2.0f));
+    return _helixAdmin.getResourceIdealState(_helixClusterName, tableConfig.getTableName());
+  }
+
+  /**
+   * Uniformly distribute segments across servers in a replica group. It adopts a simple algorithm that pre-computes
+   * the number of segments per server after rebalance and tries to assign/remove segments to/from a server until it
+   * becomes to have the correct number of segments.
+   *
+   * @param serversInReplicaGroup A list of servers within the same replica group
+   * @param serverToSegments A Mapping of servers to their segments
+   */
+  private void rebalanceReplicaGroup(List<String> serversInReplicaGroup,
+      Map<String, LinkedList<String>> serverToSegments, Set<String> segmentsToCover) {
+    // Make sure that all the segments are covered only once within a replica group.
+    Set<String> currentCoveredSegments = new HashSet<>();
+    for (String server : serversInReplicaGroup) {
+      Iterator<String> segmentIter = serverToSegments.get(server).iterator();
+      while (segmentIter.hasNext()) {
+        String segment = segmentIter.next();
+        if (currentCoveredSegments.contains(segment)) {
+          segmentIter.remove();
+        } else {
+          currentCoveredSegments.add(segment);
+        }
+      }
+    }
+
+    // Compute the segments to add
+    LinkedList<String> segmentsToAdd = new LinkedList<>(segmentsToCover);
+    segmentsToAdd.removeAll(currentCoveredSegments);
+
+    // Compute the number of segments per server after rebalance than numSegmentsPerServer
+    int numSegmentsPerServer = segmentsToCover.size() / serversInReplicaGroup.size();
+
+    // Remove segments from servers that has more segments
+    for (String server : serversInReplicaGroup) {
+      LinkedList<String> segmentsInServer = serverToSegments.get(server);
+      int segmentToMove = numSegmentsPerServer - segmentsInServer.size();
+      if (segmentToMove < 0) {
+        // Server has more segments than needed, remove segments from this server
+        for (int i = 0; i < Math.abs(segmentToMove); i++) {
+          segmentsToAdd.add(segmentsInServer.pop());
+        }
+      }
+    }
+
+    // Add segments to servers that has less segments than numSegmentsPerServer
+    for (String server : serversInReplicaGroup) {
+      LinkedList<String> segmentsInServer = serverToSegments.get(server);
+      int segmentToMove = numSegmentsPerServer - segmentsInServer.size();
+      if (segmentToMove > 0) {
+        // Server has less segments than needed, add segments from this server
+        for (int i = 0; i < segmentToMove; i++) {
+          segmentsInServer.add(segmentsToAdd.pop());
+        }
+      }
+    }
+
+    // Handling the remainder of segments to add
+    int count = 0;
+    while (!segmentsToAdd.isEmpty()) {
+      int serverIndex = count % serversInReplicaGroup.size();
+      serverToSegments.get(serversInReplicaGroup.get(serverIndex)).add(segmentsToAdd.pop());
+      count++;
+    }
+  }
+
+  /**
+   * Build the mapping of servers to their associated segments given a mapping of segments to their associated servers.
+   * @param segmentToServerMapping a mapping of segments to its associated servers
+   * @return a mapping of a server to its associated segments
+   */
+  private Map<String, LinkedList<String>> buildServerToSegmentMapping(
+      Map<String, Map<String, String>> segmentToServerMapping) {
+    Map<String, LinkedList<String>> serverToSegments = new HashMap<>();
+    for (String segment : segmentToServerMapping.keySet()) {
+      for (String server : segmentToServerMapping.get(segment).keySet()) {
+        if (!serverToSegments.containsKey(server)) {
+          serverToSegments.put(server, new LinkedList<String>());
+        }
+        serverToSegments.get(server).add(segment);
+      }
+    }
+    return serverToSegments;
+  }
+
+  /**
+   * Build the mapping of segments to their associated servers given a mapping of servers to their associated segments.
+   * @param serverToSegments a mapping of servers to their associated segments
+   * @return a mapping of segments to their associated servers
+   */
+  private Map<String, Map<String, String>> buildSegmentToServerMapping(
+      Map<String, LinkedList<String>> serverToSegments) {
+    Map<String, Map<String, String>> segmentsToServerMapping = new HashMap<>();
+    for (Map.Entry<String, LinkedList<String>> entry : serverToSegments.entrySet()) {
+      String server = entry.getKey();
+      for (String segment : entry.getValue()) {
+        if (!segmentsToServerMapping.containsKey(segment)) {
+          segmentsToServerMapping.put(segment, new HashMap<String, String>());
+        }
+        segmentsToServerMapping.get(segment)
+            .put(server, CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel.ONLINE);
+      }
+    }
+    return segmentsToServerMapping;
+  }
+
+  public enum ReplicaGroupRebalanceType {
+    REPLACE, ADD_SERVER, ADD_REPLICA_GROUP, REMOVE_SERVER, REMOVE_REPLICA_GROUP, UNSUPPORTED
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceStrategyTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/rebalance/ReplicaGroupRebalanceStrategyTest.java
@@ -1,0 +1,320 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.rebalance;
+
+import com.linkedin.pinot.common.config.ReplicaGroupStrategyConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.partition.ReplicaGroupPartitionAssignment;
+import com.linkedin.pinot.common.partition.ReplicaGroupPartitionAssignmentGenerator;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.ZkStarter;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
+import com.linkedin.pinot.controller.helix.ControllerTest;
+import com.linkedin.pinot.controller.utils.ReplicaGroupTestUtils;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.plist.PropertyListConfiguration;
+import org.apache.helix.model.IdealState;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class ReplicaGroupRebalanceStrategyTest extends ControllerTest {
+  private static final int MIN_NUM_REPLICAS = 3;
+  private static final int NUM_BROKER_INSTANCES = 2;
+  private static final int NUM_SERVER_INSTANCES = 6;
+  private static final int INITIAL_NUM_SEGMENTS = 20;
+
+  private static final String TABLE_NAME = "testReplicaRebalanceReplace";
+  private final static String PARTITION_COLUMN = "memberId";
+  private final static String OFFLINE_TENENT_NAME = "DefaultTenant_OFFLINE";
+  private final static String NEW_SEGMENT_PREFIX = "new_segment_";
+
+  private final TableConfig.Builder _offlineBuilder = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE);
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    try {
+      startZk();
+      ControllerConf config = getDefaultControllerConfiguration();
+      config.setTableMinReplicas(MIN_NUM_REPLICAS);
+      startController(config);
+      ControllerRequestBuilderUtil.addFakeBrokerInstancesToAutoJoinHelixCluster(getHelixClusterName(),
+          ZkStarter.DEFAULT_ZK_STR, NUM_BROKER_INSTANCES, true);
+      ControllerRequestBuilderUtil.addFakeDataInstancesToAutoJoinHelixCluster(getHelixClusterName(),
+          ZkStarter.DEFAULT_ZK_STR, NUM_SERVER_INSTANCES, true);
+
+      _offlineBuilder.setTableName("testOfflineTable")
+          .setTimeColumnName("timeColumn")
+          .setTimeType("DAYS")
+          .setRetentionTimeUnit("DAYS")
+          .setRetentionTimeValue("5");
+
+      setUpTable();
+
+      // Join 4 more servers as untagged
+      String[] instanceNames = {"Server_localhost_a", "Server_localhost_b", "Server_localhost_c", "Server_localhost_d"};
+      for (String instanceName : instanceNames) {
+        ControllerRequestBuilderUtil.addFakeDataInstanceToAutoJoinHelixCluster(getHelixClusterName(),
+            ZkStarter.DEFAULT_ZK_STR, instanceName, true);
+        _helixAdmin.removeInstanceTag(getHelixClusterName(), instanceName, OFFLINE_TENENT_NAME);
+      }
+
+    } catch(Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopController();
+    stopZk();
+  }
+
+  @Test
+  public void testReplicaGroupRebalanceStrategy() throws Exception {
+    Configuration rebalanceUserConfig = new PropertyListConfiguration();
+    rebalanceUserConfig.setProperty(RebalanceUserConfigConstants.DRYRUN, false);
+
+    int numInstancesPerPartition = 3;
+    ReplicaGroupStrategyConfig replicaGroupStrategyConfig = new ReplicaGroupStrategyConfig();
+    replicaGroupStrategyConfig.setNumInstancesPerPartition(numInstancesPerPartition);
+    replicaGroupStrategyConfig.setMirrorAssignmentAcrossReplicaGroups(true);
+
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME);
+    TableConfig tableConfig = _helixResourceManager.getTableConfig(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE);
+    tableConfig.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
+    tableConfig.getValidationConfig().setSegmentAssignmentStrategy("ReplicaGroupSegmentAssignmentStrategy");
+    tableConfig.getValidationConfig().setReplication("2");
+
+    _helixResourceManager.setExistingTableConfig(tableConfig, tableNameWithType,
+        CommonConstants.Helix.TableType.OFFLINE);
+
+    // Test rebalancing after migration from non-replica to replica group table
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS));
+
+    // Upload 10 more segments and validate the segment assignment
+    addNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS + 10)) {
+      Thread.sleep(100);
+    }
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+
+    // Clean up new segments
+    removeNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS)) {
+      Thread.sleep(100);
+    }
+
+    // Test replace
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_0", OFFLINE_TENENT_NAME);
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_a", OFFLINE_TENENT_NAME);
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS));
+
+    // Upload 10 more segments and validate the segment assignment
+    addNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS + 10)) {
+      Thread.sleep(100);
+    }
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+
+    // Test replace again
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_a", OFFLINE_TENENT_NAME);
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_0", OFFLINE_TENENT_NAME);
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS + 10));
+
+    // Clean up new segments
+    removeNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS)) {
+      Thread.sleep(100);
+    }
+
+    // Test adding servers to each replica group
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_a", OFFLINE_TENENT_NAME);
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_b", OFFLINE_TENENT_NAME);
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_c", OFFLINE_TENENT_NAME);
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_d", OFFLINE_TENENT_NAME);
+
+    int targetNumInstancePerPartition = 5;
+    int targetNumReplicaGroup = 2;
+    updateTableConfig(targetNumInstancePerPartition, targetNumReplicaGroup);
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS));
+
+    // Test removing servers to each replica group
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_a", OFFLINE_TENENT_NAME);
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_d", OFFLINE_TENENT_NAME);
+    targetNumInstancePerPartition = 4;
+    targetNumReplicaGroup = 2;
+    updateTableConfig(targetNumInstancePerPartition, targetNumReplicaGroup);
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS));
+
+    // Upload 10 more segments and validate the segment assignment
+    addNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS + 10)) {
+      Thread.sleep(100);
+    }
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+
+    // Clean up new segments
+    removeNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS)) {
+      Thread.sleep(100);
+    }
+
+    // Test removing two more servers to each replica group with force run
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_b", OFFLINE_TENENT_NAME);
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_c", OFFLINE_TENENT_NAME);
+
+    targetNumInstancePerPartition = 3;
+    targetNumReplicaGroup = 2;
+    updateTableConfig(targetNumInstancePerPartition, targetNumReplicaGroup);
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS));
+
+    // Test adding a replica group
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_a", OFFLINE_TENENT_NAME);
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_b", OFFLINE_TENENT_NAME);
+    _helixAdmin.addInstanceTag(getHelixClusterName(), "Server_localhost_c", OFFLINE_TENENT_NAME);
+
+    targetNumInstancePerPartition = 3;
+    targetNumReplicaGroup = 3;
+    updateTableConfig(targetNumInstancePerPartition, targetNumReplicaGroup);
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS));
+
+    // Upload 10 more segments and validate the segment assignment
+    addNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS + 10)) {
+      Thread.sleep(100);
+    }
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+
+    // Clean up segments
+    removeNewSegments();
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS)) {
+      Thread.sleep(100);
+    }
+
+    // Test removing a replica group
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_0", OFFLINE_TENENT_NAME);
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_1", OFFLINE_TENENT_NAME);
+    _helixAdmin.removeInstanceTag(getHelixClusterName(), "Server_localhost_2", OFFLINE_TENENT_NAME);
+
+    targetNumInstancePerPartition = 3;
+    targetNumReplicaGroup = 2;
+    updateTableConfig(targetNumInstancePerPartition, targetNumReplicaGroup);
+    _helixResourceManager.rebalanceTable(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE, rebalanceUserConfig);
+    Assert.assertTrue(validateTableLevelReplicaGroupRebalance());
+    Assert.assertTrue(validateNumSegments(INITIAL_NUM_SEGMENTS));
+  }
+
+  private void addNewSegments() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      ReplicaGroupTestUtils.uploadSingleSegmentWithPartitionNumber(TABLE_NAME, NEW_SEGMENT_PREFIX + i, PARTITION_COLUMN,
+          _helixResourceManager);
+    }
+  }
+
+  private void removeNewSegments() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      _helixResourceManager.deleteSegment(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME),
+          NEW_SEGMENT_PREFIX + i);
+    }
+  }
+
+  private boolean validateNumSegments(int numSegments) {
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME);
+    IdealState idealState = _helixAdmin.getResourceIdealState(getHelixClusterName(), tableNameWithType);
+    return idealState.getRecord().getMapFields().keySet().size() == numSegments;
+  }
+
+  private boolean validateTableLevelReplicaGroupRebalance() {
+    TableConfig tableConfig = _helixResourceManager.getTableConfig(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME);
+    ReplicaGroupPartitionAssignmentGenerator partitionAssignmentGenerator =
+        new ReplicaGroupPartitionAssignmentGenerator(_propertyStore);
+    ReplicaGroupPartitionAssignment replicaGroupMapping =
+        partitionAssignmentGenerator.getReplicaGroupPartitionAssignment(tableNameWithType);
+    IdealState idealState = _helixAdmin.getResourceIdealState(getHelixClusterName(), tableNameWithType);
+    Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
+    Map<Integer, Set<String>> segmentsPerPartition = new HashMap<>();
+    segmentsPerPartition.put(0, segmentAssignment.keySet());
+    return ReplicaGroupTestUtils.validateReplicaGroupSegmentAssignment(tableConfig, replicaGroupMapping,
+        segmentAssignment, segmentsPerPartition);
+  }
+
+  private void setUpTable() throws Exception {
+    // Create table config
+    TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNumReplicas(2)
+        .setSegmentAssignmentStrategy("RandomAssignmentStrategy")
+        .build();
+
+    // Create the table and upload segments
+    _helixResourceManager.addTable(tableConfig);
+
+    // Wait for table addition
+    while (!_helixResourceManager.hasOfflineTable(TABLE_NAME)) {
+      Thread.sleep(100);
+    }
+
+    // Upload segments
+    ReplicaGroupTestUtils.uploadMultipleSegmentsWithPartitionNumber(TABLE_NAME, INITIAL_NUM_SEGMENTS, PARTITION_COLUMN,
+        _helixResourceManager, 1);
+    // Wait for all segments appear in the external view
+    while (!allSegmentsPushedToIdealState(TABLE_NAME, INITIAL_NUM_SEGMENTS)) {
+      Thread.sleep(100);
+    }
+  }
+
+  private boolean allSegmentsPushedToIdealState(String tableName, int segmentNum) {
+    IdealState idealState =
+        _helixAdmin.getResourceIdealState(getHelixClusterName(), TableNameBuilder.OFFLINE.tableNameWithType(tableName));
+    return idealState != null && idealState.getPartitionSet() != null
+        && idealState.getPartitionSet().size() == segmentNum;
+  }
+
+  private void updateTableConfig(int targetNumInstancePerPartition, int targetNumReplicaGroup) throws IOException {
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME);
+    TableConfig tableConfig = _helixResourceManager.getTableConfig(TABLE_NAME, CommonConstants.Helix.TableType.OFFLINE);
+    tableConfig.getValidationConfig()
+        .getReplicaGroupStrategyConfig()
+        .setNumInstancesPerPartition(targetNumInstancePerPartition);
+    tableConfig.getValidationConfig().setReplication(Integer.toString(targetNumReplicaGroup));
+    _helixResourceManager.setExistingTableConfig(tableConfig, tableNameWithType,
+        CommonConstants.Helix.TableType.OFFLINE);
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.linkedin.pinot.controller.helix.retention;
+package com.linkedin.pinot.controller.helix.core.retention;
 
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
@@ -26,7 +26,6 @@ import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.SegmentDeletionManager;
-import com.linkedin.pinot.controller.helix.core.retention.RetentionManager;
 import com.linkedin.pinot.controller.helix.core.util.ZKMetadataUtils;
 import java.io.IOException;
 import java.lang.reflect.Method;

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/utils/ReplicaGroupTestUtils.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/utils/ReplicaGroupTestUtils.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.controller.utils;
+
+import com.linkedin.pinot.common.config.ReplicaGroupStrategyConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.partition.ReplicaGroupPartitionAssignment;
+import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+public class ReplicaGroupTestUtils {
+  private static final String SEGMENT_PREFIX = "segment_";
+
+  private ReplicaGroupTestUtils() {
+  }
+
+  public static Map<Integer, Set<String>> uploadMultipleSegmentsWithPartitionNumber(String tableName, int numSegments,
+      String partitionColumn, PinotHelixResourceManager resourceManager, int numPartition) {
+    Map<Integer, Set<String>> segmentsPerPartition = new HashMap<>();
+    for (int i = 0; i < numSegments; ++i) {
+      int partition = i % numPartition;
+      String segmentName = SEGMENT_PREFIX + i;
+      SegmentMetadata segmentMetadata =
+          SegmentMetadataMockUtils.mockSegmentMetadataWithPartitionInfo(tableName, segmentName, partitionColumn, partition);
+      resourceManager.addNewSegment(segmentMetadata, "downloadUrl");
+      if (!segmentsPerPartition.containsKey(partition)) {
+        segmentsPerPartition.put(partition, new HashSet<String>());
+      }
+      segmentsPerPartition.get(partition).add(segmentName);
+    }
+    return segmentsPerPartition;
+  }
+
+  public static void uploadSingleSegmentWithPartitionNumber(String tableName, String segmentName,
+      String partitionColumn, PinotHelixResourceManager resourceManager) {
+    SegmentMetadata segmentMetadata =
+        SegmentMetadataMockUtils.mockSegmentMetadataWithPartitionInfo(tableName, segmentName, partitionColumn, 0);
+    resourceManager.addNewSegment(segmentMetadata, "downloadUrl");
+  }
+
+  /**
+   * Validate if the segment assignments satisfies the conditions for the replica group configuration
+   *
+   * @param tableConfig Table config
+   * @param replicaGroupMapping Replica group server mapping
+   * @param segmentAssignment Segment assignment to validate
+   * @return True if the given segment assignment satisfies the condition for replica group segment assignment.
+   *         False otherwise
+   */
+  public static boolean validateReplicaGroupSegmentAssignment(TableConfig tableConfig,
+      ReplicaGroupPartitionAssignment replicaGroupMapping, Map<String, Map<String, String>> segmentAssignment,
+      Map<Integer, Set<String>> segmentsPerPartition) {
+    ReplicaGroupStrategyConfig replicaGroupConfig = tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
+
+    // Create the server to segments mapping
+    Map<String, List<String>> serverToSegments = new HashMap<>();
+    for (String server: replicaGroupMapping.getAllInstances()) {
+      serverToSegments.put(server, new ArrayList<String>());
+    }
+
+    for (Map.Entry<String, Map<String, String>> entry: segmentAssignment.entrySet()) {
+      String segment = entry.getKey();
+      for (String server: entry.getValue().keySet()) {
+        if (!serverToSegments.containsKey(server)) {
+          serverToSegments.put(server, new ArrayList<String>());
+        }
+        serverToSegments.get(server).add(segment);
+      }
+    }
+
+    // Build the mapping from partition to a list of all segments for that partition
+    int numPartitions = replicaGroupMapping.getNumPartitions();
+    int numReplicaGroups = replicaGroupMapping.getNumReplicaGroups();
+
+    // Check if the servers in a replica group covers all segments
+    for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
+      for (int replicaId = 0; replicaId < numReplicaGroups; replicaId++) {
+        List<String> replicaGroup = replicaGroupMapping.getInstancesfromReplicaGroup(partitionId, replicaId);
+        Set<String> replicaGroupSegments = new HashSet<>();
+        for (String server: replicaGroup) {
+          for (String segment: serverToSegments.get(server)) {
+            if (segmentsPerPartition.get(partitionId).contains(segment)) {
+              if (!replicaGroupSegments.contains(segment)) {
+                replicaGroupSegments.add(segment);
+              } else {
+                // Each replica group needs to cover a segment only for once
+                return false;
+              }
+            }
+          }
+        }
+        if (!segmentsPerPartition.get(partitionId).equals(replicaGroupSegments)) {
+          return false;
+        }
+      }
+    }
+
+    // If mirroring is enabled, need to check if servers with the same index contains the same segment
+    if (replicaGroupConfig.getMirrorAssignmentAcrossReplicaGroups()) {
+      for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
+        for (int serverIndex = 0; serverIndex < replicaGroupConfig.getNumInstancesPerPartition(); serverIndex++) {
+          Set<String> mirrorSegments = new HashSet<>();
+          for (int replicaId = 0; replicaId < numReplicaGroups; replicaId++) {
+            List<String> replicaGroup = replicaGroupMapping.getInstancesfromReplicaGroup(partitionId, replicaId);
+            String server = replicaGroup.get(serverIndex);
+            Set<String> currentSegments = new HashSet<>(serverToSegments.get(server));
+            mirrorSegments.addAll(currentSegments);
+            if (!mirrorSegments.equals(currentSegments)) {
+              return false;
+            }
+          }
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/utils/SegmentMetadataMockUtils.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/utils/SegmentMetadataMockUtils.java
@@ -17,8 +17,14 @@ package com.linkedin.pinot.controller.utils;
 
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
+import com.linkedin.pinot.core.segment.index.ColumnMetadata;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang.math.IntRange;
 import org.mockito.Mockito;
 
+import static org.mockito.Mockito.*;
 
 public class SegmentMetadataMockUtils {
   private SegmentMetadataMockUtils() {
@@ -54,5 +60,22 @@ public class SegmentMetadataMockUtils {
     Mockito.when(realtimeSegmentZKMetadata.getSegmentName()).thenReturn(segmentName);
     Mockito.when(realtimeSegmentZKMetadata.getTotalRawDocs()).thenReturn(numTotalDocs);
     return realtimeSegmentZKMetadata;
+  }
+
+  public static SegmentMetadata mockSegmentMetadataWithPartitionInfo(String tableName, String segmentName,
+      String columnName, int partitionNumber) {
+    ColumnMetadata columnMetadata = mock(ColumnMetadata.class);
+    List<IntRange> partitionRanges = new ArrayList<>();
+    partitionRanges.add(new IntRange(partitionNumber));
+    when(columnMetadata.getPartitionRanges()).thenReturn(partitionRanges);
+
+    SegmentMetadataImpl segmentMetadata = mock(SegmentMetadataImpl.class);
+    if (columnName != null) {
+      when(segmentMetadata.getColumnMetadataFor(columnName)).thenReturn(columnMetadata);
+    }
+    when(segmentMetadata.getTableName()).thenReturn(tableName);
+    when(segmentMetadata.getName()).thenReturn(segmentName);
+    when(segmentMetadata.getCrc()).thenReturn("0");
+    return segmentMetadata;
   }
 }


### PR DESCRIPTION
Tables with replica group segment assignment need its own way
to rebalance the table because we have more conditions to meet
when assigning segments. Replica group rebalancer supports
the following scenarios:
  1. Replacing servers
  2. Add/remove servers from each replica group
  3. Add/remove replica groups