### PR TITLE
[TE] Extend window if the view window is too small for train

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/AnomalyResource.java
@@ -81,7 +81,11 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.joda.time.DateTime;
+import org.joda.time.Days;
+import org.joda.time.Hours;
 import org.joda.time.Interval;
+import org.joda.time.Period;
+import org.joda.time.Weeks;
 import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -713,6 +717,7 @@ public class AnomalyResource {
    *      the Map that maps dimension string to the AnomalyTimelinesView
    * @throws Exception
    */
+  private static final Period DEFAULT_MINIMUN_REQUIRE_TRAINING_PERIOD = Weeks.THREE.toPeriod();
   @GET
   @Path(value = "/anomaly-function/{id}/baseline")
   @Produces(MediaType.APPLICATION_JSON)
@@ -743,8 +748,28 @@ public class AnomalyResource {
       return Response.status(Response.Status.BAD_REQUEST).entity("Start time is after end time").build();
     }
 
+    // enlarge view window when is view window is small
+    if (!mode.equalsIgnoreCase("ONLINE")) {
+      switch (anomalyFunctionSpec.getBucketUnit()) {
+        case MINUTES:
+          if (Weeks.weeksBetween(startTime, endTime).getWeeks() < DEFAULT_MINIMUN_REQUIRE_TRAINING_PERIOD.toStandardDuration().getStandardDays()/7) {
+            mode = "ONLINE";
+          }
+          break;
+        case HOURS:
+          if (Hours.hoursBetween(startTime, endTime).getHours() < DEFAULT_MINIMUN_REQUIRE_TRAINING_PERIOD.toStandardDuration().getStandardHours()) {
+            startTime = endTime.minus(DEFAULT_MINIMUN_REQUIRE_TRAINING_PERIOD);
+          }
+          break;
+        case DAYS:
+          if (Days.daysBetween(startTime, endTime).getDays() < DEFAULT_MINIMUN_REQUIRE_TRAINING_PERIOD.toStandardDuration().getStandardDays()) {
+            startTime = endTime.minus(DEFAULT_MINIMUN_REQUIRE_TRAINING_PERIOD);
+          }
+          break;
+      }
+    }
+
     // Get DimensionMap from input dimension String
-    Multimap<String, String> functionFilters = anomalyFunctionSpec.getFilterSet();
     Map<String, String> inputDimension = OBJECT_MAPPER.readValue(dimension, Map.class);
     DimensionMap dimensionsToBeEvaluated = new DimensionMap();
     if (anomalyFunctionSpec.getExploreDimensions() != null &&


### PR DESCRIPTION
For showing baseline in RCA, one problem we faced is we are not able to show baseline if the window is too small. This pr is to extend the window to a feasible site for training.