### PR TITLE
Fixed ClusterStateVerifier to consider timeout

### DIFF
--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotZKChanger.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/PinotZKChanger.java
@@ -88,7 +88,8 @@ public class PinotZKChanger {
       for (String server : mapIS.keySet()) {
         String state = mapIS.get(server);
         if (mapEV == null || mapEV.get(server) == null || !mapEV.get(server).equals(state)) {
-          LOGGER.info("Mismatch: segment" + segment + " server:" + server + " state:" + state);
+          LOGGER.info("Mismatch: segment " + segment + " server:" + server + " expected state:" + state +
+             " actual state:" + ((mapEV == null || mapEV.get(server) == null) ? "null" : mapEV.get(server)));
           numDiff = numDiff + 1;
         }
       }


### PR DESCRIPTION
ClusterStateVerifier now pays attention to the timeout setting that the caller may provide.
This was needed while testing upgrade to helix-0.8.0