### PR TITLE
[TE] rootcause - granularity and max time adjustments

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-anomaly/component.js
@@ -18,7 +18,7 @@ import { equal, reads } from '@ember/object/computed';
 
 const ROOTCAUSE_HIDDEN_DEFAULT = 'default';
 
-const OFFSETS = ['current', 'baseline', 'wo1w', 'wo2w', 'wo3w', 'wo4w'];
+const OFFSETS = ['current', 'predicted', 'wo1w', 'wo2w', 'wo3w', 'wo4w'];
 
 /**
  * Maps the status from the db to something human readable to display on the form
@@ -146,7 +146,7 @@ export default Component.extend({
    * Anomaly baseline as computed by anomaly function
    * @type {Float}
    */
-  baseline: reads('anomaly.attributes.baseline.firstObject'),
+  predicted: reads('anomaly.attributes.baseline.firstObject'),
 
   /**
    * Anomaly unique identifier
@@ -299,10 +299,10 @@ export default Component.extend({
    * @private
    */
   _getAggregate(offset) {
-    const { metricUrn, aggregates, baseline } = getProperties(this, 'metricUrn', 'aggregates', 'baseline');
+    const { metricUrn, aggregates, predicted } = getProperties(this, 'metricUrn', 'aggregates', 'predicted');
 
-    if (offset === 'baseline') {
-      return parseFloat(baseline);
+    if (offset === 'predicted') {
+      return parseFloat(predicted);
     }
 
     return aggregates[toOffsetUrn(metricUrn, offset)];

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-comparison-range/component.js
@@ -24,8 +24,6 @@ export default Component.extend({
   },
 
   compareModeOptions: [
-    'none',
-    'predicted',
     'WoW',
     'Wo2W',
     'Wo3W',
@@ -33,7 +31,9 @@ export default Component.extend({
     'mean4w',
     'median4w',
     'min4w',
-    'max4w'
+    'max4w',
+    'predicted',
+    'none'
   ],
 
   maxDateFormatted: computed({


### PR DESCRIPTION
This PR enables the RCA UI to handle gracefully any metrics with high-resolution data by requiring at least 5 minute default granularity. Furthermore, the maxTime as returned from the backend is now aligned to granularity boundaries.