### PR TITLE
[TE] rootcause - advanced baselines

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -401,8 +401,8 @@ export default Component.extend({
     if (hasPrefix(urn, 'frontend:metric:current:')) {
       const metricEntity = entities[toMetricUrn(urn)];
       const series = {
-        timestamps: timeseries[urn].timestamps,
-        values: timeseries[urn].values,
+        timestamps: timeseries[urn].timestamp,
+        values: timeseries[urn].value,
         color: metricEntity ? metricEntity.color : 'none',
         type: 'line',
         axis: 'y'
@@ -413,8 +413,8 @@ export default Component.extend({
     } else if (hasPrefix(urn, 'frontend:metric:baseline:')) {
       const metricEntity = entities[toMetricUrn(urn)];
       const series = {
-        timestamps: timeseries[urn].timestamps,
-        values: timeseries[urn].values,
+        timestamps: timeseries[urn].timestamp,
+        values: timeseries[urn].value,
         color: metricEntity ? 'light-' + metricEntity.color : 'none',
         type: 'line',
         axis: 'y'

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
@@ -27,7 +27,11 @@ export default Component.extend({
     'WoW',
     'Wo2W',
     'Wo3W',
-    'Wo4W'
+    'Wo4W',
+    'mean4w',
+    'median4w',
+    'min4w',
+    'max4w',
   ],
 
   maxDateFormatted: computed({

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -1,8 +1,7 @@
 import Service from '@ember/service';
 import {
-  toAbsoluteRange,
-  toFilters,
-  toFilterMap
+  toAbsoluteUrn,
+  toMetricUrn
 } from 'thirdeye-frontend/utils/rca-utils';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import fetch from 'fetch';
@@ -57,8 +56,7 @@ export default Service.extend({
 
     // metrics
     missing.forEach(urn => {
-      const range = toAbsoluteRange(urn, requestContext.anomalyRange, requestContext.compareMode);
-      return this._fetchSlice(urn, range, requestContext);
+      return this._fetchSlice(urn, requestContext);
     });
   },
 
@@ -78,25 +76,17 @@ export default Service.extend({
   },
 
   _extractAggregates(incoming, urn) {
-    // NOTE: only supports single time range
     const aggregates = {};
-    aggregates[urn] = Number.NaN; // default
-
-    Object.keys(incoming).forEach(range => {
-      Object.keys(incoming[range]).forEach(mid => {
-        aggregates[urn] = incoming[range][mid];
-      });
-    });
+    aggregates[urn] = incoming;
     return aggregates;
   },
 
-  _fetchSlice(urn, range, context) {
-    const metricId = urn.split(':')[3];
-    const metricFilters = toFilters([urn]);
-    const filters = toFilterMap(metricFilters);
-    const filterString = encodeURIComponent(JSON.stringify(filters));
+  _fetchSlice(urn, context) {
+    const metricUrn = toMetricUrn(urn);
+    const range = context.anomalyRange;
+    const offset = toAbsoluteUrn(urn, context.compareMode).split(':')[2].toLowerCase();
 
-    const url = `/aggregation/aggregate?metricIds=${metricId}&ranges=${range[0]}:${range[1]}&filters=${filterString}`;
+    const url = `/rootcause/metric/aggregate?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}`;
     return fetch(url)
       .then(checkStatus)
       .then(res => this._extractAggregates(res, urn))

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-aggregates-cache/service.js
@@ -85,8 +85,9 @@ export default Service.extend({
     const metricUrn = toMetricUrn(urn);
     const range = context.anomalyRange;
     const offset = toAbsoluteUrn(urn, context.compareMode).split(':')[2].toLowerCase();
+    const timezone = moment.tz.guess();
 
-    const url = `/rootcause/metric/aggregate?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}`;
+    const url = `/rootcause/metric/aggregate?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}&timezone=${timezone}`;
     return fetch(url)
       .then(checkStatus)
       .then(res => this._extractAggregates(res, urn))

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-breakdowns-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-breakdowns-cache/service.js
@@ -85,8 +85,9 @@ export default Service.extend({
     const metricUrn = toMetricUrn(urn);
     const range = context.anomalyRange;
     const offset = toAbsoluteUrn(urn, context.compareMode).split(':')[2].toLowerCase();
+    const timezone = moment.tz.guess();
 
-    const url = `/rootcause/metric/breakdown?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}`;
+    const url = `/rootcause/metric/breakdown?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}&timezone=${timezone}`;
     return fetch(url)
       .then(checkStatus)
       .then(res => this._extractBreakdowns(res, urn))

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
@@ -86,8 +86,9 @@ export default Service.extend({
     const range = context.analysisRange;
     const offset = toAbsoluteUrn(urn, context.compareMode).split(':')[2].toLowerCase();
     const granularity = context.granularity;
+    const timezone = moment.tz.guess();
 
-    const url = `/rootcause/metric/timeseries?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}&granularity=${granularity}`;
+    const url = `/rootcause/metric/timeseries?urn=${metricUrn}&start=${range[0]}&end=${range[1]}&offset=${offset}&granularity=${granularity}&timezone=${timezone}`;
     return fetch(url)
       .then(checkStatus)
       .then(res => this._extractTimeseries(res, urn))

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-timeseries-cache/service.js
@@ -93,7 +93,7 @@ export default Service.extend({
       .then(checkStatus)
       .then(res => this._extractTimeseries(res, urn))
       .then(res => this._complete(context, res))
-      // .catch(error => this._handleError(urn, error));
+      .catch(error => this._handleError(urn, error));
   },
 
   _handleError(urn, error) {

--- a/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
+++ b/thirdeye/thirdeye-frontend/app/utils/build-tooltip.js
@@ -45,7 +45,7 @@ const getTimeseriesLookup = (timeseries, hoverUrns) => {
   const lookup = {};
   frontendUrns.forEach(urn => {
     const ts = timeseries[urn];
-    lookup[urn] = ts.timestamps.map((t, i) => [parseInt(t, 10), ts.values[i]]);
+    lookup[urn] = ts.timestamp.map((t, i) => [parseInt(t, 10), ts.value[i]]);
   });
 
   return lookup;

--- a/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
@@ -205,7 +205,7 @@ export function toAbsoluteUrn(urn, contextCompareMode) {
   if (offset === 'baseline') {
     offset = contextCompareMode.toLowerCase();
   }
-  
+
   if (offset === 'wow') {
     offset = 'wo1w';
   }
@@ -339,7 +339,11 @@ export function toBaselineRange(range, offset) {
     wo1w: 1,
     wo2w: 2,
     wo3w: 3,
-    wo4w: 4
+    wo4w: 4,
+    mean4w: 1, // default. not fully supported by backend yet
+    median4w: 1, // default. not fully supported by backend yet
+    min4w: 1, // default. not fully supported by backend yet
+    max4w: 1, // default. not fully supported by backend yet
   }[offset.toLowerCase()];
 
   if (offsetWeeks === 0) {

--- a/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
@@ -185,6 +185,35 @@ export function toOffsetUrn(urn, offset) {
 }
 
 /**
+ * Converts any metric urn to its frontend metric-reference equivalent, with an absolute time offset.
+ * (I.e. the resulting metric urn does not use 'baseline', but rather the compare mode specified in the context)
+ *
+ * @param {string} urn metric urn
+ * @param {string} contextCompareMode compare mode offset ('wo1w', 'wo2w', 'wo3w', 'wo4w')
+ * @returns {string} frontend metric-reference urn with given offset
+ */
+export function toAbsoluteUrn(urn, contextCompareMode) {
+  if (urn.startsWith('thirdeye:metric:')) {
+    urn = toCurrentUrn(urn);
+  }
+
+  if (!urn.startsWith('frontend:metric:')) {
+    return urn;
+  }
+
+  let offset = urn.split(':')[2].toLowerCase();
+  if (offset === 'baseline') {
+    offset = contextCompareMode.toLowerCase();
+  }
+  
+  if (offset === 'wow') {
+    offset = 'wo1w';
+  }
+
+  return metricUrnHelper(`frontend:metric:${offset}:`, urn);
+}
+
+/**
  * Converts any metric urn to its entity equivalent
  * Example: 'frontend:metric:wo2w:123:country=IT' returns 'thirdeye:metric:123:country=IT'
  *
@@ -533,6 +562,7 @@ export default {
   toBaselineUrn,
   toMetricUrn,
   toOffsetUrn,
+  toAbsoluteUrn,
   stripTail,
   extractTail,
   appendTail,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AggregationResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AggregationResource.java
@@ -30,6 +30,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+/**
+ * Used for RCA prototype. To be removed.
+ *
+ * @see RootCauseMetricResource
+ *
+ */
+@Deprecated
 @Path(value = "/aggregation")
 @Produces(MediaType.APPLICATION_JSON)
 public class AggregationResource {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
@@ -1,0 +1,290 @@
+package com.linkedin.thirdeye.dashboard.resources.v2;
+
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.dashboard.resources.v2.aggregation.AggregationLoader;
+import com.linkedin.thirdeye.dashboard.resources.v2.timeseries.TimeSeriesLoader;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.Series;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
+import com.linkedin.thirdeye.datalayer.dto.DatasetConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.MetricConfigDTO;
+import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
+import com.linkedin.thirdeye.rootcause.timeseries.Baseline;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineAggregate;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineOffset;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@Path(value = "/rootcause/metric")
+@Produces(MediaType.APPLICATION_JSON)
+public class RootCauseMetricResource {
+  private static final Logger LOG = LoggerFactory.getLogger(RootCauseMetricResource.class);
+
+  private static final String COL_TIME = Baseline.COL_TIME;
+  private static final String COL_VALUE = Baseline.COL_VALUE;
+
+  private static final long ONE_WEEK = TimeUnit.DAYS.toMillis(7);
+  private static final long TIMEOUT = 60000;
+
+  private static final String OFFSET_DEFAULT = "current";
+  private static final String GRANULARITY_DEFAULT = MetricSlice.NATIVE_GRANULARITY.toAggregationGranularityString();
+
+  private static final Pattern PATTERN_CURRENT = Pattern.compile("current");
+  private static final Pattern PATTERN_WEEK_OVER_WEEK = Pattern.compile("wo([0-9]+)w");
+  private static final Pattern PATTERN_MEAN = Pattern.compile("mean([0-9]+)w");
+  private static final Pattern PATTERN_MEDIAN = Pattern.compile("median([0-9]+)w");
+  private static final Pattern PATTERN_MIN = Pattern.compile("min([0-9]+)w");
+  private static final Pattern PATTERN_MAX = Pattern.compile("max([0-9]+)w");
+
+  final ExecutorService executor;
+  final AggregationLoader aggregationLoader;
+  final TimeSeriesLoader timeSeriesLoader;
+  final MetricConfigManager metricDAO;
+  final DatasetConfigManager datasetDAO;
+
+  public RootCauseMetricResource(ExecutorService executor, AggregationLoader aggregationLoader,
+      TimeSeriesLoader timeSeriesLoader, MetricConfigManager metricDAO, DatasetConfigManager datasetDAO) {
+    this.executor = executor;
+    this.aggregationLoader = aggregationLoader;
+    this.timeSeriesLoader = timeSeriesLoader;
+    this.metricDAO = metricDAO;
+    this.datasetDAO = datasetDAO;
+  }
+
+  @GET
+  @Path("/aggregate")
+  public double getAggregate(
+      @QueryParam("urn") @NotNull String urn,
+      @QueryParam("start") @NotNull long start,
+      @QueryParam("end") @NotNull long end,
+      @QueryParam("offset") String offset) throws Exception {
+
+    if (StringUtils.isBlank(offset)) {
+      offset = OFFSET_DEFAULT;
+    }
+
+    MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end));
+    Baseline range = parseOffset(offset);
+
+    List<MetricSlice> slices = range.from(baseSlice);
+    Map<MetricSlice, DataFrame> data = fetchAggregates(slices);
+    LOG.info("aggregate data:\n{}", data);
+
+    DataFrame result = range.compute(baseSlice, data);
+
+    if (result.isEmpty()) {
+      return Double.NaN;
+    }
+
+    return result.getDouble(COL_VALUE, 0);
+  }
+
+  @GET
+  @Path("/breakdown")
+  public Map<String, Map<String, Double>> getBreakdown(
+      @QueryParam("urn") @NotNull String urn,
+      @QueryParam("start") @NotNull long start,
+      @QueryParam("end") @NotNull long end,
+      @QueryParam("offset") String offset) throws Exception {
+
+    if (StringUtils.isBlank(offset)) {
+      offset = OFFSET_DEFAULT;
+    }
+
+    MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end));
+    Baseline range = parseOffset(offset);
+
+    throw new IllegalStateException("Not implemented yet");
+
+    // TODO implement this
+  }
+
+  @GET
+  @Path("/timeseries")
+  public Map<String, List<? extends Number>> getTimeSeries(
+      @QueryParam("urn") @NotNull String urn,
+      @QueryParam("start") @NotNull long start,
+      @QueryParam("end") @NotNull long end,
+      @QueryParam("offset") String offset,
+      @QueryParam("granularity") String granularityString) throws Exception {
+
+    if (StringUtils.isBlank(offset)) {
+      offset = OFFSET_DEFAULT;
+    }
+
+    if (StringUtils.isBlank(granularityString)) {
+      granularityString = GRANULARITY_DEFAULT;
+    }
+
+    TimeGranularity granularity = TimeGranularity.fromString(granularityString);
+    MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end, granularity));
+    Baseline range = parseOffset(offset);
+
+    List<MetricSlice> slices = range.from(baseSlice);
+    Map<MetricSlice, DataFrame> data = fetchTimeSeries(slices);
+    LOG.info("timeseries data:\n{}", data);
+
+    DataFrame result = range.compute(baseSlice, data);
+
+    return makeMap(result);
+  }
+
+  /**
+   * Returns a map of time series (keyed by series name) derived from the results dataframe.
+   *
+   * @param data (transformed) query results
+   * @return map of lists of double or long (keyed by series name)
+   */
+  private static Map<String, List<? extends Number>> makeMap(DataFrame data) {
+    Map<String, List<? extends Number>> output = new HashMap<>();
+    for (String name : data.getSeriesNames()) {
+      Series.SeriesType type = data.get(name).type();
+      switch (type) {
+        case LONG:
+          output.put(name, data.getLongs(name).toList());
+          break;
+        case DOUBLE:
+          output.put(name, data.getDoubles(name).toList());
+          break;
+        default:
+          throw new IllegalArgumentException(String.format("Unsupported type '%s'", type));
+      }
+    }
+    return output;
+  }
+
+  private Map<MetricSlice, DataFrame> fetchAggregates(List<MetricSlice> slices) throws Exception {
+    Map<MetricSlice, Future<Double>> futures = new HashMap<>();
+
+    for (final MetricSlice slice : slices) {
+      futures.put(slice, this.executor.submit(new Callable<Double>() {
+        @Override
+        public Double call() throws Exception {
+          return RootCauseMetricResource.this.aggregationLoader.loadAggregate(slice);
+        }
+      }));
+    }
+
+    Map<MetricSlice, DataFrame> output = new HashMap<>();
+    for (Map.Entry<MetricSlice, Future<Double>> entry : futures.entrySet()) {
+      MetricSlice slice = entry.getKey();
+      double value = entry.getValue().get(TIMEOUT, TimeUnit.MILLISECONDS);
+
+      DataFrame data = new DataFrame(COL_TIME, LongSeries.buildFrom(slice.getStart()))
+          .addSeries(COL_VALUE, value);
+      output.put(slice, data);
+    }
+
+    return output;
+  }
+
+  private Map<MetricSlice, DataFrame> fetchTimeSeries(List<MetricSlice> slices) throws Exception {
+    Map<MetricSlice, Future<DataFrame>> futures = new HashMap<>();
+
+    for (final MetricSlice slice : slices) {
+      futures.put(slice, this.executor.submit(new Callable<DataFrame>() {
+        @Override
+        public DataFrame call() throws Exception {
+          return RootCauseMetricResource.this.timeSeriesLoader.load(slice);
+        }
+      }));
+    }
+
+    Map<MetricSlice, DataFrame> output = new HashMap<>();
+    for (Map.Entry<MetricSlice, Future<DataFrame>> entry : futures.entrySet()) {
+      output.put(entry.getKey(), entry.getValue().get(TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+    return output;
+  }
+
+  private MetricSlice makeSlice(String urn, long start, long end) {
+    return makeSlice(urn, start, end, MetricSlice.NATIVE_GRANULARITY);
+  }
+
+  private MetricSlice makeSlice(String urn, long start, long end, TimeGranularity granularity) {
+    MetricEntity metric = MetricEntity.fromURN(urn, 1.0);
+    return MetricSlice.from(metric.getId(), start, end, metric.getFilters(), granularity);
+  }
+
+  // TODO refactor as util. similar to dataframe utils
+  private MetricSlice alignSlice(MetricSlice slice) throws Exception {
+    MetricConfigDTO metric = this.metricDAO.findById(slice.getMetricId());
+    if (metric == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve metric id %d", slice.getMetricId()));
+    }
+
+    DatasetConfigDTO dataset = this.datasetDAO.findByDataset(metric.getDataset());
+    if (dataset == null) {
+      throw new IllegalArgumentException(String.format("Could not resolve dataset '%s' for metric id %d", metric.getDataset(), slice.getMetricId()));
+    }
+
+    TimeGranularity granularity = dataset.bucketTimeGranularity();
+    if (!MetricSlice.NATIVE_GRANULARITY.equals(slice.getGranularity())) {
+      granularity = slice.getGranularity();
+    }
+
+    long timeGranularity = granularity.toMillis();
+    long start = (slice.getStart() / timeGranularity) * timeGranularity;
+    long end = ((slice.getEnd() + timeGranularity - 1) / timeGranularity) * timeGranularity;
+
+    return slice.withStart(start).withEnd(end).withGranularity(granularity);
+  }
+
+  private static Baseline parseOffset(String offset) {
+    Matcher mCurrent = PATTERN_CURRENT.matcher(offset);
+    if (mCurrent.find()) {
+      return BaselineOffset.fromOffset(0);
+    }
+
+    Matcher mWeekOverWeek = PATTERN_WEEK_OVER_WEEK.matcher(offset);
+    if (mWeekOverWeek.find()) {
+      return BaselineOffset.fromOffset(-1 * Integer.valueOf(mWeekOverWeek.group(1)) * ONE_WEEK);
+    }
+
+    Matcher mMean = PATTERN_MEAN.matcher(offset);
+    if (mMean.find()) {
+      return BaselineAggregate.fromWeekOverWeek(BaselineType.MEAN, Integer.valueOf(mMean.group(1)), 1);
+    }
+
+    Matcher mMedian = PATTERN_MEDIAN.matcher(offset);
+    if (mMedian.find()) {
+      return BaselineAggregate.fromWeekOverWeek(BaselineType.MEDIAN, Integer.valueOf(mMedian.group(1)), 1);
+    }
+
+    Matcher mMin = PATTERN_MIN.matcher(offset);
+    if (mMin.find()) {
+      return BaselineAggregate.fromWeekOverWeek(BaselineType.MIN, Integer.valueOf(mMin.group(1)), 1);
+    }
+
+    Matcher mMax = PATTERN_MAX.matcher(offset);
+    if (mMax.find()) {
+      return BaselineAggregate.fromWeekOverWeek(BaselineType.MAX, Integer.valueOf(mMax.group(1)), 1);
+    }
+
+    throw new IllegalArgumentException(String.format("Unknown offset '%s'", offset));
+  }
+
+
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
@@ -14,7 +14,7 @@ import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
 import com.linkedin.thirdeye.rootcause.timeseries.Baseline;
 import com.linkedin.thirdeye.rootcause.timeseries.BaselineAggregate;
 import com.linkedin.thirdeye.rootcause.timeseries.BaselineOffset;
-import com.linkedin.thirdeye.rootcause.timeseries.BaselineType;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineAggregateType;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,12 +118,12 @@ public class RootCauseMetricResource {
     MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end));
     Baseline range = parseOffset(baseSlice, offset, timezone);
 
-    List<MetricSlice> slices = range.from(baseSlice);
+    List<MetricSlice> slices = range.scatter(baseSlice);
     logSlices(baseSlice, slices);
 
     Map<MetricSlice, DataFrame> data = fetchAggregates(slices);
 
-    DataFrame result = range.compute(baseSlice, data);
+    DataFrame result = range.gather(baseSlice, data);
 
     if (result.isEmpty()) {
       return Double.NaN;
@@ -173,12 +173,12 @@ public class RootCauseMetricResource {
     MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end));
     Baseline range = parseOffset(baseSlice, offset, timezone);
 
-    List<MetricSlice> slices = range.from(baseSlice);
+    List<MetricSlice> slices = range.scatter(baseSlice);
     logSlices(baseSlice, slices);
 
     Map<MetricSlice, DataFrame> data = fetchBreakdowns(slices);
 
-    DataFrame result = range.compute(baseSlice, data);
+    DataFrame result = range.gather(baseSlice, data);
 
     return makeBreakdownMap(result);
   }
@@ -225,12 +225,12 @@ public class RootCauseMetricResource {
     MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end, granularity));
     Baseline range = parseOffset(baseSlice, offset, timezone);
 
-    List<MetricSlice> slices = range.from(baseSlice);
+    List<MetricSlice> slices = range.scatter(baseSlice);
     logSlices(baseSlice, slices);
 
     Map<MetricSlice, DataFrame> data = fetchTimeSeries(slices);
 
-    DataFrame result = range.compute(baseSlice, data);
+    DataFrame result = range.gather(baseSlice, data);
 
     return makeTimeSeriesMap(result);
   }
@@ -396,27 +396,27 @@ public class RootCauseMetricResource {
 
     Matcher mWeekOverWeek = PATTERN_WEEK_OVER_WEEK.matcher(offset);
     if (mWeekOverWeek.find()) {
-      return BaselineAggregate.fromWeekOverWeek(BaselineType.MEAN, 1, Integer.valueOf(mWeekOverWeek.group(1)), timestamp, timezone);
+      return BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEAN, 1, Integer.valueOf(mWeekOverWeek.group(1)), timestamp, timezone);
     }
 
     Matcher mMean = PATTERN_MEAN.matcher(offset);
     if (mMean.find()) {
-      return BaselineAggregate.fromWeekOverWeek(BaselineType.MEAN, Integer.valueOf(mMean.group(1)), 1, timestamp, timezone);
+      return BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEAN, Integer.valueOf(mMean.group(1)), 1, timestamp, timezone);
     }
 
     Matcher mMedian = PATTERN_MEDIAN.matcher(offset);
     if (mMedian.find()) {
-      return BaselineAggregate.fromWeekOverWeek(BaselineType.MEDIAN, Integer.valueOf(mMedian.group(1)), 1, timestamp, timezone);
+      return BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEDIAN, Integer.valueOf(mMedian.group(1)), 1, timestamp, timezone);
     }
 
     Matcher mMin = PATTERN_MIN.matcher(offset);
     if (mMin.find()) {
-      return BaselineAggregate.fromWeekOverWeek(BaselineType.MIN, Integer.valueOf(mMin.group(1)), 1, timestamp, timezone);
+      return BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MIN, Integer.valueOf(mMin.group(1)), 1, timestamp, timezone);
     }
 
     Matcher mMax = PATTERN_MAX.matcher(offset);
     if (mMax.find()) {
-      return BaselineAggregate.fromWeekOverWeek(BaselineType.MAX, Integer.valueOf(mMax.group(1)), 1, timestamp, timezone);
+      return BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MAX, Integer.valueOf(mMax.group(1)), 1, timestamp, timezone);
     }
 
     throw new IllegalArgumentException(String.format("Unknown offset '%s'", offset));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/TimeSeriesResource.java
@@ -60,6 +60,13 @@ import org.joda.time.Interval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
+/**
+ * Used by legacy RCA experience. To be removed.
+ *
+ * @see RootCauseMetricResource
+ */
+@Deprecated
 @Path(value = "/timeseries")
 @Produces(MediaType.APPLICATION_JSON)
 public class TimeSeriesResource {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/aggregation/DefaultAggregationLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/aggregation/DefaultAggregationLoader.java
@@ -91,11 +91,15 @@ public class DefaultAggregationLoader implements AggregationLoader {
     ThirdEyeResponse res = this.cache.getQueryResult(rc.getRequest());
     DataFrame df = DataFrameUtils.evaluateResponse(res, rc);
 
+    if (df.isEmpty() || df.get(COL_VALUE).isNull(0)) {
+      return Double.NaN;
+    }
+
     final long maxTime = this.cache.getDataSource(dataset.getDataSource()).getMaxDataTime(dataset.getDataset());
     if (slice.getStart() > maxTime) {
       return Double.NaN;
     }
 
-    return df.getDoubles(COL_VALUE).fillNull().doubleValue();
+    return df.getDoubles(COL_VALUE).doubleValue();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/TimeSeriesLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/timeseries/TimeSeriesLoader.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.dashboard.resources.v2.timeseries;
 
 import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.util.DataFrameUtils;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 
 
@@ -8,6 +9,9 @@ import com.linkedin.thirdeye.dataframe.util.MetricSlice;
  * Loader for metric series based on slice and an (optinal) granularity. Must be thread safe.
  */
 public interface TimeSeriesLoader {
+  String COL_TIME = DataFrameUtils.COL_TIME;
+  String COL_VALUE = DataFrameUtils.COL_VALUE;
+
   /**
    * Returns the metric time series for a given time range and filter set, with a specified
    * time granularity. If the underlying time series resolution does not correspond to the desired

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/Series.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/Series.java
@@ -8,6 +8,9 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import org.apache.commons.lang.ArrayUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
 
 
 /**
@@ -1156,6 +1159,34 @@ public abstract class Series {
    */
   public Grouping.SeriesGrouping groupByExpandingWindow() {
     return new Grouping.SeriesGrouping(this, Grouping.GroupingByExpandingWindow.from(this.size()));
+  }
+
+  /**
+   * Returns a SeriesGrouping based on a time period from an origin.
+   *
+   * @see Grouping.GroupingByPeriod
+   *
+   * @param origin start time stamp
+   * @param bucketSize time bucket size
+   *
+   * @return SeriesGrouping
+   */
+  public Grouping.SeriesGrouping groupByPeriod(DateTime origin, Period bucketSize) {
+    return new Grouping.SeriesGrouping(this, Grouping.GroupingByPeriod.from(this.getLongs(), origin, bucketSize));
+  }
+
+  /**
+   * Returns a SeriesGrouping based on a time period.
+   *
+   * @see Grouping.GroupingByPeriod
+   *
+   * @param timezone time zone to interpret timestamps in
+   * @param bucketSize time bucket size
+   *
+   * @return SeriesGrouping
+   */
+  public Grouping.SeriesGrouping groupByPeriod(DateTimeZone timezone, Period bucketSize) {
+    return new Grouping.SeriesGrouping(this, Grouping.GroupingByPeriod.from(this.getLongs(), timezone, bucketSize));
   }
 
   /* *************************************************************************

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/StringSeries.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/StringSeries.java
@@ -525,7 +525,7 @@ public final class StringSeries extends TypedSeries<StringSeries> {
 
   @Override
   int hashCode(int index) {
-    return this.values[index].hashCode();
+    return Objects.hashCode(this.values[index]);
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/MetricSlice.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/MetricSlice.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 
@@ -70,5 +71,23 @@ public final class MetricSlice {
 
   public static MetricSlice from(long metricId, long start, long end, Multimap<String, String> filters, TimeGranularity granularity) {
     return new MetricSlice(metricId, start, end, filters, granularity);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MetricSlice that = (MetricSlice) o;
+    return metricId == that.metricId && start == that.start && end == that.end && Objects.equals(filters, that.filters)
+        && Objects.equals(granularity, that.granularity);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metricId, start, end, filters, granularity);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/MetricSlice.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/util/MetricSlice.java
@@ -6,6 +6,8 @@ import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.constant.MetricAggFunction;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 
 
 public final class MetricSlice {
@@ -89,5 +91,10 @@ public final class MetricSlice {
   @Override
   public int hashCode() {
     return Objects.hash(metricId, start, end, filters, granularity);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricAnalysisPipeline2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricAnalysisPipeline2.java
@@ -1,0 +1,404 @@
+package com.linkedin.thirdeye.rootcause.impl;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.Series;
+import com.linkedin.thirdeye.dataframe.util.DataFrameUtils;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import com.linkedin.thirdeye.dataframe.util.TimeSeriesRequestContainer;
+import com.linkedin.thirdeye.datalayer.bao.DatasetConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.MetricConfigManager;
+import com.linkedin.thirdeye.datasource.DAORegistry;
+import com.linkedin.thirdeye.datasource.ThirdEyeCacheRegistry;
+import com.linkedin.thirdeye.datasource.ThirdEyeRequest;
+import com.linkedin.thirdeye.datasource.ThirdEyeResponse;
+import com.linkedin.thirdeye.datasource.cache.QueryCache;
+import com.linkedin.thirdeye.rootcause.Entity;
+import com.linkedin.thirdeye.rootcause.Pipeline;
+import com.linkedin.thirdeye.rootcause.PipelineContext;
+import com.linkedin.thirdeye.rootcause.PipelineResult;
+import com.linkedin.thirdeye.rootcause.timeseries.Baseline;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineAggregate;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineOffset;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The MetricAnalysisPipeline ranks metrics based on the degree of anomalous behavior during
+ * the anomaly period. It scores anomalous behavior with user-configured strategies.
+ *
+ * <br/><b>NOTE:</b> this is the successor to {@code MetricAnalysisPipeline}. It supports computation
+ * of complex, named training windows.
+ *
+ * @see MetricAnalysisPipeline
+ */
+public class MetricAnalysisPipeline2 extends Pipeline {
+  private static final Logger LOG = LoggerFactory.getLogger(MetricAnalysisPipeline2.class);
+
+  private static final long TIMEOUT = 60000;
+
+  private static final long TRAINING_WINDOW = TimeUnit.DAYS.toMillis(7);
+
+  private static final String STRATEGY_THRESHOLD = "threshold";
+
+  private static final String PROP_STRATEGY = "strategy";
+  private static final String PROP_STRATEGY_DEFAULT = STRATEGY_THRESHOLD;
+
+  private static final String PROP_GRANULARITY = "granularity";
+  private static final String PROP_GRANULARITY_DEFAULT = "15_MINUTES";
+
+  private static final String COL_TIME = DataFrameUtils.COL_TIME;
+  private static final String COL_VALUE = DataFrameUtils.COL_VALUE;
+  private static final String COL_CURRENT = "current";
+  private static final String COL_BASELINE = "baseline";
+
+  private final QueryCache cache;
+  private final MetricConfigManager metricDAO;
+  private final DatasetConfigManager datasetDAO;
+  private final ScoringStrategyFactory strategyFactory;
+  private final TimeGranularity granularity;
+
+  /**
+   * Constructor for dependency injection
+   *
+   * @param outputName pipeline output name
+   * @param inputNames input pipeline names
+   * @param strategyFactory scoring strategy for differences
+   * @param granularity time series target granularity
+   * @param cache query cache
+   * @param metricDAO metric config DAO
+   * @param datasetDAO datset config DAO
+   */
+  public MetricAnalysisPipeline2(String outputName, Set<String> inputNames, ScoringStrategyFactory strategyFactory, TimeGranularity granularity, QueryCache cache, MetricConfigManager metricDAO, DatasetConfigManager datasetDAO) {
+    super(outputName, inputNames);
+    this.cache = cache;
+    this.metricDAO = metricDAO;
+    this.datasetDAO = datasetDAO;
+    this.strategyFactory = strategyFactory;
+    this.granularity = granularity;
+  }
+
+  /**
+   * Alternate constructor for RCAFrameworkLoader
+   *
+   * @param outputName pipeline output name
+   * @param inputNames input pipeline names
+   * @param properties configuration properties ({@code PROP_STRATEGY})
+   */
+  public MetricAnalysisPipeline2(String outputName, Set<String> inputNames, Map<String, Object> properties) {
+    super(outputName, inputNames);
+    this.metricDAO = DAORegistry.getInstance().getMetricConfigDAO();
+    this.datasetDAO = DAORegistry.getInstance().getDatasetConfigDAO();
+    this.cache = ThirdEyeCacheRegistry.getInstance().getQueryCache();
+    this.strategyFactory = parseStrategyFactory(MapUtils.getString(properties, PROP_STRATEGY, PROP_STRATEGY_DEFAULT));
+    this.granularity = TimeGranularity.fromString(MapUtils.getString(properties, PROP_GRANULARITY, PROP_GRANULARITY_DEFAULT));
+  }
+
+  @Override
+  public PipelineResult run(PipelineContext context) {
+    Set<MetricEntity> metrics = context.filter(MetricEntity.class);
+
+    TimeRangeEntity anomalyRange = TimeRangeEntity.getTimeRangeAnomaly(context);
+    TimeRangeEntity baselineRange = TimeRangeEntity.getTimeRangeBaseline(context);
+
+    Baseline rangeCurrent = BaselineOffset.fromOffset(0);
+    Baseline rangeBaseline = BaselineAggregate.fromWeekOverWeek(BaselineType.MEDIAN, 4);
+
+    Map<MetricEntity, MetricSlice> trainingSet = new HashMap<>();
+    Map<MetricEntity, MetricSlice> testSet = new HashMap<>();
+    Set<MetricSlice> slicesRaw = new HashSet<>();
+    for (MetricEntity me : metrics) {
+      MetricSlice sliceTrain = MetricSlice.from(me.getId(), anomalyRange.getStart() - TRAINING_WINDOW, anomalyRange.getStart(), me.getFilters(), this.granularity);
+      MetricSlice sliceTest = MetricSlice.from(me.getId(), anomalyRange.getStart(), anomalyRange.getEnd(), me.getFilters(), this.granularity);
+
+      trainingSet.put(me, sliceTrain);
+      testSet.put(me, sliceTest);
+
+      // TODO make training data cacheable (e.g. align to hours, days)
+
+      printSlices(rangeCurrent.from(sliceTest));
+      printSlices(rangeCurrent.from(sliceTrain));
+      printSlices(rangeBaseline.from(sliceTest));
+      printSlices(rangeBaseline.from(sliceTrain));
+
+      slicesRaw.addAll(rangeCurrent.from(sliceTest));
+      slicesRaw.addAll(rangeCurrent.from(sliceTrain));
+      slicesRaw.addAll(rangeBaseline.from(sliceTest));
+      slicesRaw.addAll(rangeBaseline.from(sliceTrain));
+    }
+
+    printSlices(slicesRaw);
+
+    List<TimeSeriesRequestContainer> requestList = makeRequests(slicesRaw);
+
+//    // NOTE: baseline lookback only affects amount of training data, training is always WoW
+//    // NOTE: data window is aligned to metric time granularity
+//    final long trainingBaselineStart = baselineRange.getStart() - TRAINING_OFFSET;
+//    final long trainingBaselineEnd = anomalyRange.getStart() - TRAINING_OFFSET;
+//    final long trainingCurrentStart = baselineRange.getStart();
+//    final long trainingCurrentEnd = anomalyRange.getStart();
+//
+//    final long testBaselineStart = baselineRange.getStart();
+//    final long testBaselineEnd = baselineRange.getEnd();
+//    final long testCurrentStart = anomalyRange.getStart();
+//    final long testCurrentEnd = anomalyRange.getEnd();
+//
+//    Multimap<String, String> filters = DimensionEntity.makeFilterSet(context);
+//
+//    LOG.info("Processing {} metrics", metrics.size());
+//
+//    // generate requests
+//    List<TimeSeriesRequestContainer> requestList = new ArrayList<>();
+//    requestList.addAll(makeRequests(metrics, trainingBaselineStart, testCurrentEnd, filters));
+
+    LOG.info("Requesting {} time series", requestList.size());
+    List<ThirdEyeRequest> thirdeyeRequests = new ArrayList<>();
+    Map<String, TimeSeriesRequestContainer> requests = new HashMap<>();
+    for(TimeSeriesRequestContainer rc : requestList) {
+      final ThirdEyeRequest req = rc.getRequest();
+      requests.put(req.getRequestReference(), rc);
+      thirdeyeRequests.add(req);
+    }
+
+    Collection<Future<ThirdEyeResponse>> futures = submitRequests(thirdeyeRequests);
+
+    // fetch responses and calculate derived metrics
+    int i = 0;
+    Map<String, DataFrame> responses = new HashMap<>();
+    for(Future<ThirdEyeResponse> future : futures) {
+      ThirdEyeResponse response;
+      try {
+        response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      } catch (Exception e) {
+        LOG.warn("Error executing request '{}'. Skipping.", requestList.get(i).getRequest().getRequestReference(), e);
+        continue;
+      } finally {
+        i++;
+      }
+
+      // parse time series
+      String id = response.getRequest().getRequestReference();
+      DataFrame df;
+      try {
+        df = DataFrameUtils.evaluateResponse(response, requests.get(id));
+      } catch (Exception e) {
+        LOG.warn("Could not parse response for '{}'. Skipping.", id, e);
+        continue;
+      }
+
+      // store time series
+      responses.put(id, df);
+    }
+
+    // Collect slices and requests
+    Map<String, MetricSlice> id2slice = new HashMap<>();
+    for (MetricSlice slice : slicesRaw) {
+      id2slice.put(makeIdentifier(slice), slice);
+    }
+
+    Map<MetricSlice, DataFrame> data = new HashMap<>();
+    for (Map.Entry<String, DataFrame> entry : responses.entrySet()) {
+      MetricSlice slice = id2slice.get(entry.getKey());
+      if (slice == null) {
+        LOG.warn("Could not associate response id '{}' with request. Skipping.", entry.getKey());
+        continue;
+      }
+
+      data.put(slice, entry.getValue());
+    }
+
+    // score metrics
+    Set<MetricEntity> output = new HashSet<>();
+    for(MetricEntity me : metrics) {
+      try {
+        MetricSlice sliceTest = testSet.get(me);
+        MetricSlice sliceTrain = trainingSet.get(me);
+
+        Map<MetricSlice, DataFrame> dataTestCurrent = rangeCurrent.filter(sliceTest, data);
+        Map<MetricSlice, DataFrame> dataTestBaseline = rangeBaseline.filter(sliceTest, data);
+        Map<MetricSlice, DataFrame> dataTrainCurrent = rangeCurrent.filter(sliceTrain, data);
+        Map<MetricSlice, DataFrame> dataTrainBaseline = rangeBaseline.filter(sliceTrain, data);
+
+        LOG.info("dataTestCurrent:\n{}", dataTestCurrent);
+        LOG.info("dataTestBaseline:\n{}", dataTestBaseline);
+        LOG.info("dataTrainCurrent:\n{}", dataTrainCurrent);
+        LOG.info("dataTrainBaseline:\n{}", dataTrainBaseline);
+
+        DataFrame testCurrent = rangeCurrent.compute(sliceTest, dataTestCurrent);
+        DataFrame testBaseline = rangeBaseline.compute(sliceTest, dataTestBaseline);
+        DataFrame trainingCurrent = rangeCurrent.compute(sliceTrain, dataTrainCurrent);
+        DataFrame trainingBaseline = rangeBaseline.compute(sliceTrain, dataTrainBaseline);
+
+//        LOG.info("Preparing training and test data for metric '{}'", me.getUrn());
+//        DataFrame trainingBaseline = extractTimeRange(timeseries, trainingBaselineStart, trainingBaselineEnd);
+//        DataFrame trainingCurrent = extractTimeRange(timeseries, trainingCurrentStart, trainingCurrentEnd);
+//        DataFrame testBaseline = extractTimeRange(timeseries, testBaselineStart, testBaselineEnd);
+//        DataFrame testCurrent = extractTimeRange(timeseries, testCurrentStart, testCurrentEnd);
+
+//        LOG.info("timeseries ({} rows): {}", timeseries.size(), timeseries.head(20));
+//        LOG.info("trainingBaseline ({} rows): from {} to {}", trainingBaseline.size(), trainingBaselineStart, trainingBaselineEnd);
+//        LOG.info("trainingCurrent ({} rows): from {} to {}", trainingCurrent.size(), trainingCurrentStart, trainingCurrentEnd);
+//        LOG.info("testBaseline ({} rows): from {} to {}", testBaseline.size(), testBaselineStart, testBaselineEnd);
+//        LOG.info("testCurrent ({} rows): from {} to {}", testCurrent.size(), testCurrentStart, testCurrentEnd);
+
+        DataFrame trainingDiff = diffTimeseries(trainingCurrent, trainingBaseline);
+        DataFrame testDiff = diffTimeseries(testCurrent, testBaseline);
+
+        LOG.info("trainingBaseline ({} rows):\n{}", trainingBaseline.size(), trainingBaseline);
+        LOG.info("trainingCurrent ({} rows):\n{}", trainingCurrent.size(), trainingCurrent);
+        LOG.info("testBaseline ({} rows):\n{}", testBaseline.size(), testBaseline);
+        LOG.info("testCurrent ({} rows):\n{}", testCurrent.size(), testCurrent);
+        LOG.info("trainingDiff ({} rows):\n{}", trainingDiff.size(), trainingDiff);
+        LOG.info("testDiff ({} rows):\n{}", testDiff.size(), testDiff);
+
+        double score = this.strategyFactory.fit(trainingDiff).apply(testDiff);
+
+        List<Entity> related = new ArrayList<>();
+        related.add(anomalyRange);
+        related.add(baselineRange);
+
+        output.add(me.withScore(score).withRelated(related));
+
+      } catch (Exception e) {
+        LOG.warn("Error processing '{}'. Skipping", me.getUrn(), e);
+      }
+    }
+
+    LOG.info("Generated {} MetricEntities with valid scores", output.size());
+
+    return new PipelineResult(context, output);
+  }
+
+  private void printSlices(Collection<MetricSlice> slicesRaw) {
+    List<MetricSlice> slices = new ArrayList<>(slicesRaw);
+    Collections.sort(slices, new Comparator<MetricSlice>() {
+      @Override
+      public int compare(MetricSlice o1, MetricSlice o2) {
+        return Long.compare(o1.getStart(), o2.getStart());
+      }
+    });
+    LOG.info("Fetching {} slices:\n{}", slices.size(), StringUtils.join(slices, "\n"));
+  }
+
+  private DataFrame diffTimeseries(DataFrame current, DataFrame baseline) {
+    DataFrame offsetCurrent = new DataFrame(COL_TIME, current.getLongs(COL_TIME))
+        .addSeries(COL_CURRENT, current.getDoubles(COL_VALUE));
+    DataFrame offsetBaseline = new DataFrame(COL_TIME, baseline.getLongs(COL_TIME))
+        .addSeries(COL_BASELINE, baseline.getDoubles(COL_VALUE));
+    DataFrame joined = offsetCurrent.joinInner(offsetBaseline);
+    joined.addSeries(COL_VALUE, joined.getDoubles(COL_CURRENT).subtract(joined.getDoubles(COL_BASELINE)));
+    return joined;
+  }
+
+  private Collection<Future<ThirdEyeResponse>> submitRequests(List<ThirdEyeRequest> thirdeyeRequests) {
+    try {
+      return this.cache.getQueryResultsAsync(thirdeyeRequests).values();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<TimeSeriesRequestContainer> makeRequests(Collection<MetricSlice> slices) {
+    List<TimeSeriesRequestContainer> requests = new ArrayList<>();
+    for(MetricSlice slice : slices) {
+      try {
+        requests.add(DataFrameUtils.makeTimeSeriesRequestAligned(slice, makeIdentifier(slice), this.metricDAO, this.datasetDAO));
+      } catch (Exception ex) {
+        LOG.warn(String.format("Could not make request. Skipping."), ex);
+      }
+    }
+    return requests;
+  }
+
+  private static ScoringStrategyFactory parseStrategyFactory(String strategy) {
+    switch(strategy) {
+      case STRATEGY_THRESHOLD:
+        return new ThresholdStrategyFactory(0.90, 0.95, 0.975, 0.99, 1.00);
+      default:
+        throw new IllegalArgumentException(String.format("Unknown strategy '%s'", strategy));
+    }
+  }
+
+  private static String makeIdentifier(MetricSlice slice) {
+    return String.valueOf(slice.hashCode());
+  }
+
+  private interface ScoringStrategyFactory {
+    ScoringStrategy fit(DataFrame training);
+  }
+
+  private interface ScoringStrategy {
+    double apply(DataFrame data);
+  }
+
+  private static class ThresholdStrategyFactory implements ScoringStrategyFactory {
+    final double[] quantiles;
+
+    ThresholdStrategyFactory(double... quantiles) {
+      this.quantiles = quantiles;
+    }
+
+    @Override
+    public ScoringStrategy fit(DataFrame training) {
+      DoubleSeries train = training.getDoubles(COL_VALUE);
+      double[] thresholds = new double[this.quantiles.length];
+      for (int i = 0; i < thresholds.length; i++) {
+        thresholds[i] = train.abs().quantile(this.quantiles[i]).fillNull(Double.POSITIVE_INFINITY).doubleValue();
+      }
+      return new ThresholdStrategy(thresholds);
+    }
+  }
+
+  private static class ThresholdStrategy implements ScoringStrategy {
+    final double[] thresholds;
+
+    ThresholdStrategy(double... thresholds) {
+      this.thresholds = thresholds;
+    }
+
+    @Override
+    public double apply(DataFrame data) {
+      DoubleSeries test = data.getDoubles(COL_VALUE);
+
+      LOG.info("thresholds: {}", this.thresholds);
+
+      long sumViolations = 0;
+      for (final double t : thresholds) {
+        sumViolations += test.abs().map(new Series.DoubleConditional() {
+          @Override
+          public boolean apply(double... values) {
+            return values[0] > t;
+          }
+        }).sum().fillNull().longValue();
+      }
+
+      final int max = test.size() * this.thresholds.length;
+      if (max <= 0) {
+        return 0;
+      }
+
+      return sumViolations / (double) max;
+    }
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
@@ -7,11 +7,35 @@ import java.util.List;
 import java.util.Map;
 
 
+/**
+ * Interface for synthetic baselines constructed from one or multiple raw metric slices pointing to
+ * different time periods. The offsets to chose for these time slices are determined by the implementation.
+ * All implementations must support multi-indexed data frames with an index consisting of at least a
+ * time column (and possibly additional columns) and a value column.
+ *
+ * The interface supports a scatter-gather flow of data - turning 1 base slice into 1..N data slices
+ * (scatter), then filtering a N..M sized set of results down to the specifically required N slices
+ * and reduce the N results down to 1 aggregate result (gather).
+ */
 public interface Baseline {
   String COL_TIME = DataFrameUtils.COL_TIME;
   String COL_VALUE = DataFrameUtils.COL_VALUE;
 
-  List<MetricSlice> from(MetricSlice slice);
-  Map<MetricSlice, DataFrame> filter(MetricSlice slice, Map<MetricSlice, DataFrame> data);
-  DataFrame compute(MetricSlice slice, Map<MetricSlice, DataFrame> data);
+  /**
+   * Returns the set of raw data slices required to compute the synthetic baseline for the given input slice.
+   *
+   * @param slice base metric slice
+   * @return set of raw metric slices
+   */
+  List<MetricSlice> scatter(MetricSlice slice);
+
+  /**
+   * Returns the synthetic baseline computed from a set of inputs.
+   * <br/><b>NOTE:</b> Must filter out non-matching slices from a potentially large pool of results.
+   *
+   * @param slice base metric slice
+   * @param data map of intermediate result dataframes (keyed by metric slice)
+   * @return synthetic result dataframe
+   */
+  DataFrame gather(MetricSlice slice, Map<MetricSlice, DataFrame> data);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
@@ -12,5 +12,6 @@ public interface Baseline {
   String COL_VALUE = DataFrameUtils.COL_VALUE;
 
   List<MetricSlice> from(MetricSlice slice);
+  Map<MetricSlice, DataFrame> filter(MetricSlice slice, Map<MetricSlice, DataFrame> data);
   DataFrame compute(MetricSlice slice, Map<MetricSlice, DataFrame> data);
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
@@ -1,0 +1,16 @@
+package com.linkedin.thirdeye.rootcause.timeseries;
+
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.util.DataFrameUtils;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import java.util.List;
+import java.util.Map;
+
+
+public interface Baseline {
+  String COL_TIME = DataFrameUtils.COL_TIME;
+  String COL_VALUE = DataFrameUtils.COL_VALUE;
+
+  List<MetricSlice> from(MetricSlice slice);
+  DataFrame compute(MetricSlice slice, Map<MetricSlice, DataFrame> data);
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/Baseline.java
@@ -31,6 +31,8 @@ public interface Baseline {
 
   /**
    * Returns the synthetic baseline computed from a set of inputs.
+   * If a series is provided for slice, aligns timestamps for coarse grained data.
+   *
    * <br/><b>NOTE:</b> Must filter out non-matching slices from a potentially large pool of results.
    *
    * @param slice base metric slice

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
@@ -82,12 +82,8 @@ public class BaselineAggregate implements Baseline {
       DataFrame df = new DataFrame(entry.getValue());
 
       df.addSeries(COL_TIME, df.getLongs(COL_TIME).subtract(offset));
-      //df.addSeries(COL_TIME, BaselineUtil.alignTimestamps(joined.getLongs(COL_TIME), df.getLongs(COL_TIME)));
-
-      System.out.println(entry.getKey());
-      System.out.println(df.dropNull());
-
       df.renameSeries(COL_VALUE, colName);
+
       if (isDailyData) {
         df = heuristicDSTCorrection(df, timestampSet);
       }
@@ -112,9 +108,13 @@ public class BaselineAggregate implements Baseline {
 
     String[] arrNames = colNames.toArray(new String[colNames.size()]);
 
-    //joined = joined.dropNull();
+    // aggregation
     output.addSeries(COL_VALUE, output.map(this.type.function, arrNames));
     output = output.dropNull();
+
+    // alignment
+    List<String> indexNames = output.getIndexNames();
+    output = output.setIndex(COL_TIME).joinRight(new DataFrame(COL_TIME, timestamps)).setIndex(indexNames);
     output.sortedBy(output.getIndexNames());
 
     return output;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 
 
 public class BaselineAggregate implements Baseline {
@@ -113,6 +116,19 @@ public class BaselineAggregate implements Baseline {
 
     for (int i = 0; i < numWeeks; i++) {
       long offset = -1 * (i + offsetWeeks) * TimeUnit.DAYS.toMillis(7);
+      offsets.add(offset);
+    }
+
+    return new BaselineAggregate(type, offsets);
+  }
+
+  public static BaselineAggregate fromWeekOverWeek(BaselineType type, int numWeeks, int offsetWeeks, long timestamp, String timezone) {
+    DateTime baseDate = new DateTime(timestamp, DateTimeZone.forID(timezone));
+
+    List<Long> offsets = new ArrayList<>();
+
+    for (int i = 0; i < numWeeks; i++) {
+      long offset = baseDate.minusWeeks(i + offsetWeeks).getMillis() - timestamp;
       offsets.add(offset);
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
@@ -1,0 +1,83 @@
+package com.linkedin.thirdeye.rootcause.timeseries;
+
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.Series;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+public class BaselineAggregate implements Baseline {
+  enum Type {
+    SUM(DoubleSeries.SUM),
+    PRODUCT(DoubleSeries.PRODUCT),
+    MEAN(DoubleSeries.MEAN),
+    MEDIAN(DoubleSeries.MEDIAN),
+    MIN(DoubleSeries.MIN),
+    MAX(DoubleSeries.MAX),
+    STD(DoubleSeries.STD);
+
+    final Series.DoubleFunction function;
+
+    Type(Series.DoubleFunction function) {
+      this.function = function;
+    }
+
+    public Series.DoubleFunction getFunction() {
+      return function;
+    }
+  }
+
+  final Type type;
+  final List<Long> offsets;
+
+  public BaselineAggregate(Type type, List<Long> offsets) {
+    this.type = type;
+    this.offsets = offsets;
+  }
+
+  @Override
+  public List<MetricSlice> from(MetricSlice slice) {
+    List<MetricSlice> slices = new ArrayList<>();
+    for (long offset : this.offsets) {
+      slices.add(slice
+          .withStart(slice.getStart() + offset)
+          .withEnd(slice.getEnd()+ offset));
+    }
+    return slices;
+  }
+
+  @Override
+  public DataFrame compute(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
+    DataFrame joined = new DataFrame(COL_TIME, BaselineUtil.makeTimestamps(slice));
+
+    List<String> colNames = new ArrayList<>();
+    for (Map.Entry<MetricSlice, DataFrame> entry : data.entrySet()) {
+      MetricSlice s = entry.getKey();
+
+      long offset = s.getStart() - slice.getStart();
+      if (!offsets.contains(offset)) {
+        throw new IllegalArgumentException(String.format("Found slice with invalid offset %d", offset));
+      }
+
+      String colName = String.valueOf(s.getStart());
+
+      DataFrame df = new DataFrame(entry.getValue());
+      df.addSeries(COL_TIME, df.getLongs(COL_TIME).subtract(offset));
+      df.renameSeries(COL_VALUE, colName);
+
+      joined.addSeries(df, colName);
+      colNames.add(colName);
+
+      // TODO fill null forward?
+    }
+
+    String[] arrNames = colNames.toArray(new String[colNames.size()]);
+
+    joined.addSeries(COL_VALUE, joined.map(this.type.function, arrNames));
+
+    return joined;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
@@ -1,6 +1,8 @@
 package com.linkedin.thirdeye.rootcause.timeseries;
 
+import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.LongSeries;
 import com.linkedin.thirdeye.dataframe.Series;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 import java.util.ArrayList;
@@ -56,9 +58,15 @@ public class BaselineAggregate implements Baseline {
   public DataFrame gather(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
     Map<MetricSlice, DataFrame> filtered = this.filter(slice, data);
 
-    DataFrame joined = new DataFrame(COL_TIME, BaselineUtil.makeTimestamps(slice));
+    // probe for daily data
+    DataFrame someData = data.values().iterator().next();
+    final boolean isDailyData = isDailyData(someData);
 
-    final Set<Long> timestamps = new HashSet<>(joined.getLongs(COL_TIME).toList());
+    LongSeries timestamps = makeTimestamps(slice, data);
+    Set<Long> timestampSet = new HashSet<>(timestamps.toList());
+
+    DataFrame output = new DataFrame(COL_TIME, BaselineUtil.makeTimestamps(slice));
+
     boolean isInitialized = false;
 
     List<String> colNames = new ArrayList<>();
@@ -74,13 +82,15 @@ public class BaselineAggregate implements Baseline {
       DataFrame df = new DataFrame(entry.getValue());
 
       df.addSeries(COL_TIME, df.getLongs(COL_TIME).subtract(offset));
+      //df.addSeries(COL_TIME, BaselineUtil.alignTimestamps(joined.getLongs(COL_TIME), df.getLongs(COL_TIME)));
+
+      System.out.println(entry.getKey());
+      System.out.println(df.dropNull());
+
       df.renameSeries(COL_VALUE, colName);
-      df = df.filter(new Series.LongConditional() {
-        @Override
-        public boolean apply(long... values) {
-          return timestamps.contains(values[0]);
-        }
-      }, COL_TIME).dropNull();
+      if (isDailyData) {
+        df = heuristicDSTCorrection(df, timestampSet);
+      }
 
       if (!isInitialized) {
         // handle multi-index via prototyping
@@ -89,12 +99,12 @@ public class BaselineAggregate implements Baseline {
           prototype.addSeries(name, df.get(name));
         }
 
-        joined = joined.joinOuter(prototype, COL_TIME);
-        joined.setIndex(df.getIndexNames());
+        output = output.joinLeft(prototype, COL_TIME);
+        output.setIndex(df.getIndexNames());
         isInitialized = true;
       }
 
-      joined = joined.joinOuter(df);
+      output = output.joinOuter(df);
       colNames.add(colName);
 
       // TODO fill null forward?
@@ -102,10 +112,12 @@ public class BaselineAggregate implements Baseline {
 
     String[] arrNames = colNames.toArray(new String[colNames.size()]);
 
-    joined.addSeries(COL_VALUE, joined.map(this.type.function, arrNames));
-    joined.sortedBy(joined.getIndexNames());
+    //joined = joined.dropNull();
+    output.addSeries(COL_VALUE, output.map(this.type.function, arrNames));
+    output = output.dropNull();
+    output.sortedBy(output.getIndexNames());
 
-    return joined;
+    return output;
   }
 
   /**
@@ -172,5 +184,76 @@ public class BaselineAggregate implements Baseline {
     }
 
     return new BaselineAggregate(type, offsets);
+  }
+
+  /**
+   * Returns acceptable timestamps given the input data set. Uses {@code slice}
+   * timestamps if available, otherwise constructs artificial time series.
+   *
+   * @param slice base metric slice
+   * @param data timeseries data
+   * @return timestamp series
+   */
+  private static LongSeries makeTimestamps(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
+    if (data.containsKey(slice)) {
+      return data.get(slice).dropNull().getLongs(COL_TIME);
+    }
+
+    DataFrame someData = data.values().iterator().next();
+
+    if (isDailyData(someData)) {
+      // construct daily timestamps
+      return BaselineUtil.makeTimestamps(slice.withGranularity(new TimeGranularity(1, TimeUnit.DAYS)));
+    } else {
+      return BaselineUtil.makeTimestamps(slice);
+    }
+  }
+
+  /**
+   * Returns a data time series aligned to a set of acceptable timestamps. Only operates
+   * on data series identified as daily data. This method is required to correct for
+   * incorrect DST adjustment of daily data at the data source level or below.
+   *
+   * @param data data series
+   * @param timestamps set of acceptable timestamps
+   * @return aligned data series
+   */
+  private static DataFrame heuristicDSTCorrection(DataFrame data, final Set<Long> timestamps) {
+    if (!isDailyData(data)) {
+      return data;
+    }
+
+    DataFrame dataPlusOneHour = new DataFrame(data).addSeries(COL_TIME, data.getLongs(COL_TIME).add(TimeUnit.HOURS.toMillis(1)));
+    DataFrame dataMinusOneHour = new DataFrame(data).addSeries(COL_TIME, data.getLongs(COL_TIME).subtract(TimeUnit.HOURS.toMillis(1)));
+
+    return new DataFrame(data)
+        .append(dataPlusOneHour, dataMinusOneHour)
+        .filter(new Series.LongConditional() {
+          @Override
+          public boolean apply(long... values) {
+            return timestamps.contains(values[0]);
+          }
+        }, COL_TIME)
+        .dropNull()
+        .sortedBy(COL_TIME);
+  }
+
+  /**
+   * Probes the input data series for daily time intervals.
+   *
+   * @param data data series
+   * @return {@code true} if found to be daily, {@code false} otherwise
+   */
+  private static boolean isDailyData(DataFrame data) {
+    if (data.size() <= 1) {
+      // not timeseries
+      return false;
+    }
+
+    LongSeries diffTimestamps = data.dropNull().getLongs(COL_TIME);
+    LongSeries diff = diffTimestamps.subtract(diffTimestamps.shift(1)).dropNull();
+    long medianDiff = diff.median().longValue();
+
+    return (medianDiff == TimeUnit.DAYS.toMillis(1));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregateType.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregateType.java
@@ -4,7 +4,12 @@ import com.linkedin.thirdeye.dataframe.DoubleSeries;
 import com.linkedin.thirdeye.dataframe.Series;
 
 
-public enum BaselineType {
+/**
+ * Aggregation types supported by BaselineAggregate.
+ *
+ * @see BaselineAggregate
+ */
+public enum BaselineAggregateType {
   SUM(DoubleSeries.SUM),
   PRODUCT(DoubleSeries.PRODUCT),
   MEAN(DoubleSeries.MEAN),
@@ -15,7 +20,7 @@ public enum BaselineType {
 
   final Series.DoubleFunction function;
 
-  BaselineType(Series.DoubleFunction function) {
+  BaselineAggregateType(Series.DoubleFunction function) {
     this.function = function;
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineOffset.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineOffset.java
@@ -1,0 +1,41 @@
+package com.linkedin.thirdeye.rootcause.timeseries;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+
+public class BaselineOffset implements Baseline {
+  final int offset;
+
+  public BaselineOffset(int offset) {
+    this.offset = offset;
+  }
+
+  @Override
+  public List<MetricSlice> from(MetricSlice slice) {
+    return Collections.singletonList(slice
+        .withStart(slice.getStart() + offset)
+        .withEnd(slice.getEnd() + offset));
+  }
+
+  @Override
+  public DataFrame compute(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
+    Preconditions.checkArgument(data.size() == 1);
+
+    MetricSlice dataSlice = data.entrySet().iterator().next().getKey();
+    DataFrame input = new DataFrame(data.entrySet().iterator().next().getValue());
+
+    long offset = dataSlice.getStart() - slice.getStart();
+    if (offset != this.offset) {
+      throw new IllegalArgumentException(String.format("Found slice with invalid offset %d", offset));
+    }
+
+    input.addSeries(COL_TIME, input.getLongs(COL_TIME).subtract(this.offset));
+
+    return new DataFrame(COL_TIME, BaselineUtil.makeTimestamps(slice)).addSeries(input, COL_VALUE);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineOffset.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineOffset.java
@@ -46,10 +46,10 @@ public class BaselineOffset implements Baseline {
       throw new IllegalArgumentException(String.format("Found slice with invalid offset %d", offset));
     }
 
-    input.addSeries(COL_TIME, input.getLongs(COL_TIME).subtract(this.offset));
+    DataFrame output = new DataFrame(input);
+    output.addSeries(COL_TIME, output.getLongs(COL_TIME).subtract(this.offset));
 
-
-    return new DataFrame(COL_TIME, BaselineUtil.makeTimestamps(slice)).addSeries(input, COL_VALUE);
+    return output;
   }
 
   public static BaselineOffset fromOffset(long offset) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineOffset.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineOffset.java
@@ -9,9 +9,9 @@ import java.util.Map;
 
 
 public class BaselineOffset implements Baseline {
-  final int offset;
+  final long offset;
 
-  public BaselineOffset(int offset) {
+  private BaselineOffset(long offset) {
     this.offset = offset;
   }
 
@@ -20,6 +20,18 @@ public class BaselineOffset implements Baseline {
     return Collections.singletonList(slice
         .withStart(slice.getStart() + offset)
         .withEnd(slice.getEnd() + offset));
+  }
+
+  @Override
+  public Map<MetricSlice, DataFrame> filter(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
+    MetricSlice pattern = from(slice).get(0);
+    DataFrame value = data.get(pattern);
+
+    if (!data.containsKey(pattern)) {
+      return Collections.emptyMap();
+    }
+
+    return Collections.singletonMap(pattern, value);
   }
 
   @Override
@@ -36,6 +48,11 @@ public class BaselineOffset implements Baseline {
 
     input.addSeries(COL_TIME, input.getLongs(COL_TIME).subtract(this.offset));
 
+
     return new DataFrame(COL_TIME, BaselineUtil.makeTimestamps(slice)).addSeries(input, COL_VALUE);
+  }
+
+  public static BaselineOffset fromOffset(long offset) {
+    return new BaselineOffset(offset);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineType.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineType.java
@@ -1,0 +1,26 @@
+package com.linkedin.thirdeye.rootcause.timeseries;
+
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.Series;
+
+
+public enum BaselineType {
+  SUM(DoubleSeries.SUM),
+  PRODUCT(DoubleSeries.PRODUCT),
+  MEAN(DoubleSeries.MEAN),
+  MEDIAN(DoubleSeries.MEDIAN),
+  MIN(DoubleSeries.MIN),
+  MAX(DoubleSeries.MAX),
+  STD(DoubleSeries.STD);
+
+  final Series.DoubleFunction function;
+
+  BaselineType(Series.DoubleFunction function) {
+    this.function = function;
+  }
+
+  public Series.DoubleFunction getFunction() {
+    return function;
+  }
+}
+

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
@@ -4,14 +4,22 @@ import com.linkedin.thirdeye.dataframe.LongSeries;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 
 
+/**
+ * Utility class for synthetic baseline computation
+ */
 public class BaselineUtil {
   private BaselineUtil() {
     // left blank
   }
 
+  /**
+   * Returns a series of timestamps computed for a given metric slice, in slice's {@code granularity}
+   * intervals starting from the slice's {@code start}.
+   *
+   * @param slice metric slice
+   * @return LongSeries of timestamps
+   */
   public static LongSeries makeTimestamps(MetricSlice slice) {
-    // NOTE: requires aligned slice!
-
     if (slice.getGranularity().toMillis() <= 0) {
       return LongSeries.buildFrom(slice.getStart());
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
@@ -1,0 +1,21 @@
+package com.linkedin.thirdeye.rootcause.timeseries;
+
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+
+
+public class BaselineUtil {
+  private BaselineUtil() {
+    // left blank
+  }
+
+  public static LongSeries makeTimestamps(MetricSlice slice) {
+    // NOTE: requires aligned slice!
+
+    final long start = slice.getStart();
+    final long interval = slice.getGranularity().toMillis();
+    final int count = (int) ((slice.getEnd() - slice.getStart()) / interval);
+
+    return LongSeries.sequence(start, count, interval);
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
@@ -30,4 +30,25 @@ public class BaselineUtil {
 
     return LongSeries.sequence(start, count, interval);
   }
+
+  /**
+   * Returns a series of timestamps from a template, applied to an actual start offset.
+   *
+   * @param template template time series
+   * @param actual actual time series
+   * @return LongSeries
+   */
+  public static LongSeries alignTimestamps(LongSeries template, LongSeries actual) {
+    if (actual.size() <= 0)
+      return actual;
+
+    if (template.size() <= 0)
+      return actual;
+
+    if (actual.size() != template.size()) {
+      throw new IllegalArgumentException("Requires series with the same length");
+    }
+
+    return template.subtract(template.min().longValue()).add(actual.min());
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
@@ -12,6 +12,10 @@ public class BaselineUtil {
   public static LongSeries makeTimestamps(MetricSlice slice) {
     // NOTE: requires aligned slice!
 
+    if (slice.getGranularity().toMillis() <= 0) {
+      return LongSeries.buildFrom(slice.getStart());
+    }
+
     final long start = slice.getStart();
     final long interval = slice.getGranularity().toMillis();
     final int count = (int) ((slice.getEnd() - slice.getStart()) / interval);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
@@ -1,0 +1,122 @@
+package com.linkedin.thirdeye.rootcause.timeseries;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.linkedin.thirdeye.api.TimeGranularity;
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang.ArrayUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class BaselineTest {
+  private static final String COL_TIME = Baseline.COL_TIME;
+  private static final String COL_VALUE = Baseline.COL_VALUE;
+
+  private static final MetricSlice baseSlice = MetricSlice.from(12345, 15000, 17000, ArrayListMultimap.<String, String>create(), new TimeGranularity(500, TimeUnit.MILLISECONDS));
+
+  @Test
+  public void testBaselineOffsetFrom() {
+    BaselineOffset baseline = new BaselineOffset(-1000);
+
+    List<MetricSlice> slices = baseline.from(baseSlice);
+    Assert.assertEquals(slices.size(), 1);
+    Assert.assertEquals(slices.get(0).getMetricId(), 12345);
+    Assert.assertEquals(slices.get(0).getStart(), 14000);
+    Assert.assertEquals(slices.get(0).getEnd(), 16000);
+  }
+
+  @Test
+  public void testBaselineOffsetCompute() {
+    BaselineOffset baseline = new BaselineOffset(-1000);
+
+    Map<MetricSlice, DataFrame> data = Collections.singletonMap(
+        MetricSlice.from(12345, 14000, 16000),
+        new DataFrame(COL_TIME, LongSeries.buildFrom(14000L, 14500L, 15000L, 15500L))
+            .addSeries(COL_VALUE, 400d, 500d, 600d, 700d)
+    );
+
+    DataFrame result = baseline.compute(baseSlice, data);
+
+    assertEquals(result.getLongs(COL_TIME), 15000L, 15500L, 16000L, 16500L);
+    assertEquals(result.getDoubles(COL_VALUE), 400d, 500d, 600d, 700d);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testBaselineOffsetComputeInvalidSlice() {
+    BaselineOffset baseline = new BaselineOffset(-1000);
+    baseline.compute(baseSlice, Collections.singletonMap(
+        baseSlice.withStart(13999), new DataFrame()
+    ));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testBaselineOffsetComputeInvalidDataSize() {
+    BaselineOffset baseline = new BaselineOffset(-1000);
+    baseline.compute(baseSlice, Collections.<MetricSlice, DataFrame>emptyMap());
+  }
+
+  @Test
+  public void testBaselineAggregateFrom() {
+    BaselineAggregate baseline = new BaselineAggregate(BaselineAggregate.Type.MEDIAN, Arrays.asList(-1200L, -4500L));
+
+    List<MetricSlice> slices = baseline.from(baseSlice);
+    Assert.assertEquals(slices.size(), 2);
+    Assert.assertEquals(slices.get(0).getMetricId(), 12345);
+    Assert.assertEquals(slices.get(0).getStart(), 13800);
+    Assert.assertEquals(slices.get(0).getEnd(), 15800);
+    Assert.assertEquals(slices.get(1).getMetricId(), 12345);
+    Assert.assertEquals(slices.get(1).getStart(), 10500);
+    Assert.assertEquals(slices.get(1).getEnd(), 12500);
+  }
+
+  @Test
+  public void testBaselineAggregateCompute() {
+    BaselineAggregate baseline = new BaselineAggregate(BaselineAggregate.Type.MEDIAN, Arrays.asList(-1200L, -4500L));
+
+    Map<MetricSlice, DataFrame> data = new HashMap<>();
+    data.put(
+        MetricSlice.from(12345, 13800, 15800),
+        new DataFrame(COL_TIME, LongSeries.buildFrom(13800L, 14300L, 14800L, 99999L))
+            .addSeries(COL_VALUE, 400d, 500d, 600d, 700d)
+    );
+    data.put(
+        MetricSlice.from(12345, 10500, 12500),
+        new DataFrame(COL_TIME, LongSeries.buildFrom(10500, 11000L, 11500L, 12000L))
+            .addSeries(COL_VALUE, 500d, 600d, 700d, 800d)
+    );
+
+    DataFrame result = baseline.compute(baseSlice, data);
+
+    assertEquals(result.getLongs(COL_TIME), 15000L, 15500L, 16000L, 16500L);
+    assertEquals(result.getDoubles(COL_VALUE), 450d, 550d, 650d, Double.NaN);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testBaselineAggregateComputeInvalidSlice() {
+    BaselineAggregate baseline = new BaselineAggregate(BaselineAggregate.Type.MEDIAN, Arrays.asList(-1200L, -4500L));
+    baseline.compute(baseSlice, Collections.singletonMap(
+        baseSlice.withStart(13999), new DataFrame()
+    ));
+  }
+
+  private static void assertEquals(LongSeries series, long... values) {
+    Assert.assertEquals(
+        Arrays.asList(ArrayUtils.toObject(series.values())),
+        Arrays.asList(ArrayUtils.toObject(values)));
+  }
+
+  private static void assertEquals(DoubleSeries series, double... values) {
+    Assert.assertEquals(
+        Arrays.asList(ArrayUtils.toObject(series.values())),
+        Arrays.asList(ArrayUtils.toObject(values)));
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
@@ -5,6 +5,7 @@ import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.dataframe.DataFrame;
 import com.linkedin.thirdeye.dataframe.DoubleSeries;
 import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.StringSeries;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +51,30 @@ public class BaselineTest {
     assertEquals(result.getDoubles(COL_VALUE), 400d, 500d, 600d, 700d);
   }
 
+  @Test
+  public void testBaselineOffsetComputeMultiIndex() {
+    BaselineOffset baseline = BaselineOffset.fromOffset(-1000);
+
+    Map<MetricSlice, DataFrame> data = Collections.singletonMap(
+        MetricSlice.from(12345, 14000, 16000),
+        new DataFrame()
+            .addSeries(COL_TIME, LongSeries.buildFrom(14000L, 14500L, 15000L, 15500L))
+            .addSeries("long", LongSeries.buildFrom(1, 2, 3, 4))
+            .addSeries("string", StringSeries.buildFrom("A", "B", "C", "D"))
+            .addSeries("double", DoubleSeries.buildFrom(2.5, 3.5, 4.5, 5.5))
+            .addSeries(COL_VALUE, 400d, 500d, 600d, 700d)
+            .setIndex(COL_TIME, "long", "string", "double")
+    );
+
+    DataFrame result = baseline.compute(baseSlice, data);
+
+    assertEquals(result.getLongs(COL_TIME), 15000L, 15500L, 16000L, 16500L);
+    assertEquals(result.getLongs("long"), 1, 2, 3, 4);
+    assertEquals(result.getStrings("string"), "A", "B", "C", "D");
+    assertEquals(result.getDoubles("double"), 2.5, 3.5, 4.5, 5.5);
+    assertEquals(result.getDoubles(COL_VALUE), 400d, 500d, 600d, 700d);
+  }
+
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testBaselineOffsetComputeInvalidSlice() {
     BaselineOffset baseline = BaselineOffset.fromOffset(-1000);
@@ -83,14 +108,12 @@ public class BaselineTest {
     BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineType.MEDIAN, Arrays.asList(-1200L, -4500L));
 
     Map<MetricSlice, DataFrame> data = new HashMap<>();
-    data.put(
-        MetricSlice.from(12345, 13800, 15800),
+    data.put(MetricSlice.from(12345, 13800, 15800),
         new DataFrame(COL_TIME, LongSeries.buildFrom(13800L, 14300L, 14800L, 99999L))
             .addSeries(COL_VALUE, 400d, 500d, 600d, 700d)
     );
-    data.put(
-        MetricSlice.from(12345, 10500, 12500),
-        new DataFrame(COL_TIME, LongSeries.buildFrom(10500, 11000L, 11500L, 12000L))
+    data.put(MetricSlice.from(12345, 10500, 12500),
+        new DataFrame(COL_TIME, LongSeries.buildFrom(10500L, 11000L, 11500L, 12000L))
             .addSeries(COL_VALUE, 500d, 600d, 700d, 800d)
     );
 
@@ -98,6 +121,33 @@ public class BaselineTest {
 
     assertEquals(result.getLongs(COL_TIME), 15000L, 15500L, 16000L, 16500L);
     assertEquals(result.getDoubles(COL_VALUE), 450d, 550d, 650d, Double.NaN);
+  }
+
+  @Test
+  public void testBaselineAggregateComputeMultiIndex() {
+    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineType.MEDIAN, Arrays.asList(-1200L, -4500L));
+
+    Map<MetricSlice, DataFrame> data = new HashMap<>();
+    data.put(MetricSlice.from(12345, 13800, 15800),
+        new DataFrame()
+            .addSeries(COL_TIME, LongSeries.buildFrom(13800L, 13800L, 14300L, 14300L, 14800L, 14800L, 15300L, 15300L))
+            .addSeries("string", StringSeries.buildFrom("A", "B", "A", "B", "A", "B", "A", "B"))
+            .addSeries(COL_VALUE, 400d, 4000d, 500d, 5000d, 600d, 6000d, 700d, 7000d)
+            .setIndex(COL_TIME, "string")
+    );
+    data.put(MetricSlice.from(12345, 10500, 12500),
+        new DataFrame()
+            .addSeries(COL_TIME, LongSeries.buildFrom(10500L, 11000L, 11500L, 12000L, 10500, 11000L, 11500L, 12000L))
+            .addSeries("string", StringSeries.buildFrom("A", "A", "A", "A", "B", "B", "B", "B"))
+            .addSeries(COL_VALUE, 500d, 600d, 700d, 800d, 5000d, 6000d, 7000d, 8000d)
+            .setIndex(COL_TIME, "string")
+    );
+
+    DataFrame result = baseline.compute(baseSlice, data).sortedBy("string", COL_TIME);
+
+    assertEquals(result.getLongs(COL_TIME), 15000L, 15500L, 16000L, 16500L, 15000L, 15500L, 16000L, 16500L);
+    assertEquals(result.getStrings("string"), "A", "A", "A", "A", "B", "B", "B", "B");
+    assertEquals(result.getDoubles(COL_VALUE), 450d, 550d, 650d, 750d, 4500d, 5500d, 6500d, 7500d);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -118,5 +168,11 @@ public class BaselineTest {
     Assert.assertEquals(
         Arrays.asList(ArrayUtils.toObject(series.values())),
         Arrays.asList(ArrayUtils.toObject(values)));
+  }
+
+  private static void assertEquals(StringSeries series, String... values) {
+    Assert.assertEquals(
+        Arrays.asList(series.values()),
+        Arrays.asList(values));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
@@ -25,7 +25,7 @@ public class BaselineTest {
 
   @Test
   public void testBaselineOffsetFrom() {
-    BaselineOffset baseline = new BaselineOffset(-1000);
+    BaselineOffset baseline = BaselineOffset.fromOffset(-1000);
 
     List<MetricSlice> slices = baseline.from(baseSlice);
     Assert.assertEquals(slices.size(), 1);
@@ -36,7 +36,7 @@ public class BaselineTest {
 
   @Test
   public void testBaselineOffsetCompute() {
-    BaselineOffset baseline = new BaselineOffset(-1000);
+    BaselineOffset baseline = BaselineOffset.fromOffset(-1000);
 
     Map<MetricSlice, DataFrame> data = Collections.singletonMap(
         MetricSlice.from(12345, 14000, 16000),
@@ -52,7 +52,7 @@ public class BaselineTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testBaselineOffsetComputeInvalidSlice() {
-    BaselineOffset baseline = new BaselineOffset(-1000);
+    BaselineOffset baseline = BaselineOffset.fromOffset(-1000);
     baseline.compute(baseSlice, Collections.singletonMap(
         baseSlice.withStart(13999), new DataFrame()
     ));
@@ -60,13 +60,13 @@ public class BaselineTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testBaselineOffsetComputeInvalidDataSize() {
-    BaselineOffset baseline = new BaselineOffset(-1000);
+    BaselineOffset baseline = BaselineOffset.fromOffset(-1000);
     baseline.compute(baseSlice, Collections.<MetricSlice, DataFrame>emptyMap());
   }
 
   @Test
   public void testBaselineAggregateFrom() {
-    BaselineAggregate baseline = new BaselineAggregate(BaselineAggregate.Type.MEDIAN, Arrays.asList(-1200L, -4500L));
+    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineType.MEDIAN, Arrays.asList(-1200L, -4500L));
 
     List<MetricSlice> slices = baseline.from(baseSlice);
     Assert.assertEquals(slices.size(), 2);
@@ -80,7 +80,7 @@ public class BaselineTest {
 
   @Test
   public void testBaselineAggregateCompute() {
-    BaselineAggregate baseline = new BaselineAggregate(BaselineAggregate.Type.MEDIAN, Arrays.asList(-1200L, -4500L));
+    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineType.MEDIAN, Arrays.asList(-1200L, -4500L));
 
     Map<MetricSlice, DataFrame> data = new HashMap<>();
     data.put(
@@ -102,7 +102,7 @@ public class BaselineTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testBaselineAggregateComputeInvalidSlice() {
-    BaselineAggregate baseline = new BaselineAggregate(BaselineAggregate.Type.MEDIAN, Arrays.asList(-1200L, -4500L));
+    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineType.MEDIAN, Arrays.asList(-1200L, -4500L));
     baseline.compute(baseSlice, Collections.singletonMap(
         baseSlice.withStart(13999), new DataFrame()
     ));


### PR DESCRIPTION
Week-over-week baselines in ThirdEye are useful for ad-hoc data-exploration workflows in the RCA UI, but the process of correcting for past outliers and data errors is manual and cumbersome. This PR adds support for synthetic baselines computed on-demand from multiple week-over-week time series that are both, robust to outliers and user-intuitive in construction.

* synthetic baseline computation from multiple weekly offsets (including DST correction)

* centralized endpoint for the retrieval of metric representations (time series, aggregation, breakdown)

* integration with RCA UI