### PR TITLE
Re-design the TransformExpressionTree, treat expressions with same synmatic as the same TransformExpressionTree

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2Compiler.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/Pql2Compiler.java
@@ -18,7 +18,6 @@ package com.linkedin.pinot.pql.parsers;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.pql.parsers.pql2.ast.AstNode;
-
 import com.linkedin.pinot.pql.parsers.pql2.ast.BaseAstNode;
 import com.linkedin.pinot.pql.parsers.pql2.ast.BetweenPredicateAstNode;
 import com.linkedin.pinot.pql.parsers.pql2.ast.ComparisonPredicateAstNode;
@@ -130,8 +129,7 @@ public class Pql2Compiler implements AbstractCompiler {
     Pql2AstListener listener = new Pql2AstListener(expression, _splitInClause);
     walker.walk(listener, parseTree);
 
-    final AstNode rootNode = listener.getRootNode();
-    return TransformExpressionTree.buildTree(rootNode);
+    return new TransformExpressionTree(listener.getRootNode());
   }
 
   private void validateHavingClause(AstNode rootNode) {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/RequestUtilsTest.java
@@ -15,12 +15,14 @@
  */
 package com.linkedin.pinot.common.utils;
 
-import com.google.common.collect.Lists;
 import com.linkedin.pinot.common.request.GroupBy;
 import com.linkedin.pinot.common.utils.request.RequestUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,63 +34,34 @@ import org.testng.annotations.Test;
  */
 public class RequestUtilsTest {
   @Test(dataProvider = "getAllGroupByColumnsDataProvider")
-  public void testGetAllGroupByColumns(GroupBy groupBy, List<String> expectedColumns) {
-    List<String> allGroupByColumns = Lists.newArrayList(RequestUtils.getAllGroupByColumns(groupBy));
-    Collections.sort(allGroupByColumns);
-    Assert.assertEquals(allGroupByColumns, expectedColumns);
+  public void testGetAllGroupByColumns(GroupBy groupBy, Set<String> expectedColumns) {
+    Assert.assertEquals(RequestUtils.getAllGroupByColumns(groupBy), expectedColumns);
   }
 
   @DataProvider(name = "getAllGroupByColumnsDataProvider")
   public Object[][] getAllGroupByColumnsDataProvider() {
     List<Object[]> entries = new ArrayList<>();
-    GroupBy groupBy = null;
 
-    entries.add(new Object[]{
-        groupBy, Lists.newArrayList()
-      });
+    entries.add(new Object[]{null, Collections.emptySet()});
 
-    groupBy = new GroupBy();
-    groupBy.setColumns(Lists.newArrayList("country"));
-    entries.add(new Object[]{
-      groupBy, Lists.newArrayList("country")
-    });
+    GroupBy groupBy = new GroupBy();
+    groupBy.setExpressions(Collections.singletonList("timeConvert(time, 'HOURS', 'DAYS')"));
+    entries.add(new Object[]{groupBy, Collections.singleton("time")});
 
     groupBy = new GroupBy();
-    groupBy.setColumns(Lists.newArrayList("country", "food"));
-    entries.add(new Object[]{
-      groupBy, Lists.newArrayList("country", "food")
-    });
+    groupBy.setExpressions(
+        Arrays.asList("timeConvert(time, 'HOURS', 'DAYS')", "dateTimeConvert(date, 'HOURS', 'DAYS')"));
+    entries.add(new Object[]{groupBy, new HashSet<>(Arrays.asList("date", "time"))});
 
     groupBy = new GroupBy();
-    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')"));
-    entries.add(new Object[]{
-      groupBy, Lists.newArrayList("time")
-    });
+    groupBy.setExpressions(Arrays.asList("country", "timeConvert(time, 'HOURS', 'DAYS')"));
+    entries.add(new Object[]{groupBy, new HashSet<>(Arrays.asList("country", "time"))});
 
     groupBy = new GroupBy();
-    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')", "dateTimeConvert(date, 'HOURS', 'DAYS')"));
-    entries.add(new Object[]{
-      groupBy, Lists.newArrayList("date", "time")
-    });
-
-    groupBy = new GroupBy();
-    groupBy.setColumns(Lists.newArrayList("country"));
-    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')"));
-    entries.add(new Object[]{
-      groupBy, Lists.newArrayList("country", "time")
-    });
-
-    groupBy = new GroupBy();
-    groupBy.setColumns(Lists.newArrayList("country", "time"));
-    groupBy.setExpressions(Lists.newArrayList("timeConvert(time, 'HOURS', 'DAYS')", "dateTimeConvert(date, 'HOURS', 'DAYS')"));
-    entries.add(new Object[]{
-      groupBy, Lists.newArrayList("country", "date", "time")
-    });
-
-    groupBy = new GroupBy();
-    entries.add(new Object[]{
-      groupBy, Lists.newArrayList()
-    });
+    groupBy.setExpressions(
+        Arrays.asList("country", "timeConvert(time, 'HOURS', 'DAYS')", "dateTimeConvert(date, 'HOURS', 'DAYS')",
+            "time"));
+    entries.add(new Object[]{groupBy, new HashSet<>(Arrays.asList("country", "time", "date"))});
 
     return entries.toArray(new Object[entries.size()][]);
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformExpressionEvaluator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformExpressionEvaluator.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.operator.transform;
 
+import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
 import java.util.Map;
@@ -27,9 +28,10 @@ import java.util.Map;
 public interface TransformExpressionEvaluator {
 
   /**
-   * Evaluates a list of expressions on a given set of docIds.
-   * @param projectionBlock Projection block for which to evaluate the expression for.
-   * @return Map containing result for each transform expression.
+   * Evaluates a set of expression trees on a given block of data.
+   *
+   * @param projectionBlock Projection block for which to evaluate the expression trees for
+   * @return Map from expression tree to the result after evaluation
    */
-  Map<String, BlockValSet> evaluate(ProjectionBlock projectionBlock);
+  Map<TransformExpressionTree, BlockValSet> evaluate(ProjectionBlock projectionBlock);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -19,7 +19,6 @@ import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.GroupBy;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.query.AggregationGroupByOperator;
 import com.linkedin.pinot.core.operator.transform.TransformExpressionOperator;
@@ -55,7 +54,7 @@ public class AggregationGroupByPlanNode implements PlanNode {
   }
 
   @Override
-  public Operator run() {
+  public AggregationGroupByOperator run() {
     TransformExpressionOperator transformOperator = (TransformExpressionOperator) _transformPlanNode.run();
     SegmentMetadata segmentMetadata = _indexSegment.getSegmentMetadata();
     return new AggregationGroupByOperator(

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ProjectionPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/ProjectionPlanNode.java
@@ -15,17 +15,15 @@
  */
 package com.linkedin.pinot.core.plan;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.BReusableFilteredDocIdSetOperator;
 import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.MProjectionOperator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -40,7 +38,7 @@ public class ProjectionPlanNode implements PlanNode {
   private final DocIdSetPlanNode _docIdSetPlanNode;
   private MProjectionOperator _projectionOperator = null;
 
-  public ProjectionPlanNode(IndexSegment indexSegment, String[] columns, DocIdSetPlanNode docIdSetPlanNode) {
+  public ProjectionPlanNode(IndexSegment indexSegment, Set<String> columns, DocIdSetPlanNode docIdSetPlanNode) {
     _docIdSetPlanNode = docIdSetPlanNode;
     for (String column : columns) {
       _dataSourcePlanNodeMap.put(column, new ColumnarDataSourcePlanNode(indexSegment, column));
@@ -48,7 +46,7 @@ public class ProjectionPlanNode implements PlanNode {
   }
 
   @Override
-  public Operator run() {
+  public MProjectionOperator run() {
     long start = System.currentTimeMillis();
     if (_projectionOperator == null) {
       Map<String, BaseOperator> dataSourceMap = new HashMap<>();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/TransformPlanNode.java
@@ -17,18 +17,12 @@ package com.linkedin.pinot.core.plan;
 
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
-import com.linkedin.pinot.common.request.GroupBy;
 import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
-import com.linkedin.pinot.core.operator.MProjectionOperator;
 import com.linkedin.pinot.core.operator.transform.TransformExpressionOperator;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
-import com.linkedin.pinot.pql.parsers.Pql2Compiler;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -41,16 +35,10 @@ import org.slf4j.LoggerFactory;
 public class TransformPlanNode implements PlanNode {
   private static final Logger LOGGER = LoggerFactory.getLogger(TransformPlanNode.class);
 
-  private final ProjectionPlanNode _projectionPlanNode;
-  private final List<TransformExpressionTree> _expressionTrees;
   private final String _segmentName;
-
-  private static ThreadLocal<Pql2Compiler> _compiler = new ThreadLocal<Pql2Compiler>() {
-    @Override
-    protected Pql2Compiler initialValue() {
-      return new Pql2Compiler();
-    }
-  };
+  private final ProjectionPlanNode _projectionPlanNode;
+  private final Set<String> _projectionColumns = new HashSet<>();
+  private final Set<TransformExpressionTree> _expressionTrees = new HashSet<>();
 
   /**
    * Constructor for the class
@@ -59,94 +47,37 @@ public class TransformPlanNode implements PlanNode {
    * @param brokerRequest BrokerRequest to process
    */
   public TransformPlanNode(@Nonnull IndexSegment indexSegment, @Nonnull BrokerRequest brokerRequest) {
-
-    Set<String> projectionColumns = new HashSet<>();
-    Set<String> transformExpressions = new HashSet<>();
     _segmentName = indexSegment.getSegmentName();
-
-    extractColumnsAndTransforms(brokerRequest, projectionColumns, transformExpressions);
-
-    if (!transformExpressions.isEmpty()) {
-      _expressionTrees = buildTransformExpressionTrees(transformExpressions);
-      projectionColumns.addAll(getTransformColumns(_expressionTrees));
-    } else {
-      _expressionTrees = null;
-    }
-
+    extractColumnsAndTransforms(brokerRequest);
     _projectionPlanNode =
-        new ProjectionPlanNode(indexSegment, projectionColumns.toArray(new String[projectionColumns.size()]),
-            new DocIdSetPlanNode(indexSegment, brokerRequest));
+        new ProjectionPlanNode(indexSegment, _projectionColumns, new DocIdSetPlanNode(indexSegment, brokerRequest));
   }
 
   /**
-   * Helper method to get all columns from expressions.
-   * @param expressionTrees List of expression trees for which to get the columns.
-   * @return List of columns from all the expression trees
-   */
-  private List<String> getTransformColumns(List<TransformExpressionTree> expressionTrees) {
-    List<String> columns = new ArrayList<>();
-    for (TransformExpressionTree expressionTree : expressionTrees) {
-      expressionTree.getColumns(columns);
-    }
-    return columns;
-  }
-
-  /**
-   * Helper method to build TransformExpressionTrees for a given set of transform expressions.
-   * Ignores any trees that are just columns.
+   * Helper method to extract projection columns and transform expressions from the given broker request.
    *
-   * @param transformExpressions Set of expressions for which to build trees.
-   * @return List of expression trees for the given transform expressions.
+   * @param brokerRequest Broker request to process
    */
-  public static List<TransformExpressionTree> buildTransformExpressionTrees(Set<String> transformExpressions) {
-    List<TransformExpressionTree> expressionTrees = new ArrayList<>(transformExpressions.size());
-
-    for (String transformExpression : transformExpressions) {
-      TransformExpressionTree expressionTree = _compiler.get().compileToExpressionTree(transformExpression);
-      if (!expressionTree.isColumn()) {
-        expressionTrees.add(expressionTree);
-      }
-    }
-    return expressionTrees;
-  }
-
-  /**
-   * Helper method to extract projection columns and transform expressions from the given
-   * BrokerRequest.
-   *  @param brokerRequest BrokerRequest to process
-   * @param projectionColumns Output projection columns from broker request
-   * @param transformExpressions Output transform expression from broker request
-   */
-  private void extractColumnsAndTransforms(BrokerRequest brokerRequest, Set<String> projectionColumns,
-      Set<String> transformExpressions) {
-
+  private void extractColumnsAndTransforms(@Nonnull BrokerRequest brokerRequest) {
     if (brokerRequest.isSetAggregationsInfo()) {
-      // TODO: Add transform support.
       for (AggregationInfo aggregationInfo : brokerRequest.getAggregationsInfo()) {
         if (!aggregationInfo.getAggregationType()
             .equalsIgnoreCase(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
-          String columns = aggregationInfo.getAggregationParams().get("column").trim();
-          projectionColumns.addAll(Arrays.asList(columns.split(",")));
+          String[] columns = aggregationInfo.getAggregationParams().get("column").split(",");
+          for (String column : columns) {
+            TransformExpressionTree transformExpressionTree = TransformExpressionTree.compileToExpressionTree(column);
+            transformExpressionTree.getColumns(_projectionColumns);
+            _expressionTrees.add(transformExpressionTree);
+          }
         }
       }
 
-      // Collect all group by related columns.
+      // Process all group-by expressions
       if (brokerRequest.isSetGroupBy()) {
-        GroupBy groupBy = brokerRequest.getGroupBy();
-        List<String> groupByColumns = groupBy.getColumns();
-
-        // GroupByColumns can be null if all group-bys are transforms.
-        if (groupByColumns != null) {
-          projectionColumns.addAll(groupByColumns);
-        }
-
-        // Check null for backward compatibility.
-        List<String> expressions = groupBy.getExpressions();
-        if (expressions != null) {
-          transformExpressions.addAll(expressions);
-          if (groupByColumns != null && !groupByColumns.isEmpty()) {
-            transformExpressions.removeAll(groupByColumns);
-          }
+        for (String expression : brokerRequest.getGroupBy().getExpressions()) {
+          TransformExpressionTree transformExpressionTree = TransformExpressionTree.compileToExpressionTree(expression);
+          transformExpressionTree.getColumns(_projectionColumns);
+          _expressionTrees.add(transformExpressionTree);
         }
       }
     } else {
@@ -158,8 +89,7 @@ public class TransformPlanNode implements PlanNode {
 
   @Override
   public Operator run() {
-    MProjectionOperator projectionOperator = (MProjectionOperator) _projectionPlanNode.run();
-    return new TransformExpressionOperator(projectionOperator, _expressionTrees);
+    return new TransformExpressionOperator(_projectionPlanNode.run(), _expressionTrees);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -34,24 +34,18 @@ import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFac
 import com.linkedin.pinot.core.query.config.QueryExecutorConfig;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
-
-import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * The <code>InstancePlanMakerImplV2</code> class is the default implementation of {@link PlanMaker}.
  */
 public class InstancePlanMakerImplV2 implements PlanMaker {
-  private static final Logger LOGGER = LoggerFactory.getLogger(InstancePlanMakerImplV2.class);
+  public static final String MAX_INITIAL_RESULT_HOLDER_CAPACITY_KEY = "max.init.group.holder.capacity";
+  public static final int DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY = 10_000;
 
-  private static final String MAX_INITIAL_RESULT_HOLDER_CAPACITY_KEY = "max.init.group.holder.capacity";
-  private static final int DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY = 10_000;
   private final int _maxInitialResultHolderCapacity;
 
   // TODO: Fix the runtime trimming and add back the number of aggregation groups limit.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -103,7 +103,7 @@ public class SelectionOperatorUtils {
    * @return all related columns.
    */
   @Nonnull
-  public static String[] extractSelectionRelatedColumns(@Nonnull Selection selection,
+  public static Set<String> extractSelectionRelatedColumns(@Nonnull Selection selection,
       @Nonnull IndexSegment indexSegment) {
     Set<String> selectionColumns = new HashSet<>(getSelectionColumns(selection.getSelectionColumns(), indexSegment));
     if (selection.getSelectionSortSequence() != null) {
@@ -111,7 +111,7 @@ public class SelectionOperatorUtils {
         selectionColumns.add(selectionSort.getColumn());
       }
     }
-    return selectionColumns.toArray(new String[selectionColumns.size()]);
+    return selectionColumns;
   }
 
   /**


### PR DESCRIPTION
This can fix the issue where IDENTIFIER and LITERAL might have the same expression and break the UDF

1. Remove field "_expression" from TransformExpressionTree because it's not standardized
2. Use field "_expressionType", "_value", "_children" to uniquely identify a TransformExpressionTree
  - For FUNCTION type, "_value" is the transform function name
  - For IDENTIFIER type, "_value" is the column name
  - For LITERAL type, "_value" is the string value of the constant
3. Add hashCode(), equals() and toString() to TransformExpressionTree, where toString() will return the standardized expression
4. Modify TransformExpressionTreeTest to test all cases including white space and quote on literal
5. Treat columns as expressions in TransformExpressionOperator, this is a prerequisite for full UDF support