### PR TITLE
[TE] implemented toggle between legacy and new rootcause

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/application/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/application/controller.js
@@ -24,15 +24,9 @@ export default Controller.extend({
       title: 'Anomalies'
     },
     {
-      className: 'rca',
-      link: 'rca',
-      title: 'Root Cause Analysis',
-      isCustomLink: false
-    },
-    {
       className: 'rootcause',
       link: 'rootcause',
-      title: 'Root Cause Analysis (beta)',
+      title: 'Root Cause Analysis',
       isCustomLink: false
     },
     {

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/controller.js
@@ -316,7 +316,7 @@ export default Controller.extend({
     },
 
     /**
-     * Resets anoamly and investigations regions
+     * Resets anomaly and investigations regions
      */
     resetAnalysisDates() {
       let offset = 1;
@@ -341,7 +341,14 @@ export default Controller.extend({
           shouldReset: false
         });
       }
-    }
+    },
 
+    /**
+     * Redirects the user to the new rootcause
+     * @param {Number} metricId
+     */
+    onLegacyToggle(metricId) {
+      this.send('transitionToNewRca', metricId);
+    }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/metrics/template.hbs
@@ -18,8 +18,8 @@
                 name="splitViewToggle"
                 onToggle=(action (mut splitView))
                 as |toggle|}}
-                  {{#toggle.label splitView=(not splitView)}}
-                    <span class="te-label">{{if splitView 'Combine View' 'Split View'}}</span>
+                  {{#toggle.label class="te-toggle__label"splitView=(not splitView)}}
+                    <span class="te-label te-label--flush">{{if splitView 'Combine View' 'Split View'}}</span>
                   {{/toggle.label}}
                   {{toggle.switch theme='ios' onLabel='diff on' offLabel='diff off'}}
               {{/x-toggle}}

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/route.js
@@ -192,6 +192,14 @@ export default Route.extend({
       if (transition.targetName === 'rca.index') {
         this.refresh();
       }
+    },
+
+    /**
+     * Redirects the user from legacy to new rootcause
+     * @param {Number} metricId the metric id to redirect to
+     */
+    transitionToNewRca(metricId) {
+      this.transitionTo('rootcause', { queryParams: { metricId } });
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/details/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/details/template.hbs
@@ -2,6 +2,18 @@
   <div class="row">
     <h2 class="te-title">Summary</h2>
     <div class="card-container">
+      <div class="card-container__header card-container__header--no-border card-container__header--right">
+        {{#containers/primary-metric-container as |summary actions|}}
+          <label class="te-label">
+            {{x-toggle
+              classNames="te-toggle pull-right"
+              theme='ios'
+              onToggle=(action "onLegacyToggle" summary.primaryMetric.metricId)
+              value=true}}
+            Use Legacy RCA
+          </label>
+        {{/containers/primary-metric-container}}
+      </div>
       <div class="card-container__body">
         <section class="rca-summary">
           <div class="row">

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -966,6 +966,23 @@ export default Controller.extend({
           break;
 
       }
+    },
+
+    /**
+     * Toggle that links to the legacy rca
+     * @param {String} urn current metricUrn
+    */
+    onLegacyToggle(urn = '') {
+      // later is used here so that the transition occurs after
+      // the component's toggle animation
+      later(() => {
+        if (urn.startsWith('thirdeye:metric')) {
+          const id = urn.split(':')[2];
+          this.send('transitionToRcaDetails', id);
+        } else {
+          this.send('transitionToRca');
+        }
+      }, 1000);
     }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -296,5 +296,32 @@ export default Route.extend(AuthenticatedRouteMixin, {
       setupMode,
       context
     });
+  },
+
+  actions: {
+    /**
+     * transition from the new rootcause to legacy rca details
+     * @param {Number} id metric Id
+     */
+    transitionToRcaDetails(id) {
+      this.transitionTo('rca.details', id, {
+        queryParams: {
+          startDate: undefined,
+          endDate: undefined,
+          analysisStart: undefined,
+          analysisEnd: undefined,
+          granularity: undefined,
+          filters: JSON.stringify({}),
+          compareMode: 'WoW'
+        }
+      });
+    },
+
+    /**
+     * transition from the new rootcause to legacy rca
+     */
+    transitionToRca() {
+      this.transitionTo('rca');
+    }
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -37,7 +37,15 @@
 
   <div class="row card-container card-container--md card-container--box-shadow">
     <div class="card-container__header card-container__header--no-border card-container__header--flush-bottom">
-      <span class="card-container__title">Root cause Analysis</span>
+      <span class="card-container__title card-container__title--grow">Root cause Analysis</span>
+      <label class="te-label">
+        {{x-toggle
+          classNames="te-toggle pull-right"
+          theme='ios'
+          onToggle=(action "onLegacyToggle" metricUrn)
+          value=false}}
+        Use Legacy RCA
+      </label>
     </div>
     <div class="card-container__body--padding-md card-container__body--flush-bottom">
       {{#if selectedUrns.size}}

--- a/thirdeye/thirdeye-frontend/app/styles/app.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/app.scss
@@ -56,6 +56,7 @@ body {
 @import 'components/metrics-table';
 @import 'components/card-container';
 @import 'components/te-anomaly-table';
+@import 'components/te-toggle';
 
 // Pod Pages
 @import 'ember-power-select/themes/bootstrap';

--- a/thirdeye/thirdeye-frontend/app/styles/components/card-container.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/card-container.scss
@@ -54,6 +54,10 @@
     &--flush-bottom {
       padding-bottom: 0;
     }
+
+    &--right {
+      justify-content: flex-end;
+    }
   }
 
   &__title {
@@ -62,6 +66,11 @@
     font-weight: 600;
     color: app-shade(black, 9);
     margin-bottom: 0;
+
+    &--grow {
+      flex: 1;
+      align-self: flex-end;
+    }
   }
 
   &__subnav {

--- a/thirdeye/thirdeye-frontend/app/styles/components/te-toggle.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/te-toggle.scss
@@ -1,0 +1,21 @@
+// overriding x-toggle default styling
+.te-toggle {
+  margin-right: 14px;
+  // necessary to override the ember-toggle component
+  .x-toggle:checked + label > .x-toggle-ios.x-toggle-btn {
+    background-color: $te-blue-6;
+  }
+
+  &--left {
+    justify-content: flex-start;
+  }
+
+  &--form {
+    margin-top: 6px;
+  }
+
+  &__label {
+    display: flex;
+    align-items: center;
+  }
+}

--- a/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/wrapper/styles.scss
@@ -209,20 +209,3 @@ body {
    }
   }
 }
-
-// overriding x-toggle default styling
-.te-toggle {
-  margin-right: 14px;
-  // necessary to override the ember-toggle component
-  .x-toggle:checked + label > .x-toggle-ios.x-toggle-btn {
-    background-color: $te-blue-6;
-  }
-
-  &--left {
-    justify-content: flex-start;
-  }
-
-  &--form {
-    margin-top: 6px;
-  }
-}

--- a/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
@@ -20,6 +20,7 @@ const HEATMAP_DROPDOWN = '#select-heatmap-mode';
 const SELECTED_HEATMAP_MODE = '.ember-power-select-selected-item';
 const EVENTS_FILTER_BAR = '.filter-bar';
 const EVENTS_TABLE = '.events-table';
+const RCA_TOGGLE = '#rootcause-to-legacy';
 
 moduleForAcceptance('Acceptance | rootcause');
 
@@ -145,4 +146,11 @@ test('Metrics, Dimensions, and Events tabs exist and should have correct informa
   assert.ok(
     find(EVENTS_TABLE).get(0),
     'events table exists in events tab');
+});
+
+test('links to legacy rca should work', async (assert) => {
+  await visit('/rootcause');
+  await click(RCA_TOGGLE);
+
+  assert.ok(currentURL().includes('rca'), currentURL());
 });

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/thirdeye.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/thirdeye.ftl
@@ -186,9 +186,8 @@
               </ul>
 
               <ul class="nav navbar-nav thirdeye-nav__tabs">
-                <li class="te-nav__link"><a href="app/#/rca">Root Cause Analysis</a></li>
                 <li class="te-nav__link">
-                  <a href="app/#/rootcause">Root Cause Analysis (beta)</a>
+                  <a href="app/#/rootcause">Root Cause Analysis</a>
                 </li>
                 <li class="te-nav__link"><a href="app/#/manage/alerts">Manage Alerts</a></li>
               </ul>


### PR DESCRIPTION
### What's new: 
- moved `te-toggle`'s css into its own file
- removed the `Root cause Analysis (beta)` link in favor of the current one
- added toggle between legacy / new rootcause 

### Screenshot: 
<img width="1138" alt="screen shot 2018-02-28 at 3 29 52 pm" src="https://user-images.githubusercontent.com/8664954/36818977-485e7db6-1c9c-11e8-9639-d40ac5af334a.png">
<img width="914" alt="screen shot 2018-02-28 at 3 21 18 pm" src="https://user-images.githubusercontent.com/8664954/36818725-2ad25a70-1c9b-11e8-9d2a-7d903a062df1.png">
<img width="929" alt="screen shot 2018-02-28 at 3 20 02 pm" src="https://user-images.githubusercontent.com/8664954/36818726-2ae7007e-1c9b-11e8-854a-1b5928474a73.png">

### Tests: 
- basic unit test from rootcause -> rca (no tests for rca.details as the page will be deprecated and mocking all the endpoints will be too time consuming)
- Visual Sanity check locally