### PR TITLE
Change AvroUtils to not infer field type by field name

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -511,7 +511,7 @@ public class SegmentGeneratorConfig {
       schema = Schema.fromFile(new File(_schemaFile));
       setSchema(schema);
     } else if (_format == FileFormat.AVRO) {
-      schema = AvroUtils.extractSchemaFromAvro(new File(_inputFilePath));
+      schema = AvroUtils.getPinotSchemaFromAvroDataFile(new File(_inputFilePath));
       setSchema(schema);
     } else {
       throw new RuntimeException("Input format " + _format + " requires schema.");

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/persist/AvroDataPublisherTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/persist/AvroDataPublisherTest.java
@@ -126,7 +126,7 @@ public class AvroDataPublisherTest {
     final String filePath = TestUtils.getFileFromResourceUrl(getClass().getClassLoader().getResource(AVRO_MULTI_DATA));
 
     final SegmentGeneratorConfig config =
-        new SegmentGeneratorConfig(AvroUtils.extractSchemaFromAvro(new File(filePath)));
+        new SegmentGeneratorConfig(AvroUtils.getPinotSchemaFromAvroDataFile(new File(filePath)));
     config.setFormat(FileFormat.AVRO);
     config.setInputFilePath(filePath);
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/segments/v1/creator/DictionariesTest.java
@@ -93,7 +93,7 @@ public class DictionariesTest {
     driver.init(config);
     driver.build();
     segmentDirectory = new File(INDEX_DIR, driver.getSegmentName());
-    final Schema schema = AvroUtils.extractSchemaFromAvro(new File(filePath));
+    final Schema schema = AvroUtils.getPinotSchemaFromAvroDataFile(new File(filePath));
 
     final DataFileStream<GenericRecord> avroReader = AvroUtils.getAvroReader(new File(filePath));
     final org.apache.avro.Schema avroSchema = avroReader.getSchema();

--- a/pinot-server/src/test/java/com/linkedin/pinot/server/util/SegmentTestUtils.java
+++ b/pinot-server/src/test/java/com/linkedin/pinot/server/util/SegmentTestUtils.java
@@ -37,7 +37,7 @@ public class SegmentTestUtils {
       throws IOException {
     SegmentGeneratorConfig segmentGeneratorConfig;
     if (pinotSchema == null) {
-      segmentGeneratorConfig = new SegmentGeneratorConfig(AvroUtils.extractSchemaFromAvro(inputAvro));
+      segmentGeneratorConfig = new SegmentGeneratorConfig(AvroUtils.getPinotSchemaFromAvroDataFile(inputAvro));
     } else {
       segmentGeneratorConfig = new SegmentGeneratorConfig(pinotSchema);
     }

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/AvroSchemaToPinotSchema.java
@@ -20,14 +20,14 @@ import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.core.util.AvroUtils;
 import com.linkedin.pinot.tools.Command;
 import java.io.File;
-import java.io.PrintWriter;
+import java.io.FileWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * Class for command to convert avro schema to pinot schema. Given that it is not always possible to
@@ -35,86 +35,73 @@ import org.slf4j.LoggerFactory;
  * manual editing on top.
  */
 public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements Command {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AddTenantCommand.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AvroSchemaToPinotSchema.class);
 
-  @Option(name = "-avroSchemaFileName", required = false, forbids = {"-avroDataFileName"},
-      metaVar = "<String>", usage = "Path to avro schema file.")
-  String _avroSchemaFileName;
+  @Option(name = "-avroSchemaFile", forbids = {"-avroDataFile"}, metaVar = "<String>", usage = "Path to avro schema file.")
+  String _avroSchemaFile;
 
-  @Option(name = "-avroDataFileName", required = false, forbids = {"-avroSchemaFileName"},
-      metaVar = "<String>", usage = "Path to avro schema file.")
-  String _avroDataFileName;
+  @Option(name = "-avroDataFile", forbids = {"-avroSchemaFile"}, metaVar = "<String>", usage = "Path to avro data file.")
+  String _avroDataFile;
 
-  @Option(name = "-pinotSchemaFileName", required = false, metaVar = "<string>", usage = "Path to pinot schema file.")
-  String _pinotSchemaFileName;
+  @Option(name = "-outputDir", required = true, metaVar = "<string>", usage = "Path to output directory")
+  String _outputDir;
 
-  @Option(name = "-dimensions", required = false, metaVar = "<string>", usage = "Comma separated dimension columns.")
+  @Option(name = "-pinotSchemaName", required = true, metaVar = "<string>", usage = "Pinot schema name")
+  String _pinotSchemaName;
+
+  @Option(name = "-dimensions", metaVar = "<string>", usage = "Comma separated dimension column names.")
   String _dimensions;
 
-  @Option(name = "-metrics", required = false, metaVar = "<string>", usage = "Comma separated metric columns.")
+  @Option(name = "-metrics", metaVar = "<string>", usage = "Comma separated metric column names.")
   String _metrics;
 
-  @Option(name = "-timeColumnName", required = false, metaVar = "<string>", usage = "Name of Time Column.")
+  @Option(name = "-timeColumnName", metaVar = "<string>", usage = "Name of the time column.")
   String _timeColumnName;
 
-  @Option(name = "-timeUnit", required = false, metaVar = "<string>", usage = "Unit for time column.")
+  @Option(name = "-timeUnit", metaVar = "<string>", usage = "Unit of the time column (default DAYS).")
   TimeUnit _timeUnit = TimeUnit.DAYS;
 
-  @Option(name = "-help", required = false, help = true, aliases = { "-h", "--h", "--help" },
-      usage = "Print this message.")
+  @SuppressWarnings("FieldCanBeLocal")
+  @Option(name = "-help", help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help = false;
 
   @Override
   public boolean execute() throws Exception {
-    Schema schema = null;
-
-    if (_dimensions == null && _metrics == null) {
-      LOGGER.error("Error: Missing required argument, please specify -dimensions, -metrics, or both");
+    if (_dimensions == null && _metrics == null && _timeColumnName == null) {
+      LOGGER.error(
+          "Error: Missing required argument, please specify at least one of -dimensions, -metrics, -timeColumnName");
       return false;
     }
 
-    if (_avroSchemaFileName != null) {
-      schema = AvroUtils.getPinotSchemaFromAvroSchemaFile(_avroSchemaFileName, buildFieldTypesMap(), _timeUnit);
-    } else if (_avroDataFileName != null) {
-      schema = AvroUtils.extractSchemaFromAvro(new File(_avroDataFileName));
+    Schema schema;
+    if (_avroSchemaFile != null) {
+      schema = AvroUtils.getPinotSchemaFromAvroSchemaFile(new File(_avroSchemaFile), buildFieldTypesMap(), _timeUnit);
+    } else if (_avroDataFile != null) {
+      schema = AvroUtils.getPinotSchemaFromAvroDataFile(new File(_avroDataFile), buildFieldTypesMap(), _timeUnit);
     } else {
-      LOGGER.error("Error: Missing required argument, please specify either -avroSchemaFileName, or -avroDataFileName");
+      LOGGER.error("Error: Missing required argument, please specify either -avroSchemaFile, or -avroDataFile");
       return false;
     }
 
-    if (schema == null) {
-      LOGGER.error("Error: Could not read avro schema from file.");
-      return false;
+    schema.setSchemaName(_pinotSchemaName);
+
+    File outputDir = new File(_outputDir);
+    if (!outputDir.isDirectory()) {
+      LOGGER.error("ERROR: Output directory: %s does not exist or is not a directory", _outputDir);
     }
+    File outputFile = new File(outputDir, _pinotSchemaName + ".json");
+    LOGGER.info("Store Pinot schema to file: {}", outputFile.getAbsolutePath());
 
-    String avroFileName = _avroSchemaFileName;
-    if (avroFileName == null) {
-      avroFileName = _avroDataFileName;
+    try (FileWriter writer = new FileWriter(outputFile)) {
+      writer.write(schema.toString());
     }
-
-    // Remove extension
-    String schemaName = avroFileName.replaceAll("\\..*", "");
-    schema.setSchemaName(schemaName);
-
-    if (_pinotSchemaFileName == null) {
-      _pinotSchemaFileName = schemaName + ".json";
-
-      LOGGER.info("Using {} as the Pinot schema file name", _pinotSchemaFileName);
-    }
-
-    ObjectMapper objectMapper = new ObjectMapper();
-    String schemaString = objectMapper.defaultPrettyPrintingWriter().writeValueAsString(schema);
-
-    PrintWriter printWriter = new PrintWriter(_pinotSchemaFileName);
-    printWriter.println(schemaString);
-    printWriter.close();
 
     return true;
   }
 
   @Override
   public String description() {
-    return "Converting Avro schema to Pinot schema.";
+    return "Extracting Pinot schema file from Avro schema or data file.";
   }
 
   @Override
@@ -124,9 +111,9 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
 
   @Override
   public String toString() {
-    return "AvroSchemaToPinotSchema -avroSchemaFileName " + _avroSchemaFileName + " -pinotSchemaFileName " +
-        _pinotSchemaFileName + " -dimensions " + _dimensions + " -metrics " + _metrics + " -timeColumnName " +
-        _timeColumnName + " -timeUnit " + _timeUnit;
+    return "AvroSchemaToPinotSchema -avroSchemaFile " + _avroSchemaFile + " -avroDataFile " + _avroDataFile
+        + " -outputDir " + _outputDir + " -pinotSchemaName " + _pinotSchemaName + " -dimensions " + _dimensions
+        + " -metrics " + _metrics + " -timeColumnName " + _timeColumnName + " -timeUnit " + _timeUnit;
   }
 
   /**
@@ -136,19 +123,17 @@ public class AvroSchemaToPinotSchema extends AbstractBaseAdminCommand implements
    * @return The column <-> fieldType map.
    */
   private Map<String, FieldSpec.FieldType> buildFieldTypesMap() {
-    Map<String, FieldSpec.FieldType> fieldTypes = new HashMap<String, FieldSpec.FieldType>();
+    Map<String, FieldSpec.FieldType> fieldTypes = new HashMap<>();
     if (_dimensions != null) {
       for (String column : _dimensions.split("\\s*,\\s*")) {
         fieldTypes.put(column, FieldSpec.FieldType.DIMENSION);
       }
     }
-
     if (_metrics != null) {
       for (String column : _metrics.split("\\s*,\\s*")) {
         fieldTypes.put(column, FieldSpec.FieldType.METRIC);
       }
     }
-
     if (_timeColumnName != null) {
       fieldTypes.put(_timeColumnName, FieldSpec.FieldType.TIME);
     }


### PR DESCRIPTION
1. When field type is not specified, always count it as dimension
2. Change AvroSchemaToPinotSchema tool to print simplified schema without redundant fields