### PR TITLE
Remove duplicate starTreeConfig from tableConfig

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/SegmentsValidationAndRetentionConfig.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.common.config;
 
-import com.linkedin.pinot.common.data.StarTreeIndexSpec;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.linkedin.pinot.startree.hll.HllConfig;
 import java.lang.reflect.Field;
@@ -40,7 +39,6 @@ public class SegmentsValidationAndRetentionConfig {
 
   private String segmentAssignmentStrategy;
   private ReplicaGroupStrategyConfig replicaGroupStrategyConfig;
-  private StarTreeIndexSpec starTreeConfig;
   private HllConfig hllConfig;
 
   // Number of replicas per partition of low-level kafka consumers. This config is used for realtime tables only.
@@ -134,14 +132,6 @@ public class SegmentsValidationAndRetentionConfig {
     this.replicaGroupStrategyConfig = replicaGroupStrategyConfig;
   }
 
-  public StarTreeIndexSpec getStarTreeConfig() {
-    return starTreeConfig;
-  }
-
-  public void setStarTreeConfig(StarTreeIndexSpec starTreeConfig) {
-    this.starTreeConfig = starTreeConfig;
-  }
-
   public HllConfig getHllConfig() {
     return hllConfig;
   }
@@ -214,7 +204,6 @@ public class SegmentsValidationAndRetentionConfig {
         EqualityUtils.isEqual(timeType, that.timeType) &&
         EqualityUtils.isEqual( segmentAssignmentStrategy, that.segmentAssignmentStrategy) &&
         EqualityUtils.isEqual(replicaGroupStrategyConfig, that.replicaGroupStrategyConfig) &&
-        EqualityUtils.isEqual(starTreeConfig, that.starTreeConfig) &&
         EqualityUtils.isEqual(hllConfig, that.hllConfig) &&
         EqualityUtils.isEqual(replicasPerPartition, that.replicasPerPartition);
   }
@@ -231,7 +220,6 @@ public class SegmentsValidationAndRetentionConfig {
     result = EqualityUtils.hashCodeOf(result, timeType);
     result = EqualityUtils.hashCodeOf(result, segmentAssignmentStrategy);
     result = EqualityUtils.hashCodeOf(result, replicaGroupStrategyConfig);
-    result = EqualityUtils.hashCodeOf(result, starTreeConfig);
     result = EqualityUtils.hashCodeOf(result, hllConfig);
     result = EqualityUtils.hashCodeOf(result, replicasPerPartition);
     return result;

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
@@ -49,7 +49,6 @@ public class TableConfigTest {
       Assert.assertNull(tableConfigToCompare.getQuotaConfig());
       Assert.assertNull(tableConfigToCompare.getValidationConfig().getReplicaGroupStrategyConfig());
       Assert.assertNull(tableConfigToCompare.getValidationConfig().getHllConfig());
-      Assert.assertNull(tableConfigToCompare.getValidationConfig().getStarTreeConfig());
 
       ZNRecord znRecord = TableConfig.toZnRecord(tableConfig);
       tableConfigToCompare = TableConfig.fromZnRecord(znRecord);
@@ -57,7 +56,6 @@ public class TableConfigTest {
       Assert.assertNull(tableConfigToCompare.getQuotaConfig());
       Assert.assertNull(tableConfig.getValidationConfig().getReplicaGroupStrategyConfig());
       Assert.assertNull(tableConfigToCompare.getValidationConfig().getHllConfig());
-      Assert.assertNull(tableConfigToCompare.getValidationConfig().getStarTreeConfig());
     }
     {
       // With quota config
@@ -145,7 +143,7 @@ public class TableConfigTest {
       starTreeIndexSpec.setSkipStarNodeCreationForDimensions(dims);
 
       TableConfig tableConfig = tableConfigBuilder.build();
-      tableConfig.getValidationConfig().setStarTreeConfig(starTreeIndexSpec);
+      tableConfig.getIndexingConfig().setStarTreeIndexSpec(starTreeIndexSpec);
 
       // Serialize then de-serialize
       JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
@@ -206,10 +204,10 @@ public class TableConfigTest {
       throws Exception {
     // Check that the segment assignment configuration does exist.
     Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
-    Assert.assertNotNull(tableConfigToCompare.getValidationConfig().getStarTreeConfig());
+    Assert.assertNotNull(tableConfigToCompare.getIndexingConfig().getStarTreeIndexSpec());
 
     // Check that the configurations are correct.
-    StarTreeIndexSpec starTreeIndexSpec = tableConfigToCompare.getValidationConfig().getStarTreeConfig();
+    StarTreeIndexSpec starTreeIndexSpec = tableConfigToCompare.getIndexingConfig().getStarTreeIndexSpec();
 
     Set<String> dims = new HashSet<>();
     dims.add("dims");


### PR DESCRIPTION
We already have a starTreeIndexSpec in tableIndexConfig. This is the one which is being used in the build and push job.
Verified that removing this will not break the existing table configs which were created with a null starTreeConfig in the segmentsConfig.