### PR TITLE
[TE] Self-Serve Onboard/Tuning flows: perf enhancements + links

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -233,8 +233,9 @@ export default Controller.extend({
         defaultSeverity
       } = this.getProperties('alertData', 'alertEvalMetrics', 'defaultSeverity');
       const features = getWithDefault(alertData, 'alertFilter.features', null);
-      const severityUnit = features && features.split(',')[1] !== 'deviation' ? '%' : '';
-      const mttdWeight = Number(extractSeverity(alertData, defaultSeverity)) * 100;
+      const severityUnit = (features && features.split(',')[1] !== 'deviation') ? '%' : '';
+      const mttdWeight = Number(extractSeverity(alertData, defaultSeverity));
+      const convertedWeight = severityUnit === '%' ? mttdWeight * 100 : mttdWeight;
       const statsCards = [
           {
             title: 'Number of anomalies',
@@ -266,12 +267,12 @@ export default Controller.extend({
             text: 'Among all anomalies that happened, the % of them detected by the system.'
           },
           {
-            title: `MTTD for > ${mttdWeight}${severityUnit} change`,
+            title: `MTTD for > ${convertedWeight}${severityUnit} change`,
             key: 'mttd',
             units: 'hrs',
             tooltip: false,
             hideProjected: true,
-            text: `Minimum time to detect for anomalies with > ${mttdWeight}${severityUnit} change`
+            text: `Minimum time to detect for anomalies with > ${convertedWeight}${severityUnit} change`
           }
         ];
 
@@ -508,7 +509,9 @@ export default Controller.extend({
       activeRangeEnd: '',
       alertEvalMetrics: {}
     });
+    // Cancel controller concurrency tasks
     this.get('checkReplayStatus').cancelAll();
+    this.get('checkForNewAnomalies').cancelAll();
   },
 
   /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -63,7 +63,6 @@ export default Controller.extend({
     const repRunStatus = this.get('repRunStatus');
     this.setProperties({
       filters: {},
-      //metricData: {},
       loadedWowData: [],
       predefinedRanges: {},
       missingAnomalyProps: {},
@@ -233,7 +232,9 @@ export default Controller.extend({
         defaultSeverity
       } = this.getProperties('alertData', 'alertEvalMetrics', 'defaultSeverity');
       const features = getWithDefault(alertData, 'alertFilter.features', null);
-      const severityUnit = (features && features.split(',')[1] !== 'deviation') ? '%' : '';
+      const mttdStr = _.has(alertData, 'alertFilter.mttd') ? alertData.alertFilter.mttd.split(';') : null;
+      const severityUnitFeatures = (features && features.split(',')[1] !== 'deviation') ? '%' : '';
+      const severityUnit = (mttdStr && mttdStr[1].split('=')[0] !== 'deviation') ? '%' : '';
       const mttdWeight = Number(extractSeverity(alertData, defaultSeverity));
       const convertedWeight = severityUnit === '%' ? mttdWeight * 100 : mttdWeight;
       const statsCards = [

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -234,7 +234,7 @@ export default Controller.extend({
       const features = getWithDefault(alertData, 'alertFilter.features', null);
       const mttdStr = _.has(alertData, 'alertFilter.mttd') ? alertData.alertFilter.mttd.split(';') : null;
       const severityUnitFeatures = (features && features.split(',')[1] !== 'deviation') ? '%' : '';
-      const severityUnit = (mttdStr && mttdStr[1].split('=')[0] !== 'deviation') ? '%' : '';
+      const severityUnit = (!mttdStr || mttdStr && mttdStr[1].split('=')[0] !== 'deviation') ? '%' : '';
       const mttdWeight = Number(extractSeverity(alertData, defaultSeverity));
       const convertedWeight = severityUnit === '%' ? mttdWeight * 100 : mttdWeight;
       const statsCards = [

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -229,8 +229,8 @@ export default Controller.extend({
       const {
         alertData,
         alertEvalMetrics,
-        defaultSeverity
-      } = this.getProperties('alertData', 'alertEvalMetrics', 'defaultSeverity');
+        DEFAULT_SEVERITY: defaultSeverity
+      } = this.getProperties('alertData', 'alertEvalMetrics', 'DEFAULT_SEVERITY');
       const features = getWithDefault(alertData, 'alertFilter.features', null);
       const mttdStr = _.has(alertData, 'alertFilter.mttd') ? alertData.alertFilter.mttd.split(';') : null;
       const severityUnitFeatures = (features && features.split(',')[1] !== 'deviation') ? '%' : '';

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -8,12 +8,15 @@ import fetch from 'fetch';
 import moment from 'moment';
 import Route from '@ember/routing/route';
 import { later } from "@ember/runloop";
-import { set, get, setProperties } from '@ember/object';
+import { task, timeout } from 'ember-concurrency';
 import { isPresent } from "@ember/utils";
+import { set, get, setProperties } from '@ember/object';
 import { checkStatus, buildDateEod, toIso } from 'thirdeye-frontend/utils/utils';
 import {
   enhanceAnomalies,
   toIdGroups,
+  setMetricData,
+  getMetricData,
   setUpTimeRangeOptions,
   getTopDimensions,
   buildMetricDataUrl,
@@ -35,9 +38,13 @@ const paginationDefault = 10;
 const dimensionCount = 7;
 const durationDefault = '3m';
 const metricDataColor = 'blue';
+const endDateDefault = moment();
+const resolutionOptions = ['All Resolutions'];
+const dimensionOptions = ['All Dimensions'];
+const wowOptions = ['Wow', 'Wo2W', 'Wo3W', 'Wo4W'];
 const durationMap = { m:'month', d:'day', w:'week' };
 const startDateDefault = buildDateEod(3, 'month').valueOf();
-const endDateDefault = moment();
+const baselineOptions = [{ name: 'Predicted', isActive: true }];
 
 /**
  * Response type options for anomalies
@@ -60,6 +67,13 @@ const anomalyResponseObj = [
     status: 'New Trend'
   }
 ];
+
+/**
+ * Build WoW array from basic options
+ */
+const newWowList = wowOptions.map((item) => {
+  return { name: item, isActive: false };
+});
 
 /**
  * Fetches all anomaly data for found anomalies - downloads all 'pages' of data from server
@@ -316,23 +330,6 @@ export default Route.extend({
       rawAnomalyData
     } = model;
 
-    // Initial value setup for displayed option lists
-    let subD = {};
-    let anomalyData = [];
-    let rawAnomalies = [];
-    const notCreateError = jobId !== -1;
-    const resolutionOptions = ['All Resolutions'];
-    const dimensionOptions = ['All Dimensions'];
-    const wowOptions = ['Wow', 'Wo2W', 'Wo3W', 'Wo4W'];
-    const baselineOptions = [{ name: 'Predicted', isActive: true }];
-    const responseOptions = anomalyResponseObj.map(response => response.name);
-    const timeRangeOptions = setUpTimeRangeOptions(['3m'], duration);
-    const alertDimension = exploreDimensions ? exploreDimensions.split(',')[0] : '';
-    const isReplayPending = isPresent(jobId) && jobId !== -1;
-    const newWowList = wowOptions.map((item) => {
-      return { name: item, isActive: false };
-    });
-
     // Prime the controller
     controller.setProperties({
       loadError,
@@ -340,17 +337,18 @@ export default Route.extend({
       alertData,
       alertId: id,
       defaultSeverity,
-      isReplayPending,
       anomalyDataUrl,
       baselineOptions,
-      responseOptions,
-      timeRangeOptions,
       anomalyResponseObj,
       alertEvalMetrics,
       anomaliesLoaded: false,
       isMetricDataInvalid: false,
       isMetricDataLoading: true,
-      alertHasDimensions: isPresent(exploreDimensions)
+      isReplayPending: isPresent(jobId) && jobId !== -1,
+      alertHasDimensions: isPresent(exploreDimensions),
+      timeRangeOptions: setUpTimeRangeOptions(['3m'], duration),
+      baselineOptionsLoading: anomalyIds && anomalyIds.length > 0,
+      responseOptions: anomalyResponseObj.map(response => response.name)
     });
 
     // Kick off controller defaults and replay status check
@@ -364,64 +362,17 @@ export default Route.extend({
       });
     });
 
-    // Fetch all anomalies we have Ids for. Enhance the data and populate power-select filter options.
-    // TODO: look into possibility of bundling calls or using async/await: https://github.com/linkedin/pinot/pull/2468
-    if (notCreateError) {
-      fetchCombinedAnomalies(anomalyIds)
-        .then((rawAnomalyData) => {
-          rawAnomalies = rawAnomalyData;
-          return fetchSeverityScores(anomalyIds);
-        })
-        .then((severityScores) => {
-          anomalyData = enhanceAnomalies(rawAnomalies, severityScores);
-          resolutionOptions.push(...new Set(anomalyData.map(record => record.anomalyFeedback)));
-          dimensionOptions.push(...new Set(anomalyData.map(anomaly => anomaly.dimensionString)));
-          controller.setProperties({
-            anomaliesLoaded: true,
-            anomalyData,
-            resolutionOptions,
-            dimensionOptions
-          });
-          return this.fetchCombinedAnomalyChangeData(anomalyData);
-        })
-        // Load and display rest of options once data is loaded ('2week', 'Last Week')
-        .then((wowData) => {
-          anomalyData.forEach((anomaly) => {
-            anomaly.wowData = wowData[anomaly.anomalyId] || {};
-          });
-          controller.setProperties({
-            anomalyData,
-            baselineOptions: [baselineOptions[0], ...newWowList]
-          });
-          return fetch(metricDataUrl).then(checkStatus);
-        })
-        // Fetch and load graph metric data. Stop spinner/loader
-        .then((metricData) => {
-          Object.assign(metricData, { color: metricDataColor });
-          controller.setProperties({
-            metricData,
-            alertDimension,
-            topDimensions: [],
-            isMetricDataLoading: false
-          });
-          // If alert has dimensions set, load them into graph once replay is done.
-          if (exploreDimensions && !isReplayPending) {
-            controller.set('topDimensions', getTopDimensions(metricData, dimensionCount));
-          }
-        })
-        .catch((errors) => {
-          controller.setProperties({
-            isMetricDataInvalid: true,
-            isMetricDataLoading: false,
-            graphMessageText: 'Error loading metric data'
-          });
-        });
+    // Begin loading anomaly and graph data as concurrency tasks
+    if (jobId !== -1) {
+      this.get('loadAnomalyData').perform(anomalyIds);
+      this.get('loadGraphData').perform(metricDataUrl, exploreDimensions);
     }
   },
 
   resetController(controller, isExiting) {
     this._super(...arguments);
 
+    // Cancel all pending concurrency tasks in controller
     if (isExiting) {
       controller.clearAll();
     }
@@ -430,6 +381,7 @@ export default Route.extend({
   /**
    * Fetches change rate data for each available anomaly id
    * @method fetchCombinedAnomalyChangeData
+   * @param {Array} anomalyData - array of processed anomalies
    * @returns {RSVP promise}
    */
   fetchCombinedAnomalyChangeData(anomalyData) {
@@ -442,6 +394,98 @@ export default Route.extend({
 
     return RSVP.hash(promises);
   },
+
+  /**
+   * Performs the repetitive task of setting graph properties based on
+   * returned metric data and dimension data
+   * @method setGraphProperties
+   * @param {Object} metricData - returned metric timeseries data
+   * @param {String} exploreDimensions - string of metric dimensions
+   * @returns {RSVP promise}
+   */
+  setGraphProperties(metricData, exploreDimensions) {
+    const alertDimension = exploreDimensions ? exploreDimensions.split(',')[0] : '';
+    Object.assign(metricData, { color: metricDataColor });
+    this.controller.setProperties({
+      metricData,
+      alertDimension,
+      topDimensions: [],
+      isMetricDataLoading: false
+    });
+    // If alert has dimensions set, load them into graph once replay is done.
+    if (exploreDimensions && !this.controller.isReplayPending) {
+      this.controller.set('topDimensions', getTopDimensions(metricData, dimensionCount));
+    }
+  },
+
+  /**
+   * Fetch all anomalies we have Ids for. Enhance the data and populate power-select filter options.
+   * Using ember concurrency parent/child tasks. When parent is cancelled, so are children
+   * http://ember-concurrency.com/docs/child-tasks.
+   * TODO: complete concurrency task error handling and refactor child tasks for cuncurrency.
+   * @param {Array} anomalyIds - the IDs of anomalies that have been reported for this alert.
+   * @return {undefined}
+   */
+  loadAnomalyData: task(function * (anomalyIds) {
+    yield timeout(300);
+    // Load data for each anomaly Id
+    const rawAnomalies = yield fetchCombinedAnomalies(anomalyIds);
+    // Fetch and append severity score to each anomaly record
+    const severityScores = yield fetchSeverityScores(anomalyIds);
+    // Process anomaly records to make them template-ready
+    const anomalyData = yield enhanceAnomalies(rawAnomalies, severityScores);
+    // Prepare de-duped power-select option arrays
+    resolutionOptions.push(...new Set(anomalyData.map(record => record.anomalyFeedback)));
+    dimensionOptions.push(...new Set(anomalyData.map(anomaly => anomaly.dimensionString)));
+    // Push anomaly data into controller
+    this.controller.setProperties({
+      anomaliesLoaded: true,
+      anomalyData,
+      resolutionOptions,
+      dimensionOptions
+    });
+    // Fetch and append extra WoW data for each anomaly record
+    const wowData = yield this.fetchCombinedAnomalyChangeData(anomalyData);
+    anomalyData.forEach((anomaly) => {
+      anomaly.wowData = wowData[anomaly.anomalyId] || {};
+    });
+    // Load enhanced dataset into controller (WoW options will appear)
+    this.controller.setProperties({
+      anomalyData,
+      baselineOptionsLoading: false,
+      baselineOptions: [baselineOptions[0], ...newWowList]
+    });
+  // We use .cancelOn('deactivate') to make sure the task cancels when the user leaves the route.
+  // We use restartable to ensure that only one instance of the task is running at a time, hence
+  // any time setupController performs the task, any prior instances are canceled.
+  }).cancelOn('deactivate').restartable(),
+
+  /**
+   * Concurrenty task to ping the job-info endpoint to check status of an ongoing replay job.
+   * If there is no progress after a set time, we display an error message.
+   * @param {Number} jobId - the id for the newly triggered replay job
+   * @param {String} functionName - user-provided new function name (used to validate creation)
+   * @return {undefined}
+   */
+  loadGraphData: task(function * (metricDataUrl, exploreDimensions) {
+    yield timeout(300);
+    const metricId = this.currentModel.config ? this.currentModel.config.id : null;
+    const isGraphDataLocal = metricId && localStorage.getItem(metricId) !== null;
+
+    // Fetch and load graph metric data.
+    fetch(metricDataUrl).then(checkStatus)
+      .then((metricData) => {
+        // Load graph with metric data from timeseries API
+        this.setGraphProperties(metricData, exploreDimensions);
+      })
+      .catch((errors) => {
+        this.controller.setProperties({
+          isMetricDataInvalid: true,
+          isMetricDataLoading: false,
+          graphMessageText: 'Error loading metric data'
+        });
+      });
+  }).cancelOn('deactivate').restartable(),
 
   actions: {
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -60,7 +60,7 @@
     {{/if}}
 
     <div class="te-content-block">
-      <h4 class="te-self-serve__block-title">Anomalies over time ({{filteredAnomalies.length}})</h4>
+      <h4 class="te-self-serve__block-title">Anomalies over time ({{#if anomaliesLoaded}}{{filteredAnomalies.length}}{{else}}...loading anomalies{{/if}})</h4>
       <a class="te-pill-selectors__side-link te-pill-selectors__side-link--high" {{action "onClickReportAnomaly" this}}>Report missing anomaly</a>
 
       {{#if filteredAnomalies}}
@@ -159,109 +159,114 @@
       {{/if}}
 
       {{!-- Alert anomaly table --}}
-      <table class="te-anomaly-table">
-        {{#if filteredAnomalies}}
-          <thead>
-            <tr class="te-anomaly-table__row te-anomaly-table__head">
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
-                  Start/Duration (PDT)
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
-               </th>
-               {{#if alertHasDimensions}}
-                  <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--fixed">Dimensions</th>
-               {{/if}}
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
-                  Severity Score
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
-               </th>
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
-                  {{baselineTitle}}
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
-               </th>
-               <th class="te-anomaly-table__cell-head">
-                <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
-                  Resolution
-                  <i class="te-anomaly-table__icon glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
-                </a>
-             </th>
-            </tr>
-          </thead>
+      <div class="te-block-container">
+        {{#if baselineOptionsLoading}}
+          <div class="spinner-wrapper spinner-wrapper--card">{{ember-spinner}}</div>
         {{/if}}
-        <tbody>
-          {{#each paginatedFilteredAnomalies as |anomaly|}}
-            <tr class="te-anomaly-table__row">
-               <td class="te-anomaly-table__cell">
-                <ul class="te-anomaly-table__list">
-                  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--shadow">{{anomaly.index}}</li>
-                  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">
-                    <a target="_blank" class="te-anomaly-table__link" href="/thirdeye#anomalies?anomaliesSearchMode=id&pageNumber=1&anomalyIds={{anomaly.anomalyId}}">
-                      {{anomaly.startDateStr}}
-                    </a>
-                  </li>
-                  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--lighter">{{anomaly.durationStr}}</li>
-                </ul>
-               </td>
-               {{#if alertHasDimensions}}
+        <table class="te-anomaly-table">
+          {{#if filteredAnomalies}}
+            <thead>
+              <tr class="te-anomaly-table__row te-anomaly-table__head">
+                 <th class="te-anomaly-table__cell-head">
+                  <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "start"}}>
+                    Start/Duration (PDT)
+                    <i class="te-anomaly-table__icon glyphicon {{if sortColumnStartUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  </a>
+                 </th>
+                 {{#if alertHasDimensions}}
+                    <th class="te-anomaly-table__cell-head te-anomaly-table__cell-head--fixed">Dimensions</th>
+                 {{/if}}
+                 <th class="te-anomaly-table__cell-head">
+                  <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "score"}}>
+                    Severity Score
+                    <i class="te-anomaly-table__icon glyphicon {{if sortColumnScoreUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  </a>
+                 </th>
+                 <th class="te-anomaly-table__cell-head">
+                  <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "change"}}>
+                    {{baselineTitle}}
+                    <i class="te-anomaly-table__icon glyphicon {{if sortColumnChangeUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  </a>
+                 </th>
+                 <th class="te-anomaly-table__cell-head">
+                  <a class="te-anomaly-table__cell-link" {{action "toggleSortDirection" "resolution"}}>
+                    Resolution
+                    <i class="te-anomaly-table__icon glyphicon {{if sortColumnResolutionUp "glyphicon-menu-up" "glyphicon-menu-down"}}"></i>
+                  </a>
+               </th>
+              </tr>
+            </thead>
+          {{/if}}
+          <tbody>
+            {{#each paginatedFilteredAnomalies as |anomaly|}}
+              <tr class="te-anomaly-table__row">
                  <td class="te-anomaly-table__cell">
                   <ul class="te-anomaly-table__list">
-                   {{#each anomaly.dimensionList as |dimension|}}
-                      <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller" title="{{dimension.dimensionVal}}">
-                        {{dimension.dimensionKey}}: <span class="stronger">{{dimension.dimensionVal}}</span>
-                      </li>
-                   {{else}}
-                      -
-                   {{/each}}
+                    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--shadow">{{anomaly.index}}</li>
+                    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--stronger">
+                      <a target="_blank" class="te-anomaly-table__link" href="/thirdeye#anomalies?anomaliesSearchMode=id&pageNumber=1&anomalyIds={{anomaly.anomalyId}}">
+                        {{anomaly.startDateStr}}
+                      </a>
+                    </li>
+                    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--lighter">{{anomaly.durationStr}}</li>
                   </ul>
                  </td>
-               {{/if}}
-               <td class="te-anomaly-table__cell">{{anomaly.severityScore}}</td>
-               <td class="te-anomaly-table__cell">
-                <ul class="te-anomaly-table__list">
-                  <li>{{anomaly.shownCurrent}} / {{anomaly.shownBaseline}}</li>
-                  <li class="te-anomaly-table__value-label te-anomaly-table__value-label--{{anomaly.changeDirectionLabel}}">
-                    ({{anomaly.shownChangeRate}}%)
-                  </li>
-                </ul>
-               </td>
-               <td class="te-anomaly-table__cell">
-                  {{#if anomaly.showResponseSaved}}
-                    <i class="te-anomaly-table__icon--status glyphicon glyphicon-ok-circle"></i>
-                  {{/if}}
+                 {{#if alertHasDimensions}}
+                   <td class="te-anomaly-table__cell">
+                    <ul class="te-anomaly-table__list">
+                     {{#each anomaly.dimensionList as |dimension|}}
+                        <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller" title="{{dimension.dimensionVal}}">
+                          {{dimension.dimensionKey}}: <span class="stronger">{{dimension.dimensionVal}}</span>
+                        </li>
+                     {{else}}
+                        -
+                     {{/each}}
+                    </ul>
+                   </td>
+                 {{/if}}
+                 <td class="te-anomaly-table__cell">{{anomaly.severityScore}}</td>
+                 <td class="te-anomaly-table__cell">
+                  <ul class="te-anomaly-table__list">
+                    <li>{{anomaly.shownCurrent}} / {{anomaly.shownBaseline}}</li>
+                    <li class="te-anomaly-table__value-label te-anomaly-table__value-label--{{anomaly.changeDirectionLabel}}">
+                      ({{anomaly.shownChangeRate}}%)
+                    </li>
+                  </ul>
+                 </td>
+                 <td class="te-anomaly-table__cell">
+                    {{#if anomaly.showResponseSaved}}
+                      <i class="te-anomaly-table__icon--status glyphicon glyphicon-ok-circle"></i>
+                    {{/if}}
 
-                  {{#if anomaly.showResponseFailed}}
-                    <i class="te-anomaly-table__icon--status glyphicon glyphicon-remove-circle"></i>
-                  {{/if}}
+                    {{#if anomaly.showResponseFailed}}
+                      <i class="te-anomaly-table__icon--status glyphicon glyphicon-remove-circle"></i>
+                    {{/if}}
 
-                  {{#if anomaly.isUserReported}}
-                    <span class="te-anomaly-table__text">User Reported</span>
-                  {{else}}
-                    {{#power-select
-                      triggerId=anomaly.anomalyId
-                      triggerClass="te-anomaly-table__select"
-                      options=responseOptions
-                      searchEnabled=false
-                      selected=anomaly.anomalyFeedback
-                      onchange=(action "onChangeAnomalyResponse" anomaly)
-                      as |response|
-                    }}
-                      {{response}}
-                    {{/power-select}}
-                  {{/if}}
+                    {{#if anomaly.isUserReported}}
+                      <span class="te-anomaly-table__text">User Reported</span>
+                    {{else}}
+                      {{#power-select
+                        triggerId=anomaly.anomalyId
+                        triggerClass="te-anomaly-table__select"
+                        options=responseOptions
+                        searchEnabled=false
+                        selected=anomaly.anomalyFeedback
+                        onchange=(action "onChangeAnomalyResponse" anomaly)
+                        as |response|
+                      }}
+                        {{response}}
+                      {{/power-select}}
+                    {{/if}}
 
-                  <div class="te-anomaly-table__link-wrapper">
-                    <a target="_blank" class="te-anomaly-table__link" href="/thirdeye#anomalies?anomaliesSearchMode=id&pageNumber=1&anomalyIds={{anomaly.anomalyId}}">Investigate</a>
-                  </div>
-               </td>
-            </tr>
-          {{/each}}
-        </tbody>
-      </table>
+                    <div class="te-anomaly-table__link-wrapper">
+                      <a target="_blank" class="te-anomaly-table__link" href="/thirdeye#anomalies?anomaliesSearchMode=id&pageNumber=1&anomalyIds={{anomaly.anomalyId}}">Investigate</a>
+                    </div>
+                 </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
 
       {{!--pagination--}}
       {{#if (gt pagesNum 1)}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -57,7 +57,7 @@ const severityMap = {
 const sensitivityDefaults = {
   selectedSeverityOption: 'Percentage of Change',
   selectedTunePattern: 'Up and Down',
-  defaultPercentChange: '30',
+  defaultPercentChange: '0.3',
   defaultMttdChange: '5'
 };
 
@@ -127,6 +127,7 @@ const processDefaultTuningParams = (alertData) => {
 
   // Load saved severity type
   const savedSeverityPattern = alertFeatures ? alertFeatures : 'weight';
+  const isAbsValue = savedSeverityPattern === 'deviation';
   for (var severityKey in severityMap) {
     if (savedSeverityPattern === severityMap[severityKey]) {
       selectedSeverityOption = severityKey;
@@ -139,7 +140,8 @@ const processDefaultTuningParams = (alertData) => {
 
   // Load saved severity value
   const severityValue = alertMttd ? alertMttd[1].split('=')[1] : 'N/A';
-  const customPercentChange = !isNaN(severityValue) ? Number(severityValue) * 100 : defaultPercentChange;
+  const rawPercentChange = !isNaN(severityValue) ? Number(severityValue) : defaultPercentChange;
+  const customPercentChange = isAbsValue ? rawPercentChange : rawPercentChange * 100;
 
   return { selectedSeverityOption, selectedTunePattern, customPercentChange, customMttdChange };
 };

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -125,8 +125,9 @@ const processDefaultTuningParams = (alertData) => {
     }
   }
 
-  // Load saved severity type
-  const savedSeverityPattern = alertFeatures ? alertFeatures : 'weight';
+  // TODO: enable once issue resolved in backend (not saving selection to new feature string)
+  // savedSeverityPattern = alertFeatures ? alertFeatures : 'weight';
+  const savedSeverityPattern = alertMttd ? alertMttd[1].split('=')[0] : 'weight';
   const isAbsValue = savedSeverityPattern === 'deviation';
   for (var severityKey in severityMap) {
     if (savedSeverityPattern === severityMap[severityKey]) {

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -236,6 +236,14 @@ export default Controller.extend({
       this.set('resultsActive', true);
     },
 
+    // Handle transition to alert page while refreshing the duration cache.
+    navigateToAlertPage(alertId) {
+      if (localStorage.getItem('duration') !== null) {
+        localStorage.removeItem('duration');
+      }
+      this.transitionToRoute('manage.alert', alertId);
+    },
+
     // Handles filtering of alerts in response to filter selection
     userDidSelectFilter(filterArr) {
       let task = {};

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
@@ -122,21 +122,14 @@
                 <span class="te-search-results__tag te-search-results__tag--list {{if alert.isActive "te-search-results__tag--active"}}">
                   {{if alert.isActive "Active" "Inactive"}}
                 </span>
-                {{#if testMode}}
-                  {{#link-to "manage.alert.explore" alert.id}}
-                    <div class="te-search-results__title-name" title={{alert.functionName}}>{{alert.functionName}}</div>
-                  {{/link-to}}
-                {{else}}
-                  <span title={{alert.functionName}}>{{alert.functionName}}</span>
-                {{/if}}
+                <a href="#" {{action "navigateToAlertPage" alert.id}}>
+                  <div class="te-search-results__title-name" title={{alert.functionName}}>{{alert.functionName}}</div>
+                </a>
               </div>
             </div>
-            {{!-- TODO: remove delete option when enabling new edit/tune flow --}}
               <div class="te-search-results__edit-button">
                 {{#if testMode}}
                   <a href="#" {{action "removeThirdEyeFunction" alert.id}}><span class="glyphicon glyphicon-trash"></span></a>
-                {{else}}
-                  {{#link-to "manage.alerts.edit" alert.id}}<span class="glyphicon glyphicon-pencil"></span>{{/link-to}}
                 {{/if}}
               </div>
           </div>

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -19,6 +19,7 @@ import {
 } from "@ember/utils";
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import {
+  setMetricData,
   buildMetricDataUrl,
   getTopDimensions
 } from 'thirdeye-frontend/utils/manage-alert-utils';
@@ -52,6 +53,7 @@ export default Controller.extend({
   graphEmailLinkProps: '',
   dimensionCount: 7,
   availableDimensions: 0,
+  selectedSeverityOption: 'Percentage of Change',
   legendText: {
     dotted: {
       text: 'WoW'
@@ -179,11 +181,12 @@ export default Controller.extend({
       };
 
       if (isCustomFilterPossible) {
-        const mttdVal = Number(customMttdChange).toFixed(2);
-        const severityThresholdVal = (Number(customPercentChange)/100).toFixed(2);
+        const mttdVal = Number.isNaN(Number(customMttdChange)) ? 0 : Number(customMttdChange).toFixed(2);
+        const severityThresholdVal = Number.isNaN(Number(customPercentChange)) ? 0 : Number(customPercentChange).toFixed(2);
+        const finalSeverity = severityMap[selectedSeverity] === 'deviation' ? severityThresholdVal : (severityThresholdVal/100).toFixed(2);
         Object.assign(filterObj, {
           features: `window_size_in_hour,${severityMap[selectedSeverity]}`,
-          mttd: `window_size_in_hour=${mttdVal};${severityMap[selectedSeverity]}=${severityThresholdVal}`
+          mttd: `window_size_in_hour=${mttdVal};${severityMap[selectedSeverity]}=${finalSeverity}`
         });
       }
 
@@ -304,6 +307,7 @@ export default Controller.extend({
     fetch(metricUrl).then(checkStatus)
       .then(metricData => {
         this.setProperties({
+          metricId: metric.id,
           isMetricSelected: true,
           isMetricDataLoading: false,
           showGraphLegend: true,
@@ -329,6 +333,7 @@ export default Controller.extend({
         this.clearAll();
         this.setProperties({
           isMetricDataLoading: false,
+          isMetricDataInvalid: true,
           selectMetricErrMsg: error
         });
       });
@@ -748,7 +753,8 @@ export default Controller.extend({
       isAlertNameDuplicate: false,
       graphEmailLinkProps: '',
       bsAlertBannerType: 'success',
-      selectedFilters: JSON.stringify({})
+      selectedFilters: JSON.stringify({}),
+      selectedSeverityOption: 'Percentage of Change'
     });
     this.send('refreshModel');
   },
@@ -1042,13 +1048,19 @@ export default Controller.extend({
      */
     onSubmit() {
       const {
+        metricId,
+        selectedMetric,
         isDuplicateEmail,
         onboardFunctionPayload,
         alertGroupNewRecipient: newEmails
-      } = this.getProperties('isDuplicateEmail', 'onboardFunctionPayload', 'alertGroupNewRecipient');
+      } = this.getProperties('metricId', 'selectedMetric', 'isDuplicateEmail', 'onboardFunctionPayload', 'alertGroupNewRecipient');
       const newEmailsArr = newEmails ? newEmails.replace(/ /g, '').split(',') : [];
       const isEmailError = !this.isEmailValid(newEmailsArr);
 
+      // TODO: cache latest selected metric data using session storage
+      // setMetricData(metricId, selectedMetric);
+
+      // Update validation properties
       this.setProperties({
         isEmailError,
         isProcessingForm: true,

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -180,6 +180,7 @@ export default Controller.extend({
         isCustom: isCustomFilterPossible
       };
 
+      // TODO: move this shared logic into utils
       if (isCustomFilterPossible) {
         const mttdVal = Number.isNaN(Number(customMttdChange)) ? 0 : Number(customMttdChange).toFixed(2);
         const severityThresholdVal = Number.isNaN(Number(customPercentChange)) ? 0 : Number(customPercentChange).toFixed(2);
@@ -304,6 +305,7 @@ export default Controller.extend({
     const metricUrl = buildMetricDataUrl({ maxTime, filters, dimension, granularity, id: metric.id });
 
     // Fetch new graph metric data
+    // TODO: const metricData = await fetch(metricUrl).then(checkStatus)
     fetch(metricUrl).then(checkStatus)
       .then(metricData => {
         this.setProperties({

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -440,6 +440,10 @@ body {
   margin: 10px 0 20px -15px;
 }
 
+.te-block-container {
+  position: relative;
+}
+
 .te-anomaly-table-stats {
   display: table;
   margin: 0;

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -94,7 +94,7 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
       isUserReported: anomaly.anomalyResultSource === 'USER_LABELED_ANOMALY',
       startDateStr: moment(anomaly.anomalyStart).format('MMM D, hh:mm A'),
       durationStr: noZeroDurationArr.join(', '),
-      severityScore: score ? score.toFixed(2) : 'N/A',
+      severityScore: score && !isNaN(score) ? score.toFixed(2) : 'N/A',
       shownCurrent: anomaly.current,
       shownBaseline: anomaly.baseline,
       showResponseSaved: false,
@@ -307,6 +307,28 @@ export function getDuration() {
 }
 
 /**
+ * Caches metric data to local storage in order to persist it across pages
+ * NOTE: not in use yet
+ * @method setMetricData
+ * @param {Number} metricId - id of selected metric
+ * @param {Object} metricData - payload for graphable metric data
+ * @return {undefined}
+ */
+export function setMetricData(metricId, metricData) {
+  localStorage.setItem(metricId, JSON.stringify(metricData));
+}
+
+/**
+ * Retrieves metric data from local storage in order to persist it across pages
+ * NOTE: not in use yet
+ * @method getMetricData
+ * @return {Object}
+ */
+export function getMetricData(metricId) {
+  return JSON.parse(localStorage.getItem(metricId));
+}
+
+/**
  * When fetching current and projected MTTD (minimum time to detect) data, we need to supply the
  * endpoint with a severity threshold. This decides whether to use the default or not.
  * @method extractSeverity
@@ -333,5 +355,7 @@ export default {
   extractSeverity,
   setDuration,
   getDuration,
+  setMetricData,
+  getMetricData,
   evalObj
 };

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -94,7 +94,7 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
       isUserReported: anomaly.anomalyResultSource === 'USER_LABELED_ANOMALY',
       startDateStr: moment(anomaly.anomalyStart).format('MMM D, hh:mm A'),
       durationStr: noZeroDurationArr.join(', '),
-      severityScore: score && !Number.isNaN(score) ? score.toFixed(2) : 'N/A',
+      severityScore: score && !isNaN(score) ? score.toFixed(2) : 'N/A',
       shownCurrent: anomaly.current,
       shownBaseline: anomaly.baseline,
       showResponseSaved: false,

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -94,7 +94,7 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
       isUserReported: anomaly.anomalyResultSource === 'USER_LABELED_ANOMALY',
       startDateStr: moment(anomaly.anomalyStart).format('MMM D, hh:mm A'),
       durationStr: noZeroDurationArr.join(', '),
-      severityScore: score && !isNaN(score) ? score.toFixed(2) : 'N/A',
+      severityScore: score && !Number.isNaN(score) ? score.toFixed(2) : 'N/A',
       shownCurrent: anomaly.current,
       shownBaseline: anomaly.baseline,
       showResponseSaved: false,


### PR DESCRIPTION
In this iteration for Self-Serve:
- Releasing manage.alerts.index links to new Alert Page
- Resolving blocked transition issues during fetch chains by using concurrency tasks
- Other small adjustments such as - adding a loader icon for anomaly table