### PR TITLE
Create tag override for realtime

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -20,10 +20,10 @@ import com.linkedin.pinot.broker.broker.AccessControlFactory;
 import com.linkedin.pinot.broker.broker.BrokerServerBuilder;
 import com.linkedin.pinot.broker.queryquota.TableQueryQuotaManager;
 import com.linkedin.pinot.broker.routing.HelixExternalViewBasedRouting;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metrics.BrokerMeter;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ServiceStatus;
 import com.linkedin.pinot.common.utils.StringUtil;
@@ -176,7 +176,7 @@ public class HelixBrokerStarter {
     if (instanceTags == null || instanceTags.isEmpty()) {
       if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_propertyStore)) {
         _helixAdmin.addInstanceTag(clusterName, instanceName,
-            TenantNameBuilder.getBrokerTenantNameForTenant(TenantNameBuilder.DEFAULT_TENANT_NAME));
+            TagNameBuilder.getBrokerTagForTenant(TagNameBuilder.DEFAULT_TENANT_NAME));
       } else {
         _helixAdmin.addInstanceTag(clusterName, instanceName, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
       }

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/OfflineTagConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/OfflineTagConfig.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.common.config;
 
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
-
 /**
  * Wrapper class over TableConfig for an offline table
  * This class will help answer questions about what are server tags for a table
@@ -28,7 +26,7 @@ public class OfflineTagConfig extends TagConfig {
   public OfflineTagConfig(TableConfig tableConfig) {
     super(tableConfig);
 
-    _offlineServerTag = TenantNameBuilder.getOfflineTenantNameForTenant(_serverTenant);
+    _offlineServerTag = TagNameBuilder.getOfflineTagForTenant(_serverTenant);
   }
 
   public String getOfflineServerTag() {

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/RealtimeTagConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/RealtimeTagConfig.java
@@ -15,8 +15,6 @@
  */
 package com.linkedin.pinot.common.config;
 
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
-
 /**
  * Wrapper class over TableConfig for a realtime table
  * This class will help answer questions about what are consuming/completed tags for a table
@@ -31,9 +29,17 @@ public class RealtimeTagConfig extends TagConfig {
   public RealtimeTagConfig(TableConfig tableConfig) {
     super(tableConfig);
 
-    // TODO: after we introduce config to override tags, pick the right ones from config for consuming and completed
-    _consumingRealtimeServerTag = TenantNameBuilder.getRealtimeTenantNameForTenant(_serverTenant);
-    _completedRealtimeServerTag = TenantNameBuilder.getRealtimeTenantNameForTenant(_serverTenant);
+    TagOverrideConfig tagOverrideConfig = tableConfig.getTenantConfig().getTagOverrideConfig();
+    if (tagOverrideConfig != null && tagOverrideConfig.getRealtimeConsuming() != null) {
+      _consumingRealtimeServerTag = tagOverrideConfig.getRealtimeConsuming();
+    } else {
+      _consumingRealtimeServerTag = TagNameBuilder.getRealtimeTagForTenant(_serverTenant);
+    }
+    if (tagOverrideConfig != null && tagOverrideConfig.getRealtimeCompleted() != null) {
+      _completedRealtimeServerTag = tagOverrideConfig.getRealtimeCompleted();
+    } else {
+      _completedRealtimeServerTag = TagNameBuilder.getRealtimeTagForTenant(_serverTenant);
+    }
 
     if (!_consumingRealtimeServerTag.equals(_completedRealtimeServerTag)) {
       _relocateCompletedSegments = true;

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TableConfig.java
@@ -25,8 +25,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.helix.ZNRecord;
@@ -380,6 +378,7 @@ public class TableConfig {
     // Tenant config related
     private String _brokerTenant;
     private String _serverTenant;
+    private TagOverrideConfig _tagOverrideConfig;
 
     // Indexing config related
     private String _loadMode = DEFAULT_LOAD_MODE;
@@ -473,6 +472,11 @@ public class TableConfig {
       return this;
     }
 
+    public Builder setTagOverrideConfig(TagOverrideConfig tagOverrideConfig) {
+      _tagOverrideConfig = tagOverrideConfig;
+      return this;
+    }
+
     public Builder setLoadMode(String loadMode) {
       if (MMAP_LOAD_MODE.equalsIgnoreCase(loadMode)) {
         _loadMode = MMAP_LOAD_MODE;
@@ -559,6 +563,7 @@ public class TableConfig {
       TenantConfig tenantConfig = new TenantConfig();
       tenantConfig.setBroker(_brokerTenant);
       tenantConfig.setServer(_serverTenant);
+      tenantConfig.setTagOverrideConfig(_tagOverrideConfig);
 
       // Indexing config
       IndexingConfig indexingConfig = new IndexingConfig();

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagNameBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagNameBuilder.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.config;
+
+import com.linkedin.pinot.common.utils.ServerType;
+import com.linkedin.pinot.common.utils.TenantRole;
+
+
+public class TagNameBuilder {
+  public final static String DEFAULT_TENANT_NAME = "DefaultTenant";
+
+  private static String buildRealtimeTagFromTenantName(String tenantName) {
+    return tenantName + "_" + ServerType.REALTIME.toString();
+  }
+
+  private static String buildOfflineTagFromTenantName(String tenantName) {
+    return tenantName + "_" + ServerType.OFFLINE.toString();
+  }
+
+  private static String buildBrokerTenantTagFromTenantName(String tenantName) {
+    return tenantName + "_" + TenantRole.BROKER.toString();
+  }
+
+  public static boolean hasValidServerTagSuffix(String tagName) {
+    if (tagName.endsWith(ServerType.REALTIME.toString()) || tagName.endsWith(ServerType.OFFLINE.toString())) {
+      return true;
+    }
+    return false;
+  }
+
+  public static TenantRole getTenantRoleFromTag(String tagName) {
+    if (tagName.endsWith(ServerType.REALTIME.toString())) {
+      return TenantRole.SERVER;
+    }
+    if (tagName.endsWith(ServerType.OFFLINE.toString())) {
+      return TenantRole.SERVER;
+    }
+    if (tagName.endsWith(TenantRole.BROKER.toString())) {
+      return TenantRole.BROKER;
+    }
+    throw new RuntimeException("Cannot identify tenant type from tag name : " + tagName);
+  }
+
+  public static String getTagFromTenantAndServerType(String tenantName, ServerType type) {
+    if (type == ServerType.OFFLINE) {
+      return getOfflineTagForTenant(tenantName);
+    }
+    return getRealtimeTagForTenant(tenantName);
+  }
+
+  public static String getRealtimeTagForTenant(String tenantName) {
+    if (tenantName == null) {
+      return TagNameBuilder.getRealtimeTagForTenant(DEFAULT_TENANT_NAME);
+    }
+    if (tenantName.endsWith(ServerType.REALTIME.toString())) {
+      return tenantName;
+    } else {
+      return TagNameBuilder.buildRealtimeTagFromTenantName(tenantName);
+    }
+  }
+
+  public static String getOfflineTagForTenant(String tenantName) {
+    if (tenantName == null) {
+      return TagNameBuilder.getOfflineTagForTenant(DEFAULT_TENANT_NAME);
+    }
+    if (tenantName.endsWith(ServerType.OFFLINE.toString())) {
+      return tenantName;
+    } else {
+      return TagNameBuilder.buildOfflineTagFromTenantName(tenantName);
+    }
+  }
+
+  public static String getBrokerTagForTenant(String tenantName) {
+    if (tenantName == null) {
+      return TagNameBuilder.getBrokerTagForTenant(DEFAULT_TENANT_NAME);
+    }
+    if (tenantName.endsWith(TenantRole.BROKER.toString())) {
+      return tenantName;
+    } else {
+      return TagNameBuilder.buildBrokerTenantTagFromTenantName(tenantName);
+    }
+  }
+
+  public static String getTenantNameFromTag(String tag) {
+    if (tag.endsWith(ServerType.REALTIME.toString())) {
+      return tag.substring(0, tag.length() - (ServerType.REALTIME.toString().length() + 1));
+    }
+    if (tag.endsWith(ServerType.OFFLINE.toString())) {
+      return tag.substring(0, tag.length() - (ServerType.OFFLINE.toString().length() + 1));
+    }
+    if (tag.endsWith(TenantRole.BROKER.toString())) {
+      return tag.substring(0, tag.length() - (TenantRole.BROKER.toString().length() + 1));
+    }
+    return tag;
+  }
+
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagOverrideConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TagOverrideConfig.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.config;
+
+import com.linkedin.pinot.common.utils.EqualityUtils;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This config will allow specifying overrides to the tags derived from tenantConfig.
+ * Supported override keys:
+ *  - realtimeConsuming - value specifies the tag to be used for realtime consuming segments
+ *  - realtimeCompleted - value specifies the tag to be used for realtime segments that are in ONLINE state.
+ *
+ * If a value is specified for the key 'realtimeCompleted' then realtime segments, once completed, will be moved
+ * from the machines that consumed the rows in the segment to a pool of machines tagged with this value.
+ *
+ * These fields expect the complete tag name including the suffix, unlike the tenantConfig server and broker
+ * where the suffix is added automatically. However the suffix in these tag names has to be one of OFFLINE
+ * or REALTIME (for the present. We may extend it to have other tag suffixes later).
+ *
+ * Basic validation of the tags does happen when the table is being added. The validations include:
+ * 1) checking if the suffix is correct (must be either _OFFLINE or _REALTIME)
+ * 2) checking if instances with the tag exist
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TagOverrideConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TagOverrideConfig.class);
+
+  @ConfigKey("realtimeConsuming")
+  @ConfigDoc("Tag override for realtime consuming segments")
+  private String realtimeConsuming;
+
+  @ConfigKey("realtimeCompleted")
+  @ConfigDoc("Tag override for realtime completed segments")
+  private String realtimeCompleted;
+
+  public String getRealtimeConsuming() {
+    return realtimeConsuming;
+  }
+
+  public void setRealtimeConsuming(String realtimeConsuming) {
+    this.realtimeConsuming = realtimeConsuming;
+  }
+
+  public String getRealtimeCompleted() {
+    return realtimeCompleted;
+  }
+
+  public void setRealtimeCompleted(String realtimeCompleted) {
+    this.realtimeCompleted = realtimeCompleted;
+  }
+
+  @Override
+  public String toString() {
+    return "TagOverrideConfig{" + "realtimeConsuming='" + realtimeConsuming + '\'' + ", realtimeCompleted="
+        + realtimeCompleted + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (EqualityUtils.isSameReference(this, o)) {
+      return true;
+    }
+
+    if (EqualityUtils.isNullOrNotSameClass(this, o)) {
+      return false;
+    }
+
+    TagOverrideConfig that = (TagOverrideConfig) o;
+
+    return EqualityUtils.isEqual(realtimeConsuming, that.realtimeConsuming) && EqualityUtils.isEqual(realtimeCompleted,
+        that.realtimeCompleted);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = EqualityUtils.hashCodeOf(realtimeConsuming);
+    result = EqualityUtils.hashCodeOf(result, realtimeCompleted);
+    return result;
+  }
+}

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/config/TenantConfig.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/config/TenantConfig.java
@@ -34,6 +34,10 @@ public class TenantConfig {
   @ConfigDoc("Server tag prefix used by this table")
   private String server;
 
+  @ConfigKey("tagOverrideConfig")
+  @ConfigDoc("Overrides for tags")
+  private TagOverrideConfig tagOverrideConfig;
+
   public String getBroker() {
     return broker;
   }
@@ -48,6 +52,14 @@ public class TenantConfig {
 
   public void setServer(String server) {
     this.server = server;
+  }
+
+  public TagOverrideConfig getTagOverrideConfig() {
+    return tagOverrideConfig;
+  }
+
+  public void setTagOverrideConfig(TagOverrideConfig tagOverrideConfig) {
+    this.tagOverrideConfig = tagOverrideConfig;
   }
 
   @Override

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/TenantNameBuilder.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/TenantNameBuilder.java
@@ -30,6 +30,13 @@ public class TenantNameBuilder {
     return tenantName + "_" + TenantRole.BROKER.toString();
   }
 
+  public static boolean hasValidServerTagSuffix(String tagName) {
+    if (tagName.endsWith(ServerType.REALTIME.toString()) || tagName.endsWith(ServerType.OFFLINE.toString())) {
+      return true;
+    }
+    return false;
+  }
+
   public static TenantRole getTenantRoleFromTenantName(String tenantName) {
     if (tenantName.endsWith(ServerType.REALTIME.toString())) {
       return TenantRole.SERVER;

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/TableConfigTest.java
@@ -92,6 +92,77 @@ public class TableConfigTest {
           tableConfig.getQuotaConfig().getStorage());
     }
     {
+      // With tenant config
+      TableConfig tableConfig = tableConfigBuilder.setServerTenant("aServerTenant").setBrokerTenant("aBrokerTenant").build();
+
+      Assert.assertEquals(tableConfig.getTableName(), "myTable_OFFLINE");
+      Assert.assertEquals(tableConfig.getTableType(), TableType.OFFLINE);
+      Assert.assertEquals(tableConfig.getIndexingConfig().getLoadMode(), "HEAP");
+      Assert.assertNotNull(tableConfig.getTenantConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getServer(), "aServerTenant");
+      Assert.assertEquals(tableConfig.getTenantConfig().getBroker(), "aBrokerTenant");
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+
+      // Serialize then de-serialize
+      JSONObject jsonConfig = TableConfig.toJSONConfig(tableConfig);
+      TableConfig tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+
+      ZNRecord znRecord = TableConfig.toZnRecord(tableConfig);
+      tableConfigToCompare = TableConfig.fromZnRecord(znRecord);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+
+      TagOverrideConfig tagOverrideConfig = new TagOverrideConfig();
+      tagOverrideConfig.setRealtimeConsuming("aRTConsumingTag_REALTIME");
+      tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+
+      Assert.assertEquals(tableConfig.getTableName(), "myTable_OFFLINE");
+      Assert.assertEquals(tableConfig.getTableType(), TableType.OFFLINE);
+      Assert.assertNotNull(tableConfig.getTenantConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getServer(), "aServerTenant");
+      Assert.assertEquals(tableConfig.getTenantConfig().getBroker(), "aBrokerTenant");
+      Assert.assertNotNull(tableConfig.getTenantConfig().getTagOverrideConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeConsuming(), "aRTConsumingTag_REALTIME");
+      Assert.assertNull(tableConfig.getTenantConfig().getTagOverrideConfig().getRealtimeCompleted());
+
+      // Serialize then de-serialize
+      jsonConfig = TableConfig.toJSONConfig(tableConfig);
+      tableConfigToCompare = TableConfig.fromJSONConfig(jsonConfig);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getTagOverrideConfig(),
+          tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+
+      znRecord = TableConfig.toZnRecord(tableConfig);
+      tableConfigToCompare = TableConfig.fromZnRecord(znRecord);
+      Assert.assertEquals(tableConfigToCompare.getTableName(), tableConfig.getTableName());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getServer(),
+          tableConfig.getTenantConfig().getServer());
+      Assert.assertEquals(tableConfigToCompare.getTenantConfig().getBroker(),
+          tableConfig.getTenantConfig().getBroker());
+      Assert.assertNotNull(tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+      Assert.assertEquals(tableConfig.getTenantConfig().getTagOverrideConfig(),
+          tableConfigToCompare.getTenantConfig().getTagOverrideConfig());
+    }
+    {
       // With SegmentAssignmentStrategyConfig
       ReplicaGroupStrategyConfig replicaGroupConfig = new ReplicaGroupStrategyConfig();
       replicaGroupConfig.setNumInstancesPerPartition(5);

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/TagConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/TagConfigTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.common.config;
+
+import com.linkedin.pinot.common.utils.CommonConstants;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class TagConfigTest {
+
+  @DataProvider(name = "realtimeTagConfigTestDataProvider")
+  public Object[][] realtimeTagConfigTestDataProvider() throws IOException, JSONException {
+    TableConfig.Builder tableConfigBuilder = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE);
+    tableConfigBuilder.setTableName("testRealtimeTable")
+        .setTimeColumnName("timeColumn")
+        .setTimeType("DAYS")
+        .setRetentionTimeUnit("DAYS")
+        .setRetentionTimeValue("5")
+        .setServerTenant("aServerTenant");
+
+    List<Object[]> inputs = new ArrayList<>();
+
+    TableConfig tableConfig = tableConfigBuilder.build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_REALTIME", "aServerTenant_REALTIME"});
+
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(null).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_REALTIME", "aServerTenant_REALTIME"});
+
+    // empty tag override
+    TagOverrideConfig tagOverrideConfig = new TagOverrideConfig();
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_REALTIME", "aServerTenant_REALTIME"});
+
+    // defined realtime consuming override
+    tagOverrideConfig = new TagOverrideConfig();
+    tagOverrideConfig.setRealtimeConsuming("overriddenTag_REALTIME");
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "overriddenTag_REALTIME", "aServerTenant_REALTIME"});
+
+    // defined realtime completed override
+    tagOverrideConfig = new TagOverrideConfig();
+    tagOverrideConfig.setRealtimeCompleted("overriddenTag_OFFLINE");
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_REALTIME", "overriddenTag_OFFLINE"});
+
+    // defined both overrides
+    tagOverrideConfig = new TagOverrideConfig();
+    tagOverrideConfig.setRealtimeConsuming("overriddenTag_REALTIME");
+    tagOverrideConfig.setRealtimeCompleted("overriddenTag_OFFLINE");
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "overriddenTag_REALTIME", "overriddenTag_OFFLINE"});
+
+    return inputs.toArray(new Object[inputs.size()][]);
+  }
+
+  @Test(dataProvider = "realtimeTagConfigTestDataProvider")
+  public void testRealtimeTagConfig(TableConfig tableConfig, String expectedServerTenant,
+      String expectedRealtimeConsumingTag, String expectedRealtimeCompletedTag) {
+    RealtimeTagConfig tagConfig = new RealtimeTagConfig(tableConfig);
+    Assert.assertEquals(tagConfig.getServerTenantName(), expectedServerTenant);
+    Assert.assertEquals(tagConfig.getConsumingServerTag(), expectedRealtimeConsumingTag);
+    Assert.assertEquals(tagConfig.getCompletedServerTag(), expectedRealtimeCompletedTag);
+  }
+
+  @DataProvider(name = "offlineTagConfigTestDataProvider")
+  public Object[][] offlineTagConfigTestDataProvider() throws IOException, JSONException {
+    TableConfig.Builder tableConfigBuilder = new TableConfig.Builder(CommonConstants.Helix.TableType.OFFLINE);
+    tableConfigBuilder.setTableName("testOfflineTable")
+        .setTimeColumnName("timeColumn")
+        .setTimeType("DAYS")
+        .setRetentionTimeUnit("DAYS")
+        .setRetentionTimeValue("5")
+        .setServerTenant("aServerTenant");
+
+    List<Object[]> inputs = new ArrayList<>();
+
+    TableConfig tableConfig = tableConfigBuilder.build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_OFFLINE"});
+
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(null).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_OFFLINE"});
+
+    TagOverrideConfig tagOverrideConfig = new TagOverrideConfig();
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_OFFLINE"});
+
+    tagOverrideConfig = new TagOverrideConfig();
+    tagOverrideConfig.setRealtimeConsuming("overriddenTag_REALTIME");
+    tagOverrideConfig.setRealtimeCompleted("overriddenTag_OFFLINE");
+    tableConfig = tableConfigBuilder.setTagOverrideConfig(tagOverrideConfig).build();
+    inputs.add(new Object[] {tableConfig, "aServerTenant", "aServerTenant_OFFLINE"});
+
+    return inputs.toArray(new Object[inputs.size()][]);
+  }
+
+  @Test(dataProvider = "offlineTagConfigTestDataProvider")
+  public void testOfflineTagConfig(TableConfig tableConfig, String expectedServerTenant, String expectedOfflineServerTag) {
+    OfflineTagConfig tagConfig = new OfflineTagConfig(tableConfig);
+    Assert.assertEquals(tagConfig.getServerTenantName(), expectedServerTenant);
+    Assert.assertEquals(tagConfig.getOfflineServerTag(), expectedOfflineServerTag);
+  }
+
+}

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/ControllerRequestBuilderUtil.java
@@ -16,10 +16,10 @@
 package com.linkedin.pinot.controller.helix;
 
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.config.Tenant;
 import com.linkedin.pinot.common.config.Tenant.TenantBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.TenantRole;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,8 +59,8 @@ public class ControllerRequestBuilderUtil {
       helixZkManager.connect();
       if (isSingleTenant) {
         helixZkManager.getClusterManagmentTool()
-            .addInstanceTag(helixClusterName, brokerId, TenantNameBuilder.getBrokerTenantNameForTenant(
-                TenantNameBuilder.DEFAULT_TENANT_NAME));
+            .addInstanceTag(helixClusterName, brokerId,
+                TagNameBuilder.getBrokerTagForTenant(TagNameBuilder.DEFAULT_TENANT_NAME));
       } else {
         helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, brokerId, UNTAGGED_BROKER_INSTANCE);
       }
@@ -112,10 +112,10 @@ public class ControllerRequestBuilderUtil {
     if (isSingleTenant) {
       helixZkManager.getClusterManagmentTool()
           .addInstanceTag(helixClusterName, instanceId,
-              TableNameBuilder.OFFLINE.tableNameWithType(TenantNameBuilder.DEFAULT_TENANT_NAME));
+              TableNameBuilder.OFFLINE.tableNameWithType(TagNameBuilder.DEFAULT_TENANT_NAME));
       helixZkManager.getClusterManagmentTool()
           .addInstanceTag(helixClusterName, instanceId,
-              TableNameBuilder.REALTIME.tableNameWithType(TenantNameBuilder.DEFAULT_TENANT_NAME));
+              TableNameBuilder.REALTIME.tableNameWithType(TagNameBuilder.DEFAULT_TENANT_NAME));
     } else {
       helixZkManager.getClusterManagmentTool().addInstanceTag(helixClusterName, instanceId, UNTAGGED_SERVER_INSTANCE);
     }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -20,12 +20,17 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.config.IndexingConfig;
+import com.linkedin.pinot.common.config.OfflineTagConfig;
+import com.linkedin.pinot.common.config.RealtimeTagConfig;
 import com.linkedin.pinot.common.config.SegmentsValidationAndRetentionConfig;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableCustomConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TagNameBuilder;
+import com.linkedin.pinot.common.config.TagOverrideConfig;
 import com.linkedin.pinot.common.config.Tenant;
 import com.linkedin.pinot.common.config.TenantConfig;
 import com.linkedin.pinot.common.data.Schema;
@@ -46,7 +51,6 @@ import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.StateModel.BrokerOnlineOfflineStateModel;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.StateModel.SegmentOnlineOfflineStateModel;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix.TableType;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.SchemaUtils;
 import com.linkedin.pinot.common.utils.TenantRole;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
@@ -295,7 +299,7 @@ public class PinotHelixResourceManager {
       }
     }
     return _helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getBrokerTenantNameForTenant(brokerTenantName));
+        TagNameBuilder.getBrokerTagForTenant(brokerTenantName));
   }
 
   /**
@@ -512,7 +516,7 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse updateBrokerTenant(Tenant tenant) {
     PinotResourceManagerResponse res = new PinotResourceManagerResponse();
-    String brokerTenantTag = TenantNameBuilder.getBrokerTenantNameForTenant(tenant.getTenantName());
+    String brokerTenantTag = TagNameBuilder.getBrokerTagForTenant(tenant.getTenantName());
     List<String> instancesInClusterWithTag =
         _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTenantTag);
     if (instancesInClusterWithTag.size() > tenant.getNumberOfInstances()) {
@@ -618,7 +622,7 @@ public class PinotHelixResourceManager {
       TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
       Preconditions.checkNotNull(tableConfig);
       String brokerTag =
-          TenantNameBuilder.getBrokerTenantNameForTenant(tableConfig.getTenantConfig().getBroker());
+          TagNameBuilder.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker());
       if (brokerTag.equals(brokerTenantTag)) {
         tableIdealState.setPartitionState(tableNameWithType, instanceName, BrokerOnlineOfflineStateModel.ONLINE);
       }
@@ -644,11 +648,11 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse updateServerTenant(Tenant serverTenant) {
     PinotResourceManagerResponse res = new PinotResourceManagerResponse();
-    String realtimeServerTag = TenantNameBuilder.getRealtimeTenantNameForTenant(serverTenant.getTenantName());
+    String realtimeServerTag = TagNameBuilder.getRealtimeTagForTenant(serverTenant.getTenantName());
     List<String> taggedRealtimeServers = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeServerTag);
-    String offlineServerTag = TenantNameBuilder.getOfflineTenantNameForTenant(serverTenant.getTenantName());
+    String offlineServerTag = TagNameBuilder.getOfflineTagForTenant(serverTenant.getTenantName());
     List<String> taggedOfflineServers = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, offlineServerTag);
-    Set<String> allServingServers = new HashSet<String>();
+    Set<String> allServingServers = new HashSet<>();
     allServingServers.addAll(taggedOfflineServers);
     allServingServers.addAll(taggedRealtimeServers);
     boolean isCurrentTenantColocated =
@@ -753,24 +757,24 @@ public class PinotHelixResourceManager {
 
   public boolean isTenantExisted(String tenantName) {
     if (!_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getBrokerTenantNameForTenant(tenantName)).isEmpty()) {
+        TagNameBuilder.getBrokerTagForTenant(tenantName)).isEmpty()) {
       return true;
     }
     if (!_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getOfflineTenantNameForTenant(tenantName)).isEmpty()) {
+        TagNameBuilder.getOfflineTagForTenant(tenantName)).isEmpty()) {
       return true;
     }
     if (!_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getRealtimeTenantNameForTenant(tenantName)).isEmpty()) {
+        TagNameBuilder.getRealtimeTagForTenant(tenantName)).isEmpty()) {
       return true;
     }
     return false;
   }
 
   public boolean isBrokerTenantDeletable(String tenantName) {
-    String brokerTag = TenantNameBuilder.getBrokerTenantNameForTenant(tenantName);
+    String brokerTag = TagNameBuilder.getBrokerTagForTenant(tenantName);
     Set<String> taggedInstances =
-        new HashSet<String>(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTag));
+        new HashSet<>(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTag));
     String brokerName = CommonConstants.Helix.BROKER_RESOURCE_INSTANCE;
     IdealState brokerIdealState = _helixAdmin.getResourceIdealState(_helixClusterName, brokerName);
     for (String partition : brokerIdealState.getPartitionSet()) {
@@ -784,11 +788,10 @@ public class PinotHelixResourceManager {
   }
 
   public boolean isServerTenantDeletable(String tenantName) {
-    Set<String> taggedInstances =
-        new HashSet<String>(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-            TenantNameBuilder.getOfflineTenantNameForTenant(tenantName)));
+    Set<String> taggedInstances = new HashSet<>(
+        _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, TagNameBuilder.getOfflineTagForTenant(tenantName)));
     taggedInstances.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getRealtimeTenantNameForTenant(tenantName)));
+        TagNameBuilder.getRealtimeTagForTenant(tenantName)));
     for (String resourceName : getAllResources()) {
       if (!TableNameBuilder.isTableResource(resourceName)) {
         continue;
@@ -806,7 +809,7 @@ public class PinotHelixResourceManager {
   }
 
   public Set<String> getAllBrokerTenantNames() {
-    Set<String> tenantSet = new HashSet<String>();
+    Set<String> tenantSet = new HashSet<>();
     List<String> instancesInCluster = _helixAdmin.getInstancesInCluster(_helixClusterName);
     for (String instanceName : instancesInCluster) {
       InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
@@ -816,8 +819,8 @@ public class PinotHelixResourceManager {
             || tag.equals(CommonConstants.Minion.UNTAGGED_INSTANCE)) {
           continue;
         }
-        if (TenantNameBuilder.getTenantRoleFromTenantName(tag) == TenantRole.BROKER) {
-          tenantSet.add(TenantNameBuilder.getExternalTenantName(tag));
+        if (TagNameBuilder.getTenantRoleFromTag(tag) == TenantRole.BROKER) {
+          tenantSet.add(TagNameBuilder.getTenantNameFromTag(tag));
         }
       }
     }
@@ -825,7 +828,7 @@ public class PinotHelixResourceManager {
   }
 
   public Set<String> getAllServerTenantNames() {
-    Set<String> tenantSet = new HashSet<String>();
+    Set<String> tenantSet = new HashSet<>();
     List<String> instancesInCluster = _helixAdmin.getInstancesInCluster(_helixClusterName);
     for (String instanceName : instancesInCluster) {
       InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
@@ -835,8 +838,8 @@ public class PinotHelixResourceManager {
             || tag.equals(CommonConstants.Minion.UNTAGGED_INSTANCE)) {
           continue;
         }
-        if (TenantNameBuilder.getTenantRoleFromTenantName(tag) == TenantRole.SERVER) {
-          tenantSet.add(TenantNameBuilder.getExternalTenantName(tag));
+        if (TagNameBuilder.getTenantRoleFromTag(tag) == TenantRole.SERVER) {
+          tenantSet.add(TagNameBuilder.getTenantNameFromTag(tag));
         }
       }
     }
@@ -873,11 +876,11 @@ public class PinotHelixResourceManager {
 
   private void assignIndependentServerTenant(Tenant serverTenant, int numberOfInstances,
       List<String> unTaggedInstanceList) {
-    String offlineServerTag = TenantNameBuilder.getOfflineTenantNameForTenant(serverTenant.getTenantName());
+    String offlineServerTag = TagNameBuilder.getOfflineTagForTenant(serverTenant.getTenantName());
     for (int i = 0; i < serverTenant.getOfflineInstances(); i++) {
       retagInstance(unTaggedInstanceList.get(i), CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE, offlineServerTag);
     }
-    String realtimeServerTag = TenantNameBuilder.getRealtimeTenantNameForTenant(serverTenant.getTenantName());
+    String realtimeServerTag = TagNameBuilder.getRealtimeTagForTenant(serverTenant.getTenantName());
     for (int i = 0; i < serverTenant.getRealtimeInstances(); i++) {
       retagInstance(unTaggedInstanceList.get(i + serverTenant.getOfflineInstances()),
           CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE, realtimeServerTag);
@@ -886,11 +889,11 @@ public class PinotHelixResourceManager {
 
   private void assignColocatedServerTenant(Tenant serverTenant, int numberOfInstances, List<String> unTaggedInstanceList) {
     int cnt = 0;
-    String offlineServerTag = TenantNameBuilder.getOfflineTenantNameForTenant(serverTenant.getTenantName());
+    String offlineServerTag = TagNameBuilder.getOfflineTagForTenant(serverTenant.getTenantName());
     for (int i = 0; i < serverTenant.getOfflineInstances(); i++) {
       retagInstance(unTaggedInstanceList.get(cnt++), CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE, offlineServerTag);
     }
-    String realtimeServerTag = TenantNameBuilder.getRealtimeTenantNameForTenant(serverTenant.getTenantName());
+    String realtimeServerTag = TagNameBuilder.getRealtimeTagForTenant(serverTenant.getTenantName());
     for (int i = 0; i < serverTenant.getRealtimeInstances(); i++) {
       retagInstance(unTaggedInstanceList.get(cnt++), CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE, realtimeServerTag);
       if (cnt == numberOfInstances) {
@@ -912,7 +915,7 @@ public class PinotHelixResourceManager {
       LOGGER.error(res.message);
       return res;
     }
-    String brokerTag = TenantNameBuilder.getBrokerTenantNameForTenant(brokerTenant.getTenantName());
+    String brokerTag = TagNameBuilder.getBrokerTagForTenant(brokerTenant.getTenantName());
     for (int i = 0; i < brokerTenant.getNumberOfInstances(); ++i) {
       retagInstance(unTaggedInstanceList.get(i), CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE, brokerTag);
     }
@@ -923,7 +926,7 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse deleteOfflineServerTenantFor(String tenantName) {
     PinotResourceManagerResponse response = new PinotResourceManagerResponse();
-    String offlineTenantTag = TenantNameBuilder.getOfflineTenantNameForTenant(tenantName);
+    String offlineTenantTag = TagNameBuilder.getOfflineTagForTenant(tenantName);
     List<String> instancesInClusterWithTag =
         _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, offlineTenantTag);
     for (String instanceName : instancesInClusterWithTag) {
@@ -938,7 +941,7 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse deleteRealtimeServerTenantFor(String tenantName) {
     PinotResourceManagerResponse response = new PinotResourceManagerResponse();
-    String realtimeTenantTag = TenantNameBuilder.getRealtimeTenantNameForTenant(tenantName);
+    String realtimeTenantTag = TagNameBuilder.getRealtimeTagForTenant(tenantName);
     List<String> instancesInClusterWithTag =
         _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeTenantTag);
     for (String instanceName : instancesInClusterWithTag) {
@@ -953,7 +956,7 @@ public class PinotHelixResourceManager {
 
   public PinotResourceManagerResponse deleteBrokerTenantFor(String tenantName) {
     PinotResourceManagerResponse response = new PinotResourceManagerResponse();
-    String brokerTag = TenantNameBuilder.getBrokerTenantNameForTenant(tenantName);
+    String brokerTag = TagNameBuilder.getBrokerTagForTenant(tenantName);
     List<String> instancesInClusterWithTag = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTag);
     for (String instance : instancesInClusterWithTag) {
       retagInstance(instance, brokerTag, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
@@ -963,18 +966,18 @@ public class PinotHelixResourceManager {
   }
 
   public Set<String> getAllInstancesForServerTenant(String tenantName) {
-    Set<String> instancesSet = new HashSet<String>();
+    Set<String> instancesSet = new HashSet<>();
     instancesSet.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getOfflineTenantNameForTenant(tenantName)));
+        TagNameBuilder.getOfflineTagForTenant(tenantName)));
     instancesSet.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getRealtimeTenantNameForTenant(tenantName)));
+        TagNameBuilder.getRealtimeTagForTenant(tenantName)));
     return instancesSet;
   }
 
   public Set<String> getAllInstancesForBrokerTenant(String tenantName) {
-    Set<String> instancesSet = new HashSet<String>();
+    Set<String> instancesSet = new HashSet<>();
     instancesSet.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getBrokerTenantNameForTenant(tenantName)));
+        TagNameBuilder.getBrokerTagForTenant(tenantName)));
     return instancesSet;
   }
 
@@ -1035,8 +1038,8 @@ public class PinotHelixResourceManager {
     TenantConfig tenantConfig;
     if (isSingleTenantCluster()) {
       tenantConfig = new TenantConfig();
-      tenantConfig.setBroker(TenantNameBuilder.DEFAULT_TENANT_NAME);
-      tenantConfig.setServer(TenantNameBuilder.DEFAULT_TENANT_NAME);
+      tenantConfig.setBroker(TagNameBuilder.DEFAULT_TENANT_NAME);
+      tenantConfig.setServer(TagNameBuilder.DEFAULT_TENANT_NAME);
       tableConfig.setTenantConfig(tenantConfig);
     } else {
       tenantConfig = tableConfig.getTenantConfig();
@@ -1047,17 +1050,45 @@ public class PinotHelixResourceManager {
 
     // Check if tenant exists before creating the table
     TableType tableType = tableConfig.getTableType();
-    String brokerTenantName = TenantNameBuilder.getBrokerTenantNameForTenant(tenantConfig.getBroker());
+    String brokerTenantName = TagNameBuilder.getBrokerTagForTenant(tenantConfig.getBroker());
     List<String> brokersForTenant = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTenantName);
     if (brokersForTenant.isEmpty()) {
       throw new InvalidTableConfigException(
           "Broker tenant: " + brokerTenantName + " does not exist for table: " + tableNameWithType);
     }
     String serverTenantName =
-        TenantNameBuilder.getTenantName(tenantConfig.getServer(), tableType.getServerType());
+        TagNameBuilder.getTagFromTenantAndServerType(tenantConfig.getServer(), tableType.getServerType());
     if (_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, serverTenantName).isEmpty()) {
       throw new InvalidTableConfigException(
           "Server tenant: " + serverTenantName + " does not exist for table: " + tableNameWithType);
+    }
+    TagOverrideConfig tagOverrideConfig = tenantConfig.getTagOverrideConfig();
+    if (tagOverrideConfig != null) {
+      String realtimeConsumingTag = tagOverrideConfig.getRealtimeConsuming();
+      if (realtimeConsumingTag != null) {
+        if (!TagNameBuilder.hasValidServerTagSuffix(realtimeConsumingTag)) {
+          throw new InvalidTableConfigException(
+              "Invalid realtime consuming tag: " + realtimeConsumingTag + ". Must have suffix _REALTIME or _OFFLINE");
+        }
+        if (_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeConsumingTag).isEmpty()) {
+          throw new InvalidTableConfigException(
+              "No instances found with overridden realtime consuming tag: " + realtimeConsumingTag + " for table: "
+                  + tableNameWithType);
+        }
+      }
+
+      String realtimeCompletedTag = tagOverrideConfig.getRealtimeCompleted();
+      if (realtimeCompletedTag != null) {
+        if (!TagNameBuilder.hasValidServerTagSuffix(realtimeCompletedTag)) {
+          throw new InvalidTableConfigException(
+              "Invalid realtime completed tag: " + realtimeCompletedTag + ". Must have suffix _REALTIME or _OFFLINE");
+        }
+        if (_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, realtimeCompletedTag).isEmpty()) {
+          throw new InvalidTableConfigException(
+              "No instances found with overridden realtime completed tag: " + realtimeCompletedTag + " for table: "
+                  + tableNameWithType);
+        }
+      }
     }
 
     SegmentsValidationAndRetentionConfig segmentsConfig = tableConfig.getValidationConfig();
@@ -1619,7 +1650,7 @@ public class PinotHelixResourceManager {
     Preconditions.checkNotNull(offlineTableConfig);
     int numReplicas = Integer.parseInt(offlineTableConfig.getValidationConfig().getReplication());
     String serverTenant =
-        TenantNameBuilder.getOfflineTenantNameForTenant(offlineTableConfig.getTenantConfig().getServer());
+        TagNameBuilder.getOfflineTagForTenant(offlineTableConfig.getTenantConfig().getServer());
     SegmentAssignmentStrategy segmentAssignmentStrategy = SegmentAssignmentStrategyFactory.getSegmentAssignmentStrategy(
         offlineTableConfig.getValidationConfig().getSegmentAssignmentStrategy());
     List<String> assignedInstances =
@@ -1919,16 +1950,22 @@ public class PinotHelixResourceManager {
 
   public List<String> getServerInstancesForTable(String tableName, TableType tableType) {
     TableConfig tableConfig = getTableConfig(tableName, tableType);
-    String serverTenantName =
-        TenantNameBuilder.getTenantName(tableConfig.getTenantConfig().getServer(), tableType.getServerType());
-    List<String> serverInstances = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, serverTenantName);
-    return serverInstances;
+    Set<String> serverInstances = new HashSet<>();
+    if (TableType.OFFLINE.equals(tableType)) {
+      OfflineTagConfig tagConfig =  new OfflineTagConfig(tableConfig);
+      serverInstances.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, tagConfig.getOfflineServerTag()));
+    } else if (TableType.REALTIME.equals(tableType)) {
+      RealtimeTagConfig tagConfig = new RealtimeTagConfig(tableConfig);
+      serverInstances.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, tagConfig.getConsumingServerTag()));
+      serverInstances.addAll(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName, tagConfig.getCompletedServerTag()));
+    }
+    return Lists.newArrayList(serverInstances);
   }
 
   public List<String> getBrokerInstancesForTable(String tableName, TableType tableType) {
     TableConfig tableConfig = getTableConfig(tableName, tableType);
     String brokerTenantName =
-        TenantNameBuilder.getBrokerTenantNameForTenant(tableConfig.getTenantConfig().getBroker());
+        TagNameBuilder.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker());
     List<String> serverInstances = _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, brokerTenantName);
     return serverInstances;
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -15,13 +15,13 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
+import com.linkedin.pinot.common.config.RealtimeTagConfig;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.instance.InstanceZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
 import com.linkedin.pinot.common.utils.CommonConstants.Helix;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.StringUtil;
 import com.linkedin.pinot.common.utils.retry.RetryPolicies;
 import com.linkedin.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
@@ -169,10 +169,9 @@ public class PinotTableIdealStateBuilder {
   public static IdealState buildInitialHighLevelRealtimeIdealStateFor(String realtimeTableName,
       TableConfig realtimeTableConfig, HelixAdmin helixAdmin, String helixClusterName,
       ZkHelixPropertyStore<ZNRecord> zkHelixPropertyStore) {
-    String realtimeServerTenant =
-        TenantNameBuilder.getRealtimeTenantNameForTenant(realtimeTableConfig.getTenantConfig().getServer());
+    RealtimeTagConfig realtimeTagConfig = new RealtimeTagConfig(realtimeTableConfig);
     final List<String> realtimeInstances = helixAdmin.getInstancesInClusterWithTag(helixClusterName,
-        realtimeServerTenant);
+        realtimeTagConfig.getConsumingServerTag());
     IdealState idealState = buildEmptyKafkaConsumerRealtimeIdealStateFor(realtimeTableName, 1);
     if (realtimeInstances.size() % Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()) != 0) {
       throw new RuntimeException(

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BalanceNumSegmentAssignmentStrategy.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.controller.helix.core.sharding;
 
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.Pairs;
 import com.linkedin.pinot.common.utils.Pairs.Number2ObjectPair;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
@@ -45,7 +45,7 @@ public class BalanceNumSegmentAssignmentStrategy implements SegmentAssignmentStr
   public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
       String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(segmentMetadata.getTableName());
-    String serverTenantName = TenantNameBuilder.getOfflineTenantNameForTenant(tenantName);
+    String serverTenantName = TagNameBuilder.getOfflineTagForTenant(tenantName);
 
     List<String> selectedInstances = new ArrayList<>();
     Map<String, Integer> currentNumSegmentsPerInstanceMap = new HashMap<>();

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/BucketizedSegmentStrategy.java
@@ -15,8 +15,8 @@
  */
 package com.linkedin.pinot.controller.helix.core.sharding;
 
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +39,7 @@ public class BucketizedSegmentStrategy implements SegmentAssignmentStrategy {
   @Override
   public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
       String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
-    String serverTenantName = TenantNameBuilder.getOfflineTenantNameForTenant(tenantName);
+    String serverTenantName = TagNameBuilder.getOfflineTagForTenant(tenantName);
 
     List<String> allInstances = HelixHelper.getEnabledInstancesWithTag(helixAdmin, helixClusterName, serverTenantName);
     List<String> selectedInstanceList = new ArrayList<>();

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/sharding/RandomAssignmentStrategy.java
@@ -15,8 +15,8 @@
  */
 package com.linkedin.pinot.controller.helix.core.sharding;
 
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,7 +41,7 @@ public class RandomAssignmentStrategy implements SegmentAssignmentStrategy {
   @Override
   public List<String> getAssignedInstances(HelixAdmin helixAdmin, ZkHelixPropertyStore<ZNRecord> propertyStore,
       String helixClusterName, SegmentMetadata segmentMetadata, int numReplicas, String tenantName) {
-    String serverTenantName = TenantNameBuilder.getOfflineTenantNameForTenant(tenantName);
+    String serverTenantName = TagNameBuilder.getOfflineTagForTenant(tenantName);
     final Random random = new Random(System.currentTimeMillis());
 
     List<String> allInstanceList =

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -17,8 +17,8 @@ package com.linkedin.pinot.controller.helix;
 
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.common.utils.helix.HelixHelper;
 import com.linkedin.pinot.controller.utils.SegmentMetadataMockUtils;
@@ -33,8 +33,8 @@ import org.testng.annotations.Test;
 public class ControllerInstanceToggleTest extends ControllerTest {
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
-  private static final String SERVER_TENANT_NAME = TenantNameBuilder.getOfflineTenantNameForTenant(null);
-  private static final String BROKER_TENANT_NAME = TenantNameBuilder.getBrokerTenantNameForTenant(null);
+  private static final String SERVER_TAG_NAME = TagNameBuilder.getOfflineTagForTenant(null);
+  private static final String BROKER_TAG_NAME = TagNameBuilder.getBrokerTagForTenant(null);
   private static final int NUM_INSTANCES = 3;
 
   private final String _helixClusterName = getHelixClusterName();
@@ -76,25 +76,25 @@ public class ControllerInstanceToggleTest extends ControllerTest {
 
     // Disable server instances
     int numEnabledInstances = NUM_INSTANCES;
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, SERVER_TENANT_NAME)) {
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, SERVER_TAG_NAME)) {
       sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "disable");
       checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, --numEnabledInstances);
     }
 
     // Enable server instances
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, SERVER_TENANT_NAME)) {
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, SERVER_TAG_NAME)) {
       sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "ENABLE");
       checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, ++numEnabledInstances);
     }
 
     // Disable broker instances
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, BROKER_TENANT_NAME)) {
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, BROKER_TAG_NAME)) {
       sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "Disable");
       checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, --numEnabledInstances);
     }
 
     // Enable broker instances
-    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, BROKER_TENANT_NAME)) {
+    for (String instanceName : _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, BROKER_TAG_NAME)) {
       sendPostRequest(_controllerRequestURLBuilder.forInstanceState(instanceName), "Enable");
       checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, ++numEnabledInstances);
     }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerSentinelTestV2.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerSentinelTestV2.java
@@ -16,8 +16,8 @@
 package com.linkedin.pinot.controller.helix;
 
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.utils.SegmentMetadataMockUtils;
 import java.io.IOException;
@@ -83,13 +83,13 @@ public class ControllerSentinelTestV2 extends ControllerTest {
             .size(), 0);
 
     Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getBrokerTenantNameForTenant(TenantNameBuilder.DEFAULT_TENANT_NAME))
+        TagNameBuilder.getBrokerTagForTenant(TagNameBuilder.DEFAULT_TENANT_NAME))
         .size(), 20);
     Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getRealtimeTenantNameForTenant(TenantNameBuilder.DEFAULT_TENANT_NAME))
+        TagNameBuilder.getRealtimeTagForTenant(TagNameBuilder.DEFAULT_TENANT_NAME))
         .size(), 20);
     Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-        TenantNameBuilder.getOfflineTenantNameForTenant(TenantNameBuilder.DEFAULT_TENANT_NAME))
+        TagNameBuilder.getOfflineTagForTenant(TagNameBuilder.DEFAULT_TENANT_NAME))
         .size(), 20);
   }
 }

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTenantTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/ControllerTenantTest.java
@@ -15,9 +15,9 @@
  */
 package com.linkedin.pinot.controller.helix;
 
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import java.io.IOException;
 import org.json.JSONException;
@@ -56,12 +56,12 @@ public class ControllerTenantTest extends ControllerTest {
   public void testBrokerTenant() throws IOException, JSONException {
     // Create broker tenants
     for (int i = 1; i <= NUM_BROKER_TAGS; i++) {
-      String brokerTag = BROKER_TAG_PREFIX + i;
+      String brokerTenant = BROKER_TAG_PREFIX + i;
       JSONObject payload =
-          ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, NUM_BROKERS_PER_TAG);
+          ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTenant, NUM_BROKERS_PER_TAG);
       sendPostRequest(_controllerRequestURLBuilder.forTenantCreate(), payload.toString());
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getBrokerTenantNameForTenant(brokerTag)).size(), NUM_BROKERS_PER_TAG);
+          TagNameBuilder.getBrokerTagForTenant(brokerTenant)).size(), NUM_BROKERS_PER_TAG);
       Assert.assertEquals(
           _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
               .size(), NUM_INSTANCES - i * NUM_BROKERS_PER_TAG);
@@ -83,11 +83,11 @@ public class ControllerTenantTest extends ControllerTest {
 
     // Update broker tenants
     for (int i = 0; i <= NUM_INSTANCES - (NUM_BROKER_TAGS - 1) * NUM_BROKERS_PER_TAG; i++) {
-      String brokerTag = BROKER_TAG_PREFIX + 1;
-      JSONObject payload = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTag, i);
+      String brokerTenant = BROKER_TAG_PREFIX + 1;
+      JSONObject payload = ControllerRequestBuilderUtil.buildBrokerTenantCreateRequestJSON(brokerTenant, i);
       sendPutRequest(_controllerRequestURLBuilder.forTenantCreate(), payload.toString());
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getBrokerTenantNameForTenant(brokerTag)).size(), i);
+          TagNameBuilder.getBrokerTagForTenant(brokerTenant)).size(), i);
       Assert.assertEquals(
           _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
               .size(), NUM_INSTANCES - (NUM_BROKER_TAGS - 1) * NUM_BROKERS_PER_TAG - i);
@@ -95,10 +95,10 @@ public class ControllerTenantTest extends ControllerTest {
 
     // Delete broker tenants
     for (int i = 1; i <= NUM_BROKER_TAGS; i++) {
-      String brokerTag = BROKER_TAG_PREFIX + i;
-      sendDeleteRequest(_controllerRequestURLBuilder.forBrokerTenantDelete(brokerTag));
+      String brokerTenant = BROKER_TAG_PREFIX + i;
+      sendDeleteRequest(_controllerRequestURLBuilder.forBrokerTenantDelete(brokerTenant));
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getBrokerTenantNameForTenant(brokerTag)).size(), 0);
+          TagNameBuilder.getBrokerTagForTenant(brokerTenant)).size(), 0);
       Assert.assertEquals(
           _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE)
               .size(), NUM_INSTANCES - (NUM_BROKER_TAGS - i) * NUM_BROKERS_PER_TAG);
@@ -109,15 +109,15 @@ public class ControllerTenantTest extends ControllerTest {
   public void testServerTenant() throws IOException, JSONException {
     // Create server tenants
     for (int i = 1; i <= NUM_SERVER_TAGS; i++) {
-      String serverTag = SERVER_TAG_PREFIX + i;
+      String serverTenant = SERVER_TAG_PREFIX + i;
       JSONObject payload =
-          ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, NUM_SERVERS_PER_TAG,
+          ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTenant, NUM_SERVERS_PER_TAG,
               NUM_OFFLINE_SERVERS_PER_TAG, NUM_REALTIME_SERVERS_PER_TAG);
       sendPostRequest(_controllerRequestURLBuilder.forTenantCreate(), payload.toString());
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getOfflineTenantNameForTenant(serverTag)).size(), NUM_OFFLINE_SERVERS_PER_TAG);
+          TagNameBuilder.getOfflineTagForTenant(serverTenant)).size(), NUM_OFFLINE_SERVERS_PER_TAG);
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getRealtimeTenantNameForTenant(serverTag)).size(), NUM_REALTIME_SERVERS_PER_TAG);
+          TagNameBuilder.getRealtimeTagForTenant(serverTenant)).size(), NUM_REALTIME_SERVERS_PER_TAG);
       Assert.assertEquals(
           _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
               .size(), NUM_INSTANCES - i * NUM_SERVERS_PER_TAG);
@@ -140,16 +140,16 @@ public class ControllerTenantTest extends ControllerTest {
     // Update server tenants
     // Note: server tenants cannot scale down
     for (int i = 0; i <= (NUM_INSTANCES - NUM_SERVER_TAGS * NUM_SERVERS_PER_TAG) / 2; i++) {
-      String serverTag = SERVER_TAG_PREFIX + 1;
+      String serverTenant = SERVER_TAG_PREFIX + 1;
       JSONObject payload =
-          ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTag, NUM_SERVERS_PER_TAG + i * 2,
+          ControllerRequestBuilderUtil.buildServerTenantCreateRequestJSON(serverTenant, NUM_SERVERS_PER_TAG + i * 2,
               NUM_OFFLINE_SERVERS_PER_TAG + i, NUM_REALTIME_SERVERS_PER_TAG + i);
       sendPutRequest(_controllerRequestURLBuilder.forTenantCreate(), payload.toString());
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getOfflineTenantNameForTenant(serverTag)).size(),
+          TagNameBuilder.getOfflineTagForTenant(serverTenant)).size(),
           NUM_OFFLINE_SERVERS_PER_TAG + i);
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getRealtimeTenantNameForTenant(serverTag)).size(),
+          TagNameBuilder.getRealtimeTagForTenant(serverTenant)).size(),
           NUM_REALTIME_SERVERS_PER_TAG + i);
       Assert.assertEquals(
           _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
@@ -158,12 +158,12 @@ public class ControllerTenantTest extends ControllerTest {
 
     // Delete server tenants
     for (int i = 1; i < NUM_SERVER_TAGS; i++) {
-      String serverTag = SERVER_TAG_PREFIX + i;
-      sendDeleteRequest(_controllerRequestURLBuilder.forServerTenantDelete(serverTag));
+      String serverTenant = SERVER_TAG_PREFIX + i;
+      sendDeleteRequest(_controllerRequestURLBuilder.forServerTenantDelete(serverTenant));
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getOfflineTenantNameForTenant(serverTag)).size(), 0);
+          TagNameBuilder.getOfflineTagForTenant(serverTenant)).size(), 0);
       Assert.assertEquals(_helixAdmin.getInstancesInClusterWithTag(_helixClusterName,
-          TenantNameBuilder.getRealtimeTenantNameForTenant(serverTag)).size(), 0);
+          TagNameBuilder.getRealtimeTagForTenant(serverTenant)).size(), 0);
       Assert.assertEquals(
           _helixAdmin.getInstancesInClusterWithTag(_helixClusterName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE)
               .size(), NUM_INSTANCES - (NUM_SERVER_TAGS - i) * NUM_SERVERS_PER_TAG);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -18,13 +18,13 @@ package com.linkedin.pinot.controller.helix.core;
 import com.google.common.collect.BiMap;
 import com.linkedin.pinot.common.config.TableConfig;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.config.Tenant;
 import com.linkedin.pinot.common.exception.InvalidConfigException;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.TenantRole;
 import com.linkedin.pinot.common.utils.ZkStarter;
 import com.linkedin.pinot.controller.ControllerConf;
@@ -101,7 +101,7 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
     // Untag all Brokers assigned to broker tenant
     for (String brokerInstance : _helixResourceManager.getAllInstancesForBrokerTenant(BROKER_TENANT_NAME)) {
       _helixAdmin.removeInstanceTag(_helixClusterName, brokerInstance,
-          TenantNameBuilder.getBrokerTenantNameForTenant(BROKER_TENANT_NAME));
+          TagNameBuilder.getBrokerTagForTenant(BROKER_TENANT_NAME));
       _helixAdmin.addInstanceTag(_helixClusterName, brokerInstance, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
     }
 
@@ -122,7 +122,7 @@ public class PinotHelixResourceManagerTest extends ControllerTest {
     // Untag all Brokers for other tests
     for (String brokerInstance : _helixResourceManager.getAllInstancesForBrokerTenant(BROKER_TENANT_NAME)) {
       _helixAdmin.removeInstanceTag(_helixClusterName, brokerInstance,
-          TenantNameBuilder.getBrokerTenantNameForTenant(BROKER_TENANT_NAME));
+          TagNameBuilder.getBrokerTagForTenant(BROKER_TENANT_NAME));
       _helixAdmin.addInstanceTag(_helixClusterName, brokerInstance, CommonConstants.Helix.UNTAGGED_BROKER_INSTANCE);
     }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/validation/ValidationManagerTest.java
@@ -16,11 +16,11 @@
 package com.linkedin.pinot.controller.validation;
 
 import com.linkedin.pinot.common.config.TableConfig;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.metadata.segment.OfflineSegmentZKMetadata;
 import com.linkedin.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import com.linkedin.pinot.common.segment.SegmentMetadata;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.HLCSegmentName;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.ZkStarter;
@@ -98,8 +98,7 @@ public class ValidationManagerTest {
     IdealState idealState = HelixHelper.getBrokerIdealStates(helixAdmin, HELIX_CLUSTER_NAME);
     // Ensure that the broker resource is not rebuilt.
     Assert.assertTrue(idealState.getInstanceSet(partitionName)
-        .equals(_pinotHelixResourceManager.getAllInstancesForBrokerTenant(
-            TenantNameBuilder.DEFAULT_TENANT_NAME)));
+        .equals(_pinotHelixResourceManager.getAllInstancesForBrokerTenant(TagNameBuilder.DEFAULT_TENANT_NAME)));
     _pinotHelixResourceManager.rebuildBrokerResourceFromHelixTags(partitionName);
 
     // Add another table that needs to be rebuilt
@@ -116,18 +115,16 @@ public class ValidationManagerTest {
     instanceConfig.setPort("2");
     helixAdmin.addInstance(HELIX_CLUSTER_NAME, instanceConfig);
     helixAdmin.addInstanceTag(HELIX_CLUSTER_NAME, instanceConfig.getInstanceName(),
-        TenantNameBuilder.getBrokerTenantNameForTenant(TenantNameBuilder.DEFAULT_TENANT_NAME));
+        TagNameBuilder.getBrokerTagForTenant(TagNameBuilder.DEFAULT_TENANT_NAME));
     idealState = HelixHelper.getBrokerIdealStates(helixAdmin, HELIX_CLUSTER_NAME);
     // Assert that the two don't equal before the call to rebuild the broker resource.
     Assert.assertTrue(!idealState.getInstanceSet(partitionNameTwo)
-        .equals(_pinotHelixResourceManager.getAllInstancesForBrokerTenant(
-            TenantNameBuilder.DEFAULT_TENANT_NAME)));
+        .equals(_pinotHelixResourceManager.getAllInstancesForBrokerTenant(TagNameBuilder.DEFAULT_TENANT_NAME)));
     _pinotHelixResourceManager.rebuildBrokerResourceFromHelixTags(partitionNameTwo);
     idealState = HelixHelper.getBrokerIdealStates(helixAdmin, HELIX_CLUSTER_NAME);
     // Assert that the two do equal after being rebuilt.
     Assert.assertTrue(idealState.getInstanceSet(partitionNameTwo)
-        .equals(_pinotHelixResourceManager.getAllInstancesForBrokerTenant(
-            TenantNameBuilder.DEFAULT_TENANT_NAME)));
+        .equals(_pinotHelixResourceManager.getAllInstancesForBrokerTenant(TagNameBuilder.DEFAULT_TENANT_NAME)));
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
+++ b/pinot-integration-tests/src/test/java/com/linkedin/pinot/integration/tests/SegmentCompletionIntegrationTests.java
@@ -18,9 +18,9 @@ package com.linkedin.pinot.integration.tests;
 
 import com.google.common.base.Function;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.protocols.SegmentCompletionProtocol;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.LLCSegmentName;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ZkStarter;
@@ -93,7 +93,7 @@ public class SegmentCompletionIntegrationTests extends LLCRealtimeClusterIntegra
     // Add Helix tag to the server
     _serverHelixManager.getClusterManagmentTool()
         .addInstanceTag(_clusterName, _serverInstance,
-            TableNameBuilder.REALTIME.tableNameWithType(TenantNameBuilder.DEFAULT_TENANT_NAME));
+            TableNameBuilder.REALTIME.tableNameWithType(TagNameBuilder.DEFAULT_TENANT_NAME));
 
     // Initialize controller leader locator
     ControllerLeaderLocator.create(_serverHelixManager);

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/HelixServerStarter.java
@@ -19,10 +19,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.config.TableNameBuilder;
+import com.linkedin.pinot.common.config.TagNameBuilder;
 import com.linkedin.pinot.common.metadata.ZKMetadataProvider;
 import com.linkedin.pinot.common.metrics.ServerMeter;
 import com.linkedin.pinot.common.utils.CommonConstants;
-import com.linkedin.pinot.common.utils.TenantNameBuilder;
 import com.linkedin.pinot.common.utils.MmapUtils;
 import com.linkedin.pinot.common.utils.NetUtil;
 import com.linkedin.pinot.common.utils.ServiceStatus;
@@ -222,9 +222,9 @@ public class HelixServerStarter {
     if (instanceTags == null || instanceTags.size() == 0) {
       if (ZKMetadataProvider.getClusterTenantIsolationEnabled(_helixManager.getHelixPropertyStore())) {
         _helixAdmin.addInstanceTag(clusterName, instanceName,
-            TableNameBuilder.OFFLINE.tableNameWithType(TenantNameBuilder.DEFAULT_TENANT_NAME));
+            TableNameBuilder.OFFLINE.tableNameWithType(TagNameBuilder.DEFAULT_TENANT_NAME));
         _helixAdmin.addInstanceTag(clusterName, instanceName,
-            TableNameBuilder.REALTIME.tableNameWithType(TenantNameBuilder.DEFAULT_TENANT_NAME));
+            TableNameBuilder.REALTIME.tableNameWithType(TagNameBuilder.DEFAULT_TENANT_NAME));
       } else {
         _helixAdmin.addInstanceTag(clusterName, instanceName, CommonConstants.Helix.UNTAGGED_SERVER_INSTANCE);
       }


### PR DESCRIPTION
Added a tag override config to the tenantConfig in tableConfig. This config will specify overrides for the realtime consuming or realtime completed server tag to use for the table.
This config is used inside TagConfig to return the appropriate tags