### PR TITLE
Support on-the-fly metrics aggregation during realtime consumption.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
@@ -43,6 +43,7 @@ public class IndexingConfig {
   private List<String> _onHeapDictionaryColumns;
   private StarTreeIndexSpec _starTreeIndexSpec;
   private SegmentPartitionConfig _segmentPartitionConfig;
+  private boolean _aggregateMetrics;
 
   public List<String> getInvertedIndexColumns() {
     return _invertedIndexColumns;
@@ -136,8 +137,16 @@ public class IndexingConfig {
     _segmentPartitionConfig = config;
   }
 
+  public void setAggregateMetrics(boolean value) {
+    _aggregateMetrics = value;
+  }
+
   public SegmentPartitionConfig getSegmentPartitionConfig() {
     return _segmentPartitionConfig;
+  }
+
+  public boolean getAggregateMetrics() {
+    return _aggregateMetrics;
   }
 
   @Override

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
@@ -45,6 +45,7 @@ public class IndexingConfigTest {
     json.put("onHeapDictionaryColumns", Arrays.asList(expectedOnHeapDictionaryColumns));
     json.put("loadMode", "MMAP");
     json.put("keyThatIsUnknown", "randomValue");
+    json.put("aggregateMetrics", "true");
 
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jsonNode = mapper.readTree(json.toString());
@@ -68,6 +69,8 @@ public class IndexingConfigTest {
     for (int i = 0; i < expectedOnHeapDictionaryColumns.length; i++) {
       Assert.assertEquals(actualOnHeapDictionaryColumns.get(i), expectedOnHeapDictionaryColumns[i]);
     }
+
+    Assert.assertTrue(indexingConfig.getAggregateMetrics());
   }
 
   @Test

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.data.manager.realtime;
 
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
@@ -162,6 +163,11 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     this.kafkaStreamProvider.init(kafkaStreamProviderConfig, tableName, serverMetrics);
     this.kafkaStreamProvider.start();
     this.tableStreamName = tableName + "_" + kafkaStreamProviderConfig.getStreamName();
+
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    if (indexingConfig != null && indexingConfig.getAggregateMetrics()) {
+      LOGGER.warn("Updating of metrics only supported for LLC consumer, ignoring.");
+    }
 
     // lets create a new realtime segment
     segmentLogger.info("Started kafka stream provider");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentConfig.java
@@ -35,12 +35,13 @@ public class RealtimeSegmentConfig {
   private final PinotDataBufferMemoryManager _memoryManager;
   private final RealtimeSegmentStatsHistory _statsHistory;
   private final SegmentPartitionConfig _segmentPartitionConfig;
+  private final boolean _aggregateMetrics;
 
   private RealtimeSegmentConfig(String segmentName, String streamName, Schema schema, int capacity,
       int avgNumMultiValues, Set<String> noDictionaryColumns, Set<String> invertedIndexColumns,
       RealtimeSegmentZKMetadata realtimeSegmentZKMetadata, boolean offHeap,
       PinotDataBufferMemoryManager memoryManager, RealtimeSegmentStatsHistory statsHistory,
-      SegmentPartitionConfig segmentPartitionConfig) {
+      SegmentPartitionConfig segmentPartitionConfig, boolean aggregateMetrics) {
     _segmentName = segmentName;
     _streamName = streamName;
     _schema = schema;
@@ -53,6 +54,7 @@ public class RealtimeSegmentConfig {
     _memoryManager = memoryManager;
     _statsHistory = statsHistory;
     _segmentPartitionConfig = segmentPartitionConfig;
+    _aggregateMetrics = aggregateMetrics;
   }
 
   public String getSegmentName() {
@@ -103,6 +105,10 @@ public class RealtimeSegmentConfig {
     return _segmentPartitionConfig;
   }
 
+  public boolean aggregateMetrics() {
+    return _aggregateMetrics;
+  }
+
   public static class Builder {
     private String _segmentName;
     private String _streamName;
@@ -116,6 +122,7 @@ public class RealtimeSegmentConfig {
     private PinotDataBufferMemoryManager _memoryManager;
     private RealtimeSegmentStatsHistory _statsHistory;
     private SegmentPartitionConfig _segmentPartitionConfig;
+    private boolean _aggregateMetrics = false;
 
     public Builder() {
     }
@@ -180,10 +187,15 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
+    public Builder setAggregateMetrics(boolean aggregateMetrics) {
+      _aggregateMetrics = aggregateMetrics;
+      return this;
+    }
+
     public RealtimeSegmentConfig build() {
       return new RealtimeSegmentConfig(_segmentName, _streamName, _schema, _capacity, _avgNumMultiValues,
           _noDictionaryColumns, _invertedIndexColumns, _realtimeSegmentZKMetadata, _offHeap, _memoryManager,
-          _statsHistory, _segmentPartitionConfig);
+          _statsHistory, _segmentPartitionConfig, _aggregateMetrics);
     }
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -491,9 +491,9 @@ public class LLRealtimeSegmentDataManagerTest {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
-      segmentDataManager.setNumRowsConsumed(maxRowsInSegment - 1);
+      segmentDataManager.setNumRowsIndexed(maxRowsInSegment - 1);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
-      segmentDataManager.setNumRowsConsumed(maxRowsInSegment);
+      segmentDataManager.setNumRowsIndexed(maxRowsInSegment);
       Assert.assertTrue(segmentDataManager.invokeEndCriteriaReached());
       Assert.assertEquals(segmentDataManager.getStopReason(), SegmentCompletionProtocol.REASON_ROW_LIMIT);
     }
@@ -822,6 +822,10 @@ public class LLRealtimeSegmentDataManagerTest {
 
     public void setNumRowsConsumed(int numRows) {
       setInt(numRows, "_numRowsConsumed");
+    }
+
+    public  void setNumRowsIndexed(int numRows) {
+      setInt(numRows, "_numRowsIndexed");
     }
 
     public void setFinalOffset(long offset) {

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImplTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentImplTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.realtime.impl;
+
+import com.linkedin.pinot.common.data.DimensionFieldSpec;
+import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
+import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
+import com.linkedin.pinot.core.io.writer.impl.MmapMemoryManager;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Random;
+import org.apache.commons.lang.RandomStringUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Unit test for {@link RealtimeSegmentImpl}
+ */
+public class RealtimeSegmentImplTest {
+
+  private static final String DIMENSION_1 = "dim1";
+  private static final String DIMENSION_2 = "dim2";
+  private static final String METRIC_COLUMN = "metric";
+  private static final String SEGMENT_NAME = "realtimeSegmentImplTest";
+  private static final String _keySeparator = "\t\t";
+  private static final int NUM_ROWS = 10001;
+
+  private RealtimeSegmentConfig.Builder _configBuilder;
+  private RealtimeSegmentImpl _realtimeSegment;
+  private Random _random;
+
+  @BeforeClass
+  public void setup() {
+    PinotDataBufferMemoryManager memoryManager = new MmapMemoryManager("/tmp", SEGMENT_NAME);
+    _configBuilder = new RealtimeSegmentConfig.Builder();
+    _random = new Random(System.nanoTime());
+
+    RealtimeSegmentStatsHistory statsHistory = mock(RealtimeSegmentStatsHistory.class);
+    when(statsHistory.getEstimatedAvgColSize(any(String.class))).thenReturn(32);
+    when(statsHistory.getEstimatedCardinality(any(String.class))).thenReturn(200);
+
+    _configBuilder.setCapacity(1000000)
+        .setMemoryManager(memoryManager)
+        .setNoDictionaryColumns(new HashSet<>(Collections.singletonList(METRIC_COLUMN)))
+        .setOffHeap(true)
+        .setSchema(buildSchema())
+        .setSegmentName(SEGMENT_NAME)
+        .setStatsHistory(statsHistory)
+        .setInvertedIndexColumns(new HashSet<>(Collections.singletonList(DIMENSION_1)))
+        .setRealtimeSegmentZKMetadata(new RealtimeSegmentZKMetadata())
+        .setAggregateMetrics(true);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _realtimeSegment.destroy();
+  }
+
+  /**
+   * This test generates a {@link RealtimeSegmentImpl} object and indexes rows with
+   * duplicate dimension values in it, and ensures that metrics are aggregated correctly.
+   *
+   */
+  @Test
+  public void test() {
+    _realtimeSegment = new RealtimeSegmentImpl(_configBuilder.build());
+    String[] stringValues = new String[10]; // 10 unique strings.
+    for (int i = 0; i < stringValues.length; i++) {
+      stringValues[i] = RandomStringUtils.random(10);
+    }
+
+    Map<String, Integer> expectedMap = new LinkedHashMap<>();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRow row = new GenericRow();
+
+      row.putField(DIMENSION_1, (long) _random.nextInt(10)); // 10 unique values
+      row.putField(DIMENSION_2, stringValues[_random.nextInt(stringValues.length)]); // 10 unique values
+
+      int metricValue = _random.nextInt();
+      row.putField(METRIC_COLUMN, metricValue);
+      _realtimeSegment.index(row);
+
+      // Collect expected results.
+      String key = buildKey(row);
+      Integer sum = expectedMap.get(key);
+      if (sum == null) {
+        expectedMap.put(key, metricValue);
+      } else {
+        expectedMap.put(key, sum + metricValue);
+      }
+    }
+
+    int numDocsIndexed = _realtimeSegment.getNumDocsIndexed();
+    Assert.assertEquals(numDocsIndexed, expectedMap.size());
+
+    GenericRow row = new GenericRow();
+    for (int docId = 0; docId < numDocsIndexed; docId++) {
+      _realtimeSegment.getRecord(docId, row);
+      String key = buildKey(row);
+      Assert.assertEquals(row.getValue(METRIC_COLUMN), expectedMap.get(key));
+    }
+  }
+
+  /**
+   * Helper method to build key containing dimension column values.
+   *
+   * @param row Generic row to be used for building key.
+   * @return String key for the given row.
+   */
+  private String buildKey(GenericRow row) {
+    return String.valueOf(row.getValue(DIMENSION_1)) +
+        _keySeparator +
+        row.getValue(DIMENSION_2);
+  }
+
+  /**
+   * Helper method to build schema for test segment, containing two dimension columns and one metric column.
+   *
+   * @return Schema for test segment.
+   */
+  private Schema buildSchema() {
+    Schema schema = new Schema();
+    schema.addField(new DimensionFieldSpec(DIMENSION_1, FieldSpec.DataType.LONG, true));
+    schema.addField(new DimensionFieldSpec(DIMENSION_2, FieldSpec.DataType.STRING, true));
+    schema.addField(new MetricFieldSpec(METRIC_COLUMN, FieldSpec.DataType.INT));
+    return schema;
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -34,6 +34,7 @@ public class RealtimeSegmentStatsHistoryTest {
     segmentStats.setMemUsedBytes(segmentId);
     segmentStats.setNumSeconds(segmentId);
     segmentStats.setNumRowsConsumed(segmentId);
+    segmentStats.setNumRowsIndexed(segmentId);
     for (int i = 0; i < 2; i++) {
       RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
       columnStats.setAvgColumnSize(segmentId*100 + i);
@@ -57,6 +58,7 @@ public class RealtimeSegmentStatsHistoryTest {
       segmentStats.setMemUsedBytes(100);
       segmentStats.setNumSeconds(101);
       segmentStats.setNumRowsConsumed(102);
+      segmentStats.setNumRowsIndexed(103);
 
       RealtimeSegmentStatsHistory.ColumnStats columnStats = new RealtimeSegmentStatsHistory.ColumnStats();
       columnStats.setAvgColumnSize(0);
@@ -71,6 +73,7 @@ public class RealtimeSegmentStatsHistoryTest {
       RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
       Assert.assertTrue(history.getEstimatedAvgColSize(columName) > 0);
       Assert.assertTrue(history.getEstimatedCardinality(columName) > 0);
+      Assert.assertEquals(history.getEstimatedRowsToIndex(), 103);
     }
   }
 
@@ -241,6 +244,7 @@ public class RealtimeSegmentStatsHistoryTest {
     Assert.assertEquals(columnStats.getAvgColumnSize(), 400);
 
     Assert.assertEquals(segmentStats.getNumRowsConsumed(), 500);
+    Assert.assertEquals(segmentStats.getNumRowsIndexed(), 0); // Input file does not have this field.
     Assert.assertEquals(segmentStats.getMemUsedBytes(), 600);
     Assert.assertEquals(segmentStats.getNumSeconds(), 700);
 


### PR DESCRIPTION
One of the reasons that serving latency of realtime nodes may be worse
than the offline counterparts is that data can (and almost always is)
aggregated in the offline pipeline, reducing the number of rows to be
processed.

For cases with high Kafka event rate and with duplicate dimension
values, this performance delta can be huge, impacting the overall
latency.

This PR addresses this problem by allowing for updating of metrics for
rows with same dimension values. The implementation is as follows:

1. We maintain an off-heap HashMap with FixedIntArray (containing
dictIds of dimension columns) as key, and docId as the value.

2. When a new row comes in, we check if the dimension values are present
in the map:
   If yes, then we fetch the docId from the map, and update the metric
columns.
   - If not, then we index the new row.
   This features requires metric columns to use no-dictionary indexing.
The reason being updating of metrics may leave unsused values in
dictionary that need to be cleaned up before segment flush. Using
no-dictionary indexing eliminates the problem completely.
   Also, this feature is only supported for LLC consumer.

3. The feature is off-by-default and can be enabled with a config
   - TableConfig.IndexingConfg.updateMetrics

4. Added unit tests for the new feature.

5. Performance gains measured by this feature using real production
data:
   - An average of 4x reduction in numRows. Although, more common
     dimension combinations (that are also frequently queried) see upto
1000x reduction in number of rows.
   - Realtime nodes now perform almost at par with offline nodes for
     query serving.