### PR TITLE
Make a cap for ExponentialBackoffRetryPolicy to avoid overflow

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/ExponentialBackoffRetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/ExponentialBackoffRetryPolicy.java
@@ -26,18 +26,20 @@ import java.util.concurrent.ThreadLocalRandom;
 public class ExponentialBackoffRetryPolicy extends BaseRetryPolicy {
   private final ThreadLocalRandom _random = ThreadLocalRandom.current();
   private final double _delayScaleFactor;
+  private final long _maxDelayMs;
   private long _minDelayMs;
 
   public ExponentialBackoffRetryPolicy(int maxNumAttempts, long initialDelayMs, double delayScaleFactor) {
     super(maxNumAttempts);
     _delayScaleFactor = delayScaleFactor;
     _minDelayMs = initialDelayMs;
+    _maxDelayMs = (long) (_minDelayMs * Math.pow(delayScaleFactor, maxNumAttempts));
   }
 
   @Override
   protected long getNextDelayMs() {
-    long maxDelayMs = (long) (_minDelayMs * _delayScaleFactor);
-    long nextDelayMs = _random.nextLong(_minDelayMs, maxDelayMs);
+    long maxDelayMs = Math.min((long) (_minDelayMs * _delayScaleFactor), _maxDelayMs);
+    long nextDelayMs = _random.nextLong(_minDelayMs, maxDelayMs + 1);
     _minDelayMs = maxDelayMs;
     return nextDelayMs;
   }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/retry/RetryPolicyTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/retry/RetryPolicyTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils.retry;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RetryPolicyTest {
+
+  @Test
+  public void testExponentialBackoffRetryPolicy() {
+    ExponentialBackoffRetryPolicy policy = RetryPolicies.exponentialBackoffRetryPolicy(5, 1000, 2);
+    long nextDelayMs = policy.getNextDelayMs();
+    Assert.assertTrue((nextDelayMs >= 1000) && (nextDelayMs < 2000));
+    nextDelayMs = policy.getNextDelayMs();
+    Assert.assertTrue((nextDelayMs >= 2000) && (nextDelayMs < 4000));
+    nextDelayMs = policy.getNextDelayMs();
+    Assert.assertTrue((nextDelayMs >= 4000) && (nextDelayMs < 8000));
+    nextDelayMs = policy.getNextDelayMs();
+    Assert.assertTrue((nextDelayMs >= 8000) && (nextDelayMs < 16000));
+    nextDelayMs = policy.getNextDelayMs();
+    Assert.assertTrue((nextDelayMs >= 16000) && (nextDelayMs < 32000));
+    nextDelayMs = policy.getNextDelayMs();
+    Assert.assertTrue((nextDelayMs == 32000));
+    nextDelayMs = policy.getNextDelayMs();
+    Assert.assertTrue((nextDelayMs == 32000));
+  }
+}


### PR DESCRIPTION
Hi team,

We are hitting an issue when we do a lot of parallel segments push.

The issue is that whenever there is an version conflict of idealstate update, the default retry policy will double the time wait, which will overflow after 54 times.

After overflow, the attempt will throw exception below without retry. This will cause some data took too long to retry and data missing if I restart the controller in between.

Do we consider to add a cap for the exponential retry policy, say by default the max retry time is 
`initialDelayMs*(delayScaleFactor^ maxNumAttempts)` or some reasonable number.


====Stacktrace===

> 
> 2018-04-06 03:07:56 WARN  HelixHelper:111 - Version changed while updating ideal state for resource: store_ratings_with_comments_OFFLINE
> 
> 2018-04-06 03:07:56 ERROR PinotSegmentUploadRestletResource:50 - Caught internal server exception while uploading segment
> 
> java.lang.RuntimeException: Caught exception while updating ideal state for resource: store_ratings_with_comments_OFFLINE
> 
>         at com.linkedin.pinot.common.utils.helix.HelixHelper.updateIdealState(HelixHelper.java:127)
> 
>         at com.linkedin.pinot.common.utils.helix.HelixHelper.addSegmentToIdealState(HelixHelper.java:385)
> 
>         at com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager.addNewOfflineSegment(PinotHelixResourceManager.java:1597)
> 
>         at com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager.addNewSegment(PinotHelixResourceManager.java:1418)
> 
>         at com.linkedin.pinot.controller.api.resources.PinotSegmentUploadRestletResource.uploadSegment(PinotSegmentUploadRestletResource.java:434)
> 
>         at com.linkedin.pinot.controller.api.resources.PinotSegmentUploadRestletResource.uploadSegmentInternal(PinotSegmentUploadRestletResource.java:364)
> 
>         at com.linkedin.pinot.controller.api.resources.PinotSegmentUploadRestletResource.uploadSegmentAsJson(PinotSegmentUploadRestletResource.java:271)
> 
>         at sun.reflect.GeneratedMethodAccessor86.invoke(Unknown Source)
> 
>         at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> 
>         at java.lang.reflect.Method.invoke(Method.java:498)
> 
>         at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)
> 
>         at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:144)
> 
>         at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:161)
> 
>         at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$VoidOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:143)
> 
>         at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:99)
> 
>         at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:389)
> 
>         at org.glassfish.jersey.server.model.ResourceMethodInvoker.access$100(ResourceMethodInvoker.java:102)
> 
>         at org.glassfish.jersey.server.model.ResourceMethodInvoker$2.call(ResourceMethodInvoker.java:336)
> 
>         at org.glassfish.jersey.server.model.ResourceMethodInvoker$2.call(ResourceMethodInvoker.java:333)
> 
>         at org.glassfish.jersey.server.ServerRuntime$AsyncResponder$2$1.run(ServerRuntime.java:893)
> 
>         at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
> 
>         at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
> 
>         at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
> 
>         at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
> 
>         at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
> 
>         at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:317)
> 
>         at org.glassfish.jersey.server.ServerRuntime$AsyncResponder$2.run(ServerRuntime.java:888)
> 
>         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
> 
>         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
> 
>         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
> 
>         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
> 
>         at java.lang.Thread.run(Thread.java:748)
> 
> Caused by: com.linkedin.pinot.common.utils.retry.RetriableOperationException: java.lang.IllegalArgumentException: bound must be greater than origin
> 
>         at com.linkedin.pinot.common.utils.retry.BaseRetryPolicy.attempt(BaseRetryPolicy.java:49)
> 
>         at com.linkedin.pinot.common.utils.helix.HelixHelper.updateIdealState(HelixHelper.java:70)
> 
>         ... 31 more
> 
> Caused by: java.lang.IllegalArgumentException: bound must be greater than origin
> 
>         at java.util.concurrent.ThreadLocalRandom.nextLong(ThreadLocalRandom.java:429)
> 
>         at com.linkedin.pinot.common.utils.retry.ExponentialBackoffRetryPolicy.getNextDelayMs(ExponentialBackoffRetryPolicy.java:40)
> 
>         at com.linkedin.pinot.common.utils.retry.BaseRetryPolicy.attempt(BaseRetryPolicy.java:46)
> 
>         ... 32 more
> 
> 2018-04-06 03:07:56 INFO  ControllerResponseFilter:48 - Handled request from 
> 
 
