### PR TITLE
[TE] fix investigate link in self serve

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -276,7 +276,9 @@
                  </td>
                  <td class="te-anomaly-table__cell">
                     <div class="te-anomaly-table__link-wrapper">
-                      <a target="_blank" class="te-anomaly-table__link" href="app/#/rootcause?anomalyId={{anomaly.anomalyId}}">Investigate</a>
+                      {{#link-to 'rootcause' (query-params anomalyId=anomaly.anomalyId) target="_blank" class="te-anomaly-table__link"}}
+                        Investigate
+                      {{/link-to}}
                     </div>
                  </td>
               </tr>


### PR DESCRIPTION
#### What's new: 
- replaced hard coded `<a>` with a {{link-to}} and they now redirect to the correct page
( previously `app/app/#/rootcause?anomalyId=....`) 

### Tests:
- all tests (266) still passing