### PR TITLE
Fix realtime table schema name reference

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1087,7 +1087,7 @@ public class PinotHelixResourceManager {
         break;
       case REALTIME:
         // Ensure that realtime table is not created for the realtime table
-        Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableNameWithType);
+        Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, segmentsConfig.getSchemaName());
         if (schema == null) {
           throw new InvalidTableConfigException("No schema defined for realtime table: " + tableNameWithType);
         }

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema
@@ -1,5 +1,5 @@
 {
-  "schemaName": "mytable",
+  "schemaName": "myschema",
   "dimensionFieldSpecs": [
     {
       "name": "AirlineID",

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_extra_columns.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_extra_columns.schema
@@ -1,5 +1,5 @@
 {
-  "schemaName": "mytable",
+  "schemaName": "myschema",
   "dimensionFieldSpecs": [
     {
       "name": "AirlineID",

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_missing_columns.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_default_column_test_missing_columns.schema
@@ -1,5 +1,5 @@
 {
-  "schemaName": "mytable",
+  "schemaName": "myschema",
   "dimensionFieldSpecs": [
     {
       "name": "ArrTimeBlk",

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema
@@ -1,5 +1,5 @@
 {
-  "schemaName": "mytable",
+  "schemaName": "myschema",
   "dimensionFieldSpecs": [
     {
       "name": "AirlineID",


### PR DESCRIPTION
https://github.com/linkedin/pinot/pull/2777 introduced a small issue when creating realtime tables whose schema name does not match the table name.

The integration unit tests didn't catch this because as luck would have it schemaName = tableName for those tests.  This PR resolves the issue and updates the schema names in those unit tests.