### PR TITLE
Remove all array types from FieldSpec.DataType

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -18,9 +18,9 @@ package com.linkedin.pinot.common.data;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.avro.Schema.Type;
 
 
@@ -52,11 +52,11 @@ public abstract class FieldSpec {
   protected DataType _dataType;
   protected boolean _isSingleValueField = true;
   protected Object _defaultNullValue;
+  // Transform function to generate this column, can be based on other columns
+  protected String _transformFunction;
 
   private transient String _stringDefaultNullValue;
-  
-  //apply a transform function to generate this column, this can be based on another column
-  private String _transformFunction; 
+
 
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.
   public FieldSpec() {
@@ -183,13 +183,15 @@ public abstract class FieldSpec {
     }
   }
 
-  /**
-   * Transform function if defined else null.
-   * @return
-   */
   public String getTransformFunction() {
     return _transformFunction;
   }
+
+  // Required by JSON de-serializer. DO NOT REMOVE.
+  public void setTransformFunction(@Nonnull String transformFunction) {
+    _transformFunction = transformFunction;
+  }
+
   /**
    * Returns the {@link JsonObject} representing the field spec.
    * <p>Only contains fields with non-default value.
@@ -292,144 +294,26 @@ public abstract class FieldSpec {
   }
 
   /**
-   * The <code>DataType</code> enum is used to demonstrate the data type of a column.
-   * <p>Array <code>DataType</code> is only used in {@link DataSchema}.
-   * <p>In {@link Schema}, use non-array <code>DataType</code> only.
-   * <p>In pinot, we store data using 5 <code>DataType</code>s: INT, LONG, FLOAT, DOUBLE, STRING. All other
-   * <code>DataType</code>s will be converted to one of them.
+   * The <code>DataType</code> enum is used to demonstrate the data type of a field.
    */
   public enum DataType {
-    BOOLEAN,      // Stored as STRING.
-    BYTE,         // Stored as INT.
-    CHAR,         // Stored as STRING.
-    SHORT,        // Stored as INT.
     INT,
     LONG,
     FLOAT,
     DOUBLE,
+    BOOLEAN,  // Stored as STRING
     STRING,
-    OBJECT,       // Used in dataTable to transfer data structure.
-    //EVERYTHING AFTER THIS MUST BE ARRAY TYPE
-    BYTE_ARRAY,   // Unused.
-    CHAR_ARRAY,   // Unused.
-    SHORT_ARRAY,  // Unused.
-    INT_ARRAY,
-    LONG_ARRAY,
-    FLOAT_ARRAY,
-    DOUBLE_ARRAY,
-    STRING_ARRAY;
-
-    public boolean isNumber() {
-      switch (this) {
-        case BYTE:
-        case SHORT:
-        case INT:
-        case LONG:
-        case FLOAT:
-        case DOUBLE:
-          return true;
-        default:
-          return false;
-      }
-    }
-
-    public boolean isInteger() {
-      switch (this) {
-        case BYTE:
-        case SHORT:
-        case INT:
-        case LONG:
-          return true;
-        default:
-          return false;
-      }
-    }
-
-    public boolean isSingleValue() {
-      return this.ordinal() < BYTE_ARRAY.ordinal();
-    }
-
-    public DataType toMultiValue() {
-      switch (this) {
-        case BYTE:
-          return BYTE_ARRAY;
-        case CHAR:
-          return CHAR_ARRAY;
-        case INT:
-          return INT_ARRAY;
-        case LONG:
-          return LONG_ARRAY;
-        case FLOAT:
-          return FLOAT_ARRAY;
-        case DOUBLE:
-          return DOUBLE_ARRAY;
-        case STRING:
-          return STRING_ARRAY;
-        default:
-          throw new UnsupportedOperationException("Unsupported toMultiValue for data type: " + this);
-      }
-    }
-
-    public DataType toSingleValue() {
-      switch (this) {
-        case BYTE_ARRAY:
-          return BYTE;
-        case CHAR_ARRAY:
-          return CHAR;
-        case INT_ARRAY:
-          return INT;
-        case LONG_ARRAY:
-          return LONG;
-        case FLOAT_ARRAY:
-          return FLOAT;
-        case DOUBLE_ARRAY:
-          return DOUBLE;
-        case STRING_ARRAY:
-          return STRING;
-        default:
-          throw new UnsupportedOperationException("Unsupported toSingleValue for data type: " + this);
-      }
-    }
-
-    public boolean isCompatible(DataType anotherDataType) {
-      // Single-value is not compatible with multi-value.
-      if (isSingleValue() != anotherDataType.isSingleValue()) {
-        return false;
-      }
-      // Number is not compatible with String.
-      if (isSingleValue()) {
-        return isNumber() == anotherDataType.isNumber();
-      } else {
-        return toSingleValue().isNumber() == anotherDataType.toSingleValue().isNumber();
-      }
-    }
+    BYTES;
 
     /**
-     * Return the {@link DataType} stored in pinot.
+     * Returns the data type stored in Pinot.
      */
     public DataType getStoredType() {
-      switch (this) {
-        case BYTE:
-        case SHORT:
-        case INT:
-          return INT;
-        case LONG:
-          return LONG;
-        case FLOAT:
-          return FLOAT;
-        case DOUBLE:
-          return DOUBLE;
-        case BOOLEAN:
-        case CHAR:
-        case STRING:
-          return STRING;
-        default:
-          throw new UnsupportedOperationException("Unsupported data type: " + this);
-      }
+      return this == BOOLEAN ? STRING : this;
     }
 
     /**
-     * Return the {@link DataType} associate with the {@link Type}
+     * Returns the data type stored in Pinot that is associated with the given Avro type.
      */
     public static DataType valueOf(Type avroType) {
       switch (avroType) {
@@ -451,7 +335,7 @@ public abstract class FieldSpec {
     }
 
     /**
-     * Return number of bytes needed for storage.
+     * Returns the number of bytes needed to store the data type.
      */
     public int size() {
       switch (this) {
@@ -464,7 +348,7 @@ public abstract class FieldSpec {
         case DOUBLE:
           return 8;
         default:
-          throw new UnsupportedOperationException("Cannot get number of bytes for: " + this);
+          throw new IllegalStateException("Cannot get number of bytes for: " + this);
       }
     }
   }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/DataTable.java
@@ -19,7 +19,6 @@ import com.linkedin.pinot.common.response.ProcessingException;
 import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 
 /**
@@ -38,24 +37,14 @@ public interface DataTable {
   void addException(@Nonnull ProcessingException processingException);
 
   @Nonnull
-  byte[] toBytes()
-      throws IOException;
+  byte[] toBytes() throws IOException;
 
   @Nonnull
   Map<String, String> getMetadata();
 
-  @Nullable
   DataSchema getDataSchema();
 
   int getNumberOfRows();
-
-  boolean getBoolean(int rowId, int colId);
-
-  char getChar(int rowId, int colId);
-
-  byte getByte(int rowId, int colId);
-
-  short getShort(int rowId, int colId);
 
   int getInt(int rowId, int colId);
 
@@ -70,15 +59,6 @@ public interface DataTable {
 
   @Nonnull
   <T> T getObject(int rowId, int colId);
-
-  @Nonnull
-  byte[] getByteArray(int rowId, int colId);
-
-  @Nonnull
-  char[] getCharArray(int rowId, int colId);
-
-  @Nonnull
-  short[] getShortArray(int rowId, int colId);
 
   @Nonnull
   int[] getIntArray(int rowId, int colId);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/time/DefaultTimeConverter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/time/DefaultTimeConverter.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.common.utils.time;
 import com.linkedin.pinot.common.data.TimeGranularitySpec;
 import com.linkedin.pinot.common.data.TimeGranularitySpec.TimeFormat;
 
+
 public class DefaultTimeConverter implements TimeConverter {
 
   TimeGranularitySpec incoming;
@@ -30,17 +31,16 @@ public class DefaultTimeConverter implements TimeConverter {
     this.outgoing = outgoing;
     conversionSupported = false;
     needConversion = true;
-    if(incoming.equals(outgoing)){
+    if (incoming.equals(outgoing)) {
       needConversion = false;
     }
-    if (TimeFormat.EPOCH.toString().equals(incoming.getTimeFormat())
-        && TimeFormat.EPOCH.toString().equals(outgoing.getTimeFormat())) {
+    if (TimeFormat.EPOCH.toString().equals(incoming.getTimeFormat()) && TimeFormat.EPOCH.toString()
+        .equals(outgoing.getTimeFormat())) {
       conversionSupported = true;
     }
     if (needConversion && !conversionSupported) {
       //TODO: Handle conversion between sdf <-> epoch
-      throw new RuntimeException(
-          "Conversion from Simple Date Format to epoch/simpleDateFormat is not supported");
+      throw new RuntimeException("Conversion from Simple Date Format to epoch/simpleDateFormat is not supported");
     }
   }
 
@@ -56,32 +56,28 @@ public class DefaultTimeConverter implements TimeConverter {
       duration = Long.parseLong(incomingTimeValue.toString());
     }
     if (conversionSupported) {
-      long outgoingTime = outgoing.getTimeType().convert(duration * incoming.getTimeUnitSize(),
-          incoming.getTimeType());
+      long outgoingTime = outgoing.getTimeType().convert(duration * incoming.getTimeUnitSize(), incoming.getTimeType());
       return convertToOutgoingDataType(outgoingTime / outgoing.getTimeUnitSize());
     } else {
       //TODO: Handle conversion between sdf <-> epoch
-      throw new RuntimeException(
-          "Conversion from Simple Date Format to epoch/simpleDateFormat is not supported");
+      throw new RuntimeException("Conversion from Simple Date Format to epoch/simpleDateFormat is not supported");
     }
   }
 
   private Object convertToOutgoingDataType(long outgoingTimeValue) {
     switch (outgoing.getDataType()) {
-    case LONG:
-      return outgoingTimeValue;
-    case STRING:
-      return new Long(outgoingTimeValue).toString();
-    case INT:
-      return new Long(outgoingTimeValue).intValue();
-    case SHORT:
-      return new Long(outgoingTimeValue).shortValue();
-    case FLOAT:
-      return new Long(outgoingTimeValue).floatValue();
-    case DOUBLE:
-      return new Long(outgoingTimeValue).doubleValue();
-    default:
-      return outgoingTimeValue;
+      case INT:
+        return (int) outgoingTimeValue;
+      case LONG:
+        return outgoingTimeValue;
+      case FLOAT:
+        return (float) outgoingTimeValue;
+      case DOUBLE:
+        return (double) outgoingTimeValue;
+      case STRING:
+        return Long.toString(outgoingTimeValue);
+      default:
+        return outgoingTimeValue;
     }
   }
 }

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/data/FieldSpecTest.java
@@ -75,16 +75,6 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
     Assert.assertEquals(fieldSpec1.getDefaultNullValue(), -0.1F);
 
-    // Short type metric field.
-    fieldSpec1 = new MetricFieldSpec();
-    fieldSpec1.setName("metric");
-    fieldSpec1.setDataType(DataType.SHORT);
-    fieldSpec2 = new MetricFieldSpec("metric", DataType.SHORT);
-    Assert.assertEquals(fieldSpec1, fieldSpec2);
-    Assert.assertEquals(fieldSpec1.toString(), fieldSpec2.toString());
-    Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
-    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), 0);
-
     // Metric field with default null value.
     fieldSpec1 = new MetricFieldSpec();
     fieldSpec1.setName("metric");
@@ -303,12 +293,6 @@ public class FieldSpecTest {
   public void testSerializeDeserialize() throws Exception {
     FieldSpec first;
     FieldSpec second;
-
-    // Short type Metric field.
-    String[] metricFields = {"\"name\":\"metric\"", "\"dataType\":\"SHORT\""};
-    first = MAPPER.readValue(getRandomOrderJsonString(metricFields), MetricFieldSpec.class);
-    second = MAPPER.readValue(first.toJsonObject().toString(), MetricFieldSpec.class);
-    Assert.assertEquals(first, second, ERROR_MESSAGE);
 
     // Single-value boolean type dimension field with default null value.
     String[] dimensionFields = {"\"name\":\"dimension\"", "\"dataType\":\"BOOLEAN\"", "\"defaultNullValue\":false"};

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/DataSchemaTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.utils;
+
+import com.linkedin.pinot.common.data.FieldSpec;
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.linkedin.pinot.common.utils.DataSchema.ColumnDataType.*;
+
+
+public class DataSchemaTest {
+  private static final String[] COLUMN_NAMES =
+      {"int", "long", "float", "double", "string", "object", "int_array", "long_array", "float_array", "double_array", "string_array"};
+  private static final int NUM_COLUMNS = COLUMN_NAMES.length;
+  private static final DataSchema.ColumnDataType[] COLUMN_DATA_TYPES =
+      {INT, LONG, FLOAT, DOUBLE, STRING, OBJECT, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY};
+  private static final DataSchema.ColumnDataType[] COMPATIBLE_COLUMN_DATA_TYPES =
+      {LONG, FLOAT, DOUBLE, INT, STRING, OBJECT, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, INT_ARRAY, STRING_ARRAY};
+  private static final DataSchema.ColumnDataType[] UPGRADED_COLUMN_DATA_TYPES =
+      {LONG, DOUBLE, DOUBLE, DOUBLE, STRING, OBJECT, LONG_ARRAY, DOUBLE_ARRAY, DOUBLE_ARRAY, DOUBLE_ARRAY, STRING_ARRAY};
+
+  @Test
+  public void testGetters() {
+    DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
+    Assert.assertEquals(dataSchema.size(), NUM_COLUMNS);
+    for (int i = 0; i < NUM_COLUMNS; i++) {
+      Assert.assertEquals(dataSchema.getColumnName(i), COLUMN_NAMES[i]);
+      Assert.assertEquals(dataSchema.getColumnDataType(i), COLUMN_DATA_TYPES[i]);
+    }
+  }
+
+  @Test
+  public void testClone() {
+    DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
+    DataSchema dataSchemaClone = dataSchema.clone();
+    Assert.assertEquals(dataSchema, dataSchemaClone);
+    Assert.assertEquals(dataSchema.hashCode(), dataSchemaClone.hashCode());
+  }
+
+  @Test
+  public void testSerDe() throws Exception {
+    DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
+    DataSchema dataSchemaAfterSerDe = DataSchema.fromBytes(dataSchema.toBytes());
+    Assert.assertEquals(dataSchema, dataSchemaAfterSerDe);
+    Assert.assertEquals(dataSchema.hashCode(), dataSchemaAfterSerDe.hashCode());
+  }
+
+  @Test
+  public void testTypeCompatible() {
+    DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
+    DataSchema compatibleDataSchema = new DataSchema(COLUMN_NAMES, COMPATIBLE_COLUMN_DATA_TYPES);
+    Assert.assertTrue(dataSchema.isTypeCompatibleWith(compatibleDataSchema));
+
+    String[] anotherColumnNames = new String[NUM_COLUMNS];
+    Arrays.fill(anotherColumnNames, "foo");
+    DataSchema incompatibleDataSchema = new DataSchema(anotherColumnNames, COLUMN_DATA_TYPES);
+    Assert.assertFalse(dataSchema.isTypeCompatibleWith(incompatibleDataSchema));
+
+    dataSchema.upgradeToCover(compatibleDataSchema);
+    DataSchema upgradedDataSchema = new DataSchema(COLUMN_NAMES, UPGRADED_COLUMN_DATA_TYPES);
+    Assert.assertEquals(dataSchema, upgradedDataSchema);
+  }
+
+  @Test
+  public void testToString() {
+    DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
+    Assert.assertEquals(dataSchema.toString(),
+        "[int(INT),long(LONG),float(FLOAT),double(DOUBLE),string(STRING),object(OBJECT),int_array(INT_ARRAY),long_array(LONG_ARRAY),float_array(FLOAT_ARRAY),double_array(DOUBLE_ARRAY),string_array(STRING_ARRAY)]");
+  }
+
+  @Test
+  public void testColumnDataType() {
+    for (DataSchema.ColumnDataType columnDataType : new DataSchema.ColumnDataType[]{INT, LONG}) {
+      Assert.assertTrue(columnDataType.isNumber());
+      Assert.assertTrue(columnDataType.isWholeNumber());
+      Assert.assertFalse(columnDataType.isArray());
+      Assert.assertFalse(columnDataType.isNumberArray());
+      Assert.assertFalse(columnDataType.isWholeNumberArray());
+      Assert.assertTrue(columnDataType.isCompatible(DOUBLE));
+      Assert.assertFalse(columnDataType.isCompatible(STRING));
+      Assert.assertFalse(columnDataType.isCompatible(DOUBLE_ARRAY));
+      Assert.assertFalse(columnDataType.isCompatible(STRING_ARRAY));
+    }
+
+    for (DataSchema.ColumnDataType columnDataType : new DataSchema.ColumnDataType[]{FLOAT, DOUBLE}) {
+      Assert.assertTrue(columnDataType.isNumber());
+      Assert.assertFalse(columnDataType.isWholeNumber());
+      Assert.assertFalse(columnDataType.isArray());
+      Assert.assertFalse(columnDataType.isNumberArray());
+      Assert.assertFalse(columnDataType.isWholeNumberArray());
+      Assert.assertTrue(columnDataType.isCompatible(LONG));
+      Assert.assertFalse(columnDataType.isCompatible(STRING));
+      Assert.assertFalse(columnDataType.isCompatible(LONG_ARRAY));
+      Assert.assertFalse(columnDataType.isCompatible(STRING_ARRAY));
+    }
+
+    Assert.assertFalse(STRING.isNumber());
+    Assert.assertFalse(STRING.isWholeNumber());
+    Assert.assertFalse(STRING.isArray());
+    Assert.assertFalse(STRING.isNumberArray());
+    Assert.assertFalse(STRING.isWholeNumberArray());
+    Assert.assertFalse(STRING.isCompatible(DOUBLE));
+    Assert.assertTrue(STRING.isCompatible(STRING));
+    Assert.assertFalse(STRING.isCompatible(DOUBLE_ARRAY));
+    Assert.assertFalse(STRING.isCompatible(STRING_ARRAY));
+
+    Assert.assertFalse(OBJECT.isNumber());
+    Assert.assertFalse(OBJECT.isWholeNumber());
+    Assert.assertFalse(OBJECT.isArray());
+    Assert.assertFalse(OBJECT.isNumberArray());
+    Assert.assertFalse(OBJECT.isWholeNumberArray());
+    Assert.assertFalse(OBJECT.isCompatible(DOUBLE));
+    Assert.assertFalse(OBJECT.isCompatible(STRING));
+    Assert.assertFalse(OBJECT.isCompatible(DOUBLE_ARRAY));
+    Assert.assertFalse(OBJECT.isCompatible(STRING_ARRAY));
+    Assert.assertTrue(OBJECT.isCompatible(OBJECT));
+
+    for (DataSchema.ColumnDataType columnDataType : new DataSchema.ColumnDataType[]{INT_ARRAY, LONG_ARRAY}) {
+      Assert.assertFalse(columnDataType.isNumber());
+      Assert.assertFalse(columnDataType.isWholeNumber());
+      Assert.assertTrue(columnDataType.isArray());
+      Assert.assertTrue(columnDataType.isNumberArray());
+      Assert.assertTrue(columnDataType.isWholeNumberArray());
+      Assert.assertFalse(columnDataType.isCompatible(DOUBLE));
+      Assert.assertFalse(columnDataType.isCompatible(STRING));
+      Assert.assertTrue(columnDataType.isCompatible(DOUBLE_ARRAY));
+      Assert.assertFalse(columnDataType.isCompatible(STRING_ARRAY));
+    }
+
+    for (DataSchema.ColumnDataType columnDataType : new DataSchema.ColumnDataType[]{FLOAT_ARRAY, DOUBLE_ARRAY}) {
+      Assert.assertFalse(columnDataType.isNumber());
+      Assert.assertFalse(columnDataType.isWholeNumber());
+      Assert.assertTrue(columnDataType.isArray());
+      Assert.assertTrue(columnDataType.isNumberArray());
+      Assert.assertFalse(columnDataType.isWholeNumberArray());
+      Assert.assertFalse(columnDataType.isCompatible(LONG));
+      Assert.assertFalse(columnDataType.isCompatible(STRING));
+      Assert.assertTrue(columnDataType.isCompatible(LONG_ARRAY));
+      Assert.assertFalse(columnDataType.isCompatible(STRING_ARRAY));
+    }
+
+    Assert.assertFalse(STRING_ARRAY.isNumber());
+    Assert.assertFalse(STRING_ARRAY.isWholeNumber());
+    Assert.assertTrue(STRING_ARRAY.isArray());
+    Assert.assertFalse(STRING_ARRAY.isNumberArray());
+    Assert.assertFalse(STRING_ARRAY.isWholeNumberArray());
+    Assert.assertFalse(STRING_ARRAY.isCompatible(DOUBLE));
+    Assert.assertFalse(STRING_ARRAY.isCompatible(STRING));
+    Assert.assertFalse(STRING_ARRAY.isCompatible(DOUBLE_ARRAY));
+    Assert.assertTrue(STRING_ARRAY.isCompatible(STRING_ARRAY));
+
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.INT, true), INT);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.INT, false), INT_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.LONG, true), LONG);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.LONG, false), LONG_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.FLOAT, true), FLOAT);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.FLOAT, false), FLOAT_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.DOUBLE, true), DOUBLE);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.DOUBLE, false), DOUBLE_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, true), STRING);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, false), STRING_ARRAY);
+  }
+}

--- a/pinot-common/src/test/resources/schemaTest.schema
+++ b/pinot-common/src/test/resources/schemaTest.schema
@@ -1,16 +1,6 @@
 {
   "metricFieldSpecs": [
     {
-      "name": "byteMetric",
-      "dataType": "BYTE",
-      "defaultNullValue": "-1"
-    },
-    {
-      "name": "shortMetric",
-      "dataType": "SHORT",
-      "singleValueField": true
-    },
-    {
       "name": "intMetric",
       "dataType": "INT",
       "defaultNullValue": -2
@@ -36,23 +26,6 @@
       "name": "booleanDimension",
       "dataType": "BOOLEAN",
       "defaultNullValue": false
-    },
-    {
-      "name": "byteDimension",
-      "dataType": "BYTE",
-      "singleValueField": true,
-      "delimiter": null
-    },
-    {
-      "name": "charDimension",
-      "dataType": "CHAR",
-      "singleValueField": false,
-      "defaultNullValue": "%"
-    },
-    {
-      "name": "shortDimension",
-      "dataType": "SHORT",
-      "delimiter": null
     },
     {
       "name": "intDimension",

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableBuilder.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.common.datatable;
 
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.Selection;
@@ -154,7 +153,7 @@ public class DataTableBuilder {
     if (dictionary == null) {
       dictionary = new HashMap<>();
       _dictionaryMap.put(columnName, dictionary);
-      _reverseDictionaryMap.put(columnName, new HashMap<Integer, String>());
+      _reverseDictionaryMap.put(columnName, new HashMap<>());
     }
 
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
@@ -167,8 +166,7 @@ public class DataTableBuilder {
     _currentRowDataByteBuffer.putInt(dictId);
   }
 
-  public void setColumn(int colId, @Nonnull Object value)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull Object value) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     byte[] bytes = ObjectCustomSerDe.serialize(value);
@@ -186,8 +184,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void setColumn(int colId, @Nonnull char[] values)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull char[] values) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
@@ -196,8 +193,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void setColumn(int colId, @Nonnull short[] values)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull short[] values) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
@@ -206,8 +202,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void setColumn(int colId, @Nonnull int[] values)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull int[] values) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
@@ -216,8 +211,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void setColumn(int colId, @Nonnull long[] values)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull long[] values) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
@@ -226,8 +220,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void setColumn(int colId, @Nonnull float[] values)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull float[] values) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
@@ -236,8 +229,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void setColumn(int colId, @Nonnull double[] values)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull double[] values) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
@@ -246,8 +238,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void setColumn(int colId, @Nonnull String[] values)
-      throws IOException {
+  public void setColumn(int colId, @Nonnull String[] values) throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
@@ -257,7 +248,7 @@ public class DataTableBuilder {
     if (dictionary == null) {
       dictionary = new HashMap<>();
       _dictionaryMap.put(columnName, dictionary);
-      _reverseDictionaryMap.put(columnName, new HashMap<Integer, String>());
+      _reverseDictionaryMap.put(columnName, new HashMap<>());
     }
 
     for (String value : values) {
@@ -271,8 +262,7 @@ public class DataTableBuilder {
     }
   }
 
-  public void finishRow()
-      throws IOException {
+  public void finishRow() throws IOException {
     _fixedSizeDataByteArrayOutputStream.write(_currentRowDataByteBuffer.array());
   }
 
@@ -284,17 +274,17 @@ public class DataTableBuilder {
   /**
    * Build an empty data table based on the broker request.
    */
-  public static DataTable buildEmptyDataTable(BrokerRequest brokerRequest)
-      throws IOException {
+  public static DataTable buildEmptyDataTable(BrokerRequest brokerRequest) throws IOException {
     // Selection query.
     if (brokerRequest.isSetSelections()) {
       Selection selection = brokerRequest.getSelections();
       List<String> selectionColumns = selection.getSelectionColumns();
       int numSelectionColumns = selectionColumns.size();
-      FieldSpec.DataType[] dataTypes = new FieldSpec.DataType[numSelectionColumns];
-      // Use STRING data type as default for selection query.
-      Arrays.fill(dataTypes, FieldSpec.DataType.STRING);
-      DataSchema dataSchema = new DataSchema(selectionColumns.toArray(new String[numSelectionColumns]), dataTypes);
+      DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numSelectionColumns];
+      // Use STRING column data type as default for selection query.
+      Arrays.fill(columnDataTypes, DataSchema.ColumnDataType.STRING);
+      DataSchema dataSchema =
+          new DataSchema(selectionColumns.toArray(new String[numSelectionColumns]), columnDataTypes);
       return new DataTableBuilder(dataSchema).build();
     }
 
@@ -309,10 +299,11 @@ public class DataTableBuilder {
       // Aggregation group-by query.
 
       String[] columnNames = new String[]{"functionName", "GroupByResultMap"};
-      FieldSpec.DataType[] columnTypes = new FieldSpec.DataType[]{FieldSpec.DataType.STRING, FieldSpec.DataType.OBJECT};
+      DataSchema.ColumnDataType[] columnDataTypes =
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.OBJECT};
 
       // Build the data table.
-      DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnTypes));
+      DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnDataTypes));
       for (int i = 0; i < numAggregations; i++) {
         dataTableBuilder.startRow();
         dataTableBuilder.setColumn(0, aggregationFunctionContexts[i].getAggregationColumnName());
@@ -324,22 +315,22 @@ public class DataTableBuilder {
       // Aggregation only query.
 
       String[] aggregationColumnNames = new String[numAggregations];
-      FieldSpec.DataType[] dataTypes = new FieldSpec.DataType[numAggregations];
+      DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numAggregations];
       Object[] aggregationResults = new Object[numAggregations];
       for (int i = 0; i < numAggregations; i++) {
         AggregationFunctionContext aggregationFunctionContext = aggregationFunctionContexts[i];
         aggregationColumnNames[i] = aggregationFunctionContext.getAggregationColumnName();
         AggregationFunction aggregationFunction = aggregationFunctionContext.getAggregationFunction();
-        dataTypes[i] = aggregationFunction.getIntermediateResultDataType();
+        columnDataTypes[i] = aggregationFunction.getIntermediateResultColumnType();
         aggregationResults[i] =
             aggregationFunction.extractAggregationResult(aggregationFunction.createAggregationResultHolder());
       }
 
       // Build the data table.
-      DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(aggregationColumnNames, dataTypes));
+      DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(aggregationColumnNames, columnDataTypes));
       dataTableBuilder.startRow();
       for (int i = 0; i < numAggregations; i++) {
-        switch (dataTypes[i]) {
+        switch (columnDataTypes[i]) {
           case LONG:
             dataTableBuilder.setColumn(i, ((Number) aggregationResults[i]).longValue());
             break;
@@ -351,7 +342,7 @@ public class DataTableBuilder {
             break;
           default:
             throw new UnsupportedOperationException(
-                "Unsupported aggregation column data type: " + dataTypes[i] + " for column: "
+                "Unsupported aggregation column data type: " + columnDataTypes[i] + " for column: "
                     + aggregationColumnNames[i]);
         }
       }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableImplV2.java
@@ -354,30 +354,6 @@ public class DataTableImplV2 implements DataTable {
   }
 
   @Override
-  public boolean getBoolean(int rowId, int colId) {
-    _fixedSizeData.position(rowId * _rowSizeInBytes + _columnOffsets[colId]);
-    return _fixedSizeData.get() == 1;
-  }
-
-  @Override
-  public char getChar(int rowId, int colId) {
-    _fixedSizeData.position(rowId * _rowSizeInBytes + _columnOffsets[colId]);
-    return _fixedSizeData.getChar();
-  }
-
-  @Override
-  public byte getByte(int rowId, int colId) {
-    _fixedSizeData.position(rowId * _rowSizeInBytes + _columnOffsets[colId]);
-    return _fixedSizeData.get();
-  }
-
-  @Override
-  public short getShort(int rowId, int colId) {
-    _fixedSizeData.position(rowId * _rowSizeInBytes + _columnOffsets[colId]);
-    return _fixedSizeData.getShort();
-  }
-
-  @Override
   public int getInt(int rowId, int colId) {
     _fixedSizeData.position(rowId * _rowSizeInBytes + _columnOffsets[colId]);
     return _fixedSizeData.getInt();
@@ -421,39 +397,6 @@ public class DataTableImplV2 implements DataTable {
     } catch (IOException e) {
       throw new RuntimeException("Caught exception while de-serializing object.", e);
     }
-  }
-
-  @Nonnull
-  @Override
-  public byte[] getByteArray(int rowId, int colId) {
-    int length = positionCursorInVariableBuffer(rowId, colId);
-    byte[] bytes = new byte[length];
-    for (int i = 0; i < length; i++) {
-      bytes[i] = _variableSizeData.get();
-    }
-    return bytes;
-  }
-
-  @Nonnull
-  @Override
-  public char[] getCharArray(int rowId, int colId) {
-    int length = positionCursorInVariableBuffer(rowId, colId);
-    char[] chars = new char[length];
-    for (int i = 0; i < length; i++) {
-      chars[i] = _variableSizeData.getChar();
-    }
-    return chars;
-  }
-
-  @Nonnull
-  @Override
-  public short[] getShortArray(int rowId, int colId) {
-    int length = positionCursorInVariableBuffer(rowId, colId);
-    short[] shorts = new short[length];
-    for (int i = 0; i < length; i++) {
-      shorts[i] = _variableSizeData.getShort();
-    }
-    return shorts;
   }
 
   @Nonnull
@@ -531,19 +474,7 @@ public class DataTableImplV2 implements DataTable {
     _fixedSizeData.position(0);
     for (int rowId = 0; rowId < _numRows; rowId++) {
       for (int colId = 0; colId < _numColumns; colId++) {
-        switch (_dataSchema.getColumnType(colId)) {
-          case BOOLEAN:
-            stringBuilder.append(_fixedSizeData.get());
-            break;
-          case BYTE:
-            stringBuilder.append(_fixedSizeData.get());
-            break;
-          case CHAR:
-            stringBuilder.append(_fixedSizeData.getChar());
-            break;
-          case SHORT:
-            stringBuilder.append(_fixedSizeData.getShort());
-            break;
+        switch (_dataSchema.getColumnDataType(colId)) {
           case INT:
             stringBuilder.append(_fixedSizeData.getInt());
             break;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/common/datatable/DataTableUtils.java
@@ -41,19 +41,7 @@ public class DataTableUtils {
     int rowSizeInBytes = 0;
     for (int i = 0; i < numColumns; i++) {
       columnOffsets[i] = rowSizeInBytes;
-      switch (dataSchema.getColumnType(i)) {
-        case BOOLEAN:
-          rowSizeInBytes += 1;
-          break;
-        case BYTE:
-          rowSizeInBytes += 1;
-          break;
-        case CHAR:
-          rowSizeInBytes += 2;
-          break;
-        case SHORT:
-          rowSizeInBytes += 2;
-          break;
+      switch (dataSchema.getColumnDataType(i)) {
         case INT:
           rowSizeInBytes += 4;
           break;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PinotDataType.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/extractors/PinotDataType.java
@@ -15,45 +15,23 @@
  */
 package com.linkedin.pinot.core.data.extractors;
 
-import com.google.common.base.Preconditions;
 import com.linkedin.pinot.common.data.FieldSpec;
 
 
 /**
  *  The <code>PinotDataType</code> enum represents the data type of a value in a row from recordReader and provides
  *  utility methods to convert value across types if applicable.
- *  <p>
- *  We don't use <code>PinotDataType</code> to maintain type information, but use it to help organize the data and use
- *  {@link com.linkedin.pinot.common.data.FieldSpec.DataType} to maintain type information separately across
- *  various readers.
+ *  <p>We don't use <code>PinotDataType</code> to maintain type information, but use it to help organize the data and
+ *  use {@link FieldSpec.DataType} to maintain type information separately across various readers.
  *  <p>NOTE:
- *  <p>- a. we will silently lose information if a conversion causes us to do so (e.g. Integer to Byte).
- *  <p>- b. We will throw exceptions if a conversion is not possible (e.g. Boolean to Byte).
- *  <p>- c. we will throw exceptions if the conversion throw exceptions (e.g. String -> Short, where parsing string
- *  throw exceptions)
+ *  <ul>
+ *    <li>We will silently lose information if a conversion causes us to do so (e.g. DOUBLE to INT)</li>
+ *    <li>We will throw exception if a conversion is not possible (e.g. BOOLEAN to INT).</li>
+ *    <li>We will throw exception if the conversion throws exception (e.g. "foo" -> INT)</li>
+ *  </ul>
  */
 public enum PinotDataType {
   BOOLEAN {
-    @Override
-    public Boolean toBoolean(Object value) {
-      return (Boolean) value;
-    }
-
-    @Override
-    public Byte toByte(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value: " + value + " from: BOOLEAN to: BYTE");
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value: " + value + " from: BOOLEAN to: CHARACTER");
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value: " + value + " from: BOOLEAN to: SHORT");
-    }
-
     @Override
     public Integer toInteger(Object value) {
       throw new UnsupportedOperationException("Cannot convert value: " + value + " from: BOOLEAN to: INTEGER");
@@ -76,26 +54,12 @@ public enum PinotDataType {
 
     @Override
     public Boolean convert(Object value, PinotDataType sourceType) {
-      return sourceType.toBoolean(value);
+      throw new UnsupportedOperationException(
+          "Cannot convert value: " + value + "from: " + sourceType + " to: BOOLEAN");
     }
   },
 
   BYTE {
-    @Override
-    public Byte toByte(Object value) {
-      return (Byte) value;
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return (char) ((Byte) value).shortValue();
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return ((Byte) value).shortValue();
-    }
-
     @Override
     public Integer toInteger(Object value) {
       return ((Byte) value).intValue();
@@ -118,26 +82,11 @@ public enum PinotDataType {
 
     @Override
     public Byte convert(Object value, PinotDataType sourceType) {
-      return sourceType.toByte(value);
+      throw new UnsupportedOperationException("Cannot convert value: " + value + "from: " + sourceType + " to: BYTE");
     }
   },
 
   CHARACTER {
-    @Override
-    public Byte toByte(Object value) {
-      return (byte) ((Character) value).charValue();
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return (Character) value;
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return (short) ((Character) value).charValue();
-    }
-
     @Override
     public Integer toInteger(Object value) {
       return (int) ((Character) value);
@@ -160,26 +109,12 @@ public enum PinotDataType {
 
     @Override
     public Character convert(Object value, PinotDataType sourceType) {
-      return sourceType.toCharacter(value);
+      throw new UnsupportedOperationException(
+          "Cannot convert value: " + value + "from: " + sourceType + " to: CHARACTER");
     }
   },
 
   SHORT {
-    @Override
-    public Byte toByte(Object value) {
-      return ((Short) value).byteValue();
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return (char) ((Short) value).shortValue();
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return (Short) value;
-    }
-
     @Override
     public Integer toInteger(Object value) {
       return ((Short) value).intValue();
@@ -202,26 +137,11 @@ public enum PinotDataType {
 
     @Override
     public Short convert(Object value, PinotDataType sourceType) {
-      return sourceType.toShort(value);
+      throw new UnsupportedOperationException("Cannot convert value: " + value + "from: " + sourceType + " to: SHORT");
     }
   },
 
   INTEGER {
-    @Override
-    public Byte toByte(Object value) {
-      return ((Integer) value).byteValue();
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return (char) ((Integer) value).shortValue();
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return ((Integer) value).shortValue();
-    }
-
     @Override
     public Integer toInteger(Object value) {
       return (Integer) value;
@@ -250,21 +170,6 @@ public enum PinotDataType {
 
   LONG {
     @Override
-    public Byte toByte(Object value) {
-      return ((Long) value).byteValue();
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return (char) ((Long) value).shortValue();
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return ((Long) value).shortValue();
-    }
-
-    @Override
     public Integer toInteger(Object value) {
       return ((Long) value).intValue();
     }
@@ -291,21 +196,6 @@ public enum PinotDataType {
   },
 
   FLOAT {
-    @Override
-    public Byte toByte(Object value) {
-      return ((Float) value).byteValue();
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return (char) ((Float) value).shortValue();
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return ((Float) value).shortValue();
-    }
-
     @Override
     public Integer toInteger(Object value) {
       return ((Float) value).intValue();
@@ -334,21 +224,6 @@ public enum PinotDataType {
 
   DOUBLE {
     @Override
-    public Byte toByte(Object value) {
-      return ((Double) value).byteValue();
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return (char) ((Double) value).shortValue();
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return ((Double) value).shortValue();
-    }
-
-    @Override
     public Integer toInteger(Object value) {
       return ((Double) value).intValue();
     }
@@ -376,26 +251,6 @@ public enum PinotDataType {
 
   STRING {
     @Override
-    public Boolean toBoolean(Object value) {
-      return Boolean.parseBoolean((String) value);
-    }
-
-    @Override
-    public Byte toByte(Object value) {
-      return Byte.parseByte((String) value);
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      return ((String) value).charAt(0);
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      return Short.parseShort((String) value);
-    }
-
-    @Override
     public Integer toInteger(Object value) {
       return Integer.parseInt((String) value);
     }
@@ -422,21 +277,6 @@ public enum PinotDataType {
   },
 
   OBJECT {
-    @Override
-    public Byte toByte(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value: " + value + " from: OBJECT to: BYTE");
-    }
-
-    @Override
-    public Character toCharacter(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value: " + value + " from: OBJECT to: CHARACTER");
-    }
-
-    @Override
-    public Short toShort(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value: " + value + " from: OBJECT to: SHORT");
-    }
-
     @Override
     public Integer toInteger(Object value) {
       throw new UnsupportedOperationException("Cannot convert value: " + value + " from: OBJECT to: INTEGER");
@@ -466,21 +306,24 @@ public enum PinotDataType {
   BYTE_ARRAY {
     @Override
     public Byte[] convert(Object value, PinotDataType sourceType) {
-      return sourceType.toByteArray(value);
+      throw new UnsupportedOperationException(
+          "Cannot convert value: " + value + "from: " + sourceType + " to: BYTE_ARRAY");
     }
   },
 
   CHARACTER_ARRAY {
     @Override
     public Character[] convert(Object value, PinotDataType sourceType) {
-      return sourceType.toCharacterArray(value);
+      throw new UnsupportedOperationException(
+          "Cannot convert value: " + value + "from: " + sourceType + " to: CHARACTER_ARRAY");
     }
   },
 
   SHORT_ARRAY {
     @Override
     public Short[] convert(Object value, PinotDataType sourceType) {
-      return sourceType.toShortArray(value);
+      throw new UnsupportedOperationException(
+          "Cannot convert value: " + value + "from: " + sourceType + " to: SHORT_ARRAY");
     }
   },
 
@@ -514,11 +357,6 @@ public enum PinotDataType {
 
   STRING_ARRAY {
     @Override
-    public Boolean toBoolean(Object value) {
-      return STRING.toBoolean(((Object[]) value)[0]);
-    }
-
-    @Override
     public String[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toStringArray(value);
     }
@@ -531,22 +369,6 @@ public enum PinotDataType {
           "Cannot convert value: " + value + "from: " + sourceType + " to: OBJECT_ARRAY");
     }
   };
-
-  public Boolean toBoolean(Object value) {
-    throw new UnsupportedOperationException("Cannot convert value: " + value + " from: " + this + " to: BOOLEAN");
-  }
-
-  public Byte toByte(Object value) {
-    return getSingleValueType().toByte(((Object[]) value)[0]);
-  }
-
-  public Character toCharacter(Object value) {
-    return getSingleValueType().toCharacter(((Object[]) value)[0]);
-  }
-
-  public Short toShort(Object value) {
-    return getSingleValueType().toShort(((Object[]) value)[0]);
-  }
 
   public Integer toInteger(Object value) {
     return getSingleValueType().toInteger(((Object[]) value)[0]);
@@ -569,51 +391,6 @@ public enum PinotDataType {
       return value.toString();
     } else {
       return ((Object[]) value)[0].toString();
-    }
-  }
-
-  public Byte[] toByteArray(Object value) {
-    if (isSingleValue()) {
-      return new Byte[]{toByte(value)};
-    } else {
-      Object[] valueArray = (Object[]) value;
-      int length = valueArray.length;
-      Byte[] byteArray = new Byte[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        byteArray[i] = singleValueType.toByte(valueArray[i]);
-      }
-      return byteArray;
-    }
-  }
-
-  public Character[] toCharacterArray(Object value) {
-    if (isSingleValue()) {
-      return new Character[]{toCharacter(value)};
-    } else {
-      Object[] valueArray = (Object[]) value;
-      int length = valueArray.length;
-      Character[] characterArray = new Character[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        characterArray[i] = singleValueType.toCharacter(valueArray[i]);
-      }
-      return characterArray;
-    }
-  }
-
-  public Short[] toShortArray(Object value) {
-    if (isSingleValue()) {
-      return new Short[]{toShort(value)};
-    } else {
-      Object[] valueArray = (Object[]) value;
-      int length = valueArray.length;
-      Short[] shortArray = new Short[length];
-      PinotDataType singleValueType = getSingleValueType();
-      for (int i = 0; i < length; i++) {
-        shortArray[i] = singleValueType.toShort(valueArray[i]);
-      }
-      return shortArray;
     }
   }
 
@@ -695,7 +472,7 @@ public enum PinotDataType {
   public abstract Object convert(Object value, PinotDataType sourceType);
 
   public boolean isSingleValue() {
-    return this.ordinal() < BYTE_ARRAY.ordinal();
+    return this.ordinal() <= OBJECT.ordinal();
   }
 
   public PinotDataType getSingleValueType() {
@@ -726,15 +503,6 @@ public enum PinotDataType {
   public static PinotDataType getPinotDataType(FieldSpec fieldSpec) {
     FieldSpec.DataType dataType = fieldSpec.getDataType();
     switch (dataType) {
-      case BOOLEAN:
-        Preconditions.checkArgument(fieldSpec.isSingleValueField());
-        return PinotDataType.BOOLEAN;
-      case BYTE:
-        return fieldSpec.isSingleValueField() ? PinotDataType.BYTE : PinotDataType.BYTE_ARRAY;
-      case CHAR:
-        return fieldSpec.isSingleValueField() ? PinotDataType.CHARACTER : PinotDataType.CHARACTER_ARRAY;
-      case SHORT:
-        return fieldSpec.isSingleValueField() ? PinotDataType.SHORT : PinotDataType.SHORT_ARRAY;
       case INT:
         return fieldSpec.isSingleValueField() ? PinotDataType.INTEGER : PinotDataType.INTEGER_ARRAY;
       case LONG:

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.operator.blocks;
 
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.response.ProcessingException;
 import com.linkedin.pinot.common.utils.DataSchema;
@@ -212,18 +211,18 @@ public class IntermediateResultsBlock implements Block {
     // Extract each aggregation column name and type from aggregation function context.
     int numAggregationFunctions = _aggregationFunctionContexts.length;
     String[] columnNames = new String[numAggregationFunctions];
-    FieldSpec.DataType[] columnTypes = new FieldSpec.DataType[numAggregationFunctions];
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {
       AggregationFunctionContext aggregationFunctionContext = _aggregationFunctionContexts[i];
       columnNames[i] = aggregationFunctionContext.getAggregationColumnName();
-      columnTypes[i] = aggregationFunctionContext.getAggregationFunction().getIntermediateResultDataType();
+      columnDataTypes[i] = aggregationFunctionContext.getAggregationFunction().getIntermediateResultColumnType();
     }
 
     // Build the data table.
-    DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnTypes));
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnDataTypes));
     dataTableBuilder.startRow();
     for (int i = 0; i < numAggregationFunctions; i++) {
-      switch (columnTypes[i]) {
+      switch (columnDataTypes[i]) {
         case LONG:
           dataTableBuilder.setColumn(i, ((Number) _aggregationResult.get(i)).longValue());
           break;
@@ -235,7 +234,7 @@ public class IntermediateResultsBlock implements Block {
           break;
         default:
           throw new UnsupportedOperationException(
-              "Unsupported aggregation column data type: " + columnTypes[i] + " for column: " + columnNames[i]);
+              "Unsupported aggregation column data type: " + columnDataTypes[i] + " for column: " + columnNames[i]);
       }
     }
     dataTableBuilder.finishRow();
@@ -245,13 +244,13 @@ public class IntermediateResultsBlock implements Block {
   }
 
   @Nonnull
-  private DataTable getAggregationGroupByResultDataTable()
-      throws Exception {
+  private DataTable getAggregationGroupByResultDataTable() throws Exception {
     String[] columnNames = new String[]{"functionName", "GroupByResultMap"};
-    FieldSpec.DataType[] columnTypes = new FieldSpec.DataType[]{FieldSpec.DataType.STRING, FieldSpec.DataType.OBJECT};
+    DataSchema.ColumnDataType[] columnDataTypes =
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.OBJECT};
 
     // Build the data table.
-    DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnTypes));
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(new DataSchema(columnNames, columnDataTypes));
     int numAggregationFunctions = _aggregationFunctionContexts.length;
     for (int i = 0; i < numAggregationFunctions; i++) {
       dataTableBuilder.startRow();

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -104,11 +104,11 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   boolean isIntermediateResultComparable();
 
   /**
-   * Get the {@link FieldSpec.DataType} of the intermediate result.
-   * <p>This data type is used for transferring data in data table.
+   * Get the {@link DataSchema.ColumnDataType} of the intermediate result.
+   * <p>This column data type is used for transferring data in data table.
    */
   @Nonnull
-  FieldSpec.DataType getIntermediateResultDataType();
+  DataSchema.ColumnDataType getIntermediateResultColumnType();
 
   /**
    * Extract the final result used in the broker response from the given intermediate result.

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -146,8 +146,8 @@ public class AvgAggregationFunction implements AggregationFunction<AvgPair, Doub
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.OBJECT;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.DoubleAggregationResultHolder;
@@ -107,8 +107,8 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.LONG;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.LONG;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.query.aggregation.function;
 
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -245,8 +246,8 @@ public class DistinctCountAggregationFunction implements AggregationFunction<Int
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.OBJECT;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.core.query.aggregation.function;
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -248,8 +249,8 @@ public class DistinctCountHLLAggregationFunction implements AggregationFunction<
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.OBJECT;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -17,14 +17,14 @@ package com.linkedin.pinot.core.query.aggregation.function;
 
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import com.linkedin.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
-import com.linkedin.pinot.startree.hll.HllConstants;
 import com.linkedin.pinot.core.startree.hll.HllUtil;
+import com.linkedin.pinot.startree.hll.HllConstants;
 import javax.annotation.Nonnull;
 
 
@@ -164,8 +164,8 @@ public class FastHLLAggregationFunction implements AggregationFunction<HyperLogL
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.OBJECT;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.DoubleAggregationResultHolder;
@@ -127,8 +127,8 @@ public class MaxAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.DOUBLE;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.DOUBLE;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.DoubleAggregationResultHolder;
@@ -127,8 +127,8 @@ public class MinAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.DOUBLE;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.DOUBLE;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -154,8 +154,8 @@ public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMa
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.OBJECT;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -165,8 +165,8 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.OBJECT;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
@@ -164,8 +164,8 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.OBJECT;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -15,7 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
-import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.BlockValSet;
 import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.DoubleAggregationResultHolder;
@@ -115,8 +115,8 @@ public class SumAggregationFunction implements AggregationFunction<Double, Doubl
 
   @Nonnull
   @Override
-  public FieldSpec.DataType getIntermediateResultDataType() {
-    return FieldSpec.DataType.DOUBLE;
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.DOUBLE;
   }
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/reduce/BrokerReduceService.java
@@ -16,7 +16,6 @@
 package com.linkedin.pinot.core.query.reduce;
 
 import com.linkedin.pinot.common.config.TableNameBuilder;
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.metrics.BrokerMeter;
 import com.linkedin.pinot.common.metrics.BrokerMetrics;
@@ -39,7 +38,6 @@ import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionUti
 import com.linkedin.pinot.core.query.aggregation.groupby.AggregationGroupByTrimmingService;
 import com.linkedin.pinot.core.query.selection.SelectionOperatorService;
 import com.linkedin.pinot.core.query.selection.SelectionOperatorUtils;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -162,8 +160,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
         List<String> selectionColumns =
             SelectionOperatorUtils.getSelectionColumns(brokerRequest.getSelections().getSelectionColumns(),
                 cachedDataSchema);
-        brokerResponseNative.setSelectionResults(
-            new SelectionResults(selectionColumns, new ArrayList<Serializable[]>(0)));
+        brokerResponseNative.setSelectionResults(new SelectionResults(selectionColumns, new ArrayList<>(0)));
       }
     } else {
       // Reduce server responses data and set query results into the broker response.
@@ -289,8 +286,8 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
     for (DataTable dataTable : dataTableMap.values()) {
       for (int i = 0; i < numAggregationFunctions; i++) {
         Object intermediateResultToMerge;
-        FieldSpec.DataType columnType = dataSchema.getColumnType(i);
-        switch (columnType) {
+        DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
+        switch (columnDataType) {
           case LONG:
             intermediateResultToMerge = dataTable.getLong(0, i);
             break;
@@ -301,7 +298,7 @@ public class BrokerReduceService implements ReduceService<BrokerResponseNative> 
             intermediateResultToMerge = dataTable.getObject(0, i);
             break;
           default:
-            throw new IllegalStateException("Illegal column type in aggregation results: " + columnType);
+            throw new IllegalStateException("Illegal column data type in aggregation results: " + columnDataType);
         }
         Object mergedIntermediateResult = intermediateResults[i];
         if (mergedIntermediateResult == null) {

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionFetcher.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionFetcher.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.query.selection;
 
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.common.Block;
 import com.linkedin.pinot.core.query.selection.iterator.DoubleArraySelectionColumnIterator;
@@ -49,11 +48,11 @@ public class SelectionFetcher {
 
     for (int i = 0; i < _numColumns; i++) {
       Block block = blocks[i];
-      FieldSpec.DataType columnType = dataSchema.getColumnType(i);
+      DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
       if (block.getMetadata().hasDictionary()) {
         // With dictionary
 
-        switch (columnType) {
+        switch (columnDataType) {
           // Single value
           case INT:
           case LONG:
@@ -84,7 +83,7 @@ public class SelectionFetcher {
       } else {
         // No dictionary
 
-        switch (columnType) {
+        switch (columnDataType) {
           case INT:
             _selectionColumnIterators[i] = new IntSelectionColumnIterator(block);
             break;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorService.java
@@ -145,7 +145,7 @@ public class SelectionOperatorService {
           Serializable v2 = o2[i];
 
           // Only compare single-value columns.
-          switch (_dataSchema.getColumnType(i)) {
+          switch (_dataSchema.getColumnDataType(i)) {
             case INT:
               if (!selectionSort.isIsAsc()) {
                 ret = ((Integer) v1).compareTo((Integer) v2);
@@ -363,7 +363,7 @@ public class SelectionOperatorService {
     for (int i = 0; i < numColumns; i++) {
       int columnIndex = columnIndices[i];
       formattedRow[i] =
-          SelectionOperatorUtils.getFormattedValue(row[columnIndex], _dataSchema.getColumnType(columnIndex));
+          SelectionOperatorUtils.getFormattedValue(row[columnIndex], _dataSchema.getColumnDataType(columnIndex));
     }
     return formattedRow;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.query.selection;
 
-import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.request.Selection;
 import com.linkedin.pinot.common.request.SelectionSort;
 import com.linkedin.pinot.common.response.ServerInstance;
@@ -145,20 +144,17 @@ public class SelectionOperatorUtils {
     }
 
     int numColumns = columnList.size();
-    String[] columns = new String[numColumns];
-    DataType[] dataTypes = new DataType[numColumns];
+    String[] columnNames = new String[numColumns];
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numColumns];
     for (int i = 0; i < numColumns; i++) {
-      String column = columnList.get(i);
-      columns[i] = column;
-      DataSourceMetadata columnMetadata = indexSegment.getDataSource(column).getDataSourceMetadata();
-      if (columnMetadata.isSingleValue()) {
-        dataTypes[i] = columnMetadata.getDataType();
-      } else {
-        dataTypes[i] = columnMetadata.getDataType().toMultiValue();
-      }
+      String columnName = columnList.get(i);
+      columnNames[i] = columnName;
+      DataSourceMetadata columnMetadata = indexSegment.getDataSource(columnName).getDataSourceMetadata();
+      columnDataTypes[i] =
+          DataSchema.ColumnDataType.fromDataType(columnMetadata.getDataType(), columnMetadata.isSingleValue());
     }
 
-    return new DataSchema(columns, dataTypes);
+    return new DataSchema(columnNames, columnDataTypes);
   }
 
   /**
@@ -235,8 +231,8 @@ public class SelectionOperatorUtils {
       dataTableBuilder.startRow();
       for (int i = 0; i < numColumns; i++) {
         Serializable columnValue = row[i];
-        DataType columnType = dataSchema.getColumnType(i);
-        switch (columnType) {
+        DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
+        switch (columnDataType) {
           // Single-value column.
           case INT:
             dataTableBuilder.setColumn(i, ((Number) columnValue).intValue());
@@ -311,7 +307,7 @@ public class SelectionOperatorUtils {
 
           default:
             throw new UnsupportedOperationException(
-                "Unsupported data type: " + columnType + " for column: " + dataSchema.getColumnName(i));
+                "Unsupported data type: " + columnDataType + " for column: " + dataSchema.getColumnName(i));
         }
       }
       dataTableBuilder.finishRow();
@@ -334,8 +330,8 @@ public class SelectionOperatorUtils {
 
     Serializable[] row = new Serializable[numColumns];
     for (int i = 0; i < numColumns; i++) {
-      DataType columnType = dataSchema.getColumnType(i);
-      switch (columnType) {
+      DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
+      switch (columnDataType) {
         // Single-value column.
         case INT:
           row[i] = dataTable.getInt(rowId, i);
@@ -372,7 +368,7 @@ public class SelectionOperatorUtils {
 
         default:
           throw new UnsupportedOperationException(
-              "Unsupported data type: " + columnType + " for column: " + dataSchema.getColumnName(i));
+              "Unsupported column data type: " + columnDataType + " for column: " + dataSchema.getColumnName(i));
       }
     }
 
@@ -451,7 +447,7 @@ public class SelectionOperatorUtils {
   private static void formatRowWithoutOrdering(@Nonnull Serializable[] row, @Nonnull DataSchema dataSchema) {
     int numColumns = row.length;
     for (int i = 0; i < numColumns; i++) {
-      row[i] = getFormattedValue(row[i], dataSchema.getColumnType(i));
+      row[i] = getFormattedValue(row[i], dataSchema.getColumnDataType(i));
     }
   }
 
@@ -463,7 +459,7 @@ public class SelectionOperatorUtils {
     for (int i = 0; i < numColumns; i++) {
       int columnIndex = columnIndices[i];
       formattedRow[i] =
-          SelectionOperatorUtils.getFormattedValue(row[columnIndex], dataSchema.getColumnType(columnIndex));
+          SelectionOperatorUtils.getFormattedValue(row[columnIndex], dataSchema.getColumnDataType(columnIndex));
     }
     return formattedRow;
   }
@@ -478,7 +474,8 @@ public class SelectionOperatorUtils {
    * @return formatted value.
    */
   @Nonnull
-  public static Serializable getFormattedValue(@Nonnull Serializable value, @Nonnull DataType dataType) {
+  public static Serializable getFormattedValue(@Nonnull Serializable value,
+      @Nonnull DataSchema.ColumnDataType dataType) {
     switch (dataType) {
       // Single-value column.
       case INT:

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/startree/MetricBuffer.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/startree/MetricBuffer.java
@@ -73,9 +73,6 @@ public class MetricBuffer {
         values[i] = HllUtil.buildHllFromBytes(hllBytes);
       } else {
         switch (metric.getDataType()) {
-          case SHORT:
-            values[i] = buffer.getShort();
-            break;
           case INT:
             values[i] = buffer.getInt();
             break;
@@ -106,9 +103,6 @@ public class MetricBuffer {
         buffer.put(((HyperLogLog)values[i]).getBytes());
       } else {
         switch (metric.getDataType()) {
-          case SHORT:
-            buffer.putShort(((Number) values[i]).shortValue());
-            break;
           case INT:
             buffer.putInt(((Number) values[i]).intValue());
             break;
@@ -140,9 +134,6 @@ public class MetricBuffer {
         }
       } else {
         switch (metric.getDataType()) {
-          case SHORT:
-            values[i] = ((Number) values[i]).shortValue() + ((Number) metrics.values[i]).shortValue();
-            break;
           case INT:
             values[i] = ((Number) values[i]).intValue() + ((Number) metrics.values[i]).intValue();
             break;

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.core.common.datatable;
 
-import com.linkedin.pinot.common.data.FieldSpec.DataType;
 import com.linkedin.pinot.common.exception.QueryException;
 import com.linkedin.pinot.common.response.ProcessingException;
 import com.linkedin.pinot.common.utils.DataSchema;
@@ -62,8 +61,8 @@ public class DataTableSerDeTest {
     String emptyString = StringUtils.EMPTY;
     String[] emptyStringArray = {StringUtils.EMPTY};
 
-    DataSchema dataSchema =
-        new DataSchema(new String[]{"SV", "MV"}, new DataType[]{DataType.STRING, DataType.STRING_ARRAY});
+    DataSchema dataSchema = new DataSchema(new String[]{"SV", "MV"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING_ARRAY});
     DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
     for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
       dataTableBuilder.startRow();
@@ -85,29 +84,22 @@ public class DataTableSerDeTest {
 
   @Test
   public void testAllDataTypes() throws IOException {
-    DataType[] columnTypes = DataType.values();
-    int numColumns = columnTypes.length;
+    DataSchema.ColumnDataType[] columnDataTypes = DataSchema.ColumnDataType.values();
+    int numColumns = columnDataTypes.length;
     String[] columnNames = new String[numColumns];
     for (int i = 0; i < numColumns; i++) {
-      columnNames[i] = columnTypes[i].name();
+      columnNames[i] = columnDataTypes[i].name();
     }
-    DataSchema dataSchema = new DataSchema(columnNames, columnTypes);
+    DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
 
     DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
 
-    boolean[] booleans = new boolean[NUM_ROWS];
-    byte[] bytes = new byte[NUM_ROWS];
-    char[] chars = new char[NUM_ROWS];
-    short[] shorts = new short[NUM_ROWS];
     int[] ints = new int[NUM_ROWS];
     long[] longs = new long[NUM_ROWS];
     float[] floats = new float[NUM_ROWS];
     double[] doubles = new double[NUM_ROWS];
     String[] strings = new String[NUM_ROWS];
     Object[] objects = new Object[NUM_ROWS];
-    byte[][] byteArrays = new byte[NUM_ROWS][];
-    char[][] charArrays = new char[NUM_ROWS][];
-    short[][] shortArrays = new short[NUM_ROWS][];
     int[][] intArrays = new int[NUM_ROWS][];
     long[][] longArrays = new long[NUM_ROWS][];
     float[][] floatArrays = new float[NUM_ROWS][];
@@ -117,23 +109,7 @@ public class DataTableSerDeTest {
     for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
       dataTableBuilder.startRow();
       for (int colId = 0; colId < numColumns; colId++) {
-        switch (columnTypes[colId]) {
-          case BOOLEAN:
-            booleans[rowId] = RANDOM.nextBoolean();
-            dataTableBuilder.setColumn(colId, booleans[rowId]);
-            break;
-          case BYTE:
-            bytes[rowId] = (byte) RANDOM.nextInt();
-            dataTableBuilder.setColumn(colId, bytes[rowId]);
-            break;
-          case CHAR:
-            chars[rowId] = (char) RANDOM.nextInt();
-            dataTableBuilder.setColumn(colId, chars[rowId]);
-            break;
-          case SHORT:
-            shorts[rowId] = (short) RANDOM.nextInt();
-            dataTableBuilder.setColumn(colId, shorts[rowId]);
-            break;
+        switch (columnDataTypes[colId]) {
           case INT:
             ints[rowId] = RANDOM.nextInt();
             dataTableBuilder.setColumn(colId, ints[rowId]);
@@ -159,35 +135,8 @@ public class DataTableSerDeTest {
             objects[rowId] = RANDOM.nextDouble();
             dataTableBuilder.setColumn(colId, objects[rowId]);
             break;
-          case BYTE_ARRAY:
-            int length = RANDOM.nextInt(20);
-            byte[] byteArray = new byte[length];
-            for (int i = 0; i < length; i++) {
-              byteArray[i] = (byte) RANDOM.nextInt();
-            }
-            byteArrays[rowId] = byteArray;
-            dataTableBuilder.setColumn(colId, byteArray);
-            break;
-          case CHAR_ARRAY:
-            length = RANDOM.nextInt(20);
-            char[] charArray = new char[length];
-            for (int i = 0; i < length; i++) {
-              charArray[i] = (char) RANDOM.nextInt();
-            }
-            charArrays[rowId] = charArray;
-            dataTableBuilder.setColumn(colId, charArray);
-            break;
-          case SHORT_ARRAY:
-            length = RANDOM.nextInt(20);
-            short[] shortArray = new short[length];
-            for (int i = 0; i < length; i++) {
-              shortArray[i] = (short) RANDOM.nextInt();
-            }
-            shortArrays[rowId] = shortArray;
-            dataTableBuilder.setColumn(colId, shortArray);
-            break;
           case INT_ARRAY:
-            length = RANDOM.nextInt(20);
+            int length = RANDOM.nextInt(20);
             int[] intArray = new int[length];
             for (int i = 0; i < length; i++) {
               intArray[i] = RANDOM.nextInt();
@@ -243,19 +192,7 @@ public class DataTableSerDeTest {
 
     for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
       for (int colId = 0; colId < numColumns; colId++) {
-        switch (columnTypes[colId]) {
-          case BOOLEAN:
-            Assert.assertEquals(newDataTable.getBoolean(rowId, colId), booleans[rowId], ERROR_MESSAGE);
-            break;
-          case BYTE:
-            Assert.assertEquals(newDataTable.getByte(rowId, colId), bytes[rowId], ERROR_MESSAGE);
-            break;
-          case CHAR:
-            Assert.assertEquals(newDataTable.getChar(rowId, colId), chars[rowId], ERROR_MESSAGE);
-            break;
-          case SHORT:
-            Assert.assertEquals(newDataTable.getShort(rowId, colId), shorts[rowId], ERROR_MESSAGE);
-            break;
+        switch (columnDataTypes[colId]) {
           case INT:
             Assert.assertEquals(newDataTable.getInt(rowId, colId), ints[rowId], ERROR_MESSAGE);
             break;
@@ -273,16 +210,6 @@ public class DataTableSerDeTest {
             break;
           case OBJECT:
             Assert.assertEquals(newDataTable.getObject(rowId, colId), objects[rowId], ERROR_MESSAGE);
-            break;
-          case BYTE_ARRAY:
-            Assert.assertTrue(Arrays.equals(newDataTable.getByteArray(rowId, colId), byteArrays[rowId]), ERROR_MESSAGE);
-            break;
-          case CHAR_ARRAY:
-            Assert.assertTrue(Arrays.equals(newDataTable.getCharArray(rowId, colId), charArrays[rowId]), ERROR_MESSAGE);
-            break;
-          case SHORT_ARRAY:
-            Assert.assertTrue(Arrays.equals(newDataTable.getShortArray(rowId, colId), shortArrays[rowId]),
-                ERROR_MESSAGE);
             break;
           case INT_ARRAY:
             Assert.assertTrue(Arrays.equals(newDataTable.getIntArray(rowId, colId), intArrays[rowId]), ERROR_MESSAGE);

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/ThriftRecordReaderTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/readers/ThriftRecordReaderTest.java
@@ -18,17 +18,6 @@ package com.linkedin.pinot.core.data.readers;
 import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.core.data.GenericRow;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.thrift.TException;
-import org.apache.thrift.TSerializer;
-import org.apache.thrift.protocol.TBinaryProtocol;
-import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -38,120 +27,126 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 
 /**
  * Test {@code com.linkedin.pinot.core.data.readers.ThriftRecordReader} for a given sample thrift
  * data.
  */
-
 public class ThriftRecordReaderTest {
+  private static final String THRIFT_DATA = "_test_sample_thrift_data.thrift";
 
-    private final String THRIFT_DATA = "_test_sample_thrift_data.thrift";
-    private File _tempFile;
+  private File _tempFile;
 
-    @BeforeClass
-    public void setUp() throws IOException, TException {
-        ThriftSampleData t1 = new ThriftSampleData();
-        t1.setActive(true);
-        t1.setCreated_at(1515541280L);
-        t1.setId(1);
-        t1.setName("name1");
-        List<Short> t1Groups = new ArrayList<>(2);
-        t1Groups.add((short) 1);
-        t1Groups.add((short) 4);
-        t1.setGroups(t1Groups);
-        Map<String, Long> mapValues = new HashMap<>();
-        mapValues.put("name1", 1L);
-        t1.setMap_values(mapValues);
-        Set<String> namesSet = new HashSet<>();
-        namesSet.add("name1");
-        t1.setSet_values(namesSet);
+  @BeforeClass
+  public void setUp() throws Exception {
+    FileUtils.deleteQuietly(_tempFile);
 
-        ThriftSampleData t2 = new ThriftSampleData();
-        t2.setActive(false);
-        t2.setCreated_at(1515541290L);
-        t2.setId(2);
-        t2.setName("name2");
-        List<Short> t2Groups = new ArrayList<>(2);
-        t2Groups.add((short) 2);
-        t2Groups.add((short) 3);
-        t2.setGroups(t2Groups);
-        List<ThriftSampleData> lists = new ArrayList<>(2);
-        lists.add(t1);
-        lists.add(t2);
-        TSerializer binarySerializer = new TSerializer(new TBinaryProtocol.Factory());
-        _tempFile = getSampleDataPath();
-        FileWriter writer = new FileWriter(_tempFile);
-        for (ThriftSampleData d : lists) {
-            IOUtils.write(binarySerializer.serialize(d), writer);
-        }
-        writer.close();
+    ThriftSampleData t1 = new ThriftSampleData();
+    t1.setActive(true);
+    t1.setCreated_at(1515541280L);
+    t1.setId(1);
+    t1.setName("name1");
+    List<Short> t1Groups = new ArrayList<>(2);
+    t1Groups.add((short) 1);
+    t1Groups.add((short) 4);
+    t1.setGroups(t1Groups);
+    Map<String, Long> mapValues = new HashMap<>();
+    mapValues.put("name1", 1L);
+    t1.setMap_values(mapValues);
+    Set<String> namesSet = new HashSet<>();
+    namesSet.add("name1");
+    t1.setSet_values(namesSet);
+
+    ThriftSampleData t2 = new ThriftSampleData();
+    t2.setActive(false);
+    t2.setCreated_at(1515541290L);
+    t2.setId(2);
+    t2.setName("name2");
+    List<Short> t2Groups = new ArrayList<>(2);
+    t2Groups.add((short) 2);
+    t2Groups.add((short) 3);
+    t2.setGroups(t2Groups);
+    List<ThriftSampleData> lists = new ArrayList<>(2);
+    lists.add(t1);
+    lists.add(t2);
+    TSerializer binarySerializer = new TSerializer(new TBinaryProtocol.Factory());
+    _tempFile = getSampleDataPath();
+    FileWriter writer = new FileWriter(_tempFile);
+    for (ThriftSampleData d : lists) {
+      IOUtils.write(binarySerializer.serialize(d), writer);
+    }
+    writer.close();
+  }
+
+  @Test
+  public void testReadData()
+      throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+    ThriftRecordReader recordReader = new ThriftRecordReader(_tempFile, getSchema(), getThriftRecordReaderConfig());
+
+    List<GenericRow> genericRows = new ArrayList<>();
+    while (recordReader.hasNext()) {
+      genericRows.add(recordReader.next());
+    }
+    recordReader.close();
+    Assert.assertEquals(genericRows.size(), 2, "The number of rows return is incorrect");
+    int id = 1;
+    for (GenericRow outputRow : genericRows) {
+      Assert.assertEquals(outputRow.getValue("id"), id);
+      Assert.assertNull(outputRow.getValue("map_values"));
+      id++;
+    }
+  }
+
+  @Test
+  public void testRewind() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
+    ThriftRecordReader recordReader = new ThriftRecordReader(_tempFile, getSchema(), getThriftRecordReaderConfig());
+    List<GenericRow> genericRows = new ArrayList<>();
+    while (recordReader.hasNext()) {
+      genericRows.add(recordReader.next());
     }
 
-    @AfterClass
-    public void tearDown() throws IOException {
-        FileUtils.deleteQuietly(_tempFile);
+    recordReader.rewind();
+
+    while (recordReader.hasNext()) {
+      genericRows.add(recordReader.next());
     }
+    recordReader.close();
+    Assert.assertEquals(genericRows.size(), 4, "The number of rows return after the rewind is incorrect");
+  }
 
-    @Test
-    public void testReadData() throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
-        ThriftRecordReader recordReader = new ThriftRecordReader(_tempFile,
-                getSchema(), getThriftRecordReaderConfig());
+  private File getSampleDataPath() throws IOException {
+    return File.createTempFile(ThriftRecordReaderTest.class.getName(), THRIFT_DATA);
+  }
 
-        List<GenericRow> genericRows = new ArrayList<>();
-        while (recordReader.hasNext()) {
-            genericRows.add(recordReader.next());
-        }
-        recordReader.close();
-        Assert.assertEquals(genericRows.size(), 2, "The number of rows return is incorrect");
-        int id = 1;
-        for (GenericRow outputRow : genericRows) {
-            Assert.assertEquals(outputRow.getValue("id"), id);
-            Assert.assertNull(outputRow.getValue("map_values"));
-            id++;
-        }
+  private ThriftRecordReaderConfig getThriftRecordReaderConfig() {
+    ThriftRecordReaderConfig config = new ThriftRecordReaderConfig();
+    config.setThriftClass("com.linkedin.pinot.core.data.readers.ThriftSampleData");
+    return config;
+  }
 
-    }
+  private Schema getSchema() {
+    return new Schema.SchemaBuilder().setSchemaName("ThriftSampleData")
+        .addSingleValueDimension("id", FieldSpec.DataType.INT)
+        .addSingleValueDimension("name", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("created_at", FieldSpec.DataType.LONG)
+        .addSingleValueDimension("active", FieldSpec.DataType.BOOLEAN)
+        .addMultiValueDimension("groups", FieldSpec.DataType.INT)
+        .addMultiValueDimension("map_values", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("set_values", FieldSpec.DataType.STRING)
+        .build();
+  }
 
-    @Test
-    public void testRewind() throws ClassNotFoundException, InstantiationException, IllegalAccessException, IOException {
-        ThriftRecordReader recordReader = new ThriftRecordReader(_tempFile,
-                getSchema(), getThriftRecordReaderConfig());
-        List<GenericRow> genericRows = new ArrayList<>();
-        while (recordReader.hasNext()) {
-            genericRows.add(recordReader.next());
-        }
-
-        recordReader.rewind();
-
-        while (recordReader.hasNext()) {
-            genericRows.add(recordReader.next());
-        }
-        recordReader.close();
-        Assert.assertEquals(genericRows.size(), 4, "The number of rows return after the rewind is incorrect");
-    }
-
-    private File getSampleDataPath() throws IOException {
-        return File.createTempFile(ThriftRecordReaderTest.class.getName(), THRIFT_DATA);
-    }
-
-    private ThriftRecordReaderConfig getThriftRecordReaderConfig() {
-        ThriftRecordReaderConfig config = new ThriftRecordReaderConfig();
-        config.setThriftClass("com.linkedin.pinot.core.data.readers.ThriftSampleData");
-        return config;
-    }
-
-    private Schema getSchema() {
-        return new Schema.SchemaBuilder()
-                .setSchemaName("ThriftSampleData")
-                .addSingleValueDimension("id", FieldSpec.DataType.INT)
-                .addSingleValueDimension("name", FieldSpec.DataType.STRING)
-                .addSingleValueDimension("created_at", FieldSpec.DataType.LONG)
-                .addSingleValueDimension("active", FieldSpec.DataType.BOOLEAN)
-                .addMultiValueDimension("groups", FieldSpec.DataType.SHORT)
-                .addMultiValueDimension("map_values", FieldSpec.DataType.STRING)
-                .addMultiValueDimension("set_values", FieldSpec.DataType.STRING)
-                .build();
-    }
-
+  @AfterClass
+  public void tearDown() {
+    FileUtils.deleteQuietly(_tempFile);
+  }
 }

--- a/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/index/readerwriter/FixedByteSingleColumnMultiValueReaderWriterTest.java
@@ -15,17 +15,16 @@
  */
 package com.linkedin.pinot.index.readerwriter;
 
+import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.core.io.readerwriter.PinotDataBufferMemoryManager;
-import java.io.IOException;
+import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
+import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 import java.util.Arrays;
 import java.util.Random;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import com.linkedin.pinot.common.data.FieldSpec;
-import com.linkedin.pinot.core.io.readerwriter.impl.FixedByteSingleColumnMultiValueReaderWriter;
-import com.linkedin.pinot.core.io.writer.impl.DirectMemoryManager;
 
 
 public class FixedByteSingleColumnMultiValueReaderWriterTest {
@@ -62,14 +61,14 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     }
   }
 
-  public void testIntArray(final long seed)
-      throws IOException {
+  public void testIntArray(final long seed) {
     FixedByteSingleColumnMultiValueReaderWriter readerWriter;
     int rows = 1000;
     int columnSizeInBytes = Integer.SIZE / 8;
     int maxNumberOfMultiValuesPerRow = 2000;
     readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 2, rows/2, columnSizeInBytes, _memoryManager, "IntArray");
+        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 2, rows / 2, columnSizeInBytes,
+            _memoryManager, "IntArray");
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -83,22 +82,21 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     int[] ret = new int[maxNumberOfMultiValuesPerRow];
     for (int i = 0; i < rows; i++) {
       int length = readerWriter.getIntArray(i, ret);
-      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
-      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed="+seed);
+      Assert.assertEquals(data[i].length, length, "Failed with seed=" + seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
     }
     readerWriter.close();
   }
 
-  public void testIntArrayFixedSize(int multiValuesPerRow, long seed)
-      throws IOException {
+  public void testIntArrayFixedSize(int multiValuesPerRow, long seed) {
     FixedByteSingleColumnMultiValueReaderWriter readerWriter;
     int rows = 1000;
     int columnSizeInBytes = Integer.SIZE / 8;
     // Keep the rowsPerChunk as a multiple of multiValuesPerRow to check the cases when both data and header buffers
     // transition to new ones
     readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(multiValuesPerRow, multiValuesPerRow, multiValuesPerRow * 2, columnSizeInBytes,
-            _memoryManager, "IntArrayFixedSize");
+        new FixedByteSingleColumnMultiValueReaderWriter(multiValuesPerRow, multiValuesPerRow, multiValuesPerRow * 2,
+            columnSizeInBytes, _memoryManager, "IntArrayFixedSize");
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -112,8 +110,8 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     int[] ret = new int[multiValuesPerRow];
     for (int i = 0; i < rows; i++) {
       int length = readerWriter.getIntArray(i, ret);
-      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
-      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed="+seed);
+      Assert.assertEquals(data[i].length, length, "Failed with seed=" + seed);
+      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
     }
     readerWriter.close();
   }
@@ -124,9 +122,8 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     int rows = 1000;
     int columnSizeInBytes = Integer.SIZE / 8;
     Random r = new Random(seed);
-    readerWriter =
-        new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 3, r.nextInt(rows) + 1, columnSizeInBytes,
-            _memoryManager, "ZeroSize");
+    readerWriter = new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, 3, r.nextInt(rows) + 1,
+        columnSizeInBytes, _memoryManager, "ZeroSize");
 
     int[][] data = new int[rows][];
     for (int i = 0; i < rows; i++) {
@@ -144,41 +141,19 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     int[] ret = new int[maxNumberOfMultiValuesPerRow];
     for (int i = 0; i < rows; i++) {
       int length = readerWriter.getIntArray(i, ret);
-      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertEquals(data[i].length, length, "Failed with seed=" + seed);
       Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
     }
     readerWriter.close();
-
   }
 
-  private FixedByteSingleColumnMultiValueReaderWriter createReaderWriter(FieldSpec.DataType type, Random r, int rows, int maxNumberOfMultiValuesPerRow) {
-    final int columnSize = sizeForType(type);
+  private FixedByteSingleColumnMultiValueReaderWriter createReaderWriter(FieldSpec.DataType dataType, Random r,
+      int rows, int maxNumberOfMultiValuesPerRow) {
     final int avgMultiValueCount = r.nextInt(maxNumberOfMultiValuesPerRow) + 1;
     final int rowCountPerChunk = r.nextInt(rows) + 1;
 
     return new FixedByteSingleColumnMultiValueReaderWriter(maxNumberOfMultiValuesPerRow, avgMultiValueCount,
-        rowCountPerChunk, columnSize, _memoryManager, "ReaderWriter");
-  }
-
-  private int sizeForType(FieldSpec.DataType type) {
-    int size;
-    switch (type) {
-      case SHORT_ARRAY:
-        size = Short.SIZE/8;
-        break;
-      case LONG_ARRAY:
-        size = Long.SIZE/8;
-        break;
-      case FLOAT_ARRAY:
-        size = Float.SIZE/8;
-        break;
-      case DOUBLE_ARRAY:
-        size = Double.SIZE/8;
-        break;
-      default:
-        throw new UnsupportedOperationException();
-    }
-    return size;
+        rowCountPerChunk, dataType.size(), _memoryManager, "ReaderWriter");
   }
 
   private long generateSeed() {
@@ -187,12 +162,13 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
   }
 
   @Test
-  public void testLongArray() throws Exception {
+  public void testLongArray() {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
-    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.LONG_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter =
+        createReaderWriter(FieldSpec.DataType.LONG, r, rows, maxNumberOfMultiValuesPerRow);
 
     long[][] data = new long[rows][];
     for (int i = 0; i < rows; i++) {
@@ -210,18 +186,20 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     long[] ret = new long[maxNumberOfMultiValuesPerRow];
     for (int i = 0; i < rows; i++) {
       int length = readerWriter.getLongArray(i, ret);
-      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertEquals(data[i].length, length, "Failed with seed=" + seed);
       Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
     }
     readerWriter.close();
   }
+
   @Test
-  public void testFloatArray() throws Exception {
+  public void testFloatArray() {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
-    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.FLOAT_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter =
+        createReaderWriter(FieldSpec.DataType.FLOAT, r, rows, maxNumberOfMultiValuesPerRow);
 
     float[][] data = new float[rows][];
     for (int i = 0; i < rows; i++) {
@@ -239,19 +217,20 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     float[] ret = new float[maxNumberOfMultiValuesPerRow];
     for (int i = 0; i < rows; i++) {
       int length = readerWriter.getFloatArray(i, ret);
-      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertEquals(data[i].length, length, "Failed with seed=" + seed);
       Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
     }
     readerWriter.close();
   }
 
   @Test
-  public void testDoubleArray() throws Exception {
+  public void testDoubleArray() {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
-    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.DOUBLE_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
+    FixedByteSingleColumnMultiValueReaderWriter readerWriter =
+        createReaderWriter(FieldSpec.DataType.DOUBLE, r, rows, maxNumberOfMultiValuesPerRow);
 
     double[][] data = new double[rows][];
     for (int i = 0; i < rows; i++) {
@@ -269,37 +248,7 @@ public class FixedByteSingleColumnMultiValueReaderWriterTest {
     double[] ret = new double[maxNumberOfMultiValuesPerRow];
     for (int i = 0; i < rows; i++) {
       int length = readerWriter.getDoubleArray(i, ret);
-      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
-      Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
-    }
-    readerWriter.close();
-  }
-
-  @Test
-  public void testShortArray() throws Exception {
-    final long seed = generateSeed();
-    Random r = new Random(seed);
-    int rows = 1000;
-    final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
-    FixedByteSingleColumnMultiValueReaderWriter readerWriter = createReaderWriter(FieldSpec.DataType.SHORT_ARRAY, r, rows, maxNumberOfMultiValuesPerRow);
-
-    short[][] data = new short[rows][];
-    for (int i = 0; i < rows; i++) {
-      if (r.nextInt() > 0) {
-        data[i] = new short[r.nextInt(maxNumberOfMultiValuesPerRow)];
-        for (int j = 0; j < data[i].length; j++) {
-          data[i][j] = (short)r.nextInt(Short.MAX_VALUE);
-        }
-        readerWriter.setShortArray(i, data[i]);
-      } else {
-        data[i] = new short[0];
-        readerWriter.setShortArray(i, data[i]);
-      }
-    }
-    short[] ret = new short[maxNumberOfMultiValuesPerRow];
-    for (int i = 0; i < rows; i++) {
-      int length = readerWriter.getShortArray(i, ret);
-      Assert.assertEquals(data[i].length, length, "Failed with seed="+seed);
+      Assert.assertEquals(data[i].length, length, "Failed with seed=" + seed);
       Assert.assertTrue(Arrays.equals(data[i], Arrays.copyOf(ret, length)), "Failed with seed=" + seed);
     }
     readerWriter.close();

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.queries;
 
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.operator.ExecutionStatistics;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -50,8 +49,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 10);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(5), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(5), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(5), DataSchema.ColumnDataType.INT_ARRAY);
     Assert.assertTrue(resultsBlock.getSelectionResult().isEmpty());
 
     // Test query with filter
@@ -66,8 +65,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 10);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(5), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(5), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(5), DataSchema.ColumnDataType.INT_ARRAY);
     Assert.assertTrue(resultsBlock.getSelectionResult().isEmpty());
   }
 
@@ -87,8 +86,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 10);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(5), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(5), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(5), DataSchema.ColumnDataType.INT_ARRAY);
     List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     Serializable[] firstRow = selectionResult.get(0);
@@ -108,8 +107,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 10);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(5), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(5), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(5), DataSchema.ColumnDataType.INT_ARRAY);
     selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
@@ -134,8 +133,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 3);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(2), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(2), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(2), DataSchema.ColumnDataType.INT_ARRAY);
     List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     Serializable[] firstRow = selectionResult.get(0);
@@ -155,8 +154,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 3);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(2), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(2), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(2), DataSchema.ColumnDataType.INT_ARRAY);
     selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
@@ -181,8 +180,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 4);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column5");
     Assert.assertEquals(selectionDataSchema.getColumnName(3), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.STRING);
-    Assert.assertEquals(selectionDataSchema.getColumnType(3), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(3), DataSchema.ColumnDataType.INT_ARRAY);
     Queue<Serializable[]> selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     Serializable[] lastRow = selectionResult.peek();
@@ -202,8 +201,8 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     Assert.assertEquals(selectionDataSchema.size(), 4);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column5");
     Assert.assertEquals(selectionDataSchema.getColumnName(3), "column6");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.STRING);
-    Assert.assertEquals(selectionDataSchema.getColumnType(3), FieldSpec.DataType.INT_ARRAY);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(3), DataSchema.ColumnDataType.INT_ARRAY);
     selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     lastRow = selectionResult.peek();

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.queries;
 
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.utils.DataSchema;
 import com.linkedin.pinot.core.operator.ExecutionStatistics;
 import com.linkedin.pinot.core.operator.blocks.IntermediateResultsBlock;
@@ -50,8 +49,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 11);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(1), "column11");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.STRING);
     Assert.assertTrue(resultsBlock.getSelectionResult().isEmpty());
 
     // Test query with filter
@@ -66,8 +65,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 11);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(1), "column11");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.STRING);
     Assert.assertTrue(resultsBlock.getSelectionResult().isEmpty());
   }
 
@@ -87,8 +86,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 11);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(1), "column11");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.STRING);
     List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     Serializable[] firstRow = selectionResult.get(0);
@@ -108,8 +107,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 11);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(1), "column11");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.STRING);
     selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
@@ -134,8 +133,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 3);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(2), "column11");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.STRING);
     List<Serializable[]> selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     Serializable[] firstRow = selectionResult.get(0);
@@ -155,8 +154,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 3);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column1");
     Assert.assertEquals(selectionDataSchema.getColumnName(2), "column11");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.STRING);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.STRING);
     selectionResult = (List<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
@@ -181,8 +180,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 4);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column6");
     Assert.assertEquals(selectionDataSchema.getColumnName(1), "column1");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.INT);
     Queue<Serializable[]> selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     Serializable[] lastRow = selectionResult.peek();
@@ -202,8 +201,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(selectionDataSchema.size(), 4);
     Assert.assertEquals(selectionDataSchema.getColumnName(0), "column6");
     Assert.assertEquals(selectionDataSchema.getColumnName(1), "column1");
-    Assert.assertEquals(selectionDataSchema.getColumnType(0), FieldSpec.DataType.INT);
-    Assert.assertEquals(selectionDataSchema.getColumnType(1), FieldSpec.DataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    Assert.assertEquals(selectionDataSchema.getColumnDataType(1), DataSchema.ColumnDataType.INT);
     selectionResult = (Queue<Serializable[]>) resultsBlock.getSelectionResult();
     Assert.assertEquals(selectionResult.size(), 10);
     lastRow = selectionResult.peek();

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/selection/SelectionOperatorServiceTest.java
@@ -15,7 +15,6 @@
  */
 package com.linkedin.pinot.query.selection;
 
-import com.linkedin.pinot.common.data.FieldSpec;
 import com.linkedin.pinot.common.request.Selection;
 import com.linkedin.pinot.common.request.SelectionSort;
 import com.linkedin.pinot.common.response.broker.SelectionResults;
@@ -42,17 +41,15 @@ import org.testng.annotations.Test;
 public class SelectionOperatorServiceTest {
   private final String[] _columnNames =
       {"int", "long", "float", "double", "string", "int_array", "long_array", "float_array", "double_array", "string_array"};
-  private final FieldSpec.DataType[] _dataTypes =
-      {FieldSpec.DataType.INT, FieldSpec.DataType.LONG, FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.STRING, FieldSpec.DataType.INT_ARRAY, FieldSpec.DataType.LONG_ARRAY, FieldSpec.DataType.FLOAT_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.STRING_ARRAY};
-  private final DataSchema _dataSchema = new DataSchema(_columnNames, _dataTypes);
-  private final FieldSpec.DataType[] _compatibleDataTypes =
-      {FieldSpec.DataType.LONG, FieldSpec.DataType.FLOAT, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.INT, FieldSpec.DataType.STRING, FieldSpec.DataType.LONG_ARRAY, FieldSpec.DataType.FLOAT_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.INT_ARRAY, FieldSpec.DataType.STRING_ARRAY};
-  private final DataSchema _compatibleDataSchema =
-      new DataSchema(_columnNames, _compatibleDataTypes);
-  private final FieldSpec.DataType[] _upgradedDataTypes =
-      new FieldSpec.DataType[]{FieldSpec.DataType.LONG, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.DOUBLE, FieldSpec.DataType.STRING, FieldSpec.DataType.LONG_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.DOUBLE_ARRAY, FieldSpec.DataType.STRING_ARRAY};
-  private final DataSchema _upgradedDataSchema =
-      new DataSchema(_columnNames, _upgradedDataTypes);
+  private final DataSchema.ColumnDataType[] _columnDataTypes =
+      {DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY};
+  private final DataSchema _dataSchema = new DataSchema(_columnNames, _columnDataTypes);
+  private final DataSchema.ColumnDataType[] _compatibleColumnDataTypes =
+      {DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY};
+  private final DataSchema _compatibleDataSchema = new DataSchema(_columnNames, _compatibleColumnDataTypes);
+  private final DataSchema.ColumnDataType[] _upgradedColumnDataTypes =
+      new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY};
+  private final DataSchema _upgradedDataSchema = new DataSchema(_columnNames, _upgradedColumnDataTypes);
   private final Serializable[] _row1 =
       {0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"}};
   private final Serializable[] _row2 =
@@ -121,8 +118,7 @@ public class SelectionOperatorServiceTest {
   }
 
   @Test
-  public void testCompatibleRowsDataTableTransformation()
-      throws Exception {
+  public void testCompatibleRowsDataTableTransformation() throws Exception {
     Collection<Serializable[]> rows = new ArrayList<>(2);
     rows.add(_row1.clone());
     rows.add(_compatibleRow1.clone());
@@ -148,8 +144,10 @@ public class SelectionOperatorServiceTest {
         SelectionOperatorUtils.renderSelectionResultsWithoutOrdering(rows, _upgradedDataSchema,
             Arrays.asList(_columnNames));
     List<Serializable[]> formattedRows = selectionResults.getRows();
-    Serializable[] expectedFormattedRow1 = {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
-    Serializable[] expectedFormattedRow2 = {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
+    Serializable[] expectedFormattedRow1 =
+        {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
+    Serializable[] expectedFormattedRow2 =
+        {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
     Assert.assertEquals(formattedRows.get(0), expectedFormattedRow1);
     Assert.assertEquals(formattedRows.get(1), expectedFormattedRow2);
   }
@@ -164,8 +162,10 @@ public class SelectionOperatorServiceTest {
     rows.offer(_compatibleRow2.clone());
     SelectionResults selectionResults = selectionOperatorService.renderSelectionResultsWithOrdering();
     List<Serializable[]> formattedRows = selectionResults.getRows();
-    Serializable[] expectedFormattedRow1 = {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
-    Serializable[] expectedFormattedRow2 = {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
+    Serializable[] expectedFormattedRow1 =
+        {"1", "2.0", "3.0", "4.0", "5", new String[]{"6"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9.0"}, new String[]{"10"}};
+    Serializable[] expectedFormattedRow2 =
+        {"0", "1.0", "2.0", "3.0", "4", new String[]{"5"}, new String[]{"6.0"}, new String[]{"7.0"}, new String[]{"8.0"}, new String[]{"9"}};
     Assert.assertEquals(formattedRows.get(0), expectedFormattedRow1);
     Assert.assertEquals(formattedRows.get(1), expectedFormattedRow2);
   }


### PR DESCRIPTION
Keep FieldSpec.DataType enums the same as Avro primitive type Schema (not including NULL): INT, LONG, FLOAT, DOUBLE, BOOLEAN, STRING, BYTES
Remove all array types, for MV field, set _isSingleValueField to false
Add ColumnType enum to DataSchema to decouple it from FieldSpec.DataType with type: INT, LONG, FLOAT, DOUBLE, STRING, OBJECT, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY
For backward-compatibility, because all ColumnType has same name as old DataType, and we use enum name to do ser/de, so it should automatically work between servers and brokers