### PR TITLE
Faster hourly detection

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnBoardJobRunner.java
@@ -41,7 +41,7 @@ public class DetectionOnBoardJobRunner implements Runnable {
 
   public DetectionOnBoardJobRunner(DetectionOnboardJobContext jobContext, List<DetectionOnboardTask> tasks,
       DetectionOnboardJobStatus jobStatus) {
-    this(jobContext, tasks, jobStatus, 5, TimeUnit.MINUTES);
+    this(jobContext, tasks, jobStatus, 30, TimeUnit.MINUTES);
   }
 
   public DetectionOnBoardJobRunner(DetectionOnboardJobContext jobContext, List<DetectionOnboardTask> tasks,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -290,7 +290,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       case HOURS:
         anomalyFunctionSpec.setType("REGRESSION_GAUSSIAN_SCAN");
         anomalyFunctionSpec.setCron("0 0 14 1/1 * ? *");
-        anomalyFunctionSpec.setWindowSize(84);
+        anomalyFunctionSpec.setWindowSize(24);
         anomalyFunctionSpec.setWindowUnit(TimeUnit.HOURS);
         anomalyFunctionSpec.setProperties("");
         break;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -483,9 +483,17 @@ public class DetectionJobResource {
    */
   private void anomalyFunctionSpeedup(long functionId) {
     AnomalyFunctionDTO anomalyFunction = anomalyFunctionDAO.findById(functionId);
-    anomalyFunction.setWindowSize(170);
-    anomalyFunction.setWindowUnit(TimeUnit.HOURS);
-    anomalyFunction.setCron("0 0 0 ? * MON *");
+    TimeUnit dataTimeUnit = anomalyFunction.getBucketUnit();
+    switch (dataTimeUnit) {
+      case MINUTES:
+        anomalyFunction.setWindowSize(170);
+        anomalyFunction.setWindowUnit(TimeUnit.HOURS);
+        anomalyFunction.setCron("0 0 0 ? * MON *");
+        break;
+      case HOURS:
+        anomalyFunction.setCron("0 0 0/6 1/1 * ? *");
+      default:
+    }
     anomalyFunctionDAO.update(anomalyFunction);
   }
 


### PR DESCRIPTION
When we onboard functions with hourly granularity, we observed time-out during replay. One reason is the monitoring is large, and the replay frequency is small. Another reason is 5 minute time limit is considerably small. This pr changes the setting for the hourly detection function, and enlarge the time-out limit.