### PR TITLE
[TE] rootcause - move predicted baseline to baseline selector

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/component.js
@@ -13,8 +13,6 @@ import _ from 'lodash';
 export default Component.extend({
   entities: null, // {}
 
-  anomalyUrns: null, // Set
-
   selectedUrns: null, // Set
 
   invisibleUrns: null, // Set
@@ -75,13 +73,6 @@ export default Component.extend({
     }
   ),
 
-  hasAnomalyFunctions: computed(
-    'metrics',
-    function () {
-      return Object.keys(this.get('anomalyFunctions')).length > 0;
-    }
-  ),
-
   hasMetrics: computed(
     'metrics',
     function () {
@@ -93,29 +84,6 @@ export default Component.extend({
     'events',
     function () {
       return Object.keys(this.get('events')).length > 0;
-    }
-  ),
-
-  anomalyFunctions: computed(
-    'selectedUrns',
-    'anomalyUrns',
-    function () {
-      const { selectedUrns, anomalyUrns } = this.getProperties('selectedUrns', 'anomalyUrns');
-
-      // NOTE: only supports single anomaly function
-      const anomalyFunctions = filterPrefix(anomalyUrns, 'frontend:anomalyfunction:');
-
-      if (_.isEmpty(anomalyFunctions)) return {};
-
-      const anomalyFunction = anomalyFunctions[0];
-
-      return [...selectedUrns].reduce((agg, urn) => {
-        agg[urn] = false;
-        if (anomalyUrns.has(urn)) {
-          agg[urn] = anomalyFunction;
-        }
-        return agg;
-      }, {});
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-legend/template.hbs
@@ -24,18 +24,6 @@
             </i>
           </a>
         </li>
-        {{#if (get-safe anomalyFunctions urn)}}
-          <li class="rootcause-legend__item rootcause-legend__item--indented" onMouseEnter={{action "onMouseEnter" (get-safe anomalyFunctions urn)}}>
-            <div class="rootcause-legend__label-group {{if (set-has invisibleUrns (get-safe anomalyFunctions urn)) 'rootcause-legend__label-group--inactive'}}" {{action "toggleVisibility" (get-safe anomalyFunctions urn)}}>
-              <div class="rootcause-legend__indicator">
-              <span class="entity-indicator entity-indicator--indented entity-indicator--light-{{get-safe colors urn}} entity-indicator--square {{if (set-has invisibleUrns (get-safe anomalyFunctions urn)) 'entity-indicator--inactive'}}">
-                {{tooltip-on-element text="Toggle view"}}
-              </span>
-              </div>
-              <span class="rootcause-legend__label">Show predicted baseline</span>
-            </div>
-          </li>
-        {{/if}}
       {{/each-in}}
     </ul>
   {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
@@ -24,7 +24,8 @@ export default Component.extend({
   },
 
   compareModeOptions: [
-    'None',
+    'none',
+    'predicted',
     'WoW',
     'Wo2W',
     'Wo3W',

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -238,7 +238,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
           anomalyRange,
           analysisRange,
           granularity,
-          compareMode,
+          compareMode: 'predicted',
           anomalyUrns: new Set([anomalyUrn, anomalyMetricUrn, anomalyFunctionUrn])
         };
 

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -56,7 +56,6 @@
             entities=entities
             selectedUrns=selectedUrns
             invisibleUrns=invisibleUrns
-            anomalyUrns=context.anomalyUrns
             onVisibility=(action "onVisibility")
             onSelection=(action "onSelection")
             onMouseEnter=(action "onLegendHover")

--- a/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/rca-utils.js
@@ -347,6 +347,7 @@ export function toBaselineRange(range, offset) {
   const offsetWeeks = {
     current: 0,
     none: 0,
+    predicted: 0,
     wow: 1,
     wo1w: 1,
     wo2w: 2,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/v2/RootCauseMetricResource.java
@@ -71,6 +71,7 @@ public class RootCauseMetricResource {
   private static final String GRANULARITY_DEFAULT = MetricSlice.NATIVE_GRANULARITY.toAggregationGranularityString();
 
   private static final Pattern PATTERN_NONE = Pattern.compile("none");
+  private static final Pattern PATTERN_PREDICTED = Pattern.compile("predicted");
   private static final Pattern PATTERN_CURRENT = Pattern.compile("current");
   private static final Pattern PATTERN_WEEK_OVER_WEEK = Pattern.compile("wo([1-9][0-9]*)w");
   private static final Pattern PATTERN_MEAN = Pattern.compile("mean([1-9][0-9]*)w");
@@ -491,6 +492,12 @@ public class RootCauseMetricResource {
 
     Matcher mNone = PATTERN_NONE.matcher(offset);
     if (mNone.find()) {
+      return new BaselineNone();
+    }
+
+    // TODO link with generic metric baseline prediction when available
+    Matcher mPredicted = PATTERN_PREDICTED.matcher(offset);
+    if (mPredicted.find()) {
       return new BaselineNone();
     }
 


### PR DESCRIPTION
This PR removes the predicted baseline toggle from the legend and instead moves it to the baseline selection box.

![image](https://user-images.githubusercontent.com/25439965/38281256-90bb089a-375e-11e8-9292-6c634816ad32.png)
