### PR TITLE
[TE] time range pill selector component and installation

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
@@ -32,6 +32,8 @@ const DEFAULT_END_DATE = moment().startOf('day').add(1, 'days');
 
 export default Component.extend({
 
+  classNames: ['range-pill-selectors'],
+
   /**
    * Properties we expect to receive for the date-range-picker
    */
@@ -65,17 +67,11 @@ export default Component.extend({
       return {
         name: range.name,
         value: range.value,
-        isActive: false,
+        isActive: range.value === activeKey,
         start,
         end
       };
     });
-
-    // Activate the last clicked option
-    const foundRangeOption = newOptions.find((range) => range.value === activeKey);
-    if (foundRangeOption) {
-      foundRangeOption.isActive = true;
-    }
 
     return newOptions;
   },
@@ -85,7 +81,7 @@ export default Component.extend({
      * Invokes the passed selectAction closure action
      */
     selectAction(rangeObj) {
-      const action = this.attrs.selectAction;
+      const action = this.get('selectAction');
       if (action) {
         return action(rangeObj);
       }

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
@@ -6,6 +6,7 @@
  * @property {Date} activeRangeStart - default start date for range picker
  * @property {Date} activeRangeEnd - default end date for range picker
  * @property {String} uiDateFormat - date format specified by parent route (often specific to metric granularity)
+ * @property {Action} selectAction - closure action from parent
  * @example
   {{range-pill-selectors
     timeRangeOptions=timeRangeOptions

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
@@ -1,0 +1,125 @@
+/**
+ * Component to render pre-set time range selection pills and a 'custom' one using date-range-picker.
+ * @module components/range-pill-selectors
+ * @property {Object} timeRangeOptions - object containing our range options
+ * @property {Number} timePickerIncrement - determines selectable time increment in date-range-picker
+ * @property {Date} activeRangeStart - default start date for range picker
+ * @property {Date} activeRangeEnd - default end date for range picker
+ * @property {String} uiDateFormat - date format specified by parent route (often specific to metric granularity)
+ * @example
+  {{range-pill-selectors
+    timeRangeOptions=timeRangeOptions
+    timePickerIncrement=5
+    maxTime=maxTime
+    activeRangeStart=activeRangeStart
+    activeRangeEnd=activeRangeEnd
+    uiDateFormat=uiDateFormat
+    selectAction=(action "onRangeSelection")
+  }}
+ * @exports range-pill-selectors
+ * @author smcclung
+ */
+
+import Component from '@ember/component';
+import moment from 'moment';
+import { buildDateEod } from 'thirdeye-frontend/utils/utils';
+
+const RANGE_FORMAT = 'YYYY-MM-DD HH:mm';
+const DEFAULT_END_DATE = buildDateEod(1, 'day').valueOf();
+
+export default Component.extend({
+
+  /**
+   * Properties we expect to receive for the date-range-picker
+   */
+  maxTime: '',
+  timeRangeOptions: '',
+  timePickerIncrement: 5,
+  activeRangeStart: '',
+  activeRangeEnd: '',
+  serverFormat: RANGE_FORMAT,
+
+  /**
+   * A set of arbitrary time ranges to help user with quick selection in date-time-picker
+   */
+  predefinedRanges: {
+    'Today': [moment(), moment().startOf('day').add(1, 'days')],
+    'Last 3 days': [moment().subtract(2, 'days').startOf('day'), moment().startOf('day').add(1, 'days')],
+    'Last 7 days': [moment().subtract(6, 'days').startOf('day'), moment().startOf('day').add(1, 'days')],
+    'Last 14 days': [moment().subtract(13, 'days').startOf('day'), moment().startOf('day').add(1, 'days')],
+    'Last 28 days': [moment().subtract(27, 'days').startOf('day'), moment().startOf('day').add(1, 'days')]
+  },
+
+  /**
+   * Reset all time range options and activate the selected one
+   * @method newTimeRangeOptions
+   * @param {String} activeKey - label for currently active time range
+   * @return {undefined}
+   */
+  newTimeRangeOptions(activeKey, start, end) {
+    const timeRangeOptions = this.get('timeRangeOptions');
+
+    // Generate a fresh new range opitons array - all inactive
+    const newOptions = timeRangeOptions.map((range) => {
+      return {
+        name: range.name,
+        value: range.value,
+        isActive: false,
+        start,
+        end
+      };
+    });
+
+    // Activate the last clicked option
+    const foundRangeOption = newOptions.find((range) => range.value === activeKey);
+    if (foundRangeOption) {
+      foundRangeOption.isActive = true;
+    }
+
+    return newOptions;
+  },
+
+  actions: {
+    /**
+     * Invokes the passed selectAction closure action
+     */
+    selectAction(rangeObj) {
+      const action = this.attrs.selectAction;
+      if (action) {
+        return action(rangeObj);
+      }
+    },
+
+    /**
+     * User applies a custom date in date-range-picker, which returns start/end.
+     * Highlight our 'custom' option and bubble it to the controller's 'selectAction'.
+     * @param {String} start - start date
+     * @param {String} end - end date
+     */
+    async onRangeSelection(start, end) {
+      const toggledOptions = this.newTimeRangeOptions('custom', start, end);
+      const customOption = toggledOptions.find(op => op.value === 'custom');
+      this.set('timeRangeOptions', toggledOptions);
+      await this.send('selectAction', customOption);
+    },
+
+    /**
+     * User clicks on a pre-set time range pill link. Highlight link and set active range in date-range-picker.
+     * @param {Object} rangeOption - the selected range object
+     */
+    async onRangeOptionClick(rangeOption) {
+      const { value, start, isActive } = rangeOption;
+      // Handle as a 'range click' only if inactive and not a custom range
+      if (value !== 'custom' && !isActive) {
+        // Set date picker defaults to new start/end dates
+        this.setProperties({
+          activeRangeStart: moment(rangeOption.start).format(RANGE_FORMAT),
+          activeRangeEnd: moment(DEFAULT_END_DATE).format(RANGE_FORMAT)
+        });
+        // Reset options and highlight selected one. Bubble selection to parent controller.
+        this.set('timeRangeOptions', this.newTimeRangeOptions(value, start, DEFAULT_END_DATE));
+        await this.send('selectAction', rangeOption);
+      }
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
@@ -65,12 +65,13 @@ export default Component.extend({
 
     // Generate a fresh new range opitons array - all inactive
     const newOptions = timeRangeOptions.map((range) => {
+      const { name, value } = range;
       return {
-        name: range.name,
-        value: range.value,
-        isActive: range.value === activeKey,
+        name,
+        value,
         start,
-        end
+        end,
+        isActive: value === activeKey
       };
     });
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
@@ -16,6 +16,9 @@
     uiDateFormat=uiDateFormat
     selectAction=(action "onRangeSelection")
   }}
+ * NOTE - timeRangeOptions format:
+ * [ { name: "3 Months", value: "3m", start: Moment, isActive: true },
+ *   { name: "Custom", value: "custom", start: null, isActive: false } ]
  * @exports range-pill-selectors
  * @author smcclung
  */
@@ -25,7 +28,7 @@ import moment from 'moment';
 import { buildDateEod } from 'thirdeye-frontend/utils/utils';
 
 const RANGE_FORMAT = 'YYYY-MM-DD HH:mm';
-const DEFAULT_END_DATE = buildDateEod(1, 'day').valueOf();
+const DEFAULT_END_DATE = moment().startOf('day').add(1, 'days');
 
 export default Component.extend({
 
@@ -43,11 +46,9 @@ export default Component.extend({
    * A set of arbitrary time ranges to help user with quick selection in date-time-picker
    */
   predefinedRanges: {
-    'Today': [moment(), moment().startOf('day').add(1, 'days')],
-    'Last 3 days': [moment().subtract(2, 'days').startOf('day'), moment().startOf('day').add(1, 'days')],
-    'Last 7 days': [moment().subtract(6, 'days').startOf('day'), moment().startOf('day').add(1, 'days')],
-    'Last 14 days': [moment().subtract(13, 'days').startOf('day'), moment().startOf('day').add(1, 'days')],
-    'Last 28 days': [moment().subtract(27, 'days').startOf('day'), moment().startOf('day').add(1, 'days')]
+    'Today': [DEFAULT_END_DATE],
+    'Last 1 month': [moment().subtract(1, 'months').startOf('day'), DEFAULT_END_DATE],
+    'Last 2 months': [moment().subtract(2, 'months').startOf('day'), DEFAULT_END_DATE]
   },
 
   /**

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/component.js
@@ -57,7 +57,7 @@ export default Component.extend({
    * Reset all time range options and activate the selected one
    * @method newTimeRangeOptions
    * @param {String} activeKey - label for currently active time range
-   * @return {undefined}
+   * @return {Array}
    */
   newTimeRangeOptions(activeKey, start, end) {
     const timeRangeOptions = this.get('timeRangeOptions');

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
@@ -1,0 +1,27 @@
+<div class="te-pill-selectors__wrapper">
+  {{!-- Date range selector --}}
+  <div class="te-pill-selectors__title">{{title}}</div>
+  <ul class="te-pill-selectors">
+    {{#each timeRangeOptions as |range|}}
+      <li class="te-pill-selectors__item {{if range.isActive "te-pill-selectors__item--active"}}" {{action "onRangeOptionClick" range}} data-value={{range.value}}>
+        {{range.name}}
+        {{#if (eq range.name "Custom")}}
+          : {{date-range-picker
+              class="te-pill-selectors__range-picker te-pill-selectors__range-picker--explore"
+              timePicker=false
+              timePicker24Hour=true
+              timePickerIncrement=timePickerIncrement
+              maxDate=maxTime
+              start=activeRangeStart
+              end=activeRangeEnd
+              ranges=predefinedRanges
+              showCustomRangeLabel=false
+              format=uiDateFormat
+              serverFormat=serverFormat
+              applyAction=(action "onRangeSelection")
+            }}
+        {{/if}}
+      </li>
+    {{/each}}
+  </ul>
+</div>

--- a/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/range-pill-selectors/template.hbs
@@ -1,27 +1,24 @@
-<div class="te-pill-selectors__wrapper">
-  {{!-- Date range selector --}}
-  <div class="te-pill-selectors__title">{{title}}</div>
-  <ul class="te-pill-selectors">
-    {{#each timeRangeOptions as |range|}}
-      <li class="te-pill-selectors__item {{if range.isActive "te-pill-selectors__item--active"}}" {{action "onRangeOptionClick" range}} data-value={{range.value}}>
-        {{range.name}}
-        {{#if (eq range.name "Custom")}}
-          : {{date-range-picker
-              class="te-pill-selectors__range-picker te-pill-selectors__range-picker--explore"
-              timePicker=false
-              timePicker24Hour=true
-              timePickerIncrement=timePickerIncrement
-              maxDate=maxTime
-              start=activeRangeStart
-              end=activeRangeEnd
-              ranges=predefinedRanges
-              showCustomRangeLabel=false
-              format=uiDateFormat
-              serverFormat=serverFormat
-              applyAction=(action "onRangeSelection")
-            }}
-        {{/if}}
-      </li>
-    {{/each}}
-  </ul>
-</div>
+<div class="range-pill-selectors__title">{{title}}</div>
+<ul class="range-pill-selectors__list">
+  {{#each timeRangeOptions as |range|}}
+    <li class="range-pill-selectors__item {{if range.isActive "range-pill-selectors__item--active"}}" {{action "onRangeOptionClick" range}} data-value={{range.value}}>
+      {{range.name}}
+      {{#if (eq range.name "Custom")}}
+        : {{date-range-picker
+            class="range-pill-selectors__range-picker range-pill-selectors__range-picker--explore"
+            timePicker=false
+            timePicker24Hour=true
+            timePickerIncrement=timePickerIncrement
+            maxDate=maxTime
+            start=activeRangeStart
+            end=activeRangeEnd
+            ranges=predefinedRanges
+            showCustomRangeLabel=false
+            format=uiDateFormat
+            serverFormat=serverFormat
+            applyAction=(action "onRangeSelection")
+          }}
+      {{/if}}
+    </li>
+  {{/each}}
+</ul>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/controller.js
@@ -231,7 +231,7 @@ export default Controller.extend({
    * @return {RSVP.Promise} A new list of functions (alerts)
    */
   prepareFunctions(configGroup) {
-    const existingFunctionList = configGroup.emailConfig ? configGroup.emailConfig.functionIds : [];
+    const existingFunctionList = getWithDefault(this, 'configGroup.emailConfig.functionIds', []);
     const newFunctionList = [];
     let cnt = 0;
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -87,7 +87,6 @@ export default Controller.extend({
       checkReplayInterval: 2000, // 2 seconds
       selectedDimension: 'All Dimensions',
       selectedResolution: 'All Resolutions',
-      dateRangeToRender: [30, 10, 5],
       currentPage: 1,
       pageSize: 10
     });
@@ -305,17 +304,6 @@ export default Controller.extend({
   ),
 
   /**
-   * Placeholder for options for range field. Here we generate arbitrary date ranges from our config.
-   * @type {Array}
-   */
-  rangeOptionsExample: computed(
-    'dateRangeToRender',
-    function() {
-      return this.get('dateRangeToRender').map(this.renderDate);
-    }
-  ),
-
-  /**
    * Find the active baseline option name
    * @type {String}
    */
@@ -440,7 +428,7 @@ export default Controller.extend({
    * @param {String} activeKey - label for currently active time range
    * @return {undefined}
    */
-  newTimeRangeOptions(activeKey) {
+/*  newTimeRangeOptions(activeKey) {
     const timeRangeOptions = this.get('timeRangeOptions');
     const newOptions = timeRangeOptions.map((range) => {
       return {
@@ -457,7 +445,7 @@ export default Controller.extend({
 
     return newOptions;
   },
-
+*/
   /**
    * Send a POST request to the report anomaly API (2-step process)
    * http://go/te-ss-alert-flow-api
@@ -689,47 +677,21 @@ export default Controller.extend({
     },
 
     /**
-     * Handle display of selected anomaly time ranges (reload the model with new query params)
-     * @method onRangeOptionClick
-     * @param {Object} rangeOption - the selected range object
-     */
-    onRangeOptionClick(rangeOption) {
-      const rangeFormat = 'YYYY-MM-DD HH:mm';
-      const defaultEndDate = buildDateEod(1, 'day').valueOf();
-      const timeRangeOptions = this.get('timeRangeOptions');
-      const duration = rangeOption.value;
-      const startDate = moment(rangeOption.start).valueOf();
-      const endDate = moment(defaultEndDate).valueOf();
-
-      if (rangeOption.value !== 'custom') {
-        // Set date picker defaults to new start/end dates
-        this.setProperties({
-          activeRangeStart: moment(rangeOption.start).format(rangeFormat),
-          activeRangeEnd: moment(defaultEndDate).format(rangeFormat)
-        });
-        // Reset options and highlight selected one
-        timeRangeOptions.forEach(op => set(op, 'isActive', false));
-        set(rangeOption, 'isActive', true);
-        // Cache chosen time range
-        setDuration(duration, startDate, endDate);
-        // Reload model according to new timerange
-        this.transitionToRoute({ queryParams: { mode: 'explore', duration, startDate, endDate }});
-      }
-    },
-
-    /**
-     * Sets the new custom date range for anomaly coverage. Also caches it.
+     * Sets the new custom date range for anomaly coverage
      * @method onRangeSelection
-     * @param {String} start  - stringified start date
-     * @param {String} end    - stringified end date
+     * @param {Object} rangeOption - the user-selected time range to load
      */
-    onRangeSelection(start, end) {
-      const duration = 'custom';
+    onRangeSelection(rangeOption) {
+      const {
+        start,
+        end,
+        value: duration
+      } = rangeOption;
       const startDate = moment(start).valueOf();
       const endDate = moment(end).valueOf();
-      this.set('timeRangeOptions', this.newTimeRangeOptions(duration));
+      // Cache the new time range and update page with it
       setDuration(duration, startDate, endDate);
-      this.transitionToRoute({ queryParams: { mode: 'explore', duration, startDate, endDate }});
+      this.transitionToRoute({ queryParams: { duration, startDate, endDate }});
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -423,30 +423,6 @@ export default Controller.extend({
   },
 
   /**
-   * Reset all time range options and activate the selected one
-   * @method newTimeRangeOptions
-   * @param {String} activeKey - label for currently active time range
-   * @return {undefined}
-   */
-/*  newTimeRangeOptions(activeKey) {
-    const timeRangeOptions = this.get('timeRangeOptions');
-    const newOptions = timeRangeOptions.map((range) => {
-      return {
-        name: range.name,
-        value: range.value,
-        isActive: false
-      };
-    });
-    const foundRangeOption = newOptions.find((range) => range.value === activeKey);
-
-    if (foundRangeOption) {
-      foundRangeOption.isActive = true;
-    }
-
-    return newOptions;
-  },
-*/
-  /**
    * Send a POST request to the report anomaly API (2-step process)
    * http://go/te-ss-alert-flow-api
    * @method reportAnomaly

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -21,7 +21,7 @@
     <div class="te-horizontal-cards te-content-block">
       <h4 class="te-self-serve__block-title">Alert Performance</h4>
       <p class="te-self-serve__block-subtext te-self-serve__block-subtext--narrow">All estimated performance numbers are based on reviewed anomalies.</p>
-      <a class="te-pill-selectors__side-link" {{action "onClickTuneSensitivity" this}}>
+      <a class="te-self-serve__side-link" {{action "onClickTuneSensitivity" this}}>
         <i class="glyphicon glyphicon-cog te-icon__inline-link"></i> Customize sensitivity
       </a>
       <div class="te-horizontal-cards__container">
@@ -51,44 +51,42 @@
 
     <div class="te-content-block">
       <h4 class="te-self-serve__block-title">Anomalies over time ({{#if anomaliesLoaded}}{{filteredAnomalies.length}}{{else}}...loading anomalies{{/if}})</h4>
-      <a class="te-pill-selectors__side-link te-pill-selectors__side-link--high" {{action "onClickReportAnomaly" this}}>Report missing anomaly</a>
+      <a class="te-self-serve__side-link te-self-serve__side-link--high" {{action "onClickReportAnomaly" this}}>Report missing anomaly</a>
 
       {{#if filteredAnomalies}}
-        <div class="te-pill-selectors__wrapper">
-          {{!-- Dimension selector --}}
-          {{#if alertHasDimensions}}
-            <div class="te-form__select te-form__select--wider col-md-3">
-              {{#power-select
-                triggerId="select-dimension"
-                triggerClass="te-form__select"
-                options=dimensionOptions
-                searchEnabled=false
-                matchTriggerWidth=true
-                matchContentWidth=true
-                selected=selectedDimension
-                onchange=(action "onSelectDimension")
-                as |dimension|
-              }}
-                {{dimension}}
-              {{/power-select}}
-            </div>
-          {{/if}}
-          {{!-- Resolution selector --}}
-          <div class="te-pill-selectors__range-picker col-md-3">
+        {{!-- Dimension selector --}}
+        {{#if alertHasDimensions}}
+          <div class="te-form__select te-form__select--wider col-md-3">
             {{#power-select
-              triggerId="select-resolution"
+              triggerId="select-dimension"
               triggerClass="te-form__select"
-              options=resolutionOptions
+              options=dimensionOptions
               searchEnabled=false
               matchTriggerWidth=true
               matchContentWidth=true
-              selected=selectedResolution
-              onchange=(action "onSelectResolution")
-              as |resolution|
+              selected=selectedDimension
+              onchange=(action "onSelectDimension")
+              as |dimension|
             }}
-              {{resolution}}
+              {{dimension}}
             {{/power-select}}
           </div>
+        {{/if}}
+        {{!-- Resolution selector --}}
+        <div class="col-md-3">
+          {{#power-select
+            triggerId="select-resolution"
+            triggerClass="te-form__select"
+            options=resolutionOptions
+            searchEnabled=false
+            matchTriggerWidth=true
+            matchContentWidth=true
+            selected=selectedResolution
+            onchange=(action "onSelectResolution")
+            as |resolution|
+          }}
+            {{resolution}}
+          {{/power-select}}
         </div>
       {{/if}}
 
@@ -141,16 +139,11 @@
 
       {{#if filteredAnomalies}}
         {{!-- Baseline type selector --}}
-        <div class="te-pill-selectors__wrapper">
-          <div class="te-pill-selectors__title">Baseline</div>
-          <ul class="te-pill-selectors">
-            {{#each baselineOptions as |baseline|}}
-              <li class="te-pill-selectors__item {{if baseline.isActive "te-pill-selectors__item--active"}}" {{action "onBaselineOptionClick" baseline}}>
-                {{baseline.name}}
-              </li>
-            {{/each}}
-          </ul>
-        </div>
+        {{range-pill-selectors
+          title="Baseline"
+          timeRangeOptions=baselineOptions
+          selectAction=(action "onBaselineOptionClick")
+        }}
       {{/if}}
 
       {{!-- Alert anomaly table --}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -1,32 +1,16 @@
 <div class="manage-alert-explore">
   {{#if (not isReplayPending)}}
-    <div class="te-pill-selectors">
-      {{!-- Date range selector --}}
-      <div class="te-pill-selectors__label">Showing</div>
-      <ul class="te-alert-page-hzlist">
-        {{#each timeRangeOptions as |range|}}
-          <li class="te-alert-page-hzlist__item {{if range.isActive "te-alert-page-hzlist__item--active"}}" {{action "onRangeOptionClick" range}}>
-            {{range.name}}
-            {{#if (eq range.name "Custom")}}
-              : {{date-range-picker
-                  class="te-pill-selectors__range-picker te-pill-selectors__range-picker--explore"
-                  timePicker=false
-                  timePicker24Hour=true
-                  timePickerIncrement=timePickerIncrement
-                  maxDate=maxTime
-                  start=activeRangeStart
-                  end=activeRangeEnd
-                  ranges=predefinedRanges
-                  showCustomRangeLabel=false
-                  format=uiDateFormat
-                  serverFormat="YYYY-MM-DD HH:mm"
-                  applyAction=(action "onRangeSelection")
-                }}
-            {{/if}}
-          </li>
-        {{/each}}
-      </ul>
-    </div>
+    {{!-- Date range selector --}}
+    {{range-pill-selectors
+      title="Showing"
+      maxTime=maxTime
+      uiDateFormat=uiDateFormat
+      activeRangeEnd=activeRangeEnd
+      activeRangeStart=activeRangeStart
+      timeRangeOptions=timeRangeOptions
+      timePickerIncrement=timePickerIncrement
+      selectAction=(action "onRangeSelection")
+    }}
 
     {{#if isPageLoadFailure}}
       {{#bs-alert type="danger" class="te-form__banner te-form__banner--failure"}}
@@ -70,7 +54,7 @@
       <a class="te-pill-selectors__side-link te-pill-selectors__side-link--high" {{action "onClickReportAnomaly" this}}>Report missing anomaly</a>
 
       {{#if filteredAnomalies}}
-        <div class="te-pill-selectors">
+        <div class="te-pill-selectors__wrapper">
           {{!-- Dimension selector --}}
           {{#if alertHasDimensions}}
             <div class="te-form__select te-form__select--wider col-md-3">
@@ -157,7 +141,7 @@
 
       {{#if filteredAnomalies}}
         {{!-- Baseline type selector --}}
-        <div class="te-pill-selectors">
+        <div class="te-pill-selectors__wrapper">
           <div class="te-pill-selectors__label">Baseline</div>
           <ul class="te-alert-page-hzlist">
             {{#each baselineOptions as |baseline|}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -142,10 +142,10 @@
       {{#if filteredAnomalies}}
         {{!-- Baseline type selector --}}
         <div class="te-pill-selectors__wrapper">
-          <div class="te-pill-selectors__label">Baseline</div>
-          <ul class="te-alert-page-hzlist">
+          <div class="te-pill-selectors__title">Baseline</div>
+          <ul class="te-pill-selectors">
             {{#each baselineOptions as |baseline|}}
-              <li class="te-alert-page-hzlist__item {{if baseline.isActive "te-alert-page-hzlist__item--active"}}" {{action "onBaselineOptionClick" baseline}}>
+              <li class="te-pill-selectors__item {{if baseline.isActive "te-pill-selectors__item--active"}}" {{action "onBaselineOptionClick" baseline}}>
                 {{baseline.name}}
               </li>
             {{/each}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
@@ -276,34 +276,6 @@ export default Controller.extend({
   actions: {
 
     /**
-     * Trigger reload in model with new time range. Transition for 'custom' dates is handled by 'onRangeSelection'
-     * @method onRangeOptionClick
-     * @param {Object} rangeOption - the selected range object
-     */
-    onRangeOptionClick(rangeOption) {
-      const rangeFormat = 'YYYY-MM-DD HH:mm';
-      const defaultEndDate = buildDateEod(1, 'day').valueOf();
-      const timeRangeOptions = this.get('timeRangeOptions');
-      const duration = rangeOption.value;
-      const startDate = moment(rangeOption.start).valueOf();
-      const endDate = moment(defaultEndDate).valueOf();
-
-      if (rangeOption.value !== 'custom') {
-        // Set date picker defaults to new start/end dates
-        this.setProperties({
-          activeRangeStart: moment(rangeOption.start).format(rangeFormat),
-          activeRangeEnd: moment(defaultEndDate).format(rangeFormat)
-        });
-        // Reset options and highlight selected one
-        timeRangeOptions.forEach(op => set(op, 'isActive', false));
-        set(rangeOption, 'isActive', true);
-        setDuration(duration, startDate, endDate);
-        // Reload model according to new timerange
-        this.transitionToRoute({ queryParams: { mode: 'explore', duration, startDate, endDate }});
-      }
-    },
-
-    /**
      * This field will not accept empty input - default back to the original value
      * @method onChangeSeverityValue
      * @param {String} severity - the custom tuning severity input
@@ -328,20 +300,19 @@ export default Controller.extend({
     /**
      * Sets the new custom date range for anomaly coverage
      * @method onRangeSelection
-     * @param {String} start  - stringified start date
-     * @param {String} end    - stringified end date
+     * @param {Object} rangeOption - the user-selected time range to load
      */
-    onRangeSelection(start, end) {
-      const duration = 'custom';
+    onRangeSelection(rangeOption) {
+      const {
+        start,
+        end,
+        value: duration
+      } = rangeOption;
       const startDate = moment(start).valueOf();
       const endDate = moment(end).valueOf();
-      const timeRangeOptions = this.get('timeRangeOptions');
-      const currOption = timeRangeOptions.find(option => option.value === 'custom');
-      // Toggle time reange button states to highlight the current one
-      timeRangeOptions.forEach(op => set(op, 'isActive', false));
-      set(currOption, 'isActive', true);
+      // Cache the new time range and update page with it
       setDuration(duration, startDate, endDate);
-      this.transitionToRoute({ queryParams: { mode: 'explore', duration, startDate, endDate }});
+      this.transitionToRoute({ queryParams: { duration, startDate, endDate }});
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/template.hbs
@@ -1,32 +1,15 @@
 <div class="manage-alert-tune">
-
-  <div class="te-pill-selectors">
-    {{!-- Date range selector --}}
-    <div class="te-pill-selectors__label">Showing</div>
-    <ul class="te-alert-page-hzlist">
-      {{#each timeRangeOptions as |range|}}
-        <li class="te-alert-page-hzlist__item {{if range.isActive "te-alert-page-hzlist__item--active"}}" {{action "onRangeOptionClick" range}}>
-          {{range.name}}
-          {{#if (eq range.name "Custom")}}
-            : {{date-range-picker
-              class="te-pill-selectors__range-picker"
-              timePicker=false
-              timePicker24Hour=true
-              timePickerIncrement=timePickerIncrement
-              maxDate=today
-              start=activeRangeStart
-              end=activeRangeEnd
-              ranges=predefinedRanges
-              showCustomRangeLabel=false
-              format=uiDateFormat
-              serverFormat="YYYY-MM-DD HH:mm"
-              applyAction=(action "onRangeSelection")
-            }}
-          {{/if}}
-        </li>
-      {{/each}}
-    </ul>
-  </div>
+  {{!-- Date range selector --}}
+  {{range-pill-selectors
+    title="Showing"
+    maxTime=maxTime
+    uiDateFormat=uiDateFormat
+    activeRangeEnd=activeRangeEnd
+    activeRangeStart=activeRangeStart
+    timeRangeOptions=timeRangeOptions
+    timePickerIncrement=timePickerIncrement
+    selectAction=(action "onRangeSelection")
+  }}
 
   <div class="te-content-block">
     <fieldset class="te-form__section te-form__section--first te-form__section--slim row">

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
@@ -1,6 +1,8 @@
 import _ from 'lodash';
+import moment from 'moment';
 import { computed, set } from '@ember/object';
 import Controller from '@ember/controller';
+import { setDuration } from 'thirdeye-frontend/utils/manage-alert-utils';
 
 export default Controller.extend({
 
@@ -55,6 +57,25 @@ export default Controller.extend({
   ),
 
   actions: {
+
+    /**
+     * Sets the new custom date range for anomaly coverage
+     * @method onRangeSelection
+     * @param {Object} rangeOption - the user-selected time range to load
+     */
+    onRangeSelection(rangeOption) {
+      const {
+        start,
+        end,
+        value: duration
+      } = rangeOption;
+      const startDate = moment(start).valueOf();
+      const endDate = moment(end).valueOf();
+      // Cache the new time range and update page with it
+      setDuration(duration, startDate, endDate);
+      this.transitionToRoute({ queryParams: { duration, startDate, endDate }});
+    },
+
     /**
      * Handle sorting for each sortable table column
      * @param {String} sortKey  - stringified start date

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -4,7 +4,6 @@
  * @exports alert create model
  */
 
-import RSVP from 'rsvp';
 import fetch from 'fetch';
 import moment from 'moment';
 import Route from '@ember/routing/route';
@@ -26,7 +25,7 @@ import {
 /**
  * If true, this reduces the list of alerts per app to 2 for a quick demo.
  */
-const isDemoMode = false;
+const isDemoMode = true;
 
 /**
  * Mapping anomaly table column names to corresponding prop keys
@@ -204,7 +203,7 @@ export default Route.extend({
       endDate
     } = transition;
 
-    return RSVP.hash({
+    return hash({
       // Fetch all alert group configurations
       configGroups: fetch('/thirdeye/entity/ALERT_CONFIG').then(res => res.json()),
       applications: fetch('/thirdeye/entity/APPLICATION').then(res => res.json()),

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -242,7 +242,7 @@ export default Route.extend({
       uiDateFormat: "MMM D, YYYY hh:mm a",
       timePickerIncrement: 5,
       isDataLoading: true
-    })
+    });
 
     // Get perf data for each alert and assign it to the model
     fetchAppAnomalies(idsByApplication, startDate, endDate)

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -25,7 +25,7 @@ import {
 /**
  * If true, this reduces the list of alerts per app to 2 for a quick demo.
  */
-const isDemoMode = true;
+const isDemoMode = false;
 
 /**
  * Mapping anomaly table column names to corresponding prop keys

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
@@ -13,6 +13,18 @@
   </div>
 {{else}}
   <div class="manage-alert-tune">
+
+    {{!-- Date range selector --}}
+    {{range-pill-selectors
+      title="Select Time Range"
+      uiDateFormat=uiDateFormat
+      activeRangeEnd=activeRangeEnd
+      activeRangeStart=activeRangeStart
+      timeRangeOptions=timeRangeOptions
+      timePickerIncrement=timePickerIncrement
+      selectAction=(action "onRangeSelection")
+    }}
+
     <div class="te-content-block">
       <h4 class="te-alert-page__subtitle">Alert Performance by Application Group</h4>
       <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{viewTotalsState}}" {{action (toggle "viewTotals" this)}}>View total values</a>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/template.hbs
@@ -27,8 +27,8 @@
 
     <div class="te-content-block">
       <h4 class="te-alert-page__subtitle">Alert Performance by Application Group</h4>
-      <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{viewTotalsState}}" {{action (toggle "viewTotals" this)}}>View total values</a>
-      <a class="te-pill-selectors__side-link te-pill-selectors__side-link--{{viewAvgState}}" {{action (toggle "viewTotals" this)}}>View average values</a>
+      <a class="te-self-serve__side-link te-self-serve__side-link--{{viewTotalsState}}" {{action (toggle "viewTotals" this)}}>View total values</a>
+      <a class="te-self-serve__side-link te-self-serve__side-link--{{viewAvgState}}" {{action (toggle "viewTotals" this)}}>View average values</a>
       {{!-- Alert anomaly table --}}
       <table class="te-anomaly-table te-anomaly-table--performance">
         <thead>

--- a/thirdeye/thirdeye-frontend/app/styles/app.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/app.scss
@@ -57,6 +57,7 @@ body {
 @import 'components/card-container';
 @import 'components/te-anomaly-table';
 @import 'components/te-toggle';
+@import 'components/range-pill-selectors';
 
 // Pod Pages
 @import 'ember-power-select/themes/bootstrap';

--- a/thirdeye/thirdeye-frontend/app/styles/components/range-pill-selectors.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/range-pill-selectors.scss
@@ -1,0 +1,57 @@
+.range-pill-selectors {
+  clear: left;
+  margin-top: 12px;
+
+  &__list {
+    display: inline-block;
+    margin-left: 10px;
+    font-size: 15px;
+    padding: 0;
+  }
+
+  &__item {
+    display: inline-block;
+    margin-right: 7px;
+    list-style: none;
+    font-weight: 600;
+    color: app-shade(black, 5);
+    padding: 4px 12px;
+    border: 1px solid app-shade(black, 5);
+    border-radius: 15px;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &--active {
+      background-color: $te-alerts-background;
+      border-color: $te-alerts-background;
+    }
+  }
+
+  &__range-picker {
+    display: inline-block;
+    color: app-shade(black, 7);
+    min-width: 250px;
+    margin: 0;
+
+    .daterangepicker-input {
+      background: none;
+      border: none;
+      box-shadow: none;
+      padding: 3px 5px;
+      height: auto;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+
+  &__title {
+    margin: 15px 0 5px 0;
+    font-weight: 600;
+    color: app-shade(black, 7);
+    display: inline-block;
+  }
+}

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -301,6 +301,95 @@ body {
 }
 
 .te-pill-selectors {
+  display: inline-block;
+  margin-left: 10px;
+  font-size: 15px;
+  padding: 0;
+
+  &__wrapper {
+    clear: left;
+    margin-top: 12px;
+  }
+
+  &__item {
+    display: inline-block;
+    margin-right: 7px;
+    list-style: none;
+    font-weight: 600;
+    color: app-shade(black, 5);
+    padding: 4px 12px;
+    border: 1px solid app-shade(black, 5);
+    border-radius: 15px;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &--active {
+      background-color: $te-alerts-background;
+      border-color: $te-alerts-background;
+    }
+  }
+
+  &__range-picker {
+    display: inline-block;
+    color: app-shade(black, 7);
+    min-width: 250px;
+    margin: 0;
+
+    .daterangepicker-input {
+      background: none;
+      border: none;
+      box-shadow: none;
+      padding: 3px 5px;
+      height: auto;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+
+  &__title {
+    margin: 15px 0 5px 0;
+    font-weight: 600;
+    color: app-shade(black, 7);
+    display: inline-block;
+  }
+
+  &__side-link {
+    font-size: 15px;
+    color: $te-link-blue;
+    font-weight: 600;
+    letter-spacing: .03em;
+    float: right;
+    margin: -15px 10px 0 0;
+    cursor: pointer;
+
+    &--high {
+      margin-top: -30px;
+    }
+
+    &--low {
+      margin-top: -5px;
+    }
+
+    &--active {
+      border-bottom: 1px dashed;
+    }
+
+    &--inactive {
+      color: app-shade(black, 3);
+    }
+
+    &:hover {
+      color: $te-link-blue;
+      text-decoration: none;
+    }
+  }
+}
+
+/*.te-pill-selectors {
   clear: left;
   margin-top: 12px;
 
@@ -360,7 +449,7 @@ body {
       text-decoration: none;
     }
   }
-}
+}*/
 
 .te-horizontal-cards {
   &--hidden {

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -271,64 +271,6 @@ body {
       margin: 0;
     }
   }
-}
-
-.te-pill-selectors {
-  display: inline-block;
-  margin-left: 10px;
-  font-size: 15px;
-  padding: 0;
-
-  &__wrapper {
-    clear: left;
-    margin-top: 12px;
-  }
-
-  &__item {
-    display: inline-block;
-    margin-right: 7px;
-    list-style: none;
-    font-weight: 600;
-    color: app-shade(black, 5);
-    padding: 4px 12px;
-    border: 1px solid app-shade(black, 5);
-    border-radius: 15px;
-
-    &:hover {
-      cursor: pointer;
-    }
-
-    &--active {
-      background-color: $te-alerts-background;
-      border-color: $te-alerts-background;
-    }
-  }
-
-  &__range-picker {
-    display: inline-block;
-    color: app-shade(black, 7);
-    min-width: 250px;
-    margin: 0;
-
-    .daterangepicker-input {
-      background: none;
-      border: none;
-      box-shadow: none;
-      padding: 3px 5px;
-      height: auto;
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-  }
-
-  &__title {
-    margin: 15px 0 5px 0;
-    font-weight: 600;
-    color: app-shade(black, 7);
-    display: inline-block;
-  }
 
   &__side-link {
     font-size: 15px;

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -273,33 +273,6 @@ body {
   }
 }
 
-.te-alert-page-hzlist {
-    display: inline-block;
-    margin-left: 10px;
-    font-size: 15px;
-    padding: 0;
-
-  &__item {
-    display: inline-block;
-    margin-right: 7px;
-    list-style: none;
-    font-weight: 600;
-    color: app-shade(black, 5);
-    padding: 4px 12px;
-    border: 1px solid app-shade(black, 5);
-    border-radius: 15px;
-
-    &:hover {
-      cursor: pointer;
-    }
-
-    &--active {
-      background-color: $te-alerts-background;
-      border-color: $te-alerts-background;
-    }
-  }
-}
-
 .te-pill-selectors {
   display: inline-block;
   margin-left: 10px;
@@ -388,68 +361,6 @@ body {
     }
   }
 }
-
-/*.te-pill-selectors {
-  clear: left;
-  margin-top: 12px;
-
-  &__range-picker {
-    display: inline-block;
-    color: app-shade(black, 7);
-    min-width: 250px;
-    margin: 0;
-
-    .daterangepicker-input {
-      background: none;
-      border: none;
-      box-shadow: none;
-      padding: 3px 5px;
-      height: auto;
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-  }
-
-  &__label {
-    margin: 15px 0 5px 0;
-    font-weight: 600;
-    color: app-shade(black, 7);
-    display: inline-block;
-  }
-
-  &__side-link {
-    font-size: 15px;
-    color: $te-link-blue;
-    font-weight: 600;
-    letter-spacing: .03em;
-    float: right;
-    margin: -15px 10px 0 0;
-    cursor: pointer;
-
-    &--high {
-      margin-top: -30px;
-    }
-
-    &--low {
-      margin-top: -5px;
-    }
-
-    &--active {
-      border-bottom: 1px dashed;
-    }
-
-    &--inactive {
-      color: app-shade(black, 3);
-    }
-
-    &:hover {
-      color: $te-link-blue;
-      text-decoration: none;
-    }
-  }
-}*/
 
 .te-horizontal-cards {
   &--hidden {

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -120,6 +120,9 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
 
 /**
  * Generates time range options for selection in the self-serve UI
+ * @example output
+ * [{ name: "3 Months", value: "3m", start: Moment, isActive: true },
+ *  { name: "Custom", value: "custom", start: null, isActive: false }]
  * @method setUpTimeRangeOptions
  * @param {Array} datesKeys - array of keys used to generate time ranges
  * @param {String} duration - the selected time span that is default

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -1,10 +1,9 @@
-import { getWithDefault } from '@ember/object';
-import _ from 'lodash';
 import moment from 'moment';
 import { isPresent } from "@ember/utils";
+import { getWithDefault } from '@ember/object';
 import { buildDateEod } from 'thirdeye-frontend/utils/utils';
-import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
 import { getFormatedDuration } from 'thirdeye-frontend/utils/anomaly';
+import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
 
 /**
  * Handles types and defaults returned from eval/projected endpoints
@@ -65,23 +64,15 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
   // Loop over all anomalies to configure display settings
   anomalies.forEach((anomaly) => {
     let dimensionList = [];
-    const startMoment = moment(anomaly.anomalyStart);
-    const endMoment = moment(anomaly.anomalyEnd);
-    const anomalyDuration = moment.duration(endMoment.diff(startMoment));
-    const days = anomalyDuration.get("days");
-    const hours = anomalyDuration.get("hours");
-    const minutes = anomalyDuration.get("minutes");
+    // Extract current anomaly's score from array of all scores
     const score = resolvedScores.length ? resolvedScores.find(score => score.id === anomaly.anomalyId).score : null;
-
     // Set up anomaly change rate display
     const changeRate = (anomaly.current && anomaly.baseline) ? floatToPercent((anomaly.current - anomaly.baseline) / anomaly.baseline) : 0;
     const isNullChangeRate = Number.isNaN(Number(changeRate));
-
     // Set 'not reviewed' label
     if (!anomaly.anomalyFeedback) {
       anomaly.anomalyFeedback = 'Not reviewed yet';
     }
-
     // Add missing properties
     Object.assign(anomaly, {
       changeRate,
@@ -96,7 +87,6 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
       showResponseSaved: false,
       showResponseFailed: false
     });
-
     // Create a list of all available dimensions for toggling. Also massage dimension property.
     if (anomaly.anomalyFunctionDimension) {
       let dimensionObj = JSON.parse(anomaly.anomalyFunctionDimension);
@@ -110,10 +100,8 @@ export function enhanceAnomalies(rawAnomalies, severityScores) {
       let dimensionString = dimensionStrArr.join(' & ');
       Object.assign(anomaly, { dimensionList, dimensionString });
     }
-
     newAnomalies.push(anomaly);
   });
-
   // List most recent anomalies first
   return newAnomalies.sortBy('anomalyStart').reverse();
 }

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -323,6 +323,8 @@ export function getDuration() {
 /**
  * Decides which time range to load as default (query params, default set, or locally cached)
  * @method prepareTimeRange
+ * @param {Object} queryParams - range-related properties in querystring
+ * @param {Object} defaultDurationObj - basic default time range setting
  * @return {Object}
  */
 export function prepareTimeRange(queryParams, defaultDurationObj) {

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/range-pill-selectors/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/range-pill-selectors/component-test.js
@@ -1,0 +1,121 @@
+import moment from 'moment';
+import { module, test } from 'qunit';
+import { later } from "@ember/runloop";
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setUpTimeRangeOptions } from 'thirdeye-frontend/utils/manage-alert-utils';
+
+module('Integration | Component | range pill selectors', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const PILL_CLASS = '.te-pill-selectors';
+  const MAXTIME = 1520863199999; // tells us how much data is available for the selected metric
+  const START_DATE = 1513151999999; // arbitrary start date in milliseconds
+  const END_DATE = 1520873345292; // arbitrary end date in milliseconds
+  const TIME_PICKER_INCREMENT = 5; // tells date picker hours field how granularly to display time
+  const ACTIVE_DURATION = '1m'; // setting this date range option as default
+  const UI_DATE_FORMAT = 'MMM D, YYYY hh:mm a'; // format for date picker to use (usually varies by route or metric)
+  const DISPLAY_DATE_FORMAT = 'YYYY-MM-DD HH:mm'; // format used consistently across app to display custom date range
+  const TODAY = moment().startOf('day').add(1, 'days');
+  const TWO_WEEKS_AGO = moment().subtract(13, 'days').startOf('day');
+  const ACTIVE_RANGE_END = moment(END_DATE).format(DISPLAY_DATE_FORMAT);
+  const ACTIVE_RANGE_START = moment(START_DATE).format(DISPLAY_DATE_FORMAT);
+  const TIME_RANGE_OPTIONS = setUpTimeRangeOptions(['1m', '3m'], ACTIVE_DURATION); // using helper to generate these
+  const PRESET_RANGES = {
+    'Today': [moment(), TODAY],
+    'Last 2 weeks': [TWO_WEEKS_AGO, TODAY]
+  };
+
+  test('Confirming that range-pill-selector component renders and dates are selected properly', async function(assert) {
+    // setUpTimeRangeOptions will generate an array such as this
+    // [ { name: "3 Months", value: "3m", start: Moment, isActive: true },
+    // { name: "Custom", value: "custom", start: null, isActive: false } ]
+
+    this.set('onRangeSelection', (actual) => {
+      let expected = {
+        start: TWO_WEEKS_AGO,
+        end: TODAY
+      };
+      assert.deepEqual(actual, expected, 'selected start/end dates are passed to external action');
+    });
+
+    // Template block usage:
+    await render(hbs`
+      {{range-pill-selectors
+        title="Testing range pills"
+        maxTime=MAXTIME
+        uiDateFormat=UI_DATE_FORMAT
+        activeRangeEnd=ACTIVE_RANGE_END
+        activeRangeStart=ACTIVE_RANGE_START
+        timeRangeOptions=TIME_RANGE_OPTIONS
+        timePickerIncrement=TIME_PICKER_INCREMENT
+        predefinedRanges=PRESET_RANGES
+      }}
+    `);
+
+    const $rangePill = this.$(`${PILL_CLASS}__item`);
+    const $rangeTitle = this.$(`${PILL_CLASS}__title`);
+    const $rangePickerModal = this.$('.daterangepicker');
+    const $rangeInput = this.$('.daterangepicker-input');
+    const $rangePresets = this.$('.daterangepicker .ranges ul li');
+    const $customPill = this.$(`${PILL_CLASS}__item[data-value="custom"]`);
+    const $firstPill = this.$(`${PILL_CLASS}__item[data-value="${ACTIVE_DURATION}"]`);
+
+    // Testing initial display of time range pills
+    assert.equal(
+      $firstPill.get(2).classList[1],
+      `${PILL_CLASS}__item--active`,
+      'Pill selected as default is highlighted');
+    assert.equal(
+      $rangeTitle.get(0).innerText,
+      'Testing range pills',
+      'Title of range pills is correct');
+    assert.equal(
+      $rangePill.get(0).innerText,
+      'Last 30 days',
+      'Label of first pill is correct');
+    assert.equal(
+      $rangePill.get(1).innerText,
+      '3 Months',
+      'Label of 2nd pill is correct');
+    assert.equal(
+      $rangePill.get(2).innerText.includes('Custom'),
+      true,
+      'Label of 3nd pill is correct');
+    assert.equal(
+      $rangeInput.val(),
+      `${ACTIVE_RANGE_START} - ${ACTIVE_RANGE_END}`,
+      'Date range is accurate');
+
+    // Clicking to activate date-range-picker modal
+    await click($rangeInput);
+
+    // Brief confirmation that modal ranges are displaying properly
+    assert.equal(
+      $rangePickerModal.get(0).style.display,
+      'block',
+      'Range picker modal is displayed');
+    assert.equal(
+      $rangePresets.get(0).innerText,
+      'Today',
+      'Range picker preset #1 is good');
+    assert.equal(
+      $rangePresets.get(1).innerText,
+      'Last 2 weeks',
+      'Range picker preset #2 is good');
+
+    // Click on one of the preset ranges
+    await click($rangePresets.get(1));
+
+    // Confirm that the custom pill gets highlighted and populated with selected dates
+    assert.equal(
+      $customPill.get(2).classList[1],
+      `${PILL_CLASS}__item--active`,
+      'Selected pill is highlighted');
+    assert.equal(
+      $rangeInput.val(),
+      `${moment(TWO_WEEKS_AGO).format(DISPLAY_DATE_FORMAT)} - ${moment(TODAY).format(DISPLAY_DATE_FORMAT)}`,
+      'Date range for selected custom preset is accurate');
+  });
+});


### PR DESCRIPTION
Adding component for `range-pill-selectors` which are used in various self-serve routes to select a time range (either pre-set or custom) for analysis. The component renders a link for each provided object in `timeRangeOptions` (these have start/end dates)  and wraps the `date-range-picker` component for a `custom` time range.

<img width="1198" alt="screen shot 2018-03-12 at 2 11 56 pm" src="https://user-images.githubusercontent.com/11814420/37309838-61cba9b0-25ff-11e8-82f5-a911389e63d8.png">

The implementation used in self-serve routes updates the page query params when a time range change is triggered and re-loads alert/anomaly data.