### PR TITLE
Add interface for RealtimeSegmentAssignmentStrategy and a PartitionAssignmentGneerator which does not depend on stream partition znode

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
@@ -25,8 +25,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.helix.ZNRecord;
@@ -380,6 +378,7 @@ public class TableConfig {
     // Tenant config related
     private String _brokerTenant;
     private String _serverTenant;
+    private TagOverrideConfig _tagOverrideConfig;
 
     // Indexing config related
     private String _loadMode = DEFAULT_LOAD_MODE;
@@ -473,6 +472,11 @@ public class TableConfig {
       return this;
     }
 
+    public Builder setTagOverrideConfig(TagOverrideConfig tagOverrideConfig) {
+      _tagOverrideConfig = tagOverrideConfig;
+      return this;
+    }
+
     public Builder setLoadMode(String loadMode) {
       if (MMAP_LOAD_MODE.equalsIgnoreCase(loadMode)) {
         _loadMode = MMAP_LOAD_MODE;
@@ -559,6 +563,7 @@ public class TableConfig {
       TenantConfig tenantConfig = new TenantConfig();
       tenantConfig.setBroker(_brokerTenant);
       tenantConfig.setServer(_serverTenant);
+      tenantConfig.setTagOverrideConfig(_tagOverrideConfig);
 
       // Indexing config
       IndexingConfig indexingConfig = new IndexingConfig();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagOverrideConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagOverrideConfig.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.config;
+
+import com.linkedin.pinot.common.utils.EqualityUtils;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TagOverrideConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TagOverrideConfig.class);
+
+  @ConfigKey("realtimeConsuming")
+  @ConfigDoc("Tag override for realtime consuming segments")
+  private String realtimeConsuming;
+
+  @ConfigKey("realtimeCompleted")
+  @ConfigDoc("Tag override for realtime completed segments")
+  private String realtimeCompleted;
+
+  public String getRealtimeConsuming() {
+    return realtimeConsuming;
+  }
+
+  public void setRealtimeConsuming(String realtimeConsuming) {
+    this.realtimeConsuming = realtimeConsuming;
+  }
+
+  public String getRealtimeCompleted() {
+    return realtimeCompleted;
+  }
+
+  public void setRealtimeCompleted(String realtimeCompleted) {
+    this.realtimeCompleted = realtimeCompleted;
+  }
+
+  @Override
+  public String toString() {
+    return "TagOverrideConfig{" + "realtimeConsuming='" + realtimeConsuming + '\'' + ", realtimeCompleted="
+        + realtimeCompleted + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (EqualityUtils.isSameReference(this, o)) {
+      return true;
+    }
+
+    if (EqualityUtils.isNullOrNotSameClass(this, o)) {
+      return false;
+    }
+
+    TagOverrideConfig that = (TagOverrideConfig) o;
+
+    return EqualityUtils.isEqual(realtimeConsuming, that.realtimeConsuming) && EqualityUtils.isEqual(realtimeCompleted,
+        that.realtimeCompleted);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = EqualityUtils.hashCodeOf(realtimeConsuming);
+    result = EqualityUtils.hashCodeOf(result, realtimeCompleted);
+    return result;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TenantConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TenantConfig.java
@@ -34,6 +34,10 @@ public class TenantConfig {
   @ConfigDoc("Server tenant used by this table")
   private String server;
 
+  @ConfigKey("tagOverrideConfig")
+  @ConfigDoc("Overrides for tags")
+  private TagOverrideConfig tagOverrideConfig;
+
   public String getBroker() {
     return broker;
   }
@@ -48,6 +52,14 @@ public class TenantConfig {
 
   public void setServer(String server) {
     this.server = server;
+  }
+
+  public TagOverrideConfig getTagOverrideConfig() {
+    return tagOverrideConfig;
+  }
+
+  public void setTagOverrideConfig(TagOverrideConfig tagOverrideConfig) {
+    this.tagOverrideConfig = tagOverrideConfig;
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ControllerTenantNameBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/ControllerTenantNameBuilder.java
@@ -30,6 +30,13 @@ public class ControllerTenantNameBuilder {
     return tenantName + "_" + TenantRole.BROKER.toString();
   }
 
+  public static boolean hasValidServerTagSuffix(String tagName) {
+    if (tagName.endsWith(ServerType.REALTIME.toString()) || tagName.endsWith(ServerType.OFFLINE.toString())) {
+      return true;
+    }
+    return false;
+  }
+
   public static TenantRole getTenantRoleFromTenantName(String tenantName) {
     if (tenantName.endsWith(ServerType.REALTIME.toString())) {
       return TenantRole.SERVER;

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
@@ -85,6 +85,77 @@ public class TableConfigTest {
           tableConfig.getQuotaConfig().getStorage());
     }
     {
+      // With tenant config
+      TableConfig tableConfig = tableConfigBuilder.setServerTenant("aServerTenant").setBrokerTenant("aBrokerTenant").build();
+
+      Assert.assertEquals(tableConfig.getTableName(), "myTable_OFFLINE");
+      Assert.assertEquals(tableConfig.getTableType(), TableType.OFFLINE);
+      Assert.assertEquals(tableConfig.getIndexingConfig().getLoadMode(), "HEAP");
+      Assert.assertNotNull(tableConfig.getTenantConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getServer(), "aServerTenant");
+      Assert.assertEquals(tableConfig.getTenantConfig().getBroker(), "aBrokerTenant");
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+
+      // Serialize then de-serialize
+      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+
+      ZNRecord znRecord = TableConfig.toZnRecord(tableConfig);
+      tableConfigToCompare = TableConfig.fromZnRecord(znRecord);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+
+      TagOverrideConfig tagOverrideConfig = new TagOverrideConfig();
+      tagOverrideConfig.setRealtimeConsuming("aRTConsumingTag_REALTIME");
+      tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+
+      Assert.assertEquals(tableConfig.getTableName(), "myTable_OFFLINE");
+      Assert.assertEquals(tableConfig.getTableType(), TableType.OFFLINE);
+      Assert.assertNotNull(tableConfig.getTenantConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getServer(), "aServerTenant");
+      Assert.assertEquals(tableConfig.getTenantConfig().getBroker(), "aBrokerTenant");
+      Assert.assertNotNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeConsuming(), "aRTConsumingTag_REALTIME");
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeCompleted());
+
+      // Serialize then de-serialize
+      jsonConfig = TableConfig.toJSONConfig(tableConfig);
+      tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getTagOverrideConfig(),
+          tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+
+      znRecord = TableConfig.toZnRecord(tableConfig);
+      tableConfigToCompare = TableConfig.fromZnRecord(znRecord);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getTagOverrideConfig(),
+          tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+    }
+    {
       // With SegmentAssignmentStrategyConfig
       ReplicaGroupStrategyConfig replicaGroupConfig = new ReplicaGroupStrategyConfig();
       replicaGroupConfig.setNumInstancesPerPartition(5);


### PR DESCRIPTION
In our attempts to remove the dependency on znode for stream partition assignment, we will replace StreamPartitionAssigmentGenerator with PartitionAssignmentGenerator. PartitionAssignmentGenerator does not depend on znode for partition assignment, and instead computes it everytime, based on numPartitions, numRpelicas and tagged instances. The tenant config can specify an override, if we need to limit the number of tagged instances that we are allowed to use. Currently we have implemented only the uniform partition assignment strategy. We will extend this to also support other partition assignment schemes like Balanced (using autorebalance), random, etc. We also plan to add an override to read from znode instead of calculating assignment on the fly.