### PR TITLE
Fix LLC consumer to handle segment build fails gracefully

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -139,9 +139,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
 
     public void deleteSegmentFile() {
-      // If segment build fails with an exception (e.g. if the value of a string column contained
-      // a nul character followed by non-null characters), then we will not be able to create a segment file,
-      // so the file name will be null.
+      // If segment build fails with an exception then we will not be able to create a segment file and
+      // the file name will be null.
       if (_segmentFile != null) {
         FileUtils.deleteQuietly(new File(_segmentFile));
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -139,7 +139,12 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
 
     public void deleteSegmentFile() {
-      FileUtils.deleteQuietly(new File(_segmentFile));
+      // If segment build fails with an exception (e.g. if the value of a string column contained
+      // a nul character followed by non-null characters), then we will not be able to create a segment file,
+      // so the file name will be null.
+      if (_segmentFile != null) {
+        FileUtils.deleteQuietly(new File(_segmentFile));
+      }
     }
   }
 


### PR DESCRIPTION
If segment build fails then we used throw NPE while tyring to delete a null file name.
Fixed the condition, and added a test.
We now handle the condition gracefully, and also set LLC_PARTITION_CONSUMING gauge to 0
so that we can alert on the partition that stopped consumption.