### PR TITLE
[TE] rootcause - reload filters before adding metric to chart

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric-dimension/component.js
@@ -101,8 +101,13 @@ export default Component.extend({
 
       const baseUrn = metricUrns[0];
 
-      this.setProperties({ baseUrn });
-      this.send('onSelect');
+      const { selectedUrn, baseUrnCache } = this.getProperties('selectedUrn', 'baseUrnCache');
+      const filterMap = toFilterMap(toFilters(selectedUrn));
+
+      if (!_.isEqual(baseUrn, baseUrnCache)) {
+        this.setProperties({ baseUrn, baseUrnCache: baseUrn });
+        this._fetchFilters(baseUrn, filterMap);
+      }
     },
 
     onFilters(filters) {


### PR DESCRIPTION
The "auto-add on select" feature created a regression where a newly selected metric would apply stale pre-selected filters even though the new metric does not support the filter dimension. This PR forces re-fetching and pruning of filters when a new metric is selected.