### PR TITLE
[TE] Self-Serve Onboarding: fix for replay banner

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
@@ -37,7 +37,7 @@ export default Route.extend({
         startDate: startDateDefault,
         endDate: endDateDefault,
         functionName: null,
-        jobId: null
+        jobId
       }});
       // Save duration to sessionStorage for guaranteed availability
       setDuration(durationDefault, startDateDefault, endDateDefault);


### PR DESCRIPTION
Replacing query param value for `jobId` - needed for replay transition and banner.