### PR TITLE
[TE] rootcause - fine-grained loading

### DIFF
--- a/thirdeye/thirdeye-frontend/app/mocks/filterBarConfig.js
+++ b/thirdeye/thirdeye-frontend/app/mocks/filterBarConfig.js
@@ -8,11 +8,13 @@
  *    a. label {string} - displayed name for the input
  *    b. labelMapping {string} - key value of label in the payload's attribute object that maps to the label
  *    c. type {string} - input type (i.e. dropdown, checkbox, drag)
+ *  5. framework {string} rca framework name for loading indicator
  */
 export default [
   {
     header: "Holidays",
     eventType: "holiday",
+    framework: "eventHoliday",
     color: "green",
     inputs: [
       {
@@ -25,6 +27,7 @@ export default [
   {
     header: "GCN",
     eventType: "gcn",
+    framework: "eventIssue",
     color: "orange",
     inputs: [
       {
@@ -47,6 +50,7 @@ export default [
   {
     header: "LiX",
     eventType: "lix",
+    framework: "eventExperiment",
     color: "purple",
     inputs: [
       {
@@ -69,6 +73,7 @@ export default [
   {
     header: "Deployments",
     eventType: "informed",
+    framework: "eventDeployment",
     color: "red",
     inputs: [
       {
@@ -91,6 +96,7 @@ export default [
   {
     header: "Anomalies",
     eventType: "anomaly",
+    framework: "eventAnomaly",
     color: "teal",
     inputs: [
       {

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/component.js
@@ -49,6 +49,12 @@ export default Component.extend({
   urnsCache: {},
 
   /**
+   * Set of frameworks currently loading
+   * @type {Set}
+   */
+  loadingFrameworks: {},
+
+  /**
    * Overwrite the init function
    * Initializes values of the filter blocks
    * Example of a filter block:

--- a/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/filter-bar/template.hbs
@@ -3,7 +3,13 @@
     <section class="filter-bar__group">
       <h5 class="filter-bar__group-title {{if block.isHidden "" "filter-bar__group-title--active "}}" {{action 'selectEventType' block.eventType}}>
         <div class="filter-bar__indicator">
-          <span class="entity-indicator entity-indicator--{{block.color}}"></span>
+          {{#if (set-has loadingFrameworks block.framework)}}
+            <span class="filter-bar--spinner">
+              {{ember-spinner scale=0.5}}
+            </span>
+          {{else}}
+            <span class="entity-indicator entity-indicator--{{block.color}}"></span>
+          {{/if}}
         </div>
         <div class="filter-bar__header">
           <span>{{block.header}} ({{get eventTypeMap block.eventType}})</span>

--- a/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
@@ -27,7 +27,9 @@ export default Component.extend({
       propertyName: 'score',
       title: 'Anomalous',
       disableFiltering: true,
-      className: 'rootcause-metric__table__column rootcause-metric__table__links-column--small'
+      className: 'rootcause-metric__table__column rootcause-metric__table__links-column--small',
+      sortPrecedence: 0,
+      sortDirection: 'desc'
     }, {
       propertyName: 'wo1w',
       template: 'custom/metrics-table-changes/wo1w',

--- a/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/metrics-table/component.js
@@ -1,9 +1,11 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { makeSortable, toMetricLabel, toColorDirection, isInverse } from 'thirdeye-frontend/utils/rca-utils';
+import { humanizeScore } from 'thirdeye-frontend/utils/utils';
 
 export default Component.extend({
   classNames: ['metrics-table'],
+
   /**
    * Columns for metrics table
    * @type Object[]
@@ -58,6 +60,48 @@ export default Component.extend({
   ],
 
   /**
+   * Metric urns in sorted order
+   * @type {string}
+   */
+  urns: null,
+
+  /**
+   * Entities cache
+   * @type {object}
+   */
+  entities: null,
+
+  /**
+   * Relative changes from offset to current
+   * @type {object}
+   */
+  changesOffset: null,
+
+  /**
+   * Formatted strings for changesOffset
+   * @type {object}
+   */
+  changesOffsetFormatted: null,
+
+  /**
+   * User-selected urns
+   * @type {Set}
+   */
+  selectedUrns: null,
+
+  /**
+   * (External) links for metric labels
+   * @type {object}
+   */
+  links: null,
+
+  /**
+   * Scores for metric entities
+   * @type {object}
+   */
+  scores: null,
+
+  /**
    * Data for metrics table
    * @type Object[] - array of objects, each corresponding to a row in the table
    */
@@ -66,10 +110,12 @@ export default Component.extend({
     'selectedUrns',
     'entities',
     'changesOffset',
+    'changesOffsetFormatted',
     'links',
+    'scores',
     function() {
-      const { urns, entities, changesOffset, selectedUrns, links } =
-        this.getProperties('urns', 'entities', 'changesOffset', 'selectedUrns', 'links');
+      const { urns, entities, changesOffset, selectedUrns, links, scores } =
+        this.getProperties('urns', 'entities', 'changesOffset', 'selectedUrns', 'links', 'scores');
 
       return urns.map(urn => {
         return {
@@ -77,7 +123,7 @@ export default Component.extend({
           links: links[urn],
           isSelected: selectedUrns.has(urn),
           label: toMetricLabel(urn, entities),
-          score: entities[urn].score.toFixed(2),
+          score: humanizeScore(scores[urn]),
           wo1w: this._makeRecord('wo1w', urn),
           wo2w: this._makeRecord('wo2w', urn),
           wo3w: this._makeRecord('wo3w', urn),

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -15,12 +15,35 @@ export default Ember.Component.extend({
   //
   // external properties
   //
-  entities: null, // {}
 
-  aggregates: null, // {}
+  /**
+   * Entities cache
+   * @type {object}
+   */
+  entities: null,
 
-  selectedUrns: null, // Set
+  /**
+   * Metric aggregates
+   * @type {object}
+   */
+  aggregates: null,
 
+  /**
+   * (Metric) entity scores
+   * @type {object}
+   */
+  scores: null,
+
+  /**
+   * User-selected urns
+   * @type {Set}
+   */
+  selectedUrns: null,
+
+  /**
+   * Callback on metric selection
+   * @type {function}
+   */
   onSelection: null, // function (Set, state)
 
   //

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/component.js
@@ -242,21 +242,6 @@ export default Ember.Component.extend({
   ),
 
   /**
-   * Anomalyity scores, keyed by metric urn
-   */
-  scores: Ember.computed(
-    'entities',
-    function () {
-      const { entities } = this.getProperties('entities');
-      return filterPrefix(Object.keys(entities), ['thirdeye:metric:'])
-        .reduce((agg, urn) => {
-          agg[urn] = entities[urn].score.toFixed(2);
-          return agg;
-        }, {});
-    }
-  ),
-
-  /**
    * Trend direction label (positive, neutral, negative) for change values
    * @type {Object}
    */

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
@@ -45,6 +45,7 @@
   {{metrics-table
     urns=urns
     links=links
+    scores=scores
     selectedUrns=selectedUrns
     entities=entities
     changesOffset=changesOffset

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-metrics/template.hbs
@@ -1,14 +1,19 @@
 <div class="row">
-  {{#if (eq selectedView "card")}}
-    <div class="col-xs-8">
+  <div class="col-xs-4">
+    {{#if (eq selectedView "card")}}
       sort
       | <a {{action "toggleSort" "metric"}}>metric</a>
       | <a {{action "toggleSort" "dataset"}}>dataset</a>
       | <a {{action "toggleSort" "change"}}>change</a>
       | <a {{action "toggleSort" "score"}}>score</a>
-    </div>
-  {{/if}}
-  <div class="col-xs-4 pull-right">
+    {{/if}}
+  </div>
+  <div class="col-xs-4">
+    {{#if isLoading}}
+      <span class="rootcause-metric-spinner">{{ember-spinner scale=0.5}}</span>
+    {{/if}}
+  </div>
+  <div class="col-xs-4">
     <ul class="rootcause-metric__display-view">
       <li class="rootcause-metric__display-option rootcause-metric__display-option--{{if (eq selectedView "table") "active"}}" {{action "selectView" 'table'}}>
         Table

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -38,7 +38,7 @@ export default Ember.Service.extend({
           .then(checkStatus)
           .then(this._jsonToEntities)
           .then(incoming => this._complete(requestContext, urns, incoming, 'identity'));
-          // .catch(error => this._handleError('identity', error));
+          .catch(error => this._handleError('identity', error));
       }
     }
 
@@ -60,7 +60,7 @@ export default Ember.Service.extend({
           .then(checkStatus)
           .then(this._jsonToEntities)
           .then(incoming => this._complete(requestContext, urns, incoming, framework));
-          // .catch(error => this._handleError(framework, error));
+          .catch(error => this._handleError(framework, error));
       });
     }
   },

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-entities-cache/service.js
@@ -37,7 +37,7 @@ export default Ember.Service.extend({
         fetch(this._makeIdentityUrl(requestNativeUrns))
           .then(checkStatus)
           .then(this._jsonToEntities)
-          .then(incoming => this._complete(requestContext, urns, incoming, 'identity'));
+          .then(incoming => this._complete(requestContext, urns, incoming, 'identity'))
           .catch(error => this._handleError('identity', error));
       }
     }
@@ -59,7 +59,7 @@ export default Ember.Service.extend({
         fetch(this._makeUrl(framework, requestContext))
           .then(checkStatus)
           .then(this._jsonToEntities)
-          .then(incoming => this._complete(requestContext, urns, incoming, framework));
+          .then(incoming => this._complete(requestContext, urns, incoming, framework))
           .catch(error => this._handleError(framework, error));
       });
     }
@@ -102,22 +102,6 @@ export default Ember.Service.extend({
     newPending.delete(framework);
 
     this.setProperties({ entities: newEntities, pending: newPending });
-  },
-
-  _trimRanges(anomalyRange, analysisRange) {
-    // trim anomaly range from start of anomaly range forward
-    const newAnomalyDuration = Math.min(anomalyRange[1] - anomalyRange[0], ROOTCAUSE_ANOMALY_DURATION_MAX);
-    const newAnomalyRange = [anomalyRange[0], anomalyRange[0] + newAnomalyDuration];
-
-    // trim analysis range from end of anomaly range backward
-    const newAnalysisDuration = Math.min(analysisRange[1] - analysisRange[0], ROOTCAUSE_ANALYSIS_DURATION_MAX);
-    const newAnalysisRangeStart = Math.max(analysisRange[0], anomalyRange[1] - newAnalysisDuration);
-    const newAnalysisRange = [newAnalysisRangeStart, anomalyRange[1]];
-
-    return Object.assign({}, {
-      anomalyRange: newAnomalyRange,
-      analysisRange: newAnalysisRange
-    });
   },
 
   _evictionCandidates(entities, framework) {

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-scores-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-scores-cache/service.js
@@ -1,0 +1,115 @@
+import Ember from 'ember';
+import { trimTimeRanges, filterPrefix, toBaselineRange } from 'thirdeye-frontend/utils/rca-utils';
+import { checkStatus } from 'thirdeye-frontend/utils/utils';
+import fetch from 'fetch';
+import _ from 'lodash';
+
+export default Ember.Service.extend({
+  scores: null, // {}
+
+  context: null, // {}
+
+  pending: null, // Set
+
+  errors: null, // Set({ urn, error })
+
+  init() {
+    this.setProperties({ scores: {}, context: {}, pending: new Set(), errors: new Set() });
+  },
+
+  clearErrors() {
+    this.setProperties({ errors: new Set() });
+  },
+
+  request(requestContext, urns) {
+    const { context, scores, pending } = this.getProperties('context', 'scores', 'pending');
+
+    const metrics = [...urns].filter(urn => urn.startsWith('thirdeye:metric:'));
+
+    // TODO eviction on cache size limit
+
+    let missing;
+    let newPending;
+    let newScores;
+    if(!_.isEqual(context, requestContext)) {
+      // new analysis range: evict all, reload, keep stale copy of incoming
+      missing = metrics;
+      newPending = new Set(metrics);
+      newScores = metrics.filter(urn => urn in scores).reduce((agg, urn) => { agg[urn] = scores[urn]; return agg; }, {});
+
+    } else {
+      // same context: load missing
+      missing = metrics.filter(urn => !(urn in scores) && !pending.has(urn));
+      newPending = new Set([...pending].concat(missing));
+      newScores = scores;
+    }
+
+    this.setProperties({ context: _.cloneDeep(requestContext), scores: newScores, pending: newPending });
+
+    if (_.isEmpty(missing)) {
+      // console.log('rootcauseScoresService: request: all metrics up-to-date. ignoring.');
+      return;
+    }
+
+    // metrics
+    fetch(this._makeUrl('metricAnalysis', requestContext, missing))
+      .then(checkStatus)
+      .then(res => this._extractScores(res, missing))
+      .then(res => this._complete(requestContext, res))
+      .catch(error => this._handleError(missing, error));
+  },
+
+  _complete(requestContext, incoming) {
+    const { context, pending, scores } = this.getProperties('context', 'pending', 'scores');
+
+    // only accept latest result
+    if (!_.isEqual(context, requestContext)) {
+      // console.log('rootcauseScoresService: _complete: received stale result. ignoring.');
+      return;
+    }
+
+    const newPending = new Set([...pending].filter(urn => !(urn in incoming)));
+    const newScores = Object.assign({}, scores, incoming);
+
+    this.setProperties({ scores: newScores, pending: newPending });
+  },
+
+  _makeUrl(framework, context, urns) {
+    const urnString = filterPrefix(urns, 'thirdeye:metric:').map(encodeURIComponent).join(',');
+    const ranges = trimTimeRanges(context.anomalyRange, context.analysisRange);
+
+    const baselineRange = toBaselineRange(ranges.anomalyRange, context.compareMode);
+    return `/rootcause/query?framework=${framework}` +
+      `&anomalyStart=${ranges.anomalyRange[0]}&anomalyEnd=${ranges.anomalyRange[1]}` +
+      `&baselineStart=${baselineRange[0]}&baselineEnd=${baselineRange[1]}` +
+      `&analysisStart=${ranges.analysisRange[0]}&analysisEnd=${ranges.analysisRange[1]}` +
+      `&urns=${urnString}`;
+  },
+
+  _extractScores(res, urns) {
+    if (_.isEmpty(res)) {
+      return {};
+    }
+    const template = [...urns].reduce((agg, urn) => {
+      agg[urn] = Number.NaN;
+      return agg;
+    }, {});
+    const results = res.reduce((agg, e) => {
+      agg[e.urn] = e.score;
+      return agg;
+    }, {});
+    return Object.assign(template, results);
+  },
+
+  _handleError(urns, error) {
+    const { errors, pending } = this.getProperties('errors', 'pending');
+
+    const newError = urns;
+    const newErrors = new Set([...errors, newError]);
+
+    const newPending = new Set(pending);
+    [...urns].forEach(urn => newPending.delete(urn));
+
+    this.setProperties({ errors: newErrors, pending: newPending });
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -373,10 +373,14 @@ export default Ember.Controller.extend({
 
   isLoadingTimeseries: Ember.computed.gt('timeseriesService.pending.size', 0),
 
-  isLoadingAggregates: Ember.computed.or('aggregatesService.pending.size', 'entitiesService.pending.size'),
+  isLoadingAggregates: Ember.computed.gt('aggregatesService.pending.size', 0),
 
   isLoadingBreakdowns: Ember.computed.gt('breakdownsService.pending.size', 0),
-
+  
+  isLoadingScores: Ember.computed.gt('scoresService.pending.size', 0),
+  
+  loadingFrameworks: Ember.computed.reads('entitiesService.pending'),
+  
   //
   // error indicators
   //
@@ -390,11 +394,14 @@ export default Ember.Controller.extend({
 
   hasErrorsBreakdowns: Ember.computed.gt('breakdownsService.errors.size', 0),
 
+  hasErrorsScores: Ember.computed.gt('scoresService.errors.size', 0),
+
   hasServiceErrors: Ember.computed.or(
     'hasErrorsEntities',
     'hasErrorsTimeseries',
     'hasErrorsAggregates',
-    'hasErrorsBreakdowns'
+    'hasErrorsBreakdowns',
+    'hasErrorsScores'
   ),
 
   //

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -50,6 +50,8 @@ export default Ember.Controller.extend({
 
   breakdownsService: Ember.inject.service('rootcause-breakdowns-cache'),
 
+  scoresService: Ember.inject.service('rootcause-scores-cache'),
+
   sessionService: Ember.inject.service('rootcause-session-datasource'),
 
   //
@@ -196,6 +198,9 @@ export default Ember.Controller.extend({
    *
    * breakdowns:   de-aggregated metric values over multiple time windows (anomaly, baseline, ...)
    *               (typically displayed in dimension heatmap)
+   * 
+   * scores:       entity scores as computed by backend pipelines (e.g. metric anomality score)
+   *               (typically displayed in metrics table)
    */
   _contextObserver: Ember.observer(
     'context',
@@ -207,8 +212,8 @@ export default Ember.Controller.extend({
     'breakdownsService',
     'activeTab',
     function () {
-      const { context, selectedUrns, entitiesService, timeseriesService, aggregatesService, breakdownsService, activeTab } =
-        this.getProperties('context', 'selectedUrns', 'entitiesService', 'timeseriesService', 'aggregatesService', 'breakdownsService', 'activeTab');
+      const { context, selectedUrns, entitiesService, timeseriesService, aggregatesService, breakdownsService, scoresService, activeTab } =
+        this.getProperties('context', 'selectedUrns', 'entitiesService', 'timeseriesService', 'aggregatesService', 'breakdownsService', 'scoresService', 'activeTab');
 
       if (!context || !selectedUrns) {
         return;
@@ -249,6 +254,11 @@ export default Ember.Controller.extend({
         .reduce((agg, l) => agg.concat(l), []);
 
       aggregatesService.request(context, new Set(offsetUrns));
+      
+      // scores
+      const scoresUrns = aggregatesUrns;
+      
+      scoresService.request(context, new Set(scoresUrns));
     }
   ),
 
@@ -275,6 +285,11 @@ export default Ember.Controller.extend({
    * Subscribed breakdowns cache
    */
   breakdowns: Ember.computed.reads('breakdownsService.breakdowns'),
+
+  /**
+   * Subscribed scores cache
+   */
+  scores: Ember.computed.reads('scoresService.scores'),
 
   /**
    * Primary metric urn for rootcause search

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -183,7 +183,7 @@
               {{/if}}
 
               {{#if (eq activeTab "metrics")}}
-                {{#if isLoadingAggregates}}
+                {{#if (set-has loadingFrameworks "metricRelated")}}
                   <div class="spinner-wrapper spinner-wrapper--card">
                     {{ember-spinner}}
                   </div>
@@ -194,6 +194,7 @@
                   aggregates=aggregates
                   scores=scores
                   selectedUrns=selectedUrns
+                  isLoading=(or isLoadingAggregates isLoadingScores)
                   onSelection=(action "onSelection")
                 }}
               {{/if}}
@@ -204,16 +205,11 @@
                     {{filter-bar
                       config=filterConfig
                       entities=eventFilterEntities
+                      loadingFrameworks=loadingFrameworks
                       onFilter=(action "onFilter")}}
                   </div>
 
                   <div class="col-xs-9">
-                    {{#if isLoadingEntities}}
-                      <div class="spinner-wrapper spinner-wrapper--card">
-                        {{ember-spinner}}
-                      </div>
-                    {{/if}}
-
                     {{rootcause-table
                       entities=eventTableEntities
                       columns=eventTableColumns

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -192,6 +192,7 @@
                 {{rootcause-metrics
                   entities=entities
                   aggregates=aggregates
+                  scores=scores
                   selectedUrns=selectedUrns
                   onSelection=(action "onSelection")
                 }}

--- a/thirdeye/thirdeye-frontend/app/styles/components/filter-bar.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/filter-bar.scss
@@ -8,7 +8,7 @@
       border-top: 1px solid $te-grey--border;
     }
   }
-  
+
   &__group-title {
     padding: 15px $te-default-element-spacing;
     margin-top: 0px;
@@ -54,6 +54,12 @@
     &--hidden {
       display: none;
     }
+  }
+
+  &--spinner {
+    position: relative;
+    width: 10px;
+    margin-right: 10px;
   }
 }
 

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-metric.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-metric.scss
@@ -91,4 +91,8 @@
       color: $te-red;
     }
   }
+
+  &--spinner {
+    position: relative;
+  }
 }

--- a/thirdeye/thirdeye-frontend/app/utils/utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/utils.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import Ember from 'ember';
 
 /**
  * The Promise returned from fetch() won't reject on HTTP error status even if the response is an HTTP 404 or 500.
@@ -31,7 +32,7 @@ export function checkStatus(response, mode = 'get', recoverBlank = false) {
  * Formatter for the human-readable floating point numbers numbers
  */
 export function humanizeFloat(f) {
-  if (Number.isNaN(f)) { return '-'; }
+  if (Ember.isNone(f) || Number.isNaN(f)) { return '-'; }
   const fixed = Math.max(3 - Math.max(Math.floor(Math.log10(f)) + 1, 0), 0);
   return f.toFixed(fixed);
 }
@@ -40,7 +41,7 @@ export function humanizeFloat(f) {
  * Formatter for the human-readable change values in percent with 1 decimal
  */
 export function humanizeChange(f) {
-  if (Number.isNaN(f)) { return '-'; }
+  if (Ember.isNone(f) || Number.isNaN(f)) { return '-'; }
   return `${f > 0 ? '+' : ''}${(Math.round(f * 1000) / 10.0).toFixed(1)}%`;
 }
 
@@ -48,7 +49,7 @@ export function humanizeChange(f) {
  * Formatter for human-readable entity scores with 2 decimals
  */
 export function humanizeScore(f) {
-  if (f === null || f === undefined ||Number.isNaN(f)) { return '-'; }
+  if (Ember.isNone(f) || Number.isNaN(f)) { return '-'; }
   return f.toFixed(2);
 }
 

--- a/thirdeye/thirdeye-frontend/app/utils/utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/utils.js
@@ -45,6 +45,14 @@ export function humanizeChange(f) {
 }
 
 /**
+ * Formatter for human-readable entity scores with 2 decimals
+ */
+export function humanizeScore(f) {
+  if (f === null || f === undefined ||Number.isNaN(f)) { return '-'; }
+  return f.toFixed(2);
+}
+
+/**
  * Helps with shorthand for repetitive date generation
  */
 export function buildDateEod(unit, type) {
@@ -94,6 +102,7 @@ export default {
   checkStatus,
   humanizeFloat,
   humanizeChange,
+  humanizeScore,
   parseProps,
   postProps,
   toIso

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/DataResource.java
@@ -179,6 +179,12 @@ public class DataResource {
       Set<String> aliasParts = new HashSet<>(Arrays.asList(name.split("\\s+")));
       metricConfigs = metricConfigDAO.findWhereAliasLikeAndActive(aliasParts);
     }
+    Collections.sort(metricConfigs, new Comparator<MetricConfigDTO>() {
+      @Override
+      public int compare(MetricConfigDTO o1, MetricConfigDTO o2) {
+        return o1.getAlias().compareTo(o2.getAlias());
+      }
+    });
     return metricConfigs;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/MetricEntityFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/MetricEntityFormatter.java
@@ -2,7 +2,6 @@ package com.linkedin.thirdeye.dashboard.resources.v2.rootcause;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import com.linkedin.thirdeye.api.TimeRange;
 import com.linkedin.thirdeye.dashboard.resources.v2.ResourceUtils;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseEntityFormatter;
 import com.linkedin.thirdeye.dashboard.resources.v2.pojo.RootCauseEntity;
@@ -18,12 +17,14 @@ import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
 import com.linkedin.thirdeye.rootcause.impl.TimeRangeEntity;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import scala.Int;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class MetricEntityFormatter extends RootCauseEntityFormatter {
+  private static final Logger LOG = LoggerFactory.getLogger(MetricEntityFormatter.class);
+
   private static final long SLICE_START_OFFSET = TimeUnit.DAYS.toMillis(7);
 
   private static final Map<String, Integer> TIME_RANGE_PRIORITY = new HashMap<>();
@@ -64,7 +65,14 @@ public class MetricEntityFormatter extends RootCauseEntityFormatter {
     MetricEntity e = (MetricEntity) entity;
 
     MetricConfigDTO metric = this.metricDAO.findById(e.getId());
+    if (metric == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve metric id %d", e.getId()));
+    }
+
     DatasetConfigDTO dataset = this.datasetDAO.findByDataset(metric.getDataset());
+    if (dataset == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for metric id %d", metric.getDataset(), metric.getId()));
+    }
 
     Multimap<String, String> attributes = ArrayListMultimap.create();
     attributes.put(ATTR_DATASET, metric.getDataset());


### PR DESCRIPTION
The existing RCA pipeline processes related events and metrics in a single pass, which leads to sluggish responsiveness as the UI only renders when everything is done processing. This PR breaks up the pipeline into separate parts and introduces granular loading indicators. It furthermore separates (fast) resolving related metrics, and (slow) ranking of related metrics.

![grnular_loading_events](https://user-images.githubusercontent.com/25439965/36129063-2e44d972-101a-11e8-9875-3dbd39ae8038.png)
