### PR TITLE
[TE] rootcause - anomaly baseline support

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -433,17 +433,6 @@ export default Component.extend({
 
       return this._transformSeries(timeseriesMode, series);
 
-    } else if (hasPrefix(urn, 'frontend:anomalyfunction:')) {
-      const series = {
-        timestamps: timeseries[urn].timestamp,
-        values: timeseries[urn].value,
-        color: 'grey',
-        type: 'line',
-        axis: 'y'
-      };
-
-      return this._transformSeries(timeseriesMode, series);
-
     } else if (hasPrefix(urn, 'thirdeye:event:')) {
       const val = _eventValues[urn];
       const endRange = context.analysisRange[1];

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -35,19 +35,17 @@ export default Component.extend({
   classNames: ['rootcause-chart'],
 
   /**
-   * id of the entity to be focused on the chart
-   * @type {String}
+   * urns of the entities to be focused on the chart
+   * @type {Set}
    */
-  focusedUrn: null,
+  focusedUrns: new Set(),
 
   /**
    * Translate an urn into a chart id
-   * @returns {String|null}
+   * @returns {Set}
    */
-  focusedId: computed('focusedUrn', function() {
-    const urn = this.get('focusedUrn');
-
-    return this._urnToChartId(urn);
+  focusedIds: computed('focusedUrns', function() {
+    return this.get('focusedUrns');
   }),
 
   init() {
@@ -527,23 +525,4 @@ export default Component.extend({
       return outputUrns;
     }
   },
-
-  /**
-   * Converts an urn into a id that's readable
-   * by the c3-library .focus method
-   * @param {String} urn focused entity's urn
-   * @private
-   */
-  _urnToChartId(urn) {
-    if (!urn) return;
-
-    if (urn.includes('metric')) {
-      var [, metric, id, ...filters] = urn.split(':');
-      urn = ['frontend', metric, 'current', id].join(':');
-      if (filters.length) {
-        urn += `:${filters.join(':')}`;
-      }
-    }
-    return urn;
-  }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -1,4 +1,5 @@
 import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 import Component from '@ember/component';
 import moment from 'moment';
 import d3 from 'd3';
@@ -145,9 +146,9 @@ export default Component.extend({
       const { entities, timeseries, selectedUrns } =
         this.getProperties('entities', 'timeseries', 'selectedUrns');
 
-      return filterPrefix(selectedUrns, ['thirdeye:event:', 'frontend:metric:', 'frontend:anomalyfunction:'])
+      return filterPrefix(selectedUrns, ['thirdeye:event:', 'frontend:metric:'])
         .filter(urn => !hasPrefix(urn, 'thirdeye:event:') || entities[urn])
-        .filter(urn => !hasPrefix(urn, ['frontend:metric:', 'frontend:anomalyfunction:']) || timeseries[urn]);
+        .filter(urn => !hasPrefix(urn, 'frontend:metric:') || timeseries[urn]);
     }
   ),
 
@@ -164,7 +165,7 @@ export default Component.extend({
       const { timeseries, timeseriesMode, displayableUrns } =
         this.getProperties('timeseries', 'timeseriesMode', 'displayableUrns');
 
-      if (timeseriesMode == TIMESERIES_MODE_SPLIT) {
+      if (timeseriesMode === TIMESERIES_MODE_SPLIT) {
         return {};
       }
 
@@ -190,33 +191,25 @@ export default Component.extend({
     'displayableUrns',
     'timeseriesMode',
     function () {
-      const { displayableUrns, timeseriesMode, context } =
-        this.getProperties('displayableUrns', 'timeseriesMode', 'context');
+      const { displayableUrns, timeseriesMode } =
+        this.getProperties('displayableUrns', 'timeseriesMode');
 
-      if (timeseriesMode != TIMESERIES_MODE_SPLIT) {
+      if (timeseriesMode !== TIMESERIES_MODE_SPLIT) {
         return {};
       }
 
       const splitSeries = {};
       const metricUrns = new Set(filterPrefix(displayableUrns, 'frontend:metric:'));
-      const anomalyFunctionUrns = new Set(filterPrefix(displayableUrns, 'frontend:anomalyfunction:'));
 
       const otherUrns = new Set([...displayableUrns].filter(urn => !metricUrns.has(urn)));
-      [...anomalyFunctionUrns].forEach(urn => otherUrns.delete(urn));
 
-      filterPrefix(metricUrns, ['frontend:metric:current:']).forEach(urn => {
+      filterPrefix(metricUrns, 'frontend:metric:current:').forEach(urn => {
         const splitMetricUrns = [urn];
-        const metricUrn = toMetricUrn(urn);
         const baselineUrn = toBaselineUrn(urn);
 
         // show related baseline
         if (metricUrns.has(baselineUrn)) {
           splitMetricUrns.push(baselineUrn);
-        }
-
-        // show related anomaly function baselines
-        if (context.anomalyUrns.has(metricUrn)) {
-          [...anomalyFunctionUrns].forEach(urn => splitMetricUrns.push(urn));
         }
 
         const splitUrns = new Set(splitMetricUrns.concat([...otherUrns]));
@@ -239,7 +232,7 @@ export default Component.extend({
       const { entities, displayableUrns, timeseriesMode } =
         this.getProperties('entities', 'displayableUrns', 'timeseriesMode');
 
-      if (timeseriesMode != TIMESERIES_MODE_SPLIT) {
+      if (timeseriesMode !== TIMESERIES_MODE_SPLIT) {
         return {};
       }
 
@@ -261,7 +254,7 @@ export default Component.extend({
       const { entities, displayableUrns, timeseriesMode } =
         this.getProperties('entities', 'displayableUrns', 'timeseriesMode');
 
-      if (timeseriesMode != TIMESERIES_MODE_SPLIT) {
+      if (timeseriesMode !== TIMESERIES_MODE_SPLIT) {
         return {};
       }
 
@@ -276,12 +269,7 @@ export default Component.extend({
   /**
    * Split view indicator
    */
-  isSplit: computed(
-    'timeseriesMode',
-    function () {
-      return this.get('timeseriesMode') == TIMESERIES_MODE_SPLIT;
-    }
-  ),
+  isSplit: equal('timeseriesMode', TIMESERIES_MODE_SPLIT),
 
   //
   // helpers

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/template.hbs
@@ -10,7 +10,7 @@
         subchart=splitSubchart
         height=splitChartHeight
         colorMapping=colorMapping
-        focusedId=focusedId
+        focusedIds=focusedIds
       }}
     </div>
   {{/each}}
@@ -22,6 +22,6 @@
     axis=axis
     subchart=subchart
     colorMapping=colorMapping
-    focusedId=focusedId
+    focusedIds=focusedIds
   }}
 {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -8,9 +8,12 @@ import {
   toMetricLabel,
   toEventLabel
 } from 'thirdeye-frontend/utils/rca-utils';
+import _ from 'lodash';
 
 export default Component.extend({
   entities: null, // {}
+
+  anomalyUrns: null, // Set
 
   selectedUrns: null, // Set
 
@@ -21,19 +24,6 @@ export default Component.extend({
   onSelection: null, // function (Set, bool)
 
   classNames: ['rootcause-legend'],
-
-  anomalyFunctions: computed(
-    'entities',
-    'selectedUrns',
-    function () {
-      const { selectedUrns } = this.getProperties('selectedUrns');
-      return filterPrefix(selectedUrns, 'frontend:anomalyfunction:')
-        .reduce((agg, urn) => {
-          agg[urn] = 'Show Detection Baseline';
-          return agg;
-        }, {});
-    }
-  ),
 
   metrics: computed(
     'entities',
@@ -103,6 +93,29 @@ export default Component.extend({
     'events',
     function () {
       return Object.keys(this.get('events')).length > 0;
+    }
+  ),
+
+  anomalyFunctions: computed(
+    'selectedUrns',
+    'anomalyUrns',
+    function () {
+      const { selectedUrns, anomalyUrns } = this.getProperties('selectedUrns', 'anomalyUrns');
+
+      // NOTE: only supports single anomaly function
+      const anomalyFunctions = filterPrefix(anomalyUrns, 'frontend:anomalyfunction:');
+
+      if (_.isEmpty(anomalyFunctions)) return {};
+
+      const anomalyFunction = anomalyFunctions[0];
+
+      return [...selectedUrns].reduce((agg, urn) => {
+        agg[urn] = false;
+        if (anomalyUrns.has(urn)) {
+          agg[urn] = anomalyFunction;
+        }
+        return agg;
+      }, {});
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -123,7 +123,7 @@ export default Component.extend({
      * @returns undefined
      */
     onMouseEnter(urn) {
-      this.attrs.onMouseEnter(urn);
+      this.attrs.onMouseEnter([urn]);
     },
 
     /**
@@ -131,7 +131,7 @@ export default Component.extend({
      * @returns undefined
      */
     onMouseLeave(){
-      this.attrs.onMouseLeave(null);
+      this.attrs.onMouseLeave([]);
     },
 
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -29,7 +29,7 @@ export default Component.extend({
       const { selectedUrns } = this.getProperties('selectedUrns');
       return filterPrefix(selectedUrns, 'frontend:anomalyfunction:')
         .reduce((agg, urn) => {
-          agg[urn] = 'Anomaly Detection Baseline';
+          agg[urn] = 'Show Detection Baseline';
           return agg;
         }, {});
     }

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/template.hbs
@@ -6,23 +6,6 @@
     | <a class="thirdeye-link" {{action "visibleMetrics"}}>metrics</a>
   </div>
 
-  {{#if hasAnomalyFunctions}}
-    <ul class="rootcause-legend__list" onMouseLeave={{action "onMouseLeave"}}>
-      {{#each-in anomalyFunctions as |urn label|}}
-        <li class="rootcause-legend__item" onMouseEnter={{action "onMouseEnter" urn}}>
-          <div class="rootcause-legend__label-group {{if (set-has invisibleUrns urn) 'rootcause-legend__label-group--inactive'}}" {{action "toggleVisibility" urn}}>
-            <div class="rootcause-legend__indicator">
-              <span class="entity-indicator entity-indicator--grey entity-indicator--square {{if (set-has invisibleUrns urn) 'entity-indicator--inactive'}}">
-                {{tooltip-on-element text="Toggle view"}}
-              </span>
-            </div>
-            <span class="rootcause-legend__label">{{label}}</span>
-          </div>
-        </li>
-      {{/each-in}}
-    </ul>
-  {{/if}}
-
   {{#if hasMetrics}}
     <ul class="rootcause-legend__list" onMouseLeave={{action "onMouseLeave"}}>
       {{#each-in metrics as |urn label|}}
@@ -41,6 +24,18 @@
             </i>
           </a>
         </li>
+        {{#if (get-safe anomalyFunctions urn)}}
+          <li class="rootcause-legend__item rootcause-legend__item--indented" onMouseEnter={{action "onMouseEnter" (get-safe anomalyFunctions urn)}}>
+            <div class="rootcause-legend__label-group {{if (set-has invisibleUrns (get-safe anomalyFunctions urn)) 'rootcause-legend__label-group--inactive'}}" {{action "toggleVisibility" (get-safe anomalyFunctions urn)}}>
+              <div class="rootcause-legend__indicator">
+              <span class="entity-indicator entity-indicator--indented entity-indicator--light-{{get-safe colors urn}} entity-indicator--square {{if (set-has invisibleUrns (get-safe anomalyFunctions urn)) 'entity-indicator--inactive'}}">
+                {{tooltip-on-element text="Toggle view"}}
+              </span>
+              </div>
+              <span class="rootcause-legend__label">Show predicted baseline</span>
+            </div>
+          </li>
+        {{/if}}
       {{/each-in}}
     </ul>
   {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/template.hbs
@@ -6,6 +6,23 @@
     | <a class="thirdeye-link" {{action "visibleMetrics"}}>metrics</a>
   </div>
 
+  {{#if hasAnomalyFunctions}}
+    <ul class="rootcause-legend__list" onMouseLeave={{action "onMouseLeave"}}>
+      {{#each-in anomalyFunctions as |urn label|}}
+        <li class="rootcause-legend__item" onMouseEnter={{action "onMouseEnter" urn}}>
+          <div class="rootcause-legend__label-group {{if (set-has invisibleUrns urn) 'rootcause-legend__label-group--inactive'}}" {{action "toggleVisibility" urn}}>
+            <div class="rootcause-legend__indicator">
+              <span class="entity-indicator entity-indicator--grey entity-indicator--square {{if (set-has invisibleUrns urn) 'entity-indicator--inactive'}}">
+                {{tooltip-on-element text="Toggle view"}}
+              </span>
+            </div>
+            <span class="rootcause-legend__label">{{label}}</span>
+          </div>
+        </li>
+      {{/each-in}}
+    </ul>
+  {{/if}}
+
   {{#if hasMetrics}}
     <ul class="rootcause-legend__list" onMouseLeave={{action "onMouseLeave"}}>
       {{#each-in metrics as |urn label|}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/timeseries-chart/component.js
@@ -24,10 +24,10 @@ export default Component.extend({
   },
 
   /**
-   * Id of the entity to focus
-   * @type {String}
+   * Ids of the entity to focus
+   * @type {Set}
    */
-  focusedId: null,
+  focusedIds: new Set(),
 
   /**
    * default height property for the chart
@@ -96,7 +96,7 @@ export default Component.extend({
     const cache = this.get('_seriesCache') || {};
     const series = this.get('series') || {};
     const colorMapping = this.get('colorMapping');
-    const { axis, legend, tooltip, focusedId } = this.getProperties('axis', 'legend', 'tooltip', 'focusedId');
+    const { axis, legend, tooltip, focusedIds } = this.getProperties('axis', 'legend', 'tooltip', 'focusedIds');
 
     const seriesKeys = Object.keys(series).sort();
 
@@ -138,7 +138,7 @@ export default Component.extend({
     const axes = {};
     loadKeys.filter(sid => 'axis' in series[sid]).forEach(sid => axes[sid] = series[sid].axis);
 
-    const config = { unload, xs, columns, types, regions, tooltip, focusedId, colors, axis, axes, legend };
+    const config = { unload, xs, columns, types, regions, tooltip, focusedIds, colors, axis, axes, legend };
     return config;
   },
 
@@ -160,11 +160,11 @@ export default Component.extend({
   /**
    * Updates the focused entity on the chart
    */
-  _updateFocusedEntity: function() {
-    const id = this.get('focusedId');
+  _updateFocusedIds: function() {
+    const ids = this.get('focusedIds');
 
-    if (id) {
-      this._focus(id);
+    if (!_.isEmpty(ids)) {
+      this._focus([...ids]);
     } else {
       this._revert();
     }
@@ -201,7 +201,7 @@ export default Component.extend({
     const series = this.get('series') || {};
     const cache = this.get('cache') || {};
 
-    this._updateFocusedEntity();
+    this._updateFocusedIds();
 
     if (!_.isEqual(series, cache)) {
       debounce(this, this._updateChart, 300);
@@ -224,7 +224,7 @@ export default Component.extend({
     config.axis = diffConfig.axis;
     config.regions = diffConfig.regions;
     config.tooltip = diffConfig.tooltip;
-    config.focusedId = diffConfig.focusedId;
+    config.focusedIds = diffConfig.focusedIds;
     config.legend = diffConfig.legend;
     config.subchart = this.get('subchart');
     config.zoom = this.get('zoom');

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-anomalyfunction-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-anomalyfunction-cache/service.js
@@ -1,0 +1,126 @@
+import Service from '@ember/service';
+import {
+  toFilters,
+  toFilterMap
+} from 'thirdeye-frontend/utils/rca-utils';
+import { checkStatus } from 'thirdeye-frontend/utils/utils';
+import fetch from 'fetch';
+import _ from 'lodash';
+import moment from 'moment';
+
+export default Service.extend({
+  timeseries: null, // {}
+
+  context: null, // {}
+
+  pending: null, // Set
+
+  errors: null, // Set({ urn, error })
+
+  init() {
+    this.setProperties({ timeseries: {}, context: {}, pending: new Set(), errors: new Set() });
+  },
+
+  clearErrors() {
+    this.setProperties({ errors: new Set() });
+  },
+
+  request(requestContext, urns) {
+    const { context, timeseries, pending } = this.getProperties('context', 'timeseries', 'pending');
+
+    const metrics = [...urns].filter(urn => urn.startsWith('frontend:anomalyfunction:'));
+
+    // TODO eviction on cache size limit
+
+    let missing;
+    let newPending;
+    let newTimeseries;
+    if(!_.isEqual(context, requestContext)) {
+      // new analysis range: evict all, reload, keep stale copy of incoming
+      missing = metrics;
+      newPending = new Set(metrics);
+      newTimeseries = metrics.filter(urn => urn in timeseries).reduce((agg, urn) => { agg[urn] = timeseries[urn]; return agg; }, {});
+
+    } else {
+      // same context: load missing
+      missing = metrics.filter(urn => !(urn in timeseries) && !pending.has(urn));
+      newPending = new Set([...pending].concat(missing));
+      newTimeseries = timeseries;
+    }
+
+    this.setProperties({ context: _.cloneDeep(requestContext), timeseries: newTimeseries, pending: newPending });
+
+    if (_.isEmpty(missing)) {
+      // console.log('rootcauseAnomalyFunctionService: request: all metrics up-to-date. ignoring.');
+      return;
+    }
+
+    // metrics
+    missing.forEach(urn => {
+      return this._fetchSlice(urn, requestContext);
+    });
+  },
+
+  _complete(requestContext, incoming) {
+    const { context, pending, timeseries } = this.getProperties('context', 'pending', 'timeseries');
+
+    // only accept latest result
+    if (!_.isEqual(context, requestContext)) {
+      // console.log('rootcauseAnomalyFunctionService: _complete: received stale result. ignoring.');
+      return;
+    }
+
+    const newPending = new Set([...pending].filter(urn => !(urn in incoming)));
+    const newTimeseries = Object.assign({}, timeseries, incoming);
+
+    this.setProperties({ timeseries: newTimeseries, pending: newPending });
+  },
+
+  _extractTimeseries(json, urn) {
+    const timestamp = json['timeBuckets'].map(bucket => parseInt(bucket['baselineStart'], 10));
+    const value = json['baselineValues'].map(parseFloat);
+
+    const timeseries = {};
+    timeseries[urn] = {
+      timestamp,
+      value
+    };
+
+    return timeseries;
+  },
+
+  _fetchSlice(urn, context) {
+    const functionId = urn.split(':')[2];
+    const startDateTime = moment(context.analysisRange[0]).utc().format();
+    const endDateTime = moment(context.analysisRange[1]).utc().format();
+    const dimensionJsonString = encodeURI(JSON.stringify(this._toFilterMapCustom(toFilters(urn))));
+
+    const url = `/dashboard/anomaly-function/${functionId}/baseline?start=${startDateTime}&end=${endDateTime}&dimension=${dimensionJsonString}`;
+    return fetch(url)
+      .then(checkStatus)
+      .then(res => this._extractTimeseries(res, urn))
+      .then(res => this._complete(context, res))
+      .catch(error => this._handleError(urn, error));
+  },
+
+  _handleError(urn, error) {
+    const { errors, pending } = this.getProperties('errors', 'pending');
+
+    const newError = urn;
+    const newErrors = new Set([...errors, newError]);
+
+    const newPending = new Set(pending);
+    newPending.delete(urn);
+
+    this.setProperties({ errors: newErrors, pending: newPending });
+  },
+
+  _toFilterMapCustom(filters) {
+    const filterMap = {};
+    [...filters].forEach(tup => {
+      const [key, value] = tup;
+      filterMap[key] = value
+    });
+    return filterMap;
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-anomalyfunction-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-anomalyfunction-cache/service.js
@@ -95,7 +95,7 @@ export default Service.extend({
     const endDateTime = moment(context.analysisRange[1]).utc().format();
     const dimensionJsonString = encodeURI(JSON.stringify(this._toFilterMapCustom(toFilters(urn))));
 
-    const url = `/dashboard/anomaly-function/${functionId}/baseline?start=${startDateTime}&end=${endDateTime}&dimension=${dimensionJsonString}`;
+    const url = `/dashboard/anomaly-function/${functionId}/baseline?start=${startDateTime}&end=${endDateTime}&dimension=${dimensionJsonString}&mode=offline`;
     return fetch(url)
       .then(checkStatus)
       .then(res => this._extractTimeseries(res, urn))

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause-anomalyfunction-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause-anomalyfunction-cache/service.js
@@ -93,7 +93,7 @@ export default Service.extend({
     const functionId = urn.split(':')[2];
     const startDateTime = moment(context.analysisRange[0]).utc().format();
     const endDateTime = moment(context.analysisRange[1]).utc().format();
-    const dimensionJsonString = encodeURI(JSON.stringify(this._toFilterMapCustom(toFilters(urn))));
+    const dimensionJsonString = encodeURIComponent(JSON.stringify(this._toFilterMapCustom(toFilters(urn))));
 
     const url = `/dashboard/anomaly-function/${functionId}/baseline?start=${startDateTime}&end=${endDateTime}&dimension=${dimensionJsonString}&mode=offline`;
     return fetch(url)

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -56,6 +56,7 @@
             entities=entities
             selectedUrns=selectedUrns
             invisibleUrns=invisibleUrns
+            anomalyUrns=context.anomalyUrns
             onVisibility=(action "onVisibility")
             onSelection=(action "onSelection")
             onMouseEnter=(action "onLegendHover")

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -80,7 +80,7 @@
               selectedUrns=chartSelectedUrns
               timeseries=timeseries
               timeseriesMode=timeseriesMode
-              focusedUrn=focusedUrn
+              focusedUrns=focusedUrns
               context=context
               onHover=(action "chartOnHover")
             }}

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-chart.scss
@@ -15,6 +15,6 @@
   stroke-width: 2px;
 }
 
-g[class^='c3-circles-frontend-metric'], g[class*=' c3-circles-frontend-metric']{
+g[class^='c3-circles-frontend-metric'], g[class*=' c3-circles-frontend-metric'], g[class*=' c3-circles-frontend-anomalyfunction']{
     display: none;
 }

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-legend.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-legend.scss
@@ -26,10 +26,14 @@
     justify-content: space-between;
     margin-bottom: 4px;
 
+    &--indented {
+      padding-left: 20px;
+    }
+
     &:hover {
       .entity-indicator {
         transform: scale(1.2);
-        transition: transform 0.1s ease-in; 
+        transition: transform 0.1s ease-in;
       }
       .rootcause-legend__remove-icon {
         visibility: visible;
@@ -69,7 +73,7 @@
     word-break: break-word;
     &--inactive {
       color: app-shade(black, 0.15);
-      transition: color 0.1s ease-in; 
+      transition: color 0.1s ease-in;
     }
   }
 

--- a/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
@@ -98,6 +98,9 @@ export function stripTail(urn) {
   if (urn.startsWith('frontend:metric:')) {
     return _.slice(parts, 0, 4).join(':');
   }
+  if (urn.startsWith('frontend:anomalyfunction:')) {
+    return _.slice(parts, 0, 3).join(':');
+  }
   return urn;
 }
 
@@ -115,6 +118,9 @@ export function extractTail(urn) {
   }
   if (urn.startsWith('frontend:metric:')) {
     return _.slice(parts, 4);
+  }
+  if (urn.startsWith('frontend:anomalyfunction:')) {
+    return _.slice(parts, 3);
   }
   return [];
 }
@@ -286,6 +292,10 @@ function metricUrnHelper(prefix, urn) {
     const tail = makeUrnTail(parts, 4);
     return `${prefix}${parts[3]}${tail}`;
   }
+  if (hasPrefix(urn, 'frontend:anomalyfunction:')) {
+    const tail = makeUrnTail(parts, 3);
+    return `${prefix}${parts[2]}${tail}`;
+  }
   throw new Error(`Requires metric urn, but found ${urn}`);
 }
 
@@ -388,7 +398,8 @@ export function toFilters(urns) {
   const dimensionFilters = filterPrefix(urns, 'thirdeye:dimension:').map(urn => _.slice(urn.split(':').map(decodeURIComponent), 2, 4));
   const metricFilters = filterPrefix(urns, 'thirdeye:metric:').map(extractTail).map(enc => enc.map(tup => splitFilterFragment(decodeURIComponent(tup)))).reduce(flatten, []);
   const frontendMetricFilters = filterPrefix(urns, 'frontend:metric:').map(extractTail).map(enc => enc.map(tup => splitFilterFragment(decodeURIComponent(tup)))).reduce(flatten, []);
-  return [...new Set([...dimensionFilters, ...metricFilters, ...frontendMetricFilters])].sort();
+  const anomalyFunctoinFilters = filterPrefix(urns, 'frontend:anomalyfunction:').map(extractTail).map(enc => enc.map(tup => splitFilterFragment(decodeURIComponent(tup)))).reduce(flatten, []);
+  return [...new Set([...dimensionFilters, ...metricFilters, ...frontendMetricFilters, ...anomalyFunctoinFilters])].sort();
 }
 
 function splitFilterFragment(fragment) {

--- a/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
@@ -319,7 +319,7 @@ function makeUrnTail(parts, baseLen) {
  * @returns {boolean}
  */
 export function hasPrefix(urn, prefixes) {
-  return !_.isEmpty(makeIterable(prefixes).filter(pre => urn.startsWith(pre)));
+  return urn && !_.isEmpty(makeIterable(prefixes).filter(pre => urn.startsWith(pre)));
 }
 
 /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/AnomaliesResource.java
@@ -718,7 +718,7 @@ public class AnomaliesResource {
   }
 
   private String getExternalURL(MergedAnomalyResultDTO mergedAnomaly) {
-    return new JSONObject(ResourceUtils.getExternalURLs(mergedAnomaly, this.metricConfigDAO)).toString();
+    return new JSONObject(ResourceUtils.getExternalURLs(mergedAnomaly, this.metricConfigDAO, this.datasetConfigDAO)).toString();
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/MetricEntityFormatter.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/rootcause/MetricEntityFormatter.java
@@ -99,7 +99,7 @@ public class MetricEntityFormatter extends RootCauseEntityFormatter {
 
     TimeRangeEntity range = estimateTimeRange(e);
     MetricSlice slice = MetricSlice.from(metric.getId(), range.getStart(), range.getEnd(), e.getFilters());
-    Map<String, String> externalUrls = ResourceUtils.getExternalURLs(slice, this.metricDAO);
+    Map<String, String> externalUrls = ResourceUtils.getExternalURLs(slice, this.metricDAO, this.datasetDAO);
 
     attributes.putAll(ATTR_EXTERNAL_URLS, externalUrls.keySet());
     for (Map.Entry<String, String> entry : externalUrls.entrySet()) {


### PR DESCRIPTION
After multiple iterations on the anomaly baseline endpoint this PoC provides support for embedding the computed anomaly function baseline in the chart. Support is orthogonal to the existing user-selected baselines and can be toggled by the user in the legend. The current implementation hosts the logic entirely in the RCA controller and replaces the default metric baseline time series when enabled.

![image](https://user-images.githubusercontent.com/25439965/37690204-c1581d24-2c66-11e8-8885-9531f009b5bf.png)

* add toggle for displaying detection baseline rather than default baseline

* service for retrieving data from anomaly function baseline endpoint

* rewrite route for anomaly entry point

* support anomaly function urns in frontend utils

* support highlight of multiple time series at once

* compensate in backend for superfluous/missing pre-aggregation keywords in stored anomalies