### PR TITLE
Fixing NoClassDefFoundError issue inside pinot-distribution

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -58,6 +58,10 @@
       <artifactId>commons-cli</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.5</version>


### PR DESCRIPTION
Got exception when try to run scripts generated in pinot-distribution:

>-> % bin/start-controller.sh
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/logging/Log
	at com.linkedin.pinot.tools.admin.command.StartControllerCommand.execute(StartControllerCommand.java:138)
	at com.linkedin.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:120)
	at com.linkedin.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:132)
	at com.linkedin.pinot.tools.admin.PinotController.main(PinotController.java:32)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.logging.Log
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:338)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 4 more