### PR TITLE
[TE] onboarding - use POST payload for create alert call

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -699,7 +699,7 @@ export default Controller.extend({
 
       return {
         jobName,
-        payload: JSON.stringify(newAlertObj)
+        payload: newAlertObj
       };
 
     }

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/route.js
@@ -122,16 +122,16 @@ export default Route.extend({
     * @method triggerReplaySequence
     */
     triggerOnboardingJob(data) {
-      const newName = JSON.parse(data.payload).functionName;
+      const newName = data.payload.functionName;
       const createAlertUrl = `/function-onboard/create-function?name=${newName}`;
-      const updateAlertUrl = `/detection-onboard/create-job?jobName=${data.jobName}&payload=${encodeURIComponent(data.payload)}`;
+      const updateAlertUrl = `/detection-onboard/create-job?jobName=${data.jobName}`;
       let onboardStartTime = moment();
       let newFunctionId = null;
 
-      fetch(createAlertUrl, postProps({ name: newName })).then(checkStatus)
+      fetch(createAlertUrl, postProps('')).then(checkStatus)
         .then((result) => {
           newFunctionId = result.id;
-          return fetch(updateAlertUrl, postProps(data)).then(checkStatus);
+          return fetch(updateAlertUrl, postProps(data.payload)).then(checkStatus);
         })
         .then((result) => {
           if (result.jobStatus && result.jobStatus.toLowerCase() === 'failed') {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/onboard/DetectionOnboardResource.java
@@ -50,7 +50,7 @@ public class DetectionOnboardResource {
   @POST
   @Path("/create-job")
   public String createDetectionOnboardingJob(@NotNull @QueryParam("jobName") String jobName,
-      @QueryParam("payload") String jsonPayload) {
+      String jsonPayload) {
 
     // Check user's input
     if (jsonPayload == null) {
@@ -60,7 +60,7 @@ public class DetectionOnboardResource {
     // Invoke backend function
     DetectionOnboardJobStatus detectionOnboardingJobStatus;
     try {
-      Map<String, String> properties = OBJECT_MAPPER.readValue(jsonPayload, HashMap.class);
+      Map<String, String> properties = OBJECT_MAPPER.readValue(jsonPayload, Map.class);
 
       // Put System Configuration into properties
       Iterator<String> systemConfigKeyIterator = systemConfig.getKeys();


### PR DESCRIPTION
The existing onboarding API serializes the payload as query param instad of using the POST payload. This PR changes the endpoint and frontend to correctly use the request payload rather than query params.