### PR TITLE
[TE] Disable data completeness check for functions besides Daily

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/DefaultDetectionOnboardJob.java
@@ -48,6 +48,7 @@ public class DefaultDetectionOnboardJob extends BaseDetectionOnboardJob {
   public static final String FUNCTION_PROPERTIES = "properties";
   public static final String FUNCTION_IS_ACTIVE = "isActive";
   public static final String CRON_EXPRESSION = "cron";
+  public static final String REQUIRE_DATA_COMPLETENESS = "requireDataCompleteness";
   public static final String ALERT_ID = "alertId";
   public static final String ALERT_NAME = "alertName";
   public static final String ALERT_CRON = "alertCron";

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/tasks/FunctionCreationOnboardingTask.java
@@ -68,6 +68,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
   public static final String PROPERTIES = DefaultDetectionOnboardJob.FUNCTION_PROPERTIES;
   public static final String IS_ACTIVE = DefaultDetectionOnboardJob.FUNCTION_IS_ACTIVE;
   public static final String CRON_EXPRESSION = DefaultDetectionOnboardJob.CRON_EXPRESSION;
+  public static final String REQUIRE_DATA_COMPLETENESS = DefaultDetectionOnboardJob.REQUIRE_DATA_COMPLETENESS;
   public static final String ALERT_FILTER_PATTERN = DefaultDetectionOnboardJob.AUTOTUNE_PATTERN;
   public static final String ALERT_FILTER_TYPE = DefaultDetectionOnboardJob.AUTOTUNE_TYPE;
   public static final String ALERT_FILTER_FEATURES = DefaultDetectionOnboardJob.AUTOTUNE_FEATURES;
@@ -217,6 +218,8 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
       anomalyFunction.setBucketSize(dataGranularity.getSize());
       anomalyFunction.setBucketUnit(dataGranularity.getUnit());
       anomalyFunction.setIsActive(configuration.getBoolean(IS_ACTIVE, DEFAULT_IS_ACTIVE));
+      anomalyFunction.setRequiresCompletenessCheck(configuration.getBoolean(REQUIRE_DATA_COMPLETENESS,
+          defaultFunctionSpec.isRequiresCompletenessCheck()));
 
       anoomalyFunctionDAO.update(anomalyFunction);
 
@@ -286,6 +289,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
         anomalyFunctionSpec.setWindowUnit(TimeUnit.HOURS);
         anomalyFunctionSpec.setFrequency(new TimeGranularity(15, TimeUnit.MINUTES));
         anomalyFunctionSpec.setProperties("");
+        anomalyFunctionSpec.setRequiresCompletenessCheck(false);
         break;
       case HOURS:
         anomalyFunctionSpec.setType("REGRESSION_GAUSSIAN_SCAN");
@@ -293,6 +297,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
         anomalyFunctionSpec.setWindowSize(24);
         anomalyFunctionSpec.setWindowUnit(TimeUnit.HOURS);
         anomalyFunctionSpec.setProperties("");
+        anomalyFunctionSpec.setRequiresCompletenessCheck(false);
         break;
       case DAYS:
         anomalyFunctionSpec.setType("SPLINE_REGRESSION_VANILLA");
@@ -300,6 +305,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
         anomalyFunctionSpec.setWindowSize(1);
         anomalyFunctionSpec.setWindowUnit(TimeUnit.DAYS);
         anomalyFunctionSpec.setProperties("");
+        anomalyFunctionSpec.setRequiresCompletenessCheck(true);
         break;
       default:
         anomalyFunctionSpec.setType("WEEK_OVER_WEEK_RULE");
@@ -307,6 +313,7 @@ public class FunctionCreationOnboardingTask extends BaseDetectionOnboardTask {
         anomalyFunctionSpec.setWindowSize(6);
         anomalyFunctionSpec.setWindowUnit(TimeUnit.HOURS);
         anomalyFunctionSpec.setProperties("");
+        anomalyFunctionSpec.setRequiresCompletenessCheck(false);
         break;
     }
     return anomalyFunctionSpec;


### PR DESCRIPTION
For most of the anomaly functions, we don't need to have data completeness checker, besides daily detection. In the original settings, data completeness checkers are set to true by default. This pr is to disable data completeness checker for minute and hourly detection. 