### PR TITLE
Identifier quote character support

### DIFF
--- a/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
+++ b/pinot-common/src/main/antlr4/com/linkedin/pinot/pql/parsers/PQL2.g4
@@ -139,7 +139,7 @@ WHITESPACE: [ \t\n]+ -> skip;
 
 LINE_COMMENT: '--' ~[\r\n]* -> channel(HIDDEN);
 
-IDENTIFIER: [A-Za-z_][A-Za-z0-9_-]*;
+IDENTIFIER: [A-Za-z_][A-Za-z0-9_-]* | '`' (~'`')+ '`';
 STRING_LITERAL: '\'' ( ~'\'' | '\'\'')* '\'' | '"' (~'"' | '""')* '"';
 INTEGER_LITERAL : SIGN? DIGIT+;
 FLOATING_POINT_LITERAL : SIGN? DIGIT+ '.' DIGIT* | SIGN? DIGIT* '.' DIGIT+;

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/GroupByAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/GroupByAstNode.java
@@ -31,11 +31,10 @@ public class GroupByAstNode extends BaseAstNode {
     for (AstNode astNode : getChildren()) {
       if (astNode instanceof IdentifierAstNode) {
         IdentifierAstNode node = (IdentifierAstNode) astNode;
-        String groupByColumnName = node.getName();
-        groupBy.addToColumns(groupByColumnName);
+        groupBy.addToColumns(node.getName());
 
         // List of expression contains columns as well as expressions to maintain ordering of group by columns.
-        groupBy.addToExpressions(groupByColumnName);
+        groupBy.addToExpressions(node.getExpression());
       } else {
         // Compile to standard expression string
         // NOTE: the purpose of this compilation is to ensure the function expression is valid. We serialize the

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/IdentifierAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/IdentifierAstNode.java
@@ -19,14 +19,27 @@ package com.linkedin.pinot.pql.parsers.pql2.ast;
  * AST node for identifiers (column names).
  */
 public class IdentifierAstNode extends BaseAstNode {
+  private String _expression;
   private String _name;
 
-  public IdentifierAstNode(String name) {
-    _name = name;
+  public IdentifierAstNode(String expression) {
+    _expression = expression;
+    if (
+      expression.charAt(0) == '`'
+      && expression.charAt(expression.length()-1) == '`'
+    ) {
+      _name = expression.substring(1, expression.length()-1);
+    } else {
+      _name = expression;
+    }
   }
 
   public String getName() {
     return _name;
+  }
+
+  public String getExpression() {
+    return _expression;
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/OptionAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/OptionAstNode.java
@@ -37,13 +37,13 @@ public class OptionAstNode extends BaseAstNode {
     AstNode rightNode = getChildren().get(1);
 
     if (leftNode instanceof IdentifierAstNode) {
-      left = ((IdentifierAstNode) leftNode).getName();
+      left = ((IdentifierAstNode) leftNode).getExpression();
     } else {
       throw new Pql2CompilationException("Expected left child node of OptionAstNode to be an identifier");
     }
 
     if (rightNode instanceof IdentifierAstNode) {
-      right = ((IdentifierAstNode) rightNode).getName();
+      right = ((IdentifierAstNode) rightNode).getExpression();
     } else if (rightNode instanceof LiteralAstNode) {
       right = ((LiteralAstNode) rightNode).getValueAsString();
     } else {


### PR DESCRIPTION
This PR adds the ability for identifiers to contain characters other than ```[A-Za-z_][A-Za-z0-9_-]*``` by way of an *identifier quote character* (ie- the backtick character).


Example-

```select avg(`attributes.age`) as `avg.age` from `person` group by `attributes.address_city` having avg(`attributes.age`)=20```

This mechansim is supported in MySQL for example: https://dev.mysql.com/doc/refman/5.7/en/identifiers.html

Further discussion in case it's helpful: https://github.com/linkedin/pinot/issues/2687
