### PR TITLE
Refactor realtime code to eliminate use of znode for storing partition assignment

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelConsumerRoutingTableBuilder.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCUtils;
 import com.linkedin.pinot.common.utils.SegmentName;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -87,7 +88,7 @@ public class KafkaLowLevelConsumerRoutingTableBuilder extends GeneratorBasedRout
     public void init(ExternalView externalView, List<InstanceConfig> instanceConfigList) {
       // 1. Gather all segments and group them by Kafka partition, sorted by sequence number
       Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition =
-          KafkaLowLevelRoutingTableBuilderUtil.getSortedSegmentsByKafkaPartition(externalView);
+          LLCUtils.sortSegmentsByStreamPartition(externalView.getPartitionSet());
 
       // 2. Ensure that for each Kafka partition, we have at most one Helix partition (Pinot segment) in consuming state
       Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition =

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelRoutingTableBuilderUtil.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelRoutingTableBuilderUtil.java
@@ -17,12 +17,10 @@
 package com.linkedin.pinot.broker.routing.builder;
 
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.SegmentName;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import org.apache.helix.model.ExternalView;
 
 
@@ -37,30 +35,6 @@ public class KafkaLowLevelRoutingTableBuilderUtil {
    * @param externalView helix external view.
    * @return map of Kafka partition to sorted set of segment names.
    */
-  public static Map<String, SortedSet<SegmentName>> getSortedSegmentsByKafkaPartition(ExternalView externalView) {
-    Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition = new HashMap<>();
-    for (String helixPartitionName : externalView.getPartitionSet()) {
-      // Ignore segments that are not low level consumer segments
-      if (!SegmentName.isLowLevelConsumerSegmentName(helixPartitionName)) {
-        continue;
-      }
-
-      final LLCSegmentName segmentName = new LLCSegmentName(helixPartitionName);
-      String kafkaPartitionName = segmentName.getPartitionRange();
-      SortedSet<SegmentName> segmentsForPartition = sortedSegmentsByKafkaPartition.get(kafkaPartitionName);
-
-      // Create sorted set if necessary
-      if (segmentsForPartition == null) {
-        segmentsForPartition = new TreeSet<>();
-
-        sortedSegmentsByKafkaPartition.put(kafkaPartitionName, segmentsForPartition);
-      }
-
-      segmentsForPartition.add(segmentName);
-    }
-    return sortedSegmentsByKafkaPartition;
-  }
-
   /**
    * Compute the map of allowed 'consuming' segments for each partition.
    *

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelRoutingTableBuilderUtil.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/KafkaLowLevelRoutingTableBuilderUtil.java
@@ -30,12 +30,6 @@ import org.apache.helix.model.ExternalView;
 public class KafkaLowLevelRoutingTableBuilderUtil {
 
   /**
-   * Compute the table of a sorted list of segments grouped by Kafka partition.
-   *
-   * @param externalView helix external view.
-   * @return map of Kafka partition to sorted set of segment names.
-   */
-  /**
    * Compute the map of allowed 'consuming' segments for each partition.
    *
    * @param externalView helix external view

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilder.java
@@ -21,6 +21,7 @@ import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.SegmentZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.common.utils.LLCUtils;
 import com.linkedin.pinot.common.utils.SegmentName;
 import java.util.HashMap;
 import java.util.List;
@@ -67,8 +68,7 @@ public class PartitionAwareRealtimeRoutingTableBuilder extends BasePartitionAwar
     }
 
     // Gather all segments and group them by Kafka partition, sorted by sequence number
-    Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition =
-        KafkaLowLevelRoutingTableBuilderUtil.getSortedSegmentsByKafkaPartition(externalView);
+    Map<String, SortedSet<SegmentName>> sortedSegmentsByKafkaPartition = LLCUtils.sortSegmentsByStreamPartition(externalView.getPartitionSet());
 
     // Ensure that for each Kafka partition, we have at most one Helix partition (Pinot segment) in consuming state
     Map<String, SegmentName> allowedSegmentInConsumingStateByKafkaPartition =

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -337,10 +337,9 @@ public class ZKMetadataProvider {
       if (znRecordList != null) {
         for (ZNRecord record : znRecordList) {
           RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = new RealtimeSegmentZKMetadata(record);
-          if (SegmentName.isHighLevelConsumerSegmentName(realtimeSegmentZKMetadata.getSegmentName())) {
-            continue;
+          if (SegmentName.isLowLevelConsumerSegmentName(realtimeSegmentZKMetadata.getSegmentName())) {
+            resultList.add(new LLCRealtimeSegmentZKMetadata(record));
           }
-          resultList.add(new LLCRealtimeSegmentZKMetadata(record));
         }
       }
     }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metadata/ZKMetadataProvider.java
@@ -323,6 +323,30 @@ public class ZKMetadataProvider {
     return resultList;
   }
 
+  public static List<LLCRealtimeSegmentZKMetadata> getLLCRealtimeSegmentZKMetadataListForTable(
+      ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceName) {
+    List<LLCRealtimeSegmentZKMetadata> resultList = new ArrayList<>();
+    if (propertyStore == null) {
+      return resultList;
+    }
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(resourceName);
+    if (propertyStore.exists(constructPropertyStorePathForResource(realtimeTableName), AccessOption.PERSISTENT)) {
+      List<ZNRecord> znRecordList =
+          propertyStore.getChildren(constructPropertyStorePathForResource(realtimeTableName), null,
+              AccessOption.PERSISTENT);
+      if (znRecordList != null) {
+        for (ZNRecord record : znRecordList) {
+          RealtimeSegmentZKMetadata realtimeSegmentZKMetadata = new RealtimeSegmentZKMetadata(record);
+          if (SegmentName.isHighLevelConsumerSegmentName(realtimeSegmentZKMetadata.getSegmentName())) {
+            continue;
+          }
+          resultList.add(new LLCRealtimeSegmentZKMetadata(record));
+        }
+      }
+    }
+    return resultList;
+  }
+
   public static void setClusterTenantIsolationEnabled(ZkHelixPropertyStore<ZNRecord> propertyStore, boolean isSingleTenantCluster) {
     final ZNRecord znRecord;
     final String path = constructPropertyStorePathForControllerConfig(CLUSTER_TENANT_ISOLATION_ENABLED_KEY);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ControllerMeter.java
@@ -52,7 +52,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_KAFKA_DATA_LOSS("dataLoss", false),
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
-  NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true);
+  NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),
+  PARTITION_ASSIGNMENT_GENERATION_ERROR("partitionAssignmentError", false);
 
 
   private final String brokerMeterName;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/partition/PartitionAssignmentGenerator.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/partition/PartitionAssignmentGenerator.java
@@ -26,8 +26,10 @@ import com.linkedin.pinot.common.utils.LLCSegmentName;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.IdealState;
 
@@ -88,6 +90,19 @@ public class PartitionAssignmentGenerator {
       }
     }
     return partitionIdToLatestSegment;
+  }
+
+  public int getNumPartitionsFromIdealState(IdealState idealState) {
+    Set<Integer> partitions = new HashSet<>();
+    Map<String, Map<String, String>> mapFields = idealState.getRecord().getMapFields();
+    for (Map.Entry<String, Map<String, String>> entry : mapFields.entrySet()) {
+      String segmentName = entry.getKey();
+      if (LLCSegmentName.isLowLevelConsumerSegmentName(segmentName)) {
+        LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+        partitions.add(llcSegmentName.getPartitionId());
+      }
+    }
+    return partitions.size();
   }
 
   /**

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/LLCUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/LLCUtils.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+public class LLCUtils {
+  /**
+   * Compute the table of a sorted list of segments grouped by Kafka partition.
+   *
+   * @param segmentSet is the set of segment names that need to be sorted.
+   * @return map of Stream partition to sorted set of segment names
+   */
+  public static Map<String, SortedSet<SegmentName>> sortSegmentsByStreamPartition(Set<String> segmentSet) {
+    Map<String, SortedSet<SegmentName>> sortedSegmentsByStreamPartition = new HashMap<>();
+    for (String segment : segmentSet) {
+      // Ignore segments that are not low level consumer segments
+      if (!SegmentName.isLowLevelConsumerSegmentName(segment)) {
+        continue;
+      }
+
+      final LLCSegmentName segmentName = new LLCSegmentName(segment);
+      String streamPartitionId = segmentName.getPartitionRange();
+      SortedSet<SegmentName> segmentsForPartition = sortedSegmentsByStreamPartition.get(streamPartitionId);
+
+      // Create sorted set if necessary
+      if (segmentsForPartition == null) {
+        segmentsForPartition = new TreeSet<>();
+
+        sortedSegmentsByStreamPartition.put(streamPartitionId, segmentsForPartition);
+      }
+
+      segmentsForPartition.add(segmentName);
+    }
+    return sortedSegmentsByStreamPartition;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/helix/HelixHelper.java
@@ -65,7 +65,7 @@ public class HelixHelper {
    */
   // TODO: since updater always update ideal state in place, it should return boolean indicating whether the ideal state get changed.
   public static void updateIdealState(final HelixManager helixManager, final String resourceName,
-      final Function<IdealState, IdealState> updater, RetryPolicy policy) {
+      final Function<IdealState, IdealState> updater, RetryPolicy policy, final boolean noChangeOk) {
     try {
       policy.attempt(new Callable<Boolean>() {
         @Override
@@ -118,7 +118,11 @@ public class HelixHelper {
               return false;
             }
           } else {
-            LOGGER.warn("Idempotent or null ideal state update for resource {}, skipping update.", resourceName);
+            if (noChangeOk) {
+              LOGGER.info("Idempotent or null ideal state update for resource {}, skipping update.", resourceName);
+            } else {
+              LOGGER.warn("Idempotent or null ideal state update for resource {}, skipping update.", resourceName);
+            }
             return true;
           }
         }
@@ -126,6 +130,11 @@ public class HelixHelper {
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while updating ideal state for resource: " + resourceName, e);
     }
+  }
+
+  public static void updateIdealState(final HelixManager helixManager, final String resourceName,
+      final Function<IdealState, IdealState> updater, RetryPolicy policy) {
+    updateIdealState(helixManager, resourceName, updater, policy, false);
   }
 
   /**

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/partition/IdealStateBuilderUtil.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/partition/IdealStateBuilderUtil.java
@@ -17,6 +17,7 @@
 package com.linkedin.pinot.common.partition;
 
 import com.google.common.collect.Lists;
+import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,19 +35,38 @@ public class IdealStateBuilderUtil {
 
   private IdealState _idealState;
   private String _tableName;
+  private String _rawTableName;
 
-  public IdealStateBuilderUtil(String resourceName) {
-    _tableName = resourceName;
-    _idealState = new IdealState(resourceName);
+  public IdealStateBuilderUtil(String tableNameWithType) {
+    _tableName = tableNameWithType;
+    _rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    _idealState = new IdealState(tableNameWithType);
   }
 
   public IdealState build() {
     return _idealState;
   }
 
+  public IdealStateBuilderUtil disableIdealState() {
+    _idealState.getRecord().setSimpleField(IdealState.IdealStateProperty.HELIX_ENABLED.name(), "false");
+    return this;
+  }
+
   public IdealStateBuilderUtil setNumReplicas(int numReplicas) {
     _idealState.setReplicas(String.valueOf(numReplicas));
     return this;
+  }
+
+  public String getSegment(int partition, int seqNum) {
+    for (String segmentName : _idealState.getRecord().getMapFields().keySet()) {
+      if (LLCSegmentName.isLowLevelConsumerSegmentName(segmentName)) {
+        LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+        if (llcSegmentName.getPartitionId() == partition && llcSegmentName.getSequenceNumber() == seqNum) {
+          return segmentName;
+        }
+      }
+    }
+    return null;
   }
 
   public IdealStateBuilderUtil addSegment(String segmentName, Map<String, String> instanceStateMap) {
@@ -57,7 +77,7 @@ public class IdealStateBuilderUtil {
   public IdealStateBuilderUtil addConsumingSegments(int numPartitions, int seqNum, int numReplicas, List<String> instances) {
     int serverId = 0;
     for (int p = 0; p < numPartitions; p++) {
-      LLCSegmentName llcSegmentName = new LLCSegmentName(_tableName, p, seqNum, System.currentTimeMillis());
+      LLCSegmentName llcSegmentName = new LLCSegmentName(_rawTableName, p, seqNum, System.currentTimeMillis());
       Map<String, String> instanceStateMap = new HashMap<>(numReplicas);
       for (int r = 0; r < numReplicas; r++) {
         instanceStateMap.put(instances.get(serverId++), CONSUMING);
@@ -86,8 +106,16 @@ public class IdealStateBuilderUtil {
     return this;
   }
 
+  public IdealStateBuilderUtil transitionToState(String segmentName, String state) {
+    Map<String, String> instanceStateMap = _idealState.getInstanceStateMap(segmentName);
+    for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
+      instanceStateMap.put(entry.getKey(), state);
+    }
+    return this;
+  }
+
   public IdealStateBuilderUtil addConsumingSegment(int partition, int seqNum, int numReplicas, List<String> instances) {
-    LLCSegmentName llcSegmentName = new LLCSegmentName(_tableName, partition, seqNum, System.currentTimeMillis());
+    LLCSegmentName llcSegmentName = new LLCSegmentName(_rawTableName, partition, seqNum, System.currentTimeMillis());
     Map<String, String> instanceStateMap = new HashMap<>(numReplicas);
     for (int i = 0; i < numReplicas; i++) {
       instanceStateMap.put(instances.get(i), CONSUMING);
@@ -128,6 +156,11 @@ public class IdealStateBuilderUtil {
       }
     }
     return instances;
+  }
+
+  public IdealStateBuilderUtil removeSegment(String segmentName) {
+    _idealState.getRecord().getMapFields().remove(segmentName);
+    return this;
   }
 
   public IdealStateBuilderUtil clear() {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/partition/IdealStateBuilderUtil.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/partition/IdealStateBuilderUtil.java
@@ -90,7 +90,7 @@ public class IdealStateBuilderUtil {
     return this;
   }
 
-  public IdealStateBuilderUtil transitionToState(int partition, int seqNum, String state) {
+  public IdealStateBuilderUtil setSegmentState(int partition, int seqNum, String state) {
     for (String segmentName : _idealState.getRecord().getMapFields().keySet()) {
       if (LLCSegmentName.isLowLevelConsumerSegmentName(segmentName)) {
         LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
@@ -106,7 +106,7 @@ public class IdealStateBuilderUtil {
     return this;
   }
 
-  public IdealStateBuilderUtil transitionToState(String segmentName, String state) {
+  public IdealStateBuilderUtil setSegmentState(String segmentName, String state) {
     Map<String, String> instanceStateMap = _idealState.getInstanceStateMap(segmentName);
     for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
       instanceStateMap.put(entry.getKey(), state);

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/partition/PartitionAssignmentGeneratorTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/partition/PartitionAssignmentGeneratorTest.java
@@ -90,15 +90,15 @@ public class PartitionAssignmentGeneratorTest {
     // 3 partitions 2 replicas, 2 on 0th seq number 1 on 1st seq number (8 segments)
     instances = idealStateBuilder.getInstances(0, 0);
     idealState =
-        idealStateBuilder.transitionToState(0, 0, "ONLINE").addConsumingSegment(0, 1, numReplicas, instances).build();
+        idealStateBuilder.setSegmentState(0, 0, "ONLINE").addConsumingSegment(0, 1, numReplicas, instances).build();
     verifyPartitionAssignmentFromIdealState(tableConfig, idealState, numPartitions);
 
     // 3 partitions 2 replicas, all on 1st seg num (12 segments)
     instances = idealStateBuilder.getInstances(1, 0);
-    idealStateBuilder.transitionToState(1, 0, "ONLINE").addConsumingSegment(1, 1, numReplicas, instances);
+    idealStateBuilder.setSegmentState(1, 0, "ONLINE").addConsumingSegment(1, 1, numReplicas, instances);
     instances = idealStateBuilder.getInstances(2, 0);
     idealState =
-        idealStateBuilder.transitionToState(2, 0, "ONLINE").addConsumingSegment(2, 1, numReplicas, instances).build();
+        idealStateBuilder.setSegmentState(2, 0, "ONLINE").addConsumingSegment(2, 1, numReplicas, instances).build();
     verifyPartitionAssignmentFromIdealState(tableConfig, idealState, numPartitions);
 
     // 3 partitions 2 replicas, seq 0 has moved to COMPLETED servers, seq 1 on CONSUMING instances
@@ -107,7 +107,7 @@ public class PartitionAssignmentGeneratorTest {
     verifyPartitionAssignmentFromIdealState(tableConfig, idealState, numPartitions);
 
     // status of latest segments OFFLINE/ERROR
-    idealState = idealStateBuilder.transitionToState(1, 1, "OFFLINE").transitionToState(2, 1, "OFFLINE").build();
+    idealState = idealStateBuilder.setSegmentState(1, 1, "OFFLINE").setSegmentState(2, 1, "OFFLINE").build();
     verifyPartitionAssignmentFromIdealState(tableConfig, idealState, numPartitions);
 
     // all non llc segments

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1197,8 +1197,7 @@ public class PinotHelixResourceManager {
       final String llcKafkaPartitionAssignmentPath = ZKMetadataProvider.constructPropertyStorePathForKafkaPartitions(
           realtimeTableName);
       if(!_propertyStore.exists(llcKafkaPartitionAssignmentPath, AccessOption.PERSISTENT)) {
-        PinotTableIdealStateBuilder.buildLowLevelRealtimeIdealStateFor(realtimeTableName, config, _helixAdmin,
-            _helixClusterName, _helixZkManager, idealState);
+        PinotTableIdealStateBuilder.buildLowLevelRealtimeIdealStateFor(realtimeTableName, config, idealState);
         LOGGER.info("Successfully added Helix entries for low-level consumers for {} ", realtimeTableName);
       } else {
         LOGGER.info("LLC is already set up for table {}, not configuring again", realtimeTableName);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -205,6 +205,7 @@ public class PinotTableIdealStateBuilder {
       idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, nReplicas);
       create = true;
     }
+    // TODO Delete all lines below, and call into PinotLLCRealtimeSegmentManager.getInstance().setupNewTable();
     LOGGER.info("Assigning partitions to instances for simple consumer for table {}", realtimeTableName);
     final StreamMetadata kafkaMetadata = new StreamMetadata(realtimeTableConfig.getIndexingConfig().getStreamConfigs());
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -16,26 +16,24 @@
 package com.linkedin.pinot.controller.helix.core;
 
 import com.linkedin.pinot.common.config.TableConfig;
-import com.linkedin.pinot.common.config.RealtimeTagConfig;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumerFactory;
-import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
+import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import org.apache.commons.compress.utils.IOUtils;
 import org.apache.helix.HelixAdmin;
-import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.builder.CustomModeISBuilder;
@@ -186,9 +184,8 @@ public class PinotTableIdealStateBuilder {
   }
 
   public static void buildLowLevelRealtimeIdealStateFor(String realtimeTableName, TableConfig realtimeTableConfig,
-      HelixAdmin helixAdmin, String helixClusterName, HelixManager helixManager, IdealState idealState) {
+      IdealState idealState) {
 
-    boolean create = false;
     // Validate replicasPerPartition here.
     final String replicasPerPartitionStr = realtimeTableConfig.getValidationConfig().getReplicasPerPartition();
     if (replicasPerPartitionStr == null || replicasPerPartitionStr.isEmpty()) {
@@ -203,19 +200,9 @@ public class PinotTableIdealStateBuilder {
     }
     if (idealState == null) {
       idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, nReplicas);
-      create = true;
     }
-    // TODO Delete all lines below, and call into PinotLLCRealtimeSegmentManager.getInstance().setupNewTable();
-    LOGGER.info("Assigning partitions to instances for simple consumer for table {}", realtimeTableName);
-    final StreamMetadata kafkaMetadata = new StreamMetadata(realtimeTableConfig.getIndexingConfig().getStreamConfigs());
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();
-    final int nPartitions = getPartitionCount(kafkaMetadata);
-    LOGGER.info("Assigning {} partitions to instances for simple consumer for table {}", nPartitions, realtimeTableName);
-
-    RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(realtimeTableConfig, helixManager);
-    final List<String> realtimeInstances = helixAdmin.getInstancesInClusterWithTag(helixClusterName,
-        realtimeTagConfig.getConsumingServerTag());
-    segmentManager.setupHelixEntries(realtimeTagConfig, kafkaMetadata, nPartitions, realtimeInstances, idealState, create);
+    segmentManager.setupNewTable(realtimeTableConfig, idealState);
   }
 
   public static int getPartitionCount(StreamMetadata kafkaMetadata) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.controller.helix.core;
 
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
@@ -202,7 +203,11 @@ public class PinotTableIdealStateBuilder {
       idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, nReplicas);
     }
     final PinotLLCRealtimeSegmentManager segmentManager = PinotLLCRealtimeSegmentManager.getInstance();
-    segmentManager.setupNewTable(realtimeTableConfig, idealState);
+    try {
+      segmentManager.setupNewTable(realtimeTableConfig, idealState);
+    } catch (InvalidConfigException e) {
+      throw new IllegalStateException("Caught exception when creating table " + realtimeTableName, e);
+    }
   }
 
   public static int getPartitionCount(StreamMetadata kafkaMetadata) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1586,7 +1586,7 @@ public class PinotLLCRealtimeSegmentManager {
    *   and so it is currently in back-off stage.
    * - ValidationManager starts to run, and finds the segment in improper state and manages to fix it in idealstate.
    * - The segment completion thread comes back to update the ideal state (should already find the same segment in there)
-   *
+   * TODO: split this method into multiple smaller methods
    */
   @VisibleForTesting
   protected IdealState validateLLCSegments(final TableConfig tableConfig, IdealState idealState,
@@ -1616,7 +1616,8 @@ public class PinotLLCRealtimeSegmentManager {
     try {
       partitionAssignment = _partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, partitionCount);
     } catch (InvalidConfigException e) {
-      throw new RuntimeException(e.getMessage());
+      throw new IllegalStateException(
+          "Caught exception when generating partition assignment for table " + tableNameWithType, e);
     }
 
     Map<String, String> oldToNewSegmentsMap = new HashMap<>();
@@ -1747,7 +1748,8 @@ public class PinotLLCRealtimeSegmentManager {
       assignments =
           segmentAssignmentStrategy.assign(Lists.newArrayList(oldToNewSegmentsMap.values()), partitionAssignment);
     } catch (InvalidConfigException e) {
-      e.printStackTrace();
+      throw new IllegalStateException(
+          "Caught exception when assigning segments using partition assignment for table " + tableNameWithType);
     }
 
     for (Map.Entry<String, String> entry : oldToNewSegmentsMap.entrySet()) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1518,6 +1518,8 @@ public class PinotLLCRealtimeSegmentManager {
    * If the controller fails after step-3, we are fine because the idealState has the new segments.
    * If the controller fails before step-1, the server will see this as an upload failure, and will re-try.
    * @param tableConfig
+   *
+   * TODO: We need to find a place to detect and update a gauge for nonConsumingPartitionsCount for a table, and reset it to 0 at the end of validateLLC
    */
   public void validateLLCSegments(final TableConfig tableConfig) {
     final String tableNameWithType = tableConfig.getTableName();
@@ -1874,7 +1876,7 @@ public class PinotLLCRealtimeSegmentManager {
 
       LLCSegmentName newLLCSegmentName = new LLCSegmentName(rawTableName, partition, nextSeqNum, now);
       createNewSegmentMetadataZNRecord(tableNameWithType, newLLCSegmentName, startOffset, partitionAssignment);
-      
+
       segmentMapper.addNewSegment(newLLCSegmentName.getSegmentName());
     }
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -206,7 +206,7 @@ public class PinotLLCRealtimeSegmentManager {
         // Perhaps we should just let validationmanager do all the adjustments, and let the leadership transfer
         // be quick. If the leadership transfer happened due to zk connection issues, then writing to zk at this time
         // may be bad as well.
-        completeCommittingSegments();
+        //completeCommittingSegments(); // TODO: validateLLC() ?
       } else {
         // We already had leadership, nothing to do.
         LOGGER.info("Already leader. Duplicate notification");
@@ -1780,7 +1780,7 @@ public class PinotLLCRealtimeSegmentManager {
     try {
       instanceAssignments = strategy.assign(Lists.newArrayList(newSegmentId), partitionAssignment);
     } catch (InvalidConfigException e) {
-      e.printStackTrace();
+      throw new RuntimeException(e.getMessage());
     }
 
     List<String> newSegmentInstances = instanceAssignments.get(newSegmentId);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -29,10 +29,10 @@ import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.ColumnPartitionMetadata;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.SegmentPartitionMetadata;
-import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.common.metrics.ControllerGauge;
 import com.linkedin.pinot.common.metrics.ControllerMeter;
 import com.linkedin.pinot.common.metrics.ControllerMetrics;
+import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
@@ -43,16 +43,16 @@ import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.api.events.MetadataEventNotifierFactory;
-import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
 import com.linkedin.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
 import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.realtime.partition.StreamPartitionAssignmentGenerator;
 import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
 import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
+import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumer;
 import com.linkedin.pinot.core.realtime.stream.PinotStreamConsumerFactory;
-import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
+import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
 import com.linkedin.pinot.core.segment.creator.impl.V1Constants;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
@@ -79,6 +79,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.math.IntRange;
@@ -190,6 +192,10 @@ public class PinotLLCRealtimeSegmentManager {
         //
         // Go through all partitions of all tables that have LL configured, and check that they have as many
         // segments in CONSUMING state in Idealstate as there are kafka partitions.
+        // TODO We should not call Kafka to get new number of partitions during controller leadership transfer.
+        // Perhaps we should just let validationmanager do all the adjustments, and let the leadership transfer
+        // be quick. If the leadership transfer happened due to zk connection issues, then writing to zk at this time
+        // may be bad as well.
         completeCommittingSegments();
       } else {
         // We already had leadership, nothing to do.
@@ -207,6 +213,18 @@ public class PinotLLCRealtimeSegmentManager {
 
   protected boolean isConnected() {
     return _helixManager.isConnected();
+  }
+
+  /**
+   *
+   * @param tableConfig
+   * @param emptyIdealState may contain HLC segments if both HLC and LLC are configured
+   */
+  public void setupNewTable(TableConfig tableConfig, IdealState emptyIdealState) {
+    final StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+    int partitionCount = getKafkaPartitionCount(streamMetadata);
+    IdealState idealState = validateLLCSegments(tableConfig, emptyIdealState, partitionCount);
+    _helixAdmin.setResourceIdealState(_clusterName, tableConfig.getTableName(), idealState);
   }
 
   /*
@@ -262,8 +280,6 @@ public class PinotLLCRealtimeSegmentManager {
 
     _helixResourceManager.deleteSegments(realtimeTableName, segmentsToRemove);
   }
-
-
 
   protected void setupInitialSegments(TableConfig tableConfig, StreamMetadata streamMetadata, PartitionAssignment partitionAssignment,
       IdealState idealState, boolean create, int flushSize) {
@@ -385,6 +401,7 @@ public class PinotLLCRealtimeSegmentManager {
   // Update the helix idealstate when a new table is added. If createResource is true, then
   // we create a helix resource before setting the idealstate to what we want it to be. Otherwise
   // we expect that idealstate entry is already there, and we update it to what we want it to be.
+  @Deprecated
   protected void updateIdealState(final IdealState idealState, String realtimeTableName,
       final Map<String, List<String>> idealStateEntries, boolean createResource, final int nReplicas) {
     if (createResource) {
@@ -410,6 +427,7 @@ public class PinotLLCRealtimeSegmentManager {
   // Update the idealstate when an old segment commits and a new one is to be started.
   // This method changes the the idealstate to reflect ONLINE state for old segment,
   // and adds a new helix partition (i.e. pinot segment) in CONSUMING state.
+  @Deprecated
   protected void updateIdealState(final String realtimeTableName, final List<String> newInstances,
       final String oldSegmentNameStr, final String newSegmentNameStr) {
     try {
@@ -427,6 +445,7 @@ public class PinotLLCRealtimeSegmentManager {
     }
   }
 
+  @Deprecated
   protected static IdealState updateForNewRealtimeSegment(IdealState idealState,
       final List<String> newInstances, final String oldSegmentNameStr, final String newSegmentNameStr) {
     if (oldSegmentNameStr != null) {
@@ -516,7 +535,6 @@ public class PinotLLCRealtimeSegmentManager {
   protected List<ZNRecord> getExistingSegmentMetadata(String realtimeTableName) {
     String propStorePath = ZKMetadataProvider.constructPropertyStorePathForResource(realtimeTableName);
     return _propertyStore.getChildren(propStorePath, null, 0);
-
   }
 
   protected boolean writeSegmentToPropertyStore(String znodePath, ZNRecord znRecord, final String realtimeTableName,
@@ -918,12 +936,14 @@ public class PinotLLCRealtimeSegmentManager {
     return new LLCRealtimeSegmentZKMetadata(znRecord);
   }
 
+  @Deprecated
   private void completeCommittingSegments() {
     for (String realtimeTableName : getAllRealtimeTables()) {
       completeCommittingSegments(realtimeTableName);
     }
   }
 
+  @Deprecated
   public void completeCommittingSegments(String realtimeTableName) {
     List<ZNRecord> segmentMetadataList = getExistingSegmentMetadata(realtimeTableName);
     if (segmentMetadataList == null || segmentMetadataList.isEmpty()) {
@@ -943,6 +963,7 @@ public class PinotLLCRealtimeSegmentManager {
     completeCommittingSegments(realtimeTableName, segmentIdToMetadataMap);
   }
 
+  @Deprecated
   private void completeCommittingSegmentsInternal(String realtimeTableName,
       Map<Integer, MinMaxPriorityQueue<LLCSegmentName>> partitionToLatestSegments,
       Map<String, LLCRealtimeSegmentZKMetadata> segmentIdToMetadataMap) {
@@ -1001,6 +1022,7 @@ public class PinotLLCRealtimeSegmentManager {
     }
   }
 
+  @Deprecated
   public void completeCommittingSegments(String realtimeTableName,
       Map<String, LLCRealtimeSegmentZKMetadata> segmentIdToMetadataMap) {
     Comparator<LLCSegmentName> comparator = new Comparator<LLCSegmentName>() {
@@ -1052,6 +1074,7 @@ public class PinotLLCRealtimeSegmentManager {
    * @param nonConsumingPartitions is a set of integers (kafka partitions that do not have a consuming segment)
    * @param llcSegments is a list of segment names in the ideal state as was observed last.
    */
+  @Deprecated
   public void createConsumingSegment(final String realtimeTableName, final Set<Integer> nonConsumingPartitions,
       final List<String> llcSegments, final TableConfig tableConfig) {
     final StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
@@ -1212,6 +1235,7 @@ public class PinotLLCRealtimeSegmentManager {
    * run, will auto-create a new segment with the appropriate offset.
    * See {@link #createConsumingSegment(String, Set, List, TableConfig)}
    */
+  @Deprecated
   public void segmentStoppedConsuming(final LLCSegmentName segmentName, final String instance) {
     String rawTableName = segmentName.getTableName();
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
@@ -1242,6 +1266,7 @@ public class PinotLLCRealtimeSegmentManager {
    *
    * @param tableConfig tableConfig from propertystore
    */
+  @Deprecated
   public void updateKafkaPartitionsIfNecessary(TableConfig tableConfig) {
 
     RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(tableConfig, _helixManager);
@@ -1391,6 +1416,392 @@ public class PinotLLCRealtimeSegmentManager {
 
   protected List<String> getInstances(String tenantName) {
     return _helixAdmin.getInstancesInClusterWithTag(_clusterName, tenantName);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////////
+
+  protected List<LLCRealtimeSegmentZKMetadata> getAllSegmentMetadata(String tableNameWithType) {
+    return ZKMetadataProvider.getLLCRealtimeSegmentZKMetadataListForTable(_helixManager.getHelixPropertyStore(), tableNameWithType);
+  }
+
+  // Gets latest 2 metadata. We need only the 2 latest metadata for each partition
+  private Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> getLatestMetadata(String tableNameWithType) {
+    List<LLCRealtimeSegmentZKMetadata> metadatas = getAllSegmentMetadata(tableNameWithType);
+
+    Comparator<LLCRealtimeSegmentZKMetadata> comparator = new Comparator<LLCRealtimeSegmentZKMetadata>() {
+      @Override
+      public int compare(LLCRealtimeSegmentZKMetadata o1, LLCRealtimeSegmentZKMetadata o2) {
+        LLCSegmentName s1 = new LLCSegmentName(o1.getSegmentName());
+        LLCSegmentName s2 = new LLCSegmentName(o2.getSegmentName());
+        return s2.compareTo(s1);
+      }
+    };
+
+    Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> partitionToLatestSegments = new HashMap<>();
+
+    for (LLCRealtimeSegmentZKMetadata metadata : metadatas) {
+      LLCSegmentName segmentName = new LLCSegmentName(metadata.getSegmentName());
+      final int partitionId = segmentName.getPartitionId();
+      MinMaxPriorityQueue latestSegments = partitionToLatestSegments.get(partitionId);
+      if (latestSegments == null) {
+        latestSegments = MinMaxPriorityQueue.orderedBy(comparator).maximumSize(2).create();
+        partitionToLatestSegments.put(partitionId, latestSegments);
+      }
+      latestSegments.offer(segmentName);
+    }
+
+    return partitionToLatestSegments;
+  }
+
+  public void validateLLCSegments(final TableConfig tableConfig) {
+    final String tableNameWithType = tableConfig.getTableName();
+    final StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+    final int partitionCount = getKafkaPartitionCount(streamMetadata);
+    HelixHelper.updateIdealState(_helixManager, tableNameWithType, new Function<IdealState, IdealState>() {
+      @Nullable
+      @Override
+      public IdealState apply(@Nullable IdealState idealState) {
+        return validateLLCSegments(tableConfig, idealState, partitionCount);
+      }
+    }, RetryPolicies.exponentialBackoffRetryPolicy(10, 1000L, 1.2f), true);
+  }
+
+  private void updateIdealStateOnSegmentCompletion(@Nonnull  final TableConfig tableConfig, @Nonnull  final String currentSegmentId, @Nonnull final String newSegmentId, @Nonnull final PartitionAssignment partitionAssignment) {
+    final String tableNameWithType = tableConfig.getTableName();
+
+    HelixHelper.updateIdealState(_helixManager, tableNameWithType, new Function<IdealState, IdealState>() {
+      @Nullable
+      @Override
+      public IdealState apply(@Nullable IdealState idealState) {
+        return updateIdealStateOnSegmentCompletion(idealState, tableConfig, currentSegmentId, newSegmentId, partitionAssignment);
+      }
+    }, RetryPolicies.exponentialBackoffRetryPolicy(10, 1000L, 1.2f));
+  }
+
+
+  private PartitionAssignment getPartitionAssignmentFromIdealState(String tableNameWithType,
+      Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> latestMetadata,
+      IdealState idealState) {
+    PartitionAssignment partitionAssignment = new PartitionAssignment(tableNameWithType);
+    for (Map.Entry<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> entry : latestMetadata.entrySet()) {
+      int partition = entry.getKey();
+      MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata> priorityQueue = entry.getValue();
+      Map<String, String> instanceStateMap = idealState.getInstanceStateMap(priorityQueue.peekFirst().getSegmentName());
+      if (instanceStateMap == null) {
+        if (priorityQueue.size() > 1) {   // Expects size to be 2
+          instanceStateMap = idealState.getInstanceStateMap(priorityQueue.peekLast().getSegmentName());
+          // We can assert that instanceStateMap cannot be null here. metadata cannot be more than
+          // one segment ahead of idealstate.
+          partitionAssignment.addPartition(Integer.toString(partition), new ArrayList<String>(instanceStateMap.keySet()));
+        }
+      } else {
+        partitionAssignment.addPartition(Integer.toString(partition), new ArrayList<String>(instanceStateMap.keySet()));
+      }
+      // TODO
+      // May be that we had one metadata and no entry in idealstate (table just created). In that case, the partition
+      // is not assigned yet, so we need to assign the partitions.
+    }
+    return partitionAssignment;
+  }
+
+  /*
+   *  A segment commit takes 3 modifications to zookeeper:
+   *  - Change old segment metadata (mark it DONE, and then other things)
+   *  - Add new metadata
+   *  - Update idealstate to change oldsegment to ONLINE and new segment to CONSUMING
+   *
+   * A controller failure before/during the first step, or after the last step, does not bother us.
+   * However, a controller failure after the first step (but before the successful completion of last step)
+   * will result in leaving zookeeper in an inconsistent state. We have logic to trigger a periodic scan
+   * of the segments, and repair those in this intermediate stage of segment completion.
+   *
+   * Now that there are two threads that may try to create new segments, we need to be careful.
+   *
+   * It may happen that the segment completion thread has just done step-1, but meanwhile the periodic
+   * validator triggers, and mistakes this segment to be in incomplete state.
+   *
+   * We check the segment's metadata to see if that is old enough for repair. If it is fairly new, we
+   * leave it as it is, to be fixed the next time repair job triggers.
+   */
+  private static int MAX_SEGMENT_COMPLETION_TIME_MINS = 10;
+  private boolean isTooSoonToCorrect(String tableNameWithType, String segmentId) {
+    long now = System.currentTimeMillis();
+    Stat stat = new Stat();
+    LLCRealtimeSegmentZKMetadata metadata = getRealtimeSegmentZKMetadata(tableNameWithType, segmentId, stat);
+    long metadataUpdateTime = stat.getMtime();
+    if (now < metadataUpdateTime + TimeUnit.MILLISECONDS.convert(MAX_SEGMENT_COMPLETION_TIME_MINS, TimeUnit.MINUTES)) {
+      // too soon to correct
+      return true;
+    }
+    return false;
+  }
+
+  private boolean isAllInstancesOffline(Map<String, String> instanceStateMap) {
+    for (String state : instanceStateMap.values()) {
+      if (!state.equals(PinotHelixSegmentOnlineOfflineStateModelGenerator.OFFLINE_STATE)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /*
+   * Validate LLC segments of a table.
+   *
+   * This method combines the logic in the previous completeCommitingSegmentsInternal()
+   * and createConsumingSegment() methods.
+   *
+   * So, the method may:
+   * - Add or modify one or more segment metadata znodes
+   * - Update the idealstate, which may fail if some other process updated the idealstate.
+   *
+   * In case idealstate update fails, then we need to start over.
+   *
+   * TODO Verify right things happen in the following case:
+   * - A segment completion is triggered, that manages to update metadata but ideal state update fails
+   *   and so it is currently in back-off stage.
+   * - ValidationManager starts to run, and finds the segment in improper state and manages to fix it in idealstate.
+   * - The segment completion thread comes back to update the ideal state (should already find the same segment in there)
+   *
+   * TODO Can we re-use this method when creating a table as well?
+   *
+   */
+  private IdealState validateLLCSegments(final TableConfig tableConfig, IdealState idealState, final int partitionCount) {
+    final String tableNameWithType = tableConfig.getTableName();
+    final StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+    if (!idealState.isEnabled()) {
+      LOGGER.info("Skipping validation for disabled table {}", tableNameWithType);
+      return idealState;
+    }
+
+    // Get the metadata for the latest 2 segments of each partition
+    Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> latestMetadata = getLatestMetadata(tableNameWithType);
+    // Get the latest segments as a set to provide for the segment assignment logic.
+    // alternatively, the segment assignment logic can scan through the idealstate to get the latest segments.
+    // TBD
+    {
+      Set<String> latestSegmentIds = new HashSet<>();
+      for (Map.Entry<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> entry : latestMetadata.entrySet()) {
+        LLCRealtimeSegmentZKMetadata[] metadatas = new LLCRealtimeSegmentZKMetadata[entry.getValue().size()];
+        entry.getValue().toArray(metadatas);
+        for (LLCRealtimeSegmentZKMetadata metadata : metadatas) {
+          latestSegmentIds.add(metadata.getSegmentName());
+        }
+      }
+    }
+    {
+      /*
+       * To merge with branch realtime_segment_assignment
+       * This will get us the partitions
+      PartitionAssignmentGenerator generator = new PartitionAsignmentGenerator(_helixAdmin)
+      PartitionAssignment partitionAssignment = generator.generatePartitionAssignment(tableConfig, partitionCount);
+      */
+    }
+
+    // Find partitions for which there is no metadata at all. These are new partitions that we need to start consuming.
+    Set<Integer> newPartitions = new HashSet<>(partitionCount);
+    for (int partition = 0; partition < partitionCount; partition++) {
+      if (!latestMetadata.containsKey(partition)) {
+        LOGGER.info("Found partition {} with no segments", partition);
+        newPartitions.add(partition);
+      }
+    }
+
+    // TODO Replace this with above partitionAssignment above (merge with realtime_segment_assignment).
+    PartitionAssignment partitionAssignment = getPartitionAssignmentFromIdealState(tableNameWithType,
+        latestMetadata, idealState);
+
+    Map<String, String> oldToNewSegmentsMap = new HashMap<>();
+    // Walk over all partitions that we have metadata for, and repair any partitions necessary.
+    // Possible things to repair:
+    // 1. The latest metadata is in DONE state, but the idealstate says segment is CONSUMING:
+    //    a. Create metadata for next segment and find hosts to assign it to.
+    //    b. update current segment in idealstate to ONLINE
+    //    c. add new segment in idealstate to CONSUMING on the hosts.
+    // 2. The latest metadata is IN_PROGRESS, but segment is not there in idealstate.
+    //    a. change prev segment to ONLINE in idealstate
+    //    b. add latest segment to CONSUMING in idealstate.
+    // 3.
+    for (Map.Entry<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> entry : latestMetadata.entrySet()) {
+      int partition = entry.getKey();
+      LLCRealtimeSegmentZKMetadata metadata = entry.getValue().pollFirst();
+      final String segmentId = metadata.getSegmentName();
+      final LLCSegmentName segmentName = new LLCSegmentName(segmentId);
+
+      if (isTooSoonToCorrect(tableNameWithType, segmentId)) {
+        LOGGER.info("Skipping correction of segment segment {} (too soon to correct)", segmentId);
+        continue;
+      }
+
+      if (idealState.getPartitionSet().contains(segmentId)) {
+        // Latest segment of metadata is in idealstate.
+        Map<String, String> instanceStateMap = idealState.getInstanceStateMap(segmentId);
+        if (instanceStateMap.values().contains(PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE)) {
+          if (metadata.getStatus().equals(CommonConstants.Segment.Realtime.Status.DONE)) {
+            // step-1 of commmitSegmentMetadata is done (i.e. marking old segment as DONE)
+            // but step-2 is not done (i.e. adding new metadata for the next segment)
+            // and ideal state update (i.e. marking old segment as ONLINE and new segment as CONSUMING) is not done either.
+            LOGGER.info("{}:Repairing segment for partition {}. " + "Old segment metadata {} has status DONE, but segments are still in CONSUMING state in ideal STATE",
+                tableNameWithType, partition, segmentId);
+
+            final int newSeqNum = segmentName.getSequenceNumber() + 1;
+            // TODO Need to create a method to get the time so that we can test it right.
+            final long now = System.currentTimeMillis();
+            LLCSegmentName newLLCSegmentName =
+                new LLCSegmentName(segmentName.getTableName(), partition, newSeqNum, now);
+
+            LOGGER.info("{}: Creating new segment metadata for {}", tableNameWithType, newLLCSegmentName.getSegmentName());
+
+            // TODO
+            // Change the lines below to do the following once segment assignment interfaces are ready
+            // 1. get PartitionAssignment from idealstate (and the new segment?)
+            // 2. use partition assignment to fill in the number of rows metadata
+            // 3. add metadata to zk
+            // 4. change idealstate.
+            createNewSegmentMetadataZNRecord(tableNameWithType, newLLCSegmentName, metadata.getEndOffset(),
+                partitionAssignment);
+
+            oldToNewSegmentsMap.put(metadata.getSegmentName(), newLLCSegmentName.getSegmentName());
+            // TODO make this a class method rather than static?
+//            updateForNewRealtimeSegment(idealState, newInstances, metadata.getSegmentName(), newLLCSegmentName.getSegmentName());
+          }
+          // else, the metadata should be IN_PROGRESS, which is the right state for a consuming segment.
+        } else if (isAllInstancesOffline(instanceStateMap)) {
+          // An in-progress segment marked itself offline for some reason the server could not consume.
+          // No instances are consuming, so create a new consuming segment.
+          int nextSeqNum = segmentName.getSequenceNumber() + 1;
+          LOGGER.info("Creating CONSUMING segment for {} partition {} with seq {}", tableNameWithType, partition,
+              nextSeqNum);
+          // To begin with, set startOffset to the oldest available offset in kafka. Fix it to be the one we want,
+          // depending on what the prev segment had.
+          long startOffset = getKafkaPartitionOffset(streamMetadata, "smallest", partition);
+          LOGGER.info("Found kafka offset {} for table {} for partition {}", startOffset, tableNameWithType, partition);
+          startOffset = getBetterStartOffsetIfNeeded(tableNameWithType, partition, segmentName, startOffset,
+              nextSeqNum);
+          // TODO Need to create a method for getting the time, so that we can test it with time moving forward.
+          LLCSegmentName newLLCSegmentName = new LLCSegmentName(segmentName.getTableName(), partition, nextSeqNum, System.currentTimeMillis());
+
+          // TODO Change the lines below to the following:
+          // 1. get PartitionAssignment from idealstate (and the new segment?)
+          // 2. use partition assignment to fill in the number of rows metadata
+          // 3. add metadata to zk
+          // 4. change idealstate.
+          createNewSegmentMetadataZNRecord(tableNameWithType, newLLCSegmentName, startOffset,
+              partitionAssignment);
+          oldToNewSegmentsMap.put("_PINOT_NEW_" + String.valueOf(partition), newLLCSegmentName.getSegmentName());
+          //updateForNewRealtimeSegment(idealState, newInstances, segmentId, newLLCSegmentName.getSegmentName());
+        }
+        // else It can be in ONLINE state, in which case there is no need to repair the segment.
+      } else {
+        // idealstate does not have an entry for the segment (but metadata is present)
+        // controller has failed between step-2 and step-3 of commitSegmentMetadata.
+        // i.e. after updating old segment metadata (old segment metadata state = DONE) and creating new segment metadata (new segment metadata state = IN_PROGRESS),
+        // but before updating ideal state (new segment ideal missing from ideal state)
+
+        // TODO Assert that the metadata is IN_PROGRESS
+        LOGGER.info("{}:Repairing segment for partition {}. Segment {} not found in idealstate", tableNameWithType,
+            partition, segmentId);
+
+//        LOGGER.info("{}: Assigning segment {} to {}", tableNameWithType, segmentId, newInstances);
+        // TODO Re-write num-partitions in metadata if needed.
+        // If there was a prev segment in the same partition, then we need to fix it to be ONLINE.
+
+        LLCRealtimeSegmentZKMetadata prevMetadata = entry.getValue().pollLast();
+        String prevSegmentId = "_PINOT_NEW" + String.valueOf(partition);
+        if (prevMetadata != null) {
+          prevSegmentId = prevMetadata.getSegmentName();
+        }
+
+        oldToNewSegmentsMap.put(prevSegmentId, segmentId);
+//        updateForNewRealtimeSegment(idealState, newInstances, prevSegmentId, segmentId);
+      }
+    }
+
+    for (int partition : newPartitions) {
+      // We will surely not have partition assignment for these, because these are partitions not even in metadata
+      // TODO Change this to get segment assignment for all partitions in one go after segment assignment code is done
+      // For now, assume that the partitions have been assigned.
+      // No segment yet in partition, Create a new one with a starting offset as per table config specification.
+      int nextSeqNum = STARTING_SEQUENCE_NUMBER;
+      LOGGER.info("Creating CONSUMING segment for {} partition {} with seq {}", tableNameWithType, partition,
+          nextSeqNum);
+      String consumerStartOffsetSpec = streamMetadata.getKafkaConsumerProperties()
+          .get(CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET);
+      long startOffset = getKafkaPartitionOffset(streamMetadata, consumerStartOffsetSpec, partition);
+      LOGGER.info("Found kafka offset {} for table {} for partition {}", startOffset, tableNameWithType, partition);
+      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+
+      LLCSegmentName newLLCSegmentName = new LLCSegmentName(rawTableName, partition, nextSeqNum, System.currentTimeMillis());
+
+      // TODO Need to create another method that we can use.
+      createNewSegmentMetadataZNRecord(tableNameWithType, newLLCSegmentName, startOffset,
+          partitionAssignment);
+      oldToNewSegmentsMap.put("_PINOT_NEW_" + String.valueOf(partition), newLLCSegmentName.getSegmentName());
+//      List<String> newInstances = partitionAssignment.getInstancesListForPartition(Integer.toString(partition));
+//      updateForNewRealtimeSegment(idealState, newInstances, null, newLLCSegmentName.getSegmentName());
+    }
+
+    // TODO Call assignment interface here
+    Map<String, List<String>> assignments = null;
+    /*
+      RealtimeSegmentAssignmentStrategy strategy = new ConsumingSegmentAssignmentStrategy();
+      assignments = strategy.assign(newSegments, partitionAssignment);
+     */
+
+    for (Map.Entry<String, String> entry : oldToNewSegmentsMap.entrySet()) {
+      String oldSeg = entry.getKey();
+      String newSeg = entry.getValue();
+      List<String> newInstances = assignments.get(newSeg);
+      Map<String, String> instanceStateMap = idealState.getInstanceStateMap(newSeg);
+      if (instanceStateMap != null) {
+        instanceStateMap.clear();
+      }
+      for (String instance : newInstances) {
+        idealState.setPartitionState(newSeg, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
+      }
+      if (!oldSeg.startsWith("_PINOT_NEW")) {
+        Set<String> oldInstances = idealState.getInstanceSet(oldSeg);
+        // TODO assert oldInstances is not null.
+        for (String instance: oldInstances) {
+          idealState.setPartitionState(oldSeg, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
+        }
+      }
+    }
+
+    return idealState;
+  }
+
+  private IdealState updateIdealStateOnSegmentCompletion(IdealState idealState,
+      TableConfig tableConfig, @Nonnull  String currentSegmentId, String newSegmentId, PartitionAssignment partitionAssignment) {
+
+    Map<String, List<String>> instanceAssignments = null;
+    /*
+    TODO make this call from commitSegmentMetadata()
+      RealtimeSegmentAssignmentStrategy strategy = new ConsumingSegmentAssignmentStrategy();
+      assignments = strategy.assign(newSegments, partitionAssignment);
+     */
+
+    List<String> newSegmentInstances = instanceAssignments.get(newSegmentId);
+    Set<String> currentSegmentInstances = idealState.getInstanceSet(currentSegmentId);
+    for (String instance : currentSegmentInstances) {
+      idealState.setPartitionState(currentSegmentId, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
+    }
+
+    // We may have (for whatever reason) a different instance list in the idealstate for the new segment.
+    // If so, clear it, and then set the instance state for the set of instances that we know should be there.
+//    Map<String, String> stateMap = idealState.getInstanceStateMap(newSegmentId);
+//    if (stateMap != null) {
+//      stateMap.clear();
+//    }
+    for (String instance : newSegmentInstances) {
+      idealState.setPartitionState(newSegmentId, instance, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
+    }
+
+    return idealState;
   }
 
   private static class KafkaOffsetFetcher implements Callable<Boolean> {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -942,6 +942,7 @@ public class SegmentCompletionManager {
     private SegmentCompletionProtocol.Response processStoppedConsuming(String instanceId, long offset, String reason, boolean createNew) {
       LOGGER.info("Instance {} stopped consuming segment {} at offset {}, state {}, createNew: {}, reason:{}",
           instanceId, _segmentName, offset, _state, createNew, reason);
+      // TODO: what happens to this method? below method is deprecated
       _segmentManager.segmentStoppedConsuming(_segmentName, instanceId);
       return SegmentCompletionProtocol.RESP_PROCESSED;
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -942,7 +942,6 @@ public class SegmentCompletionManager {
     private SegmentCompletionProtocol.Response processStoppedConsuming(String instanceId, long offset, String reason, boolean createNew) {
       LOGGER.info("Instance {} stopped consuming segment {} at offset {}, state {}, createNew: {}, reason:{}",
           instanceId, _segmentName, offset, _state, createNew, reason);
-      // TODO: what happens to this method? below method is deprecated
       _segmentManager.segmentStoppedConsuming(_segmentName, instanceId);
       return SegmentCompletionProtocol.RESP_PROCESSED;
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/partition/StreamPartitionAssignmentGenerator.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/partition/StreamPartitionAssignmentGenerator.java
@@ -36,6 +36,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
  * Class to help generate partition assignment, given the table config, number of stream partitions,
  * instances and all tables needing reassignment
  */
+@Deprecated
 public class StreamPartitionAssignmentGenerator {
 
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/rebalance/DefaultRebalanceSegmentStrategy.java
@@ -102,11 +102,8 @@ public class DefaultRebalanceSegmentStrategy implements RebalanceSegmentStrategy
       if (includeConsuming) {
 
         PartitionAssignmentGenerator partitionAssignmentGenerator = new PartitionAssignmentGenerator(_helixManager);
-        PartitionAssignment partitionAssignmentFromIdealState =
-            partitionAssignmentGenerator.getPartitionAssignmentFromIdealState(tableConfig, idealState);
-        int numPartitions = partitionAssignmentFromIdealState.getNumPartitions();
-        newPartitionAssignment =
-            partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, numPartitions);
+        int numPartitions = partitionAssignmentGenerator.getNumPartitionsFromIdealState(idealState);
+        newPartitionAssignment = partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, numPartitions);
 
       } else {
         LOGGER.info("includeConsuming = false. No need to rebalance partition assignment for {}",

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -144,10 +144,7 @@ public class ValidationManager {
       if (tableType == TableType.OFFLINE) {
         validateOfflineSegmentPush(propertyStore, tableNameWithType);
       } else {
-        List<RealtimeSegmentZKMetadata> realtimeSegmentZKMetadataList =
-            ZKMetadataProvider.getRealtimeSegmentZKMetadataListForTable(propertyStore, tableNameWithType);
         TableConfig tableConfig = null;
-        StreamMetadata streamMetadata = null;
         try {
           tableConfig = _pinotHelixResourceManager.getRealtimeTableConfig(tableNameWithType);
           if (tableConfig == null) {
@@ -158,8 +155,6 @@ public class ValidationManager {
         } catch (Exception e) {
           if (tableConfig == null) {
             LOGGER.warn("Cannot get realtime table config for table: {}", tableNameWithType);
-          } else if (streamMetadata == null) {
-            LOGGER.warn("Cannot get stream config for table: {}", tableNameWithType);
           } else {
             LOGGER.error("Exception while validating table: {}", tableNameWithType, e);
           }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -185,6 +185,7 @@ public class ValidationManager {
   }
 
   // For LLC segments, validate that there is at least one segment in CONSUMING state for every partition.
+  @Deprecated
   void validateLLCSegments(TableConfig tableConfig, List<RealtimeSegmentZKMetadata> metadataList) {
     final String realtimeTableName = tableConfig.getTableName();
     LOGGER.info("Validating LLC Segments for {}", realtimeTableName);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -146,7 +146,6 @@ public class ValidationManager {
       } else {
         List<RealtimeSegmentZKMetadata> realtimeSegmentZKMetadataList =
             ZKMetadataProvider.getRealtimeSegmentZKMetadataListForTable(propertyStore, tableNameWithType);
-        boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
         TableConfig tableConfig = null;
         StreamMetadata streamMetadata = null;
         try {
@@ -154,16 +153,8 @@ public class ValidationManager {
           if (tableConfig == null) {
             continue;
           }
-          streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
-          if (streamMetadata.hasSimpleKafkaConsumerType() && !streamMetadata.hasHighLevelKafkaConsumerType()) {
-            countHLCSegments = false;
-          }
-          // Update the gauge to contain the total document count in the segments
-          _validationMetrics.updateTotalDocumentCountGauge(tableNameWithType,
-              computeRealtimeTotalDocumentInSegments(realtimeSegmentZKMetadataList, countHLCSegments));
-          if (streamMetadata.hasSimpleKafkaConsumerType()) {
-            validateLLCSegments(tableNameWithType, tableConfig);
-          }
+          updateRealtimeDocumentCount(propertyStore, tableConfig);
+          _llcRealtimeSegmentManager.validateLLCSegments(tableConfig);
         } catch (Exception e) {
           if (tableConfig == null) {
             LOGGER.warn("Cannot get realtime table config for table: {}", tableNameWithType);
@@ -178,10 +169,32 @@ public class ValidationManager {
     LOGGER.info("Validation completed");
   }
 
+  private void updateRealtimeDocumentCount(ZkHelixPropertyStore<ZNRecord> propertystore, TableConfig tableConfig) {
+    final String tableNameWithType = tableConfig.getTableName();
+    List<RealtimeSegmentZKMetadata> metadataList =
+            ZKMetadataProvider.getRealtimeSegmentZKMetadataListForTable(propertystore, tableNameWithType);
+    boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
+    StreamMetadata streamMetadata = null;
+    streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+    if (streamMetadata.hasSimpleKafkaConsumerType() && !streamMetadata.hasHighLevelKafkaConsumerType()) {
+      countHLCSegments = false;
+    }
+    // Update the gauge to contain the total document count in the segments
+    _validationMetrics.updateTotalDocumentCountGauge(tableConfig.getTableName(),
+          computeRealtimeTotalDocumentInSegments(metadataList, countHLCSegments));
+  }
+
   // For LLC segments, validate that there is at least one segment in CONSUMING state for every partition.
-  void validateLLCSegments(final String realtimeTableName, TableConfig tableConfig) {
+  void validateLLCSegments(TableConfig tableConfig, List<RealtimeSegmentZKMetadata> metadataList) {
+    final String realtimeTableName = tableConfig.getTableName();
     LOGGER.info("Validating LLC Segments for {}", realtimeTableName);
-    Map<String, String> streamConfigs = tableConfig.getIndexingConfig().getStreamConfigs();
+
+    _llcRealtimeSegmentManager.validateLLCSegments(tableConfig);
+
+    IdealState idealState =
+        HelixHelper.getTableIdealState(_pinotHelixResourceManager.getHelixZkManager(), realtimeTableName);
+
+
     PartitionAssignment partitionAssignment = _llcRealtimeSegmentManager.getStreamPartitionAssignment(realtimeTableName);
     if (partitionAssignment == null) {
       LOGGER.warn("No partition assignment found for table {}", realtimeTableName);
@@ -195,8 +208,6 @@ public class ValidationManager {
       nonConsumingKafkaPartitions.add(Integer.valueOf(partitionStr));
     }
 
-    IdealState idealState =
-        HelixHelper.getTableIdealState(_pinotHelixResourceManager.getHelixZkManager(), realtimeTableName);
     if (!idealState.isEnabled()) {
       // No validation to be done.
       LOGGER.info("Skipping validation for {} since it is disabled", realtimeTableName);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/validation/ValidationManager.java
@@ -169,8 +169,7 @@ public class ValidationManager {
     List<RealtimeSegmentZKMetadata> metadataList =
             ZKMetadataProvider.getRealtimeSegmentZKMetadataListForTable(propertystore, tableNameWithType);
     boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
-    StreamMetadata streamMetadata = null;
-    streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
+    StreamMetadata streamMetadata = new StreamMetadata(tableConfig.getIndexingConfig().getStreamConfigs());
     if (streamMetadata.hasSimpleKafkaConsumerType() && !streamMetadata.hasHighLevelKafkaConsumerType()) {
       countHLCSegments = false;
     }
@@ -189,7 +188,6 @@ public class ValidationManager {
 
     IdealState idealState =
         HelixHelper.getTableIdealState(_pinotHelixResourceManager.getHelixZkManager(), realtimeTableName);
-
 
     PartitionAssignment partitionAssignment = _llcRealtimeSegmentManager.getStreamPartitionAssignment(realtimeTableName);
     if (partitionAssignment == null) {

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -108,7 +108,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     FileUtils.deleteDirectory(baseDir);
   }
 
-  @Test
+  @Test(enabled = false)
   public void testKafkaAssignment() throws Exception {
     testKafkaAssignment(8, 3, 2);
     testKafkaAssignment(16, 4, 3);
@@ -166,7 +166,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
   }
 
 
-  @Test
+  @Test(enabled = false)
   public void testInitialSegmentAssignments() throws Exception {
     testInitialSegmentAssignments(8, 3, 2, false);
     testInitialSegmentAssignments(16, 4, 3, true);
@@ -238,7 +238,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
-  @Test
+  @Test(enabled = false)
   public void testPreExistingSegments() throws Exception {
     LLCSegmentName existingSegmentName = new LLCSegmentName("someTable", 1, 31, 12355L);
     String[] existingSegs = {existingSegmentName.getSegmentName()};
@@ -272,7 +272,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
   }
 
   // Make sure that if we are either not leader or we are disconnected, we do not process metadata commit.
-  @Test
+  @Test(enabled = false)
   public void testCommittingSegmentIfDisconnected() throws Exception {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(true, null);
 
@@ -322,7 +322,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertEquals(segmentManager._paths.size(), 2);   // propertystore updated
   }
 
-  @Test
+  @Test(enabled = false)
   public void testCommittingSegment() throws Exception {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(true, null);
 
@@ -381,7 +381,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertEquals(oldMetadata.getIndexVersion(), FakePinotLLCRealtimeSegmentManager.SEGMENT_VERSION);
   }
 
-  @Test
+  @Test(enabled = false)
   public void testUpdateHelixForSegmentClosing() throws Exception {
     final IdealState  idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(
         "someTable_REALTIME", 17);
@@ -479,7 +479,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     return streamPropMap;
   }
 
-  @Test
+  @Test(enabled = false)
   public void testUpdatingKafkaPartitions() throws Exception {
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(false, null);
 
@@ -753,13 +753,13 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertEquals(llcSegmentName.getPartitionId(), partitionToBeFixed);
   }
 
-  @Test
+  @Test(enabled = false)
   public void testAutoReplaceConsumingSegment() throws Exception {
     testAutoReplaceConsumingSegment("smallest");
     testAutoReplaceConsumingSegment("largest");
   }
 
-  @Test
+  @Test(enabled = false)
   public void testCompleteCommittingSegments() throws Exception {
     // Run multiple times randomizing the situation.
     for (int i = 0; i < 100; i++) {
@@ -862,7 +862,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
   }
 
-  @Test
+  @Test(enabled = false)
   public void testCommitSegmentWhenControllerWentThroughGC() {
 
     FakePinotLLCRealtimeSegmentManager segmentManager1 = new FakePinotLLCRealtimeSegmentManager(true, null);
@@ -1296,7 +1296,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     return new LLCSegmentName("fakeTable_REALTIME", id, 0, 1234L).getSegmentName();
   }
 
-  @Test
+  @Test(enabled = false)
   public void testCommitSegmentFile() throws Exception {
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = new FakePinotLLCRealtimeSegmentManager(false, Collections.<String>emptyList());
     String tableName = "fakeTable_REALTIME";
@@ -1311,7 +1311,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertTrue(realtimeSegmentManager.commitSegmentFile(tableName, segmentLocation, segmentName));
   }
 
-  @Test
+  @Test(enabled = false)
   public void testSegmentAlreadyThereAndExtraneousFilesDeleted() throws Exception {
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = new FakePinotLLCRealtimeSegmentManager(false, Collections.<String>emptyList());
     String tableName = "fakeTable_REALTIME";
@@ -1334,7 +1334,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     Assert.assertFalse(new File(temporaryDirectory, extraSegmentLocation).exists());
   }
 
-  @Test
+  @Test(enabled = false)
   public void testUpdateFlushThresholdForSegmentMetadata() {
     PinotLLCRealtimeSegmentManager realtimeSegmentManager = new FakePinotLLCRealtimeSegmentManager(false,
         Collections.<String>emptyList());

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
@@ -1337,16 +1337,6 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
     }
 
     @Override
-    protected void setupInitialSegments(TableConfig tableConfig, StreamMetadata streamMetadata,
-        PartitionAssignment partitionAssignment, IdealState idealState, boolean create, int flushSize) {
-      _realtimeTableName = tableConfig.getTableName();
-      _currentTablePartitionAssignment = partitionAssignment;
-      _startOffset = streamMetadata.getKafkaConsumerProperties()
-          .get(CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET);
-      super.setupInitialSegments(tableConfig, streamMetadata, partitionAssignment, idealState, create, flushSize);
-    }
-
-    @Override
     protected List<String> getExistingSegments(String realtimeTableName) {
       return _existingLLCSegments;
     }
@@ -1357,18 +1347,6 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
         @Nonnull final PartitionAssignment partitionAssignment) {
       _nCallsToUpdateHelix++;
       super.updateIdealStateOnSegmentCompletion(_tableIdealState, currentSegmentId, newSegmentId, partitionAssignment);
-    }
-
-    @Override
-    protected void updateIdealState(IdealState idealState, String realtimeTableName,
-        Map<String, List<String>> idealStateEntries, boolean create, int nReplicas) {
-      _realtimeTableName = realtimeTableName;
-      _idealStateEntries = idealStateEntries;
-      _nReplicas = nReplicas;
-      _createNew = create;
-      for (Map.Entry<String, List<String>> entry : idealStateEntries.entrySet()) {
-        _idealStateEntries.put(entry.getKey(), entry.getValue());
-      }
     }
 
     @Override
@@ -1385,15 +1363,6 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
       return super.updateOldSegmentMetadataZNRecord(realtimeTableName, committingLLCSegmentName, nextOffset);
     }
 
-    protected void updateIdealState(final String realtimeTableName, final List<String> newInstances,
-        final String oldSegmentNameStr, final String newSegmentNameStr) {
-      _realtimeTableName = realtimeTableName;
-      _newInstances = newInstances;
-      _oldSegmentNameStr.add(oldSegmentNameStr);
-      _newSegmentNameStr.add(newSegmentNameStr);
-      _idealStateEntries.put(newSegmentNameStr, newInstances);
-      _nCallsToUpdateHelix++;
-    }
 
     @Override
     public LLCRealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(String realtimeTableName, String segmentName,

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
@@ -608,7 +608,7 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
 
           verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);
         } else {
-          // at least 1 replica of latest segments is in CONSUMING state
+          // at least 1 replica of latest segments in ideal state is in CONSUMING state
 
           final boolean step2NotDone = random.nextBoolean();
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
@@ -567,7 +567,7 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
           Map<String, LLCSegmentName> partitionToLatestSegments =
               segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
           LLCSegmentName latestSegment = partitionToLatestSegments.get(String.valueOf(randomlySelectedPartition));
-          idealState = idealStateBuilder.transitionToState(latestSegment.getSegmentName(), "OFFLINE").build();
+          idealState = idealStateBuilder.setSegmentState(latestSegment.getSegmentName(), "OFFLINE").build();
 
           nPartitions = expectedPartitionAssignment.getNumPartitions();
           Map<String, Map<String, String>> oldMapFields = idealState.getRecord().getMapFields();
@@ -855,7 +855,7 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
     String deleteSegment = newZnRec.getId();
     Map<String, String> instanceStateMap1 = idealState.getInstanceStateMap(deleteSegment);
     idealState =
-        idealStateBuilder.removeSegment(deleteSegment).transitionToState(oldZnRec.getId(), "CONSUMING").build();
+        idealStateBuilder.removeSegment(deleteSegment).setSegmentState(oldZnRec.getId(), "CONSUMING").build();
     nextOffset = 5000;
     committingSegmentMetadata = new LLCRealtimeSegmentZKMetadata(oldZnRec);
     segmentManager._paths.clear();

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
@@ -1268,7 +1268,7 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
     }
 
     @Override
-    protected boolean isTooSoonToCorrect(String tableNameWithType, String segmentId) {
+    protected boolean isTooSoonToCorrect(String tableNameWithType, String segmentId, long now) {
       return tooSoonToCorrect;
     }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
@@ -494,6 +494,7 @@ public class PinotLLCRealtimeSegmentManagerTestNew {
           // general verifyRepairs
           verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);
         } else {
+          // 2. seq number matured, latest metadata IN_PROGRESS, but segment missing
           int randomlySelectedPartition = random.nextInt(nPartitions);
 
           String rawTableName = TableNameBuilder.extractRawTableName(tableName);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTestNew.java
@@ -1,0 +1,1579 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.realtime;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.io.Files;
+import com.linkedin.pinot.common.Utils;
+import com.linkedin.pinot.common.config.IndexingConfig;
+import com.linkedin.pinot.common.config.RealtimeTagConfig;
+import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
+import com.linkedin.pinot.common.config.StreamConsumptionConfig;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TenantConfig;
+import com.linkedin.pinot.common.exception.InvalidConfigException;
+import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.metrics.ControllerMetrics;
+import com.linkedin.pinot.common.partition.IdealStateBuilderUtil;
+import com.linkedin.pinot.common.partition.PartitionAssignment;
+import com.linkedin.pinot.common.partition.PartitionAssignmentGenerator;
+import com.linkedin.pinot.common.utils.CommonConstants;
+import com.linkedin.pinot.common.utils.LLCSegmentName;
+import com.linkedin.pinot.common.utils.StringUtil;
+import com.linkedin.pinot.controller.ControllerConf;
+import com.linkedin.pinot.controller.api.resources.LLCSegmentCompletionHandlers;
+import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
+import com.linkedin.pinot.controller.helix.core.realtime.partition.StreamPartitionAssignmentStrategyEnum;
+import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
+import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
+import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerFactory;
+import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
+import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.yammer.metrics.core.MetricsRegistry;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.zookeeper.data.Stat;
+import org.joda.time.Interval;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+public class PinotLLCRealtimeSegmentManagerTestNew {
+  private static final String clusterName = "testCluster";
+  private static final String DUMMY_HOST = "dummyHost:1234";
+  private static final String KAFKA_OFFSET = "testDummy";
+  private static final String DEFAULT_SERVER_TENANT = "freeTenant";
+  private static final StreamPartitionAssignmentStrategyEnum DEFAULT_STREAM_ASSIGNMENT_STRATEGY = null;
+  private static final String SCHEME = LLCSegmentCompletionHandlers.getScheme();
+  private String[] serverNames;
+  private static File baseDir;
+
+  private List<String> getInstanceList(final int nServers) {
+    Assert.assertTrue(nServers <= serverNames.length);
+    String[] instanceArray = Arrays.copyOf(serverNames, nServers);
+    return Arrays.asList(instanceArray);
+  }
+
+  @BeforeTest
+  public void setUp() {
+    final int maxInstances = 20;
+    serverNames = new String[maxInstances];
+    for (int i = 0; i < maxInstances; i++) {
+      serverNames[i] = "Server_" + i;
+    }
+    try {
+      baseDir = Files.createTempDir();
+      baseDir.deleteOnExit();
+    } catch (Exception e) {
+
+    }
+    FakePinotLLCRealtimeSegmentManager.IS_CONNECTED = true;
+    FakePinotLLCRealtimeSegmentManager.IS_LEADER = true;
+  }
+
+  @AfterTest
+  public void cleanUp() throws IOException {
+    FileUtils.deleteDirectory(baseDir);
+  }
+
+  @Test
+  public void testValidateLLC() throws InvalidConfigException {
+    // New table case
+    testValidateLLCNewTable();
+
+    // Partition count increase
+    testValidateLLCPartitionIncrease();
+
+    // Repair errors in segment commit
+    testValidateLLCRepair();
+  }
+
+  /**
+   * Method which tests segment completion
+   * We do not care for partition increases in this method
+   * Instances increasing will be accounted for
+   */
+  @Test
+  public void testSegmentCompletion() throws InvalidConfigException {
+
+    String tableName = "testSegmentCompletion_REALTIME";
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    int nReplicas = 2;
+    TableConfig tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(null);
+    List<String> instances = getInstanceList(6);
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    IdealStateBuilderUtil idealStateBuilder = new IdealStateBuilderUtil(tableName);
+    IdealState idealState;
+    String currentSegmentName = "currentSegment";
+    String newSegmentName = "newSegment";
+    PartitionAssignment partitionAssignment = new PartitionAssignment(tableName);
+    int nPartitions = 4;
+    boolean exceptionExpected = true;
+    Random random = new Random();
+
+    // empty ideal state
+    idealState = idealStateBuilder.build();
+    try {
+      segmentManager.updateIdealStateOnSegmentCompletion(idealState, currentSegmentName, newSegmentName,
+          partitionAssignment);
+    } catch (NullPointerException e) {
+      Assert.assertTrue(exceptionExpected);
+    }
+
+    // empty partition assignment
+    clearAndSetupInitialSegments(idealStateBuilder, segmentManager, tableConfig, nPartitions);
+    try {
+      segmentManager.updateIdealStateOnSegmentCompletion(idealState, currentSegmentName, newSegmentName,
+          partitionAssignment);
+    } catch (NullPointerException e) {
+      Assert.assertTrue(exceptionExpected);
+    }
+
+    partitionAssignment =
+        segmentManager._partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, nPartitions);
+
+    // current segment in CONSUMING
+    int randomPartition = random.nextInt(nPartitions);
+    Map<String, LLCSegmentName> partitionToLatestSegments =
+        segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+    LLCSegmentName llcSegmentName = partitionToLatestSegments.get(String.valueOf(randomPartition));
+    LLCSegmentName newLlcSegmentName =
+        new LLCSegmentName(rawTableName, randomPartition, llcSegmentName.getSequenceNumber() + 1,
+            System.currentTimeMillis());
+    verifySegmentAssignmentOnCompletion(idealState, llcSegmentName.getSegmentName(), newLlcSegmentName.getSegmentName(),
+        randomPartition, partitionAssignment, segmentManager);
+
+    // current segment in OFFLINE
+    randomPartition = random.nextInt(nPartitions);
+    partitionToLatestSegments = segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+    llcSegmentName = partitionToLatestSegments.get(String.valueOf(randomPartition));
+    idealState = idealStateBuilder.transitionToState(llcSegmentName.getSegmentName(), "OFFLINE").build();
+    newLlcSegmentName = new LLCSegmentName(rawTableName, randomPartition, llcSegmentName.getSequenceNumber() + 1,
+        System.currentTimeMillis());
+    verifySegmentAssignmentOnCompletion(idealState, llcSegmentName.getSegmentName(), newLlcSegmentName.getSegmentName(),
+        randomPartition, partitionAssignment, segmentManager);
+
+    // current segment in ONLINE
+    randomPartition = random.nextInt(nPartitions);
+    partitionToLatestSegments = segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+    llcSegmentName = partitionToLatestSegments.get(String.valueOf(randomPartition));
+    idealState = idealStateBuilder.transitionToState(llcSegmentName.getSegmentName(), "ONLINE").build();
+    newLlcSegmentName = new LLCSegmentName(rawTableName, randomPartition, llcSegmentName.getSequenceNumber() + 1,
+        System.currentTimeMillis());
+    verifySegmentAssignmentOnCompletion(idealState, llcSegmentName.getSegmentName(), newLlcSegmentName.getSegmentName(),
+        randomPartition, partitionAssignment, segmentManager);
+
+    // partition assignment changed, not same as ideal state
+    instances = getInstanceList(8);
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    partitionAssignment =
+        segmentManager._partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, nPartitions);
+    randomPartition = random.nextInt(nPartitions);
+    partitionToLatestSegments = segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+    llcSegmentName = partitionToLatestSegments.get(String.valueOf(randomPartition));
+    newLlcSegmentName = new LLCSegmentName(rawTableName, randomPartition, llcSegmentName.getSequenceNumber() + 1,
+        System.currentTimeMillis());
+    verifySegmentAssignmentOnCompletion(idealState, llcSegmentName.getSegmentName(), newLlcSegmentName.getSegmentName(),
+        randomPartition, partitionAssignment, segmentManager);
+  }
+
+  private void verifySegmentAssignmentOnCompletion(IdealState idealState, String currentSegmentName,
+      String newSegmentName, int partition, PartitionAssignment partitionAssignment,
+      FakePinotLLCRealtimeSegmentManager segmentManager) {
+
+    Set<String> prevInstances = idealState.getInstanceSet(currentSegmentName);
+    segmentManager.updateIdealStateOnSegmentCompletion(idealState, currentSegmentName, newSegmentName,
+        partitionAssignment);
+    Set<String> currInstances = idealState.getInstanceSet(currentSegmentName);
+    Assert.assertEquals(prevInstances.size(), currInstances.size());
+    Assert.assertTrue(prevInstances.containsAll(currInstances));
+    Set<String> newSegmentInstances = idealState.getInstanceSet(newSegmentName);
+    List<String> expectedNewInstances = partitionAssignment.getInstancesListForPartition(String.valueOf(partition));
+    Assert.assertEquals(newSegmentInstances.size(), expectedNewInstances.size());
+    Assert.assertTrue(newSegmentInstances.containsAll(expectedNewInstances));
+  }
+
+  /**
+   * Test cases for new table being created, and initial segments setup that follows
+   */
+  private void testValidateLLCNewTable() {
+    String tableName = "validateThisTable_REALTIME";
+    int nReplicas = 2;
+    IdealStateBuilderUtil idealStateBuilder = new IdealStateBuilderUtil(tableName);
+
+    TableConfig tableConfig;
+    IdealState idealState;
+    int nPartitions;
+    boolean exceptionExpected;
+    List<String> instances = getInstanceList(1);
+
+    // noop path - insufficient instances
+    tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    idealState = idealStateBuilder.build();
+    nPartitions = 4;
+    exceptionExpected = true;
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+
+    // bad stream configs
+    tableConfig =
+        makeTableConfig(tableName, nReplicas, null, null, DEFAULT_SERVER_TENANT, DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    idealState = idealStateBuilder.build();
+    nPartitions = 4;
+    instances = getInstanceList(3);
+    exceptionExpected = true;
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+
+    // noop path - 0 partitions
+    tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    idealState = idealStateBuilder.build();
+    nPartitions = 0;
+    exceptionExpected = false;
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+
+    // noop path - ideal state disabled
+    tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    idealState = idealStateBuilder.disableIdealState().build();
+    nPartitions = 4;
+    exceptionExpected = false;
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+
+    // happy paths - new table config with nPartitions and sufficient instances
+    tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    idealState = idealStateBuilder.build();
+    nPartitions = 4;
+    exceptionExpected = false;
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+
+    idealState = idealStateBuilder.build();
+    nPartitions = 8;
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+
+    idealState = idealStateBuilder.build();
+    nPartitions = 8;
+    instances = getInstanceList(10);
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+
+    idealState = idealStateBuilder.build();
+    nPartitions = 12;
+    validateLLCNewTable(tableConfig, idealState, nPartitions, nReplicas, instances, exceptionExpected);
+  }
+
+  private IdealState validateLLCNewTable(TableConfig tableConfig, IdealState idealState, int nPartitions, int nReplicas,
+      List<String> instances, boolean exceptionExpected) {
+    IdealState updatedIdealState = null;
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(null);
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    try {
+      updatedIdealState = segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+      Assert.assertFalse(exceptionExpected);
+      Map<String, LLCSegmentName> partitionToLatestSegments =
+          segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(updatedIdealState);
+      Map<String, Map<String, String>> mapFields = updatedIdealState.getRecord().getMapFields();
+      if (!idealState.isEnabled()) {
+        Assert.assertTrue(partitionToLatestSegments.isEmpty());
+      } else {
+        Assert.assertEquals(mapFields.size(), nPartitions);
+        for (int p = 0; p < nPartitions; p++) {
+          LLCSegmentName llcSegmentName = partitionToLatestSegments.get(String.valueOf(p));
+          String segmentName = llcSegmentName.getSegmentName();
+          Map<String, String> instanceStateMap = mapFields.get(segmentName);
+          Assert.assertEquals(instanceStateMap.size(), nReplicas);
+          for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
+            Assert.assertEquals(entry.getValue(), "CONSUMING");
+          }
+          Assert.assertEquals(segmentManager._metadataMap.get(segmentName).getStatus(),
+              CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+        }
+
+        final List<String> propStorePaths = segmentManager._paths;
+        final List<ZNRecord> propStoreEntries = segmentManager._records;
+
+        Assert.assertEquals(propStorePaths.size(), nPartitions);
+        Assert.assertEquals(propStoreEntries.size(), nPartitions);
+
+        Map<Integer, ZNRecord> segmentPropStoreMap = new HashMap<>(propStorePaths.size());
+        Map<Integer, String> segmentPathsMap = new HashMap<>(propStorePaths.size());
+        for (String path : propStorePaths) {
+          String segNameStr = path.split("/")[3];
+          int partition = new LLCSegmentName(segNameStr).getPartitionId();
+          segmentPathsMap.put(partition, path);
+        }
+
+        for (ZNRecord znRecord : propStoreEntries) {
+          LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata(znRecord);
+          segmentPropStoreMap.put(new LLCSegmentName(metadata.getSegmentName()).getPartitionId(), znRecord);
+        }
+
+        Assert.assertEquals(segmentPathsMap.size(), nPartitions);
+        Assert.assertEquals(segmentPropStoreMap.size(), nPartitions);
+
+        for (int partition = 0; partition < nPartitions; partition++) {
+          final LLCRealtimeSegmentZKMetadata metadata =
+              new LLCRealtimeSegmentZKMetadata(segmentPropStoreMap.get(partition));
+          metadata.toString();  // Just for coverage
+          ZNRecord znRecord = metadata.toZNRecord();
+          LLCRealtimeSegmentZKMetadata metadataCopy = new LLCRealtimeSegmentZKMetadata(znRecord);
+          Assert.assertEquals(metadata, metadataCopy);
+          final String path = segmentPathsMap.get(partition);
+          final String segmentName = metadata.getSegmentName();
+          Assert.assertEquals(metadata.getStartOffset(), -1L);
+          Assert.assertEquals(path, "/SEGMENTS/" + tableConfig.getTableName() + "/" + segmentName);
+          LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+          Assert.assertEquals(llcSegmentName.getPartitionId(), partition);
+          Assert.assertEquals(llcSegmentName.getTableName(), TableNameBuilder.extractRawTableName(tableConfig.getTableName()));
+          Assert.assertEquals(metadata.getNumReplicas(), nReplicas);
+        }
+      }
+    } catch (Exception e) {
+      Assert.assertTrue(exceptionExpected);
+    }
+    return updatedIdealState;
+  }
+
+  /**
+   * Test cases for the scenario where stream partitions increase, and the validation manager is attempting to create segments for new partitions
+   * This test assumes that all other factors remain same (no error conditions/inconsistencies in metadata and ideal state)
+   */
+  private void testValidateLLCPartitionIncrease() {
+
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(null);
+    String tableName = "validateThisTable_REALTIME";
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    int nReplicas = 2;
+    IdealStateBuilderUtil idealStateBuilder = new IdealStateBuilderUtil(tableName);
+
+    TableConfig tableConfig;
+    IdealState idealState;
+    int nPartitions;
+    boolean exceptionExpected;
+    List<String> instances = getInstanceList(5);
+
+    // empty to 4 partitions
+    tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    idealState = idealStateBuilder.build();
+    nPartitions = 4;
+    exceptionExpected = false;
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+
+    // only initial segments present CONSUMING - metadata INPROGRESS - increase numPartitions
+    nPartitions = 6;
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+
+    // 2 partitions advanced a seq number
+    PartitionAssignment partitionAssignment =
+        segmentManager._partitionAssignmentGenerator.getPartitionAssignmentFromIdealState(tableConfig, idealState);
+    for (int p = 0; p < 2; p++) {
+      String segmentName = idealStateBuilder.getSegment(p, 0);
+      advanceASeqForPartition(idealState, segmentManager, partitionAssignment, segmentName, p, 1, 100, tableName);
+    }
+    idealState = idealStateBuilder.build();
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+
+    // increase num partitions
+    nPartitions = 10;
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+
+    // keep num partitions same - noop
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+
+    // keep num partitions same, but bad instances - error
+    instances = getInstanceList(1);
+    exceptionExpected = true;
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+
+    // increase num partitions, but bad instances - error
+    nPartitions = 12;
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+
+    // increase num partitions, but disabled ideal state - noop
+    idealState = idealStateBuilder.disableIdealState().build();
+    exceptionExpected = false;
+    instances = getInstanceList(6);
+    validateLLCPartitionsIncrease(segmentManager, idealState, tableConfig, nPartitions, nReplicas, instances,
+        exceptionExpected);
+  }
+
+  private void advanceASeqForPartition(IdealState idealState, FakePinotLLCRealtimeSegmentManager segmentManager,
+      PartitionAssignment partitionAssignment, String segmentName, int partition, int nextSeqNum, long nextOffset,
+      String tableName) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+    segmentManager.updateOldSegmentMetadataZNRecord(tableName, llcSegmentName, nextOffset);
+    LLCSegmentName newLlcSegmentName =
+        new LLCSegmentName(rawTableName, partition, nextSeqNum, System.currentTimeMillis());
+    segmentManager.createNewSegmentMetadataZNRecord(tableName, newLlcSegmentName, nextOffset, partitionAssignment);
+    segmentManager.updateIdealStateOnSegmentCompletion(idealState, segmentName, newLlcSegmentName.getSegmentName(),
+        partitionAssignment);
+  }
+
+  private void validateLLCPartitionsIncrease(FakePinotLLCRealtimeSegmentManager segmentManager, IdealState idealState,
+      TableConfig tableConfig, int nPartitions, int nReplicas, List<String> instances, boolean exceptionExpected) {
+    try {
+      Map<String, Map<String, String>> oldMapFields = new HashMap<>(idealState.getRecord().getMapFields());
+      Map<String, LLCRealtimeSegmentZKMetadata> oldMetadataMap = new HashMap<>(segmentManager._metadataMap);
+      segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+      IdealState updatedIdealState = segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+      Assert.assertFalse(exceptionExpected);
+      Map<String, Map<String, String>> updatedMapFields = updatedIdealState.getRecord().getMapFields();
+      Map<String, LLCRealtimeSegmentZKMetadata> updatedMetadataMap = segmentManager._metadataMap;
+
+      // Verify - all original metadata and segments unchanged
+      Set<Integer> oldPartitions = new HashSet<>();
+      for (Map.Entry<String, Map<String, String>> entry : oldMapFields.entrySet()) {
+        String segmentName = entry.getKey();
+        Map<String, String> instanceStateMap = entry.getValue();
+        Assert.assertTrue(updatedMapFields.containsKey(segmentName));
+        Map<String, String> updatedInstanceStateMap = updatedMapFields.get(segmentName);
+        Assert.assertEquals(instanceStateMap.size(), updatedInstanceStateMap.size());
+        Assert.assertTrue(instanceStateMap.keySet().containsAll(updatedInstanceStateMap.keySet()));
+        for (Map.Entry<String, String> instanceToState : instanceStateMap.entrySet()) {
+          Assert.assertEquals(instanceToState.getValue(), updatedInstanceStateMap.get(instanceToState.getKey()));
+        }
+        Assert.assertEquals(oldMetadataMap.get(segmentName), updatedMetadataMap.get(segmentName));
+        LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+        oldPartitions.add(llcSegmentName.getPartitionId());
+      }
+
+      List<Integer> allPartitions = new ArrayList<>(nPartitions);
+      for (int p = 0; p < nPartitions; p++) {
+        allPartitions.add(p);
+      }
+      List<Integer> newPartitions = new ArrayList<>(allPartitions);
+      newPartitions.removeAll(oldPartitions);
+
+      Map<Integer, List<String>> partitionToAllSegmentsMap = new HashMap<>(nPartitions);
+      for (Integer p : allPartitions) {
+        partitionToAllSegmentsMap.put(p, new ArrayList<String>());
+      }
+      for (Map.Entry<String, Map<String, String>> entry : updatedMapFields.entrySet()) {
+        String segmentName = entry.getKey();
+        LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+        int partitionId = llcSegmentName.getPartitionId();
+        partitionToAllSegmentsMap.get(partitionId).add(segmentName);
+      }
+      // each new partition should have exactly 1 new segment in CONSUMING state, and metadata in IN_PROGRESS state
+      for (Integer partitionId : newPartitions) {
+        List<String> allSegmentsForPartition = partitionToAllSegmentsMap.get(partitionId);
+        if (idealState.isEnabled()) {
+          Assert.assertEquals(allSegmentsForPartition.size(), 1);
+          for (String segment : allSegmentsForPartition) {
+            Map<String, String> instanceStateMap = updatedMapFields.get(segment);
+            Assert.assertEquals(instanceStateMap.size(), nReplicas);
+            for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
+              Assert.assertEquals(entry.getValue(), "CONSUMING");
+            }
+            LLCRealtimeSegmentZKMetadata newPartitionMetadata = updatedMetadataMap.get(segment);
+            Assert.assertNotNull(newPartitionMetadata);
+            Assert.assertEquals(newPartitionMetadata.getStatus(), CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+          }
+        } else {
+          Assert.assertEquals(allSegmentsForPartition.size(), 0);
+        }
+      }
+    } catch (Exception e) {
+      Assert.assertTrue(exceptionExpected);
+    }
+  }
+
+  private void testValidateLLCRepair() throws InvalidConfigException {
+
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(null);
+    String tableName = "repairThisTable_REALTIME";
+    int nReplicas = 2;
+    IdealStateBuilderUtil idealStateBuilder = new IdealStateBuilderUtil(tableName);
+
+    TableConfig tableConfig;
+    IdealState idealState;
+    int nPartitions;
+    List<String> instances = getInstanceList(5);
+
+    tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    nPartitions = 4;
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    PartitionAssignment expectedPartitionAssignment =
+        segmentManager._partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, nPartitions);
+
+    // set up a happy path - segment is present in ideal state, is CONSUMING, metadata says IN_PROGRESS
+    idealState = clearAndSetupHappyPathIdealState(idealStateBuilder, segmentManager, tableConfig, nPartitions);
+
+    // randomly introduce an error condition and assert that we repair it
+    long seed = new Random().nextLong();
+    System.out.println("Random seed for validate llc repairs " + seed);
+    Random random = new Random(seed);
+
+    for (int run = 0; run < 200; run++) {
+
+      boolean consuming = true;
+      boolean inProgress = true;
+      if (random.nextBoolean()) {
+        segmentManager.tooSoonToCorrect = true;
+      }
+      if (!random.nextBoolean()) { // not present in ideal state
+        // 1. very first metadata IN_PROGRESS, but segment missing - repair: create segment CONSUMING
+        // 2. seq number matured, latest metadata IN_PROGRESS, but segment missing - repair: create segment CONSUMING, prev segment transition to ONLINE
+        if (random.nextBoolean()) {
+          // 1. very first seq number of this partition
+          clearAndSetupInitialSegments(idealStateBuilder, segmentManager, tableConfig, nPartitions);
+
+          int randomlySelectedPartition = random.nextInt(nPartitions);
+          Map<String, LLCSegmentName> partitionToLatestSegments =
+              segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+          LLCSegmentName llcSegmentName = partitionToLatestSegments.get(String.valueOf(randomlySelectedPartition));
+          idealStateBuilder.removeSegment(llcSegmentName.getSegmentName());
+
+          Assert.assertNull(idealState.getRecord().getMapFields().get(llcSegmentName.getSegmentName()));
+          nPartitions = expectedPartitionAssignment.getNumPartitions();
+          Map<String, Map<String, String>> oldMapFields = idealState.getRecord().getMapFields();
+          segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+          if (segmentManager.tooSoonToCorrect) {
+            // validate nothing changed and try again with disabled
+            Assert.assertEquals(oldMapFields, idealState.getRecord().getMapFields());
+            segmentManager.tooSoonToCorrect = false;
+            segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+          }
+          // specific verifyRepairs - verify that new segment gets created in ideal state with CONSUMING
+          Assert.assertNotNull(idealState.getRecord().getMapFields().get(llcSegmentName.getSegmentName()));
+          Assert.assertNotNull(
+              segmentManager.getRealtimeSegmentZKMetadata(tableName, llcSegmentName.getSegmentName(), null));
+          // general verifyRepairs
+          verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);
+        } else {
+          int randomlySelectedPartition = random.nextInt(nPartitions);
+
+          String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+          Map<String, LLCSegmentName> partitionToLatestSegments =
+              segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+          LLCSegmentName latestSegment = partitionToLatestSegments.get(String.valueOf(randomlySelectedPartition));
+          LLCRealtimeSegmentZKMetadata latestMetadata =
+              segmentManager.getRealtimeSegmentZKMetadata(tableName, latestSegment.getSegmentName(), null);
+          segmentManager.updateOldSegmentMetadataZNRecord(tableName, latestSegment,
+              latestMetadata.getStartOffset() + 100);
+          LLCSegmentName newLlcSegmentName =
+              new LLCSegmentName(rawTableName, randomlySelectedPartition, latestSegment.getSequenceNumber() + 1,
+                  System.currentTimeMillis());
+          segmentManager.createNewSegmentMetadataZNRecord(tableName, newLlcSegmentName,
+              latestMetadata.getStartOffset() + 100, expectedPartitionAssignment);
+
+          Assert.assertNull(idealState.getRecord().getMapFields().get(newLlcSegmentName.getSegmentName()));
+          nPartitions = expectedPartitionAssignment.getNumPartitions();
+          Map<String, Map<String, String>> oldMapFields = idealState.getRecord().getMapFields();
+          segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+          if (segmentManager.tooSoonToCorrect) {
+            // validate nothing changed and try again with disabled
+            Assert.assertEquals(oldMapFields, idealState.getRecord().getMapFields());
+            segmentManager.tooSoonToCorrect = false;
+            segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+          }
+          // verify that new segment gets created in ideal state with CONSUMING and old segment ONLINE
+          Assert.assertNotNull(idealState.getRecord().getMapFields().get(newLlcSegmentName.getSegmentName()));
+          Assert.assertNotNull(
+              segmentManager.getRealtimeSegmentZKMetadata(tableName, latestSegment.getSegmentName(), null));
+          Assert.assertNotNull(
+              segmentManager.getRealtimeSegmentZKMetadata(tableName, newLlcSegmentName.getSegmentName(), null));
+          // general verifyRepairs
+          verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);
+        }
+      } else { // present in ideal state
+        // 1. metadata IN_PROGRESS, segment CONSUMING - happy path
+        // 2. metadata IN_PROGRESS/DONE, segment OFFLINE - repair: create new metadata and new segment
+        // 3. metadata DONE, segment CONSUMING - repair: transition segment to ONLINE, new metadata, new segment
+        if (!random.nextBoolean()) {
+          consuming = false;
+        }
+        if (!random.nextBoolean()) {
+          inProgress = false;
+        }
+
+        if (consuming) {
+          if (inProgress) { // 1. happy path
+            Map<String, Map<String, String>> oldIdealState = new HashMap<>(idealState.getRecord().getMapFields());
+            nPartitions = expectedPartitionAssignment.getNumPartitions();
+
+            Map<String, Map<String, String>> oldMapFields = idealState.getRecord().getMapFields();
+            segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+            if (segmentManager.tooSoonToCorrect) {
+              // validate nothing changed and try again with disabled
+              Assert.assertEquals(oldMapFields, idealState.getRecord().getMapFields());
+              segmentManager.tooSoonToCorrect = false;
+              segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+            }
+            // verify that nothing changed
+            Assert.assertEquals(oldIdealState, idealState.getRecord().getMapFields());
+            // general verifyRepairs
+            verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);
+          } else { // 3. DONE + CONSUMING
+            int randomlySelectedPartition = random.nextInt(nPartitions);
+            Map<String, LLCSegmentName> partitionToLatestSegments =
+                segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+            LLCSegmentName latestSegment = partitionToLatestSegments.get(String.valueOf(randomlySelectedPartition));
+            LLCRealtimeSegmentZKMetadata latestMetadata =
+                segmentManager.getRealtimeSegmentZKMetadata(tableName, latestSegment.getSegmentName(), null);
+            segmentManager.updateOldSegmentMetadataZNRecord(tableName, latestSegment,
+                latestMetadata.getStartOffset() + 100);
+
+            nPartitions = expectedPartitionAssignment.getNumPartitions();
+            Map<String, Map<String, String>> oldMapFields = idealState.getRecord().getMapFields();
+            segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+            if (segmentManager.tooSoonToCorrect) {
+              // validate nothing changed and try again with disabled
+              Assert.assertEquals(oldMapFields, idealState.getRecord().getMapFields());
+              segmentManager.tooSoonToCorrect = false;
+              segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+            }
+
+            // general verifyRepairs
+            verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);
+          }
+        } else { // 2. OFFLINE
+          int randomlySelectedPartition = random.nextInt(nPartitions);
+          Map<String, LLCSegmentName> partitionToLatestSegments =
+              segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+          LLCSegmentName latestSegment = partitionToLatestSegments.get(String.valueOf(randomlySelectedPartition));
+          idealState = idealStateBuilder.transitionToState(latestSegment.getSegmentName(), "OFFLINE").build();
+
+
+          nPartitions = expectedPartitionAssignment.getNumPartitions();
+          Map<String, Map<String, String>> oldMapFields = idealState.getRecord().getMapFields();
+          segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+          if (segmentManager.tooSoonToCorrect) {
+            // validate nothing changed and try again with disabled
+            Assert.assertEquals(oldMapFields, idealState.getRecord().getMapFields());
+            segmentManager.tooSoonToCorrect = false;
+            segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+          }
+          verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);
+        }
+      }
+
+      // randomly change instances used, or increase partition count
+      int randomExternalChanges = random.nextInt(20);
+      int[] numInstancesSet = new int[]{4, 6, 8, 10};
+      // randomly change instances and hence set a new expected partition assignment
+      if (randomExternalChanges == 0) {
+        int numInstances = numInstancesSet[random.nextInt(numInstancesSet.length)];
+        instances = getInstanceList(numInstances);
+        segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+        expectedPartitionAssignment =
+            segmentManager._partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, nPartitions);
+      } else if (randomExternalChanges == 1) {
+        // randomly increase partitions and hence set a new expected partition assignment
+        expectedPartitionAssignment =
+            segmentManager._partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, nPartitions + 1);
+      } else if (randomExternalChanges == 2) {
+        // both and hence set a new expected partition assignment
+        int numInstances = numInstancesSet[random.nextInt(numInstancesSet.length)];
+        instances = getInstanceList(numInstances);
+        segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+        expectedPartitionAssignment =
+            segmentManager._partitionAssignmentGenerator.generatePartitionAssignment(tableConfig, nPartitions + 1);
+      }
+    }
+  }
+
+  private void verifyRepairs(TableConfig tableConfig, IdealState idealState,
+      PartitionAssignment expectedPartitionAssignment, FakePinotLLCRealtimeSegmentManager segmentManager,
+      Map<String, Map<String, String>> oldMapFields) {
+
+    Map<String, Map<String, String>> mapFields = idealState.getRecord().getMapFields();
+
+    // latest metadata for each partition
+    Map<Integer, MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata>> latestMetadata =
+        segmentManager.getLatestMetadata(tableConfig.getTableName());
+
+    // latest segment in ideal state for each partition
+    Map<String, LLCSegmentName> partitionToLatestSegments =
+        segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+
+    // Assert that we have a latest metadata and segment for each partition
+    List<String> latestSegmentNames = new ArrayList<>();
+    for (int p = 0; p < expectedPartitionAssignment.getNumPartitions(); p++) {
+      MinMaxPriorityQueue<LLCRealtimeSegmentZKMetadata> llcRealtimeSegmentZKMetadata = latestMetadata.get(p);
+      LLCSegmentName latestLlcSegment = partitionToLatestSegments.get(String.valueOf(p));
+      Assert.assertNotNull(llcRealtimeSegmentZKMetadata);
+      Assert.assertNotNull(llcRealtimeSegmentZKMetadata.peekFirst());
+      Assert.assertNotNull(latestLlcSegment);
+      Assert.assertEquals(latestLlcSegment.getSegmentName(), llcRealtimeSegmentZKMetadata.peekFirst().getSegmentName());
+      latestSegmentNames.add(latestLlcSegment.getSegmentName());
+    }
+
+    // if it is latest, ideal state should have state CONSUMING. metadata should have status IN_PROGRESS
+    for (Map.Entry<String, Map<String, String>> entry : mapFields.entrySet()) {
+      String segmentName = entry.getKey();
+      Map<String, String> instanceStateMap = entry.getValue();
+      if (latestSegmentNames.contains(segmentName)) {
+        for (Map.Entry<String, String> instanceState : instanceStateMap.entrySet()) {
+          Assert.assertEquals(instanceState.getValue(), "CONSUMING");
+        }
+        LLCRealtimeSegmentZKMetadata llcRealtimeSegmentZKMetadata = segmentManager._metadataMap.get(segmentName);
+        Assert.assertEquals(llcRealtimeSegmentZKMetadata.getStatus(),
+            CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+      } else {
+        for (Map.Entry<String, String> instanceState : instanceStateMap.entrySet()) {
+          Assert.assertTrue(instanceState.getValue().equals("ONLINE") || instanceState.getValue().equals("OFFLINE"));
+        }
+      }
+    }
+
+    // newer partitions and new segments will follow new partition assignment.
+    // older segments will follow old partition assignment
+    Set<String> oldSegmentsSet = oldMapFields.keySet();
+    Set<String> newSegmentsSet = mapFields.keySet();
+    Set<String> difference = new HashSet<>(newSegmentsSet);
+    difference.removeAll(oldSegmentsSet);
+    for (String addedSegment : difference) {
+      if (LLCSegmentName.isLowLevelConsumerSegmentName(addedSegment)) {
+        LLCSegmentName segmentName = new LLCSegmentName(addedSegment);
+        Set<String> actualInstances = mapFields.get(addedSegment).keySet();
+        List<String> expectedInstances =
+            expectedPartitionAssignment.getInstancesListForPartition(String.valueOf(segmentName.getPartitionId()));
+        Assert.assertEquals(actualInstances.size(), expectedInstances.size());
+        Assert.assertTrue(actualInstances.containsAll(expectedInstances));
+      }
+    }
+    for (String segment : oldSegmentsSet) {
+      Set<String> expectedInstances = oldMapFields.get(segment).keySet();
+      Set<String> actualInstances = mapFields.get(segment).keySet();
+      Assert.assertEquals(actualInstances.size(), expectedInstances.size());
+      Assert.assertTrue(actualInstances.containsAll(expectedInstances));
+    }
+  }
+
+  private IdealState clearAndSetupHappyPathIdealState(IdealStateBuilderUtil idealStateBuilder,
+      FakePinotLLCRealtimeSegmentManager segmentManager, TableConfig tableConfig, int nPartitions) {
+    String tableName = tableConfig.getTableName();
+    IdealState idealState = idealStateBuilder.clear().build();
+    segmentManager._metadataMap.clear();
+
+    segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+    PartitionAssignment partitionAssignment =
+        segmentManager._partitionAssignmentGenerator.getPartitionAssignmentFromIdealState(tableConfig, idealState);
+    for (int p = 0; p < nPartitions; p++) {
+      String segmentName = idealStateBuilder.getSegment(p, 0);
+      advanceASeqForPartition(idealState, segmentManager, partitionAssignment, segmentName, p, 1, 100, tableName);
+    }
+    return idealStateBuilder.build();
+  }
+
+  private IdealState clearAndSetupInitialSegments(IdealStateBuilderUtil idealStateBuilder,
+      FakePinotLLCRealtimeSegmentManager segmentManager, TableConfig tableConfig, int nPartitions) {
+    IdealState idealState = idealStateBuilder.clear().build();
+    segmentManager._metadataMap.clear();
+    segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+    return idealStateBuilder.build();
+  }
+
+  @Test
+  public void testPreExistingSegments() {
+    LLCSegmentName existingSegmentName = new LLCSegmentName("someTable", 1, 31, 12355L);
+    String[] existingSegs = {existingSegmentName.getSegmentName()};
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        new FakePinotLLCRealtimeSegmentManager(Arrays.asList(existingSegs));
+
+    final String rtTableName = "testPreExistingLLCSegments_REALTIME";
+
+    TableConfig tableConfig = makeTableConfig(rtTableName, 3, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    segmentManager.addTableToStore(rtTableName, tableConfig, 8);
+    IdealState idealState = PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, 10);
+    try {
+      segmentManager.setupNewTable(tableConfig, idealState);
+      Assert.fail("Did not get expected exception when setting up new table with existing segments in ");
+    } catch (RuntimeException e) {
+      // Expected
+    }
+  }
+
+  // Make sure that if we are either not leader or we are disconnected, we do not process metadata commit.
+  @Test
+  public void testCommittingSegmentIfDisconnected() {
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(null);
+
+    final String tableName = "table_REALTIME";
+    final String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    final int nInstances = 6;
+    final int nPartitions = 16;
+    final int nReplicas = 3;
+    List<String> instances = getInstanceList(nInstances);
+    final long memoryUsedBytes = 1000;
+    TableConfig tableConfig = makeTableConfig(tableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    segmentManager.addTableToStore(tableName, tableConfig, nPartitions);
+
+    IdealState idealState =
+        PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(tableName, nReplicas);
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    segmentManager.setupNewTable(tableConfig, idealState);
+    // Now commit the first segment of partition 6.
+    final int committingPartition = 6;
+    final long nextOffset = 3425666L;
+    LLCRealtimeSegmentZKMetadata committingSegmentMetadata =
+        new LLCRealtimeSegmentZKMetadata(segmentManager._records.get(committingPartition));
+    segmentManager._paths.clear();
+    segmentManager._records.clear();
+    segmentManager.IS_CONNECTED = false;
+    boolean status =
+        segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
+            memoryUsedBytes);
+    Assert.assertFalse(status);
+    Assert.assertEquals(segmentManager._nCallsToUpdateHelix, 0);  // Idealstate not updated
+    Assert.assertEquals(segmentManager._paths.size(), 0);   // propertystore not updated
+    segmentManager.IS_CONNECTED = true;
+    segmentManager.IS_LEADER = false;
+    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
+        memoryUsedBytes);
+    Assert.assertFalse(status);
+    Assert.assertEquals(segmentManager._nCallsToUpdateHelix, 0);  // Idealstate not updated
+    Assert.assertEquals(segmentManager._paths.size(), 0);   // propertystore not updated
+    segmentManager.IS_LEADER = true;
+    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
+        memoryUsedBytes);
+    Assert.assertTrue(status);
+    Assert.assertEquals(segmentManager._nCallsToUpdateHelix, 1);  // Idealstate updated
+    Assert.assertEquals(segmentManager._paths.size(), 2);   // propertystore updated
+  }
+
+  @Test
+  public void testCommittingSegment() {
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(null);
+
+    final String rtTableName = "table_REALTIME";
+    final String rawTableName = TableNameBuilder.extractRawTableName(rtTableName);
+    final int nInstances = 6;
+    final int nPartitions = 16;
+    final int nReplicas = 3;
+    List<String> instances = getInstanceList(nInstances);
+    final long memoryUsed = 1000;
+    TableConfig tableConfig = makeTableConfig(rtTableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+
+    IdealState idealState =
+        PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, nReplicas);
+
+    segmentManager.addTableToStore(rtTableName, tableConfig, nPartitions);
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    segmentManager.setupNewTable(tableConfig, idealState);
+
+    // Now commit the first segment of partition 6.
+    final int committingPartition = 6;
+    final long nextOffset = 3425666L;
+    LLCRealtimeSegmentZKMetadata committingSegmentMetadata =
+        new LLCRealtimeSegmentZKMetadata(segmentManager._records.get(committingPartition));
+    segmentManager._paths.clear();
+    segmentManager._records.clear();
+    boolean status =
+        segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
+            memoryUsed);
+    segmentManager.verifyMetadataInteractions();
+    Assert.assertTrue(status);
+
+    // Get the old and new segment metadata and make sure that they are correct.
+    Assert.assertEquals(segmentManager._paths.size(), 2);
+    ZNRecord oldZnRec = segmentManager._records.get(0);
+    ZNRecord newZnRec = segmentManager._records.get(1);
+
+    LLCRealtimeSegmentZKMetadata oldMetadata = new LLCRealtimeSegmentZKMetadata(oldZnRec);
+    LLCRealtimeSegmentZKMetadata newMetadata = new LLCRealtimeSegmentZKMetadata(newZnRec);
+
+    LLCSegmentName oldSegmentName = new LLCSegmentName(oldMetadata.getSegmentName());
+    LLCSegmentName newSegmentName = new LLCSegmentName(newMetadata.getSegmentName());
+
+    // Assert on propertystore entries
+    Assert.assertEquals(oldSegmentName.getSegmentName(), committingSegmentMetadata.getSegmentName());
+    Assert.assertEquals(newSegmentName.getPartitionId(), oldSegmentName.getPartitionId());
+    Assert.assertEquals(newSegmentName.getSequenceNumber(), oldSegmentName.getSequenceNumber() + 1);
+    Assert.assertEquals(oldMetadata.getStatus(), CommonConstants.Segment.Realtime.Status.DONE);
+    Assert.assertEquals(newMetadata.getStatus(), CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+    Assert.assertNotNull(oldMetadata.getDownloadUrl());
+    Assert.assertEquals(Long.valueOf(oldMetadata.getCrc()), Long.valueOf(FakePinotLLCRealtimeSegmentManager.CRC));
+    Assert.assertEquals(oldMetadata.getStartTime(), FakePinotLLCRealtimeSegmentManager.INTERVAL.getStartMillis());
+    Assert.assertEquals(oldMetadata.getEndTime(), FakePinotLLCRealtimeSegmentManager.INTERVAL.getEndMillis());
+    Assert.assertEquals(oldMetadata.getTotalRawDocs(), FakePinotLLCRealtimeSegmentManager.NUM_DOCS);
+    Assert.assertEquals(oldMetadata.getIndexVersion(), FakePinotLLCRealtimeSegmentManager.SEGMENT_VERSION);
+  }
+
+  @Test
+  public void testCommitSegmentWhenControllerWentThroughGC() {
+
+    FakePinotLLCRealtimeSegmentManager segmentManager1 = new FakePinotLLCRealtimeSegmentManager(null);
+    FakePinotLLCRealtimeSegmentManager segmentManager2 = new FakePinotLLCRealtimeSegmentManagerII(null,
+        FakePinotLLCRealtimeSegmentManagerII.SCENARIO_1_ZK_VERSION_NUM_HAS_CHANGE);
+    FakePinotLLCRealtimeSegmentManager segmentManager3 = new FakePinotLLCRealtimeSegmentManagerII(null,
+        FakePinotLLCRealtimeSegmentManagerII.SCENARIO_2_METADATA_STATUS_HAS_CHANGE);
+
+    final String rtTableName = "table_REALTIME";
+    final String rawTableName = TableNameBuilder.extractRawTableName(rtTableName);
+    setupSegmentManager(segmentManager1, rtTableName);
+    setupSegmentManager(segmentManager2, rtTableName);
+    setupSegmentManager(segmentManager3, rtTableName);
+    // Now commit the first segment of partition 6.
+    final int committingPartition = 6;
+    final long nextOffset = 3425666L;
+    final long memoryUsed = 1000;
+    LLCRealtimeSegmentZKMetadata committingSegmentMetadata =
+        new LLCRealtimeSegmentZKMetadata(segmentManager2._records.get(committingPartition));
+
+    boolean status =
+        segmentManager1.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
+            memoryUsed);
+    Assert.assertTrue(status);  // Committing segment metadata succeeded.
+
+    status = segmentManager2.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
+        memoryUsed);
+    Assert.assertFalse(status); // Committing segment metadata failed.
+
+    status = segmentManager3.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
+        memoryUsed);
+    Assert.assertFalse(status); // Committing segment metadata failed.
+  }
+
+  private void setupSegmentManager(FakePinotLLCRealtimeSegmentManager segmentManager, String rtTableName) {
+    final int nInstances = 6;
+    final int nPartitions = 16;
+    final int nReplicas = 3;
+    List<String> instances = getInstanceList(nInstances);
+    TableConfig tableConfig = makeTableConfig(rtTableName, nReplicas, KAFKA_OFFSET, DUMMY_HOST, DEFAULT_SERVER_TENANT,
+        DEFAULT_STREAM_ASSIGNMENT_STRATEGY);
+    IdealState idealState =
+        PinotTableIdealStateBuilder.buildEmptyKafkaConsumerRealtimeIdealStateFor(rtTableName, nReplicas);
+
+    segmentManager.addTableToStore(rtTableName, tableConfig, nPartitions);
+    segmentManager._partitionAssignmentGenerator.setConsumingInstances(instances);
+    segmentManager.setupNewTable(tableConfig, idealState);
+  }
+
+  @Test
+  public void testCommitSegmentFile() throws Exception {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager =
+        new FakePinotLLCRealtimeSegmentManager(Collections.<String>emptyList());
+    String tableName = "fakeTable_REALTIME";
+    String segmentName = "segment";
+    String temporarySegmentLocation = SegmentCompletionUtils.generateSegmentFileName(segmentName);
+
+    File temporaryDirectory = new File(baseDir, tableName);
+    temporaryDirectory.mkdirs();
+    String segmentLocation = SCHEME + temporaryDirectory.toString() + "/" + temporarySegmentLocation;
+
+    FileUtils.write(new File(temporaryDirectory, temporarySegmentLocation), "temporary file contents");
+    Assert.assertTrue(realtimeSegmentManager.commitSegmentFile(tableName, segmentLocation, segmentName));
+  }
+
+  @Test
+  public void testSegmentAlreadyThereAndExtraneousFilesDeleted() throws Exception {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager =
+        new FakePinotLLCRealtimeSegmentManager(Collections.<String>emptyList());
+    String tableName = "fakeTable_REALTIME";
+    String segmentName = "segment";
+
+    File temporaryDirectory = new File(baseDir, tableName);
+    temporaryDirectory.mkdirs();
+
+    String segmentFileLocation = SegmentCompletionUtils.generateSegmentFileName(segmentName);
+    String segmentLocation = SCHEME + temporaryDirectory + "/" + segmentFileLocation;
+    String extraSegmentFileLocation = SegmentCompletionUtils.generateSegmentFileName(segmentName);
+    String extraSegmentLocation = SCHEME + temporaryDirectory + "/" + extraSegmentFileLocation;
+    String otherSegmentNotToBeDeleted = "segmentShouldStay";
+    FileUtils.write(new File(temporaryDirectory, segmentFileLocation), "temporary file contents");
+    FileUtils.write(new File(temporaryDirectory, extraSegmentFileLocation), "temporary file contents");
+    FileUtils.write(new File(temporaryDirectory, otherSegmentNotToBeDeleted), "temporary file contents");
+    FileUtils.write(new File(temporaryDirectory, segmentName), "temporary file contents");
+    Assert.assertTrue(realtimeSegmentManager.commitSegmentFile(tableName, segmentLocation, segmentName));
+    Assert.assertTrue(new File(temporaryDirectory, otherSegmentNotToBeDeleted).exists());
+    Assert.assertFalse(new File(temporaryDirectory, extraSegmentLocation).exists());
+  }
+
+  @Test
+  public void testUpdateFlushThresholdForSegmentMetadata() {
+    PinotLLCRealtimeSegmentManager realtimeSegmentManager =
+        new FakePinotLLCRealtimeSegmentManager(Collections.<String>emptyList());
+
+    PartitionAssignment partitionAssignment = new PartitionAssignment("fakeTable_REALTIME");
+    // 4 partitions assigned to 4 servers, 4 replicas => the segments should have 250k rows each (1M / 4)
+    for (int segmentId = 1; segmentId <= 4; ++segmentId) {
+      List<String> instances = new ArrayList<>();
+
+      for (int replicaId = 1; replicaId <= 4; ++replicaId) {
+        instances.add("Server_1.2.3.4_123" + replicaId);
+      }
+
+      partitionAssignment.addPartition(Integer.toString(segmentId), instances);
+    }
+
+    // Check that each segment has 250k rows each
+    for (int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 250000);
+    }
+
+    // 4 partitions assigned to 4 servers, 2 partitions/server => the segments should have 500k rows each (1M / 2)
+    partitionAssignment.getPartitionToInstances().clear();
+    for (int segmentId = 1; segmentId <= 4; ++segmentId) {
+      List<String> instances = new ArrayList<>();
+
+      for (int replicaId = 1; replicaId <= 2; ++replicaId) {
+        instances.add("Server_1.2.3.4_123" + ((replicaId + segmentId) % 4));
+      }
+
+      partitionAssignment.addPartition(Integer.toString(segmentId), instances);
+    }
+
+    // Check that each segment has 500k rows each
+    for (int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
+    }
+
+    // 4 partitions assigned to 4 servers, 1 partition/server => the segments should have 1M rows each (1M / 1)
+    partitionAssignment.getPartitionToInstances().clear();
+    for (int segmentId = 1; segmentId <= 4; ++segmentId) {
+      List<String> instances = new ArrayList<>();
+      instances.add("Server_1.2.3.4_123" + segmentId);
+      partitionAssignment.addPartition(Integer.toString(segmentId), instances);
+    }
+
+    // Check that each segment has 1M rows each
+    for (int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 1000000);
+    }
+
+    // Assign another partition to all servers => the servers should have 500k rows each (1M / 2)
+    List<String> instances = new ArrayList<>();
+    for (int replicaId = 1; replicaId <= 4; ++replicaId) {
+      instances.add("Server_1.2.3.4_123" + replicaId);
+    }
+    partitionAssignment.addPartition("5", instances);
+
+    // Check that each segment has 500k rows each
+    for (int segmentId = 1; segmentId <= 4; ++segmentId) {
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(makeFakeSegmentName(segmentId));
+      realtimeSegmentManager.updateFlushThresholdForSegmentMetadata(metadata, partitionAssignment, 1000000);
+      Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
+    }
+  }
+
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Fake makers
+  ///////////////////////////////////////////////////////////////////////////
+  private StreamMetadata makeKafkaStreamMetadata(String topicName, String autoOffsetReset, String bootstrapHosts) {
+    StreamMetadata streamMetadata = mock(StreamMetadata.class);
+    Map<String, String> consumerPropertiesMap = new HashMap<>();
+    consumerPropertiesMap.put(CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET, autoOffsetReset);
+    consumerPropertiesMap.put(CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE, "simple");
+    consumerPropertiesMap.put(CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST, bootstrapHosts);
+    when(streamMetadata.getKafkaConsumerProperties()).thenReturn(consumerPropertiesMap);
+    when(streamMetadata.getKafkaTopicName()).thenReturn(topicName);
+    when(streamMetadata.getBootstrapHosts()).thenReturn(bootstrapHosts);
+    when(streamMetadata.getConsumerFactoryName()).thenReturn(SimpleConsumerFactory.class.getName());
+    return streamMetadata;
+  }
+
+  private TableConfig makeTableConfig(String tableName, int nReplicas, String autoOffsetReset, String bootstrapHosts,
+      String serverTenant, StreamPartitionAssignmentStrategyEnum strategy) {
+    TableConfig mockTableConfig = mock(TableConfig.class);
+    when(mockTableConfig.getTableName()).thenReturn(tableName);
+    SegmentsValidationAndRetentionConfig mockValidationConfig = mock(SegmentsValidationAndRetentionConfig.class);
+    when(mockValidationConfig.getReplicasPerPartition()).thenReturn(Integer.toString(nReplicas));
+    when(mockValidationConfig.getReplicasPerPartitionNumber()).thenReturn(nReplicas);
+    when(mockTableConfig.getValidationConfig()).thenReturn(mockValidationConfig);
+    Map<String, String> streamConfigMap = new HashMap<>(1);
+
+    streamConfigMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "simple");
+    streamConfigMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET), autoOffsetReset);
+
+    final String bootstrapHostConfigKey = CommonConstants.Helix.DataSource.STREAM_PREFIX + "."
+        + CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST;
+    streamConfigMap.put(bootstrapHostConfigKey, bootstrapHosts);
+
+    IndexingConfig mockIndexConfig = mock(IndexingConfig.class);
+    when(mockIndexConfig.getStreamConfigs()).thenReturn(streamConfigMap);
+    if (strategy != null) {
+      StreamConsumptionConfig mockStreamConsumptionConfig = mock(StreamConsumptionConfig.class);
+      when(mockStreamConsumptionConfig.getStreamPartitionAssignmentStrategy()).thenReturn(strategy.toString());
+      when(mockIndexConfig.getStreamConsumptionConfig()).thenReturn(mockStreamConsumptionConfig);
+    } else {
+      when(mockIndexConfig.getStreamConsumptionConfig()).thenReturn(null);
+    }
+
+    when(mockTableConfig.getIndexingConfig()).thenReturn(mockIndexConfig);
+    TenantConfig mockTenantConfig = mock(TenantConfig.class);
+    when(mockTenantConfig.getServer()).thenReturn(serverTenant);
+    when(mockTableConfig.getTenantConfig()).thenReturn(mockTenantConfig);
+
+    return mockTableConfig;
+  }
+
+  private static Map<String, String> getStreamConfigs() {
+    Map<String, String> streamPropMap = new HashMap<>(1);
+    streamPropMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "simple");
+    streamPropMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_CONSUMER_PROPS_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET), "smallest");
+    streamPropMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
+        CommonConstants.Helix.DataSource.Realtime.Kafka.KAFKA_BROKER_LIST), "host:1234");
+    return streamPropMap;
+  }
+
+
+  private String makeFakeSegmentName(int id) {
+    return new LLCSegmentName("fakeTable_REALTIME", id, 0, 1234L).getSegmentName();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // Fake classes
+  /////////////////////////////////////////////////////////////////////////////////
+
+  static class FakePinotLLCRealtimeSegmentManager extends PinotLLCRealtimeSegmentManager {
+
+    private static final ControllerConf CONTROLLER_CONF = new ControllerConf();
+    private List<String> _existingLLCSegments = new ArrayList<>(1);
+
+    public String _realtimeTableName;
+    public Map<String, List<String>> _idealStateEntries = new HashMap<>(1);
+    public List<String> _paths = new ArrayList<>(16);
+    public List<ZNRecord> _records = new ArrayList<>(16);
+    public String _startOffset;
+    public boolean _createNew;
+    public int _nReplicas;
+    public Map<String, LLCRealtimeSegmentZKMetadata> _metadataMap = new HashMap<>(4);
+    private FakePartitionAssignmentGenerator _partitionAssignmentGenerator;
+    public PartitionAssignment _currentTablePartitionAssignment;
+
+    public List<String> _newInstances;
+    public List<String> _oldSegmentNameStr = new ArrayList<>(16);
+    public List<String> _newSegmentNameStr = new ArrayList<>(16);
+
+    public long _kafkaLargestOffsetToReturn;
+    public long _kafkaSmallestOffsetToReturn;
+
+    public List<ZNRecord> _existingSegmentMetadata;
+
+    public int _nCallsToUpdateHelix = 0;
+    public int _nCallsToCreateNewSegmentMetadata = 0;
+    public IdealState _tableIdealState;
+    public List<String> _currentInstanceList;
+    public String _currentTable;
+
+    public static final String CRC = "5680988776500";
+    public static final Interval INTERVAL = new Interval(3000, 4000);
+    public static final String SEGMENT_VERSION = SegmentVersion.v1.toString();
+    public static final int NUM_DOCS = 5099775;
+    public static boolean IS_LEADER = true;
+    public static boolean IS_CONNECTED = true;
+    public boolean tooSoonToCorrect = false;
+
+    public int _version;
+
+    private SegmentMetadataImpl segmentMetadata;
+
+    private TableConfigStore _tableConfigStore;
+
+    protected FakePinotLLCRealtimeSegmentManager(List<String> existingLLCSegments) {
+
+      super(null, clusterName, null, null, null, CONTROLLER_CONF, new ControllerMetrics(new MetricsRegistry()));
+      try {
+        TableConfigCache mockCache = mock(TableConfigCache.class);
+        TableConfig mockTableConfig = mock(TableConfig.class);
+        IndexingConfig mockIndexingConfig = mock(IndexingConfig.class);
+        when(mockTableConfig.getIndexingConfig()).thenReturn(mockIndexingConfig);
+        when(mockIndexingConfig.getStreamConfigs()).thenReturn(getStreamConfigs());
+        when(mockCache.getTableConfig(anyString())).thenReturn(mockTableConfig);
+
+        Field tableConfigCacheField = PinotLLCRealtimeSegmentManager.class.getDeclaredField("_tableConfigCache");
+        tableConfigCacheField.setAccessible(true);
+        tableConfigCacheField.set(this, mockCache);
+
+        HelixManager mockHelixManager = mock(HelixManager.class);
+        _partitionAssignmentGenerator = new FakePartitionAssignmentGenerator(mockHelixManager);
+        Field partitionAssignmentGeneratorField =
+            PinotLLCRealtimeSegmentManager.class.getDeclaredField("_partitionAssignmentGenerator");
+        partitionAssignmentGeneratorField.setAccessible(true);
+        partitionAssignmentGeneratorField.set(this, _partitionAssignmentGenerator);
+      } catch (Exception e) {
+        Utils.rethrowException(e);
+      }
+
+      if (existingLLCSegments != null) {
+        _existingLLCSegments = existingLLCSegments;
+      }
+      CONTROLLER_CONF.setControllerVipHost("vip");
+      CONTROLLER_CONF.setControllerPort("9000");
+      CONTROLLER_CONF.setDataDir(baseDir.toString());
+
+      _version = 0;
+
+      _tableConfigStore = new TableConfigStore();
+    }
+
+    void addTableToStore(String tableName, TableConfig tableConfig, int nKafkaPartitions) {
+      _tableConfigStore.addTable(tableName, tableConfig, nKafkaPartitions);
+    }
+
+    void removeTableFromStore(String tableName) {
+      _tableConfigStore.removeTable(tableName);
+    }
+
+    @Override
+    protected List<String> getRealtimeTablesWithServerTenant(String serverTenantName) {
+      return _tableConfigStore.getAllRealtimeTablesWithServerTenant(serverTenantName);
+    }
+
+    @Override
+    protected TableConfig getRealtimeTableConfig(String realtimeTableName) {
+      return _tableConfigStore.getTableConfig(realtimeTableName);
+    }
+
+    @Override
+    protected boolean isTooSoonToCorrect(String tableNameWithType, String segmentId) {
+      return tooSoonToCorrect;
+    }
+
+    @Override
+    protected boolean writeSegmentToPropertyStore(String nodePath, ZNRecord znRecord, final String realtimeTableName,
+        int expectedVersion) {
+      List<String> paths = new ArrayList<>();
+      List<ZNRecord> records = new ArrayList<>();
+      paths.add(nodePath);
+      records.add(znRecord);
+      if (expectedVersion != _version) {
+        return false;
+      } else {
+        writeSegmentsToPropertyStore(paths, records, realtimeTableName);
+        return true;
+      }
+    }
+
+    @Override
+    protected boolean writeSegmentToPropertyStore(String nodePath, ZNRecord znRecord, final String realtimeTableName) {
+      List<String> paths = new ArrayList<>();
+      List<ZNRecord> records = new ArrayList<>();
+      paths.add(nodePath);
+      records.add(znRecord);
+      writeSegmentsToPropertyStore(paths, records, realtimeTableName);
+      return true;
+    }
+
+    @Override
+    protected void writeSegmentsToPropertyStore(List<String> paths, List<ZNRecord> records, String realtimeTableName) {
+      _paths.addAll(paths);
+      _records.addAll(records);
+      for (int i = 0; i < paths.size(); i++) {
+        String path = paths.get(i);
+        ZNRecord znRecord = records.get(i);
+        String segmentId = getSegmentNameFromPath(path);
+        _existingLLCSegments.add(segmentId);
+        _metadataMap.put(segmentId, new LLCRealtimeSegmentZKMetadata(znRecord));
+      }
+    }
+
+    private String getSegmentNameFromPath(String path) {
+      return path.substring(path.lastIndexOf("/") + 1);
+    }
+
+    @Override
+    protected List<LLCRealtimeSegmentZKMetadata> getAllSegmentMetadata(String tableNameWithType) {
+      return Lists.newArrayList(_metadataMap.values());
+    }
+
+    @Override
+    protected void setupInitialSegments(TableConfig tableConfig, StreamMetadata streamMetadata,
+        PartitionAssignment partitionAssignment, IdealState idealState, boolean create, int flushSize) {
+      _realtimeTableName = tableConfig.getTableName();
+      _currentTablePartitionAssignment = partitionAssignment;
+      _startOffset = streamMetadata.getKafkaConsumerProperties()
+          .get(CommonConstants.Helix.DataSource.Realtime.Kafka.AUTO_OFFSET_RESET);
+      super.setupInitialSegments(tableConfig, streamMetadata, partitionAssignment, idealState, create, flushSize);
+    }
+
+    @Override
+    protected List<String> getExistingSegments(String realtimeTableName) {
+      return _existingLLCSegments;
+    }
+
+    @Override
+    protected void updateIdealStateOnSegmentCompletion(@Nonnull final String tableNameWithType,
+        @Nonnull final String currentSegmentId, @Nonnull final String newSegmentId,
+        @Nonnull final PartitionAssignment partitionAssignment) {
+      _nCallsToUpdateHelix++;
+      super.updateIdealStateOnSegmentCompletion(_tableIdealState, currentSegmentId, newSegmentId, partitionAssignment);
+    }
+
+    @Override
+    protected void updateIdealState(IdealState idealState, String realtimeTableName,
+        Map<String, List<String>> idealStateEntries, boolean create, int nReplicas) {
+      _realtimeTableName = realtimeTableName;
+      _idealStateEntries = idealStateEntries;
+      _nReplicas = nReplicas;
+      _createNew = create;
+      for (Map.Entry<String, List<String>> entry : idealStateEntries.entrySet()) {
+        _idealStateEntries.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    @Override
+    protected boolean createNewSegmentMetadataZNRecord(String realtimeTableName, LLCSegmentName newLLCSegmentName,
+        long nextOffset, PartitionAssignment partitionAssignment) {
+      _nCallsToCreateNewSegmentMetadata++;
+      return super.createNewSegmentMetadataZNRecord(realtimeTableName, newLLCSegmentName, nextOffset,
+          partitionAssignment);
+    }
+
+    @Override
+    protected boolean updateOldSegmentMetadataZNRecord(String realtimeTableName,
+        LLCSegmentName committingLLCSegmentName, long nextOffset) {
+      return super.updateOldSegmentMetadataZNRecord(realtimeTableName, committingLLCSegmentName, nextOffset);
+    }
+
+    protected void updateIdealState(final String realtimeTableName, final List<String> newInstances,
+        final String oldSegmentNameStr, final String newSegmentNameStr) {
+      _realtimeTableName = realtimeTableName;
+      _newInstances = newInstances;
+      _oldSegmentNameStr.add(oldSegmentNameStr);
+      _newSegmentNameStr.add(newSegmentNameStr);
+      _idealStateEntries.put(newSegmentNameStr, newInstances);
+      _nCallsToUpdateHelix++;
+    }
+
+    @Override
+    public LLCRealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(String realtimeTableName, String segmentName,
+        Stat stat) {
+      if (_metadataMap.containsKey(segmentName)) {
+        LLCRealtimeSegmentZKMetadata oldMetadata = _metadataMap.get(segmentName);
+
+        LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+        metadata.setSegmentName(oldMetadata.getSegmentName());
+        metadata.setDownloadUrl(oldMetadata.getDownloadUrl());
+        metadata.setNumReplicas(oldMetadata.getNumReplicas());
+        metadata.setEndOffset(oldMetadata.getEndOffset());
+        metadata.setStatus(oldMetadata.getStatus());
+        return metadata;
+      }
+      LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
+      metadata.setSegmentName(segmentName);
+      return metadata;
+    }
+
+    @Override
+    protected SegmentMetadataImpl extractSegmentMetadata(final String rawTableName, final String segmentNameStr) {
+      segmentMetadata = mock(SegmentMetadataImpl.class);
+      when(segmentMetadata.getCrc()).thenReturn(CRC);
+      when(segmentMetadata.getTimeInterval()).thenReturn(INTERVAL);
+      when(segmentMetadata.getVersion()).thenReturn(SEGMENT_VERSION);
+      when(segmentMetadata.getTotalRawDocs()).thenReturn(NUM_DOCS);
+      return segmentMetadata;
+    }
+
+    public void verifyMetadataInteractions() {
+      verify(segmentMetadata, times(1)).getCrc();
+      verify(segmentMetadata, times(2)).getTimeInterval();
+      verify(segmentMetadata, times(1)).getVersion();
+      verify(segmentMetadata, times(1)).getTotalRawDocs();
+      verify(segmentMetadata, times(1)).getColumnMetadataMap();
+      verifyNoMoreInteractions(segmentMetadata);
+    }
+
+    @Override
+    protected long getKafkaPartitionOffset(StreamMetadata streamMetadata, final String offsetCriteria,
+        int partitionId) {
+      if (offsetCriteria.equals("largest")) {
+        return _kafkaLargestOffsetToReturn;
+      } else {
+        return _kafkaSmallestOffsetToReturn;
+      }
+    }
+
+    @Override
+    protected boolean isLeader() {
+      return IS_LEADER;
+    }
+
+    @Override
+    protected boolean isConnected() {
+      return IS_CONNECTED;
+    }
+
+    @Override
+    protected List<ZNRecord> getExistingSegmentMetadata(String realtimeTableName) {
+      return _existingSegmentMetadata;
+    }
+
+    @Override
+    protected int getRealtimeTableFlushSizeForTable(String tableName) {
+      return 1000;
+    }
+
+    @Override
+    protected IdealState getTableIdealState(String realtimeTableName) {
+      return _tableIdealState;
+    }
+
+    @Override
+    protected void setTableIdealState(String realtimeTableName, IdealState idealState) {
+      _tableIdealState = idealState;
+    }
+
+    @Override
+    public void setupNewTable(TableConfig tableConfig, IdealState emptyIdealState) {
+      _currentTable = tableConfig.getTableName();
+      super.setupNewTable(tableConfig, emptyIdealState);
+    }
+
+    @Override
+    protected List<String> getInstances(String tenantName) {
+      return _currentInstanceList;
+    }
+
+    @Override
+    protected int getKafkaPartitionCount(StreamMetadata metadata) {
+      return _tableConfigStore.getNKafkaPartitions(_currentTable);
+    }
+  }
+
+  static class FakePinotLLCRealtimeSegmentManagerII extends FakePinotLLCRealtimeSegmentManager {
+
+    final static int SCENARIO_1_ZK_VERSION_NUM_HAS_CHANGE = 1;
+    final static int SCENARIO_2_METADATA_STATUS_HAS_CHANGE = 2;
+
+    private int _scenario;
+
+    FakePinotLLCRealtimeSegmentManagerII(List<String> existingLLCSegments, int scenario) {
+      super(existingLLCSegments);
+      _scenario = scenario;
+    }
+
+    @Override
+    public LLCRealtimeSegmentZKMetadata getRealtimeSegmentZKMetadata(String realtimeTableName, String segmentName,
+        Stat stat) {
+      LLCRealtimeSegmentZKMetadata metadata = super.getRealtimeSegmentZKMetadata(realtimeTableName, segmentName, stat);
+      switch (_scenario) {
+        case SCENARIO_1_ZK_VERSION_NUM_HAS_CHANGE:
+          // Mock another controller has already updated the segment metadata, which makes the version number self increase.
+          stat.setVersion(_version + 1);
+          break;
+        case SCENARIO_2_METADATA_STATUS_HAS_CHANGE:
+          // Mock another controller has updated the status of the old segment metadata.
+          metadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+          break;
+      }
+      return metadata;
+    }
+  }
+
+  private static class FakePartitionAssignmentGenerator extends PartitionAssignmentGenerator {
+
+    private List<String> _consumingInstances;
+
+    public FakePartitionAssignmentGenerator(HelixManager helixManager) {
+      super(helixManager);
+      _consumingInstances = new ArrayList<>();
+    }
+
+    @Override
+    protected List<String> getConsumingTaggedInstances(RealtimeTagConfig realtimeTagConfig) {
+      return _consumingInstances;
+    }
+
+    void setConsumingInstances(List<String> consumingInstances) {
+      _consumingInstances = consumingInstances;
+    }
+  }
+
+  static class TableConfigStore {
+    private Map<String, TableConfig> _tableConfigsStore;
+    private Map<String, Integer> _nPartitionsStore;
+
+    TableConfigStore() {
+      _tableConfigsStore = new HashMap<>(1);
+      _nPartitionsStore = new HashMap<>(1);
+    }
+
+    void addTable(String tableName, TableConfig tableConfig, int nKafkaPartitions) {
+      _tableConfigsStore.put(tableName, tableConfig);
+      _nPartitionsStore.put(tableName, nKafkaPartitions);
+    }
+
+    void removeTable(String tableName) {
+      _tableConfigsStore.remove(tableName);
+      _nPartitionsStore.remove(tableName);
+    }
+
+    TableConfig getTableConfig(String tableName) {
+      return _tableConfigsStore.get(tableName);
+    }
+
+    int getNKafkaPartitions(String tableName) {
+      return _nPartitionsStore.get(tableName);
+    }
+
+    List<String> getAllRealtimeTablesWithServerTenant(String serverTenant) {
+      List<String> realtimeTablesWithServerTenant = new ArrayList<>();
+      for (Map.Entry<String, TableConfig> entry : _tableConfigsStore.entrySet()) {
+        if (entry.getValue().getTenantConfig().getServer().equals(serverTenant)) {
+          realtimeTablesWithServerTenant.add(entry.getKey());
+        }
+      }
+      return realtimeTablesWithServerTenant;
+    }
+  }
+}

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -15,35 +15,24 @@
  */
 package com.linkedin.pinot.controller.validation;
 
-import com.linkedin.pinot.common.config.IndexingConfig;
 import com.linkedin.pinot.common.config.TableConfig;
-import com.linkedin.pinot.common.config.TableNameBuilder;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
-import com.linkedin.pinot.common.metrics.ValidationMetrics;
+import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.ControllerTenantNameBuilder;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
-import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
-import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.helix.ControllerRequestBuilderUtil;
-import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.controller.helix.core.PinotHelixResourceManager;
-import com.linkedin.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineStateModelGenerator;
-import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import com.linkedin.pinot.controller.helix.core.util.HelixSetupUtils;
 import com.linkedin.pinot.controller.utils.SegmentMetadataMockUtils;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
@@ -334,102 +323,5 @@ public class ValidationManagerTest {
 
     List<Interval> computeMissingIntervals = ValidationManager.computeMissingIntervals(intervals, frequency);
     Assert.assertEquals(computeMissingIntervals.size(), 22);
-  }
-
-  @Test
-  public void testLLCValidation() throws Exception {
-    final String topicName = "topic";
-    final int kafkaPartitionCount = 2;
-    final String realtimeTableName = "table_REALTIME";
-    final String tableName = TableNameBuilder.extractRawTableName(realtimeTableName);
-    final String S1 = "S1"; // Server 1
-    final String S2 = "S2"; // Server 2
-    final String S3 = "S3"; // Server 3
-    final List<String> hosts = Arrays.asList(new String[]{S1, S2, S3});
-    final HelixAdmin helixAdmin = _pinotHelixResourceManager.getHelixAdmin();
-
-    PartitionAssignment partitionAssignment = new PartitionAssignment(topicName);
-    for (int i = 0; i < kafkaPartitionCount; i++) {
-      partitionAssignment.addPartition(Integer.toString(i), hosts);
-    }
-    makeMockPinotLLCRealtimeSegmentManager(partitionAssignment);
-
-    long msSinceEpoch = 1540;
-
-    LLCSegmentName p0s0 = new LLCSegmentName(tableName, 0, 0, msSinceEpoch);
-    LLCSegmentName p0s1 = new LLCSegmentName(tableName, 0, 1, msSinceEpoch);
-    LLCSegmentName p1s0 = new LLCSegmentName(tableName, 1, 0, msSinceEpoch);
-    LLCSegmentName p1s1 = new LLCSegmentName(tableName, 1, 1, msSinceEpoch);
-
-    IdealState idealstate = PinotTableIdealStateBuilder.buildEmptyIdealStateFor(realtimeTableName, 3);
-    idealstate.setPartitionState(p0s0.getSegmentName(), S1,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
-    idealstate.setPartitionState(p0s0.getSegmentName(), S2,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
-    idealstate.setPartitionState(p0s0.getSegmentName(), S3,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
-//    idealstate.setPartitionState(p0s1.getSegmentName(), S1, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
-//    idealstate.setPartitionState(p0s1.getSegmentName(), S2, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
-//    idealstate.setPartitionState(p0s1.getSegmentName(), S3, PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
-    idealstate.setPartitionState(p1s0.getSegmentName(), S1,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
-    idealstate.setPartitionState(p1s0.getSegmentName(), S2,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
-    idealstate.setPartitionState(p1s0.getSegmentName(), S3,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.ONLINE_STATE);
-    idealstate.setPartitionState(p1s1.getSegmentName(), S1,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
-    idealstate.setPartitionState(p1s1.getSegmentName(), S2,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
-    idealstate.setPartitionState(p1s1.getSegmentName(), S3,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
-    helixAdmin.addResource(HELIX_CLUSTER_NAME, realtimeTableName, idealstate);
-
-    FakeValidationMetrics validationMetrics = new FakeValidationMetrics();
-
-    ValidationManager validationManager =
-        new ValidationManager(validationMetrics, _pinotHelixResourceManager, new ControllerConf(), _segmentManager);
-    Map<String, String> streamConfigs = new HashMap<String, String>(4);
-    streamConfigs.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
-        CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "highLevel,simple");
-    Field autoCreateOnError = ValidationManager.class.getDeclaredField("_autoCreateOnError");
-    autoCreateOnError.setAccessible(true);
-    autoCreateOnError.setBoolean(validationManager, false);
-    TableConfig tableConfig = mock(TableConfig.class);
-    IndexingConfig indexingConfig = mock(IndexingConfig.class);
-    when(tableConfig.getIndexingConfig()).thenReturn(indexingConfig);
-    when(indexingConfig.getStreamConfigs()).thenReturn(streamConfigs);
-
-    validationManager.validateLLCSegments(realtimeTableName, tableConfig);
-
-    Assert.assertEquals(validationMetrics.partitionCount, 1);
-
-    // Set partition 0 to have one instance in CONSUMING state, and others in OFFLINE.
-    // we should not flag any partitions to correct.
-    helixAdmin.dropResource(HELIX_CLUSTER_NAME, realtimeTableName);
-    idealstate.setPartitionState(p0s1.getSegmentName(), S1,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.CONSUMING_STATE);
-    idealstate.setPartitionState(p0s1.getSegmentName(), S2,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.OFFLINE_STATE);
-    idealstate.setPartitionState(p0s1.getSegmentName(), S3,
-        PinotHelixSegmentOnlineOfflineStateModelGenerator.OFFLINE_STATE);
-    helixAdmin.addResource(HELIX_CLUSTER_NAME, realtimeTableName, idealstate);
-    validationManager.validateLLCSegments(realtimeTableName, tableConfig);
-    Assert.assertEquals(validationMetrics.partitionCount, 0);
-
-    helixAdmin.dropResource(HELIX_CLUSTER_NAME, realtimeTableName);
-  }
-
-  private class FakeValidationMetrics extends ValidationMetrics {
-    public int partitionCount = -1;
-
-    public FakeValidationMetrics() {
-      super(null);
-    }
-
-    @Override
-    public void updateNonConsumingPartitionCountMetric(final String tableName, final int count) {
-      partitionCount = count;
-    }
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/segment/ConsumingSegmentAssignmentStrategy.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/segment/ConsumingSegmentAssignmentStrategy.java
@@ -19,6 +19,7 @@ package com.linkedin.pinot.core.realtime.segment;
 import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,7 @@ public class ConsumingSegmentAssignmentStrategy implements RealtimeSegmentAssign
    * @param partitionAssignment partition assignment for the table to which the segments belong
    * @return map of segment name to instances list
    */
-  public Map<String, List<String>> assign(List<String> newSegments, PartitionAssignment partitionAssignment)
+  public Map<String, List<String>> assign(Collection<String> newSegments, PartitionAssignment partitionAssignment)
       throws InvalidConfigException {
 
     Map<String, List<String>> segmentAssignment = new HashMap<>(newSegments.size());

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/segment/RealtimeSegmentAssignmentStrategy.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/segment/RealtimeSegmentAssignmentStrategy.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.realtime.segment;
 
 import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.partition.PartitionAssignment;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -33,6 +34,6 @@ public interface RealtimeSegmentAssignmentStrategy {
    * @param partitionAssignment
    * @return
    */
-  Map<String, List<String>> assign(List<String> newSegments, PartitionAssignment partitionAssignment)
+  Map<String, List<String>> assign(Collection<String> newSegments, PartitionAssignment partitionAssignment)
       throws InvalidConfigException;
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/segment/ConsumingSegmentAssignmentStrategyTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/realtime/segment/ConsumingSegmentAssignmentStrategyTest.java
@@ -200,9 +200,9 @@ public class ConsumingSegmentAssignmentStrategyTest {
 
     // 2) consuming segments moved to ONLINE, new set of consuming segments generated
 
-    idealState = idealStateBuilder.transitionToState(0, 0, "ONLINE")
-        .transitionToState(1, 0, "ONLINE")
-        .transitionToState(2, 0, "ONLINE")
+    idealState = idealStateBuilder.setSegmentState(0, 0, "ONLINE")
+        .setSegmentState(1, 0, "ONLINE")
+        .setSegmentState(2, 0, "ONLINE")
         .addConsumingSegments(numPartitions, 1, numReplicas, consumingInstances)
         .build();
 
@@ -235,9 +235,9 @@ public class ConsumingSegmentAssignmentStrategyTest {
 
     // 4) latest consuming segments became OFFLINE
 
-    idealState = idealStateBuilder.transitionToState(0, 1, "OFFLINE")
-        .transitionToState(1, 1, "OFFLINE")
-        .transitionToState(2, 1, "OFFLINE")
+    idealState = idealStateBuilder.setSegmentState(0, 1, "OFFLINE")
+        .setSegmentState(1, 1, "OFFLINE")
+        .setSegmentState(2, 1, "OFFLINE")
         .build();
     partitionAssignmentFromIdealState =
         partitionAssignmentGenerator.getPartitionAssignmentFromIdealState(tableConfig, idealState);


### PR DESCRIPTION
Testing done:

I] Local testing using integration test setup.
Method: start LLCRealtimeClusterIntegrationTest for setup and then sleep. Made changes to ideal state/segment metadata and let validation manager correct them.
Tests:
1) Segment absent from ideal state 
  i) but metadata present (failed after step 2 of segment completion, check: new segment created in ideal state with CONSUMING, if prev exists make it ONLINE)
  ii) Special case of i. The missing segment was the very first segment in the ideal state for this partition
2) Segment present in ideal state
   i) metadata IN_PROGRESS, ideal state CONSUMING  (happy path)
   ii) metadata DONE, ideal state CONSUMING (failed after step 1 of segment completion, check: new metadata IN_PROGRESS, new segment CONSUMING, old segment ONLINE)
   iii) metadata IN_PROGRESS, ideal state OFFLINE (check: must generate new segment with prev segment’s start offset )
   iv) metadata DONE, ideal state OFFLINE (check: must generate new segment with prev segment’s end offset)
3) Too soon to correct case - waits till too soon, fixes after that
4) new partition


II] Testing on test cluster 
1) Check that partition assignment is unfazed for an existing table, after the new change is deployed
2) New table creation
3) Repairs:
i) Segment present in ideal state:
  a) metadata IN_PROGRESS, segment CONSUMING
  b) metadata IN_PROGRESS, segment OFFLINE
  c) metadata IN_PROGRESS, 1 replica CONSUMING 1 OFFLINE
  d) metadata DONE, segment CONSUMING
  e) metadata DONE, segment OFFLINE
  f) metadata DONE, 1 replica CONSUMING 1 OFFLINE
  g) Too soon to correct
  h) Instances changed
ii) Segment absent from ideal state
  a) Initial segment (seq 0)
  b) Mature segment
