### PR TITLE
Enforce padding character to be '\0'

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -28,7 +28,6 @@ import com.linkedin.pinot.core.data.readers.RecordReaderConfig;
 import com.linkedin.pinot.core.io.compression.ChunkCompressorFactory;
 import com.linkedin.pinot.core.segment.DefaultSegmentNameGenerator;
 import com.linkedin.pinot.core.segment.SegmentNameGenerator;
-import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.util.AvroUtils;
 import com.linkedin.pinot.startree.hll.HllConfig;
 import java.io.File;
@@ -90,7 +89,6 @@ public class SegmentGeneratorConfig {
   private boolean _enableStarTreeIndex = false;
   private StarTreeIndexSpec _starTreeIndexSpec = null;
   private String _creatorVersion = null;
-  private char _paddingCharacter = V1Constants.Str.DEFAULT_STRING_PAD_CHAR;
   private HllConfig _hllConfig = null;
   private SegmentNameGenerator _segmentNameGenerator = null;
   private SegmentPartitionConfig _segmentPartitionConfig = null;
@@ -136,7 +134,6 @@ public class SegmentGeneratorConfig {
     _enableStarTreeIndex = config._enableStarTreeIndex;
     _starTreeIndexSpec = config._starTreeIndexSpec;
     _creatorVersion = config._creatorVersion;
-    _paddingCharacter = config._paddingCharacter;
     _hllConfig = config._hllConfig;
     _segmentNameGenerator = config._segmentNameGenerator;
     _segmentPartitionConfig = config._segmentPartitionConfig;
@@ -294,14 +291,6 @@ public class SegmentGeneratorConfig {
 
   public void setCreatorVersion(String creatorVersion) {
     _creatorVersion = creatorVersion;
-  }
-
-  public char getPaddingCharacter() {
-    return _paddingCharacter;
-  }
-
-  public void setPaddingCharacter(char paddingCharacter) {
-    _paddingCharacter = paddingCharacter;
   }
 
   public String getSegmentNamePostfix() {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -303,11 +303,10 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
 
     // Create dictionary.
     // We will have only one value in the dictionary.
-    SegmentDictionaryCreator segmentDictionaryCreator =
-        new SegmentDictionaryCreator(false/*hasNulls*/, sortedArray, fieldSpec, _indexDir,
-            V1Constants.Str.DEFAULT_STRING_PAD_CHAR);
-    segmentDictionaryCreator.build(new boolean[]{true}/*isSorted*/);
-    segmentDictionaryCreator.close();
+    try (SegmentDictionaryCreator creator = new SegmentDictionaryCreator(false/*hasNulls*/, sortedArray, fieldSpec,
+        _indexDir)) {
+      creator.build();
+    }
 
     // Create forward index.
     if (isSingleValue) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/ColumnMetadataTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/ColumnMetadataTest.java
@@ -24,9 +24,9 @@ import com.linkedin.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import com.linkedin.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import com.linkedin.pinot.core.segment.creator.impl.SegmentCreationDriverFactory;
 import com.linkedin.pinot.core.segment.index.loader.Loaders;
-import com.linkedin.pinot.startree.hll.HllConfig;
 import com.linkedin.pinot.core.startree.hll.SegmentWithHllIndexCreateHelper;
 import com.linkedin.pinot.segments.v1.creator.SegmentTestUtils;
+import com.linkedin.pinot.startree.hll.HllConfig;
 import com.linkedin.pinot.util.TestUtils;
 import java.io.File;
 import java.util.Arrays;
@@ -178,7 +178,6 @@ public class ColumnMetadataTest {
   public void testPaddingCharacter() throws Exception {
     // Build the Segment metadata.
     SegmentGeneratorConfig config = CreateSegmentConfigWithoutCreator();
-    config.setPaddingCharacter('\0');
     SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);
     driver.build();

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
@@ -97,27 +97,31 @@ public class ImmutableDictionaryReaderTest {
     _stringValues = stringSet.toArray(new String[NUM_VALUES]);
     Arrays.sort(_stringValues);
 
-    boolean[] isSorted = {true};
-    SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _intValues,
-        new DimensionFieldSpec(INT_COLUMN_NAME, FieldSpec.DataType.INT, true), TEMP_DIR, '\0');
-    dictionaryCreator.build(isSorted);
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _intValues,
+        new DimensionFieldSpec(INT_COLUMN_NAME, FieldSpec.DataType.INT, true), TEMP_DIR)) {
+      dictionaryCreator.build();
+    }
 
-    dictionaryCreator = new SegmentDictionaryCreator(false, _longValues,
-        new DimensionFieldSpec(LONG_COLUMN_NAME, FieldSpec.DataType.LONG, true), TEMP_DIR, '\0');
-    dictionaryCreator.build(isSorted);
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _longValues,
+        new DimensionFieldSpec(LONG_COLUMN_NAME, FieldSpec.DataType.LONG, true), TEMP_DIR)) {
+      dictionaryCreator.build();
+    }
 
-    dictionaryCreator = new SegmentDictionaryCreator(false, _floatValues,
-        new DimensionFieldSpec(FLOAT_COLUMN_NAME, FieldSpec.DataType.FLOAT, true), TEMP_DIR, '\0');
-    dictionaryCreator.build(isSorted);
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _floatValues,
+        new DimensionFieldSpec(FLOAT_COLUMN_NAME, FieldSpec.DataType.FLOAT, true), TEMP_DIR)) {
+      dictionaryCreator.build();
+    }
 
-    dictionaryCreator = new SegmentDictionaryCreator(false, _doubleValues,
-        new DimensionFieldSpec(DOUBLE_COLUMN_NAME, FieldSpec.DataType.DOUBLE, true), TEMP_DIR, '\0');
-    dictionaryCreator.build(isSorted);
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _doubleValues,
+        new DimensionFieldSpec(DOUBLE_COLUMN_NAME, FieldSpec.DataType.DOUBLE, true), TEMP_DIR)) {
+      dictionaryCreator.build();
+    }
 
-    dictionaryCreator = new SegmentDictionaryCreator(false, _stringValues,
-        new DimensionFieldSpec(STRING_COLUMN_NAME, FieldSpec.DataType.STRING, true), TEMP_DIR, '\0');
-    dictionaryCreator.build(isSorted);
-    _numBytesPerStringValue = dictionaryCreator.getStringColumnMaxLength();
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _stringValues,
+        new DimensionFieldSpec(STRING_COLUMN_NAME, FieldSpec.DataType.STRING, true), TEMP_DIR)) {
+      dictionaryCreator.build();
+      _numBytesPerStringValue = dictionaryCreator.getStringColumnMaxLength();
+    }
   }
 
   @Test


### PR DESCRIPTION
The current code will break if the padding character is not '\0'

1. Remove the config for padding character
2. Simplify the logic of creating string dictionary because the order won't change