### PR TITLE
Add failure message in entity of response from uploadSegment

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -236,11 +236,11 @@ public class FileUploadDownloadClient implements Closeable {
       controllerVersion = response.getFirstHeader(CommonConstants.Controller.VERSION_HTTP_HEADER).getValue();
     }
     StatusLine statusLine = response.getStatusLine();
-    String message = null;
+    String message;
     try {
       message = EntityUtils.toString(response.getEntity());
     } catch (Exception e) {
-      // ignore
+      message = "No message";
     }
     String errorMessage =
         String.format("Got error status code: %d with reason: %s while sending request: %s\nMessage: %s", statusLine.getStatusCode(),

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/FileUploadDownloadClient.java
@@ -51,6 +51,7 @@ import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 
 public class FileUploadDownloadClient implements Closeable {
@@ -235,9 +236,15 @@ public class FileUploadDownloadClient implements Closeable {
       controllerVersion = response.getFirstHeader(CommonConstants.Controller.VERSION_HTTP_HEADER).getValue();
     }
     StatusLine statusLine = response.getStatusLine();
+    String message = null;
+    try {
+      message = EntityUtils.toString(response.getEntity());
+    } catch (Exception e) {
+      // ignore
+    }
     String errorMessage =
-        String.format("Got error status code: %d with reason: %s while sending request: %s", statusLine.getStatusCode(),
-            statusLine.getReasonPhrase(), request.getURI());
+        String.format("Got error status code: %d with reason: %s while sending request: %s\nMessage: %s", statusLine.getStatusCode(),
+            statusLine.getReasonPhrase(), request.getURI(), message);
     if (controllerHost != null) {
       errorMessage =
           String.format("%s to controller: %s, version: %s", errorMessage, controllerHost, controllerVersion);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerApplicationException.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/ControllerApplicationException.java
@@ -36,7 +36,7 @@ class ControllerApplicationException extends WebApplicationException {
   }
 
   ControllerApplicationException(Logger logger, String message, int status, @Nullable Throwable e) {
-    super(message, status);
+    super(Response.status(status).entity(message).build());
     if (status >= 300 && status < 500) {
       if (e == null) {
         logger.info(message);


### PR DESCRIPTION
The failure message was not being propagated from controller to the client. Client received only status code and status reason, which are insufficient indicators of the failure. Passing the failure message in the response entity

`
com.linkedin.pinot.common.exception.HttpErrorStatusException: Got error status code: 403 with reason: Forbidden while sending request: http://localhost:8100/segments
Message: Quota check failed for segment: test_segment_0 of table: test_table_OFFLINE, reason: Estimated size: 140649 bytes exceeds the configured quota of 1024 (bytes) for table test_table_OFFLINE. Incoming segment size: 140650 (bytes) to controller: xxxx, version: Unknown
`
