### PR TITLE
Implementations for off-heap FixedIntArray<->Integer map, and single-value multi-column reader/writer.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/SingleValueMultiColumnReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/SingleValueMultiColumnReader.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.io.reader;
+
+/**
+ * Interface for reader for Single Value and Multiple Columns.
+ *
+ * @param <T>
+ */
+public interface SingleValueMultiColumnReader<T extends ReaderContext> extends DataFileReader<T> {
+
+  /**
+   * Get the char at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @return Char value at (row, column)
+   */
+  char getChar(int row, int column);
+
+  /**
+   * Get the short at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @return Short value at (row, column)
+   */
+  short getShort(int row, int column);
+
+  /**
+   * Get the int at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @return int value at (row, column)
+   */
+  int getInt(int row, int column);
+
+  /**
+   * Get the int at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @param context Reader context
+   * @return int value at (row, column)
+   */
+  int getInt(int row, int column, T context);
+
+  /**
+   * Get the long at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @return long value at (row, column)
+   */
+  long getLong(int row, int column);
+
+  /**
+   * Get the long at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @param context Reader context
+   *
+   * @return long value at (row, column)
+   */
+  long getLong(int row, int column, T context);
+
+  /**
+   * Get the float at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @return float value at (row, column)
+   */
+  float getFloat(int row, int column);
+
+  /**
+   * Get the float at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @param context Reader context
+   *
+   * @return float value at (row, column)
+   */
+  float getFloat(int row, int column, T context);
+
+  /**
+   * Get the double at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   *
+   * @return double value at (row, column)
+   */
+  double getDouble(int row, int column);
+
+  /**
+   * Get the double at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @param context Reader context
+   *
+   * @return double value at (row, column)
+   */
+  double getDouble(int row, int column, T context);
+
+  /**
+   * Get the String at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   * @return String value at (row, column)
+   */
+  String getString(int row, int column);
+
+  /**
+   * Get the String at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   *
+   * @param context Reader context
+   *
+   * @return String value at (row, column)
+   */
+  String getString(int row, int column, T context);
+
+  /**
+   * Get the byte at a given (row, column).
+   *
+   * @param row row id
+   * @param column column id
+   *
+   * @return byte value at (row, column)
+   */
+  byte[] getBytes(int row, int column);
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/BaseSingleValueMultiColumnReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/BaseSingleValueMultiColumnReaderWriter.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.io.readerwriter;
+
+import com.linkedin.pinot.core.io.reader.SingleValueMultiColumnReader;
+import com.linkedin.pinot.core.io.reader.ReaderContext;
+import com.linkedin.pinot.core.io.writer.SingleValueMultiColumnWriter;
+import java.io.IOException;
+
+
+/**
+ * Abstract class for reader and writer interfaces for Single-value Multiple-Columns case.
+ * @param <T>
+ */
+public abstract class BaseSingleValueMultiColumnReaderWriter<T extends ReaderContext>
+    implements SingleValueMultiColumnReader<T>, SingleValueMultiColumnWriter {
+  @Override
+  public char getChar(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public short getShort(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(int row, int column, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLong(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLong(int row, int column, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloat(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloat(int row, int column, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(int row, int column, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getString(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getString(int row, int column, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte[] getBytes(int row, int column) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public T createContext() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setInt(int row, int column, int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setLong(int row, int column, long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setFloat(int row, int column, float value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setDouble(int row, int column, double value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setString(int row, int column, String value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.io.readerwriter.impl;
+
+import com.linkedin.pinot.core.io.reader.impl.FixedByteSingleValueMultiColReader;
+import com.linkedin.pinot.core.io.readerwriter.BaseSingleValueMultiColumnReaderWriter;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.FixedByteSingleValueMultiColWriter;
+import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Extension of {@link BaseSingleValueMultiColumnReaderWriter} that fully implements a
+ * SingleValue MultiColumn reader and writer for fixed size columns.
+ *
+ * This implementation currently does not support reading with context, but can be enhanced to do so.
+ */
+public class FixedByteSingleValueMultiColumnReaderWriter extends BaseSingleValueMultiColumnReaderWriter {
+
+  private List<FixedByteSingleValueMultiColWriter> _writers;
+  private volatile List<FixedByteSingleValueMultiColReader> _readers;
+  private final int _numRowsPerChunk;
+
+  private final int[] _columnSizesInBytes;
+  private final PinotDataBufferMemoryManager _memoryManager;
+  private String _allocationContext;
+  private final long _chunkSizeInBytes;
+  private int _capacityInRows;
+  private List<PinotDataBuffer> _dataBuffers;
+  private int _numColumns;
+
+  /**
+   * Constructor for the class.
+   *
+   * @param numRowsPerChunk Number of rows per chunk of data buffer.
+   * @param columnSizesInBytes Int array containing size of columns in bytes.
+   * @param memoryManager Memory manager to be used for allocating memory.
+   * @param allocationContext Allocation context (for debugging).
+   */
+  public FixedByteSingleValueMultiColumnReaderWriter(int numRowsPerChunk, int[] columnSizesInBytes,
+      PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+
+    _numRowsPerChunk = numRowsPerChunk;
+    _columnSizesInBytes = columnSizesInBytes;
+    _memoryManager = memoryManager;
+    _allocationContext = allocationContext;
+
+    _writers = new ArrayList<>();
+    _readers = new ArrayList<>();
+    _dataBuffers = new ArrayList<>();
+
+    _capacityInRows = 0;
+    int rowSizeInBytes = 0;
+    for (int columnSizesInByte : columnSizesInBytes) {
+      rowSizeInBytes += columnSizesInByte;
+    }
+
+    _numColumns = _columnSizesInBytes.length;
+    _chunkSizeInBytes = rowSizeInBytes * numRowsPerChunk;
+  }
+
+  @Override
+  public int getInt(int row, int column) {
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+
+    return _readers.get(chunkId).getInt(rowInChunk, column);
+  }
+
+  @Override
+  public long getLong(int row, int column) {
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+
+    return _readers.get(chunkId).getLong(rowInChunk, column);
+  }
+
+  @Override
+  public float getFloat(int row, int column) {
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+
+    return _readers.get(chunkId).getFloat(rowInChunk, column);
+  }
+
+  @Override
+  public double getDouble(int row, int column) {
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+
+    return _readers.get(chunkId).getDouble(rowInChunk, column);
+  }
+
+  @Override
+  public String getString(int row, int column) {
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+
+    return _readers.get(chunkId).getString(rowInChunk, column);
+  }
+
+  @Override
+  public void setInt(int row, int column, int value) {
+    ensureCapacity(row);
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+    _writers.get(chunkId).setInt(rowInChunk, column, value);
+  }
+
+  @Override
+  public void setLong(int row, int column, long value) {
+    ensureCapacity(row);
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+    _writers.get(chunkId).setLong(rowInChunk, column, value);
+  }
+
+  @Override
+  public void setFloat(int row, int column, float value) {
+    ensureCapacity(row);
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+    _writers.get(chunkId).setFloat(rowInChunk, column, value);
+  }
+
+  @Override
+  public void setDouble(int row, int column, double value) {
+    ensureCapacity(row);
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+    _writers.get(chunkId).setDouble(rowInChunk, column, value);
+  }
+
+  @Override
+  public void setString(int row, int column, String value) {
+    ensureCapacity(row);
+    int rowInChunk = row % _numRowsPerChunk;
+    int chunkId = row / _numRowsPerChunk;
+    _writers.get(chunkId).setString(rowInChunk, column, value);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _capacityInRows = 0;
+    _writers.clear();
+    _readers.clear();
+
+    for (PinotDataBuffer dataBuffer : _dataBuffers) {
+      dataBuffer.close();
+    }
+  }
+
+  /**
+   * Helper method to ensure capacity so that a row at specified location is available
+   * for write.
+   *
+   * @param row row id to be written at.
+   */
+  private void ensureCapacity(int row) {
+    if (row >= _capacityInRows) {
+
+      // Adding _chunkSizeInBytes in the numerator for rounding up. +1 because rows are 0-based index.
+      long buffersNeeded = (row + 1 - _capacityInRows + _numRowsPerChunk) / _numRowsPerChunk;
+      for (int i = 0; i < buffersNeeded; i++) {
+        addBuffer();
+      }
+    }
+  }
+
+  /**
+   * Helper method to add data buffer during expansion.
+   */
+  private void addBuffer() {
+    PinotDataBuffer buffer = _memoryManager.allocate(_chunkSizeInBytes, _allocationContext);
+    _capacityInRows += _numRowsPerChunk;
+
+    buffer.order(ByteOrder.nativeOrder());
+    _dataBuffers.add(buffer);
+
+    FixedByteSingleValueMultiColReader reader =
+        new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, _columnSizesInBytes);
+
+    FixedByteSingleValueMultiColWriter writer =
+        new FixedByteSingleValueMultiColWriter(buffer, _numRowsPerChunk, _numColumns, _columnSizesInBytes);
+
+    _writers.add(writer);
+
+    // ArrayList is non-threadsafe. So add to a new copy and then change teh reference (_readers is volatile).
+    List<FixedByteSingleValueMultiColReader> readers = new ArrayList<>(_readers);
+    readers.add(reader);
+    _readers = readers;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/SingleValueMultiColumnWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/SingleValueMultiColumnWriter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.io.writer;
+
+/**
+ * Interface for writing multiple columns with single values.
+ */
+public interface SingleValueMultiColumnWriter extends DataFileWriter {
+
+  /**
+   * Set the given int value at the specified (row, column).
+   *
+   * @param row Row id.
+   * @param column Column id.
+   * @param value Value to be set.
+   */
+  void setInt(int row, int column, int value);
+
+  /**
+   * Set the given long value at the specified (row, column).
+   *
+   * @param row Row id.
+   * @param column Column id.
+   * @param value Value to be set.
+   */
+  void setLong(int row, int column, long value);
+
+  /**
+   * Set the given float value at the specified (row, column).
+   *
+   * @param row Row id.
+   * @param column Column id.
+   * @param value Value to be set.
+   */
+  void setFloat(int row, int column, float value);
+
+  /**
+   * Set the given double value at the specified (row, column).
+   *
+   * @param row Row id.
+   * @param column Column id.
+   * @param value Value to be set.
+   */
+  void setDouble(int row, int column, double value);
+
+  /**
+   * Set the given String value at the specified (row, column).
+   *
+   * @param row Row id.
+   * @param column Column id.
+   * @param value Value to be set.
+   */
+  void setString(int row, int column, String value);
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -19,10 +19,10 @@ import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.BlockMetadata;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.blocks.TransformBlock;
+import com.linkedin.pinot.core.util.FixedIntArray;
 import com.linkedin.pinot.core.query.aggregation.groupby.utils.ValueToIdMap;
 import com.linkedin.pinot.core.query.aggregation.groupby.utils.ValueToIdMapFactory;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -273,44 +273,5 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
         throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + dataType);
     }
     return values;
-  }
-
-  /**
-   * Wrapper around fixed size int array with hashCode() and equals() implementation.
-   * Used as a key in hash-map.
-   */
-  private static class FixedIntArray {
-    private final int[] _value;
-
-    FixedIntArray(int[] value) {
-      _value = value;
-    }
-
-    int[] elements() {
-      return _value;
-    }
-
-    int size() {
-      return _value.length;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-
-      FixedIntArray that = (FixedIntArray) o;
-
-      return Arrays.equals(_value, that._value);
-    }
-
-    @Override
-    public int hashCode() {
-      return Arrays.hashCode(_value);
-    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -197,12 +197,15 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
       PinotDataBufferMemoryManager memoryManager, String allocationContext) {
     _memoryManager = memoryManager;
     _allocationContext = allocationContext;
-    int initialRowCount = nearestPrime(estimatedCardinality);
-    _numEntries = 0;
+    _initialRowCount = nearestPrime(estimatedCardinality);
     _maxItemsInOverflowHash = maxOverflowHashSize;
+    init();
+  }
+
+  protected void init() {
+    _numEntries = 0;
     _valueToDict = new ValueToDictId(new ArrayList<IntBuffer>(0), new ConcurrentHashMap<Object, Integer>(0));
-    _initialRowCount = initialRowCount;
-    if (!_heapFirst || (maxOverflowHashSize == 0)) {
+    if (!_heapFirst || (_maxItemsInOverflowHash == 0)) {
       expand(_initialRowCount, 1);
     }
   }
@@ -252,6 +255,7 @@ public abstract class BaseOffHeapMutableDictionary extends MutableDictionary {
       throws IOException {
     doClose();
 
+    _numEntries = 0;
     ValueToDictId valueToDictId = _valueToDict;
     _valueToDict = null;
     Map<Object, Integer> overflowMap = valueToDictId.getOverflowMap();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/FixedIntArray.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/FixedIntArray.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.util;
+
+import java.util.Arrays;
+
+
+/**
+ * Wrapper around fixed size primitive int array. Provides the following so it can be used
+ * as key in Maps/Sets.
+ *
+ * <ul>
+ *   <li> hashCode()</li>
+ *   <li> equals</li>
+ * </ul>
+ *
+ * Note, does not provide a deep-copy of the value, and caller is responsible for maintaining the values.
+ */
+public class FixedIntArray {
+  private final int[] _value;
+
+  public FixedIntArray(int[] value) {
+    _value = value;
+  }
+
+  public int[] elements() {
+    return _value;
+  }
+
+  public int size() {
+    return _value.length;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FixedIntArray that = (FixedIntArray) o;
+
+    return Arrays.equals(_value, that._value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(_value);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/FixedIntArrayOffHeapIdMap.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/FixedIntArrayOffHeapIdMap.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.util;
+
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleValueMultiColumnReaderWriter;
+import com.linkedin.pinot.core.realtime.impl.dictionary.BaseOffHeapMutableDictionary;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import java.io.IOException;
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+
+
+/**
+ * Implementation of {@link IdMap} with {@link FixedIntArray} as key.
+ *
+ * This implementation also extends the {@link BaseOffHeapMutableDictionary} for code-reuse of off-heap functionality.
+ * However, it is not a full dictionary implementation (for example, does not implement getMin/Max etc).
+ *
+ */
+public class FixedIntArrayOffHeapIdMap extends BaseOffHeapMutableDictionary implements IdMap<FixedIntArray> {
+  private final FixedByteSingleValueMultiColumnReaderWriter _dictIdToValue;
+  private final int _numColumns;
+
+  public FixedIntArrayOffHeapIdMap(int estimatedCardinality, int maxOverflowHashSize, int numColumns,
+      PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+    super(estimatedCardinality, maxOverflowHashSize, memoryManager, allocationContext);
+
+    int initialSize = nearestPowerOf2(estimatedCardinality);
+    int[] columnSizesInBytes = new int[numColumns];
+    Arrays.fill(columnSizesInBytes, V1Constants.Numbers.INTEGER_SIZE);
+
+    _dictIdToValue = new FixedByteSingleValueMultiColumnReaderWriter(initialSize, columnSizesInBytes, memoryManager,
+        allocationContext);
+    _numColumns = numColumns;
+  }
+
+  @Override
+  public int put(FixedIntArray fixedIntArray) {
+    index(fixedIntArray);
+    return indexOf(fixedIntArray);
+  }
+
+  @Override
+  public int getId(FixedIntArray fixedIntArray) {
+    int id = indexOf(fixedIntArray);
+    return (id != NULL_VALUE_INDEX) ? id : INVALID_ID;
+  }
+
+  @Override
+  public FixedIntArray getKey(int id) {
+    return (FixedIntArray) get(id);
+  }
+
+  @Override
+  public int size() {
+    return length();
+  }
+
+  @Override
+  public void clear() {
+    try {
+      close();
+      init();
+    } catch (IOException e) {
+      Utils.rethrowException(e);
+    }
+  }
+
+  public Object get(int dictId) {
+    int[] value = new int[_numColumns];
+    for (int col = 0; col < _numColumns; col++) {
+      value[col] = _dictIdToValue.getInt(dictId, col);
+    }
+    return new FixedIntArray(value);
+  }
+
+  @Override
+  public int indexOf(Object rawValue) {
+    return getDictId(rawValue, null);
+  }
+
+  @Override
+  public void doClose()
+      throws IOException {
+    _dictIdToValue.close();
+  }
+
+  @Override
+  protected void setRawValueAt(int dictId, Object value, byte[] serializedValue) {
+    FixedIntArray intArray = (FixedIntArray) value; // Avoiding type check for efficiency.
+    int[] values = intArray.elements();
+
+    for (int col = 0; col < values.length; col++) {
+      _dictIdToValue.setInt(dictId, col, values[col]);
+    }
+  }
+
+  @Override
+  public void index(@Nonnull Object value) {
+    indexValue(value, null);
+  }
+
+  @Override
+  public boolean inRange(@Nonnull String lower, @Nonnull String upper, int dictIdToCompare, boolean includeLower,
+      boolean includeUpper) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Object getMinVal() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Object getMaxVal() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Nonnull
+  @Override
+  public Object getSortedValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getAvgValueSize() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/util/IdMap.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/util/IdMap.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.util;
+
+/**
+ * Interface for a map from Key to auto-generated contiguous integer Id's.
+ *
+ * @param <Key>
+ */
+public interface IdMap<Key> {
+  int INVALID_ID = -1;
+
+  /**
+   * Puts the specified key into the map. The id for the key is auto-generated as follows:
+   *
+   * <ul> If key does not exist in the map, it is inserted into the map with a new id which is equal to number of
+   * elements in the map before the key is inserted. For example, the first key inserted will have id of 0, second
+   * will have an id of 1, and so on. </ul>
+   *
+   * <ul> If key already exists in the map, then it keeps its original id.</ul>
+   *
+   * @param key Key to be inserted into the map.
+   *
+   * @return Returns the id for the key.
+   */
+  int put(Key key);
+
+  /**
+   * Returns the id associated with the specified key.
+   *
+   * <ul> Returns the id of the key if it exists. </ul>
+   * <ul> Returns {@link IdMap#INVALID_ID} if the key does not exist in the map. </ul>
+   *
+   * @param key Key to get.
+   * @return Id of the key.
+   */
+  int getId(Key key);
+
+
+  /**
+   * Returns the key associated with the specified id.
+   *
+   * <ul> Returns the id of the key if it exists. </ul>
+   * <ul> Returns null if the key does not exist in the map. </ul>
+   *
+   * @param id id for which to get the key.
+   * @return Key for the id.
+   */
+  Key getKey(int id);
+
+
+  /**
+   * Returns the current size of the map, zero if the map is empty.
+   * @return Size of the map.
+   */
+  int size();
+
+  /**
+   * Clears all contents of the map.
+   */
+  void clear();
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleValueMultiColumnReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleValueMultiColumnReaderWriterTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.index.readerwriter;
+
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleValueMultiColumnReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
+import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
+import java.io.IOException;
+import java.util.Random;
+import org.apache.commons.lang.RandomStringUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link FixedByteSingleValueMultiColumnReaderWriter}
+ */
+public class FixedByteSingleValueMultiColumnReaderWriterTest {
+  private static final int NUM_ROWS = 1001;
+  private static final int NUM_ROWS_PER_CHUNK = 23;
+
+  private static final int STRING_LENGTH = 11;
+
+  private static final int[] COLUMN_SIZES_IN_BYTES =
+      new int[]{V1Constants.Numbers.INTEGER_SIZE, V1Constants.Numbers.LONG_SIZE, V1Constants.Numbers.FLOAT_SIZE,
+          V1Constants.Numbers.DOUBLE_SIZE, STRING_LENGTH};
+
+  private PinotDataBufferMemoryManager _memoryManager;
+  private FixedByteSingleValueMultiColumnReaderWriter _readerWriter;
+  private Random _random;
+
+  @BeforeClass
+  public void setup() {
+    _memoryManager = new DirectMemoryManager(FixedByteSingleColumnSingleValueReaderWriterTest.class.getName());
+    _readerWriter =
+        new FixedByteSingleValueMultiColumnReaderWriter(NUM_ROWS_PER_CHUNK, COLUMN_SIZES_IN_BYTES, _memoryManager,
+            "test");
+    _random = new Random(System.nanoTime());
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _readerWriter.close();
+    _memoryManager.close();
+  }
+
+  @Test
+  public void test() {
+    // Test sequential read/write
+    testSequentialReadWrite(0);
+
+    // Test non-contiguous read/write, by starting to write at an offset.
+    testSequentialReadWrite(NUM_ROWS);
+
+    // Test mutability
+    testMutability();
+  }
+
+  private void testMutability() {
+    for (int i = 0; i < NUM_ROWS; i++) {
+      int row = _random.nextInt(NUM_ROWS);
+
+      int intValue = _random.nextInt();
+      _readerWriter.setInt(row, 0, intValue);
+      Assert.assertEquals(_readerWriter.getInt(row, 0), intValue);
+
+      long longValue = _random.nextLong();
+      _readerWriter.setLong(row, 1, longValue);
+      Assert.assertEquals(_readerWriter.getLong(row, 1), longValue);
+
+      float floatValue = _random.nextFloat();
+      _readerWriter.setFloat(row, 2, floatValue);
+      Assert.assertEquals(_readerWriter.getFloat(row, 2), floatValue);
+
+      double doubleValue = _random.nextDouble();
+      _readerWriter.setDouble(row, 3, doubleValue);
+      Assert.assertEquals(_readerWriter.getDouble(row, 3), doubleValue);
+
+      String stringValue = RandomStringUtils.randomAlphabetic(STRING_LENGTH);
+      _readerWriter.setString(row, 4, stringValue);
+      Assert.assertEquals(_readerWriter.getString(row, 4), stringValue);
+    }
+  }
+
+  private void testSequentialReadWrite(int startOffset) {
+    int[] intValues = new int[NUM_ROWS];
+    long[] longValues = new long[NUM_ROWS];
+    float[] floatValues = new float[NUM_ROWS];
+    double[] doubleValues = new double[NUM_ROWS];
+    String[] stringValues = new String[NUM_ROWS];
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      int row = i + startOffset;
+      intValues[i] = _random.nextInt();
+      _readerWriter.setInt(row, 0, intValues[i]);
+
+      longValues[i] = _random.nextLong();
+      _readerWriter.setLong(row, 1, longValues[i]);
+
+      floatValues[i] = _random.nextFloat();
+      _readerWriter.setFloat(row, 2, floatValues[i]);
+
+      doubleValues[i] = _random.nextDouble();
+      _readerWriter.setDouble(row, 3, doubleValues[i]);
+
+      stringValues[i] = RandomStringUtils.randomAlphanumeric(STRING_LENGTH);
+      _readerWriter.setString(row, 4, stringValues[i]);
+    }
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      int row = i + startOffset;
+      Assert.assertEquals(_readerWriter.getInt(row, 0), intValues[i]);
+      Assert.assertEquals(_readerWriter.getLong(row, 1), longValues[i]);
+      Assert.assertEquals(_readerWriter.getFloat(row, 2), floatValues[i]);
+      Assert.assertEquals(_readerWriter.getDouble(row, 3), doubleValues[i]);
+      Assert.assertEquals(_readerWriter.getString(row, 4), stringValues[i]);
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/FixedIntArrayIdMapTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/FixedIntArrayIdMapTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.segments.v1.creator;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
+import com.linkedin.pinot.core.util.FixedIntArray;
+import com.linkedin.pinot.core.util.FixedIntArrayOffHeapIdMap;
+import com.linkedin.pinot.core.util.IdMap;
+import java.io.IOException;
+import java.util.Random;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for {@link FixedIntArrayOffHeapIdMap}
+ */
+public class FixedIntArrayIdMapTest {
+  private static final int NUM_ROWS = 10001;
+  private static final int NUM_COLUMNS = 3;
+  private static final int INITIAL_CARDINALITY = 23;
+  private static final int ON_HEAP_CACHE_SIZE = 10;
+  private DirectMemoryManager _memoryManager;
+  private Random _random;
+  private IdMap<FixedIntArray> _idMap;
+
+  @BeforeClass
+  public void setup() {
+    _random = new Random(System.nanoTime());
+    _memoryManager = new DirectMemoryManager(FixedIntArrayIdMapTest.class.getName());
+
+    _idMap =
+        new FixedIntArrayOffHeapIdMap(INITIAL_CARDINALITY, ON_HEAP_CACHE_SIZE, NUM_COLUMNS, _memoryManager,
+            FixedIntArrayIdMapTest.class.getName());
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _idMap.clear();
+    _memoryManager.close();
+  }
+
+  /**
+   * This test indexes a specified number of values in the class being tested and checks correctness by
+   * comparing results against {@link BiMap} for the same input.
+   * <ul>
+   *   <li> Size of the map (cardinality) should be as expected. </li>
+   *   <li> For each value, id should be as expected. </li>
+   *   <li> For each id, should return the expected value back. </li>
+   * </ul>
+   */
+  @Test
+  public void test() {
+
+    BiMap<FixedIntArray, Integer> expectedMap = addValues(_idMap);
+    int numValues = expectedMap.size();
+    
+    // Test invalid Value
+    Assert.assertEquals(_idMap.getId(new FixedIntArray(new int[]{})), IdMap.INVALID_ID);
+
+    Assert.assertEquals(_idMap.size(), numValues);
+    testValues(expectedMap);
+
+    // Test the clear() api.
+    _idMap.clear();
+    Assert.assertEquals(_idMap.size(), 0);
+
+    // Test adding after clearing.
+    expectedMap.clear();
+    expectedMap = addValues(_idMap);
+    numValues = expectedMap.size();
+
+    Assert.assertEquals(_idMap.size(), numValues);
+    testValues(expectedMap);
+  }
+
+  private void testValues(BiMap<FixedIntArray, Integer> map) {
+    for (int dictId = 0; dictId < _idMap.size(); dictId++) {
+      FixedIntArray actual = _idMap.getKey(dictId);
+      FixedIntArray expected = map.inverse().get(dictId);
+
+      Assert.assertEquals(actual, expected);
+      Assert.assertEquals(_idMap.getId(actual), map.get(expected).intValue());
+    }
+  }
+
+  private BiMap<FixedIntArray, Integer> addValues(IdMap<FixedIntArray> idMap) {
+    BiMap<FixedIntArray, Integer> map = HashBiMap.create();
+    int numValues = 0;
+
+    for (int row = 0; row < NUM_ROWS; row++) {
+      int[] values = new int[NUM_COLUMNS];
+      for (int col = 0; col < NUM_COLUMNS; col++) {
+        values[col] = _random.nextInt(10); // Max of 1000 unique values possible, so there will be duplicates.
+      }
+      FixedIntArray value = new FixedIntArray(values);
+      idMap.put(value);
+
+      if (!map.containsKey(value)) {
+        map.put(value, numValues++);
+      }
+    }
+    return map;
+  }
+}

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkFixedIntArrayOffHeapIdMap.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkFixedIntArrayOffHeapIdMap.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.perf;
+
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
+import com.linkedin.pinot.core.util.FixedIntArray;
+import com.linkedin.pinot.core.util.FixedIntArrayOffHeapIdMap;
+import com.linkedin.pinot.core.util.IdMap;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkFixedIntArrayOffHeapIdMap {
+  private static final int ROW_COUNT = 2_500_000;
+  private static final int COLUMN_CARDINALITY = 100;
+  private static final int NUM_COLUMNS = 3;
+  private static final int CARDINALITY = (new Double(Math.pow(COLUMN_CARDINALITY, NUM_COLUMNS))).intValue();
+
+  private FixedIntArray[] _values;
+
+  @Setup
+  public void setUp() {
+    Random random = new Random(System.nanoTime());
+
+    FixedIntArray[] uniqueValues = new FixedIntArray[CARDINALITY];
+    for (int i = 0; i < uniqueValues.length; i++) {
+      uniqueValues[i] = new FixedIntArray(
+          new int[]{random.nextInt(COLUMN_CARDINALITY), random.nextInt(COLUMN_CARDINALITY), random.nextInt(
+              COLUMN_CARDINALITY)});
+    }
+
+    _values = new FixedIntArray[ROW_COUNT];
+    for (int i = 0; i < _values.length; i++) {
+      _values[i] = uniqueValues[random.nextInt(CARDINALITY)];
+    }
+  }
+
+  @TearDown
+  public void tearDown()
+      throws Exception {
+  }
+
+  // Start with mid size, with overflow
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public IdMap<FixedIntArray> benchmarkOffHeapWithResizeWithCache()
+      throws IOException {
+    PinotDataBufferMemoryManager memoryManager = new DirectMemoryManager("perfTest");
+
+    IdMap<FixedIntArray> idMap =
+        new FixedIntArrayOffHeapIdMap(CARDINALITY / 10, 1000, NUM_COLUMNS, memoryManager,
+            "perfTestWithCache");
+
+    for (FixedIntArray value : _values) {
+      idMap.put(value);
+    }
+
+    memoryManager.close();
+    return idMap;
+  }
+
+  // Start with max size, no cache
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public IdMap<FixedIntArray> benchmarkOffHeapWithReSizeWithoutCache()
+      throws IOException {
+    PinotDataBufferMemoryManager memoryManager = new DirectMemoryManager("perfTest");
+
+    IdMap<FixedIntArray> idMap =
+        new FixedIntArrayOffHeapIdMap(CARDINALITY / 10, 0, NUM_COLUMNS, memoryManager,
+            "perfTestWithCache");
+
+    for (FixedIntArray value : _values) {
+      idMap.put(value);
+    }
+
+    memoryManager.close();
+    return idMap;
+  }
+
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public IdMap<FixedIntArray> benchmarkOffHeapPreSizeWithCache()
+      throws IOException {
+    PinotDataBufferMemoryManager memoryManager = new DirectMemoryManager("perfTest");
+
+    IdMap<FixedIntArray> idMap =
+        new FixedIntArrayOffHeapIdMap(CARDINALITY, 1000, NUM_COLUMNS, memoryManager, "perfTestWithCache");
+
+    for (FixedIntArray value : _values) {
+      idMap.put(value);
+    }
+
+    memoryManager.close();
+    return idMap;
+  }
+
+  // Start with max size, no cache
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public IdMap<FixedIntArray> benchmarkOffHeapPreSizeWithoutCache()
+      throws IOException {
+    PinotDataBufferMemoryManager memoryManager = new DirectMemoryManager("perfTest");
+
+    IdMap<FixedIntArray> idMap =
+        new FixedIntArrayOffHeapIdMap(CARDINALITY, 0, NUM_COLUMNS, memoryManager, "perfTestWithCache");
+
+    for (FixedIntArray value : _values) {
+      idMap.put(value);
+    }
+
+    memoryManager.close();
+    return idMap;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkFixedIntArrayOffHeapIdMap.class.getSimpleName())
+        .warmupTime(TimeValue.seconds(10))
+        .warmupIterations(2)
+        .measurementTime(TimeValue.seconds(30))
+        .measurementIterations(5)
+        .forks(1);
+
+    new Runner(opt.build()).run();
+  }
+}


### PR DESCRIPTION
1. Created an interface IdMap<K> that maps inserted keys to contiguous
integers starting from zero. Added specialized implementation for IdMap
with FixedIntArray key.

2. Added interfaces for single-value multi-columns readers, writers
and ReaderWriter. Also added fixed-byte implementation for the
ReaderWriter interface.

3. Moved FixedIntArray from inner class from within GroupBy code into a
more generic module for re-use.

4. Added unit tests and benchmarks for new features.

5. Benchmark results (using JMH) for inserting 2.5M rows with 1M unique values into the FixedIntArrayOffHeapIdMap shows average put() time of 0.4ms per 1k rows (1044 / 2.5M).

Run progress: 0.00% complete, ETA 00:02:50
Fork: 1 of 1
Warmup Iteration   1: 1077.517 ±(99.9%) 241.410 ms/op
Warmup Iteration   2: 1023.305 ±(99.9%) 10.969 ms/op
Iteration   1: 1029.422 ±(99.9%) 4.388 ms/op
                 benchmarkOffHeapWithResizeWithCache·p0.00:   1019.216 ms/op
                 benchmarkOffHeapWithResizeWithCache·p0.50:   1029.702 ms/op
                 benchmarkOffHeapWithResizeWithCache·p0.90:   1036.937 ms/op
                 benchmarkOffHeapWithResizeWithCache·p0.95:   1043.805 ms/op
                 benchmarkOffHeapWithResizeWithCache·p0.99:   1044.382 ms/op
                 benchmarkOffHeapWithResizeWithCache·p0.999:  1044.382 ms/op
                 benchmarkOffHeapWithResizeWithCache·p0.9999: 1044.382 ms/op
                 benchmarkOffHeapWithResizeWithCache·p1.00:   1044.382 ms/op