### PR TITLE
[TE] Include number of user report anomalies to total response rates

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
@@ -53,7 +53,7 @@ public class PrecisionRecallEvaluator {
   private int userReportTrueAnomaly; // Anomaly is user reported: true anomaly that was not sent out
   private int userReportTrueAnomalyNewTrend; // Anomaly is user reported: true anomaly new trend that was not sent out
   private boolean isProjected = false;
-      // isProjected to indicate if calculating system performance or alert filter's projected performance
+  // isProjected to indicate if calculating system performance or alert filter's projected performance
 
   public static final String PRECISION = "precision";
   public static final String WEIGHTED_PRECISION = "weightedPrecision";
@@ -109,7 +109,8 @@ public class PrecisionRecallEvaluator {
   }
 
   public int getTotalResponses() {
-    return notifiedFalseAlarm + notifiedTrueAnomaly + notifiedTrueAnomalyNewTrend;
+    return notifiedFalseAlarm + notifiedTrueAnomaly + notifiedTrueAnomalyNewTrend + userReportTrueAnomaly
+        + userReportTrueAnomalyNewTrend;
   }
 
   public int getTotalAlerts() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/email/filter/PrecisionRecallEvaluator.java
@@ -108,6 +108,7 @@ public class PrecisionRecallEvaluator {
     return 1.0 * getTotalResponses() / getTotalAlerts();
   }
 
+  // Total responses is including notified labeled anomalies and user report anomalies
   public int getTotalResponses() {
     return notifiedFalseAlarm + notifiedTrueAnomaly + notifiedTrueAnomalyNewTrend + userReportTrueAnomaly
         + userReportTrueAnomalyNewTrend;

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestPrecisionRecallEvaluator.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/detector/email/filter/TestPrecisionRecallEvaluator.java
@@ -67,6 +67,7 @@ public class TestPrecisionRecallEvaluator {
     assertEquals(evaluator.getPrecision(), 0.125, 0.0001);
     assertEquals(evaluator.getRecall(), 1, 0.00001);
     assertEquals(evaluator.getPrecisionInResponse(), 1.0, 0.00001);
+    assertEquals(evaluator.getResponseRate(), 1.0/8, 0.00001);
 
     // test data with 1 positive feedback, 1 false alarm
     anomalyResultDTOS.add(notifiedFalseAnomaly);
@@ -74,13 +75,16 @@ public class TestPrecisionRecallEvaluator {
     assertEquals(evaluator.getPrecision(), 0.1111, 0.0001);
     assertEquals(evaluator.getRecall(), 1, 0.00001);
     assertEquals(evaluator.getPrecisionInResponse(), 0.5, 0.00001);
+    assertEquals(evaluator.getResponseRate(), 2.0/9, 0.00001);
 
     // test data with 1 positive feedback, 1 user report anomaly, 1 false alarm
     anomalyResultDTOS.add(userReportAnomaly);
     evaluator.init(anomalyResultDTOS);
-    assertEquals(evaluator.getPrecision(),0.1111, 0.0001);
+    // counting user report anomalies as part of the total anomalies
+    assertEquals(evaluator.getPrecision(),0.1, 0.0001);
     assertEquals(evaluator.getRecall(), 0.5, 0.00001);
-    assertEquals(evaluator.getPrecisionInResponse(), 0.5, 0.00001);
+    assertEquals(evaluator.getPrecisionInResponse(), 1.0/3, 0.00001);
+    assertEquals(evaluator.getResponseRate(), 3.0/10, 0.00001);
   }
 
 


### PR DESCRIPTION
In previous response rate calculation, we are including number of user report anomalies. As communicate with UX design, user report should be part of total responses.