### PR TITLE
Avoid catching broad 'Exception' and prefer throwing a more specific runtime exception

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/time/TimeUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/time/TimeUtils.java
@@ -100,19 +100,36 @@ public class TimeUtils {
       .appendSeconds().appendSuffix("s")
       .toFormatter();
 
+  /**
+   * Converts a string representing a period/duration to corresponding milliseconds.
+   * For ex, input "1d" would return 86400000L. Supported units are days (d), hours (h),
+   * minutes (m) and seconds (s).
+   *
+   * @param timeStr string representing the duration
+   * @return the corresponding time coverted to milliseconds
+   * @throws IllegalArgumentException if the string does not conform to the expected format
+   */
   public static Long convertPeriodToMillis(String timeStr) {
     Long millis = 0L;
     if (timeStr != null) {
       try {
         Period p = PERIOD_FORMATTER.parsePeriod(timeStr);
         millis = p.toStandardDuration().getStandardSeconds() * 1000L;
-      } catch (Exception e) {
-        throw new RuntimeException("Invalid time spec '" + timeStr + "' (Valid examples: '3h', '4h30m')", e);
+      } catch (IllegalArgumentException e) {
+        // rethrowing with more contextual information
+        throw new IllegalArgumentException("Invalid time spec '" + timeStr + "' (Valid examples: '3h', '4h30m')", e);
       }
     }
     return millis;
   }
 
+  /**
+   * Converts milliseconds into human readable duration string. For ex, input of 86400000L would
+   * return "1d".
+   *
+   * @param millis the value in milliseconds to be converted
+   * @return the corresponding human readable string or empty string if value cannot be converted
+   */
   public static  String convertMillisToPeriod(Long millis) {
     String periodStr = null;
     if (millis != null) {

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/utils/UtilsTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/utils/UtilsTest.java
@@ -61,14 +61,14 @@ public class UtilsTest {
     Assert.assertEquals(millis.longValue(), 10*1000L);
     millis = TimeUtils.convertPeriodToMillis(null);
     Assert.assertEquals(millis.longValue(), 0);
-    boolean exception = false;
+    millis = TimeUtils.convertPeriodToMillis("-1d");
+    Assert.assertEquals(millis.longValue(),  -86400000L);
     try {
       millis = TimeUtils.convertPeriodToMillis("hhh");
-    } catch (Exception e){
-      exception = true;
-      // Exception
+      Assert.fail("Expected exception to be thrown while converting an invalid input string");
+    } catch (IllegalArgumentException e){
+      // expected
     }
-    Assert.assertTrue(exception);
 
     String periodStr = TimeUtils.convertMillisToPeriod(10 * 1000L);
     Assert.assertEquals(periodStr, "10s");
@@ -82,6 +82,8 @@ public class UtilsTest {
     Assert.assertEquals(periodStr, "6h20m10s");
     periodStr = TimeUtils.convertMillisToPeriod(0L);
     Assert.assertEquals(periodStr, "0s");
+    periodStr = TimeUtils.convertMillisToPeriod(-1L);
+    Assert.assertEquals(periodStr, "");
     periodStr = TimeUtils.convertMillisToPeriod(null);
     Assert.assertEquals(periodStr, null);
   }


### PR DESCRIPTION
Currently, the code throws runtime exceptions for indicate incorrect input to the method - this forces users of the method to also catch broader category of exceptions to handle the case of invalid input (invalid input may not always be a showstopper; for ex, the users might be able to use a default value instead if the configured value is not parseable). Ideally, a checked exception would have been better, but I didn't want to make method signature changes as all callers have to be updated and some of them could be beyond this package.

- Updated javadocs to reflect method behavior.
- Unit test validates that IllegalArgumentException is indeed thrown when the input is incorrect.