### PR TITLE
[TE] datasource - filter pre-aggregated dimensions by default

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -111,6 +112,7 @@ public class PinotDataSourceDimensionFilters {
           String dimensionValue = row.get(dimension);
           values.add(dimensionValue);
         }
+        values.remove(datasetConfig.getPreAggregatedKeyword());
         Collections.sort(values);
         result.put(dimension, values);
       } else {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotThirdEyeDataSource.java
@@ -222,6 +222,7 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
       preAggregatedDimensionNames.removeAll(groupByDimensions);
     }
     // Add pre-aggregated dimension value to the remaining dimension names
+    // exclude pre-aggregated dimension for group by dimensions
     Multimap<String, String> decoratedFilterSet;
     if (filterSet != null) {
       decoratedFilterSet = HashMultimap.create(filterSet);
@@ -231,6 +232,9 @@ public class PinotThirdEyeDataSource implements ThirdEyeDataSource {
     if (preAggregatedDimensionNames.size() != 0) {
       for (String preComputedDimensionName : preAggregatedDimensionNames) {
         decoratedFilterSet.put(preComputedDimensionName, preAggregatedKeyword);
+      }
+      for (String dimensionName : groupByDimensions) {
+        decoratedFilterSet.put(dimensionName, "!" + preAggregatedKeyword);
       }
     }
 


### PR DESCRIPTION
ThirdEye already supports pre-computed data cubes for non-additive metrics in Pinot. However, ThirdEye still exposes the dummy values used for pre-aggregation to the user as valid dimension and filter values. This PR excludes dummy values from filter sets and result sets - making them fully transparent.