### PR TITLE
[TE] Add batch update and update batch deletion of DB manager

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AbstractManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AbstractManager.java
@@ -13,6 +13,8 @@ public interface AbstractManager<E extends AbstractDTO> {
 
   int update(E entity);
 
+  int update(List<E> entities);
+
   E findById(Long id);
 
   int delete(E entity);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
@@ -75,9 +75,6 @@ public abstract class AbstractManagerImpl<E extends AbstractDTO> implements Abst
   public int update(List<E> entities) {
     ArrayList<AbstractBean> beans = new ArrayList<>();
     for (E entity : entities) {
-      if (entity.getId() == null) {
-        throw new IllegalArgumentException(String.format("Need an ID to update the DB entity: %s", entity.toString()));
-      }
       beans.add(convertDTO2Bean(entity, beanClass));
     }
     return genericPojoDao.update(beans);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
@@ -70,6 +70,19 @@ public abstract class AbstractManagerImpl<E extends AbstractDTO> implements Abst
     return genericPojoDao.update(bean);
   }
 
+  // Test is located at TestAlertConfigManager.testBatchUpdate()
+  @Override
+  public int update(List<E> entities) {
+    ArrayList<AbstractBean> beans = new ArrayList<>();
+    for (E entity : entities) {
+      if (entity.getId() == null) {
+        throw new IllegalArgumentException(String.format("Need an ID to update the DB entity: %s", entity.toString()));
+      }
+      beans.add(convertDTO2Bean(entity, beanClass));
+    }
+    return genericPojoDao.update(beans);
+  }
+
   public E findById(Long id) {
     AbstractBean abstractBean = genericPojoDao.get(id, beanClass);
     if (abstractBean != null) {
@@ -85,6 +98,7 @@ public abstract class AbstractManagerImpl<E extends AbstractDTO> implements Abst
     return genericPojoDao.delete(entity.getId(), beanClass);
   }
 
+  // Test is located at TestAlertConfigManager.testBatchDeletion()
   @Override
   public int deleteById(Long id) {
     return genericPojoDao.delete(id, beanClass);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datalayer.dao;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.linkedin.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
@@ -64,6 +65,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -239,7 +241,16 @@ public class GenericPojoDao {
     }
   }
 
-  public <E extends AbstractBean> int update(final List<E> pojos) throws IllegalArgumentException {
+  /**
+   * Update the list of pojos in batch mode. Every batch contains MAX_BATCH_SIZE of entries. By default, this
+   * method update the batch of entries in one transaction. If any entries cause an exception, this method
+   * will update the entries one-by-one (i.e., in separated transactions) and skip the one that causes exceptions.
+   *
+   * @param pojos the pojo to be updated, whose ID cannot be null; otherwise, it will be ignored.
+   *
+   * @return the number of rows that are affected.
+   */
+  public <E extends AbstractBean> int update(final List<E> pojos) {
     if (CollectionUtils.isEmpty(pojos)) {
       return 0;
     }
@@ -253,14 +264,21 @@ public class GenericPojoDao {
       return runTask(new QueryTask<Integer>() {
         @Override
         public Integer handle(Connection connection) throws Exception {
+          if (CollectionUtils.isEmpty(pojos)) {
+            return 0;
+          }
+
           int updateCounter = 0;
           int minIdx = 0;
           int maxIdx = MAX_BATCH_SIZE;
-          connection.setAutoCommit(false); // Enable transaction mode
+          boolean isAutoCommit = connection.getAutoCommit();
+          // Ensure that transaction mode is enabled
+          connection.setAutoCommit(false);
           while (minIdx < pojos.size()) {
             List<E> subList = pojos.subList(minIdx, Math.min(maxIdx, pojos.size()));
             try {
               for (E pojo : subList) {
+                Preconditions.checkNotNull(pojo.getId());
                 addUpdateToConnection(pojo, Predicate.EQ("id", pojo.getId()), connection);
               }
               // Trigger commit() to ensure this batch of deletion is executed
@@ -272,8 +290,9 @@ public class GenericPojoDao {
               // Unable to do batch because of exception; fall back to single row deletion mode.
               for (final E pojo : subList) {
                 try {
-                  updateCounter += addUpdateToConnection(pojo, Predicate.EQ("id", pojo.getId()), connection);
+                  int updateRow = addUpdateToConnection(pojo, Predicate.EQ("id", pojo.getId()), connection);
                   connection.commit();
+                  updateCounter += updateRow;
                 } catch (Exception e1) {
                   connection.rollback();
                   LOG.error("Exception while executing query task; skipping entity (id={})", pojo.getId(), e);
@@ -283,6 +302,8 @@ public class GenericPojoDao {
             minIdx = maxIdx;
             maxIdx = maxIdx + MAX_BATCH_SIZE;
           }
+          // Restore the original state of connection's auto commit
+          connection.setAutoCommit(isAutoCommit);
           return updateCounter;
         }
       }, 0);
@@ -647,41 +668,75 @@ public class GenericPojoDao {
       return runTask(new QueryTask<Integer>() {
         @Override
         public Integer handle(Connection connection) throws Exception {
-          PojoInfo pojoInfo = pojoInfoMap.get(pojoClass);
-          int totalBaseRowsDeleted = 0;
-          if (CollectionUtils.isNotEmpty(idsToDelete)) {
-            int minIdx = 0;
-            int maxIdx = MAX_BATCH_SIZE;
-            while (minIdx < idsToDelete.size()) {
-              List<Long> subList = idsToDelete.subList(minIdx, Math.min(maxIdx, idsToDelete.size()));
-              //delete the ids from both base table and index table
-              int indexRowsDeleted;
-              try (PreparedStatement statement = sqlQueryBuilder.createDeleteStatement(connection,
-                  pojoInfo.indexEntityClass, subList, true)) {
-                indexRowsDeleted = statement.executeUpdate();
-              }
-              int baseRowsDeleted;
-              try (PreparedStatement baseTableDeleteStatement = sqlQueryBuilder
-                  .createDeleteStatement(connection, GenericJsonEntity.class, subList, false)) {
-                baseRowsDeleted = baseTableDeleteStatement.executeUpdate();
-              }
-              assert (baseRowsDeleted == indexRowsDeleted);
+          if (CollectionUtils.isEmpty(idsToDelete)) {
+            return 0;
+          }
 
-              totalBaseRowsDeleted += baseRowsDeleted;
-              minIdx = Math.min(maxIdx, idsToDelete.size());
-              maxIdx += MAX_BATCH_SIZE;
+          boolean isAutoCommit = connection.getAutoCommit();
+          // Ensure that transaction mode is enabled
+          connection.setAutoCommit(false);
+          Class<? extends AbstractIndexEntity> indexEntityClass = pojoInfoMap.get(pojoClass).indexEntityClass;
+          int updateCounter = 0;
+          int minIdx = 0;
+          int maxIdx = MAX_BATCH_SIZE;
+          while (minIdx < idsToDelete.size()) {
+            List<Long> subList = idsToDelete.subList(minIdx, Math.min(maxIdx, idsToDelete.size()));
+            try {
+              int updatedBaseRow = addBatchDeletionToConnection(subList, indexEntityClass, connection);
               // Trigger commit() to ensure this batch of deletion is executed
-              if (!connection.getAutoCommit()) {
-                connection.commit();
+              connection.commit();
+              updateCounter += updatedBaseRow;
+            } catch (Exception e) {
+              // Error recovery: rollback previous changes.
+              connection.rollback();
+              // Unable to do batch because of exception; fall back to single row deletion mode.
+              for (final Long pojoId : subList) {
+                try {
+                  int updatedBaseRow =
+                      addBatchDeletionToConnection(Collections.singletonList(pojoId), indexEntityClass, connection);
+                  connection.commit();
+                  updateCounter += updatedBaseRow;
+                } catch (Exception e1) {
+                  connection.rollback();
+                  LOG.error("Exception while executing query task; skipping entity (id={})", pojoId, e);
+                }
               }
             }
+            minIdx = Math.min(maxIdx, idsToDelete.size());
+            maxIdx += MAX_BATCH_SIZE;
           }
-          return totalBaseRowsDeleted;
+          // Restore the original state of connection's auto commit
+          connection.setAutoCommit(isAutoCommit);
+          return updateCounter;
         }
       }, 0);
     } finally {
       ThirdeyeMetricsUtil.dbWriteCallCounter.inc();
       ThirdeyeMetricsUtil.dbWriteDurationCounter.inc(System.nanoTime() - tStart);
+    }
+  }
+
+  /**
+   * Delete the given ids from base table and index table.
+   *
+   * @param idsToDelete the IDs to be deleted
+   * @param indexEntityClass the index entity of the entities in the ID list; this method assumes that these entities
+   *                         to be deleted belong to the same index entity
+   * @param connection the connection to the database.
+   *
+   * @return the number of base rows that are deleted.
+   *
+   * @throws Exception any exception from DB.
+   */
+  private <E extends AbstractBean> int addBatchDeletionToConnection(List<Long> idsToDelete,
+      Class<? extends AbstractIndexEntity> indexEntityClass, Connection connection) throws Exception {
+    try (PreparedStatement statement = sqlQueryBuilder.createDeleteStatement(connection, indexEntityClass, idsToDelete,
+        true)) {
+      statement.executeUpdate();
+    }
+    try (PreparedStatement baseTableDeleteStatement = sqlQueryBuilder.createDeleteStatement(connection,
+        GenericJsonEntity.class, idsToDelete, false)) {
+      return baseTableDeleteStatement.executeUpdate();
     }
   }
 
@@ -702,11 +757,12 @@ public class GenericPojoDao {
       // Enable transaction
       connection.setAutoCommit(false);
       T t = task.handle(connection);
+      // Commit this transaction
       connection.commit();
       return t;
     } catch (Exception e) {
       LOG.error("Exception while executing query task", e);
-      // Rollback data in case json table is updated but index table isn't due to error (duplicate key, etc.)
+      // Rollback transaction in case json table is updated but index table isn't due to any errors (duplicate key, etc.)
       if (connection != null) {
         try {
           connection.rollback();
@@ -716,6 +772,7 @@ public class GenericPojoDao {
       }
       return defaultReturnValue;
     } finally {
+      // Always close connection before leaving
       if (connection != null) {
         try {
           connection.close();

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AlertConfigBean.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.eclipse.jetty.util.StringUtil;
 
 
@@ -309,5 +310,33 @@ public class AlertConfigBean extends AbstractBean {
 
   public enum COMPARE_MODE {
     WoW, Wo2W, Wo3W, Wo4W
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AlertConfigBean that = (AlertConfigBean) o;
+    return isActive() == that.isActive() && Objects.equals(getName(), that.getName()) && Objects
+        .equals(getApplication(), that.getApplication()) && Objects
+        .equals(getCronExpression(), that.getCronExpression()) && Objects
+        .equals(getHolidayCronExpression(), that.getHolidayCronExpression()) && Objects
+        .equals(getAnomalyFeedConfig(), that.getAnomalyFeedConfig()) && Objects
+        .equals(getEmailConfig(), that.getEmailConfig()) && Objects
+        .equals(getReportConfigCollection(), that.getReportConfigCollection()) && Objects
+        .equals(getAlertGroupConfig(), that.getAlertGroupConfig()) && Objects
+        .equals(getEmailFormatterConfig(), that.getEmailFormatterConfig()) && Objects
+        .equals(getRecipients(), that.getRecipients()) && Objects.equals(getFromAddress(), that.getFromAddress());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getApplication(), getCronExpression(), getHolidayCronExpression(), isActive(),
+        getAnomalyFeedConfig(), getEmailConfig(), getReportConfigCollection(), getAlertGroupConfig(),
+        getEmailFormatterConfig(), getRecipients(), getFromAddress());
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/SqlQueryBuilder.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/util/SqlQueryBuilder.java
@@ -230,16 +230,16 @@ public class SqlQueryBuilder {
     return prepareStatement;
   }
 
-  public PreparedStatement createDeleteStatement(Connection connection,
-      Class<? extends AbstractEntity> entityClass, List<Long> ids, boolean isIndexTable) throws Exception {
+  public PreparedStatement createDeleteStatement(Connection connection, Class<? extends AbstractEntity> entityClass,
+      List<Long> ids, boolean useBaseId) throws Exception {
     if (ids == null || ids.isEmpty()) {
       throw new IllegalArgumentException("ids to delete cannot be null/empty");
     }
     String tableName =
         entityMappingHolder.tableToEntityNameMap.inverse().get(entityClass.getSimpleName());
     StringBuilder sqlBuilder = new StringBuilder("DELETE FROM " + tableName);
-    String whereString = " WHERE  id IN( ";
-    if (isIndexTable) {
+    String whereString = " WHERE id IN( ";
+    if (useBaseId) {
       whereString = " WHERE base_id IN( ";
     }
     StringBuilder whereClause = new StringBuilder(whereString);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAlertConfigManager.java
@@ -1,20 +1,25 @@
 package com.linkedin.thirdeye.datalayer.bao;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.alert.commons.AnomalyFeedConfig;
 import com.linkedin.thirdeye.datalayer.DaoTestUtils;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
+import com.linkedin.thirdeye.datalayer.util.Predicate;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import java.util.ArrayList;
+import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-public class TestAlertConfigManager{
+public class TestAlertConfigManager {
 
   Long alertConfigid;
-
   private DAOTestBase testDAOProvider;
   private AlertConfigManager alertConfigDAO;
+  private List<Long> batchAlertConfigIdList = new ArrayList<>();
+
   @BeforeClass
   void beforeClass() {
     testDAOProvider = DAOTestBase.getInstance();
@@ -72,4 +77,117 @@ public class TestAlertConfigManager{
     alertConfigDAO.deleteById(alertConfigid);
     Assert.assertEquals(alertConfigDAO.findAll().size(), 0);
   }
+
+  /*
+   * The Following section is the tests for AbstractManagerImpl and GenericPojoDao, which doesn't have a concrete class
+   * to be tested upon.
+   */
+  private List<AlertConfigDTO> createBatchAlertConfigs() {
+    List<AlertConfigDTO> alertConfigList = new ArrayList<>();
+    alertConfigList.add(createAlertConfig("1"));
+    alertConfigList.add(createAlertConfig("2"));
+    alertConfigList.add(createAlertConfig("3"));
+    return alertConfigList;
+  }
+
+  private AlertConfigDTO createAlertConfig(String name) {
+    AlertConfigDTO alertConfigDTO = new AlertConfigDTO();
+    alertConfigDTO.setName(name);
+    return alertConfigDTO;
+  }
+
+  @Test (expectedExceptions = IllegalArgumentException.class)
+  public void testNullUpdate() {
+    AlertConfigDTO alertConfig = createAlertConfig("nullID");
+    alertConfigDAO.update(alertConfig);
+  }
+
+  @Test (dependsOnMethods = "testDeleteAlertConfig")
+  public void testBatchUpdate() {
+    List<AlertConfigDTO> initAlertConfigs = createBatchAlertConfigs();
+    // Add multiple alert config to DB
+    for (AlertConfigDTO alertConfig : initAlertConfigs) {
+      alertConfig.setActive(false); // set the flag to false so we can update it later
+      Long id = alertConfigDAO.save(alertConfig);
+      batchAlertConfigIdList.add(id);
+    }
+
+    // Update previously saved alert configs
+    List<AlertConfigDTO> readBackAlertConfigs = new ArrayList<>();
+    for (Long alertId : batchAlertConfigIdList) {
+      AlertConfigDTO readBackAlert = alertConfigDAO.findById(alertId);
+      readBackAlert.setActive(true); // set to true to test batch update
+      readBackAlertConfigs.add(readBackAlert);
+    }
+    int affectedRows = alertConfigDAO.update(readBackAlertConfigs);
+    Assert.assertEquals(affectedRows, 3);
+
+    // Check if batch update works
+    for (Long alertId : batchAlertConfigIdList) {
+      AlertConfigDTO updatedAlert = alertConfigDAO.findById(alertId);
+      Assert.assertEquals(updatedAlert.isActive(), true);
+    }
+  }
+
+  @Test (dependsOnMethods = {"testBatchUpdate"})
+  public void testBatchDeletion() {
+    // Ensure that there are multiple alert configs in the DB; otherwise, this test is meaningless.
+    Preconditions.checkState(batchAlertConfigIdList.size() > 1);
+    for (Long alertId : batchAlertConfigIdList) {
+      Preconditions.checkState(alertConfigDAO.findById(alertId) != null);
+    }
+
+    // Delete by batch
+    alertConfigDAO.deleteByIds(batchAlertConfigIdList);
+    for (Long alertId : batchAlertConfigIdList) {
+      Assert.assertEquals(alertConfigDAO.findById(alertId), null);
+    }
+  }
+
+  @Test (dependsOnMethods = "testBatchDeletion")
+  public void testInterruptedBatchUpdate() {
+    List<AlertConfigDTO> initAlertConfigs = createBatchAlertConfigs();
+    List<Long> localBatchAlertConfigIdList = new ArrayList<>();
+    // Add multiple alert config to DB
+    for (AlertConfigDTO alertConfig : initAlertConfigs) {
+      Long id = alertConfigDAO.save(alertConfig);
+      localBatchAlertConfigIdList.add(id);
+    }
+
+    // Update previously saved alert configs
+    List<AlertConfigDTO> readBackAlertConfigs = new ArrayList<>();
+    for (Long alertId : localBatchAlertConfigIdList) {
+      AlertConfigDTO readBackAlert = alertConfigDAO.findById(alertId);
+      // Everyone update to the same name in order to trigger DB error
+      readBackAlert.setName("4");
+      readBackAlertConfigs.add(readBackAlert);
+    }
+    // Due to duplicate alert name, only the first alert config will be updated and
+    // the other two will be ignored.
+    int affectedRows = alertConfigDAO.update(readBackAlertConfigs);
+    Assert.assertEquals(affectedRows, 1);
+
+    // Check if batch update works; index table is also checked using findByPredicate() method.
+    AlertConfigDTO firstAlert = alertConfigDAO.findById(localBatchAlertConfigIdList.get(0));
+    Assert.assertEquals(firstAlert.getName(), "4");
+    Assert.assertEquals(alertConfigDAO.findByPredicate(Predicate.EQ("name", "1")).size(), 0);
+    Assert.assertEquals(alertConfigDAO.findByPredicate(Predicate.EQ("name", "4")).get(0), firstAlert);
+
+    AlertConfigDTO secondAlert = alertConfigDAO.findById(localBatchAlertConfigIdList.get(1));
+    Assert.assertEquals(secondAlert.getName(), "2");
+    Assert.assertEquals(alertConfigDAO.findByPredicate(Predicate.EQ("name", "2")).get(0), secondAlert);
+
+    AlertConfigDTO thirdAlert = alertConfigDAO.findById(localBatchAlertConfigIdList.get(2));
+    Assert.assertEquals(thirdAlert.getName(), "3");
+    Assert.assertEquals(alertConfigDAO.findByPredicate(Predicate.EQ("name", "3")).get(0), thirdAlert);
+  }
+
+  @Test (expectedExceptions = IllegalArgumentException.class)
+  public void testBatchUpdateWithNullID() {
+    List<AlertConfigDTO> initAlertConfigs = createBatchAlertConfigs();
+    alertConfigDAO.update(initAlertConfigs);
+  }
+  /*
+   * End of the section for the tests of AbstractManagerImpl and GenericPojoDao.
+   */
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/AbstractMockManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/AbstractMockManager.java
@@ -19,6 +19,11 @@ public abstract class AbstractMockManager<T extends AbstractDTO> implements Abst
   }
 
   @Override
+  public int update(List<T> entities) {
+    throw new AssertionError("not implemented");
+  }
+
+  @Override
   public T findById(Long id) {
     throw new AssertionError("not implemented");
   }


### PR DESCRIPTION
ThirdEye's MONITOR and DATA COMPLETENESS procedures both update or delete huge batches of records. Previously, we use a for-loop to delete or update single lines, which could take up to 8 hours for a DATA COMPLETENESS task and 10+ minutes for a MONITOR task to finish. With the batch update and deletion, the data completeness and monitor takes only 3 minutes and 5 seconds to finish.