### PR TITLE
Fixing the overflow issue for FixedBitSingleValueWriter

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedBitSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedBitSingleValueWriter.java
@@ -27,8 +27,10 @@ public class FixedBitSingleValueWriter implements SingleColumnSingleValueWriter 
   private FixedBitIntReaderWriter dataFileWriter;
 
   public FixedBitSingleValueWriter(File file, int rows, int columnSizeInBits) throws Exception {
+    // Convert to long in order to avoid int overflow
+    long length =  ((long) rows * columnSizeInBits + Byte.SIZE - 1) / Byte.SIZE;
     PinotDataBuffer dataBuffer =
-        PinotDataBuffer.fromFile(file, 0, (rows * columnSizeInBits + Byte.SIZE - 1) / Byte.SIZE, ReadMode.mmap,
+        PinotDataBuffer.fromFile(file, 0, (int) length, ReadMode.mmap,
             FileChannel.MapMode.READ_WRITE, file.getAbsolutePath());
     dataFileWriter = new FixedBitIntReaderWriter(dataBuffer, rows, columnSizeInBits);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/memory/PinotByteBuffer.java
@@ -78,7 +78,8 @@ public class PinotByteBuffer extends PinotDataBuffer {
     Preconditions.checkNotNull(file);
     Preconditions.checkArgument(start >= 0);
     Preconditions.checkArgument(length >= 0 && length < Integer.MAX_VALUE,
-        "Mapping files larger than 2GB is not supported, file: " + file.toString() + ", context: " + context);
+        "Mapping files larger than 2GB is not supported, file: " + file.toString() + ", context: " + context
+            + ", length: " + length);
     Preconditions.checkNotNull(context);
 
     if (openMode == FileChannel.MapMode.READ_ONLY) {


### PR DESCRIPTION
When creating a segment, the current code can cause int
overflow when the number of rows is high. This results
in failing to generate a segment even if the final size
is less than the upper bound for mapping file (2GB).