### PR TITLE
[TE] detection - discard raw anomaly results after detection

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/AnomalyMergeExecutor.java
@@ -230,9 +230,7 @@ public class AnomalyMergeExecutor implements Runnable {
     try {
       // persist the merged result
       mergedResultDAO.update(mergedResult);
-      for (RawAnomalyResultDTO rawAnomalyResultDTO : mergedResult.getAnomalyResults()) {
-        anomalyResultDAO.update(rawAnomalyResultDTO);
-      }
+
     } catch (Exception e) {
       LOG.error("Could not persist merged result : [" + mergedResult.toString() + "]", e);
     }


### PR DESCRIPTION
This PR phases out saving RawAnomalyResultDTOs after detection and merging actions to alleviate database load