### PR TITLE
[TE] datasource - use dataset maxtime when fetching filters from pinot

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
@@ -47,8 +47,15 @@ public class PinotDataSourceDimensionFilters {
    * @return dimension filters map
    */
   public Map<String, List<String>> getDimensionFilters(String dataset) {
-    DateTime startDateTime = new DateTime(System.currentTimeMillis()).minusDays(7);
-    DateTime endDateTime = new DateTime(System.currentTimeMillis());
+    long maxTime = System.currentTimeMillis();
+    try {
+      maxTime = this.pinotThirdEyeDataSource.getMaxDataTime(dataset);
+    } catch (Exception e) {
+      // left blank
+    }
+
+    DateTime endDateTime = new DateTime(maxTime);
+    DateTime startDateTime = endDateTime.minusDays(7);
 
     Map<String, List<String>> filters = null;
     try {


### PR DESCRIPTION
TE uses a fixed offset to the current timestamp to determine the time range for retrieving dimension names/values for a dataset. if the dataset does not contain data (or the server time is off) no filters are read. this PR changes the behavior to fetch data based on the latest available timestamp in the dataset instead.