### PR TITLE
Add support for config profiles

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfig.java
@@ -17,6 +17,11 @@
 package com.linkedin.pinot.common.config;
 
 import com.linkedin.pinot.common.data.Schema;
+import com.linkedin.pinot.common.utils.EqualityUtils;
+
+import static com.linkedin.pinot.common.utils.EqualityUtils.hashCodeOf;
+import static com.linkedin.pinot.common.utils.EqualityUtils.isEqual;
+import static com.linkedin.pinot.common.utils.EqualityUtils.isNullOrNotSameClass;
 
 
 /**
@@ -55,6 +60,18 @@ public class CombinedConfig {
     return _schema;
   }
 
+  public void setOffline(TableConfig offline) {
+    _offline = offline;
+  }
+
+  public void setRealtime(TableConfig realtime) {
+    _realtime = realtime;
+  }
+
+  public void setSchema(Schema schema) {
+    _schema = schema;
+  }
+
   public CombinedConfig(TableConfig offline, TableConfig realtime, Schema schema) {
     _offline = offline;
     _realtime = realtime;
@@ -62,4 +79,30 @@ public class CombinedConfig {
   }
 
   public CombinedConfig() {}
+
+  @Override
+  public boolean equals(Object o) {
+    if (EqualityUtils.isSameReference(this, o)) {
+      return true;
+    }
+
+    if (isNullOrNotSameClass(this, o)) {
+      return false;
+    }
+
+    CombinedConfig that = (CombinedConfig) o;
+
+    return
+        isEqual(_offline, that._offline) &&
+        isEqual(_realtime, that._realtime) &&
+        isEqual(_schema, that._schema);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hashCodeOf(_offline);
+    result = hashCodeOf(result, _realtime);
+    result = hashCodeOf(result, _schema);
+    return result;
+  }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfigLoader.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/CombinedConfigLoader.java
@@ -16,16 +16,20 @@
 
 package com.linkedin.pinot.common.config;
 
+import com.linkedin.pinot.common.utils.EqualityUtils;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigIncludeContext;
 import com.typesafe.config.ConfigIncluder;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigValue;
 import io.vavr.Tuple;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.HashSet;
+import io.vavr.collection.Set;
 import java.io.File;
+import java.util.Arrays;
 import java.util.Map;
 
 
@@ -34,25 +38,86 @@ import java.util.Map;
  * {@link java.lang.String}, {@link java.util.Map}, etc.
  */
 public class CombinedConfigLoader {
-  static io.vavr.collection.Map<String, ?> loadConfigFromFile(File file) {
-    Config config = ConfigFactory.parseFile(file,
-        ConfigParseOptions.defaults().prependIncluder(new ConfigIncluder() {
-          private ConfigIncluder parent = null;
+  static io.vavr.collection.Map<String, ?> loadConfigFromFile(File file, String... profiles) {
+    ConfigParseOptions options = ConfigParseOptions.defaults().prependIncluder(new ConfigIncluder() {
+      private ConfigIncluder parent = null;
 
-          public ConfigObject include(ConfigIncludeContext context, String what) {
-            return ConfigFactory.parseFileAnySyntax(new File(what)).root();
-          }
+      public ConfigObject include(ConfigIncludeContext context, String what) {
+        return ConfigFactory.parseFileAnySyntax(new File(what)).root();
+      }
 
-          public ConfigIncluder withFallback(ConfigIncluder fallback) {
-            parent = fallback;
-            return this;
-          }
-        }));
+      public ConfigIncluder withFallback(ConfigIncluder fallback) {
+        parent = fallback;
+        return this;
+      }
+    });
+
+    Config config = ConfigFactory.parseFile(file, options);
+
+    // Load profiles
+    for (String profile : profiles) {
+      Config profileConfig = ConfigFactory.parseFile(new File("profiles", profile + ".conf"), options);
+      config = config.withFallback(profileConfig);
+    }
 
     config = config.resolve();
 
+    config = processProfileConditionals(config, profiles);
+
     return HashSet.ofAll(config.entrySet())
         .toMap(entry -> Tuple.of(entry.getKey(), entry.getValue().unwrapped()));
+  }
+
+  private static Config processProfileConditionals(Config config, String... profiles) {
+    Set<String> enabledProfiles = HashSet.ofAll(Arrays.asList(profiles));
+
+    io.vavr.collection.Map<String, ConfigValue> configMap =
+        HashSet.ofAll(config.entrySet()).toMap(entry -> Tuple.of(entry.getKey(), entry.getValue()));
+
+    // Get all profile-specific keys
+    Set<String> profileKeys = configMap.keySet()
+        .filter(key -> key.contains("_"))
+        .toSet();
+
+    // Keep profile-specific keys for enabled profiles
+    Set<String> enabledProfileKeys = profileKeys
+        .filter(key -> {
+          int lastUnderscoreIndex = key.lastIndexOf('_');
+          String profile = key.substring(lastUnderscoreIndex + 1, key.length());
+          return enabledProfiles.contains(profile);
+        });
+
+    // Merge all the enabled keys together
+    io.vavr.collection.Map<String, ConfigValue> overrideConfigMap = HashMap.empty();
+
+    for (String enabledProfileKey : enabledProfileKeys) {
+      int lastUnderscoreIndex = enabledProfileKey.lastIndexOf('_');
+      String destinationKey = enabledProfileKey.substring(0, lastUnderscoreIndex);
+
+      if (!overrideConfigMap.containsKey(destinationKey)) {
+        overrideConfigMap = overrideConfigMap.put(Tuple.of(destinationKey, config.getValue(enabledProfileKey)));
+      } else {
+        // Value already exists, ensure that it is the same
+        ConfigValue previousOverrideValue = overrideConfigMap.get(destinationKey).get();
+        ConfigValue newConfigValue = config.getValue(enabledProfileKey);
+        if (!EqualityUtils.isEqual(previousOverrideValue.unwrapped(), newConfigValue.unwrapped())) {
+          throw new RuntimeException("Found conflicting value for key " + destinationKey +
+              " due to multiple enabled profiles for this configuration key. Previous override was " +
+              previousOverrideValue.unwrapped() + ", new override value is " + newConfigValue.unwrapped() +
+              ". Ensure that all enabled profiles for this profile override key have the same resulting value.");
+        }
+      }
+    }
+
+    // Remove the profile keys
+    for (String profileKey : profileKeys) {
+      config = config.withoutPath(profileKey);
+    }
+
+    // Merge the configs
+    config = ConfigFactory.parseMap(overrideConfigMap.toJavaMap()).withFallback(config);
+
+    return config;
   }
 
   static io.vavr.collection.Map<String, ?> loadConfigFromString(String string) {
@@ -90,8 +155,8 @@ public class CombinedConfigLoader {
     return loadCombinedConfig(HashMap.ofAll(config));
   }
 
-  public static CombinedConfig loadCombinedConfig(File file) {
-    return loadCombinedConfig(loadConfigFromFile(file));
+  public static CombinedConfig loadCombinedConfig(File file, String... profiles) {
+    return loadCombinedConfig(loadConfigFromFile(file, profiles));
   }
 
   public static CombinedConfig loadCombinedConfig(String string) {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/Deserializer.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/Deserializer.java
@@ -201,6 +201,11 @@ public class Deserializer {
       LOGGER.debug("Using subset config {} and config path {}", config, configPath);
     }
 
+    // Pre-inject hook?
+    if (ConfigNodeLifecycleAware.class.isAssignableFrom(clazz)) {
+      ((ConfigNodeLifecycleAware) rootObject).preInject();
+    }
+
     // Iterate over the root class fields
     List<Field> declaredFields = getClassFields(clazz);
 
@@ -270,6 +275,11 @@ public class Deserializer {
 
     // Return null if we did not write any fields in the destination object
     if (valueInjected) {
+      // Post-inject hook?
+      if (ConfigNodeLifecycleAware.class.isAssignableFrom(clazz)) {
+        ((ConfigNodeLifecycleAware) rootObject).postInject();
+      }
+
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Returning deserialized value of {}", rootObject);
       }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/MetricFieldSpec.java
@@ -17,6 +17,7 @@ package com.linkedin.pinot.common.data;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonObject;
+import com.linkedin.pinot.common.config.ConfigKey;
 import com.linkedin.pinot.common.utils.EqualityUtils;
 import javax.annotation.Nonnull;
 import org.codehaus.jackson.annotate.JsonIgnore;
@@ -37,6 +38,8 @@ public final class MetricFieldSpec extends FieldSpec {
 
   // These two fields are for derived metric fields.
   private int _fieldSize = UNDEFINED_METRIC_SIZE;
+
+  @ConfigKey("derivedMetricType")
   private DerivedMetricType _derivedMetricType = null;
 
   // Default constructor required by JSON de-serializer. DO NOT REMOVE.
@@ -48,7 +51,6 @@ public final class MetricFieldSpec extends FieldSpec {
     super(name, dataType, true);
     _fieldSize = _dataType.size();
   }
-
 
   public MetricFieldSpec(@Nonnull String name, @Nonnull DataType dataType, @Nonnull Object defaultNullValue) {
     super(name, dataType, true, defaultNullValue);
@@ -169,5 +171,11 @@ public final class MetricFieldSpec extends FieldSpec {
     int result = EqualityUtils.hashCodeOf(super.hashCode(), _fieldSize);
     result = EqualityUtils.hashCodeOf(result, _derivedMetricType);
     return result;
+  }
+
+  @Override
+  public void postInject() {
+    super.postInject();
+    _fieldSize = _dataType.size();
   }
 }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/data/Schema.java
@@ -613,10 +613,12 @@ public final class Schema {
     }
 
     Schema that = (Schema) o;
-    return EqualityUtils.isEqual(_schemaName, that._schemaName) && EqualityUtils.isEqual(_dimensionFieldSpecs,
-        that._dimensionFieldSpecs) && EqualityUtils.isEqual(_metricFieldSpecs, that._metricFieldSpecs)
-        && EqualityUtils.isEqual(_timeFieldSpec, that._timeFieldSpec) && EqualityUtils.isEqual(_dateTimeFieldSpecs,
-        that._dateTimeFieldSpecs);
+
+    return EqualityUtils.isEqual(_schemaName, that._schemaName) &&
+        EqualityUtils.isEqualIgnoreOrder(_dimensionFieldSpecs, that._dimensionFieldSpecs) &&
+        EqualityUtils.isEqualIgnoreOrder(_metricFieldSpecs, that._metricFieldSpecs) &&
+        EqualityUtils.isEqual(_timeFieldSpec, that._timeFieldSpec) &&
+        EqualityUtils.isEqualIgnoreOrder(_dateTimeFieldSpecs, that._dateTimeFieldSpecs);
   }
 
   @Override


### PR DESCRIPTION
Add support for configuration profiles, which allow configurations to
have values based on which profiles are enabled. For example, one might
have profiles for us-west, us-east, and asia-south, with different
settings:

replication_us-west=6
replication_us-east=6
replication_asia-south=3

Since more than one profile can be enabled at a time, it is also
possible to do:

replication_us=6
replication_asia-south=3

Add support for deserialization hooks, so that values that require
special support (eg. field size) can be properly filled in.

Sort FieldSpecs by name and make schema comparison independent of the
fieldspec order.