### PR TITLE
[TE] ember test + travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,14 @@ matrix:
 cache:
   directories:
     - $HOME/.m2
+  yarn: true
+
 
 dist: precise
 sudo: false
+
+addons:
+  firefox: latest
 
 install:
   - ./.travis_install.sh

--- a/thirdeye/thirdeye-frontend/package.json
+++ b/thirdeye/thirdeye-frontend/package.json
@@ -14,7 +14,7 @@
     "build": "ember build",
     "lint:js": "eslint ./*.js app config lib server tests",
     "start": "ember server --proxy http://localhost:1426",
-    "test": "ember test",
+    "test": "node_modules/.bin/ember test",
     "eslint": "node_modules/.bin/eslint",
     "eslint-app": "npm run eslint app/",
     "eslint-tests": "npm run eslint tests/"

--- a/thirdeye/thirdeye-frontend/pom.xml
+++ b/thirdeye/thirdeye-frontend/pom.xml
@@ -58,6 +58,16 @@
               <arguments>run build -- --prod --output-path=../thirdeye-pinot/src/main/resources/app</arguments>
             </configuration>
           </execution>
+          <execution>
+            <id>test front end</id>
+            <phase>test</phase>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <configuration>
+              <arguments>run test</arguments>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 

--- a/thirdeye/thirdeye-frontend/testem.js
+++ b/thirdeye/thirdeye-frontend/testem.js
@@ -2,7 +2,7 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
-    'Chrome'
+    'Firefox'
   ],
   launch_in_dev: [
     'Chrome'
@@ -13,12 +13,17 @@ module.exports = {
       args: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.TRAVIS ? '--no-sandbox' : null,
-
         '--disable-gpu',
         '--headless',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
       ].filter(Boolean)
+    },
+    Firefox: {
+      mode: 'ci',
+      args: [
+        '-headless'
+      ]
     }
   }
 };


### PR DESCRIPTION
### What's new: 
- Front-end (ember) test are now run in travis. 
  - Firefox in ci as headless chrome is still somewhat flaky in ci
  - Headless chrome is still run in the dev environment

### Success example:
https://travis-ci.org/linkedin/pinot/builds/361083762

### Failures example: 
https://travis-ci.org/linkedin/pinot/jobs/361087295