### PR TITLE
[TE] moved timerange persistence into services, set up acceptance test

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -23,9 +23,9 @@ import {
 } from 'thirdeye-frontend/utils/utils';
 import {
   buildAnomalyStats,
-  extractSeverity,
-  setDuration
+  extractSeverity
 } from 'thirdeye-frontend/utils/manage-alert-utils';
+import { inject as service } from '@ember/service';
 import floatToPercent from 'thirdeye-frontend/utils/float-to-percent';
 import * as anomalyUtil from 'thirdeye-frontend/utils/anomaly';
 
@@ -48,6 +48,11 @@ export default Controller.extend({
     change: 'changeRate',
     resolution: 'anomalyFeedback'
   },
+
+  /**
+   * Make duration service accessible
+   */
+  durationCache: service('services/duration'),
 
   /**
    * Date format for date range picker
@@ -641,11 +646,14 @@ export default Controller.extend({
         end,
         value: duration
       } = rangeOption;
-      const startDate = moment(start).valueOf();
-      const endDate = moment(end).valueOf();
+      const durationObj = {
+        duration,
+        startDate: moment(start).valueOf(),
+        endDate: moment(end).valueOf()
+      };
       // Cache the new time range and update page with it
-      setDuration(duration, startDate, endDate);
-      this.transitionToRoute({ queryParams: { duration, startDate, endDate }});
+      this.get('durationCache').setDuration(durationObj);
+      this.transitionToRoute({ queryParams: durationObj });
     },
 
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -9,6 +9,7 @@ import moment from 'moment';
 import Route from '@ember/routing/route';
 import { later } from "@ember/runloop";
 import { task, timeout } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
 import { isPresent } from "@ember/utils";
 import {
   set,
@@ -21,7 +22,6 @@ import {
   enhanceAnomalies,
   toIdGroups,
   setUpTimeRangeOptions,
-  prepareTimeRange,
   getTopDimensions,
   buildMetricDataUrl,
   extractSeverity
@@ -115,6 +115,11 @@ export default Route.extend({
     repRunStatus: queryParamsConfig
   },
 
+  /**
+   * Make duration service accessible
+   */
+  durationCache: service('services/duration'),
+
   beforeModel(transition) {
     const { duration, startDate } = transition.queryParams;
     // Default to 1 month of anomalies to show if no dates present in query params
@@ -127,12 +132,12 @@ export default Route.extend({
     const { id, alertData, jobId } = this.modelFor('manage.alert');
     if (!id) { return; }
 
-    // Get duration data
+    // Get duration data from service
     const {
       duration,
       startDate,
       endDate
-    } = prepareTimeRange(transition.queryParams, defaultDurationObj);
+    } = this.get('durationCache').getDuration(transition.queryParams, defaultDurationObj);
 
     // Prepare endpoints for eval, mttd, projected metrics calls
     const dateParams = `start=${toIso(startDate)}&end=${toIso(endDate)}`;

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
@@ -8,8 +8,8 @@ import fetch from 'fetch';
 import moment from 'moment';
 import { isPresent } from "@ember/utils";
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 import { checkStatus, buildDateEod } from 'thirdeye-frontend/utils/utils';
-import { setDuration } from 'thirdeye-frontend/utils/manage-alert-utils';
 
 // Setup for query param behavior
 const queryParamsConfig = {
@@ -21,6 +21,8 @@ export default Route.extend({
   queryParams: {
     jobId: queryParamsConfig
   },
+
+  durationCache: service('services/duration'),
 
   beforeModel(transition) {
     const id = transition.params['manage.alert'].alert_id;
@@ -39,8 +41,9 @@ export default Route.extend({
         functionName: null,
         jobId
       }});
-      // Save duration to sessionStorage for guaranteed availability
-      setDuration(durationDefault, startDateDefault, endDateDefault);
+
+      // Save duration to service object for session availability
+      this.get('durationCache').setDuration({ durationDefault, startDateDefault, endDateDefault });
     }
   },
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/controller.js
@@ -8,8 +8,9 @@ import Controller from '@ember/controller';
 import moment from 'moment';
 import { isPresent } from "@ember/utils";
 import { computed, set } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { buildDateEod } from 'thirdeye-frontend/utils/utils';
-import { buildAnomalyStats, setDuration } from 'thirdeye-frontend/utils/manage-alert-utils';
+import { buildAnomalyStats } from 'thirdeye-frontend/utils/manage-alert-utils';
 
 export default Controller.extend({
   /**
@@ -19,6 +20,11 @@ export default Controller.extend({
   duration: null,
   startDate: null,
   endDate: null,
+
+  /**
+   * Make duration service accessible
+   */
+  durationCache: service('services/duration'),
 
   /**
    * Set initial view values
@@ -308,11 +314,14 @@ export default Controller.extend({
         end,
         value: duration
       } = rangeOption;
-      const startDate = moment(start).valueOf();
-      const endDate = moment(end).valueOf();
+      const durationObj = {
+        duration,
+        startDate: moment(start).valueOf(),
+        endDate: moment(end).valueOf()
+      };
       // Cache the new time range and update page with it
-      setDuration(duration, startDate, endDate);
-      this.transitionToRoute({ queryParams: { duration, startDate, endDate }});
+      this.get('durationCache').setDuration(durationObj);
+      this.transitionToRoute({ queryParams: durationObj });
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/tune/route.js
@@ -20,11 +20,10 @@ import {
 import {
   enhanceAnomalies,
   setUpTimeRangeOptions,
-  prepareTimeRange,
   toIdGroups,
-  extractSeverity,
-  getDuration
+  extractSeverity
 } from 'thirdeye-frontend/utils/manage-alert-utils';
+import { inject as service } from '@ember/service';
 
 /**
  * Basic alert page defaults
@@ -245,6 +244,11 @@ export default Route.extend({
     endDate: queryParamsConfig
   },
 
+  /**
+   * Make duration service accessible
+   */
+  durationCache: service('services/duration'),
+
   beforeModel(transition) {
     const { duration, startDate } = transition.queryParams;
 
@@ -263,7 +267,7 @@ export default Route.extend({
       duration,
       startDate,
       endDate
-    } = prepareTimeRange(transition.queryParams, defaultDurationObj);
+    } = this.get('durationCache').getDuration(transition.queryParams, defaultDurationObj);
 
     // Prepare endpoints for the initial eval, mttd, projected metrics calls
     const tuneParams = `start=${toIso(startDate)}&end=${toIso(endDate)}`;

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -236,14 +236,6 @@ export default Controller.extend({
       this.set('resultsActive', true);
     },
 
-    // Handle transition to alert page while refreshing the duration cache.
-    navigateToAlertPage(alertId) {
-      if (sessionStorage.getItem('duration') !== null) {
-        sessionStorage.removeItem('duration');
-      }
-      this.transitionToRoute('manage.alert', alertId);
-    },
-
     // Handles filtering of alerts in response to filter selection
     userDidSelectFilter(filterArr) {
       let task = {};

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -64,7 +64,7 @@ export default Route.extend({
      * @method willTransition
      */
     willTransition(transition) {
-      this.get('durationCache').removeDuration();
+      this.get('durationCache').resetDuration();
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -61,11 +61,9 @@ export default Route.extend({
   actions: {
     /**
      * Clear duration cache (time range is reset to default when entering new alert page from index)
-     * TODO:
      * @method willTransition
      */
     willTransition(transition) {
-      sessionStorage.removeItem('duration');
       this.get('durationCache').removeDuration();
     },
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -55,6 +55,14 @@ export default Route.extend({
 
   actions: {
     /**
+     * Clear duration cache (time range is reset to default when entering new alert page from index)
+     * @method willTransition
+     */
+    willTransition(transition) {
+      sessionStorage.removeItem('duration');
+    },
+
+    /**
     * Refresh route's model.
     * @method refreshModel
     */

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/route.js
@@ -1,8 +1,13 @@
 import { hash } from 'rsvp';
 import Route from '@ember/routing/route';
 import fetch from 'fetch';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+
+  // Make duration service accessible
+  durationCache: service('services/duration'),
+
   model() {
     return hash({
       alerts: fetch('/thirdeye/entity/ANOMALY_FUNCTION').then(res => res.json()),
@@ -56,10 +61,12 @@ export default Route.extend({
   actions: {
     /**
      * Clear duration cache (time range is reset to default when entering new alert page from index)
+     * TODO:
      * @method willTransition
      */
     willTransition(transition) {
       sessionStorage.removeItem('duration');
+      this.get('durationCache').removeDuration();
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/template.hbs
@@ -122,9 +122,9 @@
                 <span class="te-search-results__tag te-search-results__tag--list {{if alert.isActive "te-search-results__tag--active"}}">
                   {{if alert.isActive "Active" "Inactive"}}
                 </span>
-                <a href="#" {{action "navigateToAlertPage" alert.id}}>
+                {{#link-to "manage.alert" alert.id}}
                   <div class="te-search-results__title-name" title={{alert.functionName}}>{{alert.functionName}}</div>
-                </a>
+                {{/link-to}}
               </div>
             </div>
               <div class="te-search-results__edit-button">

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/controller.js
@@ -2,9 +2,14 @@ import _ from 'lodash';
 import moment from 'moment';
 import { computed, set } from '@ember/object';
 import Controller from '@ember/controller';
-import { setDuration } from 'thirdeye-frontend/utils/manage-alert-utils';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
+
+  /**
+   * Make duration service accessible
+   */
+  durationCache: service('services/duration'),
 
   /**
    * Active class appendage of 'view totals' link
@@ -69,11 +74,14 @@ export default Controller.extend({
         end,
         value: duration
       } = rangeOption;
-      const startDate = moment(start).valueOf();
-      const endDate = moment(end).valueOf();
+      const durationObj = {
+        duration,
+        startDate: moment(start).valueOf(),
+        endDate: moment(end).valueOf()
+      };
       // Cache the new time range and update page with it
-      setDuration(duration, startDate, endDate);
-      this.transitionToRoute({ queryParams: { duration, startDate, endDate }});
+      this.get('durationCache').setDuration(durationObj);
+      this.transitionToRoute({ queryParams: durationObj });
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/performance/route.js
@@ -17,10 +17,7 @@ import {
   buildDateEod
 } from 'thirdeye-frontend/utils/utils';
 import { isPresent } from '@ember/utils';
-import {
-  setUpTimeRangeOptions,
-  prepareTimeRange
-} from 'thirdeye-frontend/utils/manage-alert-utils';
+import { setUpTimeRangeOptions } from 'thirdeye-frontend/utils/manage-alert-utils';
 
 /**
  * If true, this reduces the list of alerts per app to 2 for a quick demo.

--- a/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
@@ -61,10 +61,10 @@ export default Service.extend({
 
   /**
    * Clears the cached duration object (reset)
-   * @method removeDuration
+   * @method resetDuration
    * @return {undefined}
    */
-  removeDuration() {
+  resetDuration() {
     this.set('durationObj', {});
   }
 });

--- a/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
@@ -1,0 +1,66 @@
+import Service from '@ember/service';
+import { assert } from '@ember/debug';
+import { isPresent } from "@ember/utils";
+
+export default Service.extend({
+  durationObj: null,
+  durationTypes: {
+    duration: 'string',
+    startDate: 'number',
+    endDate: 'number'
+  },
+
+  init() {
+    this._super(...arguments);
+    this.set('durationObj', {});
+  },
+
+  /**
+   * Saves new time range settings to persist
+   * @method setDuration
+   * @param {Object} newDuration - new incoming time range object
+   * @return {undefined}
+   */
+  setDuration(newDuration) {
+    const propsObj = this.get('durationTypes');
+    const requiredKeys = Object.keys(propsObj);
+
+    requiredKeys.forEach((key) => {
+      assert(`you must pass ${key} param as ${propsObj[key]}.`, typeof newDuration[key] === propsObj[key]);
+    });
+
+    this.set('durationObj', newDuration);
+  },
+
+  /**
+   * Decides which time range to load as default (query params, default set, or locally cached)
+   * @method getDuration
+   * @param {Object} queryParams - range-related properties in querystring
+   * @param {Object} defaultDurationObj - basic default time range setting
+   * @return {Object}
+   */
+  getDuration(queryParams, defaultDurationObj) {
+    const cachedDuration = this.get('durationObj');
+    const isDurationCached = Object.keys(cachedDuration).length > 0;
+    // Check for presence of each time range key in qeury params
+    const isDurationInQuery = isPresent(queryParams.duration) && isPresent(queryParams.startDate) && isPresent(queryParams.endDate);
+    // Use querystring time range if present. Else, use preset defaults
+    const defaultDuration = isDurationInQuery ? queryParams : defaultDurationObj;
+    // Prefer cached time range if present. Else, load from defaults
+    const newDurationObj = isDurationCached ? cachedDuration : defaultDuration;
+    // If no time range is cached for the session, cache the new one
+    if (!isDurationCached) {
+      this.set('durationObj', newDurationObj);
+    }
+    return newDurationObj;
+  },
+
+  /**
+   * Clears the cached duration object (reset)
+   * @method removeDuration
+   * @return {undefined}
+   */
+  removeDuration() {
+    this.set('durationObj', {});
+  }
+});

--- a/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
@@ -3,7 +3,6 @@ import { assert } from '@ember/debug';
 import { isPresent } from "@ember/utils";
 
 export default Service.extend({
-  durationObj: null,
   durationTypes: {
     duration: 'string',
     startDate: 'number',
@@ -24,10 +23,13 @@ export default Service.extend({
   setDuration(newDuration) {
     const propsObj = this.get('durationTypes');
     const requiredKeys = Object.keys(propsObj);
-    // Check each required property for presence and type
+
+    // Check each required param property for presence and expected type
     requiredKeys.forEach((key) => {
       assert(`you must pass ${key} param as ${propsObj[key]}.`, typeof newDuration[key] === propsObj[key]);
     });
+
+    // Cache new incoming duration object
     this.set('durationObj', newDuration);
   },
 
@@ -39,6 +41,9 @@ export default Service.extend({
    * @return {Object}
    */
   getDuration(queryParams, defaultDurationObj) {
+    assert('you must pass queryParams param as an required argument.', queryParams);
+    assert('you must pass defaultDurationObj param as an required argument.', defaultDurationObj);
+
     const cachedDuration = this.get('durationObj');
     const isDurationCached = Object.keys(cachedDuration).length > 0;
     // Check for presence of each time range key in qeury params

--- a/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
+++ b/thirdeye/thirdeye-frontend/app/pods/services/duration/service.js
@@ -24,11 +24,10 @@ export default Service.extend({
   setDuration(newDuration) {
     const propsObj = this.get('durationTypes');
     const requiredKeys = Object.keys(propsObj);
-
+    // Check each required property for presence and type
     requiredKeys.forEach((key) => {
       assert(`you must pass ${key} param as ${propsObj[key]}.`, typeof newDuration[key] === propsObj[key]);
     });
-
     this.set('durationObj', newDuration);
   },
 

--- a/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/manage-alert-utils.js
@@ -293,52 +293,6 @@ export function formatConfigGroupProps(alertData, alertIndex) {
 }
 
 /**
- * Caches duration data to local storage in order to persist it across pages
- * TODO: Move this to self-serve services
- * @method setDuration
- * @param {String} duration - qualifies duration set as 'custom' or a range key like '3m'
- * @param {Number} startDate - start date for alert page (and list of anomalies)
- * @param {Number} endDate - end date for alert page (and list of anomalies)
- * @return {undefined}
- */
-export function setDuration(duration, startDate, endDate) {
-  sessionStorage.setItem('duration', JSON.stringify({ duration, startDate, endDate }));
-}
-
-/**
- * Retrieves duration data from local storage in order to persist it across pages
- * TODO: Move this to self-serve services
- * @method getDuration
- * @return {Object}
- */
-export function getDuration() {
-  return JSON.parse(sessionStorage.getItem('duration'));
-}
-
-/**
- * Decides which time range to load as default (query params, default set, or locally cached)
- * @method prepareTimeRange
- * @param {Object} queryParams - range-related properties in querystring
- * @param {Object} defaultDurationObj - basic default time range setting
- * @return {Object}
- */
-export function prepareTimeRange(queryParams, defaultDurationObj) {
-  const durationCached = sessionStorage.getItem('duration') !== null;
-  // Check for presence of each time range key in qeury params
-  const isDurationInQuery = isPresent(queryParams.duration) && isPresent(queryParams.startDate) && isPresent(queryParams.endDate);
-  // Use querystring time range if present. Else, use preset defaults
-  const defaultDuration = isDurationInQuery ? queryParams : defaultDurationObj;
-  // Prefer cached time range if present. Else, load from defaults
-  const durationObj = durationCached ? getDuration() : defaultDuration;
-  // If no time range is cached for the session, cache the new one
-  if (!durationCached) {
-    const { duration, startDate, endDate } = durationObj;
-    setDuration(duration, startDate, endDate);
-  }
-  return durationObj;
-}
-
-/**
  * When fetching current and projected MTTD (minimum time to detect) data, we need to supply the
  * endpoint with a severity threshold. This decides whether to use the default or not.
  * @method extractSeverity
@@ -363,9 +317,6 @@ export default {
   formatConfigGroupProps,
   buildAnomalyStats,
   buildMetricDataUrl,
-  prepareTimeRange,
   extractSeverity,
-  setDuration,
-  getDuration,
   evalObj
 };

--- a/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-time-range-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/self-serve-time-range-test.js
@@ -1,0 +1,78 @@
+import $ from 'jquery';
+import moment from 'moment';
+import { module, test } from 'qunit';
+import { run } from "@ember/runloop";
+import { setupApplicationTest } from 'ember-qunit';
+import { selfServeConst } from 'thirdeye-frontend/tests/utils/constants';
+import { visit, focus, click, currentURL } from '@ember/test-helpers';
+
+module('Acceptance | verify time range consistency', function(hooks) {
+  setupApplicationTest(hooks);
+
+  const defaultDurationLabel = '3 Months';
+  const defaultDurationKey = '3m';
+  let rangePickerCustomRange = '';
+
+  test(`going through alert page flow to test time range behavior`, async (assert) => {
+    server.createList('alert', 2);
+    await visit(`/manage/alert/1`);
+
+    assert.ok(
+      $(selfServeConst.RANGE_PILL_SELECTOR_ACTIVE).get(0).innerText.includes(defaultDurationLabel),
+      'Default time rage is active'
+    );
+
+    // Clicking to activate date-range-picker modal
+    await click(selfServeConst.RANGE_PICKER_INPUT);
+
+    // Click on one of the preset ranges
+    await click($(selfServeConst.RANGE_PICKER_PRESETS).get(1));
+
+    // Cache value of new custom time range
+    rangePickerCustomRange = $(selfServeConst.RANGE_PICKER_INPUT).val();
+
+    assert.ok(
+      $(selfServeConst.RANGE_PILL_SELECTOR_ACTIVE).get(0).innerText.includes('Custom'),
+      'Custom time range pill selected'
+    );
+
+    assert.ok(
+      currentURL().includes('duration=custom'),
+      'Custom time range is correctly set as URL query parameter'
+    );
+
+    // Navigate to tuning route to make sure time range is persisted
+    await click($(selfServeConst.LINK_TUNE_ALERT).get(0));
+
+    assert.equal(
+      $(selfServeConst.RANGE_PICKER_INPUT).val(),
+      rangePickerCustomRange,
+      'Custom time range dates as selected are persisted to tuning sub-route'
+    );
+
+    // Navigate back to Alert Page to make sure time range is persisted
+    await click($(selfServeConst.LINK_ALERT_PAGE).get(0));
+
+    assert.equal(
+      $(selfServeConst.RANGE_PICKER_INPUT).val(),
+      rangePickerCustomRange,
+      'Custom time range dates as selected are persisted to alert page'
+    );
+
+    // Navigate back to alert search/list page to test time range reset
+    await click($(selfServeConst.NAV_MANAGE_ALERTS).get(0));
+
+    // Click on any alert to confirm time range in Alert Page is now reset
+    await click($(selfServeConst.RESULTS_LINK).get(1));
+
+    assert.ok(
+      $(selfServeConst.RANGE_PILL_SELECTOR_ACTIVE).get(0).innerText.includes(defaultDurationLabel),
+      'Previous custom time rage has been reset to default'
+    );
+
+    assert.ok(
+      currentURL().includes(`duration=${defaultDurationKey}`),
+      'Default time range is correctly set as URL query parameter'
+    );
+  });
+});

--- a/thirdeye/thirdeye-frontend/tests/utils/constants.js
+++ b/thirdeye/thirdeye-frontend/tests/utils/constants.js
@@ -4,6 +4,10 @@ import { isPresent } from "@ember/utils";
  * General self-serve element selectors
  */
 export const selfServeConst = {
+  // Self-serve Nav Elements
+  NAV_MANAGE_ALERTS: '.te-nav__link:contains("Manage Alerts")',
+
+  // Onboard Alert Elements
   ALERT_NAME_INPUT: '#anomaly-form-function-name',
   SUBSCRIPTION_GROUP: '#anomaly-form-app-name',
   STATUS: '.te-toggle--form span',
@@ -54,10 +58,18 @@ export const selfServeConst = {
   ALERT_CARDS_CONTAINER: '.te-horizontal-cards__container',
   ALERT_PAGE_HEADER_PROPS: '.te-search-results__list--details-block',
   ALERT_PAGE_HEADER_LINK: '.te-search-results__cta',
+  RANGE_PILL_SELECTOR_LIST: '.range-pill-selectors__list',
   RANGE_PILL_SELECTOR_ITEM: '.range-pill-selectors__item',
+  RANGE_PILL_SELECTOR_ACTIVE: '.range-pill-selectors__item--active',
   RANGE_PILL_SELECTOR_TRIGGER: '.range-pill-selectors__range-picker .daterangepicker-input',
   RANGE_PILL_PRESET_OPTION: '.daterangepicker:last .ranges li:contains("Last 1 month")',
+  RANGE_PICKER_INPUT: '.daterangepicker-input',
+  RANGE_PICKER_PRESETS: '.daterangepicker.show-calendar .ranges ul li',
   LINK_TUNE_ALERT: '.te-self-serve__side-link:contains("Customize sensitivity")',
+
+  // Tuning Page Elements
+  LINK_ALERT_PAGE: '.te-button:contains("Back to overview")',
+
 };
 
 /**


### PR DESCRIPTION
**This covers**:
- Enable right-click on Alert search page
- Move time-range duration caching from session store to Ember services
- Set up acceptance test for time range persistence.

<img width="1183" alt="screen shot 2018-04-27 at 1 47 46 pm" src="https://user-images.githubusercontent.com/11814420/39384522-f5204982-4a21-11e8-8790-f612470f7970.png">

**Context**:
The expected behavior in ThirdEye Self-serve is consistency of time ranges within alert management routes (under the same alert ID). Once the user clicks into a new alert, we reset any pre-selected time ranges to default (currently 3 months)

**Tests**:
312 tests completed in 37925 milliseconds, with 0 failed, 0 skipped, and 0 todo.
428 assertions of 428 passed, 0 failed.