### PR TITLE
[TE] Self-Serve onboarding acceptance test 1

### DIFF
--- a/thirdeye/thirdeye-frontend/app/mirage/config.js
+++ b/thirdeye/thirdeye-frontend/app/mirage/config.js
@@ -3,6 +3,7 @@ import alertConfig from 'thirdeye-frontend/mocks/alertConfig';
 import entityApplication from 'thirdeye-frontend/mocks/entityApplication';
 import metric from 'thirdeye-frontend/mocks/metric';
 import timeseriesCompare from 'thirdeye-frontend/mocks/timeseriesCompare';
+import { filters, dimensions, granularities } from 'thirdeye-frontend/mocks/metricPeripherals';
 import { onboardJobStatus, onboardJobCreate } from 'thirdeye-frontend/mocks/detectionOnboard';
 import rootcause from './endpoints/rootcause';
 import auth from './endpoints/auth';
@@ -136,24 +137,21 @@ export default function() {
    * Returns metric granularity.
    */
   this.get(`/data/agg/granularity/metric/${metric[0].id}`, () => {
-    return [ "5_MINUTES", "HOURS", "DAYS" ];
+    return granularities;
   });
 
   /**
    * Returns available filters on this metric
    */
   this.get(`/data/autocomplete/filters/metric/${metric[0].id}`, () => {
-    return {
-      "container" : [ "container1", "container2" ],
-      "fabric" : [ "prod-xyz1", "prod-xyz2", "prod-xyz3" ]
-    };
+    return filters;
   });
 
   /**
    * Returns available dimensions for this metric
    */
   this.get(`/data/autocomplete/dimensions/metric/${metric[0].id}`, () => {
-    return [ "All", "fabric", "container", "host" ];
+    return dimensions;
   });
 
   /**

--- a/thirdeye/thirdeye-frontend/app/mocks/metricPeripherals.js
+++ b/thirdeye/thirdeye-frontend/app/mocks/metricPeripherals.js
@@ -1,0 +1,17 @@
+/**
+ * Mock for filters, dimensions and other metric-associated datasets used in alert creation/edit
+ */
+export const filters = {
+  "container" : [ "container1", "container2" ],
+  "fabric" : [ "prod-xyz1", "prod-xyz2", "prod-xyz3" ]
+};
+
+export const dimensions = [ "All", "fabric", "container", "host" ];
+
+export const granularities = [ "5_MINUTES", "HOURS", "DAYS" ];
+
+export default {
+  filters,
+  dimensions,
+  granularities
+}

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -313,13 +313,7 @@ export default Controller.extend({
           }
         }
       }).catch((error) => {
-        // The request failed. No graph to render.
-        this.clearAll();
-        this.setProperties({
-          isMetricDataLoading: false,
-          isMetricDataInvalid: true,
-          selectMetricErrMsg: error
-        });
+        this.set('selectMetricErrMsg', error);
       });
   },
 

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -2,7 +2,7 @@
 <main class="alert-create card-container card-container--padded te-form">
   <fieldset class="te-form__section te-form__section--first row">
     <div class="col-xs-12">
-      <legend class="te-form__section-title">Pick a metric to alert</legend>
+      <legend class="te-form__section-title">Select a metric to monitor</legend>
     </div>
     <div class="col-xs-12 col-sm-8">
       <div class="te-page__right te-page__right--inside">
@@ -42,7 +42,7 @@
         placeholder="Select a Granularity"
         searchPlaceholder="Type to filter..."
         triggerId="select-granularity"
-        triggerClass="te-form__select"
+        triggerClass="te-form__select te-form__select--granularity"
         disabled=isGranularitySelectDisabled
         as |granularity|
       }}
@@ -52,7 +52,7 @@
 
     <div class="col-xs-6">
       <label for="select-dimension" class="control-label te-label te-label--taller">
-        Create alert for each dimension values in: (optional)
+        Create an alert for each dimension value in: (optional)
         <span>
           <i class="glyphicon glyphicon-question-sign"></i>
           {{#tooltip-on-element class="te-tooltip"}}
@@ -352,7 +352,7 @@
     {{/if}}
 
     {{!-- Field: new alert group recipient emails --}}
-    <div class="col-xs-12">
+    <div class="col-xs-12 te-form__section-config">
       <label for="config-group" class="control-label te-label te-label--taller">
         Recipients in subscription group <span class="stronger">{{selectedConfigGroup.name}}</span>:
         <div class="te-form__sub-label"><span class="te-form__sub-label--strong">{{if selectedGroupRecipients selectedGroupRecipients "No recipients yet"}}</span></div>

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import { module, test } from 'qunit';
-import { isPresent } from "@ember/utils";
 import { setupApplicationTest } from 'ember-qunit';
+import { selfServeConst, optionsToString } from 'thirdeye-frontend/tests/test-const';
 import { visit, fillIn, click, currentURL, triggerKeyEvent } from '@ember/test-helpers';
 import { filters, dimensions, granularities } from 'thirdeye-frontend/mocks/metricPeripherals';
 import { selectChoose, clickTrigger } from 'thirdeye-frontend/tests/helpers/ember-power-select';
@@ -9,155 +9,131 @@ import { selectChoose, clickTrigger } from 'thirdeye-frontend/tests/helpers/embe
 module('Acceptance | create alert', function(hooks) {
   setupApplicationTest(hooks);
 
-  const METRIC_SELECT = '#select-metric';
-  const METRIC_INPUT = '.ember-power-select-search-input';
-  const GRANULARITY_SELECT = '#select-granularity';
-  const DIMENSION_SELECT = '#select-dimension';
-  const PATTERN_SELECT = '#select-pattern';
-  const FILTER_SELECT = '#select-filters';
-  const SUBGROUP_SELECT = '#config-group';
-  const INPUT_NAME = '#anomaly-form-function-name';
-  const GRAPH_CONTAINER = '.te-graph-alert';
-  const OPTION_LIST = '.ember-power-select-options';
-  const OPTION_ITEM = 'li.ember-power-select-option';
-  const SELECTED_ITEM = '.ember-power-select-selected-item';
-  const APP_OPTIONS = '#anomaly-form-app-name';
-  const SPINNER = '.spinner-display';
-  const CONFIG_GROUP_ALERTS = '.te-form__custom-label';
-  const CONFIG_BLOCK = '.te-form__section-config';
-  const CONFIG_RECIPIENTS_INPUT = '#config-group-add-recipients';
-  const EMAIL_WARNING = '.te-form__alert--warning';
-  const SUBMIT_BUTTON = '.te-button--submit';
-  const SELECTED_CONFIG_GROUP = 'test_alert_1';
-  const SELECTED_METRIC = 'test_collection_1::test_metric_1';
-  const GROUP_RECIPIENT = 'simba@disney.com';
-  const PATTERN_OPTIONS = [
-    'Higher or lower than expected',
-    'Higher than expected',
-    'Lower than expected'
-  ];
+  const selectedConfigGroup = 'test_alert_1';
+  const selectedMetric = 'test_collection_1::test_metric_1';
+  const groupRecipient = 'simba@disney.com';
+  const newRecipient = 'duane@therock.com';
+  const selectedApp = 'the-lion-king';
+
   // Flatten filter object in order to easily compare it to the list of options rendered
-  const FILTER_ARRAY = Object.values(filters).map(filterGroup => [...Object.values(filterGroup)]);
+  const filterArray = Object.values(filters).map(filterGroup => [...Object.values(filterGroup)]);
 
   test(`visiting alert creation page to test onboarding flow for self-serve`, async (assert) => {
     await visit(`/self-serve/create-alert`);
+    const $granularityDropdown = $(selfServeConst.GRANULARITY_SELECT);
+    const $graphContainer = $(selfServeConst.GRAPH_CONTAINER);
 
     // Initial state: fields and graph are disabled
     assert.equal(
-      $(GRANULARITY_SELECT).attr('aria-disabled'),
+      $granularityDropdown.attr('aria-disabled'),
       'true',
       'Granularity field (representative) is disabled until metric is selected'
     );
     assert.equal(
-      $(GRAPH_CONTAINER).get(0).classList[1],
+      $graphContainer.get(0).classList[1],
       'te-graph-alert--pending',
       'Graph placeholder is visible. Data is not yet loaded.'
     );
 
     // Select a metric
-    await click(METRIC_SELECT);
-    await fillIn(METRIC_INPUT, 'test');
-    await click($(`${OPTION_ITEM}:contains(${SELECTED_METRIC})`).get(0));
+    await click(selfServeConst.METRIC_SELECT);
+    await fillIn(selfServeConst.METRIC_INPUT, 'test');
+    await click($(`${selfServeConst.OPTION_ITEM}:contains(${selectedMetric})`).get(0));
 
     // Fields are now enabled with defaults and load correct options, graph is loaded
     assert.equal(
-      $(GRANULARITY_SELECT).find(SELECTED_ITEM).get(0).innerText,
+      $granularityDropdown.find(selfServeConst.SELECTED_ITEM).get(0).innerText,
       '5_MINUTES',
       'granularity field (representative) is enabled after metric is selected'
     );
     assert.equal(
-      $(GRAPH_CONTAINER).get(0).classList.length,
+      $graphContainer.get(0).classList.length,
       1,
       'Graph placeholder is replaced.'
     );
     assert.equal(
-      $(GRAPH_CONTAINER).find('svg').length,
+      $graphContainer.find('svg').length,
       3,
       'Graph and legend svg elements are rendered.'
     );
-    assert.equal(
-      $(SPINNER).length,
-      0,
+    assert.notOk(
+      $(selfServeConst.SPINNER).length,
       'Loading icon is removed.'
     );
 
     // Now, verify that our selectable options are correct
-    await click(GRANULARITY_SELECT);
+    await click(selfServeConst.GRANULARITY_SELECT);
     assert.equal(
-      Object.values($(OPTION_LIST).get(0).children).map(item => item.innerText).join(),
+      optionsToString($(selfServeConst.OPTION_ITEM)),
       granularities.join(),
       'Granularity options render, number and text of options is correct'
     );
 
-    await click(DIMENSION_SELECT);
+    await click(selfServeConst.DIMENSION_SELECT);
     assert.equal(
-      Object.values($(OPTION_LIST).get(0).children).map(item => item.innerText).join(),
+      optionsToString($(selfServeConst.OPTION_ITEM)),
       dimensions.join(),
       'Dimension options render, number and text of options is correct'
     );
 
-    await click(FILTER_SELECT);
+    await click(selfServeConst.FILTER_SELECT);
     assert.equal(
-      Object.values($(OPTION_ITEM)).map(item => item.innerText).filter(item => isPresent(item)),
-      FILTER_ARRAY.join(),
+      optionsToString($(selfServeConst.OPTION_ITEM)),
+      filterArray.join(),
       'Filter options render, number and text of options is correct'
     );
 
-    await click(PATTERN_SELECT);
+    await click(selfServeConst.PATTERN_SELECT);
     assert.equal(
-      Object.values($(OPTION_ITEM)).map(item => item.innerText).filter(item => isPresent(item)),
-      PATTERN_OPTIONS.join(),
+      optionsToString($(selfServeConst.OPTION_ITEM)),
+      selfServeConst.PATTERN_OPTIONS.join(),
       'Pattern options render, number and text of options is correct'
     );
-
-    assert.equal(
-      $(SUBMIT_BUTTON)[0].disabled,
-      true,
+    assert.ok(
+      $(selfServeConst.SUBMIT_BUTTON).get(0).disabled,
       'Submit button is still disabled'
     );
 
     // Now verify expected field conditional behavior
-    await selectChoose(PATTERN_SELECT, 'Higher or lower than expected');
-    await selectChoose(APP_OPTIONS, 'the-lion-king');
+    await selectChoose(selfServeConst.PATTERN_SELECT, selfServeConst.PATTERN_OPTIONS[0]);
+    await selectChoose(selfServeConst.APP_OPTIONS, selectedApp);
     assert.equal(
-      $(INPUT_NAME).val(),
+      $(selfServeConst.INPUT_NAME).val(),
       'theLionKing_testMetric1_upDown_5Minutes',
       'Alert name autocomplete primer is working.'
     );
 
-    await click(SUBGROUP_SELECT);
+    await click(selfServeConst.SUBGROUP_SELECT);
     assert.equal(
-      $(OPTION_ITEM).get(0).innerText,
-      SELECTED_CONFIG_GROUP,
+      $(selfServeConst.OPTION_ITEM).get(0).innerText,
+      selectedConfigGroup,
       'The config group associated with the selected app is found in the group selection options.'
     );
 
-    await selectChoose(SUBGROUP_SELECT, SELECTED_CONFIG_GROUP);
+    await selectChoose(selfServeConst.SUBGROUP_SELECT, selectedConfigGroup);
     assert.equal(
-      $(`${CONFIG_GROUP_ALERTS} a`).get(0).innerText,
-      `See all alerts monitored by: ${SELECTED_CONFIG_GROUP}`,
+      $(selfServeConst.CONFIG_GROUP_ALERTS).get(0).innerText,
+      `See all alerts monitored by: ${selectedConfigGroup}`,
       'Custom accordion block with alert table for selected group appears'
     );
     assert.equal(
-      $(CONFIG_BLOCK).find('.control-label').get(0).innerText.replace(/\r?\n?/g, ''),
-      `Recipients in subscription group ${SELECTED_CONFIG_GROUP}:${GROUP_RECIPIENT}`,
+      $(selfServeConst.CONFIG_BLOCK).find('.control-label').get(0).innerText.replace(/\r?\n?/g, ''),
+      `Recipients in subscription group ${selectedConfigGroup}:${groupRecipient}`,
       'Label and email for recipients is correctly rendered'
     );
 
-    await fillIn(CONFIG_RECIPIENTS_INPUT, GROUP_RECIPIENT);
-    await triggerKeyEvent(CONFIG_RECIPIENTS_INPUT, 'keyup', '8');
+    await fillIn(selfServeConst.CONFIG_RECIPIENTS_INPUT, groupRecipient);
+    await triggerKeyEvent(selfServeConst.CONFIG_RECIPIENTS_INPUT, 'keyup', '8');
     assert.equal(
-      $(EMAIL_WARNING).get(0).innerText,
-      `Warning: ${GROUP_RECIPIENT} is already included in this group.`,
+      $(selfServeConst.EMAIL_WARNING).get(0).innerText,
+      `Warning: ${groupRecipient} is already included in this group.`,
       'Duplicate email warning appears correctly.'
     );
 
-    await fillIn(CONFIG_RECIPIENTS_INPUT, 'duane@therock.com');
-    assert.equal(
-      $(SUBMIT_BUTTON)[0].disabled,
-      false,
+    await fillIn(selfServeConst.CONFIG_RECIPIENTS_INPUT, newRecipient);
+    assert.notOk(
+      $(selfServeConst.SUBMIT_BUTTON).get(0).disabled,
       'Submit button is enabled'
     );
   });
 });
-

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-onboarding-test.js
@@ -1,0 +1,163 @@
+import $ from 'jquery';
+import { module, test } from 'qunit';
+import { isPresent } from "@ember/utils";
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, fillIn, click, currentURL, triggerKeyEvent } from '@ember/test-helpers';
+import { filters, dimensions, granularities } from 'thirdeye-frontend/mocks/metricPeripherals';
+import { selectChoose, clickTrigger } from 'thirdeye-frontend/tests/helpers/ember-power-select';
+
+module('Acceptance | create alert', function(hooks) {
+  setupApplicationTest(hooks);
+
+  const METRIC_SELECT = '#select-metric';
+  const METRIC_INPUT = '.ember-power-select-search-input';
+  const GRANULARITY_SELECT = '#select-granularity';
+  const DIMENSION_SELECT = '#select-dimension';
+  const PATTERN_SELECT = '#select-pattern';
+  const FILTER_SELECT = '#select-filters';
+  const SUBGROUP_SELECT = '#config-group';
+  const INPUT_NAME = '#anomaly-form-function-name';
+  const GRAPH_CONTAINER = '.te-graph-alert';
+  const OPTION_LIST = '.ember-power-select-options';
+  const OPTION_ITEM = 'li.ember-power-select-option';
+  const SELECTED_ITEM = '.ember-power-select-selected-item';
+  const APP_OPTIONS = '#anomaly-form-app-name';
+  const SPINNER = '.spinner-display';
+  const CONFIG_GROUP_ALERTS = '.te-form__custom-label';
+  const CONFIG_BLOCK = '.te-form__section-config';
+  const CONFIG_RECIPIENTS_INPUT = '#config-group-add-recipients';
+  const EMAIL_WARNING = '.te-form__alert--warning';
+  const SUBMIT_BUTTON = '.te-button--submit';
+  const SELECTED_CONFIG_GROUP = 'test_alert_1';
+  const SELECTED_METRIC = 'test_collection_1::test_metric_1';
+  const GROUP_RECIPIENT = 'simba@disney.com';
+  const PATTERN_OPTIONS = [
+    'Higher or lower than expected',
+    'Higher than expected',
+    'Lower than expected'
+  ];
+  // Flatten filter object in order to easily compare it to the list of options rendered
+  const FILTER_ARRAY = Object.values(filters).map(filterGroup => [...Object.values(filterGroup)]);
+
+  test(`visiting alert creation page to test onboarding flow for self-serve`, async (assert) => {
+    await visit(`/self-serve/create-alert`);
+
+    // Initial state: fields and graph are disabled
+    assert.equal(
+      $(GRANULARITY_SELECT).attr('aria-disabled'),
+      'true',
+      'Granularity field (representative) is disabled until metric is selected'
+    );
+    assert.equal(
+      $(GRAPH_CONTAINER).get(0).classList[1],
+      'te-graph-alert--pending',
+      'Graph placeholder is visible. Data is not yet loaded.'
+    );
+
+    // Select a metric
+    await click(METRIC_SELECT);
+    await fillIn(METRIC_INPUT, 'test');
+    await click($(`${OPTION_ITEM}:contains(${SELECTED_METRIC})`).get(0));
+
+    // Fields are now enabled with defaults and load correct options, graph is loaded
+    assert.equal(
+      $(GRANULARITY_SELECT).find(SELECTED_ITEM).get(0).innerText,
+      '5_MINUTES',
+      'granularity field (representative) is enabled after metric is selected'
+    );
+    assert.equal(
+      $(GRAPH_CONTAINER).get(0).classList.length,
+      1,
+      'Graph placeholder is replaced.'
+    );
+    assert.equal(
+      $(GRAPH_CONTAINER).find('svg').length,
+      3,
+      'Graph and legend svg elements are rendered.'
+    );
+    assert.equal(
+      $(SPINNER).length,
+      0,
+      'Loading icon is removed.'
+    );
+
+    // Now, verify that our selectable options are correct
+    await click(GRANULARITY_SELECT);
+    assert.equal(
+      Object.values($(OPTION_LIST).get(0).children).map(item => item.innerText).join(),
+      granularities.join(),
+      'Granularity options render, number and text of options is correct'
+    );
+
+    await click(DIMENSION_SELECT);
+    assert.equal(
+      Object.values($(OPTION_LIST).get(0).children).map(item => item.innerText).join(),
+      dimensions.join(),
+      'Dimension options render, number and text of options is correct'
+    );
+
+    await click(FILTER_SELECT);
+    assert.equal(
+      Object.values($(OPTION_ITEM)).map(item => item.innerText).filter(item => isPresent(item)),
+      FILTER_ARRAY.join(),
+      'Filter options render, number and text of options is correct'
+    );
+
+    await click(PATTERN_SELECT);
+    assert.equal(
+      Object.values($(OPTION_ITEM)).map(item => item.innerText).filter(item => isPresent(item)),
+      PATTERN_OPTIONS.join(),
+      'Pattern options render, number and text of options is correct'
+    );
+
+    assert.equal(
+      $(SUBMIT_BUTTON)[0].disabled,
+      true,
+      'Submit button is still disabled'
+    );
+
+    // Now verify expected field conditional behavior
+    await selectChoose(PATTERN_SELECT, 'Higher or lower than expected');
+    await selectChoose(APP_OPTIONS, 'the-lion-king');
+    assert.equal(
+      $(INPUT_NAME).val(),
+      'theLionKing_testMetric1_upDown_5Minutes',
+      'Alert name autocomplete primer is working.'
+    );
+
+    await click(SUBGROUP_SELECT);
+    assert.equal(
+      $(OPTION_ITEM).get(0).innerText,
+      SELECTED_CONFIG_GROUP,
+      'The config group associated with the selected app is found in the group selection options.'
+    );
+
+    await selectChoose(SUBGROUP_SELECT, SELECTED_CONFIG_GROUP);
+    assert.equal(
+      $(`${CONFIG_GROUP_ALERTS} a`).get(0).innerText,
+      `See all alerts monitored by: ${SELECTED_CONFIG_GROUP}`,
+      'Custom accordion block with alert table for selected group appears'
+    );
+    assert.equal(
+      $(CONFIG_BLOCK).find('.control-label').get(0).innerText.replace(/\r?\n?/g, ''),
+      `Recipients in subscription group ${SELECTED_CONFIG_GROUP}:${GROUP_RECIPIENT}`,
+      'Label and email for recipients is correctly rendered'
+    );
+
+    await fillIn(CONFIG_RECIPIENTS_INPUT, GROUP_RECIPIENT);
+    await triggerKeyEvent(CONFIG_RECIPIENTS_INPUT, 'keyup', '8');
+    assert.equal(
+      $(EMAIL_WARNING).get(0).innerText,
+      `Warning: ${GROUP_RECIPIENT} is already included in this group.`,
+      'Duplicate email warning appears correctly.'
+    );
+
+    await fillIn(CONFIG_RECIPIENTS_INPUT, 'duane@therock.com');
+    assert.equal(
+      $(SUBMIT_BUTTON)[0].disabled,
+      false,
+      'Submit button is enabled'
+    );
+  });
+});
+

--- a/thirdeye/thirdeye-frontend/tests/test-const.js
+++ b/thirdeye/thirdeye-frontend/tests/test-const.js
@@ -1,0 +1,39 @@
+import { isPresent } from "@ember/utils";
+
+/**
+ * General self-serve element selectors
+ */
+export const selfServeConst = {
+  METRIC_SELECT: '#select-metric',
+  METRIC_INPUT: '.ember-power-select-search-input',
+  GRANULARITY_SELECT: '#select-granularity',
+  DIMENSION_SELECT: '#select-dimension',
+  PATTERN_SELECT: '#select-pattern',
+  FILTER_SELECT: '#select-filters',
+  SUBGROUP_SELECT: '#config-group',
+  INPUT_NAME: '#anomaly-form-function-name',
+  GRAPH_CONTAINER: '.te-graph-alert',
+  OPTION_LIST: '.ember-power-select-options',
+  OPTION_ITEM: 'li.ember-power-select-option',
+  SELECTED_ITEM: '.ember-power-select-selected-item',
+  APP_OPTIONS: '#anomaly-form-app-name',
+  SPINNER: '.spinner-display',
+  CONFIG_GROUP_ALERTS: '.panel-title',
+  CONFIG_BLOCK: '.te-form__section-config',
+  CONFIG_RECIPIENTS_INPUT: '#config-group-add-recipients',
+  EMAIL_WARNING: '.te-form__alert--warning',
+  SUBMIT_BUTTON: '.te-button--submit',
+  PATTERN_OPTIONS: ['Higher or lower than expected', 'Higher than expected', 'Lower than expected']
+};
+
+/**
+ * Converts list options to comma-separated string
+ */
+export const optionsToString = ($optionList) => {
+  return Object.values($optionList).mapBy('innerText').filter(isPresent).join();
+};
+
+export default {
+  selfServeConst,
+  optionsToString
+};


### PR DESCRIPTION
This is the first of a series of Self-serve acceptance tests. This one covers alert creation. The intention is to extend this test across the "onboarding" flow in thirdEye.

In an effort to reduce maintenance time, I'm loading the constants for mock data from mirage files (as much as possible) rather than hard-coding expected values in the test.

Also: in `create-alert/controller.js` I'm preventing a form reset in the event of a metric loading error (not the behavior we want).

Second commit : added a selector constants file for use in tests.