### PR TITLE
BYTE_ARRAY Support: Add support to read/write byte[] data using raw index.

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PlainFieldExtractor.java
@@ -26,7 +26,6 @@ import com.linkedin.pinot.common.utils.time.TimeConverter;
 import com.linkedin.pinot.common.utils.time.TimeConverterProvider;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.function.FunctionExpressionEvaluator;
-
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -77,7 +76,7 @@ public class PlainFieldExtractor implements FieldExtractor {
   private String _outgoingTimeColumnName;
   private TimeConverter _timeConverter;
   private Map<String, FunctionExpressionEvaluator> _functionEvaluatorMap;
-  
+
   public PlainFieldExtractor(Schema schema) {
     _schema = schema;
     initErrorCount();
@@ -121,7 +120,7 @@ public class PlainFieldExtractor implements FieldExtractor {
     }
   }
 
-  private void initFunctionEvaluators(){
+  private void initFunctionEvaluators() {
     _functionEvaluatorMap = new HashMap<>();
     for (String column : _schema.getColumnNames()) {
       FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
@@ -137,7 +136,7 @@ public class PlainFieldExtractor implements FieldExtractor {
       }
     }
   }
-  
+
   @Override
   public Schema getSchema() {
     return _schema;
@@ -178,12 +177,12 @@ public class PlainFieldExtractor implements FieldExtractor {
           }
         }
       } else if (fieldSpec.getTransformFunction() != null) {
-         FunctionExpressionEvaluator functionEvaluator = _functionEvaluatorMap.get(column);
-         value = functionEvaluator.evaluate(row);
+        FunctionExpressionEvaluator functionEvaluator = _functionEvaluatorMap.get(column);
+        value = functionEvaluator.evaluate(row);
       } else {
         value = row.getValue(column);
       }
-      
+
       if (value == null) {
         hasNull = true;
         _totalNullCols++;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/PinotSegmentColumnReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/readers/PinotSegmentColumnReader.java
@@ -95,6 +95,16 @@ public class PinotSegmentColumnReader {
     }
   }
 
+  Object readBytes(int docId) {
+    SingleColumnSingleValueReader svReader = (SingleColumnSingleValueReader) _reader;
+    if (_dictionary != null) {
+      int dictId = svReader.getInt(docId, _readerContext);
+      return _dictionary.get(dictId);
+    } else {
+      return svReader.getBytes(docId, _readerContext);
+    }
+  }
+
   Object[] readMV(int docId) {
     SingleColumnMultiValueReader mvReader = (SingleColumnMultiValueReader) _reader;
     int numValues = mvReader.getIntArray(docId, _mvBuffer, _readerContext);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/BaseSingleColumnSingleValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/BaseSingleColumnSingleValueReader.java
@@ -88,6 +88,10 @@ public abstract class BaseSingleColumnSingleValueReader<T extends ReaderContext>
     throw new UnsupportedOperationException();
   }
 
+  public byte[] getBytes(int row, T context) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   public void readValues(int[] rows, int rowStartPos, int rowSize, int[] values, int valuesStartPos) {
     throw new UnsupportedOperationException("not supported");

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/SingleColumnSingleValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/SingleColumnSingleValueReader.java
@@ -18,70 +18,131 @@ package com.linkedin.pinot.core.io.reader;
 public interface SingleColumnSingleValueReader<T extends ReaderContext> extends DataFileReader<T> {
 
   /**
-   * fetch the char at a row
-   * @param row
-   * @return
+   * Fetch the char at a row.
+   *
+   * @param row Row for which to fetch the value.
+   * @return Char value at row.
    */
   char getChar(int row);
 
   /**
-   * fetch short value at a specific row, col
-   * @param row
-   * @return
+   * Fetch short value at the specified row.
+   *
+   * @param row  Row for which to fetch the value.
+   * @return Short value at row.
    */
   short getShort(int row);
 
   /**
-   * @param row
-   * @return
+   * Fetch the int value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @return int value at row.
    */
   int getInt(int row);
 
+  /**
+   * Fetch the int value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @param context Reader context.
+   * @return int value at row.
+   */
   int getInt(int row, T context);
 
   /**
-   * @param row
-   * @return
+   * Fetch the long value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @return value value at row.
    */
   long getLong(int row);
 
+  /**
+   * Fetch the long value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @param context Reader context.
+   * @return long value at row.
+   */
   long getLong(int row, T context);
 
   /**
-   * @param row
-   * @return
+   * Fetch the float value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @return float value at row.
    */
   float getFloat(int row);
 
+  /**
+   * Fetch the float value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @param context Reader context.
+   * @return float value at row.
+   */
   float getFloat(int row, T context);
 
   /**
-   * @param row
-   * @return
+   * Fetch the double value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @return double value at row.
    */
   double getDouble(int row);
 
+  /**
+   * Fetch the double value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @param context Reader context.
+   * @return double value at row.
+   */
   double getDouble(int row, T context);
 
   /**
-   * @param row
-   * @return
+   * Fetch the String value at the specified row.
+   *
+   * @param row Row for which to fetch the value.
+   * @return String value at row.
    */
   String getString(int row);
 
   /**
+   * Fetch String value for the given row.
    *
    * @param row Row for which to get the string.
    * @param context Reader context.
-   * @return String at the given row
+   * @return String at row.
    */
   String getString(int row, T context);
 
   /**
-   * @param row
-   * @return
+   * Fetch the byte[] value for the given row.
+   *
+   * @param row Row for which to get the byte[].
+   * @return byte[] value at row.
    */
   byte[] getBytes(int row);
 
+  /**
+   * Fetch the byte[] value for the given row.
+   *
+   * @param row Row for which to get the byte[].
+   * @param context Reader context.
+   * @return byte[] byte[] at the given row
+   */
+  byte[] getBytes(int row, T context);
+
+  /**
+   * Read a specified number of values from a given start offset.
+   *
+   * @param rows Array containing rows id's to read.
+   * @param rowStartPos Start offset in 'rows' array.
+   * @param rowSize Number of elements to read from 'rows'.
+   * @param values Output array
+   * @param valuesStartPos Start offset of 'values' array to write the values.
+   */
   void readValues(int[] rows, int rowStartPos, int rowSize, int[] values, int valuesStartPos);
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
@@ -18,7 +18,6 @@ package com.linkedin.pinot.core.io.reader.impl.v1;
 import com.linkedin.pinot.core.io.reader.impl.ChunkReaderContext;
 import com.linkedin.pinot.core.io.writer.impl.v1.VarByteChunkSingleValueWriter;
 import com.linkedin.pinot.core.segment.memory.PinotDataBuffer;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
@@ -38,7 +37,6 @@ public class VarByteChunkSingleValueReader extends BaseChunkSingleValueReader {
    * Constructor for the class.
    *
    * @param pinotDataBuffer Data buffer to read from
-   * @throws IOException
    */
   public VarByteChunkSingleValueReader(PinotDataBuffer pinotDataBuffer) {
     super(pinotDataBuffer);
@@ -58,29 +56,65 @@ public class VarByteChunkSingleValueReader extends BaseChunkSingleValueReader {
     ByteBuffer chunkBuffer = getChunkForRow(row, context);
 
     int rowOffset = chunkBuffer.getInt(chunkRowId * INT_SIZE);
-    int nextRowOffset;
-
-    if (chunkRowId == _numDocsPerChunk - 1) {
-      // Last row in this trunk.
-      nextRowOffset = chunkBuffer.limit();
-    } else {
-      nextRowOffset = chunkBuffer.getInt((chunkRowId + 1) * INT_SIZE);
-      // For incomplete chunks, the next string's offset will be 0 as row offset for absent rows are 0.
-      if (nextRowOffset == 0) {
-        nextRowOffset = chunkBuffer.limit();
-      }
-    }
+    int nextRowOffset = getNextRowOffset(chunkRowId, chunkBuffer);
 
     int length = nextRowOffset - rowOffset;
-    chunkBuffer.position(rowOffset);
-
     byte[] bytes = _reusableBytes.get();
+
+    chunkBuffer.position(rowOffset);
     chunkBuffer.get(bytes, 0, length);
+
     return new String(bytes, 0, length, UTF_8);
+  }
+
+  @Override
+  public byte[] getBytes(int row) {
+    return getBytes(row, createContext());
+  }
+
+  @Override
+  public byte[] getBytes(int row, ChunkReaderContext context) {
+    int chunkRowId = row % _numDocsPerChunk;
+    ByteBuffer chunkBuffer = getChunkForRow(row, context);
+
+    int rowOffset = chunkBuffer.getInt(chunkRowId * INT_SIZE);
+    int nextRowOffset = getNextRowOffset(chunkRowId, chunkBuffer);
+
+    int length = nextRowOffset - rowOffset;
+    byte[] bytes = new byte[length];
+
+    chunkBuffer.position(rowOffset);
+    chunkBuffer.get(bytes, 0, length);
+    return bytes;
   }
 
   @Override
   public ChunkReaderContext createContext() {
     return new ChunkReaderContext(_maxChunkSize);
+  }
+
+  /**
+   * Helper method to compute the offset of next row in the chunk buffer.
+   *
+   * @param currentRowId Current row id within the chunk buffer.
+   * @param chunkBuffer Chunk buffer containing the rows.
+   *
+   * @return Offset of next row within the chunk buffer. If current row is the last one,
+   * chunkBuffer.limit() is returned.
+   */
+  private int getNextRowOffset(int currentRowId, ByteBuffer chunkBuffer) {
+    int nextRowOffset;
+
+    if (currentRowId == _numDocsPerChunk - 1) {
+      // Last row in this trunk.
+      nextRowOffset = chunkBuffer.limit();
+    } else {
+      nextRowOffset = chunkBuffer.getInt((currentRowId + 1) * INT_SIZE);
+      // For incomplete chunks, the next string's offset will be 0 as row offset for absent rows are 0.
+      if (nextRowOffset == 0) {
+        nextRowOffset = chunkBuffer.limit();
+      }
+    }
+    return nextRowOffset;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/BaseSingleColumnSingleValueReaderWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/readerwriter/BaseSingleColumnSingleValueReaderWriter.java
@@ -89,6 +89,11 @@ public abstract class BaseSingleColumnSingleValueReaderWriter<T extends ReaderCo
   }
 
   @Override
+  public byte[] getBytes(int row, ReaderContext context) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void readValues(int[] rows, int rowStartPos, int rowSize, int[] values, int valuesStartPos) {
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/FixedByteChunkSingleValueWriter.java
@@ -101,6 +101,13 @@ public class FixedByteChunkSingleValueWriter extends BaseChunkSingleValueWriter 
   }
 
   @Override
+  public void setBytes(int row, byte[] bytes) {
+    _chunkBuffer.put(bytes);
+    _chunkDataOffset += bytes.length;
+    flushChunkIfNeeded();
+  }
+
+  @Override
   protected void writeChunk() {
     super.writeChunk();
     _chunkDataOffset = 0;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
@@ -80,24 +80,22 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
   @Override
   public void setString(int row, String string) {
     byte[] bytes = string.getBytes(UTF_8);
-    int length = bytes.length;
+    setBytes(row, bytes);
+  }
 
+  @Override
+  public void setBytes(int row, byte[] bytes) {
     _chunkBuffer.putInt(_chunkHeaderOffset, _chunkDataOffSet);
     _chunkHeaderOffset += INT_SIZE;
 
     _chunkBuffer.position(_chunkDataOffSet);
     _chunkBuffer.put(bytes);
-    _chunkDataOffSet += length;
+    _chunkDataOffSet += bytes.length;
 
     // If buffer filled, then compress and write to file.
     if (_chunkHeaderOffset == _chunkHeaderSize) {
       writeChunk();
     }
-  }
-
-  @Override
-  public void setBytes(int row, byte[] bytes) {
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/VarByteChunkSingleValueReaderWriteTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/VarByteChunkSingleValueReaderWriteTest.java
@@ -39,14 +39,14 @@ import org.testng.annotations.Test;
 public class VarByteChunkSingleValueReaderWriteTest {
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  private static final int NUM_STRINGS = 5003;
+  private static final int NUM_ENTRIES = 5003;
   private static final int NUM_DOCS_PER_CHUNK = 1009;
   private static final int MAX_STRING_LENGTH = 101;
   private static final String TEST_FILE = System.getProperty("java.io.tmpdir") + File.separator + "varByteSVRTest";
 
   /**
-   * This test writes {@link #NUM_STRINGS} using {@link VarByteChunkSingleValueWriter}. It then reads
-   * the strings using {@link VarByteChunkSingleValueReader}, and asserts that what was written is the same as
+   * This test writes {@link #NUM_ENTRIES} using {@link VarByteChunkSingleValueWriter}. It then reads
+   * the strings & bytes using {@link VarByteChunkSingleValueReader}, and asserts that what was written is the same as
    * what was read in.
    *
    * Number of docs and docs per chunk are chosen to generate complete as well partial chunks.
@@ -56,26 +56,28 @@ public class VarByteChunkSingleValueReaderWriteTest {
   @Test
   public void test()
       throws Exception {
-    String[] expected = new String[NUM_STRINGS];
+    String[] expected = new String[NUM_ENTRIES];
     Random random = new Random();
 
     File outFile = new File(TEST_FILE);
     FileUtils.deleteQuietly(outFile);
 
     int maxStringLengthInBytes = 0;
-    for (int i = 0; i < NUM_STRINGS; i++) {
+    for (int i = 0; i < NUM_ENTRIES; i++) {
       expected[i] = RandomStringUtils.random(random.nextInt(MAX_STRING_LENGTH));
       maxStringLengthInBytes = Math.max(maxStringLengthInBytes, expected[i].getBytes(UTF_8).length);
     }
 
     ChunkCompressorFactory.CompressionType compressionType = ChunkCompressorFactory.CompressionType.SNAPPY;
     VarByteChunkSingleValueWriter writer =
-        new VarByteChunkSingleValueWriter(outFile, compressionType, NUM_STRINGS, NUM_DOCS_PER_CHUNK,
+        new VarByteChunkSingleValueWriter(outFile, compressionType, NUM_ENTRIES, NUM_DOCS_PER_CHUNK,
             maxStringLengthInBytes);
 
-    for (int i = 0; i < NUM_STRINGS; i++) {
+    for (int i = 0; i < NUM_ENTRIES; i += 2) {
       writer.setString(i, expected[i]);
+      writer.setBytes(i + 1, expected[i].getBytes(UTF_8));
     }
+
     writer.close();
 
     PinotDataBuffer pinotDataBuffer =
@@ -84,9 +86,11 @@ public class VarByteChunkSingleValueReaderWriteTest {
     VarByteChunkSingleValueReader reader = new VarByteChunkSingleValueReader(pinotDataBuffer);
     ChunkReaderContext context = reader.createContext();
 
-    for (int i = 0; i < NUM_STRINGS; i++) {
+    for (int i = 0; i < NUM_ENTRIES; i += 2) {
       String actual = reader.getString(i, context);
       Assert.assertEquals(actual, expected[i]);
+      Assert.assertEquals(actual.getBytes(UTF_8), expected[i].getBytes(UTF_8));
+      Assert.assertEquals(reader.getBytes(i + 1), expected[i].getBytes(UTF_8));
     }
     reader.close();
     FileUtils.deleteQuietly(outFile);


### PR DESCRIPTION
This is one of many PR's for BYTE_ARRAY data type support.
- Enhanced fixed and variable length Chunk based readers/writers to
  support byte-arrays.
- Enhanced SingleColumnSingleValueReader to support reading data as
  byte-arrays.
- Added unit tests to cover the new functionality.