### PR TITLE
Rewrite SegmentDictionaryCreator to use the FixedByteValueReaderWriter

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/util/FixedByteValueReaderWriter.java
@@ -73,6 +73,31 @@ public final class FixedByteValueReaderWriter implements Closeable {
     _dataBuffer.putInt(index * INT_SIZE_IN_BYTES, value);
   }
 
+  public void writeLong(int index, long value) {
+    _dataBuffer.putLong(index * LONG_SIZE_IN_BYTES, value);
+  }
+
+  public void writeFloat(int index, float value) {
+    _dataBuffer.putFloat(index * FLOAT_SIZE_IN_BYTES, value);
+  }
+
+  public void writeDouble(int index, double value) {
+    _dataBuffer.putDouble(index * DOUBLE_SIZE_IN_BYTES, value);
+  }
+
+  public void writeUnpaddedString(int index, int numBytesPerValue, byte[] value) {
+    int startIndex = index * numBytesPerValue;
+    int endIndex = startIndex + numBytesPerValue;
+
+    int i = startIndex;
+    for (byte b : value) {
+      _dataBuffer.putByte(i++, b);
+    }
+    while (i < endIndex) {
+      _dataBuffer.putByte(i++, (byte) 0);
+    }
+  }
+
   @Override
   public void close() {
     _dataBuffer.close();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -127,8 +127,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
         // Initialize dictionary creator
         SegmentDictionaryCreator dictionaryCreator =
-            new SegmentDictionaryCreator(hasNulls, indexCreationInfo.getSortedUniqueElementsArray(), fieldSpec,
-                _indexDir);
+            new SegmentDictionaryCreator(indexCreationInfo.getSortedUniqueElementsArray(), fieldSpec, _indexDir);
         _dictionaryCreatorMap.put(columnName, dictionaryCreator);
 
         // Create dictionary
@@ -326,7 +325,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       String column = entry.getKey();
       ColumnIndexCreationInfo columnIndexCreationInfo = entry.getValue();
       SegmentDictionaryCreator dictionaryCreator = _dictionaryCreatorMap.get(column);
-      int dictionaryElementSize = (dictionaryCreator != null) ? dictionaryCreator.getStringColumnMaxLength() : 0;
+      int dictionaryElementSize = (dictionaryCreator != null) ? dictionaryCreator.getNumBytesPerString() : 0;
 
       // TODO: after fixing the server-side dependency on HAS_INVERTED_INDEX and deployed, set HAS_INVERTED_INDEX properly
       // The hasInvertedIndex flag in segment metadata is picked up in ColumnMetadata, and will be used during the query

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.segment.creator.impl;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
@@ -105,6 +106,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     this.config = config;
     this.createStarTree = config.isEnableStarTreeIndex();
     recordReader = dataSource.getRecordReader();
+    Preconditions.checkState(recordReader.hasNext(), "No record in data source");
     dataSchema = recordReader.getSchema();
 
     if (config.getHllConfig() != null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/V1Constants.java
@@ -53,10 +53,6 @@ public class V1Constants {
   }
 
   public static class Dict {
-    public static final int[] INT_DICTIONARY_COL_SIZE = new int[]{4};
-    public static final int[] LONG_DICTIONARY_COL_SIZE = new int[]{8};
-    public static final int[] FLOAT_DICTIONARY_COL_SIZE = new int[]{4};
-    public static final int[] DOUBLE_DICTIONARY_COL_SIZE = new int[]{8};
     public static final String FILE_EXTENSION = ".dict";
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -267,14 +267,6 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
 
     Object sortedArray;
     switch (dataType) {
-      case STRING:
-        Preconditions.checkState(defaultValue instanceof String);
-        String stringDefaultValue = (String) defaultValue;
-        // Length of the UTF-8 encoded byte array.
-        // Default size should be 1, to gracefully handle empty strings
-        dictionaryElementSize = Math.max(stringDefaultValue.getBytes("UTF8").length, 1);
-        sortedArray = new String[]{stringDefaultValue};
-        break;
       case INT:
         Preconditions.checkState(defaultValue instanceof Integer);
         sortedArray = new int[]{(Integer) defaultValue};
@@ -291,6 +283,13 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
         Preconditions.checkState(defaultValue instanceof Double);
         sortedArray = new double[]{(Double) defaultValue};
         break;
+      case STRING:
+        Preconditions.checkState(defaultValue instanceof String);
+        String stringDefaultValue = (String) defaultValue;
+        // Length of the UTF-8 encoded byte array.
+        dictionaryElementSize = stringDefaultValue.getBytes("UTF8").length;
+        sortedArray = new String[]{stringDefaultValue};
+        break;
       default:
         throw new UnsupportedOperationException("Unsupported data type: " + dataType + " for column: " + column);
     }
@@ -304,8 +303,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
 
     // Create dictionary.
     // We will have only one value in the dictionary.
-    try (SegmentDictionaryCreator creator = new SegmentDictionaryCreator(false/*hasNulls*/, sortedArray, fieldSpec,
-        _indexDir)) {
+    try (SegmentDictionaryCreator creator = new SegmentDictionaryCreator(sortedArray, fieldSpec, _indexDir)) {
       creator.build();
     }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/segment/index/readers/ImmutableDictionaryReaderTest.java
@@ -97,30 +97,30 @@ public class ImmutableDictionaryReaderTest {
     _stringValues = stringSet.toArray(new String[NUM_VALUES]);
     Arrays.sort(_stringValues);
 
-    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _intValues,
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_intValues,
         new DimensionFieldSpec(INT_COLUMN_NAME, FieldSpec.DataType.INT, true), TEMP_DIR)) {
       dictionaryCreator.build();
     }
 
-    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _longValues,
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_longValues,
         new DimensionFieldSpec(LONG_COLUMN_NAME, FieldSpec.DataType.LONG, true), TEMP_DIR)) {
       dictionaryCreator.build();
     }
 
-    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _floatValues,
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_floatValues,
         new DimensionFieldSpec(FLOAT_COLUMN_NAME, FieldSpec.DataType.FLOAT, true), TEMP_DIR)) {
       dictionaryCreator.build();
     }
 
-    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _doubleValues,
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_doubleValues,
         new DimensionFieldSpec(DOUBLE_COLUMN_NAME, FieldSpec.DataType.DOUBLE, true), TEMP_DIR)) {
       dictionaryCreator.build();
     }
 
-    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, _stringValues,
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_stringValues,
         new DimensionFieldSpec(STRING_COLUMN_NAME, FieldSpec.DataType.STRING, true), TEMP_DIR)) {
       dictionaryCreator.build();
-      _numBytesPerStringValue = dictionaryCreator.getStringColumnMaxLength();
+      _numBytesPerStringValue = dictionaryCreator.getNumBytesPerString();
     }
   }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
@@ -389,14 +389,14 @@ public class DictionariesTest {
         new String(new byte[]{67, -61, -76, 116, 101, 32, 100, 39, 73, 118, 111, 105, 114, 101}); // "Côte d'Ivoire";
     Arrays.sort(inputStrings);
 
-    SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(false, inputStrings, fieldSpec, indexDir);
-    dictionaryCreator.build();
-
-    for (String inputString : inputStrings) {
-      Assert.assertTrue(dictionaryCreator.indexOfSV(inputString) >= 0, "Value not found in dictionary " + inputString);
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(inputStrings, fieldSpec, indexDir)) {
+      dictionaryCreator.build();
+      for (String inputString : inputStrings) {
+        Assert.assertTrue(dictionaryCreator.indexOfSV(inputString) >= 0,
+            "Value not found in dictionary " + inputString);
+      }
     }
 
-    dictionaryCreator.close();
     FileUtils.deleteQuietly(indexDir);
   }
 
@@ -409,14 +409,13 @@ public class DictionariesTest {
     indexDir.deleteOnExit();
     FieldSpec fieldSpec = new DimensionFieldSpec("test", DataType.STRING, true);
 
-    SegmentDictionaryCreator dictionaryCreator =
-        new SegmentDictionaryCreator(false, new String[]{""}, fieldSpec, indexDir);
-    dictionaryCreator.build();
+    try (SegmentDictionaryCreator dictionaryCreator =
+        new SegmentDictionaryCreator(new String[]{""}, fieldSpec, indexDir)) {
+      dictionaryCreator.build();
+      Assert.assertEquals(dictionaryCreator.getNumBytesPerString(), 0);
+      Assert.assertEquals(dictionaryCreator.indexOfSV(""), 0);
+    }
 
-    Assert.assertEquals(dictionaryCreator.getStringColumnMaxLength(), 1);
-    Assert.assertEquals(dictionaryCreator.indexOfSV(""), 0);
-
-    dictionaryCreator.close();
     FileUtils.deleteQuietly(indexDir);
   }
 

--- a/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkDictionaryCreation.java
+++ b/pinot-perf/src/main/java/com/linkedin/pinot/perf/BenchmarkDictionaryCreation.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.perf;
+
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.core.segment.creator.impl.SegmentDictionaryCreator;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkDictionaryCreation {
+  private static final FieldSpec INT_FIELD = new DimensionFieldSpec("int", FieldSpec.DataType.INT, true);
+  private static final FieldSpec LONG_FIELD = new DimensionFieldSpec("long", FieldSpec.DataType.LONG, true);
+  private static final FieldSpec FLOAT_FIELD = new DimensionFieldSpec("float", FieldSpec.DataType.FLOAT, true);
+  private static final FieldSpec DOUBLE_FIELD = new DimensionFieldSpec("double", FieldSpec.DataType.DOUBLE, true);
+  private static final FieldSpec STRING_FIELD = new DimensionFieldSpec("string", FieldSpec.DataType.STRING, true);
+  private static final int CARDINALITY = 1_000_000;
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "BenchmarkDictionaryCreation");
+
+  private final int[] _sortedInts = new int[CARDINALITY];
+  private final long[] _sortedLongs = new long[CARDINALITY];
+  private final float[] _sortedFloats = new float[CARDINALITY];
+  private final double[] _sortedDoubles = new double[CARDINALITY];
+  private final String[] _sortedStrings = new String[CARDINALITY];
+
+  @Setup
+  public void setUp() throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+    for (int i = 0; i < CARDINALITY; i++) {
+      _sortedInts[i] = i;
+      _sortedLongs[i] = i;
+      _sortedFloats[i] = i;
+      _sortedDoubles[i] = i;
+      _sortedStrings[i] = String.valueOf(i);
+    }
+    Arrays.sort(_sortedStrings);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkIntDictionaryCreation() throws IOException {
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_sortedInts, INT_FIELD, INDEX_DIR)) {
+      dictionaryCreator.build();
+      return dictionaryCreator.indexOfSV(0);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkLongDictionaryCreation() throws IOException {
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_sortedLongs, LONG_FIELD,
+        INDEX_DIR)) {
+      dictionaryCreator.build();
+      return dictionaryCreator.indexOfSV(0L);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkFloatDictionaryCreation() throws IOException {
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_sortedFloats, FLOAT_FIELD,
+        INDEX_DIR)) {
+      dictionaryCreator.build();
+      return dictionaryCreator.indexOfSV(0f);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkDoubleDictionaryCreation() throws IOException {
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_sortedDoubles, DOUBLE_FIELD,
+        INDEX_DIR)) {
+      dictionaryCreator.build();
+      return dictionaryCreator.indexOfSV(0d);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int benchmarkStringDictionaryCreation() throws IOException {
+    try (SegmentDictionaryCreator dictionaryCreator = new SegmentDictionaryCreator(_sortedStrings, STRING_FIELD,
+        INDEX_DIR)) {
+      dictionaryCreator.build();
+      return dictionaryCreator.indexOfSV("0");
+    }
+  }
+
+  @TearDown
+  public void tearDown() throws Exception {
+    FileUtils.forceDelete(INDEX_DIR);
+  }
+
+  public static void main(String[] args) throws Exception {
+    Options opt = new OptionsBuilder().include(BenchmarkDictionaryCreation.class.getSimpleName())
+        .warmupTime(TimeValue.seconds(5))
+        .warmupIterations(2)
+        .measurementTime(TimeValue.seconds(5))
+        .measurementIterations(3)
+        .forks(1)
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
Rewrite SegmentDictionaryCreator to use the FixedByteValueReaderWriter
1. For string value, only call getBytes() once for performance
2. Add empty segment check
3. Add benchmark for dictionary creation
4. Allow zero length padded string to avoid the hack of using 1 byte to store empty string (we support 0 length dictionary)

For string dictionary, benchmark score get improved from 437.810 ± 9.043  ms/op to 296.688 ± 4.540  ms/op (more than 30%)