### PR TITLE
[TE] Compress anomaly timelines view when the size is too large

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/AnomalyTimelinesView.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/AnomalyTimelinesView.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 public class AnomalyTimelinesView {
   private static final Logger LOG = LoggerFactory.getLogger(AnomalyTimelinesView.class);
   private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static int DEFAULT_MAX_SIZE = CondensedAnomalyTimelinesView.DEFAULT_MAX_LENGTH;
 
   List<TimeBucket> timeBuckets = new ArrayList<>();
   Map<String, String> summary = new HashMap<>();
@@ -64,7 +65,7 @@ public class AnomalyTimelinesView {
    */
   public String toJsonString() throws JsonProcessingException {
     // Convert the new AnomalyTimelinesView to condensed one
-    return CondensedAnomalyTimelinesView.fromAnomalyTimelinesView(this).toJsonString();
+    return CondensedAnomalyTimelinesView.fromAnomalyTimelinesView(this).compress(DEFAULT_MAX_SIZE).toJsonString();
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/CondensedAnomalyTimelinesView.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/views/CondensedAnomalyTimelinesView.java
@@ -27,6 +27,7 @@ public class CondensedAnomalyTimelinesView {
   public static final Long DEFAULT_MIN_BUCKET_UNIT = Minutes.ONE.toStandardDuration().getMillis();
 
   Long timestampOffset = 0l; // the timestamp offset of the original time series
+  Long minBucketUnit = 1l;
   Long bucketMillis = 0l;  // the bucket size of original time series
   List<Long> timeStamps = new ArrayList<>(); // the start time of data points
   Map<String, String> summary = new HashMap<>(); // the summary of the view
@@ -40,9 +41,10 @@ public class CondensedAnomalyTimelinesView {
   public CondensedAnomalyTimelinesView(Long bucketMillis, List<Long> timeStamps, List<Double> currentValues,
       List<Double> baselineValues, Map<String, String> summary) {
     this.timestampOffset = timeStamps.get(0);
-    this.bucketMillis = bucketMillis / DEFAULT_MIN_BUCKET_UNIT;
+    this.minBucketUnit = DEFAULT_MIN_BUCKET_UNIT;
+    this.bucketMillis = bucketMillis / minBucketUnit;
     for (long timestamp : timeStamps) {
-      this.timeStamps.add((timestamp - timestampOffset)/DEFAULT_MIN_BUCKET_UNIT);
+      this.timeStamps.add((timestamp - timestampOffset)/minBucketUnit);
     }
     this.summary = summary;
     this.currentValues = currentValues;
@@ -97,6 +99,14 @@ public class CondensedAnomalyTimelinesView {
     this.timestampOffset = timestampOffset;
   }
 
+  public Long getMinBucketUnit() {
+    return minBucketUnit;
+  }
+
+  public void setMinBucketUnit(Long minBucketUnit) {
+    this.minBucketUnit = minBucketUnit;
+  }
+
   /**
    * Convert current instance to an AnomalyTimelinesView instance
    * @return
@@ -105,10 +115,10 @@ public class CondensedAnomalyTimelinesView {
     AnomalyTimelinesView anomalyTimelinesView = new AnomalyTimelinesView();
     for (int i = 0; i < timeStamps.size(); i++) {
       long startTime = timeStamps.get(i);
-      TimeBucket timeBucket = new TimeBucket(startTime * DEFAULT_MIN_BUCKET_UNIT + timestampOffset,
-          (startTime + bucketMillis) * DEFAULT_MIN_BUCKET_UNIT + timestampOffset,
-          startTime * DEFAULT_MIN_BUCKET_UNIT + timestampOffset,
-          (startTime + bucketMillis) * DEFAULT_MIN_BUCKET_UNIT + timestampOffset);
+      TimeBucket timeBucket = new TimeBucket(startTime * minBucketUnit + timestampOffset,
+          (startTime + bucketMillis) * minBucketUnit + timestampOffset,
+          startTime * minBucketUnit + timestampOffset,
+          (startTime + bucketMillis) * minBucketUnit + timestampOffset);
       anomalyTimelinesView.addTimeBuckets(timeBucket);
       anomalyTimelinesView.addBaselineValues(baselineValues.get(i));
       anomalyTimelinesView.addCurrentValues(currentValues.get(i));

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/views/TestCondensedAnomalyTimelinesView.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/anomaly/views/TestCondensedAnomalyTimelinesView.java
@@ -1,0 +1,70 @@
+package com.linkedin.thirdeye.anomaly.views;
+
+import com.linkedin.thirdeye.dashboard.views.TimeBucket;
+import org.joda.time.DateTime;
+import org.joda.time.Hours;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestCondensedAnomalyTimelinesView {
+  private AnomalyTimelinesView getTestData(int num) {
+    DateTime date = new DateTime(2018, 1, 1, 0, 0, 0);
+    AnomalyTimelinesView view = new AnomalyTimelinesView();
+    for(int i = 0; i < num; i++) {
+      view.addTimeBuckets(new TimeBucket(date.getMillis(), date.plusHours(1).getMillis(), date.getMillis(), date.plusHours(1).getMillis()));
+      view.addCurrentValues((double) i);
+      view.addBaselineValues(i + 0.1);
+      date = date.plusHours(1);
+    }
+    view.addSummary("test", "test");
+    return view;
+  }
+  @Test
+  public void testFromAnomalyTimelinesView() {
+    int testNum = 100;
+    long minBucketMillis = CondensedAnomalyTimelinesView.DEFAULT_MIN_BUCKET_UNIT;
+    CondensedAnomalyTimelinesView condensedView = CondensedAnomalyTimelinesView.fromAnomalyTimelinesView(getTestData(testNum));
+    Assert.assertEquals(condensedView.bucketMillis.longValue(), Hours.ONE.toStandardDuration().getMillis() / minBucketMillis);
+    Assert.assertEquals(condensedView.getTimeStamps().size(), testNum);
+
+    DateTime date = new DateTime(2018, 1, 1, 0, 0, 0);
+    for (int i = 0; i < testNum; i++) {
+      Assert.assertEquals(condensedView.getTimeStamps().get(i).longValue(), date.getMillis() / minBucketMillis);
+      Assert.assertEquals(condensedView.getCurrentValues().get(i), i + 0d);
+      Assert.assertEquals(condensedView.getBaselineValues().get(i), i + 0.1);
+      date = date.plusHours(1);
+    }
+  }
+
+  @Test
+  public void testCompress() throws Exception {
+    int testNum = 1000;
+    long minBucketMillis = CondensedAnomalyTimelinesView.DEFAULT_MIN_BUCKET_UNIT;
+    CondensedAnomalyTimelinesView condensedView = CondensedAnomalyTimelinesView.fromAnomalyTimelinesView(getTestData(testNum));
+    Assert.assertTrue(condensedView.toJsonString().length() > CondensedAnomalyTimelinesView.DEFAULT_MAX_LENGTH);
+
+    CondensedAnomalyTimelinesView compressedView = condensedView.compress();
+    Assert.assertTrue(compressedView.toJsonString().length() < CondensedAnomalyTimelinesView.DEFAULT_MAX_LENGTH);
+    Assert.assertEquals(compressedView.bucketMillis.longValue(), 14400l);
+    DateTime date = new DateTime(2018, 1, 1, 0, 0, 0);
+    for (int i = 0; i < compressedView.getTimeStamps().size(); i++) {
+      Assert.assertEquals(compressedView.getTimeStamps().get(i).longValue(), date.getMillis() / minBucketMillis);
+      Assert.assertEquals(compressedView.getCurrentValues().get(i), i * 4 + 1.5, 0.000001);
+      Assert.assertEquals(compressedView.getBaselineValues().get(i), i * 4 + 1.6, 0.000001);
+      date = date.plusHours(4);
+    }
+
+    AnomalyTimelinesView decompressedView = compressedView.toAnomalyTimelinesView();
+    date = new DateTime(2018, 1, 1, 0, 0, 0);
+    for (int i = 0; i < decompressedView.getBaselineValues().size(); i++) {
+      TimeBucket timeBucket = decompressedView.getTimeBuckets().get(i);
+      Assert.assertEquals(timeBucket.getCurrentStart(), date.getMillis());
+      Assert.assertEquals(timeBucket.getCurrentEnd(), date.plusHours(4).getMillis());
+      Assert.assertEquals(decompressedView.getCurrentValues().get(i), i * 4 + 1.5, 0.000001);
+      Assert.assertEquals(decompressedView.getBaselineValues().get(i), i * 4 + 1.6, 0.000001);
+      date = date.plusHours(4);
+    }
+
+  }
+}


### PR DESCRIPTION
As the anomaly timelines view is also stored along with the anomaly result, we occasionally see exception of json_value overflow. Main reason is because of the size of anomaly timelines view stored in the system. To tackle this problem, we compress the view and save more space . 