### PR TITLE
[TE] self-serve endpoint adjustments 02

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-select-metric/component.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import fetch from 'fetch';
 import { toBaselineUrn, toCurrentUrn } from 'thirdeye-frontend/utils/rca-utils';
+import { selfServeApiCommon } from 'thirdeye-frontend/utils/api/self-serve';
 import { task, timeout } from 'ember-concurrency';
 import _ from 'lodash';
 
@@ -27,8 +28,7 @@ export default Component.extend({
    */
   searchMetrics: task(function* (metric) {
     yield timeout(1000);
-    const url = `/data/autocomplete/metric?name=${metric}`;
-    return fetch(url)
+    return fetch(selfServeApiCommon.metricAutoComplete(metric))
       .then(res => res.json());
   }),
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/controller.js
@@ -14,6 +14,7 @@ import { computed, set } from '@ember/object';
 import { getWithDefault } from '@ember/object';
 import { isEmpty, isPresent } from "@ember/utils";
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
+import { selfServeApiCommon } from 'thirdeye-frontend/utils/api/self-serve';
 import { formatConfigGroupProps } from 'thirdeye-frontend/utils/manage-alert-utils';
 
 export default Controller.extend({
@@ -206,7 +207,7 @@ export default Controller.extend({
    * @return {Promise}
    */
   fetchAlertByName(functionName) {
-    const url = `/data/autocomplete/functionByName?name=${functionName}`;
+    const url = selfServeApiCommon.alertFunctionByName(functionName)
     return fetch(url).then(checkStatus);
   },
 
@@ -218,7 +219,7 @@ export default Controller.extend({
    * @return {Promise}
    */
   fetchFunctionById(functionId) {
-    const url = `/onboard/function/${functionId}`;
+    const url = selfServeApiCommon.alertById(functionId);
     return fetch(url).then(checkStatus);
   },
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -27,6 +27,10 @@ import {
   buildMetricDataUrl,
   extractSeverity
 } from 'thirdeye-frontend/utils/manage-alert-utils';
+import {
+  selfServeApiCommon,
+  selfServeApiGraph
+} from 'thirdeye-frontend/utils/api/self-serve';
 import { anomalyResponseObj } from 'thirdeye-frontend/utils/anomaly';
 import { getAnomalyDataUrl } from 'thirdeye-frontend/utils/api/anomaly';
 
@@ -226,7 +230,7 @@ export default Route.extend({
     // Load endpoints for projected metrics. TODO: consolidate into CP if duplicating this logic
     const qsParams = `start=${baseStart.utc().format(dateFormat)}&end=${baseEnd.utc().format(dateFormat)}&useNotified=true`;
     const anomalyDataUrl = getAnomalyDataUrl(startStamp, endStamp);
-    const metricsUrl = `/data/autocomplete/metric?name=${dataset}::${metricName}`;
+    const metricsUrl = selfServeApiCommon.metricAutoComplete(metricName);
     const anomaliesUrl = `/dashboard/anomaly-function/${alertId}/anomalies?${qsParams}`;
     let anomalyPromiseHash = {
       projectedMttd: 0,
@@ -257,7 +261,7 @@ export default Route.extend({
           anomaliesUrl,
           config
         });
-        const maxTimeUrl = `/data/maxDataTime/metricId/${metricId}`;
+        const maxTimeUrl = selfServeApiGraph.maxDataTime(metricId);
         const maxTime = isReplayDone ? await fetch(maxTimeUrl).then(checkStatus) : moment().valueOf();
         Object.assign(model, { metricDataUrl: buildMetricDataUrl({
           maxTime,

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alerts/index/controller.js
@@ -3,13 +3,13 @@
  * @module manage/alerts/controller
  * @exports alerts controller
  */
-import { computed, set } from '@ember/object';
-
-import Controller from '@ember/controller';
-import fetch from 'fetch';
 import _ from 'lodash';
+import fetch from 'fetch';
+import { computed, set } from '@ember/object';
+import Controller from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
 import { checkStatus } from 'thirdeye-frontend/utils/utils';
+import { selfServeApiCommon } from 'thirdeye-frontend/utils/api/self-serve';
 
 export default Controller.extend({
   queryParams: ['selectedSearchMode', 'alertId', 'testMode'],
@@ -181,9 +181,7 @@ export default Controller.extend({
    */
   searchByFunctionName: task(function* (alert) {
     yield timeout(600);
-
-    const url = `/data/autocomplete/functionByName?name=${alert}`;
-    return fetch(url)
+    return fetch(selfServeApiCommon.alertFunctionByName(alert))
       .then(res => res.json());
   }),
 
@@ -194,12 +192,11 @@ export default Controller.extend({
   searchByApplicationName: task(function* (appName) {
     this.set('isLoading', true);
     yield timeout(600);
-    const url = `/data/autocomplete/functionByAppname?appname=${appName}`;
 
     this.set('selectedApplicationName', appName);
     this.set('currentPage', 1);
 
-    return fetch(url)
+    return fetch(selfServeApiCommon.alertFunctionByAppName(appName))
       .then(res => res.json())
       .then((alerts) => {
         this.set('isLoading', false);
@@ -218,8 +215,7 @@ export default Controller.extend({
     this.set('selectedsubscriberGroupNames', groupName);
     this.set('currentPage', 1);
 
-    const url = `/data/autocomplete/functionByAlertName?alertName=${groupName}`;
-    return fetch(url)
+    return fetch(selfServeApiCommon.alertFunctionByName(groupName))
       .then(res => res.json())
       .then((filters) => {
         this.set('isLoading', false);
@@ -268,7 +264,7 @@ export default Controller.extend({
         method: 'delete',
         headers: { 'content-type': 'text/plain' }
       };
-      const url = '/dashboard/anomaly-function?id=' + functionId;
+      const url = selfServeApiCommon.deleteAlert(functionId);
       fetch(url, postProps).then(checkStatus).then(() => {
         this.send('refreshModel');
       });

--- a/thirdeye/thirdeye-frontend/app/pods/rca/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rca/controller.js
@@ -2,6 +2,7 @@ import { computed } from '@ember/object';
 import { oneWay } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
+import { selfServeApiCommon } from 'thirdeye-frontend/utils/api/self-serve';
 
 export default Controller.extend({
   primaryMetric: oneWay('model'),
@@ -12,7 +13,6 @@ export default Controller.extend({
    */
   searchMetrics: task(function* (metric) {
     yield timeout(600);
-    let url = `/data/autocomplete/metric?name=${metric}`;
 
     /**
      * Necessary headers for fetch
@@ -27,7 +27,7 @@ export default Controller.extend({
       credentials: 'include'
     };
 
-    return fetch(url, headers)
+    return fetch(selfServeApiCommon.metricAutoComplete(metric), headers)
       .then(res => res.json());
   }),
 

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -245,7 +245,7 @@ export default Controller.extend({
    * @return {Promise}
    */
   fetchAlertsByName(functionName) {
-    const url = selfServeApiCommon.alertAutoComplete(functionName);
+    const url = selfServeApiCommon.alertFunctionByName(functionName);
     return fetch(url).then(checkStatus);
   },
 

--- a/thirdeye/thirdeye-frontend/app/utils/api/entity-mapping.js
+++ b/thirdeye/thirdeye-frontend/app/utils/api/entity-mapping.js
@@ -1,3 +1,5 @@
+import { selfServeApiCommon } from 'thirdeye-frontend/utils/api/self-serve';
+
 /**
  * Endpoints for entity mapping modal
  */
@@ -8,7 +10,7 @@ export const entityMappingApi = {
   getDatasetsUrl: `/data/datasets`,
   getServicesUrl: `/external/services/all`,
   metricAutoCompleteUrl(str) {
-    return `/data/autocomplete/metric?name=${str}`;
+    return selfServeApiCommon.metricAutoComplete(str);
   },
   getRelatedEntitiesDataUrl(urns) {
     return `/rootcause/raw?framework=identity&urns=${urns}`;

--- a/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
+++ b/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
@@ -46,14 +46,21 @@ const deleteAlert = functionId => `/dashboard/anomaly-function?id=${functionId}`
  * @param {String} metricName: metric name
  * @see {@link https://tinyurl.com/y7hhzm33|class DataResource}
  */
-const metricAutoComplete = metricName => `/data/autocomplete/metric?name=${metricName}`;
+const metricAutoComplete = metricName => `/data/autocomplete/metric?name=${encodeURIComponent(metricName)}`;
 
 /**
  * GET autocomplete request for alert by name
  * @param {String} functionName: alert name
  * @see {@link https://tinyurl.com/ybelagey|class DataResource}
  */
-const alertAutoComplete = functionName => `/data/autocomplete/functionByName?name=${functionName}`;
+const alertFunctionByName = functionName => `/data/autocomplete/functionByName?name=${encodeURIComponent(functionName)}`;
+
+/**
+ * GET autocomplete request for alert by app name
+ * @param {String} appName: application name
+ * @see {@link https://tinyurl.com/ybelagey|class DataResource}
+ */
+const alertFunctionByAppName = appName => `/data/autocomplete/functionByAppname?appname=${encodeURIComponent(appName)}`;
 
 /**
  * GET a single function record by id
@@ -119,12 +126,14 @@ const createNewDataset = '/onboard/create';
 
 /**
  * General self-serve endpoints
+ * TODO: rename these API utils according to entity, not UI features (self-serve, rca)
  */
 export const selfServeApiCommon = {
   alertById,
   allConfigGroups,
   allApplications,
-  alertAutoComplete,
+  alertFunctionByName,
+  alertFunctionByAppName,
   metricAutoComplete
 };
 

--- a/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/thirdeye.ftl
+++ b/thirdeye/thirdeye-pinot/src/main/resources/com/linkedin/thirdeye/dashboard/views/thirdeye.ftl
@@ -201,7 +201,7 @@
                   </a>
                   <div id="help-menu" class="te-nav__dropdown-wrapper hidden">
                     <a class="te-nav__dropdown-item" href="mailto:ask_thirdeye@linkedin.com?Subject=TE-Feedback" target="_blank">Submit Feedback</a>
-                    <a class="te-nav__dropdown-item" href="https://iwww.corp.linkedin.com/wiki/cf/display/PRT/ThirdEye+Help+Page" target="_blank">Help page</a>
+                    <a class="te-nav__dropdown-item" href="http://go/thirdeye-help" target="_blank">Help page</a>
                     <a class="te-nav__dropdown-item" href="app/#/logout">Logout</a>
                   </div>
                 </div>


### PR DESCRIPTION
- Pointing some fetch URLs to their defined constant in our API utility (note: the intention is to move toward use of the data store and services)
- URL encoding string request params
- Changing one link to help docs (intention is to later change these links to github-hosted docs)

All tests passing:
318 tests completed in 275430 milliseconds, with 0 failed, 0 skipped, and 0 todo.
435 assertions of 435 passed, 0 failed.