### PR TITLE
[TE] Add tasks' error messages during execution

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -53,7 +53,7 @@ public class DetectionTaskRunner implements TaskRunner {
 
   public static final String BACKFILL_PREFIX = "adhoc_";
 
-  private static final double DIMENSION_ERROR_THRESHOLD = 0.1; // 10%
+  private static final double DIMENSION_ERROR_THRESHOLD = 0.3; // 3 0%
   private static final int MAX_ERROR_MESSAGE_WORD_COUNT = 10_000; // 10k bytes
 
   private List<DateTime> windowStarts;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -16,10 +16,14 @@ import com.linkedin.thirdeye.detector.function.AnomalyFunctionFactory;
 import com.linkedin.thirdeye.detector.function.BaseAnomalyFunction;
 import com.linkedin.thirdeye.detector.metric.transfer.MetricTransfer;
 import com.linkedin.thirdeye.detector.metric.transfer.ScalingFactor;
+import com.linkedin.thirdeye.util.ThirdEyeUtils;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -29,12 +33,14 @@ import org.slf4j.LoggerFactory;
 public class TimeBasedAnomalyMerger {
   private final static Logger LOG = LoggerFactory.getLogger(TimeBasedAnomalyMerger.class);
   private final static Double NULL_DOUBLE = Double.NaN;
-  private final static double NORMALIZATION_FACTOR = 1000; // to prevent from double overflow
 
   private final MergedAnomalyResultManager mergedResultDAO;
   private final AnomalyFunctionFactory anomalyFunctionFactory;
 
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
+
+  private static final double MERGE_ANOMALY_ERROR_THRESHOLD = 0.1; // 10%
+  private static final int MAX_ERROR_MESSAGE_WORD_COUNT = 10_000; // 10k bytes
 
   private final static AnomalyMergeConfig DEFAULT_TIME_BASED_MERGE_CONFIG;
   static {
@@ -71,7 +77,7 @@ public class TimeBasedAnomalyMerger {
    * @return the number of merged anomalies after merging
    */
   public ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergeAnomalies(AnomalyFunctionDTO functionSpec,
-      ListMultimap<DimensionMap, AnomalyResult> unmergedAnomalies) {
+      ListMultimap<DimensionMap, AnomalyResult> unmergedAnomalies) throws Exception {
 
     int rawAnomaliesCount = 0;
     for (DimensionMap dimensionMap : unmergedAnomalies.keySet()) {
@@ -92,7 +98,9 @@ public class TimeBasedAnomalyMerger {
       LOG.info("Created anomaly function for class: {}, set mergeable keys as: {}", anomalyFunction.getClass(),
           anomalyFunction.getMergeablePropertyKeys());
     } catch (Exception e) {
-      LOG.warn("Unsuccessfully create anomaly function from anomalyFunctionFactory, {}", e.getMessage());
+      String message = String.format("Unable to create anomaly function %s from anomalyFunctionFactory.", functionSpec);
+      LOG.error(message, e);
+      throw new Exception(message, e);
     }
 
 
@@ -102,9 +110,31 @@ public class TimeBasedAnomalyMerger {
       ListMultimap<DimensionMap, MergedAnomalyResultDTO> mergedAnomalies =
           dimensionalShuffleAndUnifyMerge(functionSpec, mergeConfig, unmergedAnomalies);
 
+      List<Exception> exceptions = new ArrayList<>();
       // Update information of merged anomalies
-      for (MergedAnomalyResultDTO mergedAnomalyResultDTO : mergedAnomalies.values()) {
-        updateMergedAnomalyInfo(mergedAnomalyResultDTO, mergeConfig);
+      for (MergedAnomalyResultDTO mergedAnomaly : mergedAnomalies.values()) {
+        try {
+          computeMergedAnomalyInfo(mergedAnomaly, mergeConfig);
+        } catch (Exception e) {
+          AnomalyFunctionDTO function = mergedAnomaly.getFunction();
+          String functionName = Long.toString(mergedAnomaly.getFunctionId());
+          if (function != null) {
+            functionName = function.getFunctionName();
+          }
+
+          String message = String.format(
+              "Failed to update merged anomaly info. Dataset: %s, Metric: %s, Function: %s, Time:%s - %s.",
+              mergedAnomaly.getCollection(), mergedAnomaly.getMetric(), function.getFunctionName(),
+              new DateTime(mergedAnomaly.getStartTime()), new DateTime(mergedAnomaly.getEndTime()));
+          LOG.warn(message, e);
+          exceptions.add(new Exception(message, e));
+
+          if (Double.compare((double) exceptions.size() / (double) mergedAnomalies.values().size(),
+              MERGE_ANOMALY_ERROR_THRESHOLD) >= 0) {
+            String exceptionMessage = ThirdEyeUtils.exceptionsToString(exceptions, MAX_ERROR_MESSAGE_WORD_COUNT);
+            throw new Exception(exceptionMessage);
+          }
+        }
       }
 
       return mergedAnomalies;
@@ -149,23 +179,6 @@ public class TimeBasedAnomalyMerger {
     }
 
     return mergedAnomalies;
-  }
-
-  private void updateMergedAnomalyInfo(MergedAnomalyResultDTO mergedResult, AnomalyMergeConfig mergeConfig) {
-    // recompute weight using anomaly function specific method
-    try {
-      computeMergedAnomalyInfo(mergedResult, mergeConfig);
-    } catch (Exception e) {
-      AnomalyFunctionDTO function = mergedResult.getFunction();
-      LOG.warn(
-          "Unable to compute merged weight and the average weight of raw anomalies is used. Dataset: {}, Topic Metric: {}, Function: {}, Time:{} - {}, Exception: {}",
-          function.getCollection(), function.getTopicMetric(), function.getFunctionName(),
-          new DateTime(mergedResult.getStartTime()), new DateTime(mergedResult.getEndTime()), e);
-    }
-  }
-
-  private static double getNormalizedBucketSize(double secondsInABucket) {
-    return secondsInABucket / NORMALIZATION_FACTOR;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.anomaly.merge;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.linkedin.thirdeye.anomaly.detection.AnomalyDetectionInputContext;
@@ -116,15 +117,20 @@ public class TimeBasedAnomalyMerger {
         try {
           computeMergedAnomalyInfo(mergedAnomaly, mergeConfig);
         } catch (Exception e) {
-          AnomalyFunctionDTO function = mergedAnomaly.getFunction();
-          String functionName = Long.toString(mergedAnomaly.getFunctionId());
-          if (function != null) {
-            functionName = function.getFunctionName();
+          String functionName = "";
+          if (mergedAnomaly.getFunction() != null) {
+            functionName = Strings.nullToEmpty(mergedAnomaly.getFunction().getFunctionName());
+          } else if (mergedAnomaly.getFunctionId() != null) {
+            functionName = mergedAnomaly.getFunctionId().toString();
+          }
+          long anomalyId = -1;
+          if (mergedAnomaly.getId() != null) {
+            anomalyId = mergedAnomaly.getId();
           }
 
           String message = String.format(
-              "Failed to update merged anomaly info. Dataset: %s, Metric: %s, Function: %s, Time:%s - %s.",
-              mergedAnomaly.getCollection(), mergedAnomaly.getMetric(), function.getFunctionName(),
+              "Failed to update merged anomaly info. ID: %s, dataset: %s, metric: %s, function: %s, time window:%s - %s",
+              anomalyId, mergedAnomaly.getCollection(), mergedAnomaly.getMetric(), functionName,
               new DateTime(mergedAnomaly.getStartTime()), new DateTime(mergedAnomaly.getEndTime()));
           LOG.warn(message, e);
           exceptions.add(new Exception(message, e));

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/merge/TimeBasedAnomalyMerger.java
@@ -40,7 +40,7 @@ public class TimeBasedAnomalyMerger {
 
   private static final DAORegistry DAO_REGISTRY = DAORegistry.getInstance();
 
-  private static final double MERGE_ANOMALY_ERROR_THRESHOLD = 0.1; // 10%
+  private static final double MERGE_ANOMALY_ERROR_THRESHOLD = 0.4; // 40%
   private static final int MAX_ERROR_MESSAGE_WORD_COUNT = 10_000; // 10k bytes
 
   private final static AnomalyMergeConfig DEFAULT_TIME_BASED_MERGE_CONFIG;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/task/TaskDriver.java
@@ -5,7 +5,6 @@ import com.linkedin.thirdeye.anomaly.utils.AnomalyUtils;
 import com.linkedin.thirdeye.detector.email.filter.AlertFilterFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/RawAnomalyResult.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomalydetection/context/RawAnomalyResult.java
@@ -1,5 +1,6 @@
 package com.linkedin.thirdeye.anomalydetection.context;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.linkedin.thirdeye.api.DimensionMap;
 import com.linkedin.thirdeye.datalayer.dto.AnomalyFeedbackDTO;
@@ -120,4 +121,18 @@ public class RawAnomalyResult implements AnomalyResult {
     }
   }
 
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("startTime", startTime)
+        .add("endTime", endTime)
+        .add("dimensions", dimensions)
+        .add("score", score)
+        .add("weight", weight)
+        .add("avgCurrentVal", avgCurrentVal)
+        .add("avgBaselineVal", avgBaselineVal)
+        .add("properties", properties)
+        .add("feedback", feedback)
+        .toString();
+  }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/TaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/TaskManager.java
@@ -22,7 +22,7 @@ public interface TaskManager extends AbstractManager<TaskDTO>{
       TaskStatus newStatus, int expectedVersion);
 
   void updateStatusAndTaskEndTime(Long id, TaskStatus oldStatus, TaskStatus newStatus,
-      Long taskEndTime);
+      Long taskEndTime, String message);
 
   int deleteRecordsOlderThanDaysWithStatus(int days, TaskStatus status);
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/bao/jdbc/TaskManagerImpl.java
@@ -87,11 +87,12 @@ public class TaskManagerImpl extends AbstractManagerImpl<TaskDTO> implements Tas
 
   @Override
   public void updateStatusAndTaskEndTime(Long id, TaskStatus oldStatus, TaskStatus newStatus,
-      Long taskEndTime) {
+      Long taskEndTime, String message) {
     TaskDTO task = findById(id);
     if (task.getStatus().equals(oldStatus)) {
       task.setStatus(newStatus);
       task.setEndTime(taskEndTime);
+      task.setMessage(message);
       save(task);
     }
   }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/TaskBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/TaskBean.java
@@ -20,7 +20,10 @@ public class TaskBean extends AbstractBean {
   private TaskStatus status;
   private long startTime;
   private long endTime;
+  // A JSON string of the task info such as anomaly function, monitoring windows, etc.
   private String taskInfo;
+  // The task results, which could contain the error messages of tasks' execution.
+  private String message;
   private Timestamp lastModified;
 
   public Long getWorkerId() {
@@ -75,10 +78,17 @@ public class TaskBean extends AbstractBean {
     return taskType;
   }
 
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
   public void setTaskType(TaskType taskType) {
     this.taskType = taskType;
   }
-
 
   public Timestamp getLastModified() {
     return lastModified;
@@ -95,6 +105,7 @@ public class TaskBean extends AbstractBean {
   public void setJobId(Long jobId) {
     this.jobId = jobId;
   }
+
 
   @Override
   public boolean equals(Object o) {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -452,7 +452,7 @@ public abstract class ThirdEyeUtils {
     if (CollectionUtils.isNotEmpty(exceptions)) {
       StringBuilder sb = new StringBuilder();
       for (Exception exception : exceptions) {
-        sb.append(exception.getMessage()).append("\n").append(ExceptionUtils.getStackTrace(exception));
+        sb.append(ExceptionUtils.getStackTrace(exception));
         if (maxWordCount > 0 && sb.length() > maxWordCount) {
           message = sb.toString().substring(0, maxWordCount) + "\n...";
           break;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/util/ThirdEyeUtils.java
@@ -24,8 +24,10 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import javax.validation.Validation;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.joda.time.Period;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -435,6 +437,32 @@ public abstract class ThirdEyeUtils {
       }
     }
     return map;
+  }
+
+  /**
+   * Prints messages and stack traces of the given list of exceptions in a string.
+   *
+   * @param exceptions the list of exceptions to be printed.
+   * @param maxWordCount the length limitation of the string; set to 0 to remove the limitation.
+   *
+   * @return the string that contains the messages and stack traces of the given exceptions.
+   */
+  public static String exceptionsToString(List<Exception> exceptions, int maxWordCount) {
+    String message = "";
+    if (CollectionUtils.isNotEmpty(exceptions)) {
+      StringBuilder sb = new StringBuilder();
+      for (Exception exception : exceptions) {
+        sb.append(exception.getMessage()).append("\n").append(ExceptionUtils.getStackTrace(exception));
+        if (maxWordCount > 0 && sb.length() > maxWordCount) {
+          message = sb.toString().substring(0, maxWordCount) + "\n...";
+          break;
+        }
+      }
+      if (message.equals("")) {
+        message = sb.toString();
+      }
+    }
+    return message;
   }
 
   /**

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/bao/TestAnomalyTaskManager.java
@@ -91,10 +91,11 @@ public class TestAnomalyTaskManager {
     TaskStatus oldStatus = TaskStatus.RUNNING;
     TaskStatus newStatus = TaskStatus.COMPLETED;
     long taskEndTime = System.currentTimeMillis();
-    taskDAO.updateStatusAndTaskEndTime(anomalyTaskId1, oldStatus, newStatus, taskEndTime);
+    taskDAO.updateStatusAndTaskEndTime(anomalyTaskId1, oldStatus, newStatus, taskEndTime, "testMessage");
     TaskDTO anomalyTask = taskDAO.findById(anomalyTaskId1);
     Assert.assertEquals(anomalyTask.getStatus(), newStatus);
     Assert.assertEquals(anomalyTask.getEndTime(), taskEndTime);
+    Assert.assertEquals(anomalyTask.getMessage(), "testMessage");
   }
 
   @Test(dependsOnMethods = {"testUpdateStatusAndTaskEndTime"})

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/util/ThirdEyeUtilsTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/util/ThirdEyeUtilsTest.java
@@ -1,13 +1,9 @@
 package com.linkedin.thirdeye.util;
 
-
+import java.util.ArrayList;
+import java.util.List;
 import org.testng.Assert;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multimap;
 
 @Test
 public class ThirdEyeUtilsTest {
@@ -139,6 +135,26 @@ public class ThirdEyeUtilsTest {
     Assert.assertEquals(ThirdEyeUtils.getRoundedValue(Double.NaN), Double.toString(Double.NaN));
     Assert.assertEquals(ThirdEyeUtils.getRoundedValue(Double.POSITIVE_INFINITY), Double.toString(Double.POSITIVE_INFINITY));
     Assert.assertEquals(ThirdEyeUtils.getRoundedValue(Double.NEGATIVE_INFINITY), Double.toString(Double.NEGATIVE_INFINITY));
+  }
+
+  @Test
+  public void testExceptionToStringUnlimited() {
+    List<Exception> exceptions = new ArrayList<>();
+    exceptions.add(new Exception("e1"));
+    exceptions.add(new Exception("e2"));
+    exceptions.add(new Exception("e3"));
+    String errorMessage = ThirdEyeUtils.exceptionsToString(exceptions, 0);
+    Assert.assertTrue(errorMessage.contains("e3"));
+  }
+
+  @Test
+  public void testExceptionToStringLimited() {
+    List<Exception> exceptions = new ArrayList<>();
+    exceptions.add(new Exception("e1"));
+    exceptions.add(new Exception("e2"));
+    exceptions.add(new Exception("e3"));
+    String errorMessage = ThirdEyeUtils.exceptionsToString(exceptions, 100);
+    Assert.assertFalse(errorMessage.contains("e3"));
   }
 
 }


### PR DESCRIPTION
1. Store the message and stack trace of the exceptions that are induced during task execution.
2. If more than 10% of dimension exploration or 10% of merged anomaly updates fail, the task becomes FAILED instead of COMPLETE. The error message will be logged in TE's DB.

Tested on local anomaly detection.