### PR TITLE
Add a class TransformResultMetadata to encapsule the metadata for the result of transform function

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/TransformBlockValSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/TransformBlockValSet.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.docvalsets;
 
 import com.linkedin.pinot.core.common.BaseBlockValSet;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.operator.transform.function.TransformFunction;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 
@@ -104,15 +104,15 @@ public class TransformBlockValSet extends BaseBlockValSet {
       _numMVEntries = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
     int numDocs = _projectionBlock.getNumDocs();
-    DataSourceMetadata metadata = _transformFunction.getResultMetadata();
-    if (metadata.hasDictionary()) {
+    TransformResultMetadata resultMetadata = _transformFunction.getResultMetadata();
+    if (resultMetadata.hasDictionary()) {
       int[][] dictionaryIds = getDictionaryIdsMV();
       for (int i = 0; i < numDocs; i++) {
         _numMVEntries[i] = dictionaryIds[i].length;
       }
       return _numMVEntries;
     } else {
-      switch (metadata.getDataType()) {
+      switch (resultMetadata.getDataType()) {
         case INT:
           int[][] intValues = getIntValuesMV();
           for (int i = 0; i < numDocs; i++) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformOperator.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.core.operator.transform;
 
 import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.BaseOperator;
 import com.linkedin.pinot.core.operator.ExecutionStatistics;
 import com.linkedin.pinot.core.operator.ProjectionOperator;
@@ -46,15 +45,15 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
    * Constructor for the class
    *
    * @param projectionOperator Projection operator
-   * @param expressionTrees Set of expression trees to evaluate
+   * @param expressions Set of expressions to evaluate
    */
   public TransformOperator(@Nonnull ProjectionOperator projectionOperator,
-      @Nonnull Set<TransformExpressionTree> expressionTrees) {
+      @Nonnull Set<TransformExpressionTree> expressions) {
     _projectionOperator = projectionOperator;
     _dataSourceMap = projectionOperator.getDataSourceMap();
-    for (TransformExpressionTree expressionTree : expressionTrees) {
-      TransformFunction transformFunction = TransformFunctionFactory.get(expressionTree, _dataSourceMap);
-      _transformFunctionMap.put(expressionTree, transformFunction);
+    for (TransformExpressionTree expression : expressions) {
+      TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+      _transformFunctionMap.put(expression, transformFunction);
     }
   }
 
@@ -68,24 +67,24 @@ public class TransformOperator extends BaseOperator<TransformBlock> {
   }
 
   /**
-   * Returns the data source metadata associated with the given expression tree.
+   * Returns the transform result metadata associated with the given expression.
    *
-   * @param expressionTree Expression tree
-   * @return Data source metadata
+   * @param expression Expression
+   * @return Transform result metadata
    */
-  public DataSourceMetadata getDataSourceMetadata(@Nonnull TransformExpressionTree expressionTree) {
-    return _transformFunctionMap.get(expressionTree).getResultMetadata();
+  public TransformResultMetadata getResultMetadata(@Nonnull TransformExpressionTree expression) {
+    return _transformFunctionMap.get(expression).getResultMetadata();
   }
 
   /**
-   * Returns the dictionary associated with the given expression tree.
-   * <p>Should be called only if {@link #getDataSourceMetadata(TransformExpressionTree)} indicates that the data source
+   * Returns the dictionary associated with the given expression.
+   * <p>Should be called only if {@link #getResultMetadata(TransformExpressionTree)} indicates that the transform result
    * has dictionary.
    *
    * @return Dictionary
    */
-  public Dictionary getDictionary(@Nonnull TransformExpressionTree expressionTree) {
-    return _transformFunctionMap.get(expressionTree).getDictionary();
+  public Dictionary getDictionary(@Nonnull TransformExpressionTree expression) {
+    return _transformFunctionMap.get(expression).getDictionary();
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformResultMetadata.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/TransformResultMetadata.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.operator.transform;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+
+
+/**
+ * The <code>TransformResultMetadata</code> class contains the metadata for the transform result.
+ */
+public class TransformResultMetadata {
+  private final FieldSpec.DataType _dataType;
+  private final boolean _isSingleValue;
+  private final boolean _hasDictionary;
+
+  public TransformResultMetadata(FieldSpec.DataType dataType, boolean isSingleValue, boolean hasDictionary) {
+    _dataType = dataType;
+    _isSingleValue = isSingleValue;
+    _hasDictionary = hasDictionary;
+  }
+
+  public FieldSpec.DataType getDataType() {
+    return _dataType;
+  }
+
+  public boolean isSingleValue() {
+    return _isSingleValue;
+  }
+
+  public boolean hasDictionary() {
+    return _hasDictionary;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +58,7 @@ public class AdditionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     return DOUBLE_SV_NO_DICTIONARY_METADATA;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import com.linkedin.pinot.core.util.ArrayCopyUtils;
@@ -28,55 +28,12 @@ import javax.annotation.Nonnull;
  * Base class for transform function providing the default implementation for all data types.
  */
 public abstract class BaseTransformFunction implements TransformFunction {
-  private static class SVNoDictionaryMetadata implements DataSourceMetadata {
-    final FieldSpec.DataType _dataType;
-
-    SVNoDictionaryMetadata(FieldSpec.DataType dataType) {
-      _dataType = dataType;
-    }
-
-    @Override
-    public FieldSpec.DataType getDataType() {
-      return _dataType;
-    }
-
-    @Override
-    public boolean isSingleValue() {
-      return true;
-    }
-
-    @Override
-    public boolean isSorted() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int getNumDocs() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int getMaxNumMultiValues() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean hasInvertedIndex() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean hasDictionary() {
-      return false;
-    }
-  }
-
-  protected static final DataSourceMetadata LONG_SV_NO_DICTIONARY_METADATA =
-      new SVNoDictionaryMetadata(FieldSpec.DataType.LONG);
-  protected static final DataSourceMetadata DOUBLE_SV_NO_DICTIONARY_METADATA =
-      new SVNoDictionaryMetadata(FieldSpec.DataType.DOUBLE);
-  protected static final DataSourceMetadata STRING_SV_NO_DICTIONARY_METADATA =
-      new SVNoDictionaryMetadata(FieldSpec.DataType.STRING);
+  protected static final TransformResultMetadata LONG_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(FieldSpec.DataType.LONG, true, false);
+  protected static final TransformResultMetadata DOUBLE_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(FieldSpec.DataType.DOUBLE, true, false);
+  protected static final TransformResultMetadata STRING_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(FieldSpec.DataType.STRING, true, false);
 
   private int[] _intValuesSV;
   private long[] _longValuesSV;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -17,8 +17,8 @@ package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.common.data.DateTimeFieldSpec;
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.operator.transform.transformer.datetime.BaseDateTimeTransformer;
 import com.linkedin.pinot.core.operator.transform.transformer.datetime.DateTimeTransformerFactory;
 import com.linkedin.pinot.core.operator.transform.transformer.datetime.EpochToEpochTransformer;
@@ -81,7 +81,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
 
   private TransformFunction _mainTransformFunction;
   private BaseDateTimeTransformer _dateTimeTransformer;
-  private DataSourceMetadata _resultMetadata;
+  private TransformResultMetadata _resultMetadata;
   private long[] _longOutputTimes;
   private String[] _stringOutputTimes;
 
@@ -117,7 +117,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     return _resultMetadata;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import com.linkedin.pinot.core.util.ArrayCopyUtils;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     return DOUBLE_SV_NO_DICTIONARY_METADATA;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/IdentifierTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/IdentifierTransformFunction.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.operator.transform.function;
 import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.util.List;
 import java.util.Map;
@@ -31,10 +32,14 @@ import javax.annotation.Nonnull;
 public class IdentifierTransformFunction implements TransformFunction {
   private final String _columnName;
   private final DataSource _dataSource;
+  private final TransformResultMetadata _resultMetadata;
 
   public IdentifierTransformFunction(@Nonnull String columnName, @Nonnull DataSource dataSource) {
     _columnName = columnName;
     _dataSource = dataSource;
+    DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
+    _resultMetadata = new TransformResultMetadata(dataSourceMetadata.getDataType(), dataSourceMetadata.isSingleValue(),
+        dataSourceMetadata.hasDictionary());
   }
 
   @Override
@@ -48,8 +53,8 @@ public class IdentifierTransformFunction implements TransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
-    return _dataSource.getDataSourceMetadata();
+  public TransformResultMetadata getResultMetadata() {
+    return _resultMetadata;
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +50,7 @@ public class LiteralTransformFunction implements TransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,7 +59,7 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     return DOUBLE_SV_NO_DICTIONARY_METADATA;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import com.linkedin.pinot.core.util.ArrayCopyUtils;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     return DOUBLE_SV_NO_DICTIONARY_METADATA;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.operator.transform.transformer.timeunit.TimeUnitTransformer;
 import com.linkedin.pinot.core.operator.transform.transformer.timeunit.TimeUnitTransformerFactory;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
@@ -59,7 +59,7 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     return LONG_SV_NO_DICTIONARY_METADATA;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/TransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/TransformFunction.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.util.List;
 import java.util.Map;
@@ -48,9 +48,9 @@ public interface TransformFunction {
   /**
    * Returns the metadata for the result of the transform function.
    *
-   * @return Data source metadata of the result
+   * @return Transform result metadata
    */
-  DataSourceMetadata getResultMetadata();
+  TransformResultMetadata getResultMetadata();
 
   /**
    * DICTIONARY BASED APIs

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/ValueInTransformFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/transform/function/ValueInTransformFunction.java
@@ -17,8 +17,8 @@ package com.linkedin.pinot.core.operator.transform.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.common.DataSource;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.ProjectionBlock;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
@@ -91,7 +91,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   }
 
   @Override
-  public DataSourceMetadata getResultMetadata() {
+  public TransformResultMetadata getResultMetadata() {
     return _mainTransformFunction.getResultMetadata();
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -18,9 +18,9 @@ package com.linkedin.pinot.core.query.aggregation.groupby;
 import com.linkedin.pinot.common.request.GroupBy;
 import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.core.common.BlockValSet;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.TransformBlock;
 import com.linkedin.pinot.core.operator.transform.TransformOperator;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import com.linkedin.pinot.core.query.aggregation.AggregationFunctionContext;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
@@ -96,13 +96,9 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
     TransformExpressionTree[] groupByExpressions = new TransformExpressionTree[numGroupByExpressions];
     for (int i = 0; i < numGroupByExpressions; i++) {
       groupByExpressions[i] = TransformExpressionTree.compileToExpressionTree(groupByExpressionStrings.get(i));
-      DataSourceMetadata metadata = transformOperator.getDataSourceMetadata(groupByExpressions[i]);
-      if (!metadata.isSingleValue()) {
-        hasMVGroupByExpression = true;
-      }
-      if (!metadata.hasDictionary()) {
-        hasNoDictionaryGroupByExpression = true;
-      }
+      TransformResultMetadata transformResultMetadata = transformOperator.getResultMetadata(groupByExpressions[i]);
+      hasMVGroupByExpression |= !transformResultMetadata.isSingleValue();
+      hasNoDictionaryGroupByExpression |= !transformResultMetadata.hasDictionary();
     }
     _hasMVGroupByExpression = hasMVGroupByExpression;
     _hasNoDictionaryGroupByExpression = hasNoDictionaryGroupByExpression;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -116,7 +116,7 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         }
       }
 
-      _isSingleValueColumn[i] = transformOperator.getDataSourceMetadata(groupByExpression).isSingleValue();
+      _isSingleValueColumn[i] = transformOperator.getResultMetadata(groupByExpression).isSingleValue();
     }
 
     if (longOverflow) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -18,9 +18,9 @@ package com.linkedin.pinot.core.query.aggregation.groupby;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.core.common.BlockValSet;
-import com.linkedin.pinot.core.common.DataSourceMetadata;
 import com.linkedin.pinot.core.operator.blocks.TransformBlock;
 import com.linkedin.pinot.core.operator.transform.TransformOperator;
+import com.linkedin.pinot.core.operator.transform.TransformResultMetadata;
 import com.linkedin.pinot.core.query.aggregation.groupby.utils.ValueToIdMap;
 import com.linkedin.pinot.core.query.aggregation.groupby.utils.ValueToIdMapFactory;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
@@ -59,9 +59,9 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
 
     for (int i = 0; i < _numGroupByExpressions; i++) {
       TransformExpressionTree groupByExpression = groupByExpressions[i];
-      DataSourceMetadata metadata = transformOperator.getDataSourceMetadata(groupByExpression);
-      _dataTypes[i] = metadata.getDataType();
-      if (metadata.hasDictionary()) {
+      TransformResultMetadata transformResultMetadata = transformOperator.getResultMetadata(groupByExpression);
+      _dataTypes[i] = transformResultMetadata.getDataType();
+      if (transformResultMetadata.hasDictionary()) {
         _dictionaries[i] = transformOperator.getDictionary(groupByExpression);
       } else {
         _onTheFlyDictionaries[i] = ValueToIdMapFactory.get(_dataTypes[i]);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -49,7 +49,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   public NoDictionarySingleColumnGroupKeyGenerator(@Nonnull TransformOperator transformOperator,
       @Nonnull TransformExpressionTree groupByExpression) {
     _groupByExpression = groupByExpression;
-    _dataType = transformOperator.getDataSourceMetadata(_groupByExpression).getDataType();
+    _dataType = transformOperator.getResultMetadata(_groupByExpression).getDataType();
     _groupKeyMap = createGroupKeyMap(_dataType);
   }
 


### PR DESCRIPTION
Make a seperate metadata class for transform result instead of using DataSourceMetadata
The TransformResultMetadata encapsules 3 attributes: data type, is single value, has dictionary