### PR TITLE
[TE] Add rule-based detection in addition to algorithm-based detection

### DIFF
--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/anomaly/detection/DetectionTaskRunner.java
@@ -65,6 +65,7 @@ public class DetectionTaskRunner implements TaskRunner {
   private List<String> collectionDimensions;
   private AnomalyFunctionFactory anomalyFunctionFactory;
   private BaseAnomalyFunction anomalyFunction;
+  private BaseAnomalyFunction ruleBasedAnomalyFunction;
 
   public List<TaskResult> execute(TaskInfo taskInfo, TaskContext taskContext) throws Exception {
     detectionTaskCounter.inc();
@@ -89,6 +90,7 @@ public class DetectionTaskRunner implements TaskRunner {
     jobExecutionId = detectionTaskInfo.getJobExecutionId();
     anomalyFunctionFactory = taskContext.getAnomalyFunctionFactory();
     anomalyFunction = anomalyFunctionFactory.fromSpec(anomalyFunctionSpec);
+    ruleBasedAnomalyFunction = anomalyFunctionFactory.getRuleBasedAnomalyFunction(anomalyFunctionSpec);
     detectionJobType = detectionTaskInfo.getDetectionJobType();
 
     String dataset = anomalyFunctionSpec.getCollection();
@@ -263,6 +265,11 @@ public class DetectionTaskRunner implements TaskRunner {
     } else {
       resultsOfAnEntry =
           anomalyFunction.analyze(dimensionMap, metricTimeSeries, windowStart, windowEnd, historyMergedAnomalies);
+    }
+    if (ruleBasedAnomalyFunction != null) {
+      List<AnomalyResult> rulebasedAnomalies= ruleBasedAnomalyFunction.analyze(dimensionMap, metricTimeSeries, windowStart, windowEnd,
+          historyMergedAnomalies);
+      resultsOfAnEntry.addAll(rulebasedAnomalies);
     }
 
     // Clean up duplicate and overlapped raw anomalies

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/dashboard/resources/DetectionJobResource.java
@@ -3,10 +3,13 @@ package com.linkedin.thirdeye.dashboard.resources;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.thirdeye.anomalydetection.alertFilterAutotune.BaseAlertFilterAutoTune;
+import com.linkedin.thirdeye.api.Constants;
 import com.linkedin.thirdeye.datalayer.bao.AlertConfigManager;
 import com.linkedin.thirdeye.datalayer.dto.AlertConfigDTO;
 import com.linkedin.thirdeye.datalayer.dto.ApplicationDTO;
 import com.linkedin.thirdeye.detector.email.filter.BaseAlertFilter;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,6 +71,7 @@ import static com.linkedin.thirdeye.datalayer.dto.AnomalyFunctionDTO.*;
 
 
 @Path("/detection-job")
+@Api(tags = {Constants.DASHBOARD_TAG} )
 @Produces(MediaType.APPLICATION_JSON)
 public class DetectionJobResource {
   private final DetectionJobScheduler detectionJobScheduler;
@@ -238,6 +242,8 @@ public class DetectionJobResource {
      */
   @POST
   @Path("/{id}/replay")
+  @ApiOperation(" Breaks down the given range into consecutive monitoring windows as per function definition\n "
+      + "Regenerates anomalies for each window separately")
   public Response generateAnomaliesInRange(@PathParam("id") @NotNull final long id,
       @QueryParam("start") @NotNull String startTimeIso, @QueryParam("end") @NotNull String endTimeIso,
       @QueryParam("force") @DefaultValue("false") String isForceBackfill,

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
@@ -30,7 +30,7 @@ public class AnomalyFunctionBean extends AbstractBean {
   private MetricAggFunction metricFunction;
 
   private String type;
-  private String ruleBasedAnomalyFunctionType;
+  private List<String> secondaryAnomalyFunctionsType;
 
   private boolean isActive = true;
 
@@ -83,12 +83,12 @@ public class AnomalyFunctionBean extends AbstractBean {
    */
   private boolean requiresCompletenessCheck = true;
 
-  public String getRuleBasedAnomalyFunctionType() {
-    return ruleBasedAnomalyFunctionType;
+  public List<String> getSecondaryAnomalyFunctionsType() {
+    return secondaryAnomalyFunctionsType;
   }
 
-  public void setRuleBasedAnomalyFunctionType(String ruleBasedAnomalyFunctionType) {
-    this.ruleBasedAnomalyFunctionType = ruleBasedAnomalyFunctionType;
+  public void setSecondaryAnomalyFunctionsType(List<String> secondaryAnomalyFunctionsType) {
+    this.secondaryAnomalyFunctionsType = secondaryAnomalyFunctionsType;
   }
 
   public long getMetricId() {

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/datalayer/pojo/AnomalyFunctionBean.java
@@ -30,6 +30,7 @@ public class AnomalyFunctionBean extends AbstractBean {
   private MetricAggFunction metricFunction;
 
   private String type;
+  private String ruleBasedAnomalyFunctionType;
 
   private boolean isActive = true;
 
@@ -82,6 +83,13 @@ public class AnomalyFunctionBean extends AbstractBean {
    */
   private boolean requiresCompletenessCheck = true;
 
+  public String getRuleBasedAnomalyFunctionType() {
+    return ruleBasedAnomalyFunctionType;
+  }
+
+  public void setRuleBasedAnomalyFunctionType(String ruleBasedAnomalyFunctionType) {
+    this.ruleBasedAnomalyFunctionType = ruleBasedAnomalyFunctionType;
+  }
 
   public long getMetricId() {
     return metricId;

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
@@ -61,4 +61,19 @@ public class AnomalyFunctionFactory {
     anomalyFunction.init(functionSpec);
     return anomalyFunction;
   }
+
+  public BaseAnomalyFunction getRuleBasedAnomalyFunction(AnomalyFunctionDTO functionSpec) throws Exception {
+    BaseAnomalyFunction anomalyFunction;
+    String ruleBasedAnomalyFunctionType = functionSpec.getRuleBasedAnomalyFunctionType();
+    if (ruleBasedAnomalyFunctionType == null || !props.containsKey(ruleBasedAnomalyFunctionType)) {
+      LOGGER.error("Unsupported rule based anomaly function type " + ruleBasedAnomalyFunctionType);
+      return null;
+    }
+    String className = props.getProperty(ruleBasedAnomalyFunctionType);
+    anomalyFunction = (BaseAnomalyFunction) Class.forName(className).newInstance();
+
+    anomalyFunction.init(functionSpec);
+    return anomalyFunction;
+  }
+
 }

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
@@ -28,7 +28,6 @@ public class AnomalyFunctionFactory {
     } catch (FileNotFoundException e) {
       LOGGER.error("File {} not found", functionConfigPath, e);
     }
-
   }
 
   public AnomalyFunctionFactory(InputStream input) {
@@ -75,7 +74,7 @@ public class AnomalyFunctionFactory {
     List<BaseAnomalyFunction> baseAnomalyFunctions = new ArrayList<>();
     for (String secondaryAnomalyFunctionType : secondaryAnomalyFunctionsType) {
       if (secondaryAnomalyFunctionType == null || !props.containsKey(secondaryAnomalyFunctionType)) {
-        LOGGER.info("Unsupported rule based anomaly function type " + secondaryAnomalyFunctionType);
+        LOGGER.error("Unsupported secondary anomaly function type " + secondaryAnomalyFunctionType);
         continue;
       }
       String className = props.getProperty(secondaryAnomalyFunctionType);

--- a/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
+++ b/thirdeye/thirdeye-pinot/src/main/java/com/linkedin/thirdeye/detector/function/AnomalyFunctionFactory.java
@@ -4,6 +4,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
 
@@ -62,18 +64,26 @@ public class AnomalyFunctionFactory {
     return anomalyFunction;
   }
 
-  public BaseAnomalyFunction getRuleBasedAnomalyFunction(AnomalyFunctionDTO functionSpec) throws Exception {
-    BaseAnomalyFunction anomalyFunction;
-    String ruleBasedAnomalyFunctionType = functionSpec.getRuleBasedAnomalyFunctionType();
-    if (ruleBasedAnomalyFunctionType == null || !props.containsKey(ruleBasedAnomalyFunctionType)) {
-      LOGGER.error("Unsupported rule based anomaly function type " + ruleBasedAnomalyFunctionType);
+  public List<BaseAnomalyFunction> getSecondaryAnomalyFunctions(AnomalyFunctionDTO functionSpec) throws Exception {
+    List<String> secondaryAnomalyFunctionsType = functionSpec.getSecondaryAnomalyFunctionsType();
+
+    if (secondaryAnomalyFunctionsType == null) {
+      LOGGER.info("null secondary anomaly function");
       return null;
     }
-    String className = props.getProperty(ruleBasedAnomalyFunctionType);
-    anomalyFunction = (BaseAnomalyFunction) Class.forName(className).newInstance();
 
-    anomalyFunction.init(functionSpec);
-    return anomalyFunction;
+    List<BaseAnomalyFunction> baseAnomalyFunctions = new ArrayList<>();
+    for (String secondaryAnomalyFunctionType : secondaryAnomalyFunctionsType) {
+      if (secondaryAnomalyFunctionType == null || !props.containsKey(secondaryAnomalyFunctionType)) {
+        LOGGER.info("Unsupported rule based anomaly function type " + secondaryAnomalyFunctionType);
+        continue;
+      }
+      String className = props.getProperty(secondaryAnomalyFunctionType);
+      BaseAnomalyFunction anomalyFunction = (BaseAnomalyFunction) Class.forName(className).newInstance();
+      anomalyFunction.init(functionSpec);
+      baseAnomalyFunctions.add(anomalyFunction);
+    }
+
+    return baseAnomalyFunctions;
   }
-
 }

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
@@ -62,9 +62,10 @@ public class DaoTestUtils {
     functionSpec.setWindowDelayUnit(TimeUnit.HOURS);
     functionSpec.setWindowSize(1);
     functionSpec.setWindowUnit(TimeUnit.DAYS);
-    functionSpec.setProperties("baseline=w/w;changeThreshold=0.001");
+    functionSpec.setProperties("baseline=w/w;changeThreshold=0.001;min=100;max=900");
     functionSpec.setIsActive(true);
     functionSpec.setRequiresCompletenessCheck(false);
+    functionSpec.setRuleBasedAnomalyFunctionType("MIN_MAX_THRESHOLD");
     return functionSpec;
   }
 

--- a/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
+++ b/thirdeye/thirdeye-pinot/src/test/java/com/linkedin/thirdeye/datalayer/DaoTestUtils.java
@@ -65,7 +65,7 @@ public class DaoTestUtils {
     functionSpec.setProperties("baseline=w/w;changeThreshold=0.001;min=100;max=900");
     functionSpec.setIsActive(true);
     functionSpec.setRequiresCompletenessCheck(false);
-    functionSpec.setRuleBasedAnomalyFunctionType("MIN_MAX_THRESHOLD");
+    functionSpec.setSecondaryAnomalyFunctionsType(Arrays.asList("MIN_MAX_THRESHOLD"));
     return functionSpec;
   }
 


### PR DESCRIPTION
This PR allows rule-based anomaly detection and algorithm-based detection to run for the same anomaly function at the same time and merge the results. Also, enable the potential to add multiple secondary detection functions.