### PR TITLE
[TE] fixing default alert duration caching

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
@@ -27,23 +27,23 @@ export default Route.extend({
   beforeModel(transition) {
     const id = transition.params['manage.alert'].alert_id;
     const { jobId, functionName } = transition.queryParams;
-    const durationDefault = '3m';
-    const startDateDefault = buildDateEod(3, 'month').valueOf();
-    const endDateDefault = moment().utc().valueOf();
+    const duration = '3m';
+    const startDate = buildDateEod(3, 'month').valueOf();
+    const endDate = moment().utc().valueOf();
 
     // Enter default 'explore' route with defaults loaded in URI
     // An alert Id of 0 means there is an alert creation error to display
     if (transition.targetName === 'manage.alert.index' && Number(id) !== -1) {
       this.transitionTo('manage.alert.explore', id, { queryParams: {
-        duration: durationDefault,
-        startDate: startDateDefault,
-        endDate: endDateDefault,
+        duration,
+        startDate,
+        endDate,
         functionName: null,
         jobId
       }});
 
       // Save duration to service object for session availability
-      this.get('durationCache').setDuration({ durationDefault, startDateDefault, endDateDefault });
+      this.get('durationCache').setDuration({ duration, startDate, endDate });
     }
   },
 


### PR DESCRIPTION
The "default" duration params were not being cached with the correct keys in the Manage Alerts page.

UI tests passing:
318 tests completed in 244340 milliseconds, with 0 failed, 0 skipped, and 0 todo.
435 assertions of 435 passed, 0 failed.