### PR TITLE
[TE] Allow custom domain name in authentication

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorLdap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorLdap.java
@@ -70,7 +70,7 @@ public class ThirdEyeAuthenticatorLdap implements Authenticator<Credentials, Thi
       throw new AuthenticationException(e);
     }
 
-    LOG.info("Could not authenticate {}", principalName);
+    LOG.info("Unable to authenticate empty user name.");
     return Optional.absent();
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorLdap.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyeAuthenticatorLdap.java
@@ -41,7 +41,11 @@ public class ThirdEyeAuthenticatorLdap implements Authenticator<Credentials, Thi
           env.put(Context.SECURITY_PROTOCOL, "ssl");
         }
         env.put(Context.SECURITY_AUTHENTICATION, "simple");
-        env.put(Context.SECURITY_PRINCIPAL, credentials.getPrincipal() + '@' + this.domainSuffix);
+        if (credentials.getPrincipal().contains("@")) {
+          env.put(Context.SECURITY_PRINCIPAL, credentials.getPrincipal());
+        } else {
+          env.put(Context.SECURITY_PRINCIPAL, credentials.getPrincipal() + '@' + this.domainSuffix);
+        }
         env.put(Context.SECURITY_CREDENTIALS, credentials.getPassword());
 
         // Attempt ldap authentication

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyePrincipal.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/auth/ThirdEyePrincipal.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 
 public class ThirdEyePrincipal implements Principal {
-  String name;
+  String name; // 'username@domainName'
   Set<String> groups = new HashSet<>();
 
   @Override


### PR DESCRIPTION
Allows users to enter custom domain to support LDAP with multiple domain names.

Tested on local dashboard.