### PR TITLE
[TE] rootcause - empty baseline support

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -290,7 +290,10 @@ export default Component.extend({
 
     const series = {};
     [...urns].forEach(urn => {
-      series[this._makeLabel(urn)] = this._makeSeries(urn);
+      const s = this._makeSeries(urn);
+      if (!_.isEmpty(s.timestamps)) {
+        series[this._makeLabel(urn)] = s;
+      }
     });
 
     series['anomalyRange'] = {

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
@@ -24,6 +24,7 @@ export default Component.extend({
   },
 
   compareModeOptions: [
+    'None',
     'WoW',
     'Wo2W',
     'Wo3W',

--- a/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
@@ -335,6 +335,7 @@ export function filterPrefix(urns, prefixes) {
 export function toBaselineRange(range, offset) {
   const offsetWeeks = {
     current: 0,
+    none: 0,
     wow: 1,
     wo1w: 1,
     wo2w: 2,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
@@ -15,11 +15,12 @@ import com.linkedin.thirdeye.rootcause.impl.MetricEntity;
 import com.linkedin.thirdeye.rootcause.timeseries.Baseline;
 import com.linkedin.thirdeye.rootcause.timeseries.BaselineAggregate;
 import com.linkedin.thirdeye.rootcause.timeseries.BaselineAggregateType;
-import com.linkedin.thirdeye.rootcause.timeseries.BaselineOffset;
+import com.linkedin.thirdeye.rootcause.timeseries.BaselineNone;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Period;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
@@ -68,6 +70,7 @@ public class RootCauseMetricResource {
   private static final String TIMEZONE_DEFAULT = "UTC";
   private static final String GRANULARITY_DEFAULT = MetricSlice.NATIVE_GRANULARITY.toAggregationGranularityString();
 
+  private static final Pattern PATTERN_NONE = Pattern.compile("none");
   private static final Pattern PATTERN_CURRENT = Pattern.compile("current");
   private static final Pattern PATTERN_WEEK_OVER_WEEK = Pattern.compile("wo([1-9][0-9]*)w");
   private static final Pattern PATTERN_MEAN = Pattern.compile("mean([1-9][0-9]*)w");
@@ -465,6 +468,7 @@ public class RootCauseMetricResource {
    * <p>Supported offsets:</p>
    * <pre>
    *   current   the time range as specified by start and end)
+   *   none      empty time range
    *   woXw      week-over-week data points with a lag of X weeks)
    *   meanXw    average of data points from the the past X weeks, with a lag of 1 week)
    *   medianXw  median of data points from the the past X weeks, with a lag of 1 week)
@@ -483,6 +487,11 @@ public class RootCauseMetricResource {
     Matcher mCurrent = PATTERN_CURRENT.matcher(offset);
     if (mCurrent.find()) {
       return BaselineAggregate.fromWeekOverWeek(BaselineAggregateType.SUM, 1, 0, timeZone);
+    }
+
+    Matcher mNone = PATTERN_NONE.matcher(offset);
+    if (mNone.find()) {
+      return new BaselineNone();
     }
 
     Matcher mWeekOverWeek = PATTERN_WEEK_OVER_WEEK.matcher(offset);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineNone.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/rootcause/timeseries/BaselineNone.java
@@ -1,0 +1,26 @@
+package com.linkedin.thirdeye.rootcause.timeseries;
+
+import com.linkedin.thirdeye.dataframe.DataFrame;
+import com.linkedin.thirdeye.dataframe.DoubleSeries;
+import com.linkedin.thirdeye.dataframe.LongSeries;
+import com.linkedin.thirdeye.dataframe.util.MetricSlice;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Baseline that always returns an empty set of data
+ */
+public class BaselineNone implements Baseline {
+  @Override
+  public List<MetricSlice> scatter(MetricSlice slice) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public DataFrame gather(MetricSlice slice, Map<MetricSlice, DataFrame> data) {
+    return new DataFrame(COL_TIME, LongSeries.empty())
+        .addSeries(COL_VALUE, DoubleSeries.empty());
+  }
+}


### PR DESCRIPTION
Add support for "none" baseline which hides baseline timeseries in the chart.

![image](https://user-images.githubusercontent.com/25439965/38210840-677f7462-366d-11e8-88d3-09baffbbe928.png)
