### PR TITLE
add commons-logging to pinot-tools

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -78,6 +78,11 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
When I tried to start controller:
```
git clone https://github.com/linkedin/pinot.git
cd pinot
mvn install package  -DskipTests
cd pinot-distribution/target/pinot-0.016-pkg
pinot/pinot-distribution/target/pinot-0.016-pkg$ bin/start-controller.sh
```
I got the error messages below:
> Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/logging/Log
> 	at com.linkedin.pinot.tools.admin.command.StartControllerCommand.execute(StartControllerCommand.java:138)
> 	at com.linkedin.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:120)
> 	at com.linkedin.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:132)
> 	at com.linkedin.pinot.tools.admin.PinotController.main(PinotController.java:32)
> Caused by: java.lang.ClassNotFoundException: org.apache.commons.logging.Log
> 	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
> 	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
> 	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
> 	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
> 	... 4 more

Adding `commons-logging` package to `pinot-tools` would solve the issue.

Opening this PR for suggestions.