### PR TITLE
Cleanup: Enable splitting of in-clause strings by default.

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -79,14 +79,11 @@ public class BrokerRequestHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerRequestHandler.class);
   private static final Pql2Compiler REQUEST_COMPILER = new Pql2Compiler();
 
-  private static final String BROKER_QUERY_SPLIT_IN_CLAUSE = "pinot.broker.query.split.in.clause";
   private static final String BROKER_QUERY_LOG_LENGTH = "pinot.broker.query.log.length";
   private static final ResponseType DEFAULT_BROKER_RESPONSE_TYPE = ResponseType.BROKER_RESPONSE_TYPE_NATIVE;
-  private static final boolean DEFAULT_BROKER_QUERY_SPLIT_IN_CLAUSE = false;
   private static final int DEFAULT_QUERY_LOG_LENGTH = Integer.MAX_VALUE;
 
   private final SegmentZKMetadataPrunerService _segmentPrunerService;
-  private final boolean _splitInClause;
   private final int _queryLogLength;
   private final AccessControlFactory _accessControlFactory;
   private final RoutingTable _routingTable;
@@ -113,7 +110,6 @@ public class BrokerRequestHandler {
     _requestIdGenerator = new AtomicLong(0);
     _queryResponseLimit = config.getInt(CommonConstants.Broker.CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT,
         CommonConstants.Broker.DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
-    _splitInClause = config.getBoolean(BROKER_QUERY_SPLIT_IN_CLAUSE, DEFAULT_BROKER_QUERY_SPLIT_IN_CLAUSE);
     _queryLogLength = config.getInt(BROKER_QUERY_LOG_LENGTH, DEFAULT_QUERY_LOG_LENGTH);
     _brokerTimeOutMs = config.getLong(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS,
         CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
@@ -168,7 +164,7 @@ public class BrokerRequestHandler {
     final long compilationStartTime = System.nanoTime();
     BrokerRequest brokerRequest;
     try {
-      brokerRequest = REQUEST_COMPILER.compileToBrokerRequest(pql, _splitInClause);
+      brokerRequest = REQUEST_COMPILER.compileToBrokerRequest(pql);
     } catch (Exception e) {
       LOGGER.info("Parsing error on requestId {}: {}, {}", requestId, pql, e.getMessage());
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1L);

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer.java
@@ -159,15 +159,11 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer extends Filt
     // If there's only one value, turn it into an equality, otherwise turn it into an IN clause
     if (columnAndValues.getValue().size() == 1) {
       return new FilterQueryTree(columnAndValues.getKey(),
-          elementListToDoubleTabSingletonList(columnAndValues.getValue()), FilterOperator.EQUALITY, null);
+          new ArrayList<>(columnAndValues.getValue()), FilterOperator.EQUALITY, null);
     } else {
-      return new FilterQueryTree(columnAndValues.getKey(),
-          elementListToDoubleTabSingletonList(columnAndValues.getValue()), FilterOperator.IN, null);
+      return new FilterQueryTree(columnAndValues.getKey(), new ArrayList<>(columnAndValues.getValue()),
+          FilterOperator.IN, null);
     }
-  }
-
-  private List<String> elementListToDoubleTabSingletonList(Collection<String> elementList) {
-    return Collections.singletonList(StringUtil.join("\t\t", elementList.toArray(new String[elementList.size()])));
   }
 
   private List<String> valueDoubleTabListToElements(List<String> doubleTabSeparatedElements) {
@@ -179,10 +175,5 @@ public class MultipleOrEqualitiesToInClauseFilterQueryTreeOptimizer extends Filt
     }
 
     return valueElements;
-  }
-
-  private List<String> valueDoubleTabListToElements(String doubleTabSeparatedElements) {
-    Splitter valueSplitter = Splitter.on("\t\t");
-    return valueSplitter.splitToList(doubleTabSeparatedElements);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2AstListener.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2AstListener.java
@@ -57,11 +57,9 @@ public class Pql2AstListener extends PQL2BaseListener {
   Stack<AstNode> _nodeStack = new Stack<>();
   AstNode _rootNode = null;
   private String _expression;
-  private final boolean _splitInClause;
 
-  public Pql2AstListener(String expression, boolean splitInClause) {
+  public Pql2AstListener(String expression) {
     _expression = expression; // Original expression being parsed.
-    _splitInClause = splitInClause;
   }
 
   private void pushNode(AstNode node) {
@@ -271,7 +269,7 @@ public class Pql2AstListener extends PQL2BaseListener {
     if ("not".equalsIgnoreCase(ctx.getChild(0).getChild(1).getText())) {
       isNotInClause = true;
     }
-    pushNode(new InPredicateAstNode(isNotInClause, _splitInClause));
+    pushNode(new InPredicateAstNode(isNotInClause));
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/InPredicateAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/InPredicateAstNode.java
@@ -31,17 +31,14 @@ import java.util.TreeSet;
  * AST node for IN predicates.
  */
 public class InPredicateAstNode extends PredicateAstNode {
-  private static final String DELIMITER = "\t\t";
   private final boolean _isNotInClause;
-  private final boolean _splitInClause;
 
-  public InPredicateAstNode(boolean isNotInClause, boolean splitInClause) {
+  public InPredicateAstNode(boolean isNotInClause) {
     _isNotInClause = isNotInClause;
-    _splitInClause = splitInClause;
   }
 
   public ArrayList<String> getValues() {
-    ArrayList<String> values = new ArrayList<String>();
+    ArrayList<String> values = new ArrayList<>();
     for (AstNode astNode : getChildren()) {
       if (astNode instanceof LiteralAstNode) {
         LiteralAstNode node = (LiteralAstNode) astNode;
@@ -108,17 +105,12 @@ public class InPredicateAstNode extends PredicateAstNode {
       filterOperator = FilterOperator.IN;
     }
 
-    if (_splitInClause) {
-      return new FilterQueryTree(_identifier, new ArrayList<>(values), filterOperator, null);
-    } else {
-      String[] valueArray = values.toArray(new String[values.size()]);
-      return new FilterQueryTree(_identifier, Collections.singletonList(StringUtil.join(DELIMITER, valueArray)),
-          filterOperator, null);
-    }
+    return new FilterQueryTree(_identifier, new ArrayList<>(values), filterOperator, null);
   }
 
   @Override
   public HavingQueryTree buildHavingQueryTree() {
+
     if (_function == null) {
       throw new Pql2CompilationException("IN predicate has no function");
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/BaseInPredicate.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/predicate/BaseInPredicate.java
@@ -40,8 +40,9 @@ public abstract class BaseInPredicate extends Predicate {
   public String[] getValues() {
     /* To maintain backward compatibility, we always split if number of values is one. We do not support
        case where DELIMITER is a sub-string of value.
+       TODO: Clean this up after broker changes to enable splitting have been around for sometime.
      */
     List<String> values = getRhs();
-    return (values.size() == 1) ? values.get(0).split(DELIMITER) : values.toArray(new String[values.size()]);
+    return (values.size() > 1) ? values.toArray(new String[values.size()]) : values.get(0).split(DELIMITER);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/InPredicateTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/InPredicateTest.java
@@ -58,8 +58,8 @@ public class InPredicateTest {
     String[] expectedValues = new String[]{"abc", "xyz", "123"};
     Arrays.sort(expectedValues); /* InPredicateAstNode sorts the predicate values. */
 
-    /* Test split case */
-    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query, true /*splitInClause*/);
+    /* Ensure that predicates are returned as separate strings, and not one concatenation of all strings. */
+    BrokerRequest brokerRequest = compiler.compileToBrokerRequest(query);
     FilterQueryTree filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
     BaseInPredicate predicate = (BaseInPredicate) Predicate.newPredicate(filterQueryTree);
     String[] actualValues = predicate.getValues();
@@ -67,18 +67,6 @@ public class InPredicateTest {
 
     Assert.assertEquals(actualValues, expectedValues);
     Assert.assertTrue(EqualityUtils.isEqualIgnoreOrder(filterQueryTree.getValue(), Arrays.asList(expectedValues)));
-
-    /* Test join case */
-    brokerRequest = compiler.compileToBrokerRequest(query, false /*splitInClause*/);
-    filterQueryTree = RequestUtils.generateFilterQueryTree(brokerRequest);
-    predicate = (BaseInPredicate) Predicate.newPredicate(filterQueryTree);
-    actualValues = predicate.getValues();
-    Arrays.sort(actualValues);
-
-    Assert.assertEquals(actualValues, expectedValues);
-    actualValues = filterQueryTree.getValue().get(0).split(InPredicate.DELIMITER);
-    Arrays.sort(actualValues);
-    Assert.assertEquals(actualValues, expectedValues);
   }
 }
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/predicate/NoDictionaryInPredicateEvaluatorTest.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.core.predicate;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.core.common.predicate.InPredicate;
 import com.linkedin.pinot.core.common.predicate.NotInPredicate;
 import com.linkedin.pinot.core.operator.filter.predicate.InPredicateEvaluatorFactory;
@@ -30,8 +29,9 @@ import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import org.apache.commons.lang.RandomStringUtils;
@@ -58,22 +58,21 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
   @Test
   public void testIntPredicateEvaluators() {
-    String[] stringValues = new String[NUM_PREDICATE_VALUES];
+    List<String> stringValues = new ArrayList<>(NUM_PREDICATE_VALUES);
     IntSet valueSet = new IntOpenHashSet();
 
     for (int i = 0; i < 100; i++) {
       int value = _random.nextInt();
-      stringValues[i] = Integer.toString(value);
+      stringValues.add(Integer.toString(value));
       valueSet.add(value);
     }
 
     InPredicate inPredicate =
-        new InPredicate(COLUMN_NAME, Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+        new InPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator inPredicateEvaluator =
         InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.INT);
 
-    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME,
-        Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator notInPredicateEvaluator =
         NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.INT);
 
@@ -91,29 +90,28 @@ public class NoDictionaryInPredicateEvaluatorTest {
     int[] multiValues = new int[NUM_MULTI_VALUES];
     PredicateEvaluatorTestUtils.fillRandom(multiValues);
     multiValues[_random.nextInt(NUM_MULTI_VALUES)] =
-        Integer.parseInt(stringValues[_random.nextInt(NUM_PREDICATE_VALUES)]);
+        Integer.parseInt(stringValues.get(_random.nextInt(NUM_PREDICATE_VALUES)));
     Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
     Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
   }
 
   @Test
   public void testLongPredicateEvaluators() {
-    String[] stringValues = new String[NUM_PREDICATE_VALUES];
+    List<String> stringValues = new ArrayList<>(NUM_PREDICATE_VALUES);
     LongSet valueSet = new LongOpenHashSet();
 
     for (int i = 0; i < 100; i++) {
       long value = _random.nextLong();
-      stringValues[i] = Long.toString(value);
+      stringValues.add(Long.toString(value));
       valueSet.add(value);
     }
 
     InPredicate inPredicate =
-        new InPredicate(COLUMN_NAME, Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+        new InPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator inPredicateEvaluator =
         InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.LONG);
 
-    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME,
-        Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator notInPredicateEvaluator =
         NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.LONG);
 
@@ -131,7 +129,7 @@ public class NoDictionaryInPredicateEvaluatorTest {
     long[] multiValues = new long[NUM_MULTI_VALUES];
     PredicateEvaluatorTestUtils.fillRandom(multiValues);
     multiValues[_random.nextInt(NUM_MULTI_VALUES)] =
-        Long.parseLong(stringValues[_random.nextInt(NUM_PREDICATE_VALUES)]);
+        Long.parseLong(stringValues.get(_random.nextInt(NUM_PREDICATE_VALUES)));
 
     Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
     Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
@@ -139,22 +137,21 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
   @Test
   public void testFloatPredicateEvaluators() {
-    String[] stringValues = new String[NUM_PREDICATE_VALUES];
+    List<String> stringValues = new ArrayList<>(NUM_PREDICATE_VALUES);
     FloatSet valueSet = new FloatOpenHashSet();
 
     for (int i = 0; i < 100; i++) {
       float value = _random.nextFloat();
-      stringValues[i] = Float.toString(value);
+      stringValues.add(Float.toString(value));
       valueSet.add(value);
     }
 
     InPredicate inPredicate =
-        new InPredicate(COLUMN_NAME, Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+        new InPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator inPredicateEvaluator =
         InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.FLOAT);
 
-    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME,
-        Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator notInPredicateEvaluator =
         NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.FLOAT);
 
@@ -172,7 +169,7 @@ public class NoDictionaryInPredicateEvaluatorTest {
     float[] multiValues = new float[NUM_MULTI_VALUES];
     PredicateEvaluatorTestUtils.fillRandom(multiValues);
     multiValues[_random.nextInt(NUM_MULTI_VALUES)] =
-        Float.parseFloat(stringValues[_random.nextInt(NUM_PREDICATE_VALUES)]);
+        Float.parseFloat(stringValues.get(_random.nextInt(NUM_PREDICATE_VALUES)));
 
     Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
     Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
@@ -180,22 +177,21 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
   @Test
   public void testDoublePredicateEvaluators() {
-    String[] stringValues = new String[NUM_PREDICATE_VALUES];
+    List<String> stringValues = new ArrayList<>(NUM_PREDICATE_VALUES);
     DoubleSet valueSet = new DoubleOpenHashSet();
 
     for (int i = 0; i < 100; i++) {
       double value = _random.nextDouble();
-      stringValues[i] = Double.toString(value);
+      stringValues.add(Double.toString(value));
       valueSet.add(value);
     }
 
     InPredicate inPredicate =
-        new InPredicate(COLUMN_NAME, Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+        new InPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator inPredicateEvaluator =
         InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.DOUBLE);
 
-    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME,
-        Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator notInPredicateEvaluator =
         NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.DOUBLE);
 
@@ -213,7 +209,7 @@ public class NoDictionaryInPredicateEvaluatorTest {
     double[] multiValues = new double[NUM_MULTI_VALUES];
     PredicateEvaluatorTestUtils.fillRandom(multiValues);
     multiValues[_random.nextInt(NUM_MULTI_VALUES)] =
-        Double.parseDouble(stringValues[_random.nextInt(NUM_PREDICATE_VALUES)]);
+        Double.parseDouble(stringValues.get(_random.nextInt(NUM_PREDICATE_VALUES)));
 
     Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
     Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
@@ -221,21 +217,21 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
   @Test
   public void testStringPredicateEvaluators() {
-    String[] stringValues = new String[NUM_PREDICATE_VALUES];
+    List<String> stringValues = new ArrayList<>(NUM_PREDICATE_VALUES);
     Set<String> valueSet = new HashSet<>();
 
     for (int i = 0; i < 100; i++) {
-      stringValues[i] = RandomStringUtils.random(MAX_STRING_LENGTH).replace("\t", "");
-      valueSet.add(stringValues[i]);
+      String value = RandomStringUtils.random(MAX_STRING_LENGTH);
+      stringValues.add(value);
+      valueSet.add(value);
     }
 
     InPredicate inPredicate =
-        new InPredicate(COLUMN_NAME, Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+        new InPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator inPredicateEvaluator =
         InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.STRING);
 
-    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME,
-        Collections.singletonList(StringUtil.join(InPredicate.DELIMITER, stringValues)));
+    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_NAME, stringValues);
     PredicateEvaluator notInPredicateEvaluator =
         NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.STRING);
 
@@ -252,7 +248,7 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
     String[] multiValues = new String[NUM_MULTI_VALUES];
     PredicateEvaluatorTestUtils.fillRandom(multiValues, MAX_STRING_LENGTH);
-    multiValues[_random.nextInt(NUM_MULTI_VALUES)] = stringValues[_random.nextInt(NUM_PREDICATE_VALUES)];
+    multiValues[_random.nextInt(NUM_MULTI_VALUES)] = stringValues.get(_random.nextInt(NUM_PREDICATE_VALUES));
 
     Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
     Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));


### PR DESCRIPTION
PR's #1819 and #2188 enabled optimization that avoids unnecessary
split/join of strings in IN/NOT-IN clauses. This was done in a backward
compatible way where server side could handle both split as well as
unsplit strings.

This optimization was off-by default and was enabled with a config.
Now that the changes have been around for several months, this PR cleans
up the config and enables the change by default.

 The server-side is still backward compatible with old broker. This can
 be cleaned up future PR once broker changes have been around for a
while.
