### PR TITLE
[TE] fix acceptance tests warnings

### DIFF
--- a/thirdeye/thirdeye-frontend/tests/helpers/destroy-app.js
+++ b/thirdeye/thirdeye-frontend/tests/helpers/destroy-app.js
@@ -2,4 +2,5 @@ import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
   run(application, 'destroy');
+  server.shutdown();
 }


### PR DESCRIPTION
### What's new 
- was seeing the follow warning while running test `"You created a second Pretender instance while there was already one running"`. 
This is due to  https://github.com/linkedin/pinot/blob/master/thirdeye/thirdeye-frontend/tests/acceptance/edit-alert-test.js#L17 not being properly shutdown.  cc @ttbach 

### Test: 
Passing with no warnings