### PR TITLE
[TE] Fix the exception when getting baseline for empty dimension maps

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -748,13 +748,16 @@ public class AnomalyResource {
     String[] exploreDimensions = anomalyFunctionSpec.getExploreDimensions().split(",");
     Map<String, String> inputDimension = OBJECT_MAPPER.readValue(dimension, Map.class);
     DimensionMap dimensionsToBeEvaluated = new DimensionMap();
-    for (String exploreDimension : exploreDimensions) {
-      if (!inputDimension.containsKey(exploreDimension)) {
-        String msg = String.format("Query %s doesn't specify the value of explore dimension %s", dimension, exploreDimension);
-        LOG.error(msg);
-        throw new WebApplicationException(msg);
-      } else {
-        dimensionsToBeEvaluated.put(exploreDimension, inputDimension.get(exploreDimension));
+    if (exploreDimensions != null && StringUtils.isNotBlank(anomalyFunctionSpec.getExploreDimensions())) {
+      for (String exploreDimension : exploreDimensions) {
+        if (!inputDimension.containsKey(exploreDimension)) {
+          String msg =
+              String.format("Query %s doesn't specify the value of explore dimension %s", dimension, exploreDimension);
+          LOG.error(msg);
+          throw new WebApplicationException(msg);
+        } else {
+          dimensionsToBeEvaluated.put(exploreDimension, inputDimension.get(exploreDimension));
+        }
       }
     }
 


### PR DESCRIPTION
We saw exceptions when retrieving baseline for functions with no dimension drill down. This pr is for fixing this issue.