### PR TITLE
[TE] Improve monitor's update procedure

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorConstants.java
@@ -14,6 +14,6 @@ public class MonitorConstants {
   public static int DEFAULT_COMPLETED_JOB_RETENTION_DAYS = 14;
   public static int DEFAULT_DETECTION_STATUS_RETENTION_DAYS = 7;
   public static int DEFAULT_RAW_ANOMALY_RETENTION_DAYS = 30;
-  public static TimeGranularity DEFAULT_MONITOR_FREQUENCY = new TimeGranularity(1, TimeUnit.HOURS);
+  public static TimeGranularity DEFAULT_MONITOR_FREQUENCY = new TimeGranularity(15, TimeUnit.MINUTES);
 
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorTaskRunner.java
@@ -1,12 +1,5 @@
 package com.linkedin.thirdeye.anomaly.monitor;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorConstants.MonitorType;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants.TaskStatus;
@@ -17,15 +10,26 @@ import com.linkedin.thirdeye.anomaly.task.TaskRunner;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
 import com.linkedin.thirdeye.datalayer.dto.TaskDTO;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MonitorTaskRunner implements TaskRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(MonitorJobRunner.class);
+  private static final long MAX_TASK_TIME = TimeUnit.MINUTES.toMillis(30);
 
   private DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
   @Override
-  public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
+  public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) {
 
     MonitorTaskInfo monitorTaskInfo = (MonitorTaskInfo) taskInfo;
     MonitorType monitorType = monitorTaskInfo.getMonitorType();
@@ -42,21 +46,42 @@ public class MonitorTaskRunner implements TaskRunner {
   private void executeMonitorUpdate(MonitorTaskInfo monitorTaskInfo) {
     LOG.info("Execute monitor update {}", monitorTaskInfo);
     try {
+      // Find all jobs in SCHEDULED status
+      int jobRetentionDays = monitorTaskInfo.getDefaultRetentionDays();
+      Map<Long, JobDTO> scheduledJobs = findScheduledJobsWithinDays(jobRetentionDays);
 
-      // All jobs with status SCHEDULED
-      Set<Long> scheduledJobIds = findAllJobsWithStatusScheduled();
+      // Remove SCHEDULED jobs that has WAITING tasks
+      Set<Long> waitingJobs = findWaitingJobsWithinDays(jobRetentionDays);
+      scheduledJobs.keySet().removeAll(waitingJobs);
 
-      // All incomplete jobs with status SCHEDULED
-      Set<Long> incompleteScheduledJobIds = findIncompleteJobsWithStatusScheduled();
-
-      // All finished jobs with status SCHEDULED
-      scheduledJobIds.removeAll(incompleteScheduledJobIds);
-
-      if (!scheduledJobIds.isEmpty()) {
-        DAO_REGISTRY.getJobDAO().updateStatusAndJobEndTimeForJobIds(scheduledJobIds, JobStatus.COMPLETED, System.currentTimeMillis());
-        LOG.info("COMPLETED jobs {}", scheduledJobIds);
+      // Mark SCHEDULED jobs as TIMEOUT if it has any tasks that run for more than MAX_TASK_TIME or are marked as TIMEOUT
+      Set<Long> timeoutJobs = findTimeoutJobsWithinDays(jobRetentionDays);
+      if (!timeoutJobs.isEmpty()) {
+        List<JobDTO> jobsToUpdate = extractJobDTO(scheduledJobs, timeoutJobs);
+        if (!jobsToUpdate.isEmpty()) {
+          DAO_REGISTRY.getJobDAO().updateJobStatusAndEndTime(jobsToUpdate, JobStatus.TIMEOUT, System.currentTimeMillis());
+          LOG.info("TIMEOUT jobs {}", timeoutJobs);
+        }
       }
 
+      // Mark SCHEDULED jobs as FAILED if it has any tasks are marked as FAILED
+      Set<Long> failedJobs = findFailedJobsWithinDays(jobRetentionDays);
+      if (!failedJobs.isEmpty()) {
+        List<JobDTO> jobsToUpdate = extractJobDTO(scheduledJobs, failedJobs);
+        if (!jobsToUpdate.isEmpty()) {
+          DAO_REGISTRY.getJobDAO().updateJobStatusAndEndTime(jobsToUpdate, JobStatus.FAILED, System.currentTimeMillis());
+          LOG.info("FAILED jobs {}", timeoutJobs);
+        }
+      }
+
+      // Mark the remaining jobs as COMPLETED
+      if (!scheduledJobs.isEmpty()) {
+        List<JobDTO> jobsToUpdate = new ArrayList<>(scheduledJobs.values());
+        if (!jobsToUpdate.isEmpty()) {
+          DAO_REGISTRY.getJobDAO().updateJobStatusAndEndTime(jobsToUpdate, JobStatus.COMPLETED, System.currentTimeMillis());
+          LOG.info("COMPLETED jobs {}", scheduledJobs.keySet());
+        }
+      }
     } catch (Exception e) {
       LOG.error("Exception in monitor update task", e);
     }
@@ -122,26 +147,54 @@ public class MonitorTaskRunner implements TaskRunner {
     }
   }
 
-
-  private Set<Long> findAllJobsWithStatusScheduled() {
-    Set<Long> scheduledJobIds = new HashSet<>();
-    try {
-      List<JobDTO> scheduledJobs = DAO_REGISTRY.getJobDAO().findByStatus(JobStatus.SCHEDULED);
-      for (JobDTO job : scheduledJobs) {
-        scheduledJobIds.add(job.getId());
+  private Map<Long, JobDTO> findScheduledJobsWithinDays(int days) {
+    Map<Long, JobDTO> jobs = new HashMap<>();
+    List<JobDTO> jobList = DAO_REGISTRY.getJobDAO().findByStatusWithinDays(JobStatus.SCHEDULED, days);
+    if (CollectionUtils.isNotEmpty(jobList)) {
+      for (JobDTO jobDTO : jobList) {
+        jobs.put(jobDTO.getId(), jobDTO);
       }
-    } catch (Exception e) {
-      LOG.error("Exception in finding jobs with status scheduled", e);
     }
-    return scheduledJobIds;
+    return jobs;
   }
 
-  private Set<Long> findIncompleteJobsWithStatusScheduled() {
-    Set<Long> incompleteScheduledJobIds = new HashSet<>();
-    List<TaskDTO> incompleteTasks = DAO_REGISTRY.getTaskDAO().findByStatusNotIn(TaskStatus.COMPLETED);
-    for (TaskDTO task : incompleteTasks) {
-      incompleteScheduledJobIds.add(task.getJobId());
+  private Set<Long> findWaitingJobsWithinDays(int days) {
+    Set<Long> waitingJobIds = new HashSet<>();
+    List<TaskDTO> waitingTasks = DAO_REGISTRY.getTaskDAO().findByStatusWithinDays(TaskStatus.WAITING, days);
+    for (TaskDTO task : waitingTasks) {
+      waitingJobIds.add(task.getJobId());
     }
-    return incompleteScheduledJobIds;
+    return waitingJobIds;
+  }
+
+  private Set<Long> findTimeoutJobsWithinDays(int days) {
+    Set<Long> timeoutJobs = new HashSet<>();
+    List<TaskDTO> timeoutTasks = DAO_REGISTRY.getTaskDAO().findByStatusWithinDays(TaskStatus.TIMEOUT, days);
+    timeoutTasks.addAll(DAO_REGISTRY.getTaskDAO().findTimeoutTasksWithinDays(days, MAX_TASK_TIME));
+    for (TaskDTO task : timeoutTasks) {
+      timeoutJobs.add(task.getJobId());
+    }
+    return timeoutJobs;
+  }
+
+  private Set<Long> findFailedJobsWithinDays(int days) {
+    Set<Long> failedJobIds = new HashSet<>();
+    List<TaskDTO> failedTasks = DAO_REGISTRY.getTaskDAO().findByStatusWithinDays(TaskStatus.FAILED, days);
+    for (TaskDTO task : failedTasks) {
+      failedJobIds.add(task.getJobId());
+    }
+    return failedJobIds;
+  }
+
+  private List<JobDTO> extractJobDTO(Map<Long, JobDTO> allJobs, Set<Long> jobIdToExtract) {
+    List<JobDTO> jobsToUpdate = new ArrayList<>();
+    for (long jobId : jobIdToExtract) {
+      JobDTO jobDTO = allJobs.get(jobId);
+      if (jobDTO != null) {
+        jobsToUpdate.add(jobDTO);
+        allJobs.remove(jobId);
+      }
+    }
+    return jobsToUpdate;
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/monitor/MonitorTaskRunner.java
@@ -60,6 +60,7 @@ public class MonitorTaskRunner implements TaskRunner {
         List<JobDTO> jobsToUpdate = extractJobDTO(scheduledJobs, timeoutJobs);
         if (!jobsToUpdate.isEmpty()) {
           DAO_REGISTRY.getJobDAO().updateJobStatusAndEndTime(jobsToUpdate, JobStatus.TIMEOUT, System.currentTimeMillis());
+          scheduledJobs.keySet().removeAll(timeoutJobs);
           LOG.info("TIMEOUT jobs {}", timeoutJobs);
         }
       }
@@ -70,6 +71,7 @@ public class MonitorTaskRunner implements TaskRunner {
         List<JobDTO> jobsToUpdate = extractJobDTO(scheduledJobs, failedJobs);
         if (!jobsToUpdate.isEmpty()) {
           DAO_REGISTRY.getJobDAO().updateJobStatusAndEndTime(jobsToUpdate, JobStatus.FAILED, System.currentTimeMillis());
+          scheduledJobs.keySet().removeAll(failedJobs);
           LOG.info("FAILED jobs {}", timeoutJobs);
         }
       }
@@ -192,7 +194,6 @@ public class MonitorTaskRunner implements TaskRunner {
       JobDTO jobDTO = allJobs.get(jobId);
       if (jobDTO != null) {
         jobsToUpdate.add(jobDTO);
-        allJobs.remove(jobId);
       }
     }
     return jobsToUpdate;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskConstants.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskConstants.java
@@ -10,9 +10,7 @@ public class TaskConstants {
     ALERT2,
     MONITOR,
     DATA_COMPLETENESS,
-    CLASSIFICATION,
-    // TODO: deprecate NULL task type after old task are deleted from current (as of 4/4/2017) database
-    NULL // for backward compatibility
+    CLASSIFICATION
   }
 
   public enum TaskStatus {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskGenerator.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskGenerator.java
@@ -69,14 +69,18 @@ public class TaskGenerator {
 
   public List<MonitorTaskInfo> createMonitorTasks(MonitorJobContext monitorJobContext) {
     List<MonitorTaskInfo> tasks = new ArrayList<>();
+    MonitorConfiguration monitorConfiguration = monitorJobContext.getMonitorConfiguration();
 
-    // TODO: Currently generates 1 task for updating all the completed jobs
-    // We might need to create more tasks and assign only certain number of updations to each (say 5k)
+    // Generates the task to updating the status of all jobs and tasks
     MonitorTaskInfo updateTaskInfo = new MonitorTaskInfo();
     updateTaskInfo.setMonitorType(MonitorType.UPDATE);
+    updateTaskInfo.setCompletedJobRetentionDays(monitorConfiguration.getCompletedJobRetentionDays());
+    updateTaskInfo.setDefaultRetentionDays(monitorConfiguration.getDefaultRetentionDays());
+    updateTaskInfo.setDetectionStatusRetentionDays(monitorConfiguration.getDetectionStatusRetentionDays());
+    updateTaskInfo.setRawAnomalyRetentionDays(monitorConfiguration.getRawAnomalyRetentionDays());
     tasks.add(updateTaskInfo);
 
-    MonitorConfiguration monitorConfiguration = monitorJobContext.getMonitorConfiguration();
+    // Generates the task to expire (delete) old jobs and tasks in DB
     MonitorTaskInfo expireTaskInfo = new MonitorTaskInfo();
     expireTaskInfo.setMonitorType(MonitorType.EXPIRE);
     expireTaskInfo.setCompletedJobRetentionDays(monitorConfiguration.getCompletedJobRetentionDays());

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AbstractManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/AbstractManager.java
@@ -17,6 +17,8 @@ public interface AbstractManager<E extends AbstractDTO> {
 
   E findById(Long id);
 
+  List<E> findByIds(List<Long> id);
+
   int delete(E entity);
 
   int deleteById(Long id);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/JobManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/JobManager.java
@@ -2,7 +2,6 @@ package com.linkedin.thirdeye.datalayer.bao;
 
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
 import java.util.List;
-import java.util.Set;
 
 import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
@@ -12,7 +11,9 @@ public interface JobManager extends AbstractManager<JobDTO> {
 
   List<JobDTO> findByStatus(JobStatus status);
 
-  void updateStatusAndJobEndTimeForJobIds(Set<Long> id, JobStatus status, Long jobEndTime);
+  List<JobDTO> findByStatusWithinDays(JobStatus status, int days);
+
+  void updateJobStatusAndEndTime(List<JobDTO> jobsToUpdate, JobStatus nweStatus, long newEndTime);
 
   int deleteRecordsOlderThanDaysWithStatus(int days, JobStatus status);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/TaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/TaskManager.java
@@ -12,6 +12,10 @@ public interface TaskManager extends AbstractManager<TaskDTO>{
 
   List<TaskDTO> findByStatusNotIn(TaskStatus status);
 
+  List<TaskDTO> findByStatusWithinDays(TaskStatus status, int days);
+
+  List<TaskDTO> findTimeoutTasksWithinDays(int days, long maxTaskTime);
+
   List<TaskDTO> findByStatusOrderByCreateTime(TaskStatus status, int fetchSize, boolean asc);
 
   boolean updateStatusAndWorkerId(Long workerId, Long id, Set<TaskStatus> allowedOldStatus,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/AbstractManagerImpl.java
@@ -16,6 +16,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections.CollectionUtils;
 import org.joda.time.DateTime;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
@@ -88,6 +89,19 @@ public abstract class AbstractManagerImpl<E extends AbstractDTO> implements Abst
     } else {
       return null;
     }
+  }
+
+  @Override
+  public List<E> findByIds(List<Long> ids) {
+    List<? extends AbstractBean> abstractBeans = genericPojoDao.get(ids, beanClass);
+    List<E> abstractDTOs = new ArrayList<>();
+    if (CollectionUtils.isNotEmpty(abstractBeans)) {
+      for (AbstractBean abstractBean : abstractBeans) {
+        E abstractDTO = (E) MODEL_MAPPER.map(abstractBean, dtoClass);
+        abstractDTOs.add(abstractDTO);
+      }
+    }
+    return abstractDTOs;
   }
 
   @Override

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/JobManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/JobManagerImpl.java
@@ -1,9 +1,11 @@
 package com.linkedin.thirdeye.datalayer.bao.jdbc;
 
+import com.google.common.base.Preconditions;
 import com.google.inject.Singleton;
 import com.linkedin.thirdeye.anomaly.detection.DetectionTaskRunner;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -38,13 +40,24 @@ public class JobManagerImpl extends AbstractManagerImpl<JobDTO> implements JobMa
   }
 
   @Override
+  public List<JobDTO> findByStatusWithinDays(JobStatus status, int days) {
+    DateTime activeDate = new DateTime().minusDays(days);
+    Timestamp activeTimestamp = new Timestamp(activeDate.getMillis());
+    Predicate statusPredicate = Predicate.EQ("status", status.toString());
+    Predicate timestampPredicate = Predicate.GE("createTime", activeTimestamp);
+    return findByPredicate(Predicate.AND(statusPredicate, timestampPredicate));
+  }
+
+  @Override
   @Transactional
-  public void updateStatusAndJobEndTimeForJobIds(Set<Long> ids, JobStatus status, Long jobEndTime) {
-    for (Long id : ids) {
-      JobDTO anomalyJobSpec = findById(id);
-      anomalyJobSpec.setStatus(status);
-      anomalyJobSpec.setScheduleEndTime(jobEndTime);
-      update(anomalyJobSpec);
+  public void updateJobStatusAndEndTime(List<JobDTO> jobsToUpdate, JobStatus newStatus, long newEndTime) {
+    Preconditions.checkNotNull(newStatus);
+    if (CollectionUtils.isNotEmpty(jobsToUpdate)) {
+      for (JobDTO jobDTO : jobsToUpdate) {
+        jobDTO.setStatus(newStatus);
+        jobDTO.setScheduleEndTime(newEndTime);
+      }
+      update(jobsToUpdate);
     }
   }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
@@ -129,9 +129,9 @@ public class TaskManagerImpl extends AbstractManagerImpl<TaskDTO> implements Tas
     Timestamp activeTimestamp = new Timestamp(activeDate.getMillis());
     DateTime timeoutDate = new DateTime().minus(maxTaskTime);
     Timestamp timeoutTimestamp = new Timestamp(timeoutDate.getMillis());
-    Predicate statusPredicate = Predicate.EQ("status", TaskStatus.RUNNING);
+    Predicate statusPredicate = Predicate.EQ("status", TaskStatus.RUNNING.toString());
     Predicate daysTimestampPredicate = Predicate.GE("createTime", activeTimestamp);
-    Predicate timeoutTimestampPredicate = Predicate.LT("createTime", timeoutTimestamp);
+    Predicate timeoutTimestampPredicate = Predicate.LT("updateTime", timeoutTimestamp);
     return findByPredicate(Predicate.AND(statusPredicate, daysTimestampPredicate, timeoutTimestampPredicate));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
@@ -1,6 +1,7 @@
 package com.linkedin.thirdeye.datalayer.bao.jdbc;
 
 import com.google.inject.Singleton;
+import com.linkedin.thirdeye.anomaly.task.TaskConstants;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -111,5 +112,26 @@ public class TaskManagerImpl extends AbstractManagerImpl<TaskDTO> implements Tas
   public List<TaskDTO> findByStatusNotIn(TaskStatus status) {
     Predicate statusPredicate = Predicate.NEQ("status", status.toString());
     return findByPredicate(statusPredicate);
+  }
+
+  @Override
+  public List<TaskDTO> findByStatusWithinDays(TaskStatus status, int days) {
+    DateTime activeDate = new DateTime().minusDays(days);
+    Timestamp activeTimestamp = new Timestamp(activeDate.getMillis());
+    Predicate statusPredicate = Predicate.EQ("status", status.toString());
+    Predicate timestampPredicate = Predicate.GE("createTime", activeTimestamp);
+    return findByPredicate(Predicate.AND(statusPredicate, timestampPredicate));
+  }
+
+  @Override
+  public List<TaskDTO> findTimeoutTasksWithinDays(int days, long maxTaskTime) {
+    DateTime activeDate = new DateTime().minusDays(days);
+    Timestamp activeTimestamp = new Timestamp(activeDate.getMillis());
+    DateTime timeoutDate = new DateTime().minus(maxTaskTime);
+    Timestamp timeoutTimestamp = new Timestamp(timeoutDate.getMillis());
+    Predicate statusPredicate = Predicate.EQ("status", TaskStatus.RUNNING);
+    Predicate daysTimestampPredicate = Predicate.GE("createTime", activeTimestamp);
+    Predicate timeoutTimestampPredicate = Predicate.LT("createTime", timeoutTimestamp);
+    return findByPredicate(Predicate.AND(statusPredicate, daysTimestampPredicate, timeoutTimestampPredicate));
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/dao/GenericPojoDao.java
@@ -242,9 +242,9 @@ public class GenericPojoDao {
   }
 
   /**
-   * Update the list of pojos in batch mode. Every batch contains MAX_BATCH_SIZE of entries. By default, this
-   * method update the batch of entries in one transaction. If any entries cause an exception, this method
-   * will update the entries one-by-one (i.e., in separated transactions) and skip the one that causes exceptions.
+   * Update the list of pojos in transaction mode. Every transaction contains MAX_BATCH_SIZE of entries. By default,
+   * this method update the entries in one transaction. If any entries cause an exception, this method will
+   * update the entries one-by-one (i.e., in separated transactions) and skip the one that causes exceptions.
    *
    * @param pojos the pojo to be updated, whose ID cannot be null; otherwise, it will be ignored.
    *

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyJobManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyJobManager.java
@@ -86,4 +86,24 @@ public class TestAnomalyJobManager {
     List<JobDTO> anomalyJobs = jobDAO.findByStatus(status);
     Assert.assertEquals(anomalyJobs.size(), 0);
   }
+
+  @Test(dependsOnMethods = {"testDeleteRecordsOlderThanDaysWithStatus"})
+  public void testFindByStatusWithinDays() throws InterruptedException {
+    anomalyJobId1 = jobDAO.save(DaoTestUtils.getTestJobSpec());
+    Assert.assertNotNull(anomalyJobId1);
+    anomalyJobId2 = jobDAO.save(DaoTestUtils.getTestJobSpec());
+    Assert.assertNotNull(anomalyJobId2);
+    anomalyJobId3 = jobDAO.save(DaoTestUtils.getTestJobSpec());
+    Assert.assertNotNull(anomalyJobId3);
+
+    Thread.sleep(100); // To ensure every job has been created more than 1 ms ago
+
+    List<JobDTO> jobsWithZeroDays = jobDAO.findByStatusWithinDays(JobStatus.SCHEDULED, 0);
+    Assert.assertEquals(jobsWithZeroDays.size(), 0);
+
+    List<JobDTO> jobsWithOneDays = jobDAO.findByStatusWithinDays(JobStatus.SCHEDULED, 1);
+    Assert.assertTrue(jobsWithOneDays.size() > 0);
+  }
+
+
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyJobManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyJobManager.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.datalayer.bao;
 
 import com.linkedin.thirdeye.datalayer.DaoTestUtils;
 import com.linkedin.thirdeye.datasource.DAORegistry;
+import java.util.Arrays;
 import java.util.List;
 
 import org.testng.Assert;
@@ -9,7 +10,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.Sets;
 import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.datalayer.dto.JobDTO;
 
@@ -53,7 +53,8 @@ public class TestAnomalyJobManager {
   public void testUpdateStatusAndJobEndTime() {
     JobStatus status = JobStatus.COMPLETED;
     long jobEndTime = System.currentTimeMillis();
-    jobDAO.updateStatusAndJobEndTimeForJobIds(Sets.newHashSet(anomalyJobId1, anomalyJobId3), status, jobEndTime);
+    List<JobDTO> jobDTOs = jobDAO.findByIds(Arrays.asList(anomalyJobId1, anomalyJobId3));
+    jobDAO.updateJobStatusAndEndTime(jobDTOs, status, jobEndTime);
     JobDTO anomalyJob = jobDAO.findById(anomalyJobId1);
     Assert.assertEquals(anomalyJob.getStatus(), status);
     Assert.assertEquals(anomalyJob.getScheduleEndTime(), jobEndTime);

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -111,6 +111,38 @@ public class TestAnomalyTaskManager {
     Assert.assertEquals(numRecordsDeleted, 1);
   }
 
+  @Test(dependsOnMethods = {"testDeleteRecordOlderThanDaysWithStatus"})
+  public void testFindByStatusWithinDays() throws JsonProcessingException, InterruptedException {
+    JobDTO testAnomalyJobSpec = DaoTestUtils.getTestJobSpec();
+    anomalyJobId = jobDAO.save(testAnomalyJobSpec);
+    anomalyTaskId1 = taskDAO.save(getTestTaskSpec(testAnomalyJobSpec));
+    Assert.assertNotNull(anomalyTaskId1);
+    anomalyTaskId2 = taskDAO.save(getTestTaskSpec(testAnomalyJobSpec));
+    Assert.assertNotNull(anomalyTaskId2);
+
+    Thread.sleep(100); // To ensure every task has been created more than 1 ms ago
+
+    List<TaskDTO> tasksWithZeroDays = taskDAO.findByStatusWithinDays(TaskStatus.WAITING, 0);
+    Assert.assertEquals(tasksWithZeroDays.size(), 0);
+
+    List<TaskDTO> tasksWithOneDays = taskDAO.findByStatusWithinDays(TaskStatus.WAITING, 1);
+    Assert.assertTrue(tasksWithOneDays.size() > 0);
+  }
+
+  @Test(dependsOnMethods = {"testDeleteRecordOlderThanDaysWithStatus"})
+  public void testFindTimeoutTasksWithinDays() throws JsonProcessingException, InterruptedException {
+    TaskDTO task1 = taskDAO.findById(anomalyTaskId1);
+    task1.setStatus(TaskStatus.RUNNING);
+    taskDAO.update(task1);
+
+    Thread.sleep(100); // To ensure every task has been updated more than 50 ms ago
+
+    List<TaskDTO> all = taskDAO.findByStatusWithinDays(TaskStatus.RUNNING, 7);
+
+    List<TaskDTO> timeoutTasksWithinOneDays = taskDAO.findTimeoutTasksWithinDays(7, 50);
+    Assert.assertTrue(timeoutTasksWithinOneDays.size() > 0);
+  }
+
   TaskDTO getTestTaskSpec(JobDTO anomalyJobSpec) throws JsonProcessingException {
     TaskDTO jobSpec = new TaskDTO();
     jobSpec.setJobName("Test_Anomaly_Task");

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/integration/AnomalyApplicationEndToEndTest.java
@@ -8,6 +8,7 @@ import com.linkedin.thirdeye.anomaly.detection.DetectionJobScheduler;
 import com.linkedin.thirdeye.anomaly.classification.ClassificationJobScheduler;
 import com.linkedin.thirdeye.anomaly.job.JobConstants.JobStatus;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorConfiguration;
+import com.linkedin.thirdeye.anomaly.monitor.MonitorConstants;
 import com.linkedin.thirdeye.anomaly.monitor.MonitorJobScheduler;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants.TaskStatus;
 import com.linkedin.thirdeye.anomaly.task.TaskConstants.TaskType;
@@ -164,9 +165,15 @@ public class AnomalyApplicationEndToEndTest {
     thirdeyeAnomalyConfig = new ThirdEyeAnomalyConfiguration();
     thirdeyeAnomalyConfig.setId(id);
     thirdeyeAnomalyConfig.setDashboardHost(dashboardHost);
+    // Monitor config
     MonitorConfiguration monitorConfiguration = new MonitorConfiguration();
+    monitorConfiguration.setDefaultRetentionDays(MonitorConstants.DEFAULT_RETENTION_DAYS);
+    monitorConfiguration.setCompletedJobRetentionDays(MonitorConstants.DEFAULT_COMPLETED_JOB_RETENTION_DAYS);
+    monitorConfiguration.setDetectionStatusRetentionDays(MonitorConstants.DEFAULT_DETECTION_STATUS_RETENTION_DAYS);
+    monitorConfiguration.setRawAnomalyRetentionDays(MonitorConstants.DEFAULT_RAW_ANOMALY_RETENTION_DAYS);
     monitorConfiguration.setMonitorFrequency(new TimeGranularity(3, TimeUnit.SECONDS));
     thirdeyeAnomalyConfig.setMonitorConfiguration(monitorConfiguration);
+    // Task config
     TaskDriverConfiguration taskDriverConfiguration = new TaskDriverConfiguration();
     taskDriverConfiguration.setNoTaskDelayInMillis(1000);
     taskDriverConfiguration.setRandomDelayCapInMillis(200);
@@ -193,7 +200,7 @@ public class AnomalyApplicationEndToEndTest {
     InputStream factoryStream = AnomalyApplicationEndToEndTest.class.getResourceAsStream(functionPropertiesFile);
     anomalyFunctionFactory = new AnomalyFunctionFactory(factoryStream);
 
-    // setup alertfilter factory for worker
+    // setup alert filter factory for worker
     InputStream alertFilterStream = AnomalyApplicationEndToEndTest.class.getResourceAsStream(alertFilterPropertiesFile);
     alertFilterFactory = new AlertFilterFactory(alertFilterStream);
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/AbstractMockManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/AbstractMockManager.java
@@ -29,6 +29,11 @@ public abstract class AbstractMockManager<T extends AbstractDTO> implements Abst
   }
 
   @Override
+  public List<T> findByIds(List<Long> id) {
+    throw new AssertionError("not implemented");
+  }
+
+  @Override
   public int delete(T entity) {
     throw new AssertionError("not implemented");
   }

--- a/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
+++ b/thirdeye/thirdeye-pinot/src/test/resources/schema/create-schema.sql
@@ -22,25 +22,7 @@ create table if not exists anomaly_function_index (
     CONSTRAINT uc_functionName unique(function_name)
 ) ENGINE=InnoDB;
 create index anomaly_function_name_idx on anomaly_function_index(function_name);
-
-create table if not exists anomaly_merge_config_index (
-    name varchar(200) not null,
-    base_id bigint(20) not null,
-    create_time timestamp,
-    update_time timestamp default current_timestamp,
-    version int(10),
-    CONSTRAINT uc_merge_config_name unique(name)
-) ENGINE=InnoDB;
-
-create table if not exists email_configuration_index (
-    collection varchar(200) not null,
-    metric varchar(200),
-    active boolean,
-    base_id bigint(20) not null,
-    create_time timestamp,
-    update_time timestamp default current_timestamp,
-    version int(10)
-) ENGINE=InnoDB;
+create index anomaly_function_base_id_idx ON anomaly_function_index(base_id);
 
 create table if not exists job_index (
     name varchar(200) not null,
@@ -57,6 +39,7 @@ create table if not exists job_index (
 create index job_status_idx on job_index(status);
 create index job_type_idx on job_index(type);
 create index job_config_id_idx on job_index(config_id);
+create index job_base_id_idx ON job_index(base_id);
 
 create table if not exists task_index (
     name varchar(200) not null,
@@ -74,6 +57,7 @@ create table if not exists task_index (
 create index task_status_idx on task_index(status);
 create index task_type_idx on task_index(type);
 create index task_job_idx on task_index(job_id);
+create index task_base_id_idx ON task_index(base_id);
 
 create table if not exists anomaly_feedback_index (
     type varchar(100) not null,
@@ -82,6 +66,7 @@ create table if not exists anomaly_feedback_index (
     update_time timestamp default current_timestamp,
     version int(10)
 ) ENGINE=InnoDB;
+create index anomaly_feedback_base_id_idx ON anomaly_feedback_index(base_id);
 
 create table if not exists raw_anomaly_result_index (
     function_id bigint(20),
@@ -139,9 +124,7 @@ create table if not exists dataset_config_index (
 create index dataset_config_dataset_idx on dataset_config_index(dataset);
 create index dataset_config_active_idx on dataset_config_index(active);
 create index dataset_config_requires_completeness_check_idx on dataset_config_index(requires_completeness_check);
-
--- ALTER TABLE dataset_config_index ADD COLUMN requires_completeness_check boolean;
--- UPDATE dataset_config_index SET requires_completeness_check = 0;
+create index dataset_config_base_id_idx ON dataset_config_index(base_id);
 
 create table if not exists metric_config_index (
     name varchar(200) not null,
@@ -158,6 +141,7 @@ create index metric_config_name_idx on metric_config_index(name);
 create index metric_config_dataset_idx on metric_config_index(dataset);
 create index metric_config_alias_idx on metric_config_index(alias);
 create index metric_config_active_idx on metric_config_index(active);
+create index metric_config_base_id_idx ON metric_config_index(base_id);
 
 create table if not exists override_config_index (
     start_time bigint(20) NOT NULL,
@@ -171,7 +155,7 @@ create table if not exists override_config_index (
 ) ENGINE=InnoDB;
 create index override_config_target_entity_idx on override_config_index(target_entity);
 create index override_config_target_start_time_idx on override_config_index(start_time);
-
+create index override_config_base_id_idx ON override_config_index(base_id);
 
 create table if not exists alert_config_index (
     active boolean,
@@ -183,6 +167,7 @@ create table if not exists alert_config_index (
     CONSTRAINT uc_alert_name UNIQUE (name)
 ) ENGINE=InnoDB;
 create index alert_confix_name_idx on alert_config_index(name);
+create index alert_config_base_id_idx ON alert_config_index(base_id);
 
 create table if not exists data_completeness_config_index (
     dataset varchar(200) not null,
@@ -201,6 +186,7 @@ create index data_completeness_config_date_idx on data_completeness_config_index
 create index data_completeness_config_sdf_idx on data_completeness_config_index(date_to_check_in_sdf);
 create index data_completeness_config_complete_idx on data_completeness_config_index(data_complete);
 create index data_completeness_config_percent_idx on data_completeness_config_index(percent_complete);
+create index data_completeness_config_base_id_idx ON data_completeness_config_index(base_id);
 
 create table if not exists event_index (
   name VARCHAR (100),
@@ -217,6 +203,7 @@ create table if not exists event_index (
 create index event_event_type_idx on event_index(event_type);
 create index event_start_time_idx on event_index(start_time);
 create index event_end_time_idx on event_index(end_time);
+create index event_base_id_idx ON event_index(base_id);
 
 create table if not exists detection_status_index (
   function_id bigint(20),
@@ -235,6 +222,7 @@ create index detection_status_date_idx on detection_status_index(date_to_check_i
 create index detection_status_sdf_idx on detection_status_index(date_to_check_in_sdf);
 create index detection_status_run_idx on detection_status_index(detection_run);
 create index detection_status_function_idx on detection_status_index(function_id);
+create index detection_status_base_id_idx ON detection_status_index(base_id);
 
 create table if not exists autotune_config_index (
     function_id bigint(20),
@@ -251,6 +239,7 @@ create index autotune_config_function_idx on autotune_config_index(function_id);
 create index autotune_config_autoTuneMethod_idx on autotune_config_index(autotune_method);
 create index autotune_config_performanceEval_idx on autotune_config_index(performance_evaluation_method);
 create index autotune_config_start_time_idx on autotune_config_index(start_time);
+create index autotune_config_base_id_idx ON autotune_config_index(base_id);
 
 create table if not exists classification_config_index (
     name varchar(200) not null,
@@ -262,6 +251,7 @@ create table if not exists classification_config_index (
 ) ENGINE=InnoDB;
 ALTER TABLE `classification_config_index` ADD UNIQUE `classification_config_unique_index`(`name`);
 create index classification_config_name_index on classification_config_index(name);
+create index classification_config_base_id_idx ON classification_config_index(base_id);
 
 
 create table if not exists entity_to_entity_mapping_index (
@@ -277,6 +267,7 @@ ALTER TABLE `entity_to_entity_mapping_index` ADD UNIQUE `entity_mapping_unique_i
 create index entity_mapping_from_urn_idx on entity_to_entity_mapping_index(from_urn);
 create index entity_mapping_to_urn_idx on entity_to_entity_mapping_index(to_urn);
 create index entity_mapping_type_idx on entity_to_entity_mapping_index(mapping_type);
+create index entity_to_entity_mapping_base_id_idx ON entity_to_entity_mapping_index(base_id);
 
 create table if not exists grouped_anomaly_results_index (
     alert_config_id bigint(20) not null,
@@ -288,6 +279,7 @@ create table if not exists grouped_anomaly_results_index (
     version int(10)
 ) ENGINE=InnoDB;
 create index grouped_anomaly_results_alert_config_id on grouped_anomaly_results_index(alert_config_id);
+create index grouped_anomaly_results_base_id_idx ON grouped_anomaly_results_index(base_id);
 
 create table if not exists onboard_dataset_metric_index (
   dataset_name varchar(200) not null,
@@ -303,6 +295,7 @@ create index onboard_dataset_idx on onboard_dataset_metric_index(dataset_name);
 create index onboard_metric_idx on onboard_dataset_metric_index(metric_name);
 create index onboard_datasource_idx on onboard_dataset_metric_index(data_source);
 create index onboard_onboarded_idx on onboard_dataset_metric_index(onboarded);
+create index onboard_dataset_metric_base_id_idx ON onboard_dataset_metric_index(base_id);
 
 create table if not exists config_index (
     namespace varchar(64) not null,
@@ -315,6 +308,7 @@ create table if not exists config_index (
 ALTER TABLE `config_index` ADD UNIQUE `config_unique_index`(`namespace`, `name`);
 create index config_namespace_idx on config_index(namespace);
 create index config_name_idx on config_index(name);
+create index config_base_id_idx ON config_index(base_id);
 
 create table application_index (
   application VARCHAR (200) not null,
@@ -328,6 +322,7 @@ create table if not exists alert_snapshot_index (
     update_time timestamp default current_timestamp,
     version int(10)
 ) ENGINE=InnoDB;
+create index alert_snapshot_base_id_idx ON alert_snapshot_index(base_id);
 
 create table if not exists rootcause_session_index (
     base_id bigint(20) not null,
@@ -351,3 +346,4 @@ create index rootcause_session_anomaly_range_start_idx on rootcause_session_inde
 create index rootcause_session_anomaly_range_end_idx on rootcause_session_index(anomaly_range_end);
 create index rootcause_session_created_idx on rootcause_session_index(created);
 create index rootcause_session_updated_idx on rootcause_session_index(updated);
+create index rootcause_session_base_id_idx ON rootcause_session_index(base_id);


### PR DESCRIPTION
1. Improve the runtime of monitor's update procedure from 8-15 minutes to 15-20 seconds.
2. Minotor's update procedure now is able to update jobs' status from SCHEDULED to TIMEOUT, FAILED, COMPLETE.
3. Increase the frequency of monitor task since they takes less than 1 minutes to finish.
4. Clean up SQL script.
5. Update EndToEnd test and add new unit tests for the these changes.