### PR TITLE
[TE] rootcause - fix chart bouncing between split and absolute mode on session save

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-chart/component.js
@@ -31,7 +31,7 @@ export default Component.extend({
 
   onHover: null, // function (urns)
 
-  timeseriesMode: null, // 'absolute', 'relative', 'log'
+  timeseriesMode: null, // 'absolute', 'relative', 'log', 'split'
 
   classNames: ['rootcause-chart'],
 
@@ -48,11 +48,6 @@ export default Component.extend({
   focusedIds: computed('focusedUrns', function() {
     return this.get('focusedUrns');
   }),
-
-  init() {
-    this._super(...arguments);
-    this.set('timeseriesMode', TIMESERIES_MODE_ABSOLUTE);
-  },
 
   legend: {
     show: false

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -139,13 +139,13 @@ export default Controller.extend({
    * displayed investigation tab ('metrics', 'dimensions', ...)
    * @type {string}
    */
-  activeTab: null,
+  activeTab: ROOTCAUSE_TAB_METRICS,
 
   /**
    * display mode for timeseries chart
    * @type {string}
    */
-  timeseriesMode: null,
+  timeseriesMode: 'split',
 
   /**
    * urns of the currently focused entities in the legend component
@@ -223,9 +223,7 @@ export default Controller.extend({
     this.setProperties({
       invisibleUrns: new Set(),
       hoverUrns: new Set(),
-      filteredUrns: new Set(),
-      activeTab: ROOTCAUSE_TAB_METRICS,
-      timeseriesMode: 'split'
+      filteredUrns: new Set()
     });
 
     // This is a flag for the acceptance test for rootcause to prevent it from timing out because of this run loop
@@ -576,7 +574,7 @@ export default Controller.extend({
    * @private
    */
   _updateSession(sessionId) {
-    const { username } = this.getProperties('username');
+    const { username, metricId, anomalyId } = this.getProperties('username', 'metricId', 'anomalyId');
 
     this.setProperties({
       sessionId,
@@ -584,7 +582,19 @@ export default Controller.extend({
       sessionUpdatedTime: moment().valueOf(),
       sessionModified: false
     });
-    this.transitionToRoute({ queryParams: { sessionId, anomalyId: null, metricId: null }});
+
+    const queryParams = {};
+    queryParams['sessionId'] = sessionId;
+
+    if (!_.isEmpty(metricId)) {
+      queryParams['metricId'] = null;
+    }
+
+    if (!_.isEmpty(anomalyId)) {
+      queryParams['anomalyId'] = null;
+    }
+
+    this.transitionToRoute({ queryParams });
   },
 
   /**

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/route.js
@@ -281,6 +281,8 @@ export default Route.extend(AuthenticatedRouteMixin, {
 
     controller.setProperties({
       routeErrors,
+      anomalyId,
+      metricId,
       sessionId,
       sessionName,
       sessionText,


### PR DESCRIPTION
Prevent rootcause-chart from bouncing to absolute on session save. also prevent unnecessary reload if query params didn't change.