### PR TITLE
[TE] dashboard - anomalies summary endpoint

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -40,6 +40,7 @@ import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseMetricResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.RootCauseSessionResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.TimeSeriesResource;
+import com.linkedin.thirdeye.dashboard.resources.v2.UserDashboardResource;
 import com.linkedin.thirdeye.dashboard.resources.v2.aggregation.AggregationLoader;
 import com.linkedin.thirdeye.dashboard.resources.v2.aggregation.DefaultAggregationLoader;
 import com.linkedin.thirdeye.dashboard.resources.v2.rootcause.DefaultEntityFormatter;
@@ -149,6 +150,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new FunctionOnboardingResource());
     env.jersey().register(new CustomizedEventResource(DAO_REGISTRY.getEventDAO()));
     env.jersey().register(new TimeSeriesResource());
+    env.jersey().register(new UserDashboardResource(DAO_REGISTRY.getMergedAnomalyResultDAO(), DAO_REGISTRY.getAnomalyFunctionDAO(), DAO_REGISTRY.getAlertConfigDAO()));
 
     TimeSeriesLoader timeSeriesLoader = new DefaultTimeSeriesLoader(DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(), ThirdEyeCacheRegistry.getInstance().getQueryCache());
     AggregationLoader aggregationLoader = new DefaultAggregationLoader(DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(), ThirdEyeCacheRegistry.getInstance().getQueryCache(), ThirdEyeCacheRegistry.getInstance().getDatasetMaxDataTimeCache());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/ThirdEyeDashboardApplication.java
@@ -150,7 +150,7 @@ public class ThirdEyeDashboardApplication
     env.jersey().register(new FunctionOnboardingResource());
     env.jersey().register(new CustomizedEventResource(DAO_REGISTRY.getEventDAO()));
     env.jersey().register(new TimeSeriesResource());
-    env.jersey().register(new UserDashboardResource(DAO_REGISTRY.getMergedAnomalyResultDAO(), DAO_REGISTRY.getAnomalyFunctionDAO(), DAO_REGISTRY.getAlertConfigDAO()));
+    env.jersey().register(new UserDashboardResource(DAO_REGISTRY.getMergedAnomalyResultDAO(), DAO_REGISTRY.getAnomalyFunctionDAO()));
 
     TimeSeriesLoader timeSeriesLoader = new DefaultTimeSeriesLoader(DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(), ThirdEyeCacheRegistry.getInstance().getQueryCache());
     AggregationLoader aggregationLoader = new DefaultAggregationLoader(DAO_REGISTRY.getMetricConfigDAO(), DAO_REGISTRY.getDatasetConfigDAO(), ThirdEyeCacheRegistry.getInstance().getQueryCache(), ThirdEyeCacheRegistry.getInstance().getDatasetMaxDataTimeCache());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/UserDashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/UserDashboardResource.java
@@ -3,7 +3,7 @@ package com.linkedin.thirdeye.dashboard.resources.v2;
 import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
 import com.linkedin.thirdeye.constant.AnomalyResultSource;
-import com.linkedin.thirdeye.dashboard.resources.v2.userdashboard.AnomalySummary;
+import com.linkedin.thirdeye.dashboard.resources.v2.pojo.AnomalySummary;
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
@@ -60,7 +60,9 @@ public class UserDashboardResource {
    *     "current" : 1213.0,
    *     "baseline" : 550.0,
    *     "feedback" : "NO_FEEDBACK",
+   *     "metricId" : 12346
    *     "metric" : "page_views",
+   *     "functionId" : 12347
    *     "functionName" : "page_views_monitoring"
    *     },
    *     ...
@@ -194,12 +196,14 @@ public class UserDashboardResource {
       summary.setEnd(anomaly.getEndTime());
       summary.setCurrent(anomaly.getAvgCurrentVal());
       summary.setBaseline(anomaly.getAvgBaselineVal());
+      summary.setMetricId(anomaly.getFunction().getMetricId());
       summary.setMetric(anomaly.getMetric());
       summary.setDimensions(anomaly.getDimensions());
 
       // TODO use alert filter if necessary
       summary.setSeverity(Math.abs(anomaly.getWeight()));
 
+      summary.setFunctionId(anomaly.getFunctionId());
       if (id2function.get(anomaly.getFunctionId()) != null) {
         summary.setFunctionName(id2function.get(anomaly.getFunctionId()).getFunctionName());
       }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/UserDashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/UserDashboardResource.java
@@ -7,7 +7,6 @@ import com.linkedin.thirdeye.dashboard.resources.v2.pojo.AnomalySummary;
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
 import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
 import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
-import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
 import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
 import com.linkedin.thirdeye.datalayer.util.Predicate;
@@ -36,13 +35,10 @@ import javax.ws.rs.core.MediaType;
 public class UserDashboardResource {
   private final MergedAnomalyResultManager anomalyDAO;
   private final AnomalyFunctionManager functionDAO;
-  private final AlertConfigManager alertDAO;
 
-  public UserDashboardResource(MergedAnomalyResultManager anomalyDAO, AnomalyFunctionManager functionDAO,
-      AlertConfigManager alertDAO) {
+  public UserDashboardResource(MergedAnomalyResultManager anomalyDAO, AnomalyFunctionManager functionDAO) {
     this.anomalyDAO = anomalyDAO;
     this.functionDAO = functionDAO;
-    this.alertDAO = alertDAO;
   }
 
   /**
@@ -105,9 +101,9 @@ public class UserDashboardResource {
     // application (indirect)
     Set<Long> applicationFunctionIds = new HashSet<>();
     if (application != null) {
-      List<AlertConfigDTO> alerts = this.alertDAO.findByPredicate(Predicate.EQ("application", application));
-      for (AlertConfigDTO alert : alerts) {
-        applicationFunctionIds.addAll(alert.getEmailConfig().getFunctionIds());
+      List<AnomalyFunctionDTO> functions = this.functionDAO.findAllByApplication(application);
+      for (AnomalyFunctionDTO function : functions) {
+        applicationFunctionIds.add(function.getId());
       }
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/UserDashboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/UserDashboardResource.java
@@ -1,0 +1,217 @@
+package com.linkedin.thirdeye.dashboard.resources.v2;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
+import com.linkedin.thirdeye.constant.AnomalyResultSource;
+import com.linkedin.thirdeye.dashboard.resources.v2.userdashboard.AnomalySummary;
+import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
+import com.linkedin.thirdeye.datalayer.bao.AnomalyFunctionManager;
+import com.linkedin.thirdeye.datalayer.bao.MergedAnomalyResultManager;
+import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
+import com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO;
+import com.linkedin.thirdeye.datalayer.dto.MergedAnomalyResultDTO;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+
+/**
+ * Endpoints for user-customized dashboards (currently alerts only)
+ */
+@Path(value = "/userdashboard")
+@Produces(MediaType.APPLICATION_JSON)
+public class UserDashboardResource {
+  private final MergedAnomalyResultManager anomalyDAO;
+  private final AnomalyFunctionManager functionDAO;
+  private final AlertConfigManager alertDAO;
+
+  public UserDashboardResource(MergedAnomalyResultManager anomalyDAO, AnomalyFunctionManager functionDAO,
+      AlertConfigManager alertDAO) {
+    this.anomalyDAO = anomalyDAO;
+    this.functionDAO = functionDAO;
+    this.alertDAO = alertDAO;
+  }
+
+  /**
+   * Returns a list of AnomalySummary for a set of query parameters. Anomalies are
+   * sorted by start time (descending).
+   *
+   * <br/><b>Example:</b>
+   * <pre>
+   *   [ {
+   *     "id" : 12345,
+   *     "start" : 1517000000000,
+   *     "end" : 1517100000000,
+   *     "dimensions" : { "country": "us" },
+   *     "severity" : 0.517,
+   *     "current" : 1213.0,
+   *     "baseline" : 550.0,
+   *     "feedback" : "NO_FEEDBACK",
+   *     "metric" : "page_views",
+   *     "functionName" : "page_views_monitoring"
+   *     },
+   *     ...
+   *   ]
+   * </pre>
+   *
+   * @see AnomalySummary
+   *
+   * @param start window start time
+   * @param end window end time (optional)
+   * @param owner anomaly function owner only (optional)
+   * @param application anomaly function for application alert groups only (optional)
+   *
+   * @return List of AnomalySummary
+   */
+  @GET
+  @Path("/anomalies")
+  public List<AnomalySummary> queryAnomalies(
+      @QueryParam("start") Long start,
+      @QueryParam("end") Long end,
+      @QueryParam("owner") String owner,
+      @QueryParam("application") String application,
+      @QueryParam("limit") Integer limit) {
+
+    //
+    // query params
+    //
+
+    // safety condition
+    Preconditions.checkNotNull(start);
+
+    List<Predicate> predicates = new ArrayList<>();
+
+    // TODO support index select on user-reported anomalies
+//    predicates.add(Predicate.OR(
+//        Predicate.EQ("notified", true),
+//        Predicate.EQ("anomalyResultSource", AnomalyResultSource.USER_LABELED_ANOMALY)));
+
+
+    // application (indirect)
+    Set<Long> applicationFunctionIds = new HashSet<>();
+    if (application != null) {
+      List<AlertConfigDTO> alerts = this.alertDAO.findByPredicate(Predicate.EQ("application", application));
+      for (AlertConfigDTO alert : alerts) {
+        applicationFunctionIds.addAll(alert.getEmailConfig().getFunctionIds());
+      }
+    }
+
+    // owner (indirect)
+    Set<Long> ownerFunctionIds = new HashSet<>();
+    if (owner != null) {
+      // TODO: replace database scan with targeted select
+      List<AnomalyFunctionDTO> functions = this.functionDAO.findAll();
+      for (AnomalyFunctionDTO function : functions) {
+        if (Objects.equals(function.getCreatedBy(), owner)) {
+          ownerFunctionIds.add(function.getId());
+        }
+      }
+    }
+
+    // anomaly function ids
+    if (application != null || owner != null) {
+      Set<Long> functionIds = new HashSet<>();
+      functionIds.addAll(applicationFunctionIds);
+      functionIds.addAll(ownerFunctionIds);
+
+      predicates.add(Predicate.IN("functionId", functionIds.toArray()));
+    }
+
+    // anomaly window start
+    if (start != null) {
+      predicates.add(Predicate.GT("endTime", start));
+    }
+
+    // anomaly window end
+    if (end != null) {
+      predicates.add(Predicate.LT("startTime", end));
+    }
+
+    //
+    // fetch anomalies
+    //
+    List<MergedAnomalyResultDTO> anomalies = this.anomalyDAO.findByPredicate(Predicate.AND(predicates.toArray(new Predicate[predicates.size()])));
+
+    // filter (un-notified && non-user-reported) anomalies
+    // TODO remove once index select on user-reported anomalies available
+    Iterator<MergedAnomalyResultDTO> itAnomaly = anomalies.iterator();
+    while (itAnomaly.hasNext()) {
+      MergedAnomalyResultDTO anomaly = itAnomaly.next();
+      if (!anomaly.isNotified() &&
+          !AnomalyResultSource.USER_LABELED_ANOMALY.equals(anomaly.getAnomalyResultSource())) {
+        itAnomaly.remove();
+      }
+    }
+
+    // sort descending by start time
+    Collections.sort(anomalies, new Comparator<MergedAnomalyResultDTO>() {
+      @Override
+      public int compare(MergedAnomalyResultDTO o1, MergedAnomalyResultDTO o2) {
+        return -1 * Long.compare(o1.getStartTime(), o2.getStartTime());
+      }
+    });
+
+    // limit result size
+    if (limit != null) {
+      anomalies = anomalies.subList(0, limit);
+    }
+
+    //
+    // fetch functions
+    //
+    Set<Long> anomalyFunctionIds = new HashSet<>();
+    for (MergedAnomalyResultDTO anomaly : anomalies) {
+      anomalyFunctionIds.add(anomaly.getFunctionId());
+    }
+
+    List<AnomalyFunctionDTO> functions = this.functionDAO.findByPredicate(Predicate.IN("baseId", anomalyFunctionIds.toArray()));
+    Map<Long, AnomalyFunctionDTO> id2function = new HashMap<>();
+    for (AnomalyFunctionDTO function : functions) {
+      id2function.put(function.getId(), function);
+    }
+
+    //
+    // format output
+    //
+    List<AnomalySummary> output = new ArrayList<>();
+    for (MergedAnomalyResultDTO anomaly : anomalies) {
+      AnomalySummary summary = new AnomalySummary();
+      summary.setId(anomaly.getId());
+      summary.setStart(anomaly.getEndTime());
+      summary.setEnd(anomaly.getEndTime());
+      summary.setCurrent(anomaly.getAvgCurrentVal());
+      summary.setBaseline(anomaly.getAvgBaselineVal());
+      summary.setMetric(anomaly.getMetric());
+      summary.setDimensions(anomaly.getDimensions());
+
+      // TODO use alert filter if necessary
+      summary.setSeverity(Math.abs(anomaly.getWeight()));
+
+      if (id2function.get(anomaly.getFunctionId()) != null) {
+        summary.setFunctionName(id2function.get(anomaly.getFunctionId()).getFunctionName());
+      }
+
+      summary.setFeedback(AnomalyFeedbackType.NO_FEEDBACK);
+      if (anomaly.getFeedback() != null) {
+        summary.setFeedback(anomaly.getFeedback().getFeedbackType());
+      }
+
+      output.add(summary);
+    }
+
+    return output;
+  }
+}

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/AnomalySummary.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/pojo/AnomalySummary.java
@@ -1,4 +1,4 @@
-package com.linkedin.thirdeye.dashboard.resources.v2.userdashboard;
+package com.linkedin.thirdeye.dashboard.resources.v2.pojo;
 
 import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
 import java.util.Map;
@@ -17,7 +17,9 @@ public class AnomalySummary {
   private double baseline;
   private AnomalyFeedbackType feedback;
   private String metric;
+  private long metricId;
   private String functionName;
+  private long functionId;
 
   public AnomalySummary() {
     // left blank
@@ -101,5 +103,21 @@ public class AnomalySummary {
 
   public void setFunctionName(String functionName) {
     this.functionName = functionName;
+  }
+
+  public long getMetricId() {
+    return metricId;
+  }
+
+  public void setMetricId(long metricId) {
+    this.metricId = metricId;
+  }
+
+  public long getFunctionId() {
+    return functionId;
+  }
+
+  public void setFunctionId(long functionId) {
+    this.functionId = functionId;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/userdashboard/AnomalySummary.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/userdashboard/AnomalySummary.java
@@ -1,0 +1,105 @@
+package com.linkedin.thirdeye.dashboard.resources.v2.userdashboard;
+
+import com.linkedin.thirdeye.constant.AnomalyFeedbackType;
+import java.util.Map;
+
+
+/**
+ * Container object for user dashboard summarized anomaly view
+ */
+public class AnomalySummary {
+  private long id;
+  private long start;
+  private long end;
+  private Map<String, String> dimensions;
+  private double severity;
+  private double current;
+  private double baseline;
+  private AnomalyFeedbackType feedback;
+  private String metric;
+  private String functionName;
+
+  public AnomalySummary() {
+    // left blank
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getStart() {
+    return start;
+  }
+
+  public void setStart(long start) {
+    this.start = start;
+  }
+
+  public long getEnd() {
+    return end;
+  }
+
+  public void setEnd(long end) {
+    this.end = end;
+  }
+
+  public Map<String, String> getDimensions() {
+    return dimensions;
+  }
+
+  public void setDimensions(Map<String, String> dimensions) {
+    this.dimensions = dimensions;
+  }
+
+  public double getSeverity() {
+    return severity;
+  }
+
+  public void setSeverity(double severity) {
+    this.severity = severity;
+  }
+
+  public double getCurrent() {
+    return current;
+  }
+
+  public void setCurrent(double current) {
+    this.current = current;
+  }
+
+  public double getBaseline() {
+    return baseline;
+  }
+
+  public void setBaseline(double baseline) {
+    this.baseline = baseline;
+  }
+
+  public AnomalyFeedbackType getFeedback() {
+    return feedback;
+  }
+
+  public void setFeedback(AnomalyFeedbackType feedback) {
+    this.feedback = feedback;
+  }
+
+  public String getMetric() {
+    return metric;
+  }
+
+  public void setMetric(String metric) {
+    this.metric = metric;
+  }
+
+  public String getFunctionName() {
+    return functionName;
+  }
+
+  public void setFunctionName(String functionName) {
+    this.functionName = functionName;
+  }
+}


### PR DESCRIPTION
Clean endpoint for retrieval of anomaly summaries for display in a user dashboard. Supports time range, owner, and application predicates. Several potential performance bottlenecks remain for future work.

* anomaly summary query endpoint (start, end, application, owner, limit)

* anomaly summary container