### PR TITLE
Initial code to support derived fields

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -55,7 +55,7 @@ public abstract class FieldSpec {
 
   private transient String _stringDefaultNullValue;
   
-  //apply a transform function to generate this column, this can be based on any other column
+  //apply a transform function to generate this column, this can be based on another column
   private String _transformFunction; 
 
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -54,6 +54,9 @@ public abstract class FieldSpec {
   protected Object _defaultNullValue;
 
   private transient String _stringDefaultNullValue;
+  
+  //apply a transform function to generate this column, this can be based on any other column
+  private String _transformFunction; 
 
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.
   public FieldSpec() {
@@ -180,6 +183,13 @@ public abstract class FieldSpec {
     }
   }
 
+  /**
+   * Transform function if defined else null.
+   * @return
+   */
+  public String getTransformFunction() {
+    return _transformFunction;
+  }
   /**
    * Returns the {@link JsonObject} representing the field spec.
    * <p>Only contains fields with non-default value.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
@@ -25,6 +25,8 @@ import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.time.TimeConverter;
 import com.linkedin.pinot.common.utils.time.TimeConverterProvider;
 import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.core.data.function.FunctionExpressionEvaluator;
+
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -74,12 +76,14 @@ public class PlainFieldExtractor implements FieldExtractor {
   private String _incomingTimeColumnName;
   private String _outgoingTimeColumnName;
   private TimeConverter _timeConverter;
-
+  private Map<String, FunctionExpressionEvaluator> _functionEvaluatorMap;
+  
   public PlainFieldExtractor(Schema schema) {
     _schema = schema;
     initErrorCount();
     initColumnTypes();
     initTimeConverters();
+    initFunctionEvaluators();
   }
 
   public void resetCounters() {
@@ -117,6 +121,23 @@ public class PlainFieldExtractor implements FieldExtractor {
     }
   }
 
+  private void initFunctionEvaluators(){
+    _functionEvaluatorMap = new HashMap<>();
+    for (String column : _schema.getColumnNames()) {
+      FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
+      if (fieldSpec.getTransformFunction() != null) {
+        String expression = fieldSpec.getTransformFunction();
+        FunctionExpressionEvaluator functionEvaluator;
+        try {
+          functionEvaluator = new FunctionExpressionEvaluator(column, expression);
+          _functionEvaluatorMap.put(column, functionEvaluator);
+        } catch (Exception e) {
+          LOGGER.error("Unable to instantiate function evaluator for {}", expression, e);
+        }
+      }
+    }
+  }
+  
   @Override
   public Schema getSchema() {
     return _schema;
@@ -146,10 +167,7 @@ public class PlainFieldExtractor implements FieldExtractor {
       if (column.equals(_outgoingTimeColumnName) && _timeConverter != null) {
         // Convert incoming time to outgoing time.
         value = row.getValue(_incomingTimeColumnName);
-        if (value == null) {
-          hasNull = true;
-          _totalNullCols++;
-        } else {
+        if (value != null) {
           try {
             value = _timeConverter.convert(value);
           } catch (Exception e) {
@@ -159,12 +177,16 @@ public class PlainFieldExtractor implements FieldExtractor {
             _errorCount.put(column, _errorCount.get(column) + 1);
           }
         }
+      } else if (fieldSpec.getTransformFunction() != null) {
+         FunctionExpressionEvaluator functionEvaluator = _functionEvaluatorMap.get(column);
+         value = functionEvaluator.evaluate(row);
       } else {
         value = row.getValue(column);
-        if (value == null) {
-          hasNull = true;
-          _totalNullCols++;
-        }
+      }
+      
+      if (value == null) {
+        hasNull = true;
+        _totalNullCols++;
       }
 
       // Convert value if necessary.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluator.java
@@ -23,12 +23,12 @@ import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.pql.parsers.Pql2Compiler;
 
 /**
- * Evaluates a function expression. This is optimized <br>
- * for evaluating the same expression many times with different inputs.
+ * Evaluates a function expression. This is optimized 
+ * for evaluating the an expression multiple times with different inputs.
  * Overall idea 
  *  - Parse the function expression into an expression tree
  *  - Convert each node in the expression tree into and ExecutableNode
- *  - A ExecutableNode can be a 
+ *  - An ExecutableNode can be a 
  *      - FunctionNode - That executes another function
  *      - ColumnNode - fetches the value of the column from the input GenericRow
  *      - ConstantNode - returns the same value - typically constant function arguments are represented using a ConstantNode
@@ -128,15 +128,15 @@ public class FunctionExpressionEvaluator {
   }
 
   private static class ConstantExecutionNode implements ExecutableNode {
-    private String _constant;
+    private String _value;
 
-    public ConstantExecutionNode(String constant) {
-      this._constant = constant;
+    public ConstantExecutionNode(String value) {
+      _value = value;
     }
 
     @Override
     public Object execute(GenericRow row) {
-      return _constant;
+      return _value;
     }
 
     @Override
@@ -150,7 +150,7 @@ public class FunctionExpressionEvaluator {
     private String _column;
 
     public ColumnExecutionNode(String column) {
-      this._column = column;
+      _column = column;
     }
 
     @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluator.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.data.function;
+
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
+import com.linkedin.pinot.core.data.GenericRow;
+import com.linkedin.pinot.pql.parsers.Pql2Compiler;
+
+/**
+ * Evaluates a function expression. This is optimized <br>
+ * for evaluating the same expression many times with different inputs.
+ * Overall idea 
+ *  - Parse the function expression into an expression tree
+ *  - Convert each node in the expression tree into and ExecutableNode
+ *  - A ExecutableNode can be a 
+ *      - FunctionNode - That executes another function
+ *      - ColumnNode - fetches the value of the column from the input GenericRow
+ *      - ConstantNode - returns the same value - typically constant function arguments are represented using a ConstantNode
+ */
+public class FunctionExpressionEvaluator {
+  /**
+   * PQL compilers are not thread safe. Creating one per thread
+   */
+  static ThreadLocal<Pql2Compiler> COMPILER_CACHE = new ThreadLocal<Pql2Compiler>() {
+    protected Pql2Compiler initialValue() {
+      return new Pql2Compiler();
+    };
+  };
+  /**
+   * Root of the execution tree
+   */
+  ExecutableNode _rootNode;
+
+  public FunctionExpressionEvaluator(String columnName, String expression) throws Exception {
+    TransformExpressionTree expressionTree;
+    expressionTree = COMPILER_CACHE.get().compileToExpressionTree(expression);
+    _rootNode = planExecution(expressionTree);
+  }
+
+  private ExecutableNode planExecution(TransformExpressionTree expressionTree) throws Exception {
+    String transformName = expressionTree.getValue();
+    List<TransformExpressionTree> children = expressionTree.getChildren();
+    Class<?>[] argumentTypes = new Class<?>[children.size()];
+    ExecutableNode[] childNodes = new ExecutableNode[children.size()];
+    for (int i = 0; i < children.size(); i++) {
+      TransformExpressionTree childExpression = children.get(i);
+      ExecutableNode childNode;
+      switch (childExpression.getExpressionType()) {
+      case FUNCTION:
+        childNode = planExecution(childExpression);
+        break;
+      case IDENTIFIER:
+        childNode = new ColumnExecutionNode(childExpression.getValue());
+        break;
+      case LITERAL:
+        childNode = new ConstantExecutionNode(childExpression.getValue());
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported expression type:" + childExpression.getExpressionType());
+      }
+      childNodes[i] = childNode;
+      argumentTypes[i] = childNode.getReturnType();
+    }
+
+    FunctionInfo functionInfo = FunctionRegistry.resolve(transformName, argumentTypes);
+    return new FunctionExecutionNode(functionInfo, childNodes);
+  }
+
+  public Object evaluate(GenericRow row) {
+    return _rootNode.execute(row);
+  }
+
+  private static interface ExecutableNode {
+    /**
+     * 
+     * @param row
+     * @return
+     */
+    Object execute(GenericRow row);
+
+    /**
+     * 
+     * @return
+     */
+    Class<?> getReturnType();
+
+  }
+
+  private static class FunctionExecutionNode implements ExecutableNode {
+    FunctionInvoker _functionInvoker;
+    ExecutableNode[] _argumentProviders;
+    Object[] _argInputs;
+
+    public FunctionExecutionNode(FunctionInfo functionInfo, ExecutableNode[] argumentProviders) throws Exception {
+      Preconditions.checkNotNull(functionInfo);
+      Preconditions.checkNotNull(argumentProviders);
+      _functionInvoker = new FunctionInvoker(functionInfo);
+      _argumentProviders = argumentProviders;
+      _argInputs = new Object[_argumentProviders.length];
+    }
+
+    public Object execute(GenericRow row) {
+      for (int i = 0; i < _argumentProviders.length; i++) {
+        _argInputs[i] = _argumentProviders[i].execute(row);
+      }
+      return _functionInvoker.process(_argInputs);
+    }
+
+    public Class<?> getReturnType() {
+      return _functionInvoker.getReturnType();
+    }
+  }
+
+  private static class ConstantExecutionNode implements ExecutableNode {
+    private String _constant;
+
+    public ConstantExecutionNode(String constant) {
+      this._constant = constant;
+    }
+
+    @Override
+    public Object execute(GenericRow row) {
+      return _constant;
+    }
+
+    @Override
+    public Class<?> getReturnType() {
+      return String.class;
+    }
+
+  }
+
+  private static class ColumnExecutionNode implements ExecutableNode {
+    private String _column;
+
+    public ColumnExecutionNode(String column) {
+      this._column = column;
+    }
+
+    @Override
+    public Object execute(GenericRow row) {
+      return row.getValue(_column);
+    }
+
+    @Override
+    public Class<?> getReturnType() {
+      return Object.class;
+    }
+
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInfo.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInfo.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.data.function;
+
+import java.lang.reflect.Method;
+
+public class FunctionInfo {
+
+  private final Method _method;
+  private final Class<?> _clazz;
+
+  public FunctionInfo(Method method, Class<?> clazz) {
+    super();
+    this._method = method;
+    this._clazz = clazz;
+  }
+
+  public Method getMethod() {
+    return _method;
+  }
+
+  public Class<?> getClazz() {
+    return _clazz;
+  }
+
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInfo.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInfo.java
@@ -47,11 +47,12 @@ public class FunctionInfo {
    */
   public boolean isApplicable(Class<?>[] argumentTypes) {
 
-    if (_method.getParameterCount() != argumentTypes.length) {
+    Class<?>[] parameterTypes = _method.getParameterTypes();
+
+    if (parameterTypes.length != argumentTypes.length) {
       return false;
     }
 
-    Class<?>[] parameterTypes = _method.getParameterTypes();
     for (int i = 0; i < parameterTypes.length; i++) {
       Class<?> type = parameterTypes[i];
       //

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInfo.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInfo.java
@@ -36,4 +36,39 @@ public class FunctionInfo {
     return _clazz;
   }
 
+  /**
+   * Check if the Function is applicable to the argumentTypes.
+   * We can only know the types at runtime, so we can validate if the return type is Object.
+   * For e.g funcA( funcB('3.14'), columnA)
+   * We can only know return type of funcB and 3.14 (String.class) but 
+   * we cannot know the type of columnA in advance without knowing the source schema
+   * @param argumentTypes
+   * @return
+   */
+  public boolean isApplicable(Class<?>[] argumentTypes) {
+
+    if (_method.getParameterCount() != argumentTypes.length) {
+      return false;
+    }
+
+    Class<?>[] parameterTypes = _method.getParameterTypes();
+    for (int i = 0; i < parameterTypes.length; i++) {
+      Class<?> type = parameterTypes[i];
+      //
+      if (!type.isAssignableFrom(argumentTypes[i]) && argumentTypes[i] != Object.class) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Eventually we will need to convert the input datatypes before invoking the actual method. For now, there is no conversion
+   * 
+   * @param args
+   * @return
+   */
+  public Object[] convertTypes(Object[] args) {
+    return args;
+  }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInvoker.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInvoker.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.data.function;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple code to invoke a method in any class using reflection.
+ * Eventually this will support annotations on the method but for now its a simple wrapper on any java method
+ */
+public class FunctionInvoker {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FunctionInvoker.class);
+  // Don't log more than 10 entries in 5 MINUTES 
+  //TODO:Convert this functionality into a class that can be used in other places
+  private static long EXCEPTION_LIMIT_DURATION = TimeUnit.MINUTES.toMillis(5);
+  private static long EXCEPTION_LIMIT_RATE = 10;
+  Method _method;
+  Object _instance;
+  int exceptionCount;
+  long lastExceptionTime = 0;
+
+  public FunctionInvoker(FunctionInfo info) throws Exception {
+    _method = info.getMethod();
+    Class<?> clazz = info.getClazz();
+    if (Modifier.isStatic(_method.getModifiers())) {
+      _instance = null;
+    } else {
+      _instance = clazz.newInstance();
+    }
+  }
+
+  public Class<?>[] getParameterTypes() {
+    return _method.getParameterTypes();
+  }
+
+  public Class<?> getReturnType() {
+    return _method.getReturnType();
+  }
+
+  public Object process(Object[] args) {
+    try {
+      return _method.invoke(_instance, args);
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      //most likely the exception is in the udf,  get the exceptio
+      Throwable cause = e.getCause();
+      if (cause == null) {
+        cause = e;
+      }
+      //some udf's might be configured incorrectly and we dont want to pollute the log
+      //keep track of the last time an exception was logged and reset the counter if the last exception is more than the EXCEPTION_LIMIT_DURATION
+      if(Duration.millis(System.currentTimeMillis() - lastExceptionTime).getStandardMinutes() > EXCEPTION_LIMIT_DURATION) {
+        exceptionCount = 0;
+      }
+      if(exceptionCount < EXCEPTION_LIMIT_RATE) {
+        exceptionCount = exceptionCount + 1;
+        LOGGER.error("Exception invoking method:{} with args:{}, exception message: {}", _method.getName(), Arrays.toString(args), cause.getMessage());
+      }
+      return null;
+    }
+  }
+
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInvoker.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionInvoker.java
@@ -37,14 +37,16 @@ public class FunctionInvoker {
   //TODO:Convert this functionality into a class that can be used in other places
   private static long EXCEPTION_LIMIT_DURATION = TimeUnit.MINUTES.toMillis(5);
   private static long EXCEPTION_LIMIT_RATE = 10;
-  Method _method;
-  Object _instance;
-  int exceptionCount;
-  long lastExceptionTime = 0;
+  private Method _method;
+  private Object _instance;
+  private int exceptionCount;
+  private long lastExceptionTime = 0;
+  private FunctionInfo _functionInfo;
 
-  public FunctionInvoker(FunctionInfo info) throws Exception {
-    _method = info.getMethod();
-    Class<?> clazz = info.getClazz();
+  public FunctionInvoker(FunctionInfo functionInfo) throws Exception {
+    _functionInfo = functionInfo;
+    _method = functionInfo.getMethod();
+    Class<?> clazz = functionInfo.getClazz();
     if (Modifier.isStatic(_method.getModifiers())) {
       _instance = null;
     } else {
@@ -62,7 +64,7 @@ public class FunctionInvoker {
 
   public Object process(Object[] args) {
     try {
-      return _method.invoke(_instance, args);
+      return _method.invoke(_instance, _functionInfo.convertTypes(args));
     } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
       //most likely the exception is in the udf,  get the exceptio
       Throwable cause = e.getCause();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionRegistry.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionRegistry.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.data.function;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FunctionRegistry {
+
+  static Map<String, List<FunctionInfo>> _functionHandleMap = new HashMap<>();
+
+  public static FunctionInfo resolve(String functionName, Object[] argumentTypes) {
+    List<FunctionInfo> list = _functionHandleMap.get(functionName.toLowerCase());
+    if(list != null && list.size() > 0) {
+      return list.get(0);
+    }
+    return null;
+  }
+
+  public static void registerStaticFunction(Method method) {
+
+    List<FunctionInfo> list = new ArrayList<>();
+    FunctionInfo functionInfo = new FunctionInfo(method, method.getDeclaringClass());
+    list.add(functionInfo);
+    _functionHandleMap.put(method.getName().toLowerCase(), list);
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionRegistry.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/function/FunctionRegistry.java
@@ -16,28 +16,37 @@
 package com.linkedin.pinot.core.data.function;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.Preconditions;
+
 public class FunctionRegistry {
 
-  static Map<String, List<FunctionInfo>> _functionHandleMap = new HashMap<>();
+  static Map<String, List<FunctionInfo>> _functionInfoMap = new HashMap<>();
 
-  public static FunctionInfo resolve(String functionName, Object[] argumentTypes) {
-    List<FunctionInfo> list = _functionHandleMap.get(functionName.toLowerCase());
-    if(list != null && list.size() > 0) {
-      return list.get(0);
+  public static FunctionInfo resolve(String functionName, Class<?>[] argumentTypes) {
+    List<FunctionInfo> list = _functionInfoMap.get(functionName.toLowerCase());
+    FunctionInfo bestMatch = null;
+    if (list != null && list.size() > 0) {
+      for (FunctionInfo functionInfo : list) {
+        if(functionInfo.isApplicable(argumentTypes)){
+          bestMatch = functionInfo;
+          break;
+        }
+      }
     }
-    return null;
+    return bestMatch;
   }
 
   public static void registerStaticFunction(Method method) {
-
+    Preconditions.checkArgument(Modifier.isStatic(method.getModifiers()), "Method needs to be static:" + method);
     List<FunctionInfo> list = new ArrayList<>();
     FunctionInfo functionInfo = new FunctionInfo(method, method.getDeclaringClass());
     list.add(functionInfo);
-    _functionHandleMap.put(method.getName().toLowerCase(), list);
+    _functionInfoMap.put(method.getName().toLowerCase(), list);
   }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluatorTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.data.function;
+
+import org.joda.time.DateTime;
+import org.joda.time.Days;
+import org.joda.time.MutableDateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.pinot.core.data.GenericRow;
+
+import scala.collection.mutable.StringBuilder;
+
+public class FunctionExpressionEvaluatorTest {
+
+  @Test
+  public void testExpressionWithColumn() throws Exception {
+    FunctionRegistry.registerStaticFunction(MyFunc.class.getDeclaredMethod("reverseString", String.class));
+    String expression = "reverseString(testColumn)";
+
+    FunctionExpressionEvaluator evaluator = new FunctionExpressionEvaluator("testColumn", expression);
+    GenericRow row = new GenericRow();
+    for (int i = 0; i < 5; i++) {
+      String value = "testValue" + i;
+      row.putField("testColumn", value);
+      Object result = evaluator.evaluate(row);
+      Assert.assertEquals(result, new StringBuilder(value).reverse().toString());
+    }
+
+  }
+
+  @Test
+  public void testExpressionWithConstant() throws Exception {
+    FunctionRegistry.registerStaticFunction(MyFunc.class.getDeclaredMethod("daysSinceEpoch", String.class, String.class));
+    String input= "1980-01-01";
+    String format = "yyyy-MM-dd";
+    String expression = String.format("daysSinceEpoch('%s', '%s')",input, format);
+    FunctionExpressionEvaluator evaluator = new FunctionExpressionEvaluator("testColumn", expression);
+    GenericRow row = new GenericRow();
+    Object result = evaluator.evaluate(row);
+    Assert.assertEquals(result, MyFunc.daysSinceEpoch(input, format));
+  }
+  @Test
+  public void testMultiFunctionExpression() throws Exception {
+    FunctionRegistry.registerStaticFunction(MyFunc.class.getDeclaredMethod("reverseString", String.class));
+    FunctionRegistry.registerStaticFunction(MyFunc.class.getDeclaredMethod("daysSinceEpoch", String.class, String.class));
+    String input = "1980-01-01";
+    String reversedInput = MyFunc.reverseString(input);
+    String format = "yyyy-MM-dd";
+    String expression = String.format("daysSinceEpoch(reverseString('%s'), '%s')",reversedInput, format);
+    FunctionExpressionEvaluator evaluator = new FunctionExpressionEvaluator("testColumn", expression);
+    GenericRow row = new GenericRow();
+    Object result = evaluator.evaluate(row);
+    Assert.assertEquals(result, MyFunc.daysSinceEpoch(input, format));
+  }
+
+  static class MyFunc {
+
+    public static String reverseString(String input) {
+      return new StringBuilder(input).reverse().toString();
+    }
+
+    static MutableDateTime EPOCH_START = new MutableDateTime();
+    static {
+      EPOCH_START.setDate(0L); // Set to Epoch time
+    }
+
+    public static int daysSinceEpoch(String input, String format) {
+      DateTime dateTime = DateTimeFormat.forPattern(format).parseDateTime(input);
+      return Days.daysBetween(EPOCH_START, dateTime).getDays();
+    }
+  }
+}

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluatorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/function/FunctionExpressionEvaluatorTest.java
@@ -15,6 +15,8 @@
  */
 package com.linkedin.pinot.core.data.function;
 
+import java.lang.reflect.Method;
+
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.MutableDateTime;
@@ -30,7 +32,10 @@ public class FunctionExpressionEvaluatorTest {
 
   @Test
   public void testExpressionWithColumn() throws Exception {
-    FunctionRegistry.registerStaticFunction(MyFunc.class.getDeclaredMethod("reverseString", String.class));
+    Method method = MyFunc.class.getDeclaredMethod("reverseString", String.class);
+    FunctionRegistry.registerStaticFunction(method);
+    FunctionInfo functionInfo = FunctionRegistry.resolve("reverseString", new Class<?>[]{Object.class});
+    System.out.println(functionInfo);
     String expression = "reverseString(testColumn)";
 
     FunctionExpressionEvaluator evaluator = new FunctionExpressionEvaluator("testColumn", expression);


### PR DESCRIPTION
Current implementation introduces the ability to specify a transformFunction to compute the value of a field. This will work only if the columns referenced in the transform functions are also part of the schema. 

The overall goal was to have one common code to compute derived fields across segment generation in batch mode and real-time ingestion. But we currently have two different interfaces to decode the input data into pinot generic row. 

Offline: Uses RecordReader interface to abstract underlying format such as AVRO, JSON, Thrift etc. Schema is optional here.
Realtime: Uses MessageDecoder interface to convert a single row in the stream into GenericRow. Schema is mandatory for realtime.

We need to use the same interface and make Schema mandatory across both offline and real-time.

While defining the interfaces, we need to change eliminate the need for Decoder/RecordReader to know about the schema. 


