### PR TITLE
license - unbreak local build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1000,7 +1000,7 @@
             <exclude>**/com/linkedin/pinot/common/request/*.*</exclude>
             <exclude>**/com/linkedin/pinot/common/response/*.*</exclude>
             <exclude>pinot-dashboard/**/*.*</exclude>
-            <exclude>thirdeye/**/*.*</exclude>
+            <exclude>thirdeye/**/*</exclude>
             <!-- Files that already had a different license header -->
             <exclude>**/NamedThreadFactory.java</exclude>
             <exclude>**/FileUploadUtils.java</exclude>


### PR DESCRIPTION
The current license plugin config breaks for thirdeye with fully built frontend. This PR fixes the exclusion path to unbreak local builds of pinot and thirdeye