### PR TITLE
Add noDictionaryConfig into IndexingConfig.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/IndexingConfig.java
@@ -39,7 +39,8 @@ public class IndexingConfig {
   private StreamConsumptionConfig _streamConsumptionConfig;
   private String _segmentFormatVersion;
   private String _columnMinMaxValueGeneratorMode;
-  private List<String> _noDictionaryColumns;
+  private List<String> _noDictionaryColumns; // TODO: replace this with noDictionaryConfig.
+  private Map<String, String> _noDictionaryConfig;
   private List<String> _onHeapDictionaryColumns;
   private StarTreeIndexSpec _starTreeIndexSpec;
   private SegmentPartitionConfig _segmentPartitionConfig;
@@ -113,12 +114,20 @@ public class IndexingConfig {
     return _noDictionaryColumns;
   }
 
+  public Map<String, String> getnoDictionaryConfig() {
+    return _noDictionaryConfig;
+  }
+
   public List<String> getOnHeapDictionaryColumns() {
     return _onHeapDictionaryColumns;
   }
 
   public void setNoDictionaryColumns(List<String> noDictionaryColumns) {
     _noDictionaryColumns = noDictionaryColumns;
+  }
+
+  public void setnoDictionaryConfig(Map<String, String> noDictionaryConfig) {
+    _noDictionaryConfig = noDictionaryConfig;
   }
 
   public void setOnHeapDictionaryColumns(List<String> onHeapDictionaryColumns) {
@@ -201,6 +210,7 @@ public class IndexingConfig {
         EqualityUtils.isEqual(_segmentFormatVersion, that._segmentFormatVersion) &&
         EqualityUtils.isEqual(_columnMinMaxValueGeneratorMode, that._columnMinMaxValueGeneratorMode) &&
         EqualityUtils.isEqual(_noDictionaryColumns, that._noDictionaryColumns) &&
+        EqualityUtils.isEqual(_noDictionaryConfig, that._noDictionaryConfig) &&
         EqualityUtils.isEqual(_onHeapDictionaryColumns, that._onHeapDictionaryColumns) &&
         EqualityUtils.isEqual(_starTreeIndexSpec, that._starTreeIndexSpec) &&
         EqualityUtils.isEqual(_segmentPartitionConfig, that._segmentPartitionConfig);
@@ -216,6 +226,7 @@ public class IndexingConfig {
     result = EqualityUtils.hashCodeOf(result, _segmentFormatVersion);
     result = EqualityUtils.hashCodeOf(result, _columnMinMaxValueGeneratorMode);
     result = EqualityUtils.hashCodeOf(result, _noDictionaryColumns);
+    result = EqualityUtils.hashCodeOf(result, _noDictionaryConfig);
     result = EqualityUtils.hashCodeOf(result, _onHeapDictionaryColumns);
     result = EqualityUtils.hashCodeOf(result, _starTreeIndexSpec);
     result = EqualityUtils.hashCodeOf(result, _segmentPartitionConfig);

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/IndexingConfigTest.java
@@ -47,6 +47,11 @@ public class IndexingConfigTest {
     json.put("keyThatIsUnknown", "randomValue");
     json.put("aggregateMetrics", "true");
 
+    JSONObject noDictConfig = new JSONObject();
+    noDictConfig.put("a", "SNAPPY");
+    noDictConfig.put("b", "PASS_THROUGH");
+    json.put("noDictionaryConfig", noDictConfig);
+
     ObjectMapper mapper = new ObjectMapper();
     JsonNode jsonNode = mapper.readTree(json.toString());
     IndexingConfig indexingConfig = mapper.readValue(jsonNode, IndexingConfig.class);
@@ -63,6 +68,12 @@ public class IndexingConfigTest {
     Assert.assertEquals("d", sortedIndexColumns.get(0));
     Assert.assertEquals("e", sortedIndexColumns.get(1));
     Assert.assertEquals("f", sortedIndexColumns.get(2));
+
+    // Test for noDictionaryConfig.
+    Map<String, String> noDictConfigMap = indexingConfig.getnoDictionaryConfig();
+    Assert.assertEquals(noDictConfigMap.size(), 2);
+    Assert.assertEquals(noDictConfig.get("a"), "SNAPPY");
+    Assert.assertEquals(noDictConfig.get("b"), "PASS_THROUGH");
 
     List<String> actualOnHeapDictionaryColumns = indexingConfig.getOnHeapDictionaryColumns();
     Assert.assertEquals(actualOnHeapDictionaryColumns.size(), expectedOnHeapDictionaryColumns.length);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/index/loader/IndexLoadingConfig.java
@@ -23,8 +23,10 @@ import com.linkedin.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.segment.index.loader.columnminmaxvalue.ColumnMinMaxValueGeneratorMode;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -39,7 +41,8 @@ public class IndexLoadingConfig {
   private ReadMode _readMode = ReadMode.DEFAULT_MODE;
   private List<String> _sortedColumns = Collections.emptyList();
   private Set<String> _invertedIndexColumns = new HashSet<>();
-  private Set<String> _noDictionaryColumns = new HashSet<>();
+  private Set<String> _noDictionaryColumns = new HashSet<>(); // TODO: replace this by _noDictionaryConfig.
+  private Map<String, String> _noDictionaryConfig = new HashMap<>();
   private Set<String> _onHeapDictionaryColumns = new HashSet<>();
   private SegmentVersion _segmentVersion;
   // This value will remain true only when the empty constructor is invoked.
@@ -76,6 +79,11 @@ public class IndexLoadingConfig {
     List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
     if (noDictionaryColumns != null) {
       _noDictionaryColumns.addAll(noDictionaryColumns);
+    }
+
+    Map<String, String> noDictionaryConfig = indexingConfig.getnoDictionaryConfig();
+    if (noDictionaryConfig != null) {
+      _noDictionaryConfig.putAll(noDictionaryConfig);
     }
 
     List<String> onHeapDictionaryColumns = indexingConfig.getOnHeapDictionaryColumns();
@@ -163,6 +171,11 @@ public class IndexLoadingConfig {
   @Nonnull
   public Set<String> getNoDictionaryColumns() {
     return _noDictionaryColumns;
+  }
+
+  @Nonnull
+  public Map<String, String> getnoDictionaryConfig() {
+    return _noDictionaryConfig;
   }
 
   @Nonnull


### PR DESCRIPTION
Currently the indexing config just contains noDictionary columns list,
but not the compression type for each column.

1. Created a new config that contains column:compression map. This can
potentially eliminate the noDictionary columns list in future.

2. Added unit test for the same.