### PR TITLE
Make time column name available from table/user config in places where primary time column is needed

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -63,6 +63,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final String tableName;
   private final String segmentName;
   private final Schema schema;
+  private final String timeColumnName;
   private final PlainFieldExtractor extractor;
   private final RealtimeSegmentZKMetadata segmentMetatdaZk;
 
@@ -105,6 +106,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     this.serverMetrics =serverMetrics;
     this.segmentName = realtimeSegmentZKMetadata.getSegmentName();
     this.tableName = tableConfig.getTableName();
+    this.timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {
@@ -279,7 +281,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           // lets convert the segment now
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
-                  realtimeSegmentZKMetadata.getTableName(), realtimeSegmentZKMetadata.getSegmentName(), sortedColumn,
+                  realtimeSegmentZKMetadata.getTableName(), timeColumnName, realtimeSegmentZKMetadata.getSegmentName(), sortedColumn,
                   HLRealtimeSegmentDataManager.this.invertedIndexColumns,
                   noDictionaryColumns, null/*StarTreeIndexSpec*/); // Star tree not supported for HLC.
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -213,6 +213,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private PinotStreamConsumer _consumerWrapper = null;
   private final File _resourceTmpDir;
   private final String _tableName;
+  private final String _timeColumnName;
   private final List<String> _invertedIndexColumns;
   private final List<String> _noDictionaryColumns;
   private final StarTreeIndexSpec _starTreeIndexSpec;
@@ -631,7 +632,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       // lets convert the segment now
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
-              _segmentZKMetadata.getTableName(), _segmentZKMetadata.getSegmentName(), _sortedColumn,
+              _segmentZKMetadata.getTableName(), _timeColumnName, _segmentZKMetadata.getSegmentName(), _sortedColumn,
               _invertedIndexColumns, _noDictionaryColumns, _starTreeIndexSpec);
       logStatistics();
       segmentLogger.info("Trying to build segment");
@@ -973,6 +974,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     _segmentName = new LLCSegmentName(_segmentNameStr);
     _kafkaPartitionId = _segmentName.getPartitionId();
     _tableName = _tableConfig.getTableName();
+    _timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     _metricKeyName = _tableName + "-" + _kafkaTopic + "-" + _kafkaPartitionId;
     segmentLogger = LoggerFactory.getLogger(LLRealtimeSegmentDataManager.class.getName() +
         "_" + _segmentNameStr);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/indexsegment/generator/SegmentGeneratorConfig.java
@@ -308,6 +308,7 @@ public class SegmentGeneratorConfig {
     if (_segmentTimeColumnName != null) {
       return _segmentTimeColumnName;
     }
+    // TODO: if segmentTimeColumnName is null, getQualifyingFields DATETIME. If multiple found, throw exception "must specify primary timeColumnName"
     return getQualifyingFields(FieldType.TIME);
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -43,7 +43,7 @@ public class RealtimeSegmentConverter {
   private String outputPath;
   private Schema dataSchema;
   private String tableName;
-  private String timeColumnName;
+  private String timeColumnName; // TODO: use this to set time column in segment generator config
   private String segmentName;
   private String sortedColumn;
   private List<String> invertedIndexColumns;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -43,7 +43,7 @@ public class RealtimeSegmentConverter {
   private String outputPath;
   private Schema dataSchema;
   private String tableName;
-  private String timeColumnName; // TODO: use this to set time column in segment generator config
+  private String timeColumnName;
   private String segmentName;
   private String sortedColumn;
   private List<String> invertedIndexColumns;
@@ -122,7 +122,9 @@ public class RealtimeSegmentConverter {
       genConfig.enableStarTreeIndex(starTreeIndexSpec);
     }
 
+    // TODO: use timeColumnName field
     genConfig.setTimeColumnName(dataSchema.getTimeFieldSpec().getOutgoingTimeColumnName());
+    // TODO: find timeColumnName in schema.getDateTimeFieldSpec, in order to get the timeUnit
     genConfig.setSegmentTimeUnit(dataSchema.getTimeFieldSpec().getOutgoingGranularitySpec().getTimeType());
     if (segmentVersion != null) {
       genConfig.setSegmentVersion(segmentVersion);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/realtime/converter/RealtimeSegmentConverter.java
@@ -43,6 +43,7 @@ public class RealtimeSegmentConverter {
   private String outputPath;
   private Schema dataSchema;
   private String tableName;
+  private String timeColumnName;
   private String segmentName;
   private String sortedColumn;
   private List<String> invertedIndexColumns;
@@ -50,7 +51,7 @@ public class RealtimeSegmentConverter {
   private StarTreeIndexSpec starTreeIndexSpec;
 
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, String outputPath, Schema schema,
-      String tableName, String segmentName, String sortedColumn, List<String> invertedIndexColumns,
+      String tableName, String timeColumnName, String segmentName, String sortedColumn, List<String> invertedIndexColumns,
       List<String> noDictionaryColumns, StarTreeIndexSpec starTreeIndexSpec) {
     if (new File(outputPath).exists()) {
       throw new IllegalAccessError("path already exists:" + outputPath);
@@ -85,9 +86,9 @@ public class RealtimeSegmentConverter {
   }
 
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, String outputPath, Schema schema,
-      String tableName, String segmentName, String sortedColumn) {
-    this(realtimeSegment, outputPath, schema, tableName, segmentName, sortedColumn, new ArrayList<String>(),
-        new ArrayList<String>(), null/*StarTreeIndexSpec*/);
+      String tableName, String timeColumnName, String segmentName, String sortedColumn) {
+    this(realtimeSegment, outputPath, schema, tableName, timeColumnName, segmentName, sortedColumn, new ArrayList<>(),
+        new ArrayList<>(), null/*StarTreeIndexSpec*/);
   }
 
   public void build(@Nullable SegmentVersion segmentVersion, ServerMetrics serverMetrics) throws Exception {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -67,6 +67,9 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   @Option(name = "-segmentName", metaVar = "<string>", usage = "Name of the segment.")
   private String _segmentName;
 
+  @Option(name = "-timeColumnName", metaVar = "<string>", usage = "Primary time column.")
+  private String _timeColumnName;
+
   @Option(name = "-schemaFile", metaVar = "<string>", usage = "File containing schema for data.")
   private String _schemaFile;
 
@@ -130,6 +133,11 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
     return this;
   }
 
+  public CreateSegmentCommand setTimeColumnName(String timeColumnName) {
+    _timeColumnName = timeColumnName;
+    return this;
+  }
+
   public CreateSegmentCommand setSchemaFile(String schemaFile) {
     _schemaFile = schemaFile;
     return this;
@@ -171,10 +179,10 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   public String toString() {
     return ("CreateSegment  -generatorConfigFile " + _generatorConfigFile + " -dataDir " + _dataDir + " -format "
         + _format + " -outDir " + _outDir + " -overwrite " + _overwrite + " -tableName " + _tableName + " -segmentName "
-        + _segmentName + " -schemaFile " + _schemaFile + " -readerConfigFile " + _readerConfigFile
-        + " -enableStarTreeIndex " + _enableStarTreeIndex + " -starTreeIndexSpecFile " + _starTreeIndexSpecFile
-        + " -hllSize " + _hllSize + " -hllColumns " + _hllColumns + " -hllSuffix " + _hllSuffix + " -numThreads "
-        + _numThreads);
+        + _segmentName + " -timeColumnName " + _timeColumnName + " -schemaFile " + _schemaFile
+        + " -readerConfigFile " + _readerConfigFile + " -enableStarTreeIndex " + _enableStarTreeIndex
+        + " -starTreeIndexSpecFile " + _starTreeIndexSpecFile + " -hllSize " + _hllSize + " -hllColumns "
+        + _hllColumns + " -hllSuffix " + _hllSuffix + " -numThreads " + _numThreads);
   }
 
   @Override
@@ -272,6 +280,19 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
       }
     }
 
+    String configDateTimeColumnName = segmentGeneratorConfig.getTimeColumnName();
+    if (_timeColumnName == null) {
+      if (configDateTimeColumnName == null) {
+        throw new RuntimeException("Must specify dateTimeColumnName.");
+      }
+      _timeColumnName = configDateTimeColumnName;
+    } else {
+      if (configDateTimeColumnName != null && !configDateTimeColumnName.equals(_timeColumnName)) {
+        LOGGER.warn("Found dateTimeColumnName conflict in command line and config file, using config in command line: {}",
+            _segmentName);
+      }
+    }
+
     // Filter out all input files.
     File dir = new File(_dataDir);
     if (!dir.exists() || !dir.isDirectory()) {
@@ -309,6 +330,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
     segmentGeneratorConfig.setOverwrite(_overwrite);
     segmentGeneratorConfig.setTableName(_tableName);
     segmentGeneratorConfig.setSegmentName(_segmentName);
+    segmentGeneratorConfig.setTimeColumnName(_timeColumnName);
     if (_schemaFile != null) {
       if (segmentGeneratorConfig.getSchemaFile() != null && !segmentGeneratorConfig.getSchemaFile()
           .equals(_schemaFile)) {

--- a/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/com/linkedin/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -282,9 +282,6 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
 
     String configDateTimeColumnName = segmentGeneratorConfig.getTimeColumnName();
     if (_timeColumnName == null) {
-      if (configDateTimeColumnName == null) {
-        throw new RuntimeException("Must specify dateTimeColumnName.");
-      }
       _timeColumnName = configDateTimeColumnName;
     } else {
       if (configDateTimeColumnName != null && !configDateTimeColumnName.equals(_timeColumnName)) {


### PR DESCRIPTION
Make time column name available from table/user config in places where primary time column is needed, in order to be able to support migration of single time column to multiple datetime columns