### PR TITLE
[PINOT-5728] Backing out changes to SegmentStatusChecker to get table sizes every 5 minutes

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/SegmentStatusChecker.java
@@ -272,21 +272,6 @@ public class SegmentStatusChecker {
           nErrors);
       _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE,
           (nSegments > 0) ? (100 - (nOffline * 100 / nSegments)) : 100);
-
-      // Emit estimated sizes of realtime/offline tables.
-      TableSizeReader.TableSizeDetails tableSizeDetails = _tableSizeReader.getTableSizeDetails(tableName,
-          _config.getServerAdminRequestTimeoutSeconds() * 1000);
-      if (tableSizeDetails != null) {
-        if (tableSizeDetails.realtimeSegments != null) {
-          long realtimeTableEstimatedSize = tableSizeDetails.realtimeSegments.estimatedSizeInBytes;
-          _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.REALTIME_TABLE_ESTIMATED_SIZE, realtimeTableEstimatedSize);
-        }
-        if (tableSizeDetails.offlineSegments != null) {
-          long offlineTableEstimatedSize = tableSizeDetails.offlineSegments.estimatedSizeInBytes;
-          _metricsRegistry.setValueOfTableGauge(tableName, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE, offlineTableEstimatedSize);
-        }
-      }
-
       if (nOffline > 0) {
         LOGGER.warn("Table {} has {} segments with no online replicas", tableName, nOffline);
       }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/StorageQuotaChecker.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/StorageQuotaChecker.java
@@ -107,6 +107,8 @@ public class StorageQuotaChecker {
     TableSizeReader.SegmentSizeDetails sizeDetails = tableSubtypeSize.segments.get(segmentName);
     long existingSegmentSizeBytes = sizeDetails != null ?  sizeDetails.estimatedSizeInBytes : 0;
 
+    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE, existingSegmentSizeBytes);
+
     long estimatedFinalSizeBytes = tableSubtypeSize.estimatedSizeInBytes - existingSegmentSizeBytes + incomingSegmentSizeBytes;
     if (estimatedFinalSizeBytes <= allowedStorageBytes) {
       String message = String.format("Estimated size: %d bytes is within the configured quota of %d (bytes) for table %s. Incoming segment size: %d (bytes)",

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -15,81 +15,42 @@
  */
 package com.linkedin.pinot.controller.helix;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
 import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.metrics.ControllerGauge;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
-import com.linkedin.pinot.common.restlet.resources.SegmentSizeInfo;
-import com.linkedin.pinot.common.restlet.resources.TableSizeInfo;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
 import com.yammer.metrics.core.MetricsRegistry;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
-import org.apache.helix.InstanceType;
 import org.apache.helix.ZNRecord;
-import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.mockito.ArgumentMatchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class SegmentStatusCheckerTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentStatusCheckerTest.class);
   private SegmentStatusChecker segmentStatusChecker;
   private PinotHelixResourceManager helixResourceManager;
   private MetricsRegistry metricsRegistry;
   private ControllerMetrics controllerMetrics;
   private ControllerConf config;
-  private Map<String, FakeSizeServer> serverMap = new HashMap<>();
-  private final int serverPortStart = 20000;
-  private final String URI_PATH = "/table/";
-  private final HelixManager helixManager = new ZKHelixManager("StatusChecker", null, InstanceType.CONTROLLER, "");
 
   @BeforeSuite
   public void setUp() throws Exception {
-
-    int counter = 0;
-    // server0
-    FakeSizeServer s = new FakeSizeServer(Arrays.asList("s1","s2", "s3"), serverPortStart + counter);
-    s.start(URI_PATH, createHandler(200, s.sizes, 0));
-    serverMap.put(serverName(counter), s);
-    ++counter;
-
-    // server1
-    s = new FakeSizeServer(Arrays.asList("s2","s5"), serverPortStart + counter);
-    s.start(URI_PATH, createHandler(200, s.sizes, 0));
-    serverMap.put(serverName(counter), s);
-    ++counter;
   }
 
   @AfterSuite
@@ -134,51 +95,15 @@ public class SegmentStatusCheckerTest {
       when(helixResourceManager.getAllTables()).thenReturn(allTableNames);
       when(helixResourceManager.getHelixClusterName()).thenReturn("StatusChecker");
       when(helixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
-      when(helixResourceManager.getHelixZkManager()).thenReturn(helixManager);
-      when(helixResourceManager.hasOfflineTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("offline") >= 0;
-        }
-      });
-      when(helixResourceManager.hasRealtimeTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("realtime") >= 0;
-        }
-      });
-      final String[] servers = { "server0", "server1"};
-      when(helixResourceManager.getInstanceToSegmentsInATableMap(anyString()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return subsetOfServerSegments(servers);
-            }
-          });
-      when(helixResourceManager.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return serverEndpoints(servers);
-            }
-          });
     }
     {
       config = mock(ControllerConf.class);
       when(config.getStatusCheckerFrequencyInSeconds()).thenReturn(300);
       when(config.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(300);
-      when(config.getServerAdminRequestTimeoutSeconds()).thenReturn(100);
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-
     segmentStatusChecker.runSegmentMetrics();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.SEGMENTS_IN_ERROR_STATE), 1);
@@ -188,10 +113,6 @@ public class SegmentStatusCheckerTest {
         ControllerGauge.PERCENT_OF_REPLICAS), 33);
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.PERCENT_SEGMENTS_AVAILABLE), 100);
-    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
-        ControllerGauge.REALTIME_TABLE_ESTIMATED_SIZE), 0L);
-    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
-        ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 630L);
     segmentStatusChecker.stop();
   }
 
@@ -240,52 +161,15 @@ public class SegmentStatusCheckerTest {
       when(helixResourceManager.getAllTables()).thenReturn(allTableNames);
       when(helixResourceManager.getHelixClusterName()).thenReturn("StatusChecker");
       when(helixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
-      when(helixResourceManager.getHelixZkManager()).thenReturn(helixManager);
-      when(helixResourceManager.hasOfflineTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("offline") >= 0;
-        }
-      });
-      when(helixResourceManager.hasRealtimeTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("realtime") >= 0;
-        }
-      });
-      final String[] servers = { "server0", "server1"};
-      when(helixResourceManager.getInstanceToSegmentsInATableMap(anyString()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return subsetOfServerSegments(servers);
-            }
-          });
-
-      when(helixResourceManager.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return serverEndpoints(servers);
-            }
-          });
     }
     {
       config = mock(ControllerConf.class);
       when(config.getStatusCheckerFrequencyInSeconds()).thenReturn(300);
       when(config.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(300);
-      when(config.getServerAdminRequestTimeoutSeconds()).thenReturn(100);
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-
     segmentStatusChecker.runSegmentMetrics();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
@@ -295,10 +179,6 @@ public class SegmentStatusCheckerTest {
         ControllerGauge.PERCENT_OF_REPLICAS), 100);
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.PERCENT_SEGMENTS_AVAILABLE), 100);
-    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
-        ControllerGauge.REALTIME_TABLE_ESTIMATED_SIZE), 630L);
-    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
-        ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 0L);
     segmentStatusChecker.stop();
   }
 
@@ -392,52 +272,15 @@ public class SegmentStatusCheckerTest {
       when(helixResourceManager.getHelixClusterName()).thenReturn("StatusChecker");
       when(helixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
       when(helixResourceManager.getPropertyStore()).thenReturn(propertyStore);
-      when(helixResourceManager.getHelixZkManager()).thenReturn(helixManager);
-      when(helixResourceManager.hasOfflineTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("offline") >= 0;
-        }
-      });
-      when(helixResourceManager.hasRealtimeTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("realtime") >= 0;
-        }
-      });
-      final String[] servers = { "server0", "server1"};
-      when(helixResourceManager.getInstanceToSegmentsInATableMap(anyString()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return subsetOfServerSegments(servers);
-            }
-          });
-
-      when(helixResourceManager.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return serverEndpoints(servers);
-            }
-          });
     }
     {
       config = mock(ControllerConf.class);
       when(config.getStatusCheckerFrequencyInSeconds()).thenReturn(300);
       when(config.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(0);
-      when(config.getServerAdminRequestTimeoutSeconds()).thenReturn(100);
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-
     segmentStatusChecker.runSegmentMetrics();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.SEGMENTS_IN_ERROR_STATE), 1);
@@ -445,10 +288,6 @@ public class SegmentStatusCheckerTest {
         ControllerGauge.NUMBER_OF_REPLICAS), 0);
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.PERCENT_SEGMENTS_AVAILABLE), 75);
-    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
-        ControllerGauge.REALTIME_TABLE_ESTIMATED_SIZE), 0L);
-    Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
-        ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 630L);
     segmentStatusChecker.stop();
   }
 
@@ -480,53 +319,15 @@ public class SegmentStatusCheckerTest {
       when(helixResourceManager.getAllTables()).thenReturn(allTableNames);
       when(helixResourceManager.getHelixClusterName()).thenReturn("StatusChecker");
       when(helixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
-      when(helixResourceManager.getHelixZkManager()).thenReturn(helixManager);
-
-      when(helixResourceManager.hasOfflineTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("offline") >= 0;
-        }
-      });
-      when(helixResourceManager.hasRealtimeTable(anyString())).thenAnswer(new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock)
-            throws Throwable {
-          String table = (String) invocationOnMock.getArguments()[0];
-          return table.indexOf("realtime") >= 0;
-        }
-      });
-      final String[] servers = { "server0", "server1"};
-      when(helixResourceManager.getInstanceToSegmentsInATableMap(anyString()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return subsetOfServerSegments(servers);
-            }
-          });
-
-      when(helixResourceManager.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
-          .thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock)
-                throws Throwable {
-              return serverEndpoints(servers);
-            }
-          });
     }
     {
       config = mock(ControllerConf.class);
       when(config.getStatusCheckerFrequencyInSeconds()).thenReturn(300);
       when(config.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(300);
-      when(config.getServerAdminRequestTimeoutSeconds()).thenReturn(100);
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-
     segmentStatusChecker.runSegmentMetrics();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
         ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
@@ -622,55 +423,15 @@ public class SegmentStatusCheckerTest {
       when(helixResourceManager.getHelixClusterName()).thenReturn("StatusChecker");
       when(helixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
       when(helixResourceManager.getPropertyStore()).thenReturn(propertyStore);
-      when(helixResourceManager.getHelixZkManager()).thenReturn(helixManager);
     }
     {
       config = mock(ControllerConf.class);
       when(config.getStatusCheckerFrequencyInSeconds()).thenReturn(300);
       when(config.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(300);
-      when(config.getServerAdminRequestTimeoutSeconds()).thenReturn(100);
     }
-
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-
-    when(helixResourceManager.hasOfflineTable(anyString())).thenAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocationOnMock)
-          throws Throwable {
-        String table = (String) invocationOnMock.getArguments()[0];
-        return table.indexOf("offline") >= 0;
-      }
-    });
-    when(helixResourceManager.hasRealtimeTable(anyString())).thenAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocationOnMock)
-          throws Throwable {
-        String table = (String) invocationOnMock.getArguments()[0];
-        return table.indexOf("realtime") >= 0;
-      }
-    });
-
-    final String[] servers = { "server0", "server1"};
-    when(helixResourceManager.getInstanceToSegmentsInATableMap(anyString()))
-        .thenAnswer(new Answer<Object>() {
-          @Override
-          public Object answer(InvocationOnMock invocationOnMock)
-              throws Throwable {
-            return subsetOfServerSegments(servers);
-          }
-        });
-
-    when(helixResourceManager.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
-        .thenAnswer(new Answer<Object>() {
-          @Override
-          public Object answer(InvocationOnMock invocationOnMock)
-              throws Throwable {
-            return serverEndpoints(servers);
-          }
-        });
-
     segmentStatusChecker.runSegmentMetrics();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(externalView.getId(),
         ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
@@ -707,54 +468,15 @@ public class SegmentStatusCheckerTest {
       when(helixResourceManager.getAllTables()).thenReturn(allTableNames);
       when(helixResourceManager.getHelixClusterName()).thenReturn("StatusChecker");
       when(helixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
-      when(helixResourceManager.getHelixZkManager()).thenReturn(helixManager);
     }
     {
       config = mock(ControllerConf.class);
       when(config.getStatusCheckerFrequencyInSeconds()).thenReturn(300);
       when(config.getStatusCheckerWaitForPushTimeInSeconds()).thenReturn(300);
-      when(config.getServerAdminRequestTimeoutSeconds()).thenReturn(100);
     }
     metricsRegistry = new MetricsRegistry();
     controllerMetrics = new ControllerMetrics(metricsRegistry);
     segmentStatusChecker = new SegmentStatusChecker(helixResourceManager, config, controllerMetrics);
-
-    when(helixResourceManager.hasOfflineTable(anyString())).thenAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocationOnMock)
-          throws Throwable {
-        String table = (String) invocationOnMock.getArguments()[0];
-        return table.indexOf("offline") >= 0;
-      }
-    });
-    when(helixResourceManager.hasRealtimeTable(anyString())).thenAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocationOnMock)
-          throws Throwable {
-        String table = (String) invocationOnMock.getArguments()[0];
-        return table.indexOf("realtime") >= 0;
-      }
-    });
-
-    final String[] servers = { "server0", "server1"};
-    when(helixResourceManager.getInstanceToSegmentsInATableMap(anyString()))
-        .thenAnswer(new Answer<Object>() {
-          @Override
-          public Object answer(InvocationOnMock invocationOnMock)
-              throws Throwable {
-            return subsetOfServerSegments(servers);
-          }
-        });
-
-    when(helixResourceManager.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
-        .thenAnswer(new Answer<Object>() {
-          @Override
-          public Object answer(InvocationOnMock invocationOnMock)
-              throws Throwable {
-            return serverEndpoints(servers);
-          }
-        });
-
     segmentStatusChecker.runSegmentMetrics();
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
         ControllerGauge.SEGMENTS_IN_ERROR_STATE), 0);
@@ -858,94 +580,5 @@ public class SegmentStatusCheckerTest {
     Assert.assertEquals(controllerMetrics.getValueOfTableGauge(tableName,
         ControllerGauge.PERCENT_SEGMENTS_AVAILABLE), 100);
     segmentStatusChecker.stop();
-  }
-
-  private Map<String, List<String>> subsetOfServerSegments(String...servers) {
-    Map<String, List<String>> subset = new HashMap<>();
-    for (String server : servers) {
-      subset.put(server, serverMap.get(server).segments);
-    }
-    return subset;
-  }
-
-  private BiMap<String, String> serverEndpoints(String...servers) {
-    BiMap<String, String> endpoints = HashBiMap.create(servers.length);
-    for (String server : servers) {
-      endpoints.put(server, serverMap.get(server).endpoint);
-    }
-    return endpoints;
-  }
-
-  private static class FakeSizeServer {
-    List<String> segments;
-    String endpoint;
-    int port;
-    List<SegmentSizeInfo> sizes = new ArrayList<>();
-    HttpServer httpServer;
-
-    FakeSizeServer(List<String> segments, int port) {
-      this.segments = segments;
-      this.endpoint = "localhost:" + port;
-      this.port = port;
-      populateSizes(segments);
-    }
-
-    void populateSizes(List<String> segments) {
-      for (String segment : segments) {
-        SegmentSizeInfo sizeInfo =
-            new SegmentSizeInfo(segment, getSegmentSize(segment));
-        sizes.add(sizeInfo);
-      }
-    }
-
-    static long getSegmentSize(String segment) {
-      int index = Integer.parseInt(segment.substring(1));
-      return 100 + index * 10;
-    }
-
-    private void  start(String path, HttpHandler handler)
-        throws IOException {
-      httpServer = HttpServer.create(new InetSocketAddress(port), 0);
-      httpServer.createContext(path, handler);
-      new Thread(new Runnable() {
-        @Override
-        public void run() {
-          httpServer.start();
-        }
-      }).start();
-    }
-  }
-
-  private HttpHandler createHandler(final int status,
-      final List<SegmentSizeInfo> segmentSizes, final int sleepTimeMs) {
-    return new HttpHandler() {
-      @Override
-      public void handle(HttpExchange httpExchange)
-          throws IOException {
-        if (sleepTimeMs > 0) {
-          try {
-            Thread.sleep(sleepTimeMs);
-          } catch (InterruptedException e) {
-            LOGGER.info("Handler interrupted during sleep");
-          }
-        }
-
-        TableSizeInfo tableInfo = new TableSizeInfo("myTable", 0);
-        tableInfo.segments = segmentSizes;
-        for (SegmentSizeInfo segmentSize : segmentSizes) {
-          tableInfo.diskSizeInBytes += segmentSize.diskSizeInBytes;
-        }
-
-        String json = new ObjectMapper().writeValueAsString(tableInfo);
-        httpExchange.sendResponseHeaders(status, json.length());
-        OutputStream responseBody = httpExchange.getResponseBody();
-        responseBody.write(json.getBytes());
-        responseBody.close();
-      }
-    };
-  }
-
-  private String serverName(int index) {
-    return "server" + index;
   }
 }


### PR DESCRIPTION
We can get this information for offline tables during segment push. We will add a similar
case for realtime tables as well.