### PR TITLE
Updating numReplicas correctly for realtime partition aware routing

### DIFF
--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareOfflineRoutingTableBuilderTest.java
@@ -214,7 +214,7 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
 
     Set<String> servers = new HashSet<>();
     for (int i = 0; i < 100; i++) {
-      String countStarQuery = "select count(*) from myTable";
+      String countStarQuery = "select count(*) from " + OFFLINE_TABLE_NAME;
       Map<String, List<String>> routingTable =
           routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery));
       Assert.assertEquals(routingTable.keySet().size(), 1);
@@ -271,7 +271,7 @@ public class PartitionAwareOfflineRoutingTableBuilderTest {
     for (int serverId = 0; serverId < NUM_SERVERS; serverId++) {
       int groupId = serverId / numServersPerReplica;
       if (!replicaGroupServers.containsKey(groupId)) {
-        replicaGroupServers.put(groupId, new ArrayList<String>());
+        replicaGroupServers.put(groupId, new ArrayList<>());
       }
       String serverName = "Server_localhost_" + serverId;
       replicaGroupServers.get(groupId).add(serverName);

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/routing/builder/PartitionAwareRealtimeRoutingTableBuilderTest.java
@@ -86,19 +86,17 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
       // Create instance Configs
       List<InstanceConfig> instanceConfigs = new ArrayList<>();
-      for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+      for (int serverId = 0; serverId < NUM_SERVERS; serverId++) {
         String serverName = "Server_localhost_" + serverId;
         instanceConfigs.add(new InstanceConfig(serverName));
       }
 
-      // Update replica group mapping zk metadata
-      Map<Integer, List<String>> partitionToServerMapping =
-          buildKafkaPartitionMapping(REALTIME_TABLE_NAME, fakePropertyStore, instanceConfigs);
+      // Build the kafka partition mapping
+      Map<Integer, List<String>> partitionToServerMapping = buildKafkaPartitionMapping(instanceConfigs);
 
       // Create the fake external view
       ExternalView externalView =
           buildExternalView(REALTIME_TABLE_NAME, fakePropertyStore, partitionToServerMapping, segmentList);
-
 
       // Create the partition aware realtime routing table builder.
       RoutingTableBuilder routingTableBuilder =
@@ -112,7 +110,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
       // Check that all segments are covered exactly for once.
       Set<String> assignedSegments = new HashSet<>();
       for (List<String> segmentsForServer : routingTable.values()) {
-        for (String segmentName: segmentsForServer) {
+        for (String segmentName : segmentsForServer) {
           Assert.assertFalse(assignedSegments.contains(segmentName));
           assignedSegments.add(segmentName);
         }
@@ -127,7 +125,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
         int partition = queryPartition % NUM_PARTITION;
         assignedSegments = new HashSet<>();
         for (List<String> segmentsForServer : routingTable.values()) {
-          for (String segmentName: segmentsForServer) {
+          for (String segmentName : segmentsForServer) {
             Assert.assertFalse(assignedSegments.contains(segmentName));
             assignedSegments.add(segmentName);
           }
@@ -160,14 +158,13 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
     // Create instance Configs
     List<InstanceConfig> instanceConfigs = new ArrayList<>();
-    for (int serverId = 0; serverId <= NUM_SERVERS; serverId++) {
+    for (int serverId = 0; serverId < NUM_SERVERS; serverId++) {
       String serverName = "Server_localhost_" + serverId;
       instanceConfigs.add(new InstanceConfig(serverName));
     }
 
     // Update replica group mapping zk metadata
-    Map<Integer, List<String>> partitionToServerMapping =
-        buildKafkaPartitionMapping(REALTIME_TABLE_NAME, fakePropertyStore, instanceConfigs);
+    Map<Integer, List<String>> partitionToServerMapping = buildKafkaPartitionMapping(instanceConfigs);
 
     ExternalView externalView =
         buildExternalView(REALTIME_TABLE_NAME, fakePropertyStore, partitionToServerMapping, segmentList);
@@ -189,7 +186,7 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     // Check that all segments are covered exactly for once.
     Set<String> assignedSegments = new HashSet<>();
     for (List<String> segmentsForServer : routingTable.values()) {
-      for (String segmentName: segmentsForServer) {
+      for (String segmentName : segmentsForServer) {
         Assert.assertFalse(assignedSegments.contains(segmentName));
         assignedSegments.add(segmentName);
       }
@@ -201,6 +198,71 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     for (int i = ONLINE_SEGMENTS + 1; i < NUM_SEGMENTS; i++) {
       Assert.assertFalse(assignedSegments.contains(segmentList.get(i)));
     }
+  }
+
+  @Test
+  public void testRoutingAfterRebalance() throws Exception {
+    NUM_PARTITION = 10;
+    NUM_REPLICA = 1;
+    NUM_SERVERS = 1;
+    NUM_SEGMENTS = 10;
+
+    // Create the fake property store
+    FakePropertyStore fakePropertyStore = new FakePropertyStore();
+
+    // Create the table config, partition mapping,
+    TableConfig tableConfig = buildRealtimeTableConfig();
+
+    Map<Integer, Integer> partitionSegmentCount = new HashMap<>();
+    for (int i = 0; i < NUM_PARTITION; i++) {
+      partitionSegmentCount.put(i, 0);
+    }
+
+    List<String> segmentList = updateZkMetadataAndBuildSegmentList(partitionSegmentCount, fakePropertyStore);
+
+    // Create instance Configs
+    List<InstanceConfig> instanceConfigs = new ArrayList<>();
+    for (int serverId = 0; serverId < NUM_SERVERS; serverId++) {
+      String serverName = "Server_localhost_" + serverId;
+      instanceConfigs.add(new InstanceConfig(serverName));
+    }
+
+    // Build Kafka partition mapping
+    Map<Integer, List<String>> partitionToServerMapping = buildKafkaPartitionMapping(instanceConfigs);
+
+    ExternalView externalView =
+        buildExternalView(REALTIME_TABLE_NAME, fakePropertyStore, partitionToServerMapping, segmentList);
+
+    // Create the partition aware realtime routing table builder.
+    RoutingTableBuilder routingTableBuilder =
+        buildPartitionAwareRealtimeRoutingTableBuilder(fakePropertyStore, tableConfig, externalView, instanceConfigs);
+
+    NUM_REPLICA = 2;
+    NUM_SERVERS = 2;
+
+    // Update instance configs
+    String newServerName = "Server_localhost_" + (NUM_SERVERS - 1);
+    instanceConfigs.add(new InstanceConfig(newServerName));
+
+    // Update external view
+    partitionToServerMapping = buildKafkaPartitionMapping(instanceConfigs);
+    ExternalView newExternalView =
+        buildExternalView(REALTIME_TABLE_NAME, fakePropertyStore, partitionToServerMapping, segmentList);
+
+    // Compute routing table
+    routingTableBuilder.computeRoutingTableFromExternalView(REALTIME_TABLE_NAME, newExternalView, instanceConfigs);
+
+    Set<String> servers = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      String countStarQuery = "select count(*) from " + REALTIME_TABLE_NAME;
+      Map<String, List<String>> routingTable =
+          routingTableBuilder.getRoutingTable(buildRoutingTableLookupRequest(countStarQuery));
+      Assert.assertEquals(routingTable.keySet().size(), 1);
+      servers.addAll(routingTable.keySet());
+    }
+
+    // Check if both servers are get picked
+    Assert.assertEquals(servers.size(), 2);
   }
 
   private List<String> updateZkMetadataAndBuildSegmentList(Map<Integer, Integer> partitionSegmentCount,
@@ -227,11 +289,9 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     return segmentList;
   }
 
-  private Map<Integer, List<String>> buildKafkaPartitionMapping(String tableName, FakePropertyStore propertyStore,
-      List<InstanceConfig> instanceConfigs) {
+  private Map<Integer, List<String>> buildKafkaPartitionMapping(List<InstanceConfig> instanceConfigs) {
     // Create partition assignment mapping table.
     Map<Integer, List<String>> partitionToServers = new HashMap<>();
-    ZNRecord kafkaPartitionMapping = new ZNRecord(REALTIME_TABLE_NAME);
 
     int serverIndex = 0;
     for (int partitionId = 0; partitionId < NUM_PARTITION; partitionId++) {
@@ -241,17 +301,13 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
         serverIndex++;
       }
       partitionToServers.put(partitionId, assignedServers);
-      kafkaPartitionMapping.setListField(Integer.toString(partitionId), assignedServers);
     }
-
-    String path = ZKMetadataProvider.constructPropertyStorePathForKafkaPartitions(tableName);
-    propertyStore.set(path, kafkaPartitionMapping, AccessOption.PERSISTENT);
 
     return partitionToServers;
   }
 
   private RoutingTableBuilder buildPartitionAwareRealtimeRoutingTableBuilder(FakePropertyStore propertyStore,
-      TableConfig tableConfig, ExternalView externalView, List<InstanceConfig> instanceConfigs) throws Exception{
+      TableConfig tableConfig, ExternalView externalView, List<InstanceConfig> instanceConfigs) throws Exception {
 
     PartitionAwareRealtimeRoutingTableBuilder routingTableBuilder = new PartitionAwareRealtimeRoutingTableBuilder();
     routingTableBuilder.init(null, tableConfig, propertyStore);
@@ -265,10 +321,10 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
 
     // Create External View
     ExternalView externalView = new ExternalView(tableName);
-    for (String segmentName: segmentList) {
+    for (String segmentName : segmentList) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
       int partitionId = llcSegmentName.getPartitionId();
-      for (String server: partitionToServerMapping.get(partitionId)) {
+      for (String server : partitionToServerMapping.get(partitionId)) {
         externalView.setState(segmentName, server, "ONLINE");
       }
     }
@@ -290,10 +346,11 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     routingConfig.setRoutingTableBuilderName("PartitionAwareOffline");
 
     // Create table config
-    TableConfig tableConfig = new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME)
-        .setTableName(REALTIME_TABLE_NAME)
-        .setNumReplicas(NUM_REPLICA)
-        .build();
+    TableConfig tableConfig =
+        new TableConfig.Builder(CommonConstants.Helix.TableType.REALTIME)
+            .setTableName(REALTIME_TABLE_NAME)
+            .setNumReplicas(NUM_REPLICA)
+            .build();
 
     tableConfig.getValidationConfig().setReplicasPerPartition(Integer.toString(NUM_REPLICA));
     tableConfig.getIndexingConfig().setSegmentPartitionConfig(partitionConfig);
@@ -313,5 +370,4 @@ public class PartitionAwareRealtimeRoutingTableBuilderTest {
     metadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
     return metadata;
   }
-
 }


### PR DESCRIPTION
numReplicas is only updated during the initialization so that the
broker has to be restarted when there is a change in the number of
replication. This pr addresses the issue.