### PR TITLE
CRITICAL: Fix the bug where ExponentialBackoffRetryPolicy is not stateless

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/ExponentialBackoffRetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/ExponentialBackoffRetryPolicy.java
@@ -20,25 +20,24 @@ import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Retry policy with exponential backoff delay between attempts.
- * <p>The delay between the i<sup>th</sup> and (i + 1)<sup>th</sup> attempts is between delayScaleFactor<sup>i - 1</sup>
- * * initialDelayMs and delayScaleFactor<sup>i</sup> * initialDelayMs.
+ * <p>The delay between the i<sup>th</sup> and (i + 1)<sup>th</sup> attempts is between delayScaleFactor<sup>i</sup>
+ * * initialDelayMs and delayScaleFactor<sup>(i + 1)</sup> * initialDelayMs.
  */
 public class ExponentialBackoffRetryPolicy extends BaseRetryPolicy {
   private final ThreadLocalRandom _random = ThreadLocalRandom.current();
+  private final long _initialDelayMs;
   private final double _delayScaleFactor;
-  private long _minDelayMs;
 
   public ExponentialBackoffRetryPolicy(int maxNumAttempts, long initialDelayMs, double delayScaleFactor) {
     super(maxNumAttempts);
+    _initialDelayMs = initialDelayMs;
     _delayScaleFactor = delayScaleFactor;
-    _minDelayMs = initialDelayMs;
   }
 
   @Override
-  protected long getNextDelayMs() {
-    long maxDelayMs = (long) (_minDelayMs * _delayScaleFactor);
-    long nextDelayMs = _random.nextLong(_minDelayMs, maxDelayMs);
-    _minDelayMs = maxDelayMs;
-    return nextDelayMs;
+  protected long getDelayMs(int currentAttempt) {
+    double minDelayMs = _initialDelayMs * Math.pow(_delayScaleFactor, currentAttempt);
+    double maxDelayMs = minDelayMs * _delayScaleFactor;
+    return _random.nextLong((long) minDelayMs, (long) maxDelayMs);
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/FixedDelayRetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/FixedDelayRetryPolicy.java
@@ -27,7 +27,7 @@ public class FixedDelayRetryPolicy extends BaseRetryPolicy {
   }
 
   @Override
-  protected long getNextDelayMs() {
+  protected long getDelayMs(int currentAttempt) {
     return _delayMs;
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/NoDelayRetryPolicy.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/retry/NoDelayRetryPolicy.java
@@ -25,7 +25,7 @@ public class NoDelayRetryPolicy extends BaseRetryPolicy {
   }
 
   @Override
-  protected long getNextDelayMs() {
+  protected long getDelayMs(int currentAttempt) {
     return 0L;
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/retry/RetryPolicyTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/retry/RetryPolicyTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils.retry;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class RetryPolicyTest {
+  private static final int NUM_ROUNDS = 10;
+  private static final int MAX_NUM_ATTEMPTS = 5;
+
+  @Test
+  public void testNoDelayRetryPolicy() {
+    NoDelayRetryPolicy noDelayRetryPolicy = new NoDelayRetryPolicy(MAX_NUM_ATTEMPTS);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
+        Assert.assertEquals(noDelayRetryPolicy.getDelayMs(j), 0);
+      }
+    }
+  }
+
+  @Test
+  public void testFixedDelayRetryPolicy() {
+    FixedDelayRetryPolicy fixedDelayRetryPolicy = new FixedDelayRetryPolicy(MAX_NUM_ATTEMPTS, 10);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
+        Assert.assertEquals(fixedDelayRetryPolicy.getDelayMs(j), 10);
+      }
+    }
+  }
+
+  @Test
+  public void testExponentialBackoffRetryPolicy() {
+    ExponentialBackoffRetryPolicy exponentialBackoffRetryPolicy =
+        new ExponentialBackoffRetryPolicy(MAX_NUM_ATTEMPTS, 10, 2.0);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
+        long delayMs = exponentialBackoffRetryPolicy.getDelayMs(j);
+        Assert.assertTrue(delayMs >= 10 * Math.pow(2.0, j));
+        Assert.assertTrue(delayMs < 10 * Math.pow(2.0, j + 1));
+      }
+    }
+  }
+
+  @Test
+  public void testBaseRetryPolicy() throws Exception {
+    RetryPolicy retryPolicy = RetryPolicies.noDelayRetryPolicy(MAX_NUM_ATTEMPTS);
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      retryPolicy.attempt(() -> true);
+
+      try {
+        retryPolicy.attempt(() -> false);
+        Assert.fail();
+      } catch (AttemptsExceededException e) {
+        // Expected
+      }
+
+      try {
+        retryPolicy.attempt(() -> null);
+        Assert.fail();
+      } catch (AttemptsExceededException e) {
+        // Expected
+      }
+
+      try {
+        retryPolicy.attempt(() -> {
+          throw new RuntimeException();
+        });
+        Assert.fail();
+      } catch (RetriableOperationException e) {
+        // Expected
+      }
+    }
+  }
+}


### PR DESCRIPTION
Make ExponentialBackoffRetryPolicy stateless so that it can be cached and reused
Fix the issue where retry policy will throw exception when operation returns null