### PR TITLE
Remove 'queryOptions' from PinotClientRequest

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/api/resources/PinotClientRequest.java
@@ -63,8 +63,7 @@ public class PinotClientRequest {
       // Query param "bql" is for backward compatibility
       @ApiParam(value = "Query", required = true) @QueryParam("bql") String query,
       @ApiParam(value = "Trace enabled") @QueryParam(TRACE) String traceEnabled,
-      @ApiParam(value = "Debug options") @QueryParam(DEBUG_OPTIONS) String debugOptions,
-      @ApiParam(value = "Query options") @QueryParam(QUERY_OPTIONS) String queryOptions
+      @ApiParam(value = "Debug options") @QueryParam(DEBUG_OPTIONS) String debugOptions
   ) {
     try {
       JSONObject requestJson = new JSONObject();
@@ -74,9 +73,6 @@ public class PinotClientRequest {
       }
       if (debugOptions != null) {
         requestJson.put(DEBUG_OPTIONS, debugOptions);
-      }
-      if (queryOptions != null) {
-        requestJson.put(QUERY_OPTIONS, queryOptions);
       }
       BrokerResponse brokerResponse = requestHandler.handleRequest(requestJson, null);
       return brokerResponse.toJsonString();

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -229,15 +229,6 @@ public class BrokerRequestHandler {
       LOGGER.debug("Debug options are set to: {} for requestId {}: {}", debugOptions, requestId, query);
       brokerRequest.setDebugOptions(debugOptions);
     }
-    if (request.has(QUERY_OPTIONS)) {
-      Map<String, String> queryOptions = Splitter.on(';')
-          .omitEmptyStrings()
-          .trimResults()
-          .withKeyValueSeparator('=')
-          .split(request.getString(QUERY_OPTIONS));
-      LOGGER.debug("Query options are set to: {} for requestId {}: {}", queryOptions, requestId, query);
-      brokerRequest.setQueryOptions(queryOptions);
-    }
     brokerRequest.setResponseFormat(ResponseType.BROKER_RESPONSE_TYPE_NATIVE.name());
 
     _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.QUERIES, 1L);

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/CommonConstants.java
@@ -218,7 +218,6 @@ public class CommonConstants {
       public static final String PQL = "pql";
       public static final String TRACE = "trace";
       public static final String DEBUG_OPTIONS = "debugOptions";
-      public static final String QUERY_OPTIONS = "queryOptions";
     }
   }
 

--- a/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/OptionsAstNode.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/pql/parsers/pql2/ast/OptionsAstNode.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 public class OptionsAstNode extends BaseAstNode {
   @Override
   public void updateBrokerRequest(BrokerRequest brokerRequest) {
-    brokerRequest.setQueryOptions(new HashMap<String, String>());
+    brokerRequest.setQueryOptions(new HashMap<>());
     sendBrokerRequestUpdateToChildren(brokerRequest);
   }
 }


### PR DESCRIPTION
Query options should be parsed from query instead of from HTTP parameters
E.g. SELECT COUNT(*) FROM table OPTION(key='value')