### PR TITLE
 [TE] frontend - aaronucsd/Add ember data to TE on Dashboard (Home)

### DIFF
--- a/thirdeye/thirdeye-frontend/app/adapters/anomalies.js
+++ b/thirdeye/thirdeye-frontend/app/adapters/anomalies.js
@@ -1,0 +1,6 @@
+import BaseAdapter from './base';
+
+export default BaseAdapter.extend({
+  //for api call - /userdashboard/anomalies?application=lms-ads&start=1513123200000
+  namespace: '/userdashboard'
+});

--- a/thirdeye/thirdeye-frontend/app/adapters/application.js
+++ b/thirdeye/thirdeye-frontend/app/adapters/application.js
@@ -1,0 +1,11 @@
+import BaseAdapter from './base';
+
+export default BaseAdapter.extend({
+  //for api call - /thirdeye/entity/APPLICATION
+  namespace: '/thirdeye/entity',
+  pathForType(type) {
+    // path customization is needed here since ember data will try to plurize model names (applications)
+    return type.toUpperCase();
+  }
+  //use shouldBackgroundReloadAll, shouldReloadAll for `findAll` which will pull from local + network each time
+});

--- a/thirdeye/thirdeye-frontend/app/adapters/base.js
+++ b/thirdeye/thirdeye-frontend/app/adapters/base.js
@@ -1,0 +1,51 @@
+import DS from 'ember-data';
+
+/*
+ * @summary This base supports the standard advanced configurations needed for making the requests.
+ */
+export default DS.RESTAdapter.extend({
+  headers: {
+    'Accept': '*/*'
+  },
+  ajaxOptions() {
+    let ajaxOptions = this._super(...arguments);
+    // when server returns an empty response, we'll make it valid by replacing with {}
+    ajaxOptions.converters = {
+      'text json': function(data) {
+        return data === '' ? {} : JSON.parse(data);
+      }
+    };
+
+    return ajaxOptions;
+  },
+
+  handleResponse(status, headers, payload, requestData) {
+    // For creates we look into the header
+    if (status === 201 || status === 204) {
+      headers['content-type'] = 'application/json';
+      const id = headers['x-restli-id'] || headers['X-RestLi-Id'];
+      if (id) {
+        payload = { id };
+      }
+    }
+    let response = this._super(status, headers, payload, requestData);
+    return response;
+  },
+
+  // TODO: Will keep for reference - lohuynh
+  // query: function query(store, type, query) {
+  //   const url = `${this.get('namespace')}/${query.appName}`;
+  //   delete query.appName;//remove from query as not needed for actual request
+  //   return this.ajax(url, 'GET', { data: query });
+  // },
+  // The urlForQuery works like the `query` hook above. Both allow mutating the request url.
+  urlForQuery (query, modelName) {
+    /* The switch allows for adding more model names that needs custom request url */
+    switch(modelName) {
+      case 'performance':
+        return `${this.get('namespace')}/${query.appName}`;
+      default:
+        return this._super(...arguments);
+    }
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/adapters/performance.js
+++ b/thirdeye/thirdeye-frontend/app/adapters/performance.js
@@ -1,0 +1,10 @@
+import BaseAdapter from './base';
+
+/*
+ * @description This model is unique as it does not match the query url.
+ * @example /detection-job/eval/application/lss?
+*/
+export default BaseAdapter.extend({
+  //for api call - /detection-job/eval/application/{someAppName}?start={2017-09-01T00:00:00Z}&end={2018-04-01T00:00:00Z}
+  namespace: '/detection-job/eval/application'
+});

--- a/thirdeye/thirdeye-frontend/app/models/anomalies.js
+++ b/thirdeye/thirdeye-frontend/app/models/anomalies.js
@@ -1,0 +1,16 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  start: DS.attr(),
+  end: DS.attr(),
+  dimensions: DS.attr(),
+  severity: DS.attr(),
+  current: DS.attr(),
+  baseline: DS.attr(),
+  feedback: DS.attr(),
+  metricName: DS.attr(),
+  metricId: DS.attr(),
+  functionName: DS.attr(),
+  functionId: DS.attr(),
+  dataset: DS.attr()
+});

--- a/thirdeye/thirdeye-frontend/app/models/application.js
+++ b/thirdeye/thirdeye-frontend/app/models/application.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  application: DS.attr(),
+  createdBy: DS.attr(),
+  recipients: DS.attr(),
+  updatedBy: DS.attr(),
+  version: DS.attr()
+});

--- a/thirdeye/thirdeye-frontend/app/models/performance.js
+++ b/thirdeye/thirdeye-frontend/app/models/performance.js
@@ -1,0 +1,18 @@
+import DS from 'ember-data';
+
+/*
+ * @description This model is unique as it does not match the query url.
+ * @example /detection-job/eval/application/lss?
+*/
+export default DS.Model.extend({
+  falseAlarm: DS.attr(),
+  newTrend: DS.attr(),
+  precision: DS.attr(),
+  recall: DS.attr(),
+  responseRate: DS.attr(),
+  totalAlerts: DS.attr(),
+  totalResponses: DS.attr(),
+  trueAnomalies: DS.attr(),
+  userReportAnomaly: DS.attr(),
+  weightedPrecision: DS.attr()
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/stats-cards/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/stats-cards/component.js
@@ -57,7 +57,7 @@ export default Component.extend({
 
       card.forEach((stat, index) => {
         const property = props[index];
-        obj[property] = (property === 'value' && Number.isNaN(stat)) ? 0 : stat;//let's return a number vs NaN
+        obj[property] = stat;
       });
       cards.push(obj);
     });

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/current-wow/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/current-wow/template.hbs
@@ -1,4 +1,4 @@
 <p>{{record.current}}/{{record.baseline}}</p>
 <p class="te-anomaly-table__value-label te-anomaly-table__value-label--{{calculate-direction record.change}}">
-  ({{record.humanizedChange}})
+  ({{record.humanizedChangeDisplay}})
 </p>

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/dimensions/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/dimensions/template.hbs
@@ -1,10 +1,10 @@
 <ul class="te-anomaly-table__list">
-  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller" title="{{record.functionName}}">
+  <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller" title="{{record.anomaly.functionName}}">
     {{#link-to 'rootcause' (query-params anomalyId=record.id)}}
-      {{record.functionName}}
+      {{record.anomaly.functionName}}
     {{/link-to}}
   </li>
-  {{#each-in record.dimensions as |dimName dimList|}}
+  {{#each-in record.anomaly.dimensions as |dimName dimList|}}
    <li class="te-anomaly-table__list-item te-anomaly-table__list-item--smaller" title="{{dimension.dimensionVal}}">
      {{dimName}}:<span class="te-anomaly-table__list-value">{{dimList}}</span>
    </li>

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/component.js
@@ -17,41 +17,47 @@ import { getWithDefault } from '@ember/object';
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
 import { set, setProperties } from '@ember/object';
 import { getAnomalyDataUrl } from 'thirdeye-frontend/utils/api/anomaly';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
+  store: service('store'),
+
   tagName: '',//using tagless so i can add my own in hbs
   anomalyResponseNames: anomalyUtil.anomalyResponseObj.mapBy('name'),
   anomalyDataUrl: getAnomalyDataUrl(),
+  showResponseSaved: false,
 
   actions: {
     /**
      * Handle dynamically saving anomaly feedback responses
      * @method onChangeAnomalyResponse
-     * @param {Object} anomalyRecord - the anomaly being responded to
+     * @param {Object} humanizedAnomaly - the anomaly being responded to
      * @param {String} selectedResponse - user-selected anomaly feedback option
      * @param {Object} inputObj - the selection object
      */
-     onChangeAnomalyResponse: async function(anomalyRecord, selectedResponse, inputObj) {
+     onChangeAnomalyResponse: async function(humanizedAnomaly, selectedResponse, inputObj) {
       const responseObj = anomalyUtil.anomalyResponseObj.find(res => res.name === selectedResponse);
 
       set(inputObj, 'selected', selectedResponse);
       let res;
       try {
+        const id = humanizedAnomaly.get('id');
         // Save anomaly feedback
-        res = await anomalyUtil.updateAnomalyFeedback(anomalyRecord.id, responseObj.value)
+        res = await anomalyUtil.updateAnomalyFeedback(id, responseObj.value);
         // We make a call to ensure our new response got saved
-        res = await anomalyUtil.verifyAnomalyFeedback(anomalyRecord.id, responseObj.status)
+        res = await anomalyUtil.verifyAnomalyFeedback(id, responseObj.status);
+        // TODO: right now we will update the union wrapper cached record for this anomalyId
+        humanizedAnomaly.set('anomaly.feedback', responseObj.value);
+
         const filterMap = getWithDefault(res, 'searchFilters.statusFilterMap', null);
         if (filterMap && filterMap.hasOwnProperty(responseObj.status)) {
-          setProperties(anomalyRecord, {
-            anomalyFeedback: selectedResponse,
-            showResponseSaved: true
-          });
+          humanizedAnomaly.set('anomalyFeedback', selectedResponse);
+          this.set('showResponseSaved', true);
         } else {
           return Promise.reject(new Error('Response not saved'));
         }
       } catch (err) {
-        setProperties(anomalyRecord, {
+        this.setProperties({
           showResponseFailed: true,
           showResponseSaved: false
         });

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/resolution/template.hbs
@@ -1,8 +1,8 @@
 <div class="anomalies-table__column-cell">
-  {{#if record.showResponseSaved}}
-    <i class="{{if record.showResponseSaved "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-ok-circle" ></i>
+  {{#if showResponseSaved}}
+    <i class="{{if showResponseSaved "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-ok-circle" ></i>
   {{else}}
-    <i class="{{if record.showResponseFailed "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-remove-circle" ></i>
+    <i class="{{if showResponseFailed "te-anomaly-table__icon--status-no-margin" "te-anomaly-table__icon--hidden"}} glyphicon glyphicon-remove-circle" ></i>
   {{/if}}
 
   {{#if record.isUserReported}}

--- a/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/severity/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/anomalies-table/severity/template.hbs
@@ -1,0 +1,1 @@
+{{record.severity}}

--- a/thirdeye/thirdeye-frontend/app/pods/home/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/home/route.js
@@ -1,20 +1,14 @@
 import Route from '@ember/routing/route';
-import { humanizeFloat, humanizeChange, checkStatus } from 'thirdeye-frontend/utils/utils';
-import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
 import columns from 'thirdeye-frontend/shared/anomaliesTableColumns';
 import fetch from 'fetch';
 import { hash } from 'rsvp';
-import {
-  getFormatedDuration,
-  getAnomaliesByAppName,
-  anomalyResponseObj,
-  getPerformanceByAppNameUrl
-} from 'thirdeye-frontend/utils/anomaly';
 import { selfServeApiCommon } from 'thirdeye-frontend/utils/api/self-serve';
 import { setProperties } from '@ember/object';
 import { task } from 'ember-concurrency';
 import RSVP from "rsvp";
 import moment from 'moment';
+import { inject as service } from '@ember/service';
+import _ from 'lodash';
 
 const queryParamsConfig = {
   refreshModel: true,
@@ -22,6 +16,9 @@ const queryParamsConfig = {
 };
 
 export default Route.extend({
+  store: service('store'),
+  anomaliesApiService: service('services/api/anomalies'),
+
   queryParams: {
     appName: queryParamsConfig,
     startDate: queryParamsConfig,
@@ -31,6 +28,7 @@ export default Route.extend({
   appName: null,
   startDate: moment().startOf('day').utc().valueOf(),
   endDate: moment().utc().valueOf(),
+  duration: '1d',
 
   /**
    * Returns a mapping of anomalies by metric and functionName (aka alert), performance stats for anomalies by
@@ -48,96 +46,72 @@ export default Route.extend({
    *   }
    * }
    */
-  model(params) {
-    const { appName, startDate, endDate } = params;
+  async model(params) {
+    const { appName, startDate, endDate, duration } = params;//check params
+    const applications = await this.get('anomaliesApiService').queryApplications(appName, startDate, endDate);// Get all applicatons available
+
     return hash({
       appName,
       startDate,
       endDate,
-      applications: fetch(selfServeApiCommon.allApplications).then(checkStatus)
+      duration,
+      applications
     });
   },
 
   afterModel(model) {
-    const appName = model.appName || model.applications[0].application;
-    const startDate = Number(model.startDate) || this.get('startDate');
+    // Overrides with params if exists
+    const appName = model.appName || null;//model.applications.get('firstObject.application');
+    const startDate = Number(model.startDate) || this.get('startDate');//TODO: we can use ember transform here
     const endDate = Number(model.endDate) || this.get('endDate');
+    const duration = model.duration || this.get('duration');
 
+    // Update props
     this.setProperties({
       appName,
       startDate,
-      endDate
+      endDate,
+      duration
     });
 
     return new RSVP.Promise(async (resolve, reject) => {
       try {
-        const anomalyMapping = await this.get('_getAnomalyMapping').perform(model);
-        const anomalyPerformance = await getPerformanceByAppNameUrl(appName, moment(this.get('startDate')).startOf('day').utc().format(), moment(this.get('endDate')).startOf('day').utc().format());
+        const anomalyMapping = appName ? await this.get('_getAnomalyMapping').perform(model) : [];
+        const anomalyPerformance = appName ? await this.get('anomaliesApiService').queryPerformanceByAppNameUrl(appName, moment(this.get('startDate')).startOf('day').utc().format(), moment(this.get('endDate')).startOf('day').utc().format()) : [];
         const defaultParams = {
           anomalyMapping,
-          anomalyPerformance
+          anomalyPerformance,
+          appName,
+          startDate,
+          endDate,
+          duration
         };
+        // Update model
         resolve(Object.assign(model, { ...defaultParams }));
       } catch (error) {
-        reject(new Error('Unable to retrieve anomaly data. ${error}'));
+        reject(new Error(`Unable to retrieve anomaly data. ${error}`));
       }
     });
   },
 
   _getAnomalyMapping: task (function * (model) {//TODO: need to add to anomaly util - LH
     let anomalyMapping = {};
-    let redirectLink = {};
-    //fetch the anomalies
-    const applicationAnomalies = yield getAnomaliesByAppName(this.get('appName'), this.get('startDate'));
+    //fetch the anomalies from the onion wrapper cache.
+    const applicationAnomalies = yield this.get('anomaliesApiService').queryAnomaliesByAppName(this.get('appName'), this.get('startDate'));
     this.set('applicationAnomalies', applicationAnomalies);
-    try {
-      this.get('applicationAnomalies').forEach(anomaly => {
-        const { metricName, functionName, current, baseline, metricId } = anomaly;
 
-        if (!anomalyMapping[metricName]) {
-          anomalyMapping[metricName] = [];
-        }
+    applicationAnomalies.forEach(anomaly => {
+      const metricName = anomaly.get('metricName');
+      //Grouping the anomalies of the same metric name
+      if (!anomalyMapping[metricName]) {
+        anomalyMapping[metricName] = [];
+      }
 
-        // if (!anomalyMapping[metric][functionName]) {//TODO: not used now. Clean up to follow - lohuynh
-        //   anomalyMapping[metric][functionName] = [];
-        // }
+      // Group anomalies by metricName and function name (alertName)
+      anomalyMapping[metricName].push(this.get('anomaliesApiService').getHumanizedEntity(anomaly));
+    });
 
-        if(!redirectLink[metricName]) {
-          redirectLink[metricName] = {};
-        }
-
-        // if (!redirectLink[metricName][functionName]) {//TODO: not used now. Clean up to follow - lohuynh
-        //   // TODO: Once start/end times are introduced, add these to the link below
-        //   redirectLink[metricName][functionName] = `/thirdeye#anomalies?anomaliesSearchMode=metric&pageNumber=1&metricId=${metricId}\
-        //                         &searchFilters={"functionFilterMap":["${functionName}"]}`;
-        // }
-
-        // Format current and baseline numbers, so numbers in the millions+ don't overflow
-        const anomalyName = anomalyResponseObj.find(res => res.value === anomaly.feedback).name;
-        setProperties(anomaly, {
-          current: humanizeFloat(anomaly.current),
-          baseline: humanizeFloat(anomaly.baseline),
-          severity: parseFloat(anomaly.severity, 10).toFixed(2),
-          anomalyFeedback: anomalyName
-        });
-
-        // Calculate change
-        const changeFloat = (current - baseline) / baseline;
-        setProperties(anomaly, {
-          change: floatToPercent(changeFloat),
-          humanizedChange: humanizeChange(changeFloat),
-          duration: getFormatedDuration(anomaly.start, anomaly.end)
-        });
-
-        // Group anomalies by metricName and function name (alertName)
-        //anomalyMapping[metricName][functionName].push(anomaly);TODO: not used now. Clean up to follow - lohuynh
-        anomalyMapping[metricName].push(anomaly);
-      });
-
-      return anomalyMapping;
-    } catch (error) {
-      throw error;
-    }
+    return anomalyMapping;
   }).drop(),
 
   /**
@@ -148,9 +122,8 @@ export default Route.extend({
   getMetrics() {
     let metricSet = new Set();
     this.get('applicationAnomalies').forEach(anomaly => {
-      metricSet.add(anomaly.metric);
+      metricSet.add(anomaly.get('metric'));
     });
-
     return [...metricSet];
   },
 
@@ -160,10 +133,12 @@ export default Route.extend({
    */
   getAlerts() {
     let alertSet = new Set();
-    this.get('applicationAnomalies').forEach(anomaly => {
-      alertSet.add(anomaly.functionName);
-    });
-
+    const applicationAnomalies = this.get('applicationAnomalies');
+    if (applicationAnomalies) {
+      applicationAnomalies.forEach(anomaly => {
+        alertSet.add(anomaly.get('functionName'));
+      });
+    }
     return [...alertSet];
   },
 
@@ -177,7 +152,7 @@ export default Route.extend({
       columns,
       appNameSelected: model.applications.findBy('application', this.get('appName')),
       //metricList: this.getMetrics(),//TODO: clean up - lohuynh
-      alertList: this.getAlerts(),
+      // alertList: this.getAlerts(),
       appName: this.get('appName'),
       anomaliesCount:  Object.keys(model.anomalyMapping).length
     });

--- a/thirdeye/thirdeye-frontend/app/pods/home/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/home/template.hbs
@@ -2,14 +2,15 @@
   <header>
     {{range-pill-selectors
       title="Showing"
-      uiDateFormat=uiDateFormat
-      activeRangeEnd=activeRangeEnd
-      activeRangeStart=activeRangeStart
-      timeRangeOptions=timeRangeOptions
-      timePickerIncrement=timePickerIncrement
+      uiDateFormat=pill.uiDateFormat
+      activeRangeEnd=pill.activeRangeEnd
+      activeRangeStart=pill.activeRangeStart
+      timeRangeOptions=pill.timeRangeOptions
+      timePickerIncrement=pill.timePickerIncrement
       selectAction=(action "onRangeSelection")
     }}
   </header>
+
   <article class="dashboard-container__body">
     <section class="dashboard-container__application-header">
       <h2 class="dashboard-container__title">Application:<span>{{appName}}</span></h2>
@@ -17,6 +18,7 @@
         {{#power-select
           options=model.applications
           selected=appNameSelected
+          placeholder="Please pick an application"
           onchange=(action "selectApplication")
           as |app|}}
           {{app.application}}
@@ -32,7 +34,7 @@
       {{#if (gt anomaliesCount 0)}}
         {{#each-in model.anomalyMapping as |metric alertList|}}
           <h4 class="dashboard-container__title">Metric:
-            <span><strong>{{metric}} ({{alertList.length}} {{if (gt alertList.length 1) "alerts" "alert"}})</strong></span>
+            <span><strong>{{metric}} ({{alertList.length}} {{if (gt alertList.length 1) "anomalies" "anomaly"}})</strong></span>
           </h4>
             {{models-table
               data=alertList
@@ -43,18 +45,19 @@
               filteringIgnoreCase=true
               multipleExpand=true
               pageSize=5
-              showComponentFooter=false
+              showComponentFooter=true
             }}
+            {{!-- TODO: leave to decide if after poc we need it - lohuynh
             {{#if (gt alertList.length 5)}}
               <a href="{{get (get model.redirectLink metric) alert}}" class="dashboard-container__redirect-link">
                 See More
               </a>
-            {{/if}}
+            {{/if}} --}}
         {{/each-in}}
       {{else}}
         <div class="card-container card-container--md card-container--flush-top">
           {{rootcause-placeholder
-            message="No anomalies found for this time range."
+            message="No anomalies found."
             iconClass="glyphicon glyphicon-equalizer"}}
         </div>
       {{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/api/anomalies/service.js
@@ -1,0 +1,158 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { assert } from '@ember/debug';
+import EmberObject, { computed, get } from '@ember/object';
+import { humanizeFloat, humanizeChange } from 'thirdeye-frontend/utils/utils';
+import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
+import {
+  getFormatedDuration,
+  anomalyResponseObj
+} from 'thirdeye-frontend/utils/anomaly';
+
+const HumanizedAnomaly = EmberObject.extend({//TODO: rename `anomaly` to `record` for generic? - lohuynh
+  id: computed.alias('anomaly.id'),
+  _changeFloat: computed('anomaly.{current,baseline}', function() {
+    const current = get(this, 'anomaly.current');
+    const baseline = get(this, 'anomaly.baseline');
+    return Number((current - baseline) / baseline);
+  }),
+  change: computed('_changeFloat', function() {
+    return floatToPercent(get(this, '_changeFloat'));
+  }),
+  humanizedChangeDisplay: computed('_changeFloat', function() {
+    return humanizeChange(get(this, '_changeFloat'));
+  }),
+  duration: computed('anomaly.{start,end}', function() {
+    return getFormatedDuration(get(this, 'anomaly.start'), get(this, 'anomaly.end'));
+  }),
+  current: computed('anomaly.current', function() {
+    return humanizeFloat(get(this, 'anomaly.current'));
+  }),
+  baseline: computed('anomaly.baseline', function() {
+    return humanizeFloat(get(this, 'anomaly.baseline'));
+  }),
+  severity: computed('anomaly.severity', function() {
+    return humanizeFloat(get(this, 'anomaly.severity'));
+  }),
+  anomalyFeedback: computed('anomaly.feedback', function() {
+    return get(this, 'anomaly.feedback') ? anomalyResponseObj.find(res => res.value === get(this, 'anomaly.feedback')).name : '';
+  })
+});
+
+/**
+ * @type {Ember.Service}
+ * @summary This service provides all the api calls for anomalies related data. An `Ember.Service`
+   is a long-lived Ember object that can be made available in different parts of your application.
+ * @example anomaliesApiService: service('services/api/anomalies');
+ */
+export default Service.extend({
+  store: service('store'),
+  queryCache: service('services/query-cache'),
+
+  init() {
+    this._super();
+    this._humanizedAnomaliesCache = Object.create(null);//create our humanized cache for this service (store humanized anomalies)
+  },
+
+  /**
+   * @summary Return the cache for the humanized anomalies
+   * @method getHumanizedAnomalies
+   * @return {Object.array}
+   * @example:
+     usage: `this.get('anomaliesApiService').getHumanizedAnomalies();`
+   */
+  async getHumanizedAnomalies() {
+    return this._humanizedAnomaliesCache;
+  },
+
+/**
+ * @summary Return the cached humanized anomaly if exists, if not we store it into cache and return it.
+   1. Check for the existance of the entity (anomaly record) in the cache by cacheKey/id.
+   2. Add the entity (anomaly record) to the `HumanizedAnomaly` to be used later. This save us the need to directly access the store (findRecord).
+   3. Save to the cache the new HumanizedAnomaly ember object to cache. This contains all the display/humanized properties, including the anomaly record itself.
+      `HumanizedAnomaly.create({ entity })`
+   4. Assign to humanizedEntity the new HumanizedAnomaly ember object. This allow us not to mutate the actual anomaly record later.
+   5. Return the humanizedEntity
+ * @method getHumanizedEntity
+ * @param {object} anomaly - an anomaly record from the store cache (proxy model). This param name must match the name used in `HumanizedAnomaly`
+ * @return {Ember.Object}
+ * @example:
+   usage: `this.get('anomaliesApiService').getHumanizedEntity(entity);`
+ */
+  getHumanizedEntity(anomaly) {
+    assert('you must pass anomaly record.', anomaly);
+
+    let cacheKey = get(anomaly, 'id');
+    let humanizedEntity = this._humanizedAnomaliesCache[cacheKey];//retrieve the anomaly from cache if exists
+    if (!humanizedEntity) {
+      humanizedEntity = this._humanizedAnomaliesCache[cacheKey] = HumanizedAnomaly.create({ anomaly });// add to our dictionary
+    }
+
+    return humanizedEntity;
+  },
+
+  /**
+   * @summary Fetch all application names. We can use it to list in the select box.
+   * @method queryApplications
+   * @param {String} appName - the application name for creating the cacheKey
+   * @return {Ember.RSVP.Promise}
+   * @example: /thirdeye/entity/APPLICATION
+     usage: `this.get('anomaliesApiService').queryApplications();`
+   */
+  async queryApplications(appName, start, end) {
+    const queryCache = this.get('queryCache');
+    const modelName = 'application';
+    const query = { appName, start, end };
+    const cacheKey = queryCache.urlForQueryKey(modelName, {});//TODO: Won't pass all the `query` here. The `cacheKey` do not need to be uniqued, since all apps has the same list of apps.
+    const applications = await queryCache.query(modelName, query, { reload: false, cacheKey });
+    return applications;
+  },
+
+  /**
+   * @summary Fetch all anomalies by application name and start time
+   * @method queryAnomaliesByAppName
+   * @param {String} appName - the application name
+   * @param {Number} startStamp - the anomaly iso start time
+   * @return {Ember.RSVP.Promise}
+   * @example: for call `/userdashboard/anomalies?application={someAppName}&start={1508472800000}`
+     usage: `this.get('anomaliesApiService').queryAnomaliesByAppName(this.get('appName'), this.get('startDate'));`
+   */
+  async queryAnomaliesByAppName(appName, start) {
+    assert('you must pass appName param as an required argument.', appName);
+    assert('you must pass start param as an required argument.', start);
+
+    const queryCache = this.get('queryCache');
+    const modelName = 'anomalies';
+    const query = { application: appName, start };
+    const anomalies = await queryCache.query(modelName, query, { reload: false, cacheKey: queryCache.urlForQueryKey(modelName, query) });
+    return anomalies;
+    //const url = anomalyApiUrls.getAnomaliesByAppNameUrl(appName, startTime);//TODO: remove from the utils/api/anomaly.js - lohuynh
+    //return fetch(url).then(checkStatus).catch(() => {});//TODO: leave to document in RFC. Will remove. - lohuynh
+  },
+
+  /**
+   * @summary Fetch the application performance details
+   * @method queryPerformanceByAppNameUrl
+   * @param {String} appName - the application name
+   * @param {Number} startStamp - the anomaly iso start time
+   * @param {Number} endStamp - the anomaly iso end time
+   * @return {Ember.RSVP.Promise}
+   * @example: /detection-job/eval/application/{someAppName}?start={2017-09-01T00:00:00Z}&end={2018-04-01T00:00:00Z}
+     usage: `this.get('anomaliesApiService').queryPerformanceByAppNameUrl(appName, moment(this.get('startDate')).startOf('day').utc().format(), moment(this.get('endDate')).startOf('day').utc().format());`
+   */
+  async queryPerformanceByAppNameUrl(appName, start, end) {
+    assert('you must pass appName param as an required argument.', appName);
+    assert('you must pass start param as an required argument.', start);
+    assert('you must pass end param as an required argument.', end);
+
+    const queryCache = this.get('queryCache');
+    const modelName = 'performance';
+    const query = { appName, start, end };
+    const cacheKey = queryCache.urlForQueryKey(modelName, query);
+    const performanceInfo = await queryCache.query(modelName, query, { reload: false, cacheKey });
+    return EmberObject.create(performanceInfo.meta);//Wrap it in an ember object for easier usage later (get/set etc).
+    // const url = anomalyApiUrls.getPerformanceByAppNameUrl(appName, startTime, endTime) ;//TODO: remove from the utils/api/anomaly.js
+    // return fetch(url).then(checkStatus).catch(() => {});//TODO: leave to document in RFC. Will remove. - lohuynh
+  }
+
+});

--- a/thirdeye/thirdeye-frontend/app/pods/services/query-cache/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/query-cache/service.js
@@ -1,0 +1,68 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { assert } from '@ember/debug';
+/**
+ * @type {Ember.Service}
+ * @summary This service is to also cached the query response data for `this.get('store').query()` calls. In general,
+   the call to `this.get('store').query()` does not do auto cache under the hood.
+   The `onion wrapper` cache only caches the info that ember-data does not currently cache for us. Meaning if the internal records
+   in the ember store changes it changes for this cache as well.
+   This is caching the `onion wrapper` we get back with the data document.
+   An `Ember.Service` is a long-lived Ember object that can be made available in different parts of your application.
+ * @example  a typical json-api doc.
+    {
+      links: {}
+      meta: {},
+      data: [] | {}  <- Note: this will have the entity or entities that the ember-data will cache in its store.
+    }
+ * @see {@link http://jsonapi.org/|jsonapi.org}
+ * //To debug what is in the store - this.get('store')._identityMap.
+ * @example   anomaliesApiService: service('services/api/anomalies'),
+ */
+export default Service.extend({
+  init() {
+    this._super();
+    this._cache = Object.create(null);//create our cache
+  },
+
+  store: service('store'),
+
+  /**
+   * @summary  This query method is a wrapper of the ember store `query`. It will add the dictionary caching that we need.
+   * @method query
+   * @param {String} type - modelName
+   * @param {Object} query - query object
+   * @param {Object} adapterOptions - adapter options object
+   * @example
+       const query = { application: appName, start };
+       const anomalies = await queryCache.query(modelName, query, { reload: false, cacheKey: queryCache.urlForQueryKey(modelName, query) });
+   * @return {Obect}
+   */
+  query(type, query, adapterOptions) {
+    assert('you must pass adapterOptions to queryCache.query', adapterOptions);
+    assert('you must pass adapterOptions.cacheKey to queryCache.query', adapterOptions.cacheKey);
+
+    let cached = this._cache[adapterOptions.cacheKey];
+    if (!cached || adapterOptions.reload) {
+       cached = this._cache[adapterOptions.cacheKey] = this.get('store').query(type, query, adapterOptions);//add to our dictionary
+    }
+
+    return cached;
+  },
+
+  /**
+   * @summary  We can use the `url` as the `cacheKey` in the `query` hook.
+     which would be different with each change in query params.
+   * @method urlForQueryKey
+   * @param {String} modelName
+   * @param {Object} query
+   * @example
+       const query = { application: appName, start };
+       const anomalies = await queryCache.query(modelName, query, { reload: false, cacheKey: queryCache.urlForQueryKey(modelName, query) });
+   * @return {String}
+   */
+  urlForQueryKey(modelName, query) {
+    const key = `${this.get('store').adapterFor(modelName).urlForQuery(query, modelName)}::${JSON.stringify(query)}`;//making a unique `cacheKey`. + JSON.stringify(query)
+    return key;
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/serializers/anomalies.js
+++ b/thirdeye/thirdeye-frontend/app/serializers/anomalies.js
@@ -1,0 +1,3 @@
+import BaseAPISerializer from './base';
+
+export default BaseAPISerializer.extend({});

--- a/thirdeye/thirdeye-frontend/app/serializers/application.js
+++ b/thirdeye/thirdeye-frontend/app/serializers/application.js
@@ -1,0 +1,3 @@
+import BaseAPISerializer from './base';
+
+export default BaseAPISerializer.extend({});

--- a/thirdeye/thirdeye-frontend/app/serializers/base.js
+++ b/thirdeye/thirdeye-frontend/app/serializers/base.js
@@ -1,0 +1,43 @@
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  /*
+   * @summary normalizing the payload from api response with array type ([{},{}..]) to correct json-api format spec. See  http://jsonapi.org/
+   */
+  normalizeArrayResponse(store, primaryModelClass, payload, id, requestType) {
+    //we are kind of doing the job of the this._super(...) here to convert a 'classic JSON' payload into JSON API.
+    let data = payload.map((resourcePayload) => {
+      let attributes = {};
+      primaryModelClass.eachAttribute(key => {
+        attributes[key] = resourcePayload[key];
+      });
+
+      return {
+        id: resourcePayload.id,
+        type: primaryModelClass.modelName,
+        attributes
+      };
+    });
+
+    return {
+      data
+    };
+  }
+  /*
+   * serializing the data to send to the api server
+   */
+   //TODO: Will keep this as we will need it when we implement the save/post api methods. - lohuynh
+  // serialize(snapshot, options) {
+  //   let json = this._super(...arguments);
+  //
+  //   json.data.attributes.cost = {
+  //     amount: json.data.attributes.amount,
+  //     currency: json.data.attributes.currency
+  //   };
+  //
+  //   delete json.data.attributes.amount;
+  //   delete json.data.attributes.currency;
+  //
+  //   return json;
+  // }
+});

--- a/thirdeye/thirdeye-frontend/app/serializers/performance.js
+++ b/thirdeye/thirdeye-frontend/app/serializers/performance.js
@@ -1,0 +1,19 @@
+import DS from 'ember-data';
+
+export default DS.JSONSerializer.extend({
+   /**
+    * @summary A serializer hook. Normalizing the payload from api response simpler or legacy json that may not support the http://jsonapi.org/ spec
+    * @method normalizeQueryResponse
+    * @param {DS.Store} store
+    * @param {DS.Model} primaryModelClass
+    * @param {Object} payload - the data object
+    * @return {Obect}
+    */
+  normalizeQueryResponse(store, primaryModelClass, payload) {
+    // The response for this is just an object. So we need to normalize it into the meta.
+    return {
+      meta: payload,
+      data: []
+    };
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/shared/anomaliesTableColumns.js
+++ b/thirdeye/thirdeye-frontend/app/shared/anomaliesTableColumns.js
@@ -4,41 +4,42 @@ export default [
     propertyName: 'start',
     template: 'custom/anomalies-table/start-duration',
     title: 'Start/Duration',
-    className: 'anomalies-table__column',
+    className: 'anomalies-table__column anomalies-table__column--med-width',
     disableFiltering: true
   },
   {
     propertyName: 'dimensions',
     template: 'custom/anomalies-table/dimensions',
     title: 'Alert/Dimensions',
-    className: 'anomalies-table__column',
+    className: 'anomalies-table__column anomalies-table__column--large-width',
     disableFiltering: true
   },
   {
     propertyName: 'severity',
+    template: 'custom/anomalies-table/severity',
     title: 'Severity Score',
-    className: 'anomalies-table__column',
+    className: 'anomalies-table__column anomalies-table__column--small-width',
     disableFiltering: true
   },
   {
     propertyName: 'baseline',
     template: 'custom/anomalies-table/current-wow',
     title: 'Current/WoW',
-    className: 'anomalies-table__column',
+    className: 'anomalies-table__column anomalies-table__column--med-width',
     disableFiltering: true
   },
   {
     propertyName: 'feedback',
     component: 'custom/anomalies-table/resolution',
     title: 'Resolution',
-    className: 'anomalies-table__column',
+    className: 'anomalies-table__column anomalies-table__column--large-width',
     disableFiltering: true
   },
   {
     propertyName: 'link',
     template: 'custom/anomalies-table/investigation-link',
     title: 'Investigation Link',
-    className: 'anomalies-table__column',
+    className: 'anomalies-table__column anomalies-table__column--med-width',
     disableFiltering: true
   }
 ];

--- a/thirdeye/thirdeye-frontend/app/styles/pods/home/alerts-dashboard.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/pods/home/alerts-dashboard.scss
@@ -2,8 +2,8 @@
   &__body {
     background-color: #FFF;
     margin-bottom: $te-default-element-spacing;
-    padding: 0 15px;
-    border: app-shade(black, 0.1);
+    padding: 0 15px 15px 15px;
+    border: 1px solid app-shade(black, 0.1);
   }
 
   &__title {
@@ -31,5 +31,20 @@
     border-top: none;
     padding-top: 10px;
     padding-bottom: 10px;
+  }
+
+  //dashboard table styles
+  .anomalies-table {
+    &__column {
+        &--small-width {
+          width: 60px;
+        }
+        &--med-width {
+          width: 120px;
+        }
+        &--large-width {
+          width: 250px;;
+        }
+    }
   }
 }

--- a/thirdeye/thirdeye-frontend/app/utils/anomaly.js
+++ b/thirdeye/thirdeye-frontend/app/utils/anomaly.js
@@ -52,7 +52,7 @@ export function updateAnomalyFeedback(anomalyId, feedbackType) {
  * @return {Ember.RSVP.Promise}
  */
 export function verifyAnomalyFeedback(anomalyId) {
-  const url = `anomalyApiUrls.getAnomalyDataUrl()${anomalyId}`;
+  const url = `${anomalyApiUrls.getAnomalyDataUrl()}${anomalyId}`;
   return fetch(url).then(checkStatus);
 }
 
@@ -71,7 +71,7 @@ export function getAnomaliesByAppName(appName, startTime) {
   if (!startTime) {
     return Promise.reject(new Error('startTime param is required.'));
   }
-  const url = anomalyApiUrls.getAnomaliesByAppNameUrl(appName, startTime) ;
+  const url = anomalyApiUrls.getAnomaliesByAppNameUrl(appName, startTime);
   return fetch(url).then(checkStatus).catch(() => {});
 }
 

--- a/thirdeye/thirdeye-frontend/app/utils/float-to-percent.js
+++ b/thirdeye/thirdeye-frontend/app/utils/float-to-percent.js
@@ -5,5 +5,5 @@
  * @return {float} - percentage value of float
  */
 export default function floatToPercent(float) {
-  return (float * 100).toFixed(2);
+  return Number.isNaN(Number(float)) ? '-' : (float * 100).toFixed(2);
 }


### PR DESCRIPTION
![screen shot 2018-04-17 at 2 07 14 pm](https://user-images.githubusercontent.com/8840761/38965070-47f85428-432f-11e8-99ec-6110de22b209.png)
1. Added the models, adapters, and serilizers for ember data for the anomaly  apis.
2. Added new anomaly service to replace the need of `utils/api/anomaly.js` and `utils/anomaly.js` as the adapters will do those internally.
   This anomaly servie has a built in humanized caching to cache the ember objects meant for display purposes only and not mutate the actual proxy models (records).
3. Added a new query cache service. This will add a new caching layer serivce to save the `union wrapper` data that ember-data do not cache in the store.
Ember data will only cache the entities (resources) only. This service can be used for other client persistant libs ($ajax, redux etc).
4. Updated Dashboard to use the new `api/anomalies/services.js` methods.
5. Made fix for the styles for the metric tables.
6. Added the pagination for the metric tables vs `Show more` link as table will not support that.
7. Fixed the time picker codes for dashboard to work now with the cachhing as well. Reload of the same url query will pull from the cache now and draw instantly.
8. TODO: tests for the new services
9. TODO: Write guideline to use ember data conversion for ThirdEye.
10. TODO: Update the anomaly's resolution option to also use ember data.