### PR TITLE
Populating protocol parameters in segment completion

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -111,6 +111,7 @@ public class SegmentCompletionProtocol {
   public static final String PARAM_OFFSET = "offset";
   public static final String PARAM_INSTANCE_ID = "instance";
   public static final String PARAM_MEMORY_USED_BYTES = "memoryUsedBytes";
+  public static final String PARAM_SEGMENT_SIZE_BYTES = "segmentSizeBytes";
   public static final String PARAM_REASON = "reason";
   public static final String PARAM_EXTRA_TIME_SEC = "extraTimeSec"; // Sent by servers to request additional time to build
   public static final String PARAM_ROW_COUNT = "rowCount"; // Sent by servers to indicate the number of rows read so far
@@ -166,6 +167,8 @@ public class SegmentCompletionProtocol {
           (_params.getBuildTimeMillis() <= 0 ? "" :("&" + PARAM_BUILD_TIME_MILLIS + "=" + _params.getBuildTimeMillis())) +
           (_params.getWaitTimeMillis() <= 0 ? "" : ("&" + PARAM_WAIT_TIME_MILLIS + "=" + _params.getWaitTimeMillis())) +
           (_params.getExtraTimeSec() <= 0 ? "" : ("&" + PARAM_EXTRA_TIME_SEC + "=" + _params.getExtraTimeSec())) +
+          (_params.getMemoryUsedBytes() <= 0 ? "" : ("&" + PARAM_MEMORY_USED_BYTES + "=" + _params.getMemoryUsedBytes())) +
+          (_params.getSegmentSizeBytes() <= 0 ? "" : ("&" + PARAM_SEGMENT_SIZE_BYTES + "=" + _params.getSegmentSizeBytes())) +
           (_params.getNumRows() <= 0 ? "" : ("&" + PARAM_ROW_COUNT + "=" + _params.getNumRows())) +
           (_params.getSegmentLocation() == null ? "" : ("&" + PARAM_SEGMENT_LOCATION + "=" + _params.getSegmentLocation()));
     }
@@ -181,6 +184,7 @@ public class SegmentCompletionProtocol {
       private int _extraTimeSec;
       private String _segmentLocation;
       private long _memoryUsedBytes;
+      private long _segmentSizeBytes;
 
       public Params() {
         _offset = -1L;
@@ -192,6 +196,7 @@ public class SegmentCompletionProtocol {
         _extraTimeSec = -1;
         _segmentLocation = null;
         _memoryUsedBytes = -1;
+        _segmentSizeBytes = -1;
       }
 
       public Params withOffset(long offset) {
@@ -243,6 +248,11 @@ public class SegmentCompletionProtocol {
         return this;
       }
 
+      public Params withSegmentSizeBytes(long segmentSizeBytes) {
+        _segmentSizeBytes = segmentSizeBytes;
+        return this;
+      }
+
       public String getSegmentName() {
         return _segmentName;
       }
@@ -279,7 +289,13 @@ public class SegmentCompletionProtocol {
         return _segmentLocation;
       }
 
-      public long getMemoryUsedBytes() { return _memoryUsedBytes; }
+      public long getMemoryUsedBytes() {
+        return _memoryUsedBytes;
+      }
+
+      public long getSegmentSizeBytes() {
+        return _segmentSizeBytes;
+      }
 
       public String toString() {
         return "Offset: " + _offset
@@ -291,7 +307,8 @@ public class SegmentCompletionProtocol {
             + ",WaitTimeMillis: " + _waitTimeMillis
             + ",ExtraTimeSec: " + _extraTimeSec
             + ",SegmentLocation: " + _segmentLocation
-            + ",Memory Used Bytes: " + _memoryUsedBytes;
+            + ",MemoryUsedBytes: " + _memoryUsedBytes
+            + ",SegmentSizeBytes: " + _segmentSizeBytes;
       }
     }
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -170,7 +170,10 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_NAME) String segmentName,
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_LOCATION) String segmentLocation,
       @QueryParam(SegmentCompletionProtocol.PARAM_OFFSET) long offset,
-      @QueryParam(SegmentCompletionProtocol.PARAM_MEMORY_USED_BYTES) long memoryUsedBytes) {
+      @QueryParam(SegmentCompletionProtocol.PARAM_MEMORY_USED_BYTES) long memoryUsedBytes,
+      @QueryParam(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS) long buildTimeMillis,
+      @QueryParam(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS) long waitTimeMillis,
+      @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes) {
     if (instanceId == null || segmentName == null || offset == -1 || segmentLocation == null) {
       LOGGER.error("Invalid call: offset={}, segmentName={}, instanceId={}, segmentLocation={}", offset, segmentName,
           instanceId, segmentLocation);
@@ -183,6 +186,9 @@ public class LLCSegmentCompletionHandlers {
         .withSegmentName(segmentName)
         .withOffset(offset)
         .withSegmentLocation(segmentLocation)
+        .withSegmentSizeBytes(segmentSizeBytes)
+        .withBuildTimeMillis(buildTimeMillis)
+        .withWaitTimeMillis(waitTimeMillis)
         .withMemoryUsedBytes(memoryUsedBytes);
     LOGGER.info("Processing segmentCommitEnd:{}", requestParams.toString());
 
@@ -204,11 +210,17 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_NAME) String segmentName,
       @QueryParam(SegmentCompletionProtocol.PARAM_OFFSET) long offset,
       @QueryParam(SegmentCompletionProtocol.PARAM_MEMORY_USED_BYTES) long memoryUsedBytes,
+      @QueryParam(SegmentCompletionProtocol.PARAM_BUILD_TIME_MILLIS) long buildTimeMillis,
+      @QueryParam(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS) long waitTimeMillis,
+      @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes,
       FormDataMultiPart multiPart) {
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId)
         .withSegmentName(segmentName)
         .withOffset(offset)
+        .withSegmentSizeBytes(segmentSizeBytes)
+        .withBuildTimeMillis(buildTimeMillis)
+        .withWaitTimeMillis(waitTimeMillis)
         .withMemoryUsedBytes(memoryUsedBytes);
     LOGGER.info("Processing segmentCommit:{}", requestParams.toString());
 

--- a/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -784,7 +784,7 @@ public class LLRealtimeSegmentDataManagerTest {
         return null;
       }
       if (!forCommit) {
-        return new SegmentBuildDescriptor(null, getCurrentOffset(), _segmentDir, 0, 0);
+        return new SegmentBuildDescriptor(null, getCurrentOffset(), _segmentDir, 0, 0, -1);
       }
       final String segTarFileName =  _segmentDir + "/" + "segmentFile";
       File segmentTgzFile = new File(segTarFileName);
@@ -793,7 +793,7 @@ public class LLRealtimeSegmentDataManagerTest {
       } catch (IOException e) {
         Assert.fail("Could not create file " + segmentTgzFile);
       }
-      return new SegmentBuildDescriptor(segTarFileName, getCurrentOffset(), null, 0, 0);
+      return new SegmentBuildDescriptor(segTarFileName, getCurrentOffset(), null, 0, 0, -1);
     }
 
     @Override


### PR DESCRIPTION
Updated code to populate the parameters buildTime, waitTime, and memoryUsed.
Added protocol parameter segment size.
Changed server to send memoryUsed only if offheap is set (otherwise the number is not accurate)