### PR TITLE
[TE] rootcause - dimensions entity for multi-filter support

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntity.java
@@ -16,6 +16,7 @@ import java.util.Set;
  * by a key-value pair. Note, that dimension names may require standardization across different
  * metrics. The URN namespace is defined as 'thirdeye:dimension:{name}:{value}:{type}'.
  */
+@Deprecated
 public class DimensionEntity extends Entity {
   public static final EntityType TYPE = new EntityType("thirdeye:dimension:");
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionsEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/DimensionsEntity.java
@@ -1,0 +1,68 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.rootcause.Entity;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+
+/**
+ * DimensionsEntity represents a dimension cut of the data without being bound
+ * to a specific entity, such as a metric. The the DimensionsEntity holds (uri encoded)
+ * tuples of keys and values, e.g. 'thirdeye:dimensions:key1=value1:key2=value2'.
+ *
+ * <br/><b>NOTE:</b> it is the successor of DimensionEntity
+ *
+ * @see DimensionEntity
+ */
+public class DimensionsEntity extends Entity {
+  public static final EntityType TYPE = new EntityType("thirdeye:dimensions:");
+
+  private final Multimap<String, String> dimensions;
+
+  private DimensionsEntity(String urn, double score, List<? extends Entity> related,
+      Multimap<String, String> dimensions) {
+    super(urn, score, related);
+    this.dimensions = dimensions;
+  }
+
+  public Multimap<String, String> getDimensions() {
+    return dimensions;
+  }
+
+  @Override
+  public DimensionsEntity withScore(double score) {
+    return fromDimensions(score, this.getRelated(), this.dimensions);
+  }
+
+  @Override
+  public DimensionsEntity withRelated(List<? extends Entity> related) {
+    return fromDimensions(this.getScore(), related, this.dimensions);
+  }
+
+  public DimensionsEntity withDimensions(Multimap<String, String> dimensions) {
+    return fromDimensions(this.getScore(), this.getRelated(), dimensions);
+  }
+
+  public static DimensionsEntity fromDimensions(double score, Multimap<String, String> dimensions) {
+    return fromDimensions(score, Collections.<Entity>emptyList(), dimensions);
+  }
+
+  public static DimensionsEntity fromDimensions(double score, Collection<? extends Entity> related, Multimap<String, String> dimensions) {
+    return new DimensionsEntity(TYPE.formatURN(EntityUtils.encodeDimensions(dimensions)), score, new ArrayList<>(related), dimensions);
+  }
+
+  public static DimensionsEntity fromURN(String urn, double score) {
+    if(!TYPE.isType(urn))
+      throw new IllegalArgumentException(String.format("URN '%s' is not type '%s'", urn, TYPE.getPrefix()));
+    // TODO handle filter strings containing ":"
+    String[] parts = urn.split(":");
+    if(parts.length <= 1)
+      throw new IllegalArgumentException(String.format("URN must have at least 2 parts but has '%d'", parts.length));
+    List<String> filterStrings = Arrays.asList(Arrays.copyOfRange(parts, 2, parts.length));
+    return fromDimensions(score, EntityUtils.decodeDimensions(filterStrings));
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricEntity.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricEntity.java
@@ -3,14 +3,10 @@ package com.linkedin.thirdeye.rootcause.impl;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
 import com.linkedin.thirdeye.rootcause.Entity;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 
 /**
@@ -48,7 +44,7 @@ public class MetricEntity extends Entity {
   }
 
   public MetricEntity withFilters(Multimap<String, String> filters) {
-    return new MetricEntity(TYPE.formatURN(this.id, encodeFilters(filters)), this.getScore(), this.getRelated(), this.id, filters);
+    return new MetricEntity(TYPE.formatURN(this.id, EntityUtils.encodeDimensions(filters)), this.getScore(), this.getRelated(), this.id, filters);
   }
 
   public MetricEntity withoutFilters() {
@@ -56,7 +52,7 @@ public class MetricEntity extends Entity {
   }
 
   public static MetricEntity fromMetric(double score, Collection<? extends Entity> related, long id, Multimap<String, String> filters) {
-    return new MetricEntity(TYPE.formatURN(id, encodeFilters(filters)), score, new ArrayList<>(related), id, TreeMultimap.create(filters));
+    return new MetricEntity(TYPE.formatURN(id, EntityUtils.encodeDimensions(filters)), score, new ArrayList<>(related), id, TreeMultimap.create(filters));
   }
 
   public static MetricEntity fromMetric(double score, Collection<? extends Entity> related, long id) {
@@ -79,32 +75,6 @@ public class MetricEntity extends Entity {
     if(parts.length <= 2)
       throw new IllegalArgumentException(String.format("URN must have at least 3 parts but has '%d'", parts.length));
     List<String> filterStrings = Arrays.asList(Arrays.copyOfRange(parts, 3, parts.length));
-    return fromMetric(score, Long.parseLong(parts[2]), decodeFilters(filterStrings));
+    return fromMetric(score, Long.parseLong(parts[2]), EntityUtils.decodeDimensions(filterStrings));
   }
-
-  private static Multimap<String, String> decodeFilters(List<String> filterStrings) {
-    Multimap<String, String> filters = TreeMultimap.create();
-
-    for(String filterString : filterStrings) {
-      String[] parts = EntityUtils.decodeURNComponent(filterString).split("=", 2);
-      if (parts.length != 2) {
-        throw new IllegalArgumentException(String.format("Could not parse filter string '%s'", filterString));
-      }
-      filters.put(parts[0], parts[1]);
-    }
-
-    return filters;
-  }
-
-  private static List<String> encodeFilters(Multimap<String, String> filters) {
-    List<String> output = new ArrayList<>();
-
-    Multimap<String, String> sorted = TreeMultimap.create(filters);
-    for(Map.Entry<String, String> entry : sorted.entries()) {
-      output.add(EntityUtils.encodeURNComponent(String.format("%s=%s", entry.getKey(), entry.getValue())));
-    }
-
-    return output;
-  }
-
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/DimensionEntityTest.java
@@ -3,7 +3,7 @@ package com.linkedin.thirdeye.rootcause.impl;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
+@Deprecated
 public class DimensionEntityTest {
   @Test
   public void testFromDimension() {

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/DimensionsEntityTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/impl/DimensionsEntityTest.java
@@ -1,0 +1,72 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DimensionsEntityTest {
+  @Test
+  public void testWithoutDimensions() {
+    DimensionsEntity e = DimensionsEntity.fromDimensions(1.0, ArrayListMultimap.<String, String>create());
+    Assert.assertEquals(e.getUrn(), "thirdeye:dimensions:");
+    Assert.assertTrue(e.getDimensions().isEmpty());
+  }
+
+  @Test
+  public void testWithoutDimensionsUrn() {
+    DimensionsEntity e = DimensionsEntity.fromURN("thirdeye:dimensions:", 1.0);
+    Assert.assertTrue(e.getDimensions().isEmpty());
+  }
+
+  @Test
+  public void testEncode() {
+    Multimap<String, String> dimensions = ArrayListMultimap.create();
+    dimensions.put("key", "value!");
+    dimensions.put("key", "other=Value");
+    dimensions.put("otherKey", "another:Value");
+
+    DimensionsEntity e = DimensionsEntity.fromDimensions(1.0, dimensions);
+
+    Assert.assertEquals(e.getUrn(), "thirdeye:dimensions:key%3Dother%3DValue:key%3Dvalue!:otherKey%3Danother%3AValue");
+  }
+
+  @Test
+  public void testDecode() {
+    final String urn = "thirdeye:dimensions:key%3Dother%3DValue:key%3Dvalue!:otherKey%3Danother%3AValue";
+
+    DimensionsEntity e = DimensionsEntity.fromURN(urn, 1.0);
+
+    Assert.assertEquals(e.getDimensions().size(), 3);
+    Assert.assertEquals(e.getDimensions().get("key").size(), 2);
+    Assert.assertTrue(e.getDimensions().get("key").contains("value!"));
+    Assert.assertTrue(e.getDimensions().get("key").contains("other=Value"));
+    Assert.assertEquals(e.getDimensions().get("otherKey").size(), 1);
+    Assert.assertTrue(e.getDimensions().get("otherKey").contains("another:Value"));
+  }
+
+  @Test
+  public void testDecodePlain() {
+    final String urn = "thirdeye:dimensions:key=other=Value:key=value!:otherKey=another/Value";
+
+    DimensionsEntity e = DimensionsEntity.fromURN(urn, 1.0);
+
+    Assert.assertEquals(e.getDimensions().size(), 3);
+    Assert.assertEquals(e.getDimensions().get("key").size(), 2);
+    Assert.assertTrue(e.getDimensions().get("key").contains("value!"));
+    Assert.assertTrue(e.getDimensions().get("key").contains("other=Value"));
+    Assert.assertEquals(e.getDimensions().get("otherKey").size(), 1);
+    Assert.assertTrue(e.getDimensions().get("otherKey").contains("another/Value"));
+  }
+
+  @Test
+  public void testDuplicateDimensionsUrn() {
+    final String urn = "thirdeye:dimensions:key=value:key=value";
+
+    DimensionsEntity e = DimensionsEntity.fromURN(urn, 1.0);
+
+    Assert.assertEquals(e.getDimensions().size(), 1);
+    Assert.assertTrue(e.getDimensions().get("key").contains("value"));
+  }
+}


### PR DESCRIPTION
The legacy DimensionEntity only supports a single key-value pair for filtering. This PR add the DimensionsEntity with multi-filter support, similar to metric entities. The legacy entity is marked deprecated, but retained until legacy RCA support is withdrawn fully.