### PR TITLE
Segment size based flush threshold update

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/StreamConsumptionConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/StreamConsumptionConfig.java
@@ -30,7 +30,6 @@ public class StreamConsumptionConfig {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private String _streamPartitionAssignmentStrategy;
-  private String _flushThresholdUpdateStrategy;
 
   public String getStreamPartitionAssignmentStrategy() {
     return _streamPartitionAssignmentStrategy;
@@ -38,14 +37,6 @@ public class StreamConsumptionConfig {
 
   public void setStreamPartitionAssignmentStrategy(String streamPartitionAssignmentStrategy) {
     _streamPartitionAssignmentStrategy = streamPartitionAssignmentStrategy;
-  }
-
-  public String getFlushThresholdUpdateStrategy() {
-    return _flushThresholdUpdateStrategy;
-  }
-
-  public void setFlushThresholdUpdateStrategy(String flushThresholdUpdateStrategy) {
-    _flushThresholdUpdateStrategy = flushThresholdUpdateStrategy;
   }
 
   @Override

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -560,7 +560,8 @@ public class PinotLLCRealtimeSegmentManager {
         partitionAssignment.getNumPartitions());
     final LLCRealtimeSegmentZKMetadata newSegmentZKMetadata = new LLCRealtimeSegmentZKMetadata(newZnRecord);
 
-    FlushThresholdUpdater flushThresholdUpdater = getFlushThresholdUpdater(realtimeTableConfig);
+    FlushThresholdUpdater flushThresholdUpdater =
+        _flushThresholdUpdateManager.getFlushThresholdUpdater(realtimeTableConfig);
     FlushThresholdUpdaterParams params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentSizeBytes(committingSegmentSizeBytes);
     params.setPartitionAssignment(partitionAssignment);
@@ -587,10 +588,6 @@ public class PinotLLCRealtimeSegmentManager {
           newSegmentNameStr, rawTableName, isLeader(), isConnected());
     }
     return success;
-  }
-
-  protected FlushThresholdUpdater getFlushThresholdUpdater(TableConfig realtimeTableConfig) {
-    return _flushThresholdUpdateManager.getFlushThresholdUpdater(realtimeTableConfig);
   }
 
   /**

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -50,7 +50,7 @@ import com.linkedin.pinot.controller.helix.core.PinotHelixSegmentOnlineOfflineSt
 import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.realtime.segment.FlushThresholdUpdateManager;
 import com.linkedin.pinot.controller.helix.core.realtime.segment.FlushThresholdUpdater;
-import com.linkedin.pinot.controller.helix.core.realtime.segment.FlushThresholdUpdaterParams;
+import com.linkedin.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
 import com.linkedin.pinot.core.realtime.impl.kafka.SimpleConsumerWrapper;
 import com.linkedin.pinot.core.realtime.segment.ConsumingSegmentAssignmentStrategy;
@@ -112,7 +112,7 @@ public class PinotLLCRealtimeSegmentManager {
   /**
    * After step 1 of segment completion is done,
    * this is the max time until which step 3 is allowed to complete.
-   * See {@link PinotLLCRealtimeSegmentManager#commitSegmentMetadata(String, String, long, SegmentCompletionProtocol.Request.Params)} for explanation of steps 1 2 3
+   * See {@link PinotLLCRealtimeSegmentManager#commitSegmentMetadata(String, SegmentCompletionProtocol.Request.Params)} for explanation of steps 1 2 3
    * This includes any backoffs and retries for the steps 2 and 3
    * The segment will be eligible for repairs by the validation manager, if the time  exceeds this value
    */
@@ -561,11 +561,10 @@ public class PinotLLCRealtimeSegmentManager {
 
     FlushThresholdUpdater flushThresholdUpdater =
         _flushThresholdUpdateManager.getFlushThresholdUpdater(realtimeTableConfig);
-    FlushThresholdUpdaterParams params = new FlushThresholdUpdaterParams();
-    params.setCommittingSegmentSizeBytes(committingSegmentSizeBytes);
-    params.setPartitionAssignment(partitionAssignment);
-    params.setCommittingSegmentZkMetadata(committingSegmentMetadata);
-    flushThresholdUpdater.updateFlushThreshold(newSegmentZKMetadata, params);
+    CommittingSegmentDescriptor committingSegmentDescriptor = new CommittingSegmentDescriptor();
+    committingSegmentDescriptor.setCommittingSegmentSizeBytes(committingSegmentSizeBytes);
+    committingSegmentDescriptor.setCommittingSegmentZkMetadata(committingSegmentMetadata);
+    flushThresholdUpdater.updateFlushThreshold(newSegmentZKMetadata, committingSegmentDescriptor, partitionAssignment);
 
     newZnRecord = newSegmentZKMetadata.toZNRecord();
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -389,13 +389,10 @@ public class PinotLLCRealtimeSegmentManager {
    * records for new segments, and puts them in idealstate in CONSUMING state.
    *
    * @param rawTableName Raw table name
-   * @param committingSegmentNameStr Committing segment name
-   * @param nextOffset The offset with which the next segment should start.
    * @param reqParams
    * @return boolean
    */
-  public boolean commitSegmentMetadata(String rawTableName, final String committingSegmentNameStr, long nextOffset,
-      SegmentCompletionProtocol.Request.Params reqParams) {
+  public boolean commitSegmentMetadata(String rawTableName, SegmentCompletionProtocol.Request.Params reqParams) {
     final String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
     TableConfig tableConfig = getRealtimeTableConfig(realtimeTableName);
     if (tableConfig == null) {
@@ -411,6 +408,8 @@ public class PinotLLCRealtimeSegmentManager {
      * Step 3: Update IDEALSTATES to include new segment in CONSUMING state, and change old segment to ONLINE state.
      */
 
+    final String committingSegmentNameStr = reqParams.getSegmentName();
+    final long nextOffset = reqParams.getOffset();
     final LLCSegmentName committingLLCSegmentName = new LLCSegmentName(committingSegmentNameStr);
     final int partitionId = committingLLCSegmentName.getPartitionId();
     final int newSeqNum = committingLLCSegmentName.getSequenceNumber() + 1;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -604,8 +604,7 @@ public class SegmentCompletionManager {
           LOGGER.error("Segment upload failed");
           return abortAndReturnFailed();
         }
-        SegmentCompletionProtocol.Response response =
-            commitSegment(reqParams, isSplitCommit);
+        SegmentCompletionProtocol.Response response = commitSegment(reqParams, isSplitCommit);
         if (!response.equals(SegmentCompletionProtocol.RESP_COMMIT_SUCCESS)) {
           return abortAndReturnFailed();
         } else {
@@ -1001,8 +1000,7 @@ public class SegmentCompletionManager {
           return SegmentCompletionProtocol.RESP_FAILED;
         }
       }
-      success = _segmentManager.commitSegmentMetadata(_segmentName.getTableName(), _segmentName.getSegmentName(),
-          _winningOffset, reqParams);
+      success = _segmentManager.commitSegmentMetadata(_segmentName.getTableName(), reqParams);
       if (success) {
         _state = State.COMMITTED;
         LOGGER.info("Committed segment {} at offset {} winner {}", _segmentName.getSegmentName(), offset, instanceId);

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
@@ -16,29 +16,67 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
-import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 
 
 /**
  * Class to hold properties of the committing segment
  */
 public class CommittingSegmentDescriptor {
-  private LLCRealtimeSegmentZKMetadata _committingSegmentZkMetadata;
-  private long _committingSegmentSizeBytes;
+  private String _segmentName;
+  private long _segmentSizeBytes;
+  private String _segmentLocation;
+  private long _nextOffset;
 
-  public LLCRealtimeSegmentZKMetadata getCommittingSegmentZkMetadata() {
-    return _committingSegmentZkMetadata;
+  public static CommittingSegmentDescriptor fromSegmentCompletionReqParams(
+      SegmentCompletionProtocol.Request.Params reqParams) {
+    CommittingSegmentDescriptor committingSegmentDescriptor =
+        new CommittingSegmentDescriptor(reqParams.getSegmentName(), reqParams.getOffset(),
+            reqParams.getSegmentSizeBytes());
+    committingSegmentDescriptor.setSegmentLocation(reqParams.getSegmentLocation());
+    return committingSegmentDescriptor;
   }
 
-  public void setCommittingSegmentZkMetadata(LLCRealtimeSegmentZKMetadata committingSegmentZkMetadata) {
-    _committingSegmentZkMetadata = committingSegmentZkMetadata;
+  public CommittingSegmentDescriptor(String segmentName, long nextOffset, long segmentSizeBytes) {
+    _segmentName = segmentName;
+    _nextOffset = nextOffset;
+    _segmentSizeBytes = segmentSizeBytes;
   }
 
-  public long getCommittingSegmentSizeBytes() {
-    return _committingSegmentSizeBytes;
+  public CommittingSegmentDescriptor(String segmentName, long nextOffset, long segmentSizeBytes, String segmentLocation) {
+    this(segmentName, nextOffset, segmentSizeBytes);
+    _segmentLocation = segmentLocation;
   }
 
-  public void setCommittingSegmentSizeBytes(long segmentSize) {
-    _committingSegmentSizeBytes = segmentSize;
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public void setSegmentName(String segmentName) {
+    _segmentName = segmentName;
+  }
+
+  public long getSegmentSizeBytes() {
+    return _segmentSizeBytes;
+  }
+
+  public void setSegmentSizeBytes(long segmentSizeBytes) {
+    _segmentSizeBytes = segmentSizeBytes;
+  }
+
+  public String getSegmentLocation() {
+    return _segmentLocation;
+  }
+
+  public void setSegmentLocation(String segmentLocation) {
+    _segmentLocation = segmentLocation;
+  }
+
+  public long getNextOffset() {
+    return _nextOffset;
+  }
+
+  public void setNextOffset(long nextOffset) {
+    _nextOffset = nextOffset;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
@@ -17,16 +17,14 @@
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
-import com.linkedin.pinot.common.partition.PartitionAssignment;
 
 
 /**
- * Class to hold params required by flush threshold updater strategies
+ * Class to hold properties of the committing segment
  */
-public class FlushThresholdUpdaterParams {
+public class CommittingSegmentDescriptor {
   private LLCRealtimeSegmentZKMetadata _committingSegmentZkMetadata;
   private long _committingSegmentSizeBytes;
-  private PartitionAssignment _partitionAssignment;
 
   public LLCRealtimeSegmentZKMetadata getCommittingSegmentZkMetadata() {
     return _committingSegmentZkMetadata;
@@ -42,13 +40,5 @@ public class FlushThresholdUpdaterParams {
 
   public void setCommittingSegmentSizeBytes(long segmentSize) {
     _committingSegmentSizeBytes = segmentSize;
-  }
-
-  public PartitionAssignment getPartitionAssignment() {
-    return _partitionAssignment;
-  }
-
-  public void setPartitionAssignment(PartitionAssignment partitionAssignment) {
-    _partitionAssignment = partitionAssignment;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -31,7 +31,7 @@ import java.util.Map;
  */
 public class DefaultFlushThresholdUpdater extends FlushThresholdUpdater {
 
-  public DefaultFlushThresholdUpdater(TableConfig realtimeTableConfig) {
+  protected DefaultFlushThresholdUpdater(TableConfig realtimeTableConfig) {
     super(realtimeTableConfig);
   }
 

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
@@ -66,6 +67,7 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
     newSegmentZKMetadata.setSizeThresholdToFlushSegment(segmentFlushSize);
   }
 
+  @VisibleForTesting
   int getTableFlushSize() {
     return _tableFlushSize;
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -66,4 +66,8 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
     newSegmentZKMetadata.setSizeThresholdToFlushSegment(segmentFlushSize);
   }
 
+  int getTableFlushSize() {
+    return _tableFlushSize;
+  }
+
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -38,10 +38,9 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
 
   @Override
   public void updateFlushThreshold(LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      FlushThresholdUpdaterParams params) {
+      CommittingSegmentDescriptor committingSegmentDescriptor, PartitionAssignment partitionAssignment) {
 
     // Gather list of instances for this partition
-    PartitionAssignment partitionAssignment = params.getPartitionAssignment();
     String partitionId = new LLCSegmentName(newSegmentZKMetadata.getSegmentName()).getPartitionRange();
     List<String> instancesListForPartition = partitionAssignment.getInstancesListForPartition(partitionId);
     Map<String, Integer> partitionCountForInstance = new HashMap<>(instancesListForPartition.size());
@@ -49,7 +48,8 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
 
     // Find partition count for each instance
     int maxPartitionCountPerInstance = 1;
-    for (Map.Entry<String, List<String>> partitionAndInstanceList : partitionAssignment.getPartitionToInstances().entrySet()) {
+    for (Map.Entry<String, List<String>> partitionAndInstanceList : partitionAssignment.getPartitionToInstances()
+        .entrySet()) {
       List<String> instances = partitionAndInstanceList.getValue();
       for (String instance : instances) {
         if (partitionCountForInstance.containsKey(instance)) {
@@ -71,5 +71,4 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
   int getTableFlushSize() {
     return _tableFlushSize;
   }
-
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -37,7 +37,7 @@ public class DefaultFlushThresholdUpdater extends FlushThresholdUpdater {
 
   @Override
   public void updateFlushThreshold(LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      PartitionAssignment partitionAssignment) {
+      FlushThresholdUpdaterParams params) {
 
     int tableFlushSize = getRealtimeTableFlushSizeForTable(_realtimeTableConfig);
 
@@ -47,6 +47,7 @@ public class DefaultFlushThresholdUpdater extends FlushThresholdUpdater {
     }
 
     // Gather list of instances for this partition
+    PartitionAssignment partitionAssignment = params.getPartitionAssignment();
     String partitionId = new LLCSegmentName(newSegmentZKMetadata.getSegmentName()).getPartitionRange();
     List<String> instancesListForPartition = partitionAssignment.getInstancesListForPartition(partitionId);
     Map<String, Integer> partitionCountForInstance = new HashMap<>(instancesListForPartition.size());

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -22,6 +22,7 @@ import com.linkedin.pinot.common.utils.LLCSegmentName;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 
 /**
@@ -37,8 +38,9 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
   }
 
   @Override
-  public void updateFlushThreshold(LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      CommittingSegmentDescriptor committingSegmentDescriptor, PartitionAssignment partitionAssignment) {
+  public void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
+      LLCRealtimeSegmentZKMetadata committingSegmentZKMetadata, CommittingSegmentDescriptor committingSegmentDescriptor,
+      @Nonnull PartitionAssignment partitionAssignment) {
 
     // Gather list of instances for this partition
     String partitionId = new LLCSegmentName(newSegmentZKMetadata.getSegmentName()).getPartitionRange();

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
@@ -20,6 +20,7 @@ import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public abstract class FlushThresholdUpdater {
 
   protected TableConfig _realtimeTableConfig;
-  public FlushThresholdUpdater(TableConfig realtimeTableConfig) {
+  protected FlushThresholdUpdater(TableConfig realtimeTableConfig) {
     _realtimeTableConfig = realtimeTableConfig;
   }
 
@@ -42,8 +43,8 @@ public abstract class FlushThresholdUpdater {
    * @param newSegmentZKMetadata - new segment metadata for which the thresholds need to be set
    * @param flushThresholdUpdaterParams
    */
-  public abstract void updateFlushThreshold(LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      FlushThresholdUpdaterParams flushThresholdUpdaterParams);
+  public abstract void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
+      @Nonnull FlushThresholdUpdaterParams flushThresholdUpdaterParams);
 
 
   protected int getRealtimeTableFlushSizeForTable(TableConfig tableConfig) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
@@ -16,76 +16,22 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
-import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
-import com.linkedin.pinot.common.utils.CommonConstants;
-import java.util.Map;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * Base abstract class for the flush threshold updation strategies
+ * Interface for the flush threshold updation strategies
  * These implementations are responsible for updating the flush threshold (rows/time) in the given segment metadata
  */
-public abstract class FlushThresholdUpdater {
-
-  protected TableConfig _realtimeTableConfig;
-  protected FlushThresholdUpdater(TableConfig realtimeTableConfig) {
-    _realtimeTableConfig = realtimeTableConfig;
-  }
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(FlushThresholdUpdater.class);
+public interface FlushThresholdUpdater {
 
   /**
    * Updated the flush threshold of the segment metadata
    * @param newSegmentZKMetadata - new segment metadata for which the thresholds need to be set
    * @param flushThresholdUpdaterParams
    */
-  public abstract void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
+  void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
       @Nonnull FlushThresholdUpdaterParams flushThresholdUpdaterParams);
-
-
-  protected int getRealtimeTableFlushSizeForTable(TableConfig tableConfig) {
-    return getLLCRealtimeTableFlushSize(tableConfig);
-  }
-
-  /**
-   * Returns the max number of rows that a host holds across all consuming LLC partitions.
-   * This number should be divided by the number of partitions on the host, so as to get
-   * the flush limit for each segment.
-   *
-   * If flush threshold is configured for LLC, return it, otherwise, if flush threshold is
-   * configured for HLC, then return that value, else return -1.
-   *
-   * @param tableConfig
-   * @return -1 if tableConfig is null, or neither value is configured
-   */
-  private int getLLCRealtimeTableFlushSize(TableConfig tableConfig) {
-    final Map<String, String> streamConfigs = tableConfig.getIndexingConfig().getStreamConfigs();
-    String flushSizeStr;
-    if (streamConfigs == null) {
-      return -1;
-    }
-    if (streamConfigs.containsKey(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE)) {
-      flushSizeStr = streamConfigs.get(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE);
-      try {
-        return Integer.parseInt(flushSizeStr);
-      } catch (Exception e) {
-        LOGGER.warn("Failed to parse LLC flush size of {} for table {}", flushSizeStr, tableConfig.getTableName(), e);
-      }
-    }
-
-    if (streamConfigs.containsKey(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE)) {
-      flushSizeStr = streamConfigs.get(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE);
-      try {
-        return Integer.parseInt(flushSizeStr);
-      } catch (Exception e) {
-        LOGGER.warn("Failed to parse flush size of {} for table {}", flushSizeStr, tableConfig.getTableName(), e);
-      }
-    }
-    return -1;
-  }
 
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
@@ -30,10 +30,11 @@ public interface FlushThresholdUpdater {
   /**
    * Updated the flush threshold of the segment metadata
    * @param newSegmentZKMetadata - new segment metadata for which the thresholds need to be set
+   * @param committingSegmentZKMetadata - metadata of the committing segment
    * @param committingSegmentDescriptor
-   * @param partitionAssignment
+   * @param partitionAssignment - partition assignment for the table
    */
   void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      @Nonnull CommittingSegmentDescriptor committingSegmentDescriptor, PartitionAssignment partitionAssignment);
-
+      LLCRealtimeSegmentZKMetadata committingSegmentZKMetadata, CommittingSegmentDescriptor committingSegmentDescriptor,
+      PartitionAssignment partitionAssignment);
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
@@ -18,7 +18,6 @@ package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
-import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -29,7 +28,6 @@ import org.slf4j.LoggerFactory;
  * Base abstract class for the flush threshold updation strategies
  * These implementations are responsible for updating the flush threshold (rows/time) in the given segment metadata
  */
-// TODO: introduce more implememtations such as segment size based threshold tuning, memory based etc.
 public abstract class FlushThresholdUpdater {
 
   protected TableConfig _realtimeTableConfig;
@@ -41,14 +39,11 @@ public abstract class FlushThresholdUpdater {
 
   /**
    * Updated the flush threshold of the segment metadata
-   * @param newSegmentZKMetadata
-   * @param partitionAssignment
+   * @param newSegmentZKMetadata - new segment metadata for which the thresholds need to be set
+   * @param flushThresholdUpdaterParams
    */
-  // TODO: we can add more parameters to this definition as we introduce more updation strategies.
-  // For now, these two are sufficient
-  // We could introduce a FlushThresholdUpdateConfig to hold all the inputs required eg. partitions assignment, segment size, latest metadata e
   public abstract void updateFlushThreshold(LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      PartitionAssignment partitionAssignment);
+      FlushThresholdUpdaterParams flushThresholdUpdaterParams);
 
 
   protected int getRealtimeTableFlushSizeForTable(TableConfig tableConfig) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
@@ -17,6 +17,7 @@
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.partition.PartitionAssignment;
 import javax.annotation.Nonnull;
 
 
@@ -29,9 +30,10 @@ public interface FlushThresholdUpdater {
   /**
    * Updated the flush threshold of the segment metadata
    * @param newSegmentZKMetadata - new segment metadata for which the thresholds need to be set
-   * @param flushThresholdUpdaterParams
+   * @param committingSegmentDescriptor
+   * @param partitionAssignment
    */
   void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
-      @Nonnull FlushThresholdUpdaterParams flushThresholdUpdaterParams);
+      @Nonnull CommittingSegmentDescriptor committingSegmentDescriptor, PartitionAssignment partitionAssignment);
 
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterParams.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterParams.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.realtime.segment;
+
+import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.partition.PartitionAssignment;
+
+
+/**
+ * Class to hold params required by flush threshold updater strategies
+ */
+public class FlushThresholdUpdaterParams {
+  private LLCRealtimeSegmentZKMetadata _committingSegmentZkMetadata;
+  private long _committingSegmentSizeBytes;
+  private PartitionAssignment _partitionAssignment;
+
+  public LLCRealtimeSegmentZKMetadata getCommittingSegmentZkMetadata() {
+    return _committingSegmentZkMetadata;
+  }
+
+  public void setCommittingSegmentZkMetadata(LLCRealtimeSegmentZKMetadata committingSegmentZkMetadata) {
+    _committingSegmentZkMetadata = committingSegmentZkMetadata;
+  }
+
+  public long getCommittingSegmentSizeBytes() {
+    return _committingSegmentSizeBytes;
+  }
+
+  public void setCommittingSegmentSizeBytes(long segmentSize) {
+    _committingSegmentSizeBytes = segmentSize;
+  }
+
+  public PartitionAssignment getPartitionAssignment() {
+    return _partitionAssignment;
+  }
+
+  public void setPartitionAssignment(PartitionAssignment partitionAssignment) {
+    _partitionAssignment = partitionAssignment;
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -36,7 +36,7 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
 
-  private static final long IDEAL_SEGMENT_SIZE_BYTES = 500 * 1024 * 1024;
+  private static final long IDEAL_SEGMENT_SIZE_BYTES = 200 * 1024 * 1024;
   /** Below this size, we double the rows threshold */
   private static final double OPTIMAL_SEGMENT_SIZE_BYTES_MIN = IDEAL_SEGMENT_SIZE_BYTES / 2;
   /** Above this size we half the row threshold */
@@ -103,6 +103,13 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
       } else {
         _latestSegmentRowsToSizeRatio = currentRatio;
       }
+    }
+
+    if (numRowsConsumed < numRowsThreshold) {
+      LOGGER.info("Segment {} reached time threshold, setting thresholds for segment {} from previous segment",
+          committingSegmentZkMetadata.getSegmentName(), newSegmentZKMetadata.getSegmentName());
+      newSegmentZKMetadata.setSizeThresholdToFlushSegment(committingSegmentZkMetadata.getSizeThresholdToFlushSegment());
+      return;
     }
 
     long targetSegmentNumRows;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -36,8 +36,10 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
 
   static final long IDEAL_SEGMENT_SIZE_BYTES = 500 * 1024 * 1024;
-  private static final double MIN_ALLOWED_SEGMENT_SIZE_BYTES = 250 * 1024 * 1024;
-  private static final double MAX_ALLOWED_SEGMENT_SIZE_BYTES = 750 * 1024 * 1024;
+  /** Below this size, we double the rows threshold */
+  private static final double MIN_ALLOWED_SEGMENT_SIZE_BYTES = IDEAL_SEGMENT_SIZE_BYTES / 2;
+  /** Above this size we half the row threshold */
+  private static final double MAX_ALLOWED_SEGMENT_SIZE_BYTES = IDEAL_SEGMENT_SIZE_BYTES + IDEAL_SEGMENT_SIZE_BYTES / 2;
   static final int INITIAL_ROWS_THRESHOLD = 100_000;
 
   static final double CURRENT_SEGMENT_RATIO_WEIGHT = 0.25;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.linkedin.pinot.controller.helix.core.realtime.segment;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
+import com.linkedin.pinot.common.utils.time.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Updates the flush threshold rows of the new segment metadata, based on the segment size and number of rows of previous segment
+ * The formula used to compute new number of rows is:
+ * targetNumRows = ideal_segment_size * ( a * current_rows_to_size_ratio + b * previous_rows_to_size_ratio)
+ * where a = 0.25, b = 0.75
+ * This ensures that we take into account the history of the segment size and number rows
+ */
+public class SegmentSizeBasedFlushThresholdUpdater extends FlushThresholdUpdater {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
+
+  private static final long IDEAL_SEGMENT_SIZE_BYTES = 500 * 1024 * 1024;
+  private static final double MIN_ALLOWED_SEGMENT_SIZE_BYTES = 250 * 1024 * 1024;
+  private static final double MAX_ALLOWED_SEGMENT_SIZE_BYTES = 750 * 1024 * 1024;
+  private static final int INITIAL_ROWS_THRESHOLD = 100_000;
+  private static final String MAX_TIME_THRESHOLD = "24h";
+
+  private static final double CURRENT_SEGMENT_RATIO_WEIGHT = 0.25;
+  private static final double PREVIOUS_SEGMENT_RATIO_WEIGHT = 0.75;
+
+  private AtomicDouble _latestSegmentRowsToSizeRatio = new AtomicDouble();
+
+  public SegmentSizeBasedFlushThresholdUpdater(TableConfig realtimeTableConfig) {
+    super(realtimeTableConfig);
+  }
+
+  @Override
+  public void updateFlushThreshold(LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
+      FlushThresholdUpdaterParams params) {
+    LLCRealtimeSegmentZKMetadata committingSegmentZkMetadata = params.getCommittingSegmentZkMetadata();
+    if (committingSegmentZkMetadata == null) { // first segment
+      LOGGER.info("Committing segment zk metadata is not available, setting default thresholds for segment {}",
+          newSegmentZKMetadata.getSegmentName());
+      newSegmentZKMetadata.setSizeThresholdToFlushSegment(INITIAL_ROWS_THRESHOLD);
+      newSegmentZKMetadata.setTimeThresholdToFlushSegment(MAX_TIME_THRESHOLD);
+      return;
+    }
+    long committingSegmentSizeBytes = params.getCommittingSegmentSizeBytes();
+    if (committingSegmentSizeBytes == 0) { // repair segment
+      LOGGER.info(
+          "Committing segment size is not available, setting, setting thresholds for segment {} from previous segment {}",
+          newSegmentZKMetadata.getSegmentName(), committingSegmentZkMetadata.getSegmentName());
+      newSegmentZKMetadata.setSizeThresholdToFlushSegment(committingSegmentZkMetadata.getSizeThresholdToFlushSegment());
+      newSegmentZKMetadata.setTimeThresholdToFlushSegment(committingSegmentZkMetadata.getTimeThresholdToFlushSegment());
+    }
+
+    // time taken by committing segment
+    long timeConsumed = committingSegmentZkMetadata.getEndTime() - committingSegmentZkMetadata.getStartTime();
+
+    // rows consumed by committing segment
+    int numRowsConsumed =
+        (int) (committingSegmentZkMetadata.getEndOffset() - committingSegmentZkMetadata.getStartOffset());
+
+    // rows threshold for committing segment
+    int numRowsThreshold = committingSegmentZkMetadata.getSizeThresholdToFlushSegment();
+
+    if (timeConsumed >= TimeUtils.convertPeriodToMillis(MAX_TIME_THRESHOLD)) {
+      LOGGER.info("Time threshold {} reached for committing segment {}", MAX_TIME_THRESHOLD,
+          committingSegmentZkMetadata.getSegmentName());
+    }
+    if (numRowsConsumed >= numRowsThreshold) {
+      LOGGER.info("Number of rows threshold {} reached for segment {}", numRowsThreshold,
+          committingSegmentZkMetadata.getSegmentName());
+    }
+
+    double currentRatio = (double) numRowsConsumed / committingSegmentSizeBytes;
+    double prevRatio = _latestSegmentRowsToSizeRatio.getAndSet(currentRatio);
+    if (committingSegmentSizeBytes < MIN_ALLOWED_SEGMENT_SIZE_BYTES) {
+      // double the number of rows
+      newSegmentZKMetadata.setSizeThresholdToFlushSegment(numRowsConsumed * 2);
+      newSegmentZKMetadata.setTimeThresholdToFlushSegment(MAX_TIME_THRESHOLD);
+    } else if (committingSegmentSizeBytes > MAX_ALLOWED_SEGMENT_SIZE_BYTES) {
+      // half it
+      newSegmentZKMetadata.setSizeThresholdToFlushSegment(numRowsConsumed / 2);
+      newSegmentZKMetadata.setTimeThresholdToFlushSegment(MAX_TIME_THRESHOLD);
+    } else {
+      int targetSegmentNumRows;
+      if (prevRatio == 0) {
+        targetSegmentNumRows = (int) (IDEAL_SEGMENT_SIZE_BYTES * currentRatio);
+      } else {
+        targetSegmentNumRows = (int) (IDEAL_SEGMENT_SIZE_BYTES * (CURRENT_SEGMENT_RATIO_WEIGHT * currentRatio
+            + PREVIOUS_SEGMENT_RATIO_WEIGHT * prevRatio));
+      }
+      newSegmentZKMetadata.setSizeThresholdToFlushSegment(targetSegmentNumRows);
+      newSegmentZKMetadata.setTimeThresholdToFlushSegment(MAX_TIME_THRESHOLD);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -17,7 +17,6 @@
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
 import com.google.common.util.concurrent.AtomicDouble;
-import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.time.TimeUtils;
 import javax.annotation.Nonnull;
@@ -32,24 +31,20 @@ import org.slf4j.LoggerFactory;
  * where a = 0.25, b = 0.75
  * This ensures that we take into account the history of the segment size and number rows
  */
-public class SegmentSizeBasedFlushThresholdUpdater extends FlushThresholdUpdater {
+public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpdater {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
 
   static final long IDEAL_SEGMENT_SIZE_BYTES = 500 * 1024 * 1024;
-  static final double MIN_ALLOWED_SEGMENT_SIZE_BYTES = 250 * 1024 * 1024;
-  static final double MAX_ALLOWED_SEGMENT_SIZE_BYTES = 750 * 1024 * 1024;
+  private static final double MIN_ALLOWED_SEGMENT_SIZE_BYTES = 250 * 1024 * 1024;
+  private static final double MAX_ALLOWED_SEGMENT_SIZE_BYTES = 750 * 1024 * 1024;
   static final int INITIAL_ROWS_THRESHOLD = 100_000;
   static final String MAX_TIME_THRESHOLD = "24h";
 
-  private static final double CURRENT_SEGMENT_RATIO_WEIGHT = 0.25;
-  private static final double PREVIOUS_SEGMENT_RATIO_WEIGHT = 0.75;
+  static final double CURRENT_SEGMENT_RATIO_WEIGHT = 0.25;
+  static final double PREVIOUS_SEGMENT_RATIO_WEIGHT = 0.75;
 
   private AtomicDouble _latestSegmentRowsToSizeRatio = new AtomicDouble();
-
-  protected SegmentSizeBasedFlushThresholdUpdater(TableConfig realtimeTableConfig) {
-    super(realtimeTableConfig);
-  }
 
   @Override
   public void updateFlushThreshold(@Nonnull LLCRealtimeSegmentZKMetadata newSegmentZKMetadata,
@@ -79,6 +74,7 @@ public class SegmentSizeBasedFlushThresholdUpdater extends FlushThresholdUpdater
           newSegmentZKMetadata.getSegmentName(), committingSegmentZkMetadata.getSegmentName());
       newSegmentZKMetadata.setSizeThresholdToFlushSegment(committingSegmentZkMetadata.getSizeThresholdToFlushSegment());
       newSegmentZKMetadata.setTimeThresholdToFlushSegment(committingSegmentZkMetadata.getTimeThresholdToFlushSegment());
+      return;
     }
 
     // time taken by committing segment

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.time.TimeUtils;
@@ -27,23 +28,33 @@ import org.slf4j.LoggerFactory;
 /**
  * Updates the flush threshold rows of the new segment metadata, based on the segment size and number of rows of previous segment
  * The formula used to compute new number of rows is:
- * targetNumRows = ideal_segment_size * ( a * current_rows_to_size_ratio + b * previous_rows_to_size_ratio)
- * where a = 0.25, b = 0.75
+ * targetNumRows = ideal_segment_size * (a * current_rows_to_size_ratio + b * previous_rows_to_size_ratio)
+ * where a = 0.25, b = 0.75, prev ratio= ratio collected over all previous segment completions
  * This ensures that we take into account the history of the segment size and number rows
  */
 public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpdater {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
 
-  static final long IDEAL_SEGMENT_SIZE_BYTES = 500 * 1024 * 1024;
+  private static final long IDEAL_SEGMENT_SIZE_BYTES = 500 * 1024 * 1024;
   /** Below this size, we double the rows threshold */
-  private static final double MIN_ALLOWED_SEGMENT_SIZE_BYTES = IDEAL_SEGMENT_SIZE_BYTES / 2;
+  private static final double OPTIMAL_SEGMENT_SIZE_BYTES_MIN = IDEAL_SEGMENT_SIZE_BYTES / 2;
   /** Above this size we half the row threshold */
-  private static final double MAX_ALLOWED_SEGMENT_SIZE_BYTES = IDEAL_SEGMENT_SIZE_BYTES + IDEAL_SEGMENT_SIZE_BYTES / 2;
-  static final int INITIAL_ROWS_THRESHOLD = 100_000;
+  private static final double OPTIMAL_SEGMENT_SIZE_BYTES_MAX = IDEAL_SEGMENT_SIZE_BYTES * 1.5;
+  private static final int INITIAL_ROWS_THRESHOLD = 100_000;
 
-  static final double CURRENT_SEGMENT_RATIO_WEIGHT = 0.25;
-  static final double PREVIOUS_SEGMENT_RATIO_WEIGHT = 0.75;
+  private static final double CURRENT_SEGMENT_RATIO_WEIGHT = 0.25;
+  private static final double PREVIOUS_SEGMENT_RATIO_WEIGHT = 0.75;
+
+  @VisibleForTesting
+  long getIdealSegmentSizeBytes() {
+    return IDEAL_SEGMENT_SIZE_BYTES;
+  }
+
+  @VisibleForTesting
+  int getInitialRowsThreshold() {
+    return INITIAL_ROWS_THRESHOLD;
+  }
 
   // num rows to segment size ratio of last committed segment for this table
   private AtomicDouble _latestSegmentRowsToSizeRatio = new AtomicDouble();
@@ -59,7 +70,9 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
         LOGGER.info(
             "Committing segment zk metadata is not available, setting rows threshold for segment {} using previous segments ratio",
             newSegmentZKMetadata.getSegmentName());
-        newSegmentZKMetadata.setSizeThresholdToFlushSegment((int) (IDEAL_SEGMENT_SIZE_BYTES * prevRatio));
+        long targetSegmentNumRows = (long) (IDEAL_SEGMENT_SIZE_BYTES * prevRatio);
+        targetSegmentNumRows = capNumRowsIfOverflow(targetSegmentNumRows);
+        newSegmentZKMetadata.setSizeThresholdToFlushSegment((int) targetSegmentNumRows);
       } else {
         LOGGER.info("Committing segment zk metadata is not available, setting default rows threshold for segment {}",
             newSegmentZKMetadata.getSegmentName());
@@ -78,35 +91,43 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
     }
 
     long timeConsumed = System.currentTimeMillis() - committingSegmentZkMetadata.getCreationTime();
-    int numRowsConsumed = (int) (committingSegmentZkMetadata.getTotalRawDocs());
+    long numRowsConsumed = committingSegmentZkMetadata.getTotalRawDocs();
     int numRowsThreshold = committingSegmentZkMetadata.getSizeThresholdToFlushSegment();
     LOGGER.info("Time consumed:{}  Num rows consumed:{} Num rows threshold:{} Committing segment size bytes:{}",
         TimeUtils.convertMillisToPeriod(timeConsumed), numRowsConsumed, numRowsThreshold, committingSegmentSizeBytes);
 
-    /**
-     * TODO: {@link LLCRealtimeSegmentZKMetadata.getSizeThresholdToFlushSegment()} is an int. Auto tuning the size could cause overflow.
-     * Need to fix it. Will do so in an upcoming PR, as change touches multiple files
-     */
     double currentRatio = (double) numRowsConsumed / committingSegmentSizeBytes;
-    double prevRatio = _latestSegmentRowsToSizeRatio.getAndSet(currentRatio);
-    if (committingSegmentSizeBytes < MIN_ALLOWED_SEGMENT_SIZE_BYTES) {
-      newSegmentZKMetadata.setSizeThresholdToFlushSegment(numRowsConsumed * 2);
-      LOGGER.info("Committing segment size is less than min segment size {}, doubling rows threshold to : {}",
-          MIN_ALLOWED_SEGMENT_SIZE_BYTES, newSegmentZKMetadata.getSizeThresholdToFlushSegment());
-    } else if (committingSegmentSizeBytes > MAX_ALLOWED_SEGMENT_SIZE_BYTES) {
-      newSegmentZKMetadata.setSizeThresholdToFlushSegment(numRowsConsumed / 2);
-      LOGGER.info("Committing segment size is greater than max segment size {}, halving rows threshold {}",
-          MAX_ALLOWED_SEGMENT_SIZE_BYTES, newSegmentZKMetadata.getSizeThresholdToFlushSegment());
-    } else {
-      int targetSegmentNumRows;
-      if (prevRatio <= 0) {
-        targetSegmentNumRows = (int) (IDEAL_SEGMENT_SIZE_BYTES * currentRatio);
+    synchronized (_latestSegmentRowsToSizeRatio) {
+      double prevRatio = _latestSegmentRowsToSizeRatio.get();
+      if (prevRatio > 0) {
+        _latestSegmentRowsToSizeRatio.set(CURRENT_SEGMENT_RATIO_WEIGHT * currentRatio + PREVIOUS_SEGMENT_RATIO_WEIGHT * prevRatio);
       } else {
-        targetSegmentNumRows = (int) (IDEAL_SEGMENT_SIZE_BYTES * (CURRENT_SEGMENT_RATIO_WEIGHT * currentRatio
-            + PREVIOUS_SEGMENT_RATIO_WEIGHT * prevRatio));
+        _latestSegmentRowsToSizeRatio.set(currentRatio);
       }
-      newSegmentZKMetadata.setSizeThresholdToFlushSegment(targetSegmentNumRows);
+    }
+
+    long targetSegmentNumRows;
+    if (committingSegmentSizeBytes < OPTIMAL_SEGMENT_SIZE_BYTES_MIN) {
+      targetSegmentNumRows = numRowsConsumed + numRowsConsumed / 2;
+      LOGGER.info("Committing segment size is less than min segment size {}, doubling rows threshold to : {}",
+          OPTIMAL_SEGMENT_SIZE_BYTES_MIN, newSegmentZKMetadata.getSizeThresholdToFlushSegment());
+    } else if (committingSegmentSizeBytes > OPTIMAL_SEGMENT_SIZE_BYTES_MAX) {
+      targetSegmentNumRows = numRowsConsumed / 2;
+      LOGGER.info("Committing segment size is greater than max segment size {}, halving rows threshold {}",
+          OPTIMAL_SEGMENT_SIZE_BYTES_MAX, newSegmentZKMetadata.getSizeThresholdToFlushSegment());
+    } else {
+      targetSegmentNumRows = (long) (IDEAL_SEGMENT_SIZE_BYTES * _latestSegmentRowsToSizeRatio.get());
       LOGGER.info("Setting new rows threshold : {}", newSegmentZKMetadata.getSizeThresholdToFlushSegment());
     }
+    targetSegmentNumRows = capNumRowsIfOverflow(targetSegmentNumRows);
+
+    newSegmentZKMetadata.setSizeThresholdToFlushSegment((int) targetSegmentNumRows);
+  }
+
+  private long capNumRowsIfOverflow(long targetSegmentNumRows) {
+    if (targetSegmentNumRows > Integer.MAX_VALUE) {
+      targetSegmentNumRows = Integer.MAX_VALUE;
+    }
+    return targetSegmentNumRows;
   }
 }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -118,10 +118,11 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
       // If we set new threshold to be committingSegmentZKMetadata.getSizeThresholdToFlushSegment(), we might end up using a lot more memory than required for the segment
       // Using a minor bump strategy, until we add feature to adjust time
       // We will only slightly bump the threshold based on numRowsConsumed
-      long targetSegmentNumRows = (long) (numRowsConsumed * 1.1);
+      long targetSegmentNumRows = (long) (numRowsConsumed * ROWS_MULTIPLIER_WHEN_TIME_THRESHOLD_HIT);
       targetSegmentNumRows = capNumRowsIfOverflow(targetSegmentNumRows);
-      LOGGER.info("Segment {} reached time threshold, bumping segment size threshold 1.1 times to {} for segment {}",
-          committingSegmentZKMetadata.getSegmentName(), targetSegmentNumRows, newSegmentZKMetadata.getSegmentName());
+      LOGGER.info("Segment {} reached time threshold, bumping segment size threshold {} times to {} for segment {}",
+          committingSegmentZKMetadata.getSegmentName(), ROWS_MULTIPLIER_WHEN_TIME_THRESHOLD_HIT, targetSegmentNumRows,
+          newSegmentZKMetadata.getSegmentName());
       newSegmentZKMetadata.setSizeThresholdToFlushSegment((int) targetSegmentNumRows);
       return;
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -41,8 +41,6 @@ import com.linkedin.pinot.controller.ControllerConf;
 import com.linkedin.pinot.controller.api.resources.LLCSegmentCompletionHandlers;
 import com.linkedin.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import com.linkedin.pinot.controller.helix.core.realtime.partition.StreamPartitionAssignmentStrategyEnum;
-import com.linkedin.pinot.controller.helix.core.realtime.segment.DefaultFlushThresholdUpdater;
-import com.linkedin.pinot.controller.helix.core.realtime.segment.FlushThresholdUpdater;
 import com.linkedin.pinot.controller.util.SegmentCompletionUtils;
 import com.linkedin.pinot.core.indexsegment.generator.SegmentVersion;
 import com.linkedin.pinot.core.realtime.stream.StreamMetadata;
@@ -1130,7 +1128,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(mockValidationConfig.getReplicasPerPartitionNumber()).thenReturn(nReplicas);
     when(mockTableConfig.getValidationConfig()).thenReturn(mockValidationConfig);
     Map<String, String> streamConfigMap = new HashMap<>(1);
-
+    streamConfigMap.put(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE,
+        "100000");
     streamConfigMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
         CommonConstants.Helix.DataSource.Realtime.Kafka.CONSUMER_TYPE), "simple");
     streamConfigMap.put(StringUtil.join(".", CommonConstants.Helix.DataSource.STREAM_PREFIX,
@@ -1396,11 +1395,6 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    protected FlushThresholdUpdater getFlushThresholdUpdater(TableConfig realtimeTableConfig) {
-      return new FakeFlushThresholdUpdater(realtimeTableConfig);
-    }
-
-    @Override
     protected IdealState getTableIdealState(String realtimeTableName) {
       return _tableIdealState;
     }
@@ -1419,18 +1413,6 @@ public class PinotLLCRealtimeSegmentManagerTest {
     @Override
     protected int getKafkaPartitionCount(StreamMetadata metadata) {
       return _tableConfigStore.getNKafkaPartitions(_currentTable);
-    }
-  }
-
-  static class FakeFlushThresholdUpdater extends DefaultFlushThresholdUpdater {
-
-    public FakeFlushThresholdUpdater(TableConfig realtimeTableConfig) {
-      super(realtimeTableConfig);
-    }
-
-    @Override
-    protected int getRealtimeTableFlushSizeForTable(TableConfig tableConfig) {
-      return 1000;
     }
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -851,22 +851,19 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._paths.clear();
     segmentManager._records.clear();
     segmentManager.IS_CONNECTED = false;
-    boolean status =
-        segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-            reqParams);
+    reqParams.withSegmentName(committingSegmentMetadata.getSegmentName()).withOffset(nextOffset);
+    boolean status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     Assert.assertFalse(status);
     Assert.assertEquals(segmentManager._nCallsToUpdateHelix, 0);  // Idealstate not updated
     Assert.assertEquals(segmentManager._paths.size(), 0);   // propertystore not updated
     segmentManager.IS_CONNECTED = true;
     segmentManager.IS_LEADER = false;
-    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     Assert.assertFalse(status);
     Assert.assertEquals(segmentManager._nCallsToUpdateHelix, 0);  // Idealstate not updated
     Assert.assertEquals(segmentManager._paths.size(), 0);   // propertystore not updated
     segmentManager.IS_LEADER = true;
-    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     Assert.assertTrue(status);
     Assert.assertEquals(segmentManager._nCallsToUpdateHelix, 1);  // Idealstate updated
     Assert.assertEquals(segmentManager._paths.size(), 2);   // propertystore updated
@@ -908,9 +905,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._paths.clear();
     segmentManager._records.clear();
     Set<String> prevInstances = idealState.getInstanceSet(committingSegmentMetadata.getSegmentName());
-    boolean status =
-        segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-            reqParams);
+    reqParams.withSegmentName(committingSegmentMetadata.getSegmentName()).withOffset(nextOffset);
+    boolean status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     segmentManager.verifyMetadataInteractions();
     Assert.assertTrue(status);
     Assert.assertEquals(segmentManager._paths.size(), 2);
@@ -931,8 +927,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._paths.clear();
     segmentManager._records.clear();
     prevInstances = idealState.getInstanceSet(committingSegmentMetadata.getSegmentName());
-    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    reqParams.withSegmentName(committingSegmentMetadata.getSegmentName()).withOffset(nextOffset);
+    status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     segmentManager.verifyMetadataInteractions();
     Assert.assertTrue(status);
     Assert.assertEquals(segmentManager._paths.size(), 2);
@@ -948,8 +944,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     committingSegmentMetadata = new LLCRealtimeSegmentZKMetadata(newZnRec);
     segmentManager._paths.clear();
     segmentManager._records.clear();
-    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    reqParams.withSegmentName(committingSegmentMetadata.getSegmentName()).withOffset(nextOffset);
+    status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     segmentManager.verifyMetadataInteractions();
     Assert.assertFalse(status);
 
@@ -963,8 +959,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     committingSegmentMetadata = new LLCRealtimeSegmentZKMetadata(oldZnRec);
     segmentManager._paths.clear();
     segmentManager._records.clear();
-    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    reqParams.withSegmentName(committingSegmentMetadata.getSegmentName()).withOffset(nextOffset);
+    status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     segmentManager.verifyMetadataInteractions();
     Assert.assertFalse(status);
 
@@ -977,8 +973,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._records.clear();
     committingSegmentMetadata = new LLCRealtimeSegmentZKMetadata(newZnRec);
     prevInstances = idealState.getInstanceSet(committingSegmentMetadata.getSegmentName());
-    status = segmentManager.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    reqParams.withSegmentName(committingSegmentMetadata.getSegmentName()).withOffset(nextOffset);
+    status = segmentManager.commitSegmentMetadata(rawTableName, reqParams);
     segmentManager.verifyMetadataInteractions();
     Assert.assertTrue(status);
     Assert.assertEquals(segmentManager._paths.size(), 2);
@@ -1044,17 +1040,14 @@ public class PinotLLCRealtimeSegmentManagerTest {
     LLCRealtimeSegmentZKMetadata committingSegmentMetadata =
         new LLCRealtimeSegmentZKMetadata(segmentManager2._records.get(committingPartition));
 
-    boolean status =
-        segmentManager1.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-            reqParams);
+    reqParams.withSegmentName(committingSegmentMetadata.getSegmentName()).withOffset(nextOffset);
+    boolean status = segmentManager1.commitSegmentMetadata(rawTableName, reqParams);
     Assert.assertTrue(status);  // Committing segment metadata succeeded.
 
-    status = segmentManager2.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    status = segmentManager2.commitSegmentMetadata(rawTableName, reqParams);
     Assert.assertFalse(status); // Committing segment metadata failed.
 
-    status = segmentManager3.commitSegmentMetadata(rawTableName, committingSegmentMetadata.getSegmentName(), nextOffset,
-        reqParams);
+    status = segmentManager3.commitSegmentMetadata(rawTableName, reqParams);
     Assert.assertFalse(status); // Committing segment metadata failed.
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1099,12 +1099,11 @@ public class SegmentCompletionTest {
     }
 
     @Override
-         public boolean commitSegmentMetadata(String rawTableName, String committingSegmentName, long nextOffset,
-        SegmentCompletionProtocol.Request.Params reqParams) {
+         public boolean commitSegmentMetadata(String rawTableName, SegmentCompletionProtocol.Request.Params reqParams) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
-      _segmentMetadata.setEndOffset(nextOffset);
+      _segmentMetadata.setEndOffset(reqParams.getOffset());
       _segmentMetadata.setDownloadUrl(
-          ControllerConf.constructDownloadUrl(rawTableName, committingSegmentName, CONTROLLER_CONF.generateVipUrl()));
+          ControllerConf.constructDownloadUrl(rawTableName, reqParams.getSegmentName(), CONTROLLER_CONF.generateVipUrl()));
       _segmentMetadata.setEndTime(_segmentCompletionMgr.getCurrentTimeMs());
       return true;
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1100,7 +1100,7 @@ public class SegmentCompletionTest {
 
     @Override
          public boolean commitSegmentMetadata(String rawTableName, String committingSegmentName, long nextOffset,
-        long memoryUsedBytes, long segmentSizeBytes) {
+        SegmentCompletionProtocol.Request.Params reqParams) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
       _segmentMetadata.setEndOffset(nextOffset);
       _segmentMetadata.setDownloadUrl(

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -16,6 +16,7 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime;
 
+import com.linkedin.pinot.controller.helix.core.realtime.segment.CommittingSegmentDescriptor;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
@@ -1099,18 +1100,18 @@ public class SegmentCompletionTest {
     }
 
     @Override
-         public boolean commitSegmentMetadata(String rawTableName, SegmentCompletionProtocol.Request.Params reqParams) {
+         public boolean commitSegmentMetadata(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
-      _segmentMetadata.setEndOffset(reqParams.getOffset());
+      _segmentMetadata.setEndOffset(committingSegmentDescriptor.getNextOffset());
       _segmentMetadata.setDownloadUrl(
-          ControllerConf.constructDownloadUrl(rawTableName, reqParams.getSegmentName(), CONTROLLER_CONF.generateVipUrl()));
+          ControllerConf.constructDownloadUrl(rawTableName, committingSegmentDescriptor.getSegmentName(), CONTROLLER_CONF.generateVipUrl()));
       _segmentMetadata.setEndTime(_segmentCompletionMgr.getCurrentTimeMs());
       return true;
     }
 
     @Override
-    public boolean commitSegmentFile(String rawTableName, String segmentLocation, String segmentName) {
-      if (segmentLocation.equals("doNotCommitMe")) {
+    public boolean commitSegmentFile(String rawTableName, CommittingSegmentDescriptor committingSegmentDescriptor) {
+      if (committingSegmentDescriptor.getSegmentLocation().equals("doNotCommitMe")) {
         return false;
       } else {
         return true;

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/SegmentCompletionTest.java
@@ -1100,7 +1100,7 @@ public class SegmentCompletionTest {
 
     @Override
          public boolean commitSegmentMetadata(String rawTableName, String committingSegmentName, long nextOffset,
-        long memoryUsedBytes) {
+        long memoryUsedBytes, long segmentSizeBytes) {
       _segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
       _segmentMetadata.setEndOffset(nextOffset);
       _segmentMetadata.setDownloadUrl(

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -142,8 +142,6 @@ public class FlushThresholdUpdaterTest {
     segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p0_0, params);
     Assert.assertEquals(segmentMetadata_p0_0.getSizeThresholdToFlushSegment(),
         SegmentSizeBasedFlushThresholdUpdater.INITIAL_ROWS_THRESHOLD);
-    Assert.assertEquals(segmentMetadata_p0_0.getTimeThresholdToFlushSegment(),
-        SegmentSizeBasedFlushThresholdUpdater.MAX_TIME_THRESHOLD);
 
     // partition:0 segment:0 commits with 200M size
     segmentSizeBytes = 200 * 1024 * 1024;
@@ -270,8 +268,7 @@ public class FlushThresholdUpdaterTest {
     startOffset_p0 += 1000;
     updateCommittingSegmentMetadata(segmentMetadata_p0_4, startOffset_p0,
         segmentMetadata_p0_4.getSizeThresholdToFlushSegment() - 200);
-    segmentMetadata_p0_4.setCreationTime(System.currentTimeMillis() - TimeUtils.convertPeriodToMillis(
-        SegmentSizeBasedFlushThresholdUpdater.MAX_TIME_THRESHOLD));
+    segmentMetadata_p0_4.setCreationTime(System.currentTimeMillis() - TimeUtils.convertPeriodToMillis("8h"));
     LLCRealtimeSegmentZKMetadata segmentMetadata_p0_5 =
         getNextSegmentMetadata(tableName, startOffset_p0, partitionId_0, seqNum_p0++);
     params = new FlushThresholdUpdaterParams();
@@ -451,8 +448,6 @@ public class FlushThresholdUpdaterTest {
 
     double currentRatio = (double) (metadata0.getTotalRawDocs()) / committingSegmentSizeBytes;
     int expectedNumRows = getTargetNumRows(currentRatio);
-    Assert.assertEquals(metadata1.getTimeThresholdToFlushSegment(),
-        SegmentSizeBasedFlushThresholdUpdater.MAX_TIME_THRESHOLD);
     Assert.assertEquals(metadata1.getSizeThresholdToFlushSegment(), expectedNumRows);
 
     // before committing we switched back to default strategy, verify that thresholds are set according to default logic

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -16,13 +16,19 @@
 
 package com.linkedin.pinot.controller.helix.core.realtime.segment;
 
+import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.partition.PartitionAssignment;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.time.TimeUtils;
+import com.linkedin.pinot.core.realtime.impl.kafka.KafkaHighLevelStreamProviderConfig;
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.json.JSONException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -117,10 +123,8 @@ public class FlushThresholdUpdaterTest {
   @Test
   public void testSegmentSizeBasedFlushThresholdUpdate() {
     String tableName = "aRealtimeTable_REALTIME";
-
-    //Scenarios:
-    // 1. starts at lesser than min
-    SegmentSizeBasedFlushThresholdUpdater updater = new SegmentSizeBasedFlushThresholdUpdater();
+    SegmentSizeBasedFlushThresholdUpdater segmentSizeBasedFlushThresholdUpdater =
+        new SegmentSizeBasedFlushThresholdUpdater();
 
     long startOffset_p0 = 0;
     int seqNum_p0 = 0;
@@ -135,7 +139,7 @@ public class FlushThresholdUpdaterTest {
     LLCRealtimeSegmentZKMetadata segmentMetadata_p0_0 =
         getNextSegmentMetadata(tableName, startOffset_p0, partitionId_0, seqNum_p0++);
     params = new FlushThresholdUpdaterParams();
-    updater.updateFlushThreshold(segmentMetadata_p0_0, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p0_0, params);
     Assert.assertEquals(segmentMetadata_p0_0.getSizeThresholdToFlushSegment(),
         SegmentSizeBasedFlushThresholdUpdater.INITIAL_ROWS_THRESHOLD);
     Assert.assertEquals(segmentMetadata_p0_0.getTimeThresholdToFlushSegment(),
@@ -143,14 +147,15 @@ public class FlushThresholdUpdaterTest {
 
     // partition:0 segment:0 commits with 200M size
     segmentSizeBytes = 200 * 1024 * 1024;
-    startOffset_p0 += segmentMetadata_p0_0.getSizeThresholdToFlushSegment();
-    updateCommittingSegmentMetadata(segmentMetadata_p0_0, startOffset_p0);
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p0_0, startOffset_p0,
+        segmentMetadata_p0_0.getSizeThresholdToFlushSegment());
     LLCRealtimeSegmentZKMetadata segmentMetadata_p0_1 =
         getNextSegmentMetadata(tableName, startOffset_p0, partitionId_0, seqNum_p0++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p0_0);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p0_1, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p0_1, params);
     currentRatio = (double) segmentMetadata_p0_0.getSizeThresholdToFlushSegment() / segmentSizeBytes;
     expectedNumRows = segmentMetadata_p0_0.getSizeThresholdToFlushSegment() * 2;
     Assert.assertEquals(segmentMetadata_p0_1.getSizeThresholdToFlushSegment(), expectedNumRows);
@@ -158,14 +163,15 @@ public class FlushThresholdUpdaterTest {
 
     // partition:0 segment:1 commits with 420M size
     segmentSizeBytes = 420 * 1024 * 1024;
-    startOffset_p0 += segmentMetadata_p0_1.getSizeThresholdToFlushSegment();
-    updateCommittingSegmentMetadata(segmentMetadata_p0_1, startOffset_p0);
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p0_1, startOffset_p0,
+        segmentMetadata_p0_1.getSizeThresholdToFlushSegment());
     LLCRealtimeSegmentZKMetadata segmentMetadata_p0_2 =
         getNextSegmentMetadata(tableName, startOffset_p0, partitionId_0, seqNum_p0++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p0_1);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p0_2, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p0_2, params);
     currentRatio = (double) segmentMetadata_p0_1.getSizeThresholdToFlushSegment() / segmentSizeBytes;
     expectedNumRows = getTargetNumRows(currentRatio, prevRatio);
     Assert.assertEquals(segmentMetadata_p0_2.getSizeThresholdToFlushSegment(), expectedNumRows);
@@ -173,40 +179,42 @@ public class FlushThresholdUpdaterTest {
 
     // partition:0 segment:2 commits with 485M size
     segmentSizeBytes = 485 * 1024 * 1024;
-    startOffset_p0 += segmentMetadata_p0_2.getSizeThresholdToFlushSegment();
-    updateCommittingSegmentMetadata(segmentMetadata_p0_2, startOffset_p0);
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p0_2, startOffset_p0,
+        segmentMetadata_p0_2.getSizeThresholdToFlushSegment());
     LLCRealtimeSegmentZKMetadata segmentMetadata_p0_3 =
         getNextSegmentMetadata(tableName, startOffset_p0, partitionId_0, seqNum_p0++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p0_2);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p0_3, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p0_3, params);
     currentRatio = (double) segmentMetadata_p0_2.getSizeThresholdToFlushSegment() / segmentSizeBytes;
     expectedNumRows = getTargetNumRows(currentRatio, prevRatio);
     Assert.assertEquals(segmentMetadata_p0_3.getSizeThresholdToFlushSegment(), expectedNumRows);
     prevRatio = currentRatio;
 
-    // partition:1 segment:0
+    // partition:1 segment:0 created
     long startOffset_p1 = 0;
     int seqNum_p1 = 0;
     int partitionId_1 = 1;
     LLCRealtimeSegmentZKMetadata segmentMetadata_p1_0 =
         getNextSegmentMetadata(tableName, startOffset_p1, partitionId_1, seqNum_p1++);
     params = new FlushThresholdUpdaterParams();
-    updater.updateFlushThreshold(segmentMetadata_p1_0, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p1_0, params);
     expectedNumRows = getTargetNumRows(prevRatio);
     Assert.assertEquals(segmentMetadata_p1_0.getSizeThresholdToFlushSegment(), expectedNumRows);
 
     // partition:0 segment:3 commits with 520M size
     segmentSizeBytes = 520 * 1024 * 1024;
-    startOffset_p0 += segmentMetadata_p0_3.getSizeThresholdToFlushSegment();
-    updateCommittingSegmentMetadata(segmentMetadata_p0_3, startOffset_p0);
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p0_3, startOffset_p0,
+        segmentMetadata_p0_3.getSizeThresholdToFlushSegment());
     LLCRealtimeSegmentZKMetadata segmentMetadata_p0_4 =
         getNextSegmentMetadata(tableName, startOffset_p0, partitionId_0, seqNum_p0++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p0_3);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p0_4, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p0_4, params);
     currentRatio = (double) segmentMetadata_p0_3.getSizeThresholdToFlushSegment() / segmentSizeBytes;
     expectedNumRows = getTargetNumRows(currentRatio, prevRatio);
     Assert.assertEquals(segmentMetadata_p0_4.getSizeThresholdToFlushSegment(), expectedNumRows);
@@ -214,27 +222,28 @@ public class FlushThresholdUpdaterTest {
 
     // partition:1 segment:0 in error state. repair case. committing segment size=0.
     segmentSizeBytes = 0;
-    startOffset_p1 += segmentMetadata_p1_0.getSizeThresholdToFlushSegment();
-    updateCommittingSegmentMetadata(segmentMetadata_p1_0, startOffset_p1);
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p1_0, -1, -1);
     LLCRealtimeSegmentZKMetadata segmentMetadata_p1_1 =
         getNextSegmentMetadata(tableName, startOffset_p1, partitionId_1, seqNum_p1++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p1_0);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p1_1, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p1_1, params);
     expectedNumRows = segmentMetadata_p1_0.getSizeThresholdToFlushSegment();
     Assert.assertEquals(segmentMetadata_p1_1.getSizeThresholdToFlushSegment(), expectedNumRows);
 
     // partition:1 segment:1 commits with 490M size
     segmentSizeBytes = 490 * 1024 * 1024;
-    startOffset_p1 += segmentMetadata_p1_1.getSizeThresholdToFlushSegment();
-    updateCommittingSegmentMetadata(segmentMetadata_p1_1, startOffset_p1);
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p1_1, startOffset_p1,
+        segmentMetadata_p1_1.getSizeThresholdToFlushSegment());
     LLCRealtimeSegmentZKMetadata segmentMetadata_p1_2 =
         getNextSegmentMetadata(tableName, startOffset_p1, partitionId_1, seqNum_p1++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p1_1);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p1_2, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p1_2, params);
     currentRatio = (double) segmentMetadata_p1_1.getSizeThresholdToFlushSegment() / segmentSizeBytes;
     expectedNumRows = getTargetNumRows(currentRatio, prevRatio);
     Assert.assertEquals(segmentMetadata_p1_2.getSizeThresholdToFlushSegment(), expectedNumRows);
@@ -242,14 +251,15 @@ public class FlushThresholdUpdaterTest {
 
     // partition:1 segment:2 commits with 790M size
     segmentSizeBytes = 790 * 1024 * 1024;
-    startOffset_p1 += segmentMetadata_p1_2.getSizeThresholdToFlushSegment();
-    updateCommittingSegmentMetadata(segmentMetadata_p1_2, startOffset_p1);
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p1_2, startOffset_p1,
+        segmentMetadata_p1_2.getSizeThresholdToFlushSegment());
     LLCRealtimeSegmentZKMetadata segmentMetadata_p1_3 =
         getNextSegmentMetadata(tableName, startOffset_p1, partitionId_1, seqNum_p1++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p1_2);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p1_3, params);
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p1_3, params);
     currentRatio = (double) segmentMetadata_p1_2.getSizeThresholdToFlushSegment() / segmentSizeBytes;
     expectedNumRows = segmentMetadata_p1_2.getSizeThresholdToFlushSegment() / 2;
     Assert.assertEquals(segmentMetadata_p1_3.getSizeThresholdToFlushSegment(), expectedNumRows);
@@ -257,17 +267,19 @@ public class FlushThresholdUpdaterTest {
 
     // partition:0 segment:4 commits, time threshold reached
     segmentSizeBytes = 310 * 1024 * 1024;
-    startOffset_p0 += segmentMetadata_p0_4.getSizeThresholdToFlushSegment() - 2000;
-    updateCommittingSegmentMetadata(segmentMetadata_p0_4, startOffset_p0);
-    segmentMetadata_p0_4.setStartTime(segmentMetadata_p0_4.getEndTime() - TimeUtils.convertPeriodToMillis(
+    startOffset_p0 += 1000;
+    updateCommittingSegmentMetadata(segmentMetadata_p0_4, startOffset_p0,
+        segmentMetadata_p0_4.getSizeThresholdToFlushSegment() - 200);
+    segmentMetadata_p0_4.setCreationTime(System.currentTimeMillis() - TimeUtils.convertPeriodToMillis(
         SegmentSizeBasedFlushThresholdUpdater.MAX_TIME_THRESHOLD));
     LLCRealtimeSegmentZKMetadata segmentMetadata_p0_5 =
         getNextSegmentMetadata(tableName, startOffset_p0, partitionId_0, seqNum_p0++);
     params = new FlushThresholdUpdaterParams();
     params.setCommittingSegmentZkMetadata(segmentMetadata_p0_4);
     params.setCommittingSegmentSizeBytes(segmentSizeBytes);
-    updater.updateFlushThreshold(segmentMetadata_p0_5, params);
-    currentRatio = (double) (segmentMetadata_p0_4.getEndOffset() - segmentMetadata_p0_4.getStartOffset()) / segmentSizeBytes;
+    segmentSizeBasedFlushThresholdUpdater.updateFlushThreshold(segmentMetadata_p0_5, params);
+    currentRatio =
+        (double) (segmentMetadata_p0_4.getTotalRawDocs()) / segmentSizeBytes;
     expectedNumRows = getTargetNumRows(currentRatio, prevRatio);
     Assert.assertEquals(segmentMetadata_p0_5.getSizeThresholdToFlushSegment(), expectedNumRows);
     prevRatio = currentRatio;
@@ -298,10 +310,165 @@ public class FlushThresholdUpdaterTest {
     return newSegMetadata;
   }
 
-  private void updateCommittingSegmentMetadata(LLCRealtimeSegmentZKMetadata committingSegmentMetadata, long endOffset) {
+  private void updateCommittingSegmentMetadata(LLCRealtimeSegmentZKMetadata committingSegmentMetadata, long endOffset,
+      long numDocs) {
     committingSegmentMetadata.setEndOffset(endOffset);
     committingSegmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     committingSegmentMetadata.setStartTime(System.currentTimeMillis());
     committingSegmentMetadata.setEndTime(System.currentTimeMillis());
+    committingSegmentMetadata.setTotalRawDocs(numDocs);
+  }
+
+  /**
+   * Tests that the flush threshold manager returns the right updater given various scenarios of flush threshold setting in the table config
+   * @throws IOException
+   * @throws JSONException
+   */
+  @Test
+  public void testFlushThresholdUpdater() throws IOException, JSONException {
+    FlushThresholdUpdateManager manager = new FlushThresholdUpdateManager();
+    TableConfig.Builder tableConfigBuilder = new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME);
+    tableConfigBuilder.setTableName("tableName_REALTIME");
+    TableConfig realtimeTableConfig;
+
+    FlushThresholdUpdater flushThresholdUpdater;
+
+    // null stream configs - default flush size
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
+    Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(),
+        KafkaHighLevelStreamProviderConfig.getDefaultMaxRealtimeRowsCount());
+
+    // nothing set - default flush size
+    Map<String, String> streamConfigs = new HashMap<>();
+    tableConfigBuilder.setStreamConfigs(streamConfigs);
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
+    Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(),
+        KafkaHighLevelStreamProviderConfig.getDefaultMaxRealtimeRowsCount());
+
+    // flush size set
+    streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, "10000");
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
+    Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 10000);
+
+    // llc flush size set
+    streamConfigs.remove(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE);
+    streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE, "5000");
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
+    Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 5000);
+
+    // invalid string flush size set
+    streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE, "aaa");
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
+    Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(),
+        KafkaHighLevelStreamProviderConfig.getDefaultMaxRealtimeRowsCount());
+
+    // negative flush size set
+    streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE, "-10");
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
+    Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(),
+        KafkaHighLevelStreamProviderConfig.getDefaultMaxRealtimeRowsCount());
+
+    // 0 flush size set
+    streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE, "0");
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), SegmentSizeBasedFlushThresholdUpdater.class);
+
+    // called again with 0 flush size - same object as above
+    streamConfigs.remove(CommonConstants.Helix.DataSource.Realtime.LLC_REALTIME_SEGMENT_FLUSH_SIZE);
+    streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, "0");
+    realtimeTableConfig = tableConfigBuilder.build();
+    FlushThresholdUpdater flushThresholdUpdaterSame = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdaterSame.getClass(), SegmentSizeBasedFlushThresholdUpdater.class);
+    Assert.assertEquals(flushThresholdUpdater, flushThresholdUpdaterSame);
+
+    // flush size reset to some number - default received, map cleared of segmentsize based
+    streamConfigs.put(CommonConstants.Helix.DataSource.Realtime.REALTIME_SEGMENT_FLUSH_SIZE, "20000");
+    realtimeTableConfig = tableConfigBuilder.build();
+    flushThresholdUpdater = manager.getFlushThresholdUpdater(realtimeTableConfig);
+    Assert.assertEquals(flushThresholdUpdater.getClass(), DefaultFlushThresholdUpdater.class);
+    Assert.assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 20000);
+  }
+
+  @Test
+  public void testUpdaterChange() {
+    String tableName = "fakeTable_REALTIME";
+    int tableFlushSize = 1_000_000;
+    int partitionId = 0;
+    int seqNum = 0;
+    long startOffset = 0;
+    long committingSegmentSizeBytes = 0;
+
+    PartitionAssignment partitionAssignment = new PartitionAssignment(tableName);
+    // 4 partitions assigned to 4 servers, 4 replicas => the segments should have 250k rows each (1M / 4)
+    for (int p = 0; p < 4; p++) {
+      List<String> instances = new ArrayList<>();
+
+      for (int replicaId = 0; replicaId < 4; replicaId++) {
+        instances.add("Server_1.2.3.4_123" + replicaId);
+      }
+
+      partitionAssignment.addPartition(Integer.toString(p), instances);
+    }
+
+    // Initially we were using default flush threshold updation - verify that thresholds are as per default strategy
+    LLCRealtimeSegmentZKMetadata metadata0 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
+
+    FlushThresholdUpdater flushThresholdUpdater = new DefaultFlushThresholdUpdater(tableFlushSize);
+    FlushThresholdUpdaterParams params = new FlushThresholdUpdaterParams();
+    params.setCommittingSegmentSizeBytes(committingSegmentSizeBytes);
+    params.setCommittingSegmentZkMetadata(null);
+    params.setPartitionAssignment(partitionAssignment);
+    flushThresholdUpdater.updateFlushThreshold(metadata0, params);
+
+    Assert.assertEquals(metadata0.getSizeThresholdToFlushSegment(), 250_000);
+    Assert.assertNull(metadata0.getTimeThresholdToFlushSegment());
+
+    // before committing segment, we switched to size based updation - verify that new thresholds are set as per size based strategy
+    flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
+
+    startOffset += 1000;
+    updateCommittingSegmentMetadata(metadata0, startOffset, 225_000);
+    committingSegmentSizeBytes = 400 * 1024 * 1024;
+    params = new FlushThresholdUpdaterParams();
+    params.setCommittingSegmentSizeBytes(committingSegmentSizeBytes);
+    params.setCommittingSegmentZkMetadata(metadata0);
+    params.setPartitionAssignment(partitionAssignment);
+    LLCRealtimeSegmentZKMetadata metadata1 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
+    flushThresholdUpdater.updateFlushThreshold(metadata1, params);
+
+    double currentRatio = (double) (metadata0.getTotalRawDocs()) / committingSegmentSizeBytes;
+    int expectedNumRows = getTargetNumRows(currentRatio);
+    Assert.assertEquals(metadata1.getTimeThresholdToFlushSegment(),
+        SegmentSizeBasedFlushThresholdUpdater.MAX_TIME_THRESHOLD);
+    Assert.assertEquals(metadata1.getSizeThresholdToFlushSegment(), expectedNumRows);
+
+    // before committing we switched back to default strategy, verify that thresholds are set according to default logic
+    flushThresholdUpdater = new DefaultFlushThresholdUpdater(tableFlushSize);
+
+    startOffset += 1000;
+    updateCommittingSegmentMetadata(metadata1, startOffset, metadata1.getSizeThresholdToFlushSegment());
+    committingSegmentSizeBytes = 420 * 1024 * 1024;
+    params = new FlushThresholdUpdaterParams();
+    params.setCommittingSegmentSizeBytes(committingSegmentSizeBytes);
+    params.setCommittingSegmentZkMetadata(metadata1);
+    params.setPartitionAssignment(partitionAssignment);
+    LLCRealtimeSegmentZKMetadata metadata2 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
+    flushThresholdUpdater.updateFlushThreshold(metadata2, params);
+
+    Assert.assertEquals(metadata2.getSizeThresholdToFlushSegment(), 250_000);
+    Assert.assertNull(metadata2.getTimeThresholdToFlushSegment());
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -50,11 +50,13 @@ public class FlushThresholdUpdaterTest {
     }
 
     FlushThresholdUpdater flushThresholdUpdater = new FakeFlushThresholdUpdater(tableConfig, 1000000);
+    FlushThresholdUpdaterParams params = new FlushThresholdUpdaterParams();
+    params.setPartitionAssignment(partitionAssignment);
     // Check that each segment has 250k rows each
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, params);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 250000);
     }
 
@@ -74,7 +76,7 @@ public class FlushThresholdUpdaterTest {
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, params);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
     }
 
@@ -90,7 +92,7 @@ public class FlushThresholdUpdaterTest {
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, params);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 1000000);
     }
 
@@ -105,7 +107,7 @@ public class FlushThresholdUpdaterTest {
     for (int segmentId = 1; segmentId <= 4; ++segmentId) {
       LLCRealtimeSegmentZKMetadata metadata = new LLCRealtimeSegmentZKMetadata();
       metadata.setSegmentName(makeFakeSegmentName(segmentId));
-      flushThresholdUpdater.updateFlushThreshold(metadata, partitionAssignment);
+      flushThresholdUpdater.updateFlushThreshold(metadata, params);
       Assert.assertEquals(metadata.getSizeThresholdToFlushSegment(), 500000);
     }
   }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -427,17 +427,17 @@ public class FlushThresholdUpdaterTest {
 
     // next segment hit time threshold
     startOffset += 1000;
-    updateCommittingSegmentMetadata(metadata0, startOffset, 90_000);
+    updateCommittingSegmentMetadata(metadata0, startOffset, 98372);
     committingSegmentSizeBytes = 180 * 1024 * 1024;
     committingSegmentDescriptor = new CommittingSegmentDescriptor(metadata0.getSegmentName(), startOffset, committingSegmentSizeBytes);
     LLCRealtimeSegmentZKMetadata metadata1 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
     flushThresholdUpdater.updateFlushThreshold(metadata1, metadata0, committingSegmentDescriptor, null);
-    Assert.assertEquals(metadata1.getSizeThresholdToFlushSegment(), flushThresholdUpdater.getInitialRowsThreshold());
+    Assert.assertEquals(metadata1.getSizeThresholdToFlushSegment(), (int) (metadata0.getTotalRawDocs() * flushThresholdUpdater.getRowsMultiplierWhenTimeThresholdHit()));
 
     // now we hit rows threshold
     startOffset += 1000;
     updateCommittingSegmentMetadata(metadata1, startOffset, metadata1.getSizeThresholdToFlushSegment());
-    committingSegmentSizeBytes = 220 * 1024 * 1024;
+    committingSegmentSizeBytes = 240 * 1024 * 1024;
     committingSegmentDescriptor = new CommittingSegmentDescriptor(metadata1.getSegmentName(), startOffset, committingSegmentSizeBytes);
     LLCRealtimeSegmentZKMetadata metadata2 = getNextSegmentMetadata(tableName, startOffset, partitionId, seqNum++);
     flushThresholdUpdater.updateFlushThreshold(metadata2, metadata1, committingSegmentDescriptor, null);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -36,7 +36,6 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.TarGzCompressionUtils;
-import com.linkedin.pinot.common.utils.time.TimeUtils;
 import com.linkedin.pinot.core.data.GenericRow;
 import com.linkedin.pinot.core.data.extractors.FieldExtractorFactory;
 import com.linkedin.pinot.core.data.extractors.PlainFieldExtractor;
@@ -1097,12 +1096,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     long now = now();
     _consumeStartTime = now;
-    long flushThresholdTimeMillis = kafkaStreamProviderConfig.getTimeThresholdToFlushSegment();
-    String flushThresholdTimeFromSegment = segmentZKMetadata.getTimeThresholdToFlushSegment();
-    if (flushThresholdTimeFromSegment != null) {
-      flushThresholdTimeMillis = TimeUtils.convertPeriodToMillis(flushThresholdTimeFromSegment);
-    }
-    _consumeEndTime = now + flushThresholdTimeMillis;
+    _consumeEndTime = now + kafkaStreamProviderConfig.getTimeThresholdToFlushSegment();
 
     LOGGER.info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}",
         _segmentName, _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC).toString());


### PR DESCRIPTION
Adding a segment size based flush threshold updater which updates the flush threshold rows of the new segment metadata, based on the segment size and number of rows of previous segment
The formula used to compute new number of rows is:
  `targetNumRows = ideal_segment_size * ( a * current_rows_to_size_ratio + b * previous_rows_to_size_ratio)`
  where a = 0.25, b = 0.75
  This ensures that we take into account the history of the segment size and number rows