### PR TITLE
[TE] rootcause - generalized baseline granularity

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * The endpoint parses metric urns and a unified set of "offsets", i.e. time-warped baseline of the
  * specified metric. It further aligns queried time stamps to sensibly match the raw dataset.</p>
  *
- * @see RootCauseMetricResource#parseOffset(MetricSlice, String, String) supported offsets
+ * @see RootCauseMetricResource#parseOffset(String, String) supported offsets
  */
 @Path(value = "/rootcause/metric")
 @Produces(MediaType.APPLICATION_JSON)
@@ -100,7 +100,7 @@ public class RootCauseMetricResource {
    * @param offset offset identifier (e.g. "current", "wo2w")
    * @param timezone timezone identifier (e.g. "America/Los_Angeles")
    *
-   * @see RootCauseMetricResource#parseOffset(MetricSlice, String, String) supported offsets
+   * @see RootCauseMetricResource#parseOffset(String, String) supported offsets
    *
    * @return aggregate value, or NaN if data not available
    * @throws Exception on catch-all execution failure
@@ -123,7 +123,7 @@ public class RootCauseMetricResource {
     }
 
     MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end), timezone);
-    Baseline range = parseOffset(baseSlice, offset, timezone);
+    Baseline range = parseOffset(offset, timezone);
 
     List<MetricSlice> slices = range.scatter(baseSlice);
     logSlices(baseSlice, slices);
@@ -148,7 +148,7 @@ public class RootCauseMetricResource {
    * @param offsets A list of offset identifier (e.g. "current", "wo2w")
    * @param timezone timezone identifier (e.g. "America/Los_Angeles")
    *
-   * @see RootCauseMetricResource#parseOffset(MetricSlice, String, String) supported offsets
+   * @see RootCauseMetricResource#parseOffset(String, String) supported offsets
    *
    * @return aggregate value, or NaN if data not available
    * @throws Exception on catch-all execution failure
@@ -183,7 +183,7 @@ public class RootCauseMetricResource {
       MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end), timezone);
       offsetToBaseSlice.put(offset, baseSlice);
 
-      Baseline range = parseOffset(baseSlice, offset, timezone);
+      Baseline range = parseOffset(offset, timezone);
       offsetToRange.put(offset, range);
 
       List<MetricSlice> currentSlices = range.scatter(baseSlice);
@@ -218,7 +218,7 @@ public class RootCauseMetricResource {
    * @param timezone timezone identifier (e.g. "America/Los_Angeles")
    * @param rollup limit results to the top k elements, plus an 'OTHER' rollup element
    *
-   * @see RootCauseMetricResource#parseOffset(MetricSlice, String, String) supported offsets
+   * @see RootCauseMetricResource#parseOffset(String, String) supported offsets
    *
    * @return aggregate value, or NaN if data not available
    * @throws Exception on catch-all execution failure
@@ -254,7 +254,7 @@ public class RootCauseMetricResource {
     }
 
     MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end), timezone);
-    Baseline range = parseOffset(baseSlice, offset, timezone);
+    Baseline range = parseOffset(offset, timezone);
 
     List<MetricSlice> slices = range.scatter(baseSlice);
     logSlices(baseSlice, slices);
@@ -277,7 +277,7 @@ public class RootCauseMetricResource {
    * @param timezone timezone identifier (e.g. "America/Los_Angeles")
    * @param granularityString time granularity (e.g. "5_MINUTES", "1_HOURS")
    *
-   * @see RootCauseMetricResource#parseOffset(MetricSlice, String, String) supported offsets
+   * @see RootCauseMetricResource#parseOffset(String, String) supported offsets
    *
    * @return aggregate value, or NaN if data not available
    * @throws Exception on catch-all execution failure
@@ -314,10 +314,9 @@ public class RootCauseMetricResource {
 
     TimeGranularity granularity = TimeGranularity.fromString(granularityString);
     MetricSlice baseSlice = alignSlice(makeSlice(urn, start, end, granularity), timezone);
-    Baseline range = parseOffset(baseSlice, offset, timezone);
+    Baseline range = parseOffset(offset, timezone);
 
     List<MetricSlice> slices = new ArrayList<>(range.scatter(baseSlice));
-    slices.add(baseSlice); // add baseSlice for alignment
     logSlices(baseSlice, slices);
 
     Map<MetricSlice, DataFrame> data = fetchTimeSeries(slices);
@@ -473,18 +472,17 @@ public class RootCauseMetricResource {
    *   maxXw     maximum of data points from the the past X weeks, with a lag of 1 week)
    * </pre>
    *
-   * @param baseSlice metric slice that acts as base
    * @param offset offset identifier
    * @param timeZoneString timezone identifier (location long format)
    * @return Baseline instance
    * @throws IllegalArgumentException if the offset cannot be parsed
    */
-  private Baseline parseOffset(MetricSlice baseSlice, String offset, String timeZoneString) {
+  private Baseline parseOffset(String offset, String timeZoneString) {
     DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
 
     Matcher mCurrent = PATTERN_CURRENT.matcher(offset);
     if (mCurrent.find()) {
-      return BaselineOffset.fromOffset(0);
+      return BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.SUM, 1, 0, timeZone);
     }
 
     Matcher mWeekOverWeek = PATTERN_WEEK_OVER_WEEK.matcher(offset);
@@ -558,7 +556,7 @@ public class RootCauseMetricResource {
 
   private static void logSlices(MetricSlice baseSlice, List<MetricSlice> slices) {
     final DateTimeFormatter formatter = DateTimeFormat.forStyle("LL");
-    LOG.info("{} - {}", formatter.print(baseSlice.getStart()), formatter.print(baseSlice.getEnd()));
+    LOG.info("{} - {} (base)", formatter.print(baseSlice.getStart()), formatter.print(baseSlice.getEnd()));
     for (MetricSlice slice : slices) {
       LOG.info("{} - {}", formatter.print(slice.getStart()), formatter.print(slice.getEnd()));
     }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dataframe/DataFrame.java
@@ -1287,7 +1287,7 @@ public class DataFrame {
     DataFrame df = this;
     for(int i=seriesNames.size()-1; i>=0; i--) {
       // TODO support "-series" order inversion
-      df = df.project(assertSeriesExists(seriesNames.get(i)).sortedIndex());
+      df = df.project(df.get(seriesNames.get(i)).sortedIndex());
     }
     return df;
   }
@@ -1526,8 +1526,28 @@ public class DataFrame {
    * @return DataFrame copy without null rows
    */
   public DataFrame dropNull() {
+    return this.dropNull(new ArrayList<>(this.getSeriesNames()));
+  }
+
+  /**
+   * Returns a copy of the DataFrame omitting rows that contain a {@code null} value in any given series.
+   *
+   * @param seriesNames series names to drop null values for
+   * @return DataFrame copy without null rows
+   */
+  public DataFrame dropNull(String... seriesNames) {
+    return this.dropNull(Arrays.asList(seriesNames));
+  }
+
+  /**
+   * Returns a copy of the DataFrame omitting rows that contain a {@code null} value in any given series.
+   *
+   * @param seriesNames series names to drop null values for
+   * @return DataFrame copy without null rows
+   */
+  public DataFrame dropNull(List<String> seriesNames) {
     BooleanSeries isNull = BooleanSeries.fillValues(this.size(), false);
-    for(Series s : this.series.values()) {
+    for(Series s : assertSeriesExist(seriesNames)) {
       isNull = isNull.or(s.isNull());
     }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricAnalysisPipeline2.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/impl/MetricAnalysisPipeline2.java
@@ -35,6 +35,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,8 +120,8 @@ public class MetricAnalysisPipeline2 extends Pipeline {
     TimeRangeEntity anomalyRange = TimeRangeEntity.getTimeRangeAnomaly(context);
     TimeRangeEntity baselineRange = TimeRangeEntity.getTimeRangeBaseline(context);
 
-    BaselineAggregate rangeCurrent = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, Collections.singletonList(0L), false);
-    BaselineAggregate rangeBaseline = BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEDIAN, 4, 0, false);
+    BaselineAggregate rangeCurrent = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, Collections.singletonList(new Period(0, PeriodType.weeks())), DateTimeZone.UTC);
+    BaselineAggregate rangeBaseline = BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.MEDIAN, 4, 0, DateTimeZone.UTC);
 
     Map<MetricEntity, MetricSlice> trainingSet = new HashMap<>();
     Map<MetricEntity, MetricSlice> testSet = new HashMap<>();
@@ -234,10 +237,10 @@ public class MetricAnalysisPipeline2 extends Pipeline {
 
         boolean isDailyData = this.isDailyData(sliceTest.getMetricId());
 
-        DataFrame testCurrent = rangeCurrent.withDailyData(isDailyData).gather(sliceTest, data);
-        DataFrame testBaseline = rangeBaseline.withDailyData(isDailyData).gather(sliceTest, data);
-        DataFrame trainingCurrent = rangeCurrent.withDailyData(isDailyData).gather(sliceTrain, data);
-        DataFrame trainingBaseline = rangeBaseline.withDailyData(isDailyData).gather(sliceTrain, data);
+        DataFrame testCurrent = rangeCurrent.gather(sliceTest, data);
+        DataFrame testBaseline = rangeBaseline.gather(sliceTest, data);
+        DataFrame trainingCurrent = rangeCurrent.gather(sliceTrain, data);
+        DataFrame trainingBaseline = rangeBaseline.gather(sliceTrain, data);
 
 //        LOG.info("Preparing training and test data for metric '{}'", me.getUrn());
 //        DataFrame trainingBaseline = extractTimeRange(timeseries, trainingBaselineStart, trainingBaselineEnd);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
@@ -1,19 +1,24 @@
 package com.linkedin.thirdeye.rootcause.timeseries;
 
-import com.linkedin.thirdeye.api.TimeGranularity;
 import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.Grouping;
 import com.linkedin.thirdeye.dataframe.LongSeries;
 import com.linkedin.thirdeye.dataframe.Series;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Partial;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
 
 
 /**
@@ -22,35 +27,43 @@ import org.joda.time.DateTimeZone;
  * @see BaselineAggregateType
  */
 public class BaselineAggregate implements Baseline {
-  private final BaselineAggregateType type;
-  private final List<Long> offsets;
-  private final boolean isDailyData;
+  private static final String COL_KEY = Grouping.GROUP_KEY;
 
-  private BaselineAggregate(BaselineAggregateType type, List<Long> offsets, boolean isDailyData) {
+  private final BaselineAggregateType type;
+  private final List<Period> offsets;
+  private final DateTimeZone timeZone;
+  private final PeriodType periodType;
+
+  private BaselineAggregate(BaselineAggregateType type, List<Period> offsets, DateTimeZone timezone, PeriodType periodType) {
     this.type = type;
     this.offsets = offsets;
-    this.isDailyData = isDailyData;
+    this.timeZone = timezone;
+    this.periodType = periodType;
   }
 
   public BaselineAggregate withType(BaselineAggregateType type) {
-    return new BaselineAggregate(type, this.offsets, this.isDailyData);
+    return new BaselineAggregate(type, this.offsets, this.timeZone, this.periodType);
   }
 
-  public BaselineAggregate withOffsets(List<Long> offsets) {
-    return new BaselineAggregate(this.type, offsets, this.isDailyData);
+  public BaselineAggregate withOffsets(List<Period> offsets) {
+    return new BaselineAggregate(this.type, offsets, this.timeZone, this.periodType);
   }
 
-  public BaselineAggregate withDailyData(boolean isDailyData) {
-    return new BaselineAggregate(this.type, this.offsets, isDailyData);
+  public BaselineAggregate withTimeZone(DateTimeZone timeZone) {
+    return new BaselineAggregate(this.type, this.offsets, timeZone, this.periodType);
+  }
+
+  public BaselineAggregate withPeriodType(PeriodType periodType) {
+    return new BaselineAggregate(this.type, this.offsets, this.timeZone, periodType);
   }
 
   @Override
   public List<MetricSlice> scatter(MetricSlice slice) {
     List<MetricSlice> slices = new ArrayList<>();
-    for (long offset : this.offsets) {
+    for (Period offset : this.offsets) {
       slices.add(slice
-          .withStart(slice.getStart() + offset)
-          .withEnd(slice.getEnd()+ offset));
+          .withStart(new DateTime(slice.getStart(), this.timeZone).plus(offset).getMillis())
+          .withEnd(new DateTime(slice.getEnd(), this.timeZone).plus(offset).getMillis()));
     }
     return slices;
   }
@@ -69,66 +82,77 @@ public class BaselineAggregate implements Baseline {
   }
 
   @Override
-  public DataFrame gather(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
+  public DataFrame gather(final MetricSlice slice, Map<MetricSlice, DataFrame> data) {
     Map<MetricSlice, DataFrame> filtered = this.filter(slice, data);
 
-    // probe for daily data
-    LongSeries timestamps = makeTimestamps(slice, data);
-    Set<Long> timestampSet = new HashSet<>(timestamps.toList());
-
-    DataFrame output = new DataFrame(COL_TIME, BaselineUtil.makeTimestamps(slice));
-
-    boolean isInitialized = false;
+    DataFrame output = new DataFrame(COL_TIME, LongSeries.empty());
 
     List<String> colNames = new ArrayList<>();
     for (Map.Entry<MetricSlice, DataFrame> entry : filtered.entrySet()) {
       MetricSlice s = entry.getKey();
 
-      long offset = s.getStart() - slice.getStart();
-      if (!offsets.contains(offset)) {
-        throw new IllegalArgumentException(String.format("Found slice with invalid offset %d", offset));
+      Period period = new Period(
+          new DateTime(slice.getStart(), this.timeZone),
+          new DateTime(s.getStart(), this.timeZone),
+          this.periodType);
+
+      if (!offsets.contains(period)) {
+        // throw new IllegalArgumentException(String.format("Found slice with invalid offset '%s'", period));
+        continue;
       }
 
       String colName = String.valueOf(s.getStart());
       DataFrame df = new DataFrame(entry.getValue());
 
-      df.addSeries(COL_TIME, df.getLongs(COL_TIME).subtract(offset));
-      df.renameSeries(COL_VALUE, colName);
+      DataFrame dfTransform = new DataFrame(df);
+      dfTransform.addSeries(COL_TIME, this.toVirtualSeries(s.getStart(), dfTransform.getLongs(COL_TIME)));
+      dfTransform = eliminateDuplicates(dfTransform);
 
-      if (isDailyData) {
-        df = applyDSTCorrection(df, timestampSet);
-      }
+      dfTransform.renameSeries(COL_VALUE, colName);
 
-      if (!isInitialized) {
+      if (output.isEmpty()) {
         // handle multi-index via prototyping
-        DataFrame prototype = new DataFrame();
-        for (String name : df.getIndexNames()) {
-          prototype.addSeries(name, df.get(name));
-        }
+        output = dfTransform;
 
-        output = output.joinLeft(prototype, COL_TIME);
-        output.setIndex(df.getIndexNames());
-        isInitialized = true;
+      } else {
+        output = output.joinOuter(dfTransform);
       }
 
-      output = output.joinOuter(df);
       colNames.add(colName);
-
-      // TODO fill null forward?
     }
 
     String[] arrNames = colNames.toArray(new String[colNames.size()]);
 
     // aggregation
     output.addSeries(COL_VALUE, output.map(this.type.function, arrNames));
-    output = output.dropNull();
 
     // alignment
-    List<String> indexNames = output.getIndexNames();
-    output = output.setIndex(COL_TIME).joinRight(new DataFrame(COL_TIME, timestamps)).setIndex(indexNames);
-    output.sortedBy(output.getIndexNames());
+    output.addSeries(COL_TIME, this.toTimestampSeries(slice.getStart(), output.getLongs(COL_TIME)));
+
+    // filter by original time range
+    List<String> dropNames = new ArrayList<>(output.getSeriesNames());
+    dropNames.removeAll(output.getIndexNames());
+
+    output = output.filter(new Series.LongConditional() {
+      @Override
+      public boolean apply(long... values) {
+        return values[0] >= slice.getStart() && values[0] < slice.getEnd();
+      }
+    }, COL_TIME).dropNull(output.getIndexNames());
 
     return output;
+  }
+
+  private static DataFrame eliminateDuplicates(DataFrame df) {
+    List<String> aggExpressions = new ArrayList<>();
+    for (String seriesName : df.getIndexNames()) {
+      aggExpressions.add(String.format("%s:FIRST", seriesName));
+    }
+    aggExpressions.add(COL_VALUE + ":MEAN");
+
+    DataFrame res = df.groupByValue(df.getIndexNames()).aggregate(aggExpressions).dropSeries(COL_KEY);
+
+    return res.setIndex(df.getIndexNames());
   }
 
   /**
@@ -138,115 +162,266 @@ public class BaselineAggregate implements Baseline {
    *
    * @param type aggregation type
    * @param offsets time offsets
-   * @param isDailyData daily time series flag
    * @return BaselineAggregate with given type and offsets
    */
-  public static BaselineAggregate fromOffsets(BaselineAggregateType type, List<Long> offsets, boolean isDailyData) {
-    return new BaselineAggregate(type, offsets, isDailyData);
-  }
-
-  /**
-   * Returns an instance of BaselineAggregate for the specified type and {@code numWeeks} offsets
-   * computed on a consecutive week-over-week basis (in UTC time) starting with a lag of {@code offsetWeeks}.
-   * A lag of {@code 0} corresponds to the current week.
-   *
-   * @see BaselineAggregateType
-   *
-   * @param type aggregation type
-   * @param numWeeks number of consecutive weeks
-   * @param offsetWeeks lag for starting consecutive weeks
-   * @param isDailyData daily time series flag
-   * @return BaselineAggregate with given type and weekly offsets
-   */
-  public static BaselineAggregate fromWeekOverWeek(BaselineAggregateType type, int numWeeks, int offsetWeeks, boolean isDailyData) {
-    List<Long> offsets = new ArrayList<>();
-
-    for (int i = 0; i < numWeeks; i++) {
-      long offset = -1 * (i + offsetWeeks) * TimeUnit.DAYS.toMillis(7);
-      offsets.add(offset);
+  public static BaselineAggregate fromOffsets(BaselineAggregateType type, List<Period> offsets, DateTimeZone timeZone) {
+    if (offsets.isEmpty()) {
+      throw new IllegalArgumentException("Must provide at least one offset");
     }
 
-    return new BaselineAggregate(type, offsets, isDailyData);
+    PeriodType periodType = offsets.get(0).getPeriodType();
+    for (Period p : offsets) {
+      if (!periodType.equals(p.getPeriodType())) {
+        throw new IllegalArgumentException(String.format("Expected uniform period type but found '%s' and '%s'", periodType, p.getPeriodType()));
+      }
+    }
+
+    return new BaselineAggregate(type, offsets, timeZone, periodType);
   }
 
   /**
    * Returns an instance of BaselineAggregate for the specified type and {@code numWeeks} offsets
    * computed on a consecutive week-over-week basis starting with a lag of {@code offsetWeeks}.
-   * Additionally corrects for DST changes assuming a start date of {@code timestamp} in {@code timezone}.
+   * Additionally corrects for DST changes assuming a start date of {@code timestamp} in {@code timeZone}.
    * <br/><b>NOTE:</b> As offsets are pre-computed, the DST correction will produce incorrect offsets
    * if used to scatter a slice that does not start at {@code timestamp}.
    *
-   * @see BaselineAggregate#fromWeekOverWeek(BaselineAggregateType, int, int, boolean)
+   * @see BaselineAggregate#fromWeekOverWeek(BaselineAggregateType, int, int, DateTimeZone)
    * @see BaselineAggregateType
    *
    * @param type aggregation type
    * @param numWeeks number of consecutive weeks
    * @param offsetWeeks lag for starting consecutive weeks
-   * @param timestamp assumed slice start timestamp
-   * @param timezone time zone (long form)
-   * @param isDailyData daily time series flag
+   * @param timeZone time zone
    * @return BaselineAggregate with given type and weekly offsets corrected for DST
    */
-  public static BaselineAggregate fromWeekOverWeek(BaselineAggregateType type, int numWeeks, int offsetWeeks, long timestamp, String timezone, boolean isDailyData) {
-    DateTime baseDate = new DateTime(timestamp, DateTimeZone.forID(timezone));
-
-    List<Long> offsets = new ArrayList<>();
-
+  public static BaselineAggregate fromWeekOverWeek(BaselineAggregateType type, int numWeeks, int offsetWeeks, DateTimeZone timeZone) {
+    List<Period> offsets = new ArrayList<>();
     for (int i = 0; i < numWeeks; i++) {
-      long offset = baseDate.minusWeeks(i + offsetWeeks).getMillis() - timestamp;
-      offsets.add(offset);
+      offsets.add(new Period(-1 * (i + offsetWeeks), PeriodType.weeks()));
     }
-
-    return new BaselineAggregate(type, offsets, isDailyData);
+    return new BaselineAggregate(type, offsets, timeZone, PeriodType.weeks());
   }
 
   /**
-   * Returns acceptable timestamps given the input data set. Uses {@code slice}
-   * timestamps if available, otherwise constructs artificial time series.
+   * Transform UTC timestamps into relative day-time-of-day timestamps
    *
-   * @param slice base metric slice
-   * @param data timeseries data
-   * @return timestamp series
+   * @param origin origin timestamp
+   * @param timestampSeries timestamp series
+   * @return day-time-of-day series
    */
-  private LongSeries makeTimestamps(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
-    if (data.containsKey(slice)) {
-      return data.get(slice).dropNull().getLongs(COL_TIME);
-    }
+  private LongSeries toVirtualSeries(long origin, LongSeries timestampSeries) {
+    final DateTime dateOrigin = new DateTime(origin, this.timeZone).withFields(makeOriginPartial());
+    return timestampSeries.map(this.makeTimestampToVirtualFunction(dateOrigin));
+  }
 
-    if (this.isDailyData) {
-      // construct daily timestamps
-      return BaselineUtil.makeTimestamps(slice.withGranularity(new TimeGranularity(1, TimeUnit.DAYS)));
+  /**
+   * Transform day-time-of-day timestamps into UTC timestamps
+   *
+   * @param origin origin timestamp
+   * @param virtualSeries day-time-of-day series
+   * @return utc timestamp series
+   */
+  private LongSeries toTimestampSeries(long origin, LongSeries virtualSeries) {
+    final DateTime dateOrigin = new DateTime(origin, this.timeZone).withFields(makeOriginPartial());
+    return virtualSeries.map(this.makeVirtualToTimestampFunction(dateOrigin));
+  }
+
+  /**
+   * Returns partial to zero out date fields based on period type
+   *
+   * @return partial
+   */
+  private Partial makeOriginPartial() {
+    List<DateTimeFieldType> fields = new ArrayList<>();
+
+    if (PeriodType.millis().equals(this.periodType)) {
+      // left blank
+
+    } else if (PeriodType.seconds().equals(this.periodType)) {
+      fields.add(DateTimeFieldType.millisOfSecond());
+
+    } else if (PeriodType.minutes().equals(this.periodType)) {
+      fields.add(DateTimeFieldType.millisOfSecond());
+      fields.add(DateTimeFieldType.secondOfMinute());
+
+    } else if (PeriodType.hours().equals(this.periodType)) {
+      fields.add(DateTimeFieldType.millisOfSecond());
+      fields.add(DateTimeFieldType.secondOfMinute());
+      fields.add(DateTimeFieldType.minuteOfHour());
+
+    } else if (PeriodType.days().equals(this.periodType)
+        || PeriodType.weeks().equals(this.periodType)) {
+      fields.add(DateTimeFieldType.millisOfSecond());
+      fields.add(DateTimeFieldType.secondOfMinute());
+      fields.add(DateTimeFieldType.minuteOfHour());
+      fields.add(DateTimeFieldType.hourOfDay());
+
     } else {
-      return BaselineUtil.makeTimestamps(slice);
+      throw new IllegalArgumentException(String.format("Unsupported PeriodType '%s'", this.periodType));
+    }
+
+    int[] zeros = new int[fields.size()];
+    Arrays.fill(zeros, 0);
+
+    return new Partial(fields.toArray(new DateTimeFieldType[fields.size()]), zeros);
+  }
+
+  /**
+   * Returns a conversion function from utc timestamps to virtual, relative timestamps based
+   * on period type and an origin
+   *
+   * @param origin origin to base relative timestamp on
+   * @return LongFunction for converting to relative timestamps
+   */
+  private Series.LongFunction makeTimestampToVirtualFunction(final DateTime origin) {
+    if (PeriodType.millis().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          return values[0] - origin.getMillis();
+        }
+      };
+
+    } else if (PeriodType.seconds().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          DateTime dateTime = new DateTime(values[0], BaselineAggregate.this.timeZone);
+          int seconds = new Period(origin, dateTime).getSeconds();
+          int millis = dateTime.getMillisOfSecond();
+          return seconds * 1000 + millis;
+        }
+      };
+
+    } else if (PeriodType.minutes().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          DateTime dateTime = new DateTime(values[0], BaselineAggregate.this.timeZone);
+          int minutes = new Period(origin, dateTime).getMinutes();
+          int seconds = dateTime.getSecondOfMinute();
+          int millis = dateTime.getMillisOfSecond();
+          return minutes * 100000 + seconds * 1000 + millis;
+        }
+      };
+
+    } else if (PeriodType.hours().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          DateTime dateTime = new DateTime(values[0], BaselineAggregate.this.timeZone);
+          int hours = new Period(origin, dateTime).getHours();
+          int minutes = dateTime.getMinuteOfHour();
+          int seconds = dateTime.getSecondOfMinute();
+          int millis = dateTime.getMillisOfSecond();
+          return hours * 10000000 + minutes * 100000 + seconds * 1000 + millis;
+        }
+      };
+
+    } else if (PeriodType.days().equals(this.periodType)
+        || PeriodType.weeks().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          DateTime dateTime = new DateTime(values[0], BaselineAggregate.this.timeZone);
+          int days = new Period(origin, dateTime).getDays();
+          int hours = dateTime.getHourOfDay();
+          int minutes = dateTime.getMinuteOfHour();
+          int seconds = dateTime.getSecondOfMinute();
+          int millis = dateTime.getMillisOfSecond();
+          return days * 1000000000 + hours * 10000000 + minutes * 100000 + seconds * 1000 + millis;
+        }
+      };
+
+    } else {
+      throw new IllegalArgumentException(String.format("Unsupported PeriodType '%s'", this.periodType));
     }
   }
 
   /**
-   * Returns a data time series aligned to a set of acceptable timestamps. Only operates
-   * on data series identified as daily data. This method is required to correct for
-   * incorrect DST adjustment of daily data at the data source level or below.
+   * Returns a conversion function from virtual, relative timestamps to UTC timestamps given
+   * a period type and an origin
    *
-   * @param data data series
-   * @param timestamps set of acceptable timestamps
-   * @return aligned data series
+   * @param origin origin to base absolute timestamps on
+   * @return LongFunction for converting to UTC timestamps
    */
-  private DataFrame applyDSTCorrection(DataFrame data, final Set<Long> timestamps) {
-    if (!this.isDailyData) {
-      return data;
+  private Series.LongFunction makeVirtualToTimestampFunction(final DateTime origin) {
+    if (PeriodType.millis().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          return values[0] + origin.getMillis();
+        }
+      };
+
+    } else if (PeriodType.seconds().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          int seconds = (int) (values[0] / 1000);
+          int millis = (int) (values[0] % 1000);
+          return origin
+              .plusSeconds(seconds)
+              .plusMillis(millis)
+              .getMillis();
+        }
+      };
+
+    } else if (PeriodType.minutes().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          int minutes = (int) (values[0] / 100000);
+          int seconds = (int) (values[0] / 1000 % 100000);
+          int millis = (int) (values[0] % 1000);
+          return origin
+              .plusMinutes(minutes)
+              .plusSeconds(seconds)
+              .plusMillis(millis)
+              .getMillis();
+        }
+      };
+
+    } else if (PeriodType.hours().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          int hours = (int) (values[0] / 10000000);
+          int minutes = (int) (values[0] / 100000 % 10000000);
+          int seconds = (int) (values[0] / 1000 % 100000);
+          int millis = (int) (values[0] % 1000);
+          return origin
+              .plusHours(hours)
+              .plusMinutes(minutes)
+              .plusSeconds(seconds)
+              .plusMillis(millis)
+              .getMillis();
+        }
+      };
+
+    } else if (PeriodType.days().equals(this.periodType)
+        || PeriodType.weeks().equals(this.periodType)) {
+      return new Series.LongFunction() {
+        @Override
+        public long apply(long... values) {
+          int days = (int) (values[0] / 1000000000);
+          int hours = (int) (values[0] / 10000000 % 1000000000);
+          int minutes = (int) (values[0] / 100000 % 10000000);
+          int seconds = (int) (values[0] / 1000 % 100000);
+          int millis = (int) (values[0] % 1000);
+          return origin
+              .plusDays(days)
+              .plusHours(hours)
+              .plusMinutes(minutes)
+              .plusSeconds(seconds)
+              .plusMillis(millis)
+              .getMillis();
+        }
+      };
+
+    } else {
+      throw new IllegalArgumentException(String.format("Unsupported PeriodType '%s'", this.periodType));
     }
-
-    DataFrame dataPlusOneHour = new DataFrame(data).addSeries(COL_TIME, data.getLongs(COL_TIME).add(TimeUnit.HOURS.toMillis(1)));
-    DataFrame dataMinusOneHour = new DataFrame(data).addSeries(COL_TIME, data.getLongs(COL_TIME).subtract(TimeUnit.HOURS.toMillis(1)));
-
-    return new DataFrame(data)
-        .append(dataPlusOneHour, dataMinusOneHour)
-        .filter(new Series.LongConditional() {
-          @Override
-          public boolean apply(long... values) {
-            return timestamps.contains(values[0]);
-          }
-        }, COL_TIME)
-        .dropNull()
-        .sortedBy(COL_TIME);
   }
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineAggregate.java
@@ -96,7 +96,6 @@ public class BaselineAggregate implements Baseline {
           this.periodType);
 
       if (!offsets.contains(period)) {
-        // throw new IllegalArgumentException(String.format("Found slice with invalid offset '%s'", period));
         continue;
       }
 

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineUtil.java
@@ -2,6 +2,7 @@ package com.linkedin.thirdeye.rootcause.timeseries;
 
 import com.linkedin.thirdeye.dataframe.LongSeries;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import org.joda.time.DateTimeZone;
 
 
 /**

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/dataframe/DataFrameTest.java
@@ -1228,7 +1228,7 @@ public class DataFrameTest {
     assertEquals(sdfa.getLongs("index"), 5, 6, 1, 2, 7, 8, 3, 4);
 
     DataFrame sdfb = mydf.sortedBy("long", "double");
-    assertEquals(sdfb.getLongs("index"), 3, 4, 7, 8, 1, 2, 5, 6);
+    assertEquals(sdfb.getLongs("index"), 5, 6, 7, 8, 1, 2, 3, 4);
   }
 
   @Test
@@ -1241,7 +1241,7 @@ public class DataFrameTest {
     assertEquals(sdfa.getLongs("index"), 5, 6, 1, 2, 7, 8, 3, 4);
 
     DataFrame sdfb = mydf.sortedBy("boolean", "string");
-    assertEquals(sdfb.getLongs("index"), 3, 4, 7, 8, 1, 2, 5, 6);
+    assertEquals(sdfb.getLongs("index"), 5, 6, 7, 8, 1, 2, 3, 4);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineTest.java
@@ -7,6 +7,7 @@ import com.linkedin.thirdeye.dataframe.DoubleSeries;
 import com.linkedin.thirdeye.dataframe.LongSeries;
 import com.linkedin.thirdeye.dataframe.StringSeries;
 import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -14,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.ArrayUtils;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -95,7 +99,7 @@ public class BaselineTest {
 
   @Test
   public void testBaselineAggregateFrom() {
-    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, Arrays.asList(-1200L, -4500L), false);
+    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, makePeriods(PeriodType.millis(), -1200L, -4500L), DateTimeZone.UTC);
 
     List<MetricSlice> slices = baseline.scatter(BASE_SLICE);
     Assert.assertEquals(slices.size(), 2);
@@ -109,7 +113,7 @@ public class BaselineTest {
 
   @Test
   public void testBaselineAggregateCompute() {
-    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, Arrays.asList(-1200L, -4500L), false);
+    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, makePeriods(PeriodType.millis(), -1200L, -4500L), DateTimeZone.UTC);
 
     Map<MetricSlice, DataFrame> data = new HashMap<>();
     data.put(BASE_SLICE.withStart(13800).withEnd(15800),
@@ -133,7 +137,7 @@ public class BaselineTest {
 
   @Test
   public void testBaselineAggregateComputeMultiIndex() {
-    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, Arrays.asList(-1200L, -4500L), false);
+    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, makePeriods(PeriodType.millis(), -1200L, -4500L), DateTimeZone.UTC);
 
     Map<MetricSlice, DataFrame> data = new HashMap<>();
     data.put(BASE_SLICE.withStart(13800).withEnd(15800),
@@ -158,12 +162,12 @@ public class BaselineTest {
     assertEquals(result.getDoubles(COL_VALUE), 450d, 550d, 650d, 750d, 4500d, 5500d, 6500d, 7500d);
   }
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testBaselineAggregateComputeInvalidSlice() {
-    BaselineAggregate baseline = BaselineAggregate.fromOffsets(BaselineAggregateType.MEDIAN, Arrays.asList(-1200L, -4500L), false);
-    baseline.gather(BASE_SLICE, Collections.singletonMap(
-        BASE_SLICE.withStart(13999), new DataFrame()
-    ));
+  private static List<Period> makePeriods(PeriodType periodType, long... offsetMillis) {
+    List<Period> output = new ArrayList<>();
+    for (long offset : offsetMillis) {
+      output.add(new Period(offset, periodType));
+    }
+    return output;
   }
 
   private static void assertEquals(LongSeries series, long... values) {


### PR DESCRIPTION
The existing baseline API still had some issues due to heuristic DST correction. This PR replaces the heuristic with deterministic, generalized timestamp alignment that operates on granular date ranges, e.g. '2 days' =/= '48 hours'. Also contains minor cleanup and extension the RCA metric and dataframe APIs.