### PR TITLE
Avoid exception for BYTES size() call when not generating Star Tree.

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/FieldSpec.java
@@ -383,6 +383,9 @@ public abstract class FieldSpec {
           return Float.BYTES;
         case DOUBLE:
           return Double.BYTES;
+        case BYTES:
+          // TODO: Metric size is only used for Star-tree generation, which is not supported yet.
+          return MetricFieldSpec.UNDEFINED_METRIC_SIZE;
         default:
           throw new IllegalStateException("Cannot get number of bytes for: " + this);
       }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
@@ -33,10 +33,10 @@ import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class MetricFieldSpec extends FieldSpec {
-  private static final int UNDEFINED_FIELD_SIZE = -1;
+  protected static final int UNDEFINED_METRIC_SIZE = -1;
 
   // These two fields are for derived metric fields.
-  private int _fieldSize = UNDEFINED_FIELD_SIZE;
+  private int _fieldSize = UNDEFINED_METRIC_SIZE;
   private DerivedMetricType _derivedMetricType = null;
 
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.
@@ -48,6 +48,7 @@ public final class MetricFieldSpec extends FieldSpec {
     super(name, dataType, true);
     _fieldSize = _dataType.size();
   }
+
 
   public MetricFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull Object defaultNullValue) {
     super(name, dataType, true, defaultNullValue);
@@ -104,7 +105,7 @@ public final class MetricFieldSpec extends FieldSpec {
   @Override
   public void setDataType(@Nonnull DataType dataType) {
     super.setDataType(dataType);
-    if (_dataType != DataType.STRING) {
+    if (_dataType != DataType.STRING && _dataType != DataType.BYTES) {
       _fieldSize = _dataType.size();
     }
   }
@@ -137,7 +138,7 @@ public final class MetricFieldSpec extends FieldSpec {
   @Override
   public JsonObject toJsonObject() {
     JsonObject jsonObject = super.toJsonObject();
-    if (_dataType == DataType.STRING && _fieldSize != UNDEFINED_FIELD_SIZE) {
+    if (_dataType == DataType.STRING && _fieldSize != UNDEFINED_METRIC_SIZE) {
       jsonObject.addProperty("fieldSize", _fieldSize);
     }
     if (_derivedMetricType != null) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -404,6 +404,7 @@ public final class Schema {
             case FLOAT:
             case DOUBLE:
             case STRING:
+            case BYTES:
               break;
             default:
               ctxLogger.info("Unsupported data type: {} in DIMENSION/TIME field: {}", dataType, fieldName);
@@ -416,6 +417,7 @@ public final class Schema {
             case LONG:
             case FLOAT:
             case DOUBLE:
+            case BYTES:
               break;
             case STRING:
               MetricFieldSpec metricFieldSpec = (MetricFieldSpec) fieldSpec;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/SingleValueIterator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvaliterators/SingleValueIterator.java
@@ -59,6 +59,11 @@ public final class SingleValueIterator extends BlockSingleValIterator {
   }
 
   @Override
+  public byte[] nextBytesVal() {
+    return _reader.getBytes(_nextDocId++, _context);
+  }
+
+  @Override
   public boolean hasNext() {
     return _nextDocId < _numDocs;
   }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/docvalsets/SingleValueSet.java
@@ -146,6 +146,19 @@ public final class SingleValueSet extends BaseBlockValSet {
   }
 
   @Override
+  public void getBytesValues(int[] inDocIds, int inStartPos, int inDocIdsSize, byte[][] outValues, int outStartPos) {
+    int inEndPos = inStartPos + inDocIdsSize;
+    ReaderContext context = _reader.createContext();
+    if (_dataType.equals(DataType.BYTES)) {
+      for (int i = inStartPos; i < inEndPos; i++) {
+        outValues[outStartPos++] = _reader.getBytes(inDocIds[i], context);
+      }
+    } else {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
   public void getDictionaryIds(int[] inDocIds, int inStartPos, int inDocIdsSize, int[] outDictionaryIds,
       int outStartPos) {
     _reader.readValues(inDocIds, inStartPos, inDocIdsSize, outDictionaryIds, outStartPos);

--- a/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/queries/PercentileTDigestQueriesTest.java
@@ -18,6 +18,7 @@ package com.linkedin.pinot.queries;
 import com.clearspring.analytics.stream.quantile.TDigest;
 import com.linkedin.pinot.common.data.DimensionFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
+import com.linkedin.pinot.common.data.MetricFieldSpec;
 import com.linkedin.pinot.common.data.Schema;
 import com.linkedin.pinot.common.response.broker.AggregationResult;
 import com.linkedin.pinot.common.response.broker.BrokerResponseNative;
@@ -129,7 +130,7 @@ public class PercentileTDigestQueriesTest extends BaseQueriesTest {
       throws Exception {
 
     Schema schema = new Schema();
-    schema.addField(new DimensionFieldSpec(TDIGEST_COLUMN, FieldSpec.DataType.BYTES, true));
+    schema.addField(new MetricFieldSpec(TDIGEST_COLUMN, FieldSpec.DataType.BYTES));
     schema.addField(new DimensionFieldSpec(GROUPBY_COLUMN, FieldSpec.DataType.STRING, true));
 
     _random = new Random(RANDOM_SEED);


### PR DESCRIPTION
Only StartTree generation requires to know size of a metric. However,
for BYTES, we cannot define a size upfront.

1. Return UNDEFINED_METRIC_SIZE for getSize() on BYTES data type.

2. Modify test to define TDigest as metric to exercise the code.

Star Tree generation will continue to not work, but at least no Star
Tree code will not throw exception.