### PR TITLE
[TE] detection - abort long-running detection task on interrupt

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -175,6 +175,10 @@ public class DetectionTaskRunner implements TaskRunner {
 
     DataFilter dataFilter = DataFilterFactory.fromSpec(anomalyFunctionSpec.getDataFilter());
     for (DimensionMap dimensionMap : anomalyDetectionInputContext.getDimensionMapMetricTimeSeriesMap().keySet()) {
+      if (Thread.interrupted()) {
+        throw new IllegalStateException("Thread interrupted. Aborting.");
+      }
+
       // Skip anomaly detection if the current time series does not pass data filter, which may check if the traffic
       // or total count of the data has enough volume for produce sufficient confidence anomaly results
       MetricTimeSeries metricTimeSeries =


### PR DESCRIPTION
ThirdEye currently does not allow interruption of detection tasks running across multiple dimension combinations (potentially millions). This causes the controller to appear unresponsive to systems and monitoring tools outside the VM. This PR makes the detection task runner aware of interrupts to abort ongoing tasks and shut down gracefully.