### PR TITLE
Fix the bug of data table deserialization failure for empty string

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 
 
 public class DataTableImplV2 implements DataTable {
@@ -97,8 +98,7 @@ public class DataTableImplV2 implements DataTable {
   /**
    * Construct data table from byte array. (broker side)
    */
-  public DataTableImplV2(@Nonnull ByteBuffer byteBuffer)
-      throws IOException {
+  public DataTableImplV2(@Nonnull ByteBuffer byteBuffer) throws IOException {
     // Read header.
     _numRows = byteBuffer.getInt();
     _numColumns = byteBuffer.getInt();
@@ -166,61 +166,54 @@ public class DataTableImplV2 implements DataTable {
     }
   }
 
-  private Map<String, Map<Integer, String>> deserializeDictionaryMap(byte[] bytes)
-      throws IOException {
-    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-    DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+  private Map<String, Map<Integer, String>> deserializeDictionaryMap(byte[] bytes) throws IOException {
+    try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+        DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream)) {
+      int numDictionaries = dataInputStream.readInt();
+      Map<String, Map<Integer, String>> dictionaryMap = new HashMap<>(numDictionaries);
 
-    int numDictionaries = dataInputStream.readInt();
-    Map<String, Map<Integer, String>> dictionaryMap = new HashMap<>(numDictionaries);
-
-    int readLength;
-    for (int i = 0; i < numDictionaries; i++) {
-      int columnNameLength = dataInputStream.readInt();
-      byte[] columnNameBytes = new byte[columnNameLength];
-      readLength = dataInputStream.read(columnNameBytes);
-      assert readLength == columnNameLength;
-      Map<Integer, String> dictionary = new HashMap<>();
-      dictionaryMap.put(new String(columnNameBytes, UTF_8), dictionary);
-
-      int dictionarySize = dataInputStream.readInt();
-      for (int j = 0; j < dictionarySize; j++) {
-        int key = dataInputStream.readInt();
-        int valueLength = dataInputStream.readInt();
-        byte[] valueBytes = new byte[valueLength];
-        readLength = dataInputStream.read(valueBytes);
-        assert readLength == valueLength;
-        dictionary.put(key, new String(valueBytes, UTF_8));
+      for (int i = 0; i < numDictionaries; i++) {
+        String column = decodeString(dataInputStream);
+        int dictionarySize = dataInputStream.readInt();
+        Map<Integer, String> dictionary = new HashMap<>(dictionarySize);
+        for (int j = 0; j < dictionarySize; j++) {
+          int key = dataInputStream.readInt();
+          String value = decodeString(dataInputStream);
+          dictionary.put(key, value);
+        }
+        dictionaryMap.put(column, dictionary);
       }
-    }
 
-    return dictionaryMap;
+      return dictionaryMap;
+    }
   }
 
-  private Map<String, String> deserializeMetadata(byte[] bytes)
-      throws IOException {
-    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-    DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+  private Map<String, String> deserializeMetadata(byte[] bytes) throws IOException {
+    try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+        DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream)) {
+      int numEntries = dataInputStream.readInt();
+      Map<String, String> metadata = new HashMap<>(numEntries);
 
-    int numEntries = dataInputStream.readInt();
-    Map<String, String> metadata = new HashMap<>(numEntries);
+      for (int i = 0; i < numEntries; i++) {
+        String key = decodeString(dataInputStream);
+        String value = decodeString(dataInputStream);
+        metadata.put(key, value);
+      }
 
-    int readLength;
-    for (int i = 0; i < numEntries; i++) {
-      int keyLength = dataInputStream.readInt();
-      byte[] keyBytes = new byte[keyLength];
-      readLength = dataInputStream.read(keyBytes);
-      assert readLength == keyLength;
-
-      int valueLength = dataInputStream.readInt();
-      byte[] valueBytes = new byte[valueLength];
-      readLength = dataInputStream.read(valueBytes);
-      assert readLength == valueLength;
-
-      metadata.put(new String(keyBytes, UTF_8), new String(valueBytes, UTF_8));
+      return metadata;
     }
+  }
 
-    return metadata;
+  private static String decodeString(DataInputStream dataInputStream) throws IOException {
+    int length = dataInputStream.readInt();
+    if (length == 0) {
+      return StringUtils.EMPTY;
+    } else {
+      byte[] buffer = new byte[length];
+      int numBytesRead = dataInputStream.read(buffer);
+      assert numBytesRead == length;
+      return new String(buffer, UTF_8);
+    }
   }
 
   @Override
@@ -230,8 +223,7 @@ public class DataTableImplV2 implements DataTable {
 
   @Nonnull
   @Override
-  public byte[] toBytes()
-      throws IOException {
+  public byte[] toBytes() throws IOException {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
     dataOutputStream.writeInt(VERSION);
@@ -302,8 +294,7 @@ public class DataTableImplV2 implements DataTable {
     return byteArrayOutputStream.toByteArray();
   }
 
-  private byte[] serializeDictionaryMap()
-      throws IOException {
+  private byte[] serializeDictionaryMap() throws IOException {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
 
@@ -327,8 +318,7 @@ public class DataTableImplV2 implements DataTable {
     return byteArrayOutputStream.toByteArray();
   }
 
-  private byte[] serializeMetadata()
-      throws IOException {
+  private byte[] serializeMetadata() throws IOException {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -39,8 +40,7 @@ public class DataTableSerDeTest {
   private static final int NUM_ROWS = 100;
 
   @Test
-  public void testException()
-      throws IOException {
+  public void testException() throws IOException {
     Exception exception = new UnsupportedOperationException("Caught exception.");
     ProcessingException processingException =
         QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, exception);
@@ -58,8 +58,33 @@ public class DataTableSerDeTest {
   }
 
   @Test
-  public void testAllDataTypes()
-      throws IOException {
+  public void testEmptyStrings() throws IOException {
+    String emptyString = StringUtils.EMPTY;
+    String[] emptyStringArray = {StringUtils.EMPTY};
+
+    DataSchema dataSchema =
+        new DataSchema(new String[]{"SV", "MV"}, new DataType[]{DataType.STRING, DataType.STRING_ARRAY});
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
+    for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
+      dataTableBuilder.startRow();
+      dataTableBuilder.setColumn(0, emptyString);
+      dataTableBuilder.setColumn(1, emptyStringArray);
+      dataTableBuilder.finishRow();
+    }
+
+    DataTable dataTable = dataTableBuilder.build();
+    DataTable newDataTable = DataTableFactory.getDataTable(dataTable.toBytes());
+    Assert.assertEquals(newDataTable.getDataSchema(), dataSchema);
+    Assert.assertEquals(newDataTable.getNumberOfRows(), NUM_ROWS);
+
+    for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
+      Assert.assertEquals(newDataTable.getString(rowId, 0), emptyString);
+      Assert.assertEquals(newDataTable.getStringArray(rowId, 1), emptyStringArray);
+    }
+  }
+
+  @Test
+  public void testAllDataTypes() throws IOException {
     DataType[] columnTypes = DataType.values();
     int numColumns = columnTypes.length;
     String[] columnNames = new String[numColumns];

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -177,7 +177,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
    *   <li>"newAddedLongDimension", DIMENSION, LONG, single-value, default (Long.MIN_VALUE)</li>
    *   <li>"newAddedFloatDimension", DIMENSION, FLOAT, single-value, default (Float.NEGATIVE_INFINITY)</li>
    *   <li>"newAddedDoubleDimension", DIMENSION, DOUBLE, single-value, default (Double.NEGATIVE_INFINITY)</li>
-   *   <li>"newAddedStringDimension", DIMENSION, STRING, multi-value, "newAdded"</li>
+   *   <li>"newAddedSVStringDimension", DIMENSION, STRING, single-value, default ("null")</li>
+   *   <li>"newAddedMVStringDimension", DIMENSION, STRING, multi-value, ""</li>
    * </ul>
    */
   @Test
@@ -187,7 +188,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     reloadDefaultColumns(true);
     JSONObject queryResponse = postQuery(SELECT_STAR_QUERY);
     Assert.assertEquals(queryResponse.getLong("totalDocs"), numTotalDocs);
-    Assert.assertEquals(queryResponse.getJSONObject("selectionResults").getJSONArray("columns").length(), 88);
+    Assert.assertEquals(queryResponse.getJSONObject("selectionResults").getJSONArray("columns").length(), 89);
 
     testNewAddedColumns();
 
@@ -274,7 +275,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     pqlQuery = "SELECT COUNT(*) FROM mytable WHERE NewAddedDoubleDimension < 0.0";
     sqlQuery = "SELECT COUNT(*) FROM mytable";
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
-    pqlQuery = "SELECT COUNT(*) FROM mytable WHERE NewAddedStringDimension = 'newAdded'";
+    pqlQuery = "SELECT COUNT(*) FROM mytable WHERE NewAddedSVStringDimension = 'null'";
+    sqlQuery = "SELECT COUNT(*) FROM mytable";
+    testQuery(pqlQuery, Collections.singletonList(sqlQuery));
+    pqlQuery = "SELECT COUNT(*) FROM mytable WHERE NewAddedMVStringDimension = ''";
     sqlQuery = "SELECT COUNT(*) FROM mytable";
     testQuery(pqlQuery, Collections.singletonList(sqlQuery));
 
@@ -295,12 +299,12 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // Test other query forms with new added columns
     JSONObject response;
     JSONObject groupByResult;
-    pqlQuery = "SELECT SUM(NewAddedFloatMetric) FROM mytable GROUP BY NewAddedStringDimension";
+    pqlQuery = "SELECT SUM(NewAddedFloatMetric) FROM mytable GROUP BY NewAddedSVStringDimension";
     response = postQuery(pqlQuery);
     groupByResult =
         response.getJSONArray("aggregationResults").getJSONObject(0).getJSONArray("groupByResult").getJSONObject(0);
     Assert.assertEquals(groupByResult.getInt("value"), 0);
-    Assert.assertEquals(groupByResult.getJSONArray("group").getString(0), "newAdded");
+    Assert.assertEquals(groupByResult.getJSONArray("group").getString(0), "null");
     pqlQuery = "SELECT SUM(NewAddedDoubleMetric) FROM mytable GROUP BY NewAddedIntDimension";
     response = postQuery(pqlQuery);
     groupByResult =
@@ -316,7 +320,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     pqlQuery =
         "SELECT SUM(NewAddedIntMetric), SUM(NewAddedLongMetric), SUM(NewAddedFloatMetric), SUM(NewAddedDoubleMetric) "
             + "FROM mytable GROUP BY NewAddedIntDimension, NewAddedLongDimension, NewAddedFloatDimension, "
-            + "NewAddedDoubleDimension, NewAddedStringDimension";
+            + "NewAddedDoubleDimension, NewAddedSVStringDimension, NewAddedMVStringDimension";
     response = postQuery(pqlQuery);
     JSONArray groupByResultArray = response.getJSONArray("aggregationResults");
     groupByResult = groupByResultArray.getJSONObject(0).getJSONArray("groupByResult").getJSONObject(0);

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema
@@ -1,388 +1,335 @@
 {
-  "metricFieldSpecs": [
-    {
-      "dataType": "INT",
-      "name": "ActualElapsedTime"
-    },
-    {
-      "dataType": "INT",
-      "name": "AirTime"
-    },
-    {
-      "dataType": "INT",
-      "name": "ArrDel15"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "ArrDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "ArrivalDelayGroups"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "ArrDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "Cancelled"
-    },
-    {
-      "dataType": "INT",
-      "name": "CarrierDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepDel15"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "DepDelay"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "DepDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepartureDelayGroups"
-    },
-    {
-      "dataType": "INT",
-      "name": "LateAircraftDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "NASDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "SecurityDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "WeatherDelay"
-    }
-  ],
+  "schemaName": "mytable",
   "dimensionFieldSpecs": [
     {
-      "dataType": "LONG",
       "name": "AirlineID",
-      "singleValueField": true
+      "dataType": "LONG"
     },
     {
-      "dataType": "INT",
       "name": "ArrTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "ArrTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "CRSArrTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSDepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "CancellationCode",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Carrier",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DayOfWeek",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DayofMonth",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DepTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Dest",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportSeqID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestCityMarketID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestCityName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "DestState",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestStateFips",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestStateName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestWac",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Distance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DistanceGroup",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivActualElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivAirportIDs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivAirportLandings",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivAirportSeqIDs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "STRING",
       "name": "DivAirports",
+      "dataType": "STRING",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivArrDelay",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivDistance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "FLOAT",
       "name": "DivLongestGTimes",
+      "dataType": "FLOAT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivReachedDest",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DivTailNums",
+      "dataType": "STRING",
       "singleValueField": false
     },
     {
-      "dataType": "LONG",
       "name": "DivTotalGTimes",
+      "dataType": "LONG",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivWheelsOffs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivWheelsOns",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "Diverted",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "FirstDepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "FlightDate",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "FlightNum",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Flights",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "LongestAddGTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Month",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "Origin",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginAirportID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "OriginAirportSeqID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "OriginCityMarketID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "OriginCityName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "OriginState",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginStateFips",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "OriginStateName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginWac",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Quarter",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "RandomAirports",
+      "dataType": "STRING",
       "singleValueField": false
     },
     {
-      "dataType": "STRING",
       "name": "TailNum",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "TaxiIn",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "TaxiOut",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Year",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "WheelsOn",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "WheelsOff",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "UniqueCarrier",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "TotalAddGTime",
-      "singleValueField": true
+      "dataType": "INT"
+    }
+  ],
+  "metricFieldSpecs": [
+    {
+      "name": "ActualElapsedTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "AirTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelay",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "ArrivalDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelayMinutes",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "Cancelled",
+      "dataType": "INT"
+    },
+    {
+      "name": "CarrierDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDelay",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "DepDelayMinutes",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "DepartureDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "LateAircraftDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "NASDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "SecurityDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "WeatherDelay",
+      "dataType": "INT"
     }
   ],
   "timeFieldSpec": {
     "incomingGranularitySpec": {
+      "name": "DaysSinceEpoch",
       "dataType": "INT",
-      "timeType": "DAYS",
-      "name": "DaysSinceEpoch"
+      "timeType": "DAYS"
     }
-  },
-  "schemaName": "fightDataSchema"
+  }
 }

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_extra_columns.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_extra_columns.schema
@@ -1,432 +1,379 @@
 {
-  "metricFieldSpecs": [
-    {
-      "dataType": "INT",
-      "name": "ActualElapsedTime"
-    },
-    {
-      "dataType": "INT",
-      "name": "AirTime"
-    },
-    {
-      "dataType": "INT",
-      "name": "ArrDel15"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "ArrDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "ArrivalDelayGroups"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "ArrDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "Cancelled"
-    },
-    {
-      "dataType": "INT",
-      "name": "CarrierDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepDel15"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "DepDelay"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "DepDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepartureDelayGroups"
-    },
-    {
-      "dataType": "INT",
-      "name": "LateAircraftDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "NASDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "SecurityDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "WeatherDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "NewAddedIntMetric",
-      "defaultNullValue": 1
-    },
-    {
-      "dataType": "LONG",
-      "name": "NewAddedLongMetric",
-      "defaultNullValue": 1
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "NewAddedFloatMetric"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "NewAddedDoubleMetric"
-    }
-  ],
+  "schemaName": "mytable",
   "dimensionFieldSpecs": [
     {
-      "dataType": "LONG",
       "name": "AirlineID",
-      "singleValueField": true
+      "dataType": "LONG"
     },
     {
-      "dataType": "INT",
       "name": "ArrTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "ArrTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "CRSArrTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSDepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "CancellationCode",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Carrier",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DayOfWeek",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DayofMonth",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DepTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Dest",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportSeqID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestCityMarketID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestCityName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "DestState",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestStateFips",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestStateName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestWac",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Distance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DistanceGroup",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivActualElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivAirportIDs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivAirportLandings",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivAirportSeqIDs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "STRING",
       "name": "DivAirports",
+      "dataType": "STRING",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivArrDelay",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivDistance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "FLOAT",
       "name": "DivLongestGTimes",
-      "singleValueField": false
-    },
-    {
-      "dataType": "INT",
-      "name": "DivReachedDest",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "DivTailNums",
-      "singleValueField": false
-    },
-    {
-      "dataType": "LONG",
-      "name": "DivTotalGTimes",
-      "singleValueField": false
-    },
-    {
-      "dataType": "INT",
-      "name": "DivWheelsOffs",
-      "singleValueField": false
-    },
-    {
-      "dataType": "INT",
-      "name": "DivWheelsOns",
-      "singleValueField": false
-    },
-    {
-      "dataType": "INT",
-      "name": "Diverted",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "FirstDepTime",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "FlightDate",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "FlightNum",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "Flights",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "LongestAddGTime",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "Month",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "Origin",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "OriginAirportID",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "OriginAirportSeqID",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "OriginCityMarketID",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "OriginCityName",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "OriginState",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "OriginStateFips",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "OriginStateName",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "OriginWac",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "Quarter",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "RandomAirports",
-      "singleValueField": false
-    },
-    {
-      "dataType": "STRING",
-      "name": "TailNum",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "TaxiIn",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "TaxiOut",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "Year",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "WheelsOn",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "WheelsOff",
-      "singleValueField": true
-    },
-    {
-      "dataType": "STRING",
-      "name": "UniqueCarrier",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "TotalAddGTime",
-      "singleValueField": true
-    },
-    {
-      "dataType": "INT",
-      "name": "NewAddedIntDimension",
-      "singleValueField": true
-    },
-    {
-      "dataType": "LONG",
-      "name": "NewAddedLongDimension",
-      "singleValueField": true
-    },
-    {
       "dataType": "FLOAT",
-      "name": "NewAddedFloatDimension",
-      "singleValueField": true
+      "singleValueField": false
     },
     {
-      "dataType": "DOUBLE",
-      "name": "NewAddedDoubleDimension",
-      "singleValueField": true
+      "name": "DivReachedDest",
+      "dataType": "INT"
     },
     {
+      "name": "DivTailNums",
       "dataType": "STRING",
-      "name": "NewAddedStringDimension",
+      "singleValueField": false
+    },
+    {
+      "name": "DivTotalGTimes",
+      "dataType": "LONG",
+      "singleValueField": false
+    },
+    {
+      "name": "DivWheelsOffs",
+      "dataType": "INT",
+      "singleValueField": false
+    },
+    {
+      "name": "DivWheelsOns",
+      "dataType": "INT",
+      "singleValueField": false
+    },
+    {
+      "name": "Diverted",
+      "dataType": "INT"
+    },
+    {
+      "name": "FirstDepTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "FlightDate",
+      "dataType": "STRING"
+    },
+    {
+      "name": "FlightNum",
+      "dataType": "INT"
+    },
+    {
+      "name": "Flights",
+      "dataType": "INT"
+    },
+    {
+      "name": "LongestAddGTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "Month",
+      "dataType": "INT"
+    },
+    {
+      "name": "Origin",
+      "dataType": "STRING"
+    },
+    {
+      "name": "OriginAirportID",
+      "dataType": "INT"
+    },
+    {
+      "name": "OriginAirportSeqID",
+      "dataType": "INT"
+    },
+    {
+      "name": "OriginCityMarketID",
+      "dataType": "INT"
+    },
+    {
+      "name": "OriginCityName",
+      "dataType": "STRING"
+    },
+    {
+      "name": "OriginState",
+      "dataType": "STRING"
+    },
+    {
+      "name": "OriginStateFips",
+      "dataType": "INT"
+    },
+    {
+      "name": "OriginStateName",
+      "dataType": "STRING"
+    },
+    {
+      "name": "OriginWac",
+      "dataType": "INT"
+    },
+    {
+      "name": "Quarter",
+      "dataType": "INT"
+    },
+    {
+      "name": "RandomAirports",
+      "dataType": "STRING",
+      "singleValueField": false
+    },
+    {
+      "name": "TailNum",
+      "dataType": "STRING"
+    },
+    {
+      "name": "TaxiIn",
+      "dataType": "INT"
+    },
+    {
+      "name": "TaxiOut",
+      "dataType": "INT"
+    },
+    {
+      "name": "Year",
+      "dataType": "INT"
+    },
+    {
+      "name": "WheelsOn",
+      "dataType": "INT"
+    },
+    {
+      "name": "WheelsOff",
+      "dataType": "INT"
+    },
+    {
+      "name": "UniqueCarrier",
+      "dataType": "STRING"
+    },
+    {
+      "name": "TotalAddGTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "NewAddedIntDimension",
+      "dataType": "INT"
+    },
+    {
+      "name": "NewAddedLongDimension",
+      "dataType": "LONG"
+    },
+    {
+      "name": "NewAddedFloatDimension",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "NewAddedDoubleDimension",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "NewAddedSVStringDimension",
+      "dataType": "STRING"
+    },
+    {
+      "name": "NewAddedMVStringDimension",
+      "dataType": "STRING",
       "singleValueField": false,
-      "defaultNullValue": "newAdded"
+      "defaultNullValue": ""
+    }
+  ],
+  "metricFieldSpecs": [
+    {
+      "name": "ActualElapsedTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "AirTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelay",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "ArrivalDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelayMinutes",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "Cancelled",
+      "dataType": "INT"
+    },
+    {
+      "name": "CarrierDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDelay",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "DepDelayMinutes",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "DepartureDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "LateAircraftDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "NASDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "SecurityDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "WeatherDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "NewAddedIntMetric",
+      "dataType": "INT",
+      "defaultNullValue": 1
+    },
+    {
+      "name": "NewAddedLongMetric",
+      "dataType": "LONG",
+      "defaultNullValue": 1
+    },
+    {
+      "name": "NewAddedFloatMetric",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "NewAddedDoubleMetric",
+      "dataType": "DOUBLE"
     }
   ],
   "timeFieldSpec": {
     "incomingGranularitySpec": {
+      "name": "DaysSinceEpoch",
       "dataType": "INT",
-      "timeType": "DAYS",
-      "name": "DaysSinceEpoch"
+      "timeType": "DAYS"
     }
-  },
-  "schemaName": "mytable"
+  }
 }

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_missing_columns.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_missing_columns.schema
@@ -1,370 +1,319 @@
 {
-  "metricFieldSpecs": [
-    {
-      "dataType": "INT",
-      "name": "ArrDel15"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "ArrDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "ArrivalDelayGroups"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "ArrDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "Cancelled"
-    },
-    {
-      "dataType": "INT",
-      "name": "CarrierDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepDel15"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "DepDelay"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "DepDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepartureDelayGroups"
-    },
-    {
-      "dataType": "INT",
-      "name": "LateAircraftDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "NASDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "SecurityDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "WeatherDelay"
-    }
-  ],
+  "schemaName": "mytable",
   "dimensionFieldSpecs": [
     {
-      "dataType": "STRING",
       "name": "ArrTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "CRSArrTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSDepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "CancellationCode",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Carrier",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DayOfWeek",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DayofMonth",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DepTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Dest",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportSeqID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestCityMarketID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestCityName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "DestState",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestStateFips",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestStateName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestWac",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Distance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DistanceGroup",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivActualElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivAirportIDs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivAirportLandings",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivAirportSeqIDs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "STRING",
       "name": "DivAirports",
+      "dataType": "STRING",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivArrDelay",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivDistance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "FLOAT",
       "name": "DivLongestGTimes",
+      "dataType": "FLOAT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivReachedDest",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DivTailNums",
+      "dataType": "STRING",
       "singleValueField": false
     },
     {
-      "dataType": "LONG",
       "name": "DivTotalGTimes",
+      "dataType": "LONG",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivWheelsOffs",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "DivWheelsOns",
+      "dataType": "INT",
       "singleValueField": false
     },
     {
-      "dataType": "INT",
       "name": "Diverted",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "FirstDepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "FlightDate",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "FlightNum",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Flights",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "LongestAddGTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Month",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "Origin",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginAirportID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "OriginAirportSeqID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "OriginCityMarketID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "OriginCityName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "OriginState",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginStateFips",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "OriginStateName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginWac",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Quarter",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "RandomAirports",
+      "dataType": "STRING",
       "singleValueField": false
     },
     {
-      "dataType": "STRING",
       "name": "TailNum",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "TaxiIn",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "TaxiOut",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Year",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "WheelsOn",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "WheelsOff",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "UniqueCarrier",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "TotalAddGTime",
-      "singleValueField": true
+      "dataType": "INT"
+    }
+  ],
+  "metricFieldSpecs": [
+    {
+      "name": "ArrDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelay",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "ArrivalDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelayMinutes",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "Cancelled",
+      "dataType": "INT"
+    },
+    {
+      "name": "CarrierDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDelay",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "DepDelayMinutes",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "DepartureDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "LateAircraftDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "NASDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "SecurityDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "WeatherDelay",
+      "dataType": "INT"
     }
   ],
   "timeFieldSpec": {
     "incomingGranularitySpec": {
+      "name": "DaysSinceEpoch",
       "dataType": "INT",
-      "timeType": "DAYS",
-      "name": "DaysSinceEpoch"
+      "timeType": "DAYS"
     }
-  },
-  "schemaName": "mytable"
+  }
 }

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema
@@ -1,343 +1,290 @@
 {
-  "metricFieldSpecs": [
-    {
-      "dataType": "INT",
-      "name": "ActualElapsedTime"
-    },
-    {
-      "dataType": "INT",
-      "name": "AirTime"
-    },
-    {
-      "dataType": "INT",
-      "name": "ArrDel15"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "ArrDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "ArrivalDelayGroups"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "ArrDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "Cancelled"
-    },
-    {
-      "dataType": "INT",
-      "name": "CarrierDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepDel15"
-    },
-    {
-      "dataType": "DOUBLE",
-      "name": "DepDelay"
-    },
-    {
-      "dataType": "FLOAT",
-      "name": "DepDelayMinutes"
-    },
-    {
-      "dataType": "INT",
-      "name": "DepartureDelayGroups"
-    },
-    {
-      "dataType": "INT",
-      "name": "LateAircraftDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "NASDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "SecurityDelay"
-    },
-    {
-      "dataType": "INT",
-      "name": "WeatherDelay"
-    }
-  ],
+  "schemaName": "mytable",
   "dimensionFieldSpecs": [
     {
-      "dataType": "LONG",
       "name": "AirlineID",
-      "singleValueField": true
+      "dataType": "LONG"
     },
     {
-      "dataType": "INT",
       "name": "ArrTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "ArrTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "CRSArrTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSDepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "CRSElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "CancellationCode",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Carrier",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DayOfWeek",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DayofMonth",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DepTimeBlk",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "Dest",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestAirportSeqID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DestCityMarketID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestCityName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "DestState",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestStateFips",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "DestStateName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "DestWac",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Distance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DistanceGroup",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivActualElapsedTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivAirportLandings",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivArrDelay",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivDistance",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "DivReachedDest",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Diverted",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "FirstDepTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "FlightDate",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "FlightNum",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Flights",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "LongestAddGTime",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Month",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "Origin",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginAirportID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "OriginAirportSeqID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "OriginCityMarketID",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "OriginCityName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "STRING",
       "name": "OriginState",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginStateFips",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "OriginStateName",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "OriginWac",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Quarter",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "TailNum",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "TaxiIn",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "TaxiOut",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "Year",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "WheelsOn",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "INT",
       "name": "WheelsOff",
-      "singleValueField": true
+      "dataType": "INT"
     },
     {
-      "dataType": "STRING",
       "name": "UniqueCarrier",
-      "singleValueField": true
+      "dataType": "STRING"
     },
     {
-      "dataType": "INT",
       "name": "TotalAddGTime",
-      "singleValueField": true
+      "dataType": "INT"
+    }
+  ],
+  "metricFieldSpecs": [
+    {
+      "name": "ActualElapsedTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "AirTime",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelay",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "ArrivalDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "ArrDelayMinutes",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "Cancelled",
+      "dataType": "INT"
+    },
+    {
+      "name": "CarrierDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDel15",
+      "dataType": "INT"
+    },
+    {
+      "name": "DepDelay",
+      "dataType": "DOUBLE"
+    },
+    {
+      "name": "DepDelayMinutes",
+      "dataType": "FLOAT"
+    },
+    {
+      "name": "DepartureDelayGroups",
+      "dataType": "INT"
+    },
+    {
+      "name": "LateAircraftDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "NASDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "SecurityDelay",
+      "dataType": "INT"
+    },
+    {
+      "name": "WeatherDelay",
+      "dataType": "INT"
     }
   ],
   "timeFieldSpec": {
     "incomingGranularitySpec": {
+      "name": "DaysSinceEpoch",
       "dataType": "INT",
-      "timeType": "DAYS",
-      "name": "DaysSinceEpoch"
+      "timeType": "DAYS"
     }
-  },
-  "schemaName": "fightDataSchema"
+  }
 }


### PR DESCRIPTION
When hitting the end of the input stream, ByteArrayInputStream.read(b) returns -1 instead of 0 when length of b is 0 (not the same as the java doc).
Added decodeString() method to handle this behavior.
Added empty string test to DataTableSerDeTest and default column integration test