### PR TITLE
Add a test case to cover realtime table creation with diferent schem  name than the table name

### DIFF
--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -140,8 +140,17 @@ public class PinotTableRestletResourceTest extends ControllerTest {
       Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 400"));
     }
 
+    // Creating a REALTIME table with a different schema name in the config should succeed (backwards compatibility mode)
+    realtimeTableConfig.setTableName(REALTIME_TABLE_NAME);
+    String schemaName = "differentRTSchema";
+    _realtimeBuilder.setSchemaName(schemaName);
+    addDummySchema(schemaName);
+    TableConfig diffConfig = _realtimeBuilder.build();
+    sendPostRequest(_createTableUrl, realtimeTableConfig.toJSONConfigString());
+
     // Create a REALTIME table with a valid name and schema which should succeed
     realtimeTableConfig.setTableName(REALTIME_TABLE_NAME);
+    _realtimeBuilder.setSchemaName(REALTIME_TABLE_NAME);
     String realtimeTableJSONConfigString = realtimeTableConfig.toJSONConfigString();
     sendPostRequest(_createTableUrl, realtimeTableJSONConfigString);
 


### PR DESCRIPTION
Adding a test case to cover the case brought up in #2838.