### PR TITLE
[TE] frontend - aaronucsd/Add new tab components

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/component.js
@@ -1,0 +1,28 @@
+/**
+ * @description Common-tabs Component
+ * @summary Renders tabs. Enable a user to switch between views within a given screen. Provides high-level organization of information into navigable categories.
+ * @module components/shared/common-tabs
+ * @example
+    {{#shared/common-tabs selection=activeTab activeTab=activeTab as |tabs|}}
+      {{#tabs.tablist as |tablist|}}
+        {{#tablist.tab name="metrics"}}Metrics{{/tablist.tab}}
+        {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
+      {{/tabs.tablist}}
+
+      {{!-- metrics --}}
+      {{#tabs.tabpanel name="metrics"}}
+        {{!-- IMPORTANT metrics CODE --}}
+      {{/tabs.tabpanel}}
+      {{!-- dimensions --}}
+      {{#tabs.tabpanel name="dimensions"}}
+        {{!-- IMPORTANT dimensions CODE --}}
+      {{/tabs.tabpanel}}
+    {{/shared/common-tabs}}
+ *
+ * @exports common-tabs
+ */
+import Component from '@ember/component';
+
+export default Component.extend({
+  classNames: ['common-tabs']
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/component.js
@@ -1,0 +1,30 @@
+/**
+ * @description Tablist Component
+ * @summary Displays a tablist body. This is meant for usage with `Common-tabs` component.
+ * @module components/shared/common-tabs/tablist
+ * @example
+ * @example
+    {{#shared/common-tabs selection=activeTab activeTab=activeTab as |tabs|}}
+      {{#tabs.tablist as |tablist|}}
+        {{#tablist.tab name="metrics"}}Metrics{{/tablist.tab}}
+        {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
+      {{/tabs.tablist}}
+
+      {{!-- metrics --}}
+      {{#tabs.tabpanel name="metrics"}}
+        {{!-- IMPORTANT metrics CODE --}}
+      {{/tabs.tabpanel}}
+      {{!-- dimensions --}}
+      {{#tabs.tabpanel name="dimensions"}}
+        {{!-- IMPORTANT dimensions CODE --}}
+      {{/tabs.tabpanel}}
+    {{/shared/common-tabs}}
+ *
+ * @exports tablist
+ */
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: 'ul',
+  classNames: ['common-tabs__header']
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/tab/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/tab/component.js
@@ -1,0 +1,30 @@
+/**
+ * @description Tab Component
+ * @summary Displays a tablist tab body. This is meant for usage with `Common-tabs` component.
+ * @module components/shared/common-tabs/tablist/tab
+ * @example
+ * @example
+    {{#shared/common-tabs selection=activeTab activeTab=activeTab as |tabs|}}
+      {{#tabs.tablist as |tablist|}}
+        {{#tablist.tab name="metrics"}}Metrics{{/tablist.tab}}
+        {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
+      {{/tabs.tablist}}
+
+      {{!-- metrics --}}
+      {{#tabs.tabpanel name="metrics"}}
+        {{!-- IMPORTANT metrics CODE --}}
+      {{/tabs.tabpanel}}
+      {{!-- dimensions --}}
+      {{#tabs.tabpanel name="dimensions"}}
+        {{!-- IMPORTANT dimensions CODE --}}
+      {{/tabs.tabpanel}}
+    {{/shared/common-tabs}}
+ *
+ * @exports tab
+ */
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: 'li',
+  classNames: ['common-tabs__subnav']
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/tab/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/tab/template.hbs
@@ -1,0 +1,3 @@
+<a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab name) "thirdeye-link--active"}}" {{action (mut activeTab) name}}>
+  {{yield}}
+</a>

--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tablist/template.hbs
@@ -1,0 +1,1 @@
+{{yield (hash tab=(component "shared/common-tabs/tablist/tab" activeTab=activeTab))}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tabpanel/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tabpanel/component.js
@@ -1,0 +1,29 @@
+/**
+ * @description Tabpanel Component
+ * @summary Displays a tab's panel body. This is meant for usage with `Common-tabs` component.
+ * @module components/shared/common-tabs/tabpanel
+ * @example
+ * @example
+    {{#shared/common-tabs selection=activeTab activeTab=activeTab as |tabs|}}
+      {{#tabs.tablist as |tablist|}}
+        {{#tablist.tab name="metrics"}}Metrics{{/tablist.tab}}
+        {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
+      {{/tabs.tablist}}
+
+      {{!-- metrics --}}
+      {{#tabs.tabpanel name="metrics"}}
+        {{!-- IMPORTANT metrics CODE --}}
+      {{/tabs.tabpanel}}
+      {{!-- dimensions --}}
+      {{#tabs.tabpanel name="dimensions"}}
+        {{!-- IMPORTANT dimensions CODE --}}
+      {{/tabs.tabpanel}}
+    {{/shared/common-tabs}}
+ *
+ * @exports tabpanel
+ */
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: ''
+});

--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tabpanel/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/tabpanel/template.hbs
@@ -1,0 +1,9 @@
+{{#if (eq activeTab name)}}
+  <div class="common-tabs__body common-tabs__body--padding-md">
+    <div class="row">
+      <div class="col-xs-12">
+        {{yield}}
+      </div>
+    </div>
+  </div>
+{{/if}}

--- a/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/shared/common-tabs/template.hbs
@@ -1,0 +1,2 @@
+{{yield (hash tablist=(component "shared/common-tabs/tablist" activeTab=activeTab))}}
+{{yield (hash tabpanel=(component "shared/common-tabs/tabpanel" activeTab=activeTab))}}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/template.hbs
@@ -152,50 +152,18 @@
       </div>
 
       {{#if context.urns.size}}
-        <div class="card-container__header rootcause-tabs">
-          <div class="card-container__subnav">
-            <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "metrics") "thirdeye-link--active "}}" {{action (mut activeTab)
-              "metrics"}}>
-              Metrics
-            </a>
-          </div>
-          <div class="card-container__subnav">
-            <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "dimensions") "thirdeye-link--active"}}" {{action (mut activeTab) "dimensions"}}>
-              Dimensions
-            </a>
-          </div>
-          <div class="card-container__subnav">
-            <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "events") "thirdeye-link--active"}}" {{action (mut activeTab) "events"}}>
-              Events
-            </a>
-          </div>
-          <div class="card-container__subnav">
-            <a class="thirdeye-link thirdeye-link--nav {{if (eq activeTab "trend") "thirdeye-link--active"}}" {{action (mut activeTab) "trend"}}>
-              Trend
-            </a>
-          </div>
-        </div>
+        <div class="card-container__row card-container__row--flex row">
+          <div class="col-xs-12 rootcause-tabs card-container__row--bg-color">
+            {{#shared/common-tabs selection=activeTab activeTab=activeTab as |tabs|}}
+              {{#tabs.tablist as |tablist|}}
+                {{#tablist.tab name="metrics"}}Metrics{{/tablist.tab}}
+                {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
+                {{#tablist.tab name="events"}}Events{{/tablist.tab}}
+                {{#tablist.tab name="trend"}}Trend{{/tablist.tab}}
+              {{/tabs.tablist}}
 
-        <div class="card-container__body card-container__body--padding-md">
-          <div class="row">
-            <div class="col-xs-12">
-              {{#if (eq activeTab "dimensions")}}
-                {{#if isLoadingBreakdowns}}
-                  <div class="spinner-wrapper spinner-wrapper--card">
-                    {{ember-spinner}}
-                  </div>
-                {{/if}}
-
-                {{rootcause-heatmap
-                  entities=entities
-                  breakdowns=breakdowns
-                  selectedUrn=metricUrn
-                  isLoadingBreakdowns=isLoadingBreakdowns
-                  onSelection=(action "heatmapOnSelection")
-                }}
-              {{/if}}
-
-              {{#if (eq activeTab "metrics")}}
+              {{!-- metrics --}}
+              {{#tabs.tabpanel name="metrics"}}
                 {{#if (set-has loadingFrameworks "metricRelated")}}
                   <div class="spinner-wrapper spinner-wrapper--card">
                     {{ember-spinner}}
@@ -221,28 +189,48 @@
                   isLoading=(or isLoadingAggregates isLoadingScores)
                   onSelection=(action "onSelection")
                 }}
-              {{/if}}
+              {{/tabs.tabpanel}}
 
-              {{#if (eq activeTab "events")}}
+              {{!-- dimensions --}}
+              {{#tabs.tabpanel name="dimensions"}}
+                {{#if isLoadingBreakdowns}}
+                  <div class="spinner-wrapper spinner-wrapper--card">
+                    {{ember-spinner}}
+                  </div>
+                {{/if}}
+
+                {{rootcause-heatmap
+                  entities=entities
+                  breakdowns=breakdowns
+                  selectedUrn=metricUrn
+                  isLoadingBreakdowns=isLoadingBreakdowns
+                  onSelection=(action "heatmapOnSelection")
+                }}
+              {{/tabs.tabpanel}}
+
+              {{!-- events --}}
+              {{#tabs.tabpanel name="events"}}
                 <div class="row">
+                  <div class="col-xs-12">
+                    <div class="pull-right">
+                      <a {{action "onCreateEventClick"}} class="thirdeye-link thirdeye-link--settings">
+                        + add event
+                      </a>
+                      <span class="te-tooltip-wrapper">
+                        <i class="glyphicon glyphicon-question-sign">
+                          {{#tooltip-on-element class="te-tooltip"}}
+                            Can't find your event? Click here to add a new event.
+                          {{/tooltip-on-element}}
+                        </i>
+                      </span>
+                    </div>
+                  </div>
                   <div class="col-xs-3">
                     {{filter-bar
                       config=filterConfig
                       entities=eventFilterEntities
                       loadingFrameworks=loadingFrameworks
                       onFilter=(action "onFilter")}}
-                  </div>
-                  <div class="pull-right">
-                    <a {{action "onCreateEventClick"}} class="thirdeye-link thirdeye-link--settings">
-                      + add event
-                    </a>
-                    <span class="te-tooltip-wrapper">
-                    <i class="glyphicon glyphicon-question-sign">
-                      {{#tooltip-on-element class="te-tooltip"}}
-                        Can't find your event? Click here to add a new event.
-                      {{/tooltip-on-element}}
-                    </i>
-                  </span>
                   </div>
                   <div class="col-xs-9">
                     {{rootcause-table
@@ -253,9 +241,10 @@
                     }}
                   </div>
                 </div>
-              {{/if}}
+              {{/tabs.tabpanel}}
 
-              {{#if (eq activeTab "trend")}}
+              {{!-- trend --}}
+              {{#tabs.tabpanel name="trend"}}
                 {{#if (set-has loadingFrameworks "metricRelated")}}
                   <div class="spinner-wrapper spinner-wrapper--card">
                     {{ember-spinner}}
@@ -281,9 +270,8 @@
                   isLoading=isLoadingTimeseries
                   onSelection=(action "onSelection")
                 }}
-              {{/if}}
-
-            </div>
+              {{/tabs.tabpanel}}
+            {{/shared/common-tabs}}
           </div>
         </div>
       {{/if}}

--- a/thirdeye/thirdeye-frontend/app/styles/app.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/app.scss
@@ -59,6 +59,7 @@ body {
 @import 'components/te-anomaly-table';
 @import 'components/te-toggle';
 @import 'components/range-pill-selectors';
+@import 'components/shared/common-tabs';
 
 // Pod Pages
 @import 'ember-power-select/themes/bootstrap';

--- a/thirdeye/thirdeye-frontend/app/styles/components/rootcause-trend.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/rootcause-trend.scss
@@ -2,5 +2,6 @@
 .rootcause-trend {
   &__toolbar {
     margin-bottom: 16px;
+    padding-left: 5px;
   }
 }

--- a/thirdeye/thirdeye-frontend/app/styles/components/shared/common-tabs.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/components/shared/common-tabs.scss
@@ -1,0 +1,43 @@
+.common-tabs {
+  top: $te-spacing--sm;
+  margin-bottom: $te-spacing--md;
+
+  &--no-bg-color {
+    background-color: inherit;
+  }
+
+  &__header {
+    display: flex;
+    margin-bottom: 0;
+    border-bottom: 1px solid $te-grey--border;
+    padding: 10px 0;
+    color: app-shade(black, 0.85);
+    list-style-type: none;
+
+    &--no-border {
+      border: none;
+    }
+
+    &--flush-bottom {
+      padding-bottom: 0;
+    }
+
+    &--right {
+      justify-content: flex-end;
+    }
+  }
+
+  &__subnav {
+    margin-right: $te-spacing--md;
+    font-size: 17px;
+  }
+
+  &__body {
+    background-color: white;
+    padding: $te-spacing--md 0;
+
+    &--flush-bottom {
+      padding-bottom: 0;
+    }
+  }
+}

--- a/thirdeye/thirdeye-frontend/app/styles/pods/rootcause.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/pods/rootcause.scss
@@ -54,3 +54,11 @@
 .rootcause-alert {
   margin: 0 $te-spacing--lg 10px $te-spacing--lg;
 }
+
+.rootcause-tabs {
+  background-color: app-shade($te-main-background, 0.8);
+
+  .pull-right {
+    margin-right: 5px;
+  }
+}

--- a/thirdeye/thirdeye-frontend/app/utils/utils.js
+++ b/thirdeye/thirdeye-frontend/app/utils/utils.js
@@ -66,9 +66,9 @@ export function humanizeFloat(f) {
 export function humanizeChange(f) {
   if (!isValidForDisplay(f)) { return '-'; }
   if (f > 10) {
-    return '+1000%+'
+    return '+1000%+';
   } else if (f < -10) {
-    return '-1000%+'
+    return '-1000%+';
   }
   return `${f > 0 ? '+' : ''}${Math.round(f * 100).toFixed(1)}%`;
 }

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/shared/common-tabs/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/shared/common-tabs/component-test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | shared/common-tabs', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders component `shared/common-tabs` well', async function(assert) {
+    this.setProperties({
+      activeTab: 'metrics'
+    });
+
+    await render(hbs`
+      {{#shared/common-tabs selection=activeTab activeTab=activeTab as |tabs|}}
+        {{#tabs.tablist as |tablist|}}
+          {{#tablist.tab name="metrics"}}Metrics{{/tablist.tab}}
+          {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
+        {{/tabs.tablist}}
+
+        {{!-- metrics --}}
+        {{#tabs.tabpanel name="metrics"}}
+          {{!-- IMPORTANT metrics CODE --}}
+        {{/tabs.tabpanel}}
+        {{!-- dimensions --}}
+        {{#tabs.tabpanel name="dimensions"}}
+          {{!-- IMPORTANT dimensions CODE --}}
+        {{/tabs.tabpanel}}
+      {{/shared/common-tabs}}
+    `);
+
+    const $tabs = this.$('.common-tabs ul li');
+
+    // Testing tabs
+    assert.equal($tabs.get(0).innerText, 'Metrics', 'Name of the first tab matches `Metrics` is correct.');
+    assert.equal($tabs.get(1).innerText, 'Dimensions', 'Name of the first tab matches `Dimensions` is correct.');
+  });
+});

--- a/thirdeye/thirdeye-frontend/tests/utils/constants.js
+++ b/thirdeye/thirdeye-frontend/tests/utils/constants.js
@@ -77,7 +77,7 @@ export const selfServeConst = {
  */
 export const rootCauseConst = {
   PLACEHOLDER: '.rootcause-placeholder',
-  TABS: '.rootcause-tabs',
+  TABS: '.common-tabs',
   LABEL: '.rootcause-legend__label',
   SELECTED_METRIC: '.rootcause-select-metric-dimension',
   ROOTCAUSE_HEADER: 'rootcause-header',


### PR DESCRIPTION
![screen shot 2018-04-27 at 10 20 05 am](https://user-images.githubusercontent.com/8840761/39375937-d480b3be-4a04-11e8-93ca-1775ffb3e048.png)
![screen shot 2018-04-30 at 1 32 17 pm](https://user-images.githubusercontent.com/8840761/39449105-025b877c-4c7c-11e8-8560-7b4000a43885.png)


1. Added new common-tabs components (and its sub components - tablist, tabpanel, tab)
2. Added new styles for this common-tabs component
3. Added integration tests for the new component
4. Updated RCA page to use this new component
5. Documented  example of usage (see below).
```
  @example
    {{#shared/common-tabs selection=activeTab activeTab=activeTab as |tabs|}}
      {{#tabs.tablist as |tablist|}}
        {{#tablist.tab name="metrics"}}Metrics{{/tablist.tab}}
        {{#tablist.tab name="dimensions"}}Dimensions{{/tablist.tab}}
      {{/tabs.tablist}}

      {{!-- metrics --}}
      {{#tabs.tabpanel name="metrics"}}
        {{!-- IMPORTANT metrics CODE --}}
      {{/tabs.tabpanel}}
      {{!-- dimensions --}}
      {{#tabs.tabpanel name="dimensions"}}
        {{!-- IMPORTANT dimensions CODE --}}
      {{/tabs.tabpanel}}
    {{/shared/common-tabs}}
```