### PR TITLE
[TE] Self-Serve Api import 1

### DIFF
--- a/thirdeye/thirdeye-frontend/app/api/self-serve.js
+++ b/thirdeye/thirdeye-frontend/app/api/self-serve.js
@@ -1,0 +1,65 @@
+/**
+ * GET request for all alert subscription groups
+ * @see {@link namepathOrURL|link text}
+ */
+const allConfigGroups = '/thirdeye/entity/ALERT_CONFIG';
+
+/**
+ * GET request for all alert application groups
+ * @see {@link namepathOrURL|link text}
+ */
+const allApplications = '/thirdeye/entity/APPLICATION';
+
+/**
+ * GET request for job status (a sequence of events including create, replay, autotune)
+ * Requires 'jobId' query param
+ * @see {@link namepathOrURL|link text}
+ */
+const jobStatus = jobId => `/detection-onboard/get-status?jobId=${jobId}`;
+
+/**
+ * POST request to create alert container in DB
+ * Requires 'name' query param
+ * @param {String} newAlertName: Name of new alert function
+ * @see {@link namepathOrURL|link text}
+ */
+const createAlertFunction = newAlertName => `/function-onboard/create-function?name=${newAlertName}`;
+
+/**
+ * POST request to update an existing alert function with properties payload
+ * Requires 'payload' object in request body and 'jobName' in query param
+ * @param {String} jobName: unique name of new job for alert setup task
+ * @see {@link namepathOrURL|link text}
+ */
+const updateAlertFunction = jobName => `/detection-onboard/create-job?jobName=${jobName}`;
+
+/**
+ * DELETE request to remove an alert function from the DB
+ * Requires query param 'id'
+ * @param {String} functionId: id of alert to remove
+ * @see {@link namepathOrURL|link text}
+ */
+const deleteAlertFunction = functionId => `/dashboard/anomaly-function?id=${functionId}`;
+
+/**
+ * General self-serve endpoints
+ */
+export const general = {
+  allConfigGroups,
+  allApplications
+};
+
+/**
+ * Onboarding endpoints for self-serve
+ */
+export const onboard = {
+  jobStatus,
+  createAlertFunction,
+  updateAlertFunction,
+  deleteAlertFunction
+};
+
+export default {
+  general,
+  onboard
+};

--- a/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
+++ b/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
@@ -1,19 +1,19 @@
 /**
  * GET request for all alert subscription groups
- * @see {@link namepathOrURL|link text}
+ * @see {@link https://tinyurl.com/ycv55yyx|class EntityManagerResource}
  */
 const allConfigGroups = '/thirdeye/entity/ALERT_CONFIG';
 
 /**
  * GET request for all alert application groups
- * @see {@link namepathOrURL|link text}
+ * @see {@link https://tinyurl.com/ycv55yyx|class EntityManagerResource}
  */
 const allApplications = '/thirdeye/entity/APPLICATION';
 
 /**
  * GET request for job status (a sequence of events including create, replay, autotune)
  * Requires 'jobId' query param
- * @see {@link namepathOrURL|link text}
+ * @see {@link https://tinyurl.com/ya6mwyjt|class DetectionOnboardResource}
  */
 const jobStatus = jobId => `/detection-onboard/get-status?jobId=${jobId}`;
 
@@ -21,7 +21,7 @@ const jobStatus = jobId => `/detection-onboard/get-status?jobId=${jobId}`;
  * POST request to create alert container in DB
  * Requires 'name' query param
  * @param {String} newAlertName: Name of new alert function
- * @see {@link namepathOrURL|link text}
+ * @see {@link https://tinyurl.com/yb4ebnbd|class FunctionOnboardingResource}
  */
 const createAlert = newAlertName => `/function-onboard/create-function?name=${newAlertName}`;
 
@@ -29,7 +29,7 @@ const createAlert = newAlertName => `/function-onboard/create-function?name=${ne
  * POST request to update an existing alert function with properties payload
  * Requires 'payload' object in request body and 'jobName' in query param
  * @param {String} jobName: unique name of new job for alert setup task
- * @see {@link namepathOrURL|link text}
+ * @see {@link https://tinyurl.com/yd84uj2b|class DetectionOnboardResource}
  */
 const updateAlert = jobName => `/detection-onboard/create-job?jobName=${jobName}`;
 
@@ -37,7 +37,7 @@ const updateAlert = jobName => `/detection-onboard/create-job?jobName=${jobName}
  * DELETE request to remove an alert function from the DB
  * Requires query param 'id'
  * @param {String} functionId: id of alert to remove
- * @see {@link namepathOrURL|link text}
+ * @see {@link https://tinyurl.com/ybmgmzhd|class AnomalyResource}
  */
 const deleteAlert = functionId => `/dashboard/anomaly-function?id=${functionId}`;
 

--- a/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
+++ b/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
@@ -23,7 +23,7 @@ const jobStatus = jobId => `/detection-onboard/get-status?jobId=${jobId}`;
  * @param {String} newAlertName: Name of new alert function
  * @see {@link namepathOrURL|link text}
  */
-const createAlertFunction = newAlertName => `/function-onboard/create-function?name=${newAlertName}`;
+const createAlert = newAlertName => `/function-onboard/create-function?name=${newAlertName}`;
 
 /**
  * POST request to update an existing alert function with properties payload
@@ -31,7 +31,7 @@ const createAlertFunction = newAlertName => `/function-onboard/create-function?n
  * @param {String} jobName: unique name of new job for alert setup task
  * @see {@link namepathOrURL|link text}
  */
-const updateAlertFunction = jobName => `/detection-onboard/create-job?jobName=${jobName}`;
+const updateAlert = jobName => `/detection-onboard/create-job?jobName=${jobName}`;
 
 /**
  * DELETE request to remove an alert function from the DB
@@ -39,12 +39,12 @@ const updateAlertFunction = jobName => `/detection-onboard/create-job?jobName=${
  * @param {String} functionId: id of alert to remove
  * @see {@link namepathOrURL|link text}
  */
-const deleteAlertFunction = functionId => `/dashboard/anomaly-function?id=${functionId}`;
+const deleteAlert = functionId => `/dashboard/anomaly-function?id=${functionId}`;
 
 /**
  * General self-serve endpoints
  */
-export const general = {
+export const selfServeApiCommon = {
   allConfigGroups,
   allApplications
 };
@@ -52,14 +52,14 @@ export const general = {
 /**
  * Onboarding endpoints for self-serve
  */
-export const onboard = {
+export const selfServeApiOnboard = {
   jobStatus,
-  createAlertFunction,
-  updateAlertFunction,
-  deleteAlertFunction
+  createAlert,
+  updateAlert,
+  deleteAlert
 };
 
 export default {
-  general,
-  onboard
+  selfServeApiCommon,
+  selfServeApiOnboard
 };


### PR DESCRIPTION
Collecting self-serve endpoints into master import file.

In second commit, moved API file under /utils and removed 'swagger' placeholders in jsDocs.