### PR TITLE
[PINOT-5857] Fix off-heap dictionary to return UTF-8 encoded String objects.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -49,7 +49,7 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public Object get(int dictionaryId) {
-    return new String(_byteStore.get(dictionaryId));
+    return new String(_byteStore.get(dictionaryId), UTF_8);
   }
 
   @Override
@@ -71,7 +71,7 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   private String getInternal(int dictId) {
-    return new String(_byteStore.get(dictId));
+    return new String(_byteStore.get(dictId), UTF_8);
   }
 
   @Override
@@ -127,7 +127,7 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
     String[] sortedValues = new String[numValues];
 
     for (int i = 0; i < numValues; i++) {
-      sortedValues[i] = new String(getInternal(i));
+      sortedValues[i] = getInternal(i);
     }
 
     Arrays.sort(sortedValues);


### PR DESCRIPTION
Not caught by unit test, because unit tests are running with default charset set to UTF-8.
The bug manifests on JVMs that run with US-ASCII as the default charset.