### PR TITLE
[TE] datasource - ignore date column dimension by default

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/aggregation/DefaultAggregationLoader.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/aggregation/DefaultAggregationLoader.java
@@ -48,6 +48,7 @@ public class DefaultAggregationLoader implements AggregationLoader {
 
     List<String> dimensions = new ArrayList<>(dataset.getDimensions());
     dimensions.removeAll(slice.getFilters().keySet());
+    dimensions.remove(dataset.getTimeColumn());
 
     LOG.info("Aggregating metric id {} with {} filters for dimensions {}", metricId, slice.getFilters().size(), dimensions);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datasource/pinot/PinotDataSourceDimensionFilters.java
@@ -112,13 +112,20 @@ public class PinotDataSourceDimensionFilters {
           String dimensionValue = row.get(dimension);
           values.add(dimensionValue);
         }
+
+        // remove pre-aggregation dimension value by default
         values.remove(datasetConfig.getPreAggregatedKeyword());
+
         Collections.sort(values);
         result.put(dimension, values);
       } else {
         result.put(dimension, Collections.<String>emptyList());
       }
     }
+
+    // remove time column dimension by default
+    result.remove(datasetConfig.getTimeColumn());
+
     return result;
   }
 


### PR DESCRIPTION
Data sets are commonly mis-specified and contain the time column as part of their dimension list. This PR adds blanket logic to remove the date column from filter and breakdown queries to compensate for this.