### PR TITLE
[TE] Self-Serve Onboard/Tuning flows: perf enhancements 02

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/controller.js
@@ -14,6 +14,7 @@ export default Controller.extend({
   queryParams: ['jobId', 'functionName'],
   jobId: null,
   functionName: null,
+  isOverviewLoaded: true,
 
   actions: {
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/route.js
@@ -12,22 +12,22 @@ export default Route.extend({
     if (!id) { return; }
 
     return {
-       alertData,
-       email,
-       allConfigGroups,
-       allAppNames
+      alertData,
+      email,
+      allConfigGroups,
+      allAppNames
     };
   },
 
   afterModel(model) {
-   const {
+    const {
       alertData,
       email: groupByAlertId,
       allConfigGroups,
       allAppNames
-   } = model;
+    } = model;
 
-   const {
+    const {
       id,
       filters,
       bucketSize,

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -238,44 +238,44 @@ export default Controller.extend({
       const mttdWeight = Number(extractSeverity(alertData, defaultSeverity));
       const convertedWeight = severityUnit === '%' ? mttdWeight * 100 : mttdWeight;
       const statsCards = [
-          {
-            title: 'Number of anomalies',
-            key: 'totalAlerts',
-            tooltip: false,
-            hideProjected: false,
-            text: 'Actual number of alerts received'
-          },
-          {
-            title: 'Response Rate',
-            key: 'responseRate',
-            units: '%',
-            tooltip: false,
-            hideProjected: true,
-            text: '% of anomalies that are reviewed.'
-          },
-          {
-            title: 'Precision',
-            key: 'precision',
-            units: '%',
-            tooltip: false,
-            text: 'Among all anomalies reviewed, the % of them that are true.'
-          },
-          {
-            title: 'Recall',
-            key: 'recall',
-            units: '%',
-            tooltip: false,
-            text: 'Among all anomalies that happened, the % of them detected by the system.'
-          },
-          {
-            title: `MTTD for > ${convertedWeight}${severityUnit} change`,
-            key: 'mttd',
-            units: 'hrs',
-            tooltip: false,
-            hideProjected: true,
-            text: `Minimum time to detect for anomalies with > ${convertedWeight}${severityUnit} change`
-          }
-        ];
+        {
+          title: 'Number of anomalies',
+          key: 'totalAlerts',
+          tooltip: false,
+          hideProjected: false,
+          text: 'Actual number of alerts received'
+        },
+        {
+          title: 'Response Rate',
+          key: 'responseRate',
+          units: '%',
+          tooltip: false,
+          hideProjected: true,
+          text: '% of anomalies that are reviewed.'
+        },
+        {
+          title: 'Precision',
+          key: 'precision',
+          units: '%',
+          tooltip: false,
+          text: 'Among all anomalies reviewed, the % of them that are true.'
+        },
+        {
+          title: 'Recall',
+          key: 'recall',
+          units: '%',
+          tooltip: false,
+          text: 'Among all anomalies that happened, the % of them detected by the system.'
+        },
+        {
+          title: `MTTD for > ${convertedWeight}${severityUnit} change`,
+          key: 'mttd',
+          units: 'hrs',
+          tooltip: false,
+          hideProjected: true,
+          text: `Minimum time to detect for anomalies with > ${convertedWeight}${severityUnit} change`
+        }
+      ];
 
       return buildAnomalyStats(alertEvalMetrics, statsCards, true);
     }
@@ -696,15 +696,25 @@ export default Controller.extend({
      * @param {Object} rangeOption - the selected range object
      */
     onRangeOptionClick(rangeOption) {
-      const rangeFormat = 'YYYY-MM-DD';
+      const rangeFormat = 'YYYY-MM-DD HH:mm';
       const defaultEndDate = buildDateEod(1, 'day').valueOf();
+      const timeRangeOptions = this.get('timeRangeOptions');
       const duration = rangeOption.value;
-      const startDate = moment(rangeOption.start).valueOf;
+      const startDate = moment(rangeOption.start).valueOf();
       const endDate = moment(defaultEndDate).valueOf();
-      // Trigger reload in model with new time range. Transition for 'custom' dates is handled by 'onRangeSelection'
+
       if (rangeOption.value !== 'custom') {
+        // Set date picker defaults to new start/end dates
+        this.setProperties({
+          activeRangeStart: moment(rangeOption.start).format(rangeFormat),
+          activeRangeEnd: moment(defaultEndDate).format(rangeFormat)
+        });
+        // Reset options and highlight selected one
+        timeRangeOptions.forEach(op => set(op, 'isActive', false));
+        set(rangeOption, 'isActive', true);
         // Cache chosen time range
         setDuration(duration, startDate, endDate);
+        // Reload model according to new timerange
         this.transitionToRoute({ queryParams: { mode: 'explore', duration, startDate, endDate }});
       }
     },

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
@@ -39,7 +39,7 @@ export default Route.extend({
         functionName: null,
         jobId
       }});
-      // Save duration to localstorage for guaranteed availability
+      // Save duration to sessionStorage for guaranteed availability
       setDuration(durationDefault, startDateDefault, endDateDefault);
     }
   },
@@ -117,16 +117,28 @@ export default Route.extend({
       isLoadError,
       isEditModeActive,
       alertData: newAlertData,
+      isTransitionDone: true,
       isOverViewModeActive: !isEditModeActive,
       isReplayPending: isPresent(jobId)
     });
   },
 
   actions: {
+    /**
+     * Set loader on start of transition
+     */
     willTransition(transition) {
+      this.controller.set('isTransitionDone', false);
       if (transition.targetName === 'manage.alert.index') {
         this.refresh();
       }
+    },
+
+    /**
+     * Once transition is complete, remove loader
+     */
+    didTransition() {
+      this.controller.set('isTransitionDone', true);
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/template.hbs
@@ -130,6 +130,9 @@
         <p class="te-alert-page-pending__text">{{errorText}}</p>
       </div>
     {{else}}
+      {{#if (not isTransitionDone)}}
+        <div class="spinner-wrapper spinner-wrapper--card">{{ember-spinner}}</div>
+      {{/if}}
       {{outlet}}
     {{/if}}
   </div>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
@@ -38,9 +38,11 @@ export default Controller.extend({
       selectedSortMode: '',
       activeRangeStart: '',
       activeRangeEnd: '',
+      removedAnomalies: 0,
       sortColumnStartUp: false,
       sortColumnScoreUp: false,
       sortColumnChangeUp: false,
+      isAnomalyTableLoading: false,
       sortColumnResolutionUp: false,
       isPerformanceDataLoading: false
     });
@@ -103,7 +105,7 @@ export default Controller.extend({
       const featureString = `window_size_in_hour,${severityMap[selectedSeverity]}`;
       const mttdString = `window_size_in_hour=${mttdVal};${severityMap[selectedSeverity]}=${severityThresholdVal}`;
       const patternString = patternMap[selectedPattern] ? `&pattern=${encodeURIComponent(patternMap[selectedPattern])}` : '';
-      const configString = `&features=${encodeURIComponent(featureString)}&mttd=${encodeURIComponent(mttdString)}${patternString}`;
+      const configString = `&tuningFeatures=${encodeURIComponent(featureString)}&mttd=${encodeURIComponent(mttdString)}${patternString}`;
       return { configString, severityVal: severityThresholdVal };
     }
   ),
@@ -173,34 +175,34 @@ export default Controller.extend({
       const severityUnit = isTuneAmountPercent ? '%' : '';
       const isPerfDataReady = _.has(metrics, 'current');
       const statsCards = [
-          {
-            title: 'Estimated number of anomalies',
-            key: 'totalAlerts',
-            tooltip: false,
-            text: 'Estimated number of anomalies  based on alert settings'
-          },
-          {
-            title: 'Estimated precision',
-            key: 'precision',
-            units: '%',
-            tooltip: false,
-            text: 'Among all anomalies sent by the alert, the % of them that are true.'
-          },
-          {
-            title: 'Estimated recall',
-            key: 'recall',
-            units: '%',
-            tooltip: false,
-            text: 'Among all anomalies that happened, the % of them sent by the alert.'
-          },
-          {
-            title: `MTTD for > ${severity}${severityUnit} change`,
-            key: 'mttd',
-            units: 'hrs',
-            tooltip: false,
-            text: `Minimum time to detect for anomalies with > ${severity}${severityUnit} change`
-          }
-        ];
+        {
+          title: 'Estimated number of anomalies',
+          key: 'totalAlerts',
+          tooltip: false,
+          text: 'Estimated number of anomalies  based on alert settings'
+        },
+        {
+          title: 'Estimated precision',
+          key: 'precision',
+          units: '%',
+          tooltip: false,
+          text: 'Among all anomalies sent by the alert, the % of them that are true.'
+        },
+        {
+          title: 'Estimated recall',
+          key: 'recall',
+          units: '%',
+          tooltip: false,
+          text: 'Among all anomalies that happened, the % of them sent by the alert.'
+        },
+        {
+          title: `MTTD for > ${severity}${severityUnit} change`,
+          key: 'mttd',
+          units: 'hrs',
+          tooltip: false,
+          text: `Minimum time to detect for anomalies with > ${severity}${severityUnit} change`
+        }
+      ];
 
       return isPerfDataReady ? buildAnomalyStats(metrics, statsCards, false) : [];
     }

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -363,14 +363,14 @@ export default Route.extend({
    * @return {undefined}
    */
   triggerTuningSequence: task(function * (configObj) {
+    const { configString, severityVal} = configObj;
+    const {
+      id: alertId,
+      startDate,
+      endDate,
+      tuneIdUrl
+    } = this.currentModel;
     try {
-      const { configString, severityVal} = configObj;
-      const {
-        id: alertId,
-        startDate,
-        endDate,
-        tuneIdUrl
-      } = this.currentModel;
       // Send the new tuning settings to backend to get an auto-tune Id
       const tuneId = yield fetch(tuneIdUrl + configString, postProps('')).then(checkStatus);
       // Use the autotune Id to fetch new performance metrics for this alert, and load them into the template

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -10,6 +10,7 @@ import moment from 'moment';
 import Route from '@ember/routing/route';
 import { isPresent } from "@ember/utils";
 import { later } from "@ember/runloop";
+import { task } from 'ember-concurrency';
 import {
   checkStatus,
   postProps,
@@ -126,7 +127,6 @@ const processDefaultTuningParams = (alertData) => {
   }
 
   // TODO: enable once issue resolved in backend (not saving selection to new feature string)
-  // savedSeverityPattern = alertFeatures ? alertFeatures : 'weight';
   const savedSeverityPattern = alertMttd ? alertMttd[1].split('=')[0] : 'weight';
   const isAbsValue = savedSeverityPattern === 'deviation';
   for (var severityKey in severityMap) {
@@ -346,6 +346,7 @@ export default Route.extend({
     this._super(...arguments);
 
     if (isExiting) {
+      this.get('triggerTuningSequence').cancelAll();
       controller.clearAll();
     }
   },
@@ -353,6 +354,55 @@ export default Route.extend({
   saveAutoTuneSettings(id) {
     return fetch(`/detection-job/update/filter/${id}`, postProps('')).then(checkStatus);
   },
+
+  /**
+   * This concurrency task fetches anomaly performance metrics and data for all anomalies which
+   * would not be included in the notification set under the user-selected tuning settings.
+   * @method triggerTuningSequence
+   * @param {Object} configObj - the user-selected type and value of tuning severity thresholds
+   * @return {undefined}
+   */
+  triggerTuningSequence: task(function * (configObj) {
+    try {
+      const { configString, severityVal} = configObj;
+      const {
+        id: alertId,
+        startDate,
+        endDate,
+        tuneIdUrl
+      } = this.currentModel;
+      // Send the new tuning settings to backend to get an auto-tune Id
+      const tuneId = yield fetch(tuneIdUrl + configString, postProps('')).then(checkStatus);
+      // Use the autotune Id to fetch new performance metrics for this alert, and load them into the template
+      const performanceData = yield RSVP.hash(tuningPromiseHash(startDate, endDate, tuneId[0], alertId, severityVal));
+      const idsRemoved = anomalyDiff(performanceData.idListA, performanceData.idListB).idsRemoved;
+      const projectedStats = performanceData.projectedEval;
+      Object.assign(projectedStats, { mttd: performanceData.projectedMttd });
+      this.controller.set('alertEvalMetrics.projected', projectedStats);
+      this.controller.setProperties({
+        removedAnomalies: idsRemoved.length,
+        isTunePreviewActive: true,
+        isAnomalyTableLoading: true,
+        isPerformanceDataLoading: false
+      });
+      // Fetch all anomaly data for the list of removed anomalies
+      const rawAnomalyData = yield fetchCombinedAnomalies(idsRemoved);
+      // Fetch severity scores for each anomaly
+      const severityScores = yield fetchSeverityScores(idsRemoved);
+      const anomalyData = enhanceAnomalies(rawAnomalyData, severityScores);
+      this.controller.setProperties({
+        anomalyData,
+        autoTuneId: tuneId[0],
+        isAnomalyTableLoading: false,
+        tableStats: anomalyTableStats(anomalyData)
+      });
+    } catch(error) {
+      this.controller.setProperties({
+        loadError: true,
+        loadErrorMsg: error
+      });
+    }
+  }).cancelOn('deactivate').restartable(),
 
   actions: {
 
@@ -395,52 +445,7 @@ export default Route.extend({
 
     // User clicks "preview", having configured performance settings
     triggerTuningSequence(configObj) {
-      const { configString, severityVal} = configObj;
-      const {
-        id: alertId,
-        startDate,
-        endDate,
-        tuneIdUrl
-      } = this.currentModel;
-      let projectedStats = {};
-      let rawAnomalies = [];
-      let idsRemoved = [];
-
-      fetch(tuneIdUrl + configString, postProps('')).then(checkStatus)
-        .then((tuneId) => {
-          const autoTuneId = tuneId[0];
-          this.controller.set('autoTuneId', autoTuneId);
-          return RSVP.hash(tuningPromiseHash(startDate, endDate, autoTuneId, alertId, severityVal));
-        })
-        .then((data) => {
-          idsRemoved = anomalyDiff(data.idListA, data.idListB).idsRemoved;
-          projectedStats = data.projectedEval;
-          projectedStats.mttd = data.projectedMttd;
-          this.controller.set('alertEvalMetrics.projected', projectedStats);
-          this.controller.setProperties({
-            isTunePreviewActive: true,
-            isPerformanceDataLoading: false
-          });
-          return fetchCombinedAnomalies(idsRemoved);
-        })
-        .then((rawAnomalyData) => {
-          rawAnomalies = rawAnomalyData;
-          return fetchSeverityScores(idsRemoved);
-        })
-        .then((severityScores) => {
-          const anomalyData = enhanceAnomalies(rawAnomalies, severityScores);
-          this.controller.setProperties({
-            anomalyData,
-            tableStats: anomalyTableStats(anomalyData)
-          });
-        })
-        // Got errors?
-        .catch((err) => {
-          this.controller.setProperties({
-            loadError: true,
-            loadErrorMsg: err
-          });
-        });
+      this.get('triggerTuningSequence').perform(configObj);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
@@ -170,11 +170,14 @@
 
   {{#if isTunePreviewActive}}
     <div class="te-horizontal-cards te-content-block">
-      <h4 class="te-self-serve__block-title">{{anomalyData.length}} Anomalies removed with these settings</h4>
-      {{#if diffedAnomalies}}
+      <h4 class="te-self-serve__block-title">{{removedAnomalies}} Anomalies removed with these settings</h4>
+      {{#if (gt removedAnomalies 0)}}
         <p class="te-self-serve__block-subtext">The following previously sent anomalies <span class="stronger">would not have been sent</span> under the new settings.</p>
       {{else}}
         <p class="te-self-serve__block-subtext">These settings would result in <span class="stronger">NO reduction</span> of sent anomalies</p>
+      {{/if}}
+      {{#if isAnomalyTableLoading}}
+        <div class="spinner-wrapper-self-serve spinner-wrapper-self-serve__content-block">{{ember-spinner}}</div>
       {{/if}}
 
       {{!-- Alert anomaly table --}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -238,8 +238,8 @@ export default Controller.extend({
 
     // Handle transition to alert page while refreshing the duration cache.
     navigateToAlertPage(alertId) {
-      if (localStorage.getItem('duration') !== null) {
-        localStorage.removeItem('duration');
+      if (sessionStorage.getItem('duration') !== null) {
+        sessionStorage.removeItem('duration');
       }
       this.transitionToRoute('manage.alert', alertId);
     },

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -19,7 +19,6 @@ import {
 } from "@ember/utils";
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
 import {
-  setMetricData,
   buildMetricDataUrl,
   getTopDimensions
 } from 'thirdeye-frontend/utils/manage-alert-utils';
@@ -696,7 +695,7 @@ export default Controller.extend({
 
       // Do we have custom sensitivity settings to add?
       if (alertFilterObj.isCustom) {
-        Object.assign(newAlertObj, { features: alertFilterObj.features, mttd: alertFilterObj.mttd });
+        Object.assign(newAlertObj, { tuningFeatures: alertFilterObj.features, mttd: alertFilterObj.mttd });
       }
 
       // Add filters property if present
@@ -1058,9 +1057,6 @@ export default Controller.extend({
       } = this.getProperties('metricId', 'selectedMetric', 'isDuplicateEmail', 'onboardFunctionPayload', 'alertGroupNewRecipient');
       const newEmailsArr = newEmails ? newEmails.replace(/ /g, '').split(',') : [];
       const isEmailError = !this.isEmailValid(newEmailsArr);
-
-      // TODO: cache latest selected metric data using session storage
-      // setMetricData(metricId, selectedMetric);
 
       // Update validation properties
       this.setProperties({

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -276,7 +276,7 @@ body {
   &__range-picker {
     display: inline-block;
     color: app-shade(black, 7);
-    min-width: 237px;
+    min-width: 250px;
     margin: 0;
 
     .daterangepicker-input {

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -16,7 +16,9 @@ export function formatEvalMetric(metric, isPercentage = false) {
   const multiplier = isPercentage ? 100 : 1;
   const convertedNum = metric * multiplier;
   const formattedNum = isWhole ? convertedNum : convertedNum.toFixed(1);
-  return isFinite(metric) ? formattedNum : shown;
+  let displayNum = isFinite(metric) ? formattedNum : shown;
+  // Prevent meaninglessly large numbers
+  return (Number(displayNum) > 10000) ? 'N/A' : displayNum;
 }
 
 /**
@@ -293,7 +295,7 @@ export function buildAnomalyStats(alertEvalMetrics, anomalyStats, showProjected 
  * @return {undefined}
  */
 export function setDuration(duration, startDate, endDate) {
-  localStorage.setItem('duration', JSON.stringify({ duration, startDate, endDate }));
+  sessionStorage.setItem('duration', JSON.stringify({ duration, startDate, endDate }));
 }
 
 /**
@@ -303,29 +305,7 @@ export function setDuration(duration, startDate, endDate) {
  * @return {Object}
  */
 export function getDuration() {
-  return JSON.parse(localStorage.getItem('duration'));
-}
-
-/**
- * Caches metric data to local storage in order to persist it across pages
- * NOTE: not in use yet
- * @method setMetricData
- * @param {Number} metricId - id of selected metric
- * @param {Object} metricData - payload for graphable metric data
- * @return {undefined}
- */
-export function setMetricData(metricId, metricData) {
-  localStorage.setItem(metricId, JSON.stringify(metricData));
-}
-
-/**
- * Retrieves metric data from local storage in order to persist it across pages
- * NOTE: not in use yet
- * @method getMetricData
- * @return {Object}
- */
-export function getMetricData(metricId) {
-  return JSON.parse(localStorage.getItem(metricId));
+  return JSON.parse(sessionStorage.getItem('duration'));
 }
 
 /**
@@ -355,7 +335,5 @@ export default {
   extractSeverity,
   setDuration,
   getDuration,
-  setMetricData,
-  getMetricData,
   evalObj
 };


### PR DESCRIPTION
This includes the following self-serve flow improvements:
- Added loading icons for transitions and table loads
- Standardizing data range picker action in manage.alert.explore
- Converting fetch chains to cancellable **concurrency tasks** to prevent transition lag for large datasets
- Resetting the time span or “duration” cache each time a new alert is selected
- Preventing display of erroneous performance numbers (long number edge cases)
- If we encounter an error during onboarding (resulting in an empty alert function), we now delete it.