### PR TITLE
[TE] rootcause - remove legacy toggle

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -1065,23 +1065,6 @@ export default Controller.extend({
     },
 
     /**
-     * Toggle that links to the legacy rca
-     * @param {String} urn current metricUrn
-    */
-    onLegacyToggle(urn = '') {
-      // later is used here so that the transition occurs after
-      // the component's toggle animation
-      later(() => {
-        if (urn.startsWith('thirdeye:metric')) {
-          const id = urn.split(':')[2];
-          this.send('transitionToRcaDetails', id);
-        } else {
-          this.send('transitionToRca');
-        }
-      }, 1000);
-    },
-
-    /**
      * Toggles the modal view
     */
     onEntityMappingClick() {

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -38,17 +38,6 @@
   {{/if}}
 
   <div class="row card-container card-container--md card-container--box-shadow">
-    <div class="card-container__header card-container__header--no-border card-container__header--flush-bottom">
-      <span class="card-container__title card-container__title--grow">Root cause Analysis</span>
-      <label class="te-label">
-        {{x-toggle
-          classNames="te-toggle pull-right rootcause-to-legacy-toggle"
-          theme='ios'
-          onToggle=(action "onLegacyToggle" metricUrn)
-          value=false}}
-        Use Legacy RCA
-      </label>
-    </div>
     <div class="card-container__body--padding-md card-container__body--flush-bottom">
       {{#if selectedUrns.size}}
         <div class="rootcause-wrapper">

--- a/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/rootcause-test.js
@@ -108,11 +108,4 @@ module('Acceptance | rootcause', async function(hooks) {
       $(rcEl.EVENTS_TABLE).get(0),
       'events table exists in events tab');
   });
-
-  test('links to legacy rca should work', async (assert) => {
-    await visit('/rootcause');
-    await click(rcEl.RCA_TOGGLE);
-
-    assert.ok(currentURL().includes('rca'), currentURL());
-  });
 });


### PR DESCRIPTION
All use-cases are migrated. This removal makes to old RCA page inaccessible from the UI, but still leaves it reachable via deep links.