### PR TITLE
Add log to track field name when exception thrown; Hot fix for calculating buffer length

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -139,9 +139,9 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         try {
           dictionaryCreator.build();
         } catch (Exception e) {
-          LOGGER.error("Error building dictionary for field: {}, cardinality: {}, max length in bytes: {}",
+          LOGGER.error("Error building dictionary for field: {}, cardinality: {}, number of bytes per entry: {}",
               fieldSpec.getName(), indexCreationInfo.getDistinctValueCount(), dictionaryCreator.getNumBytesPerEntry());
-          Utils.rethrowException(e);
+          throw e;
         }
 
         // Initialize forward index creator

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -16,6 +16,7 @@
 package com.linkedin.pinot.core.segment.creator.impl;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.pinot.common.Utils;
 import com.linkedin.pinot.common.config.ColumnPartitionConfig;
 import com.linkedin.pinot.common.data.DateTimeFieldSpec;
 import com.linkedin.pinot.common.data.FieldSpec;
@@ -53,6 +54,8 @@ import java.util.Set;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.math.IntRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -67,6 +70,7 @@ import static com.linkedin.pinot.core.segment.creator.impl.V1Constants.MetadataK
 // TODO: check resource leaks
 public class SegmentColumnarIndexCreator implements SegmentCreator {
   // TODO Refactor class name to match interface name
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentColumnarIndexCreator.class);
   private SegmentGeneratorConfig config;
   private Map<String, ColumnIndexCreationInfo> indexCreationInfoMap;
   private Map<String, SegmentDictionaryCreator> _dictionaryCreatorMap = new HashMap<>();
@@ -86,8 +90,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
   @Override
   public void init(SegmentGeneratorConfig segmentCreationSpec, SegmentIndexCreationInfo segmentIndexCreationInfo,
-      Map<String, ColumnIndexCreationInfo> indexCreationInfoMap, Schema schema, File outDir)
-      throws Exception {
+      Map<String, ColumnIndexCreationInfo> indexCreationInfoMap, Schema schema, File outDir) throws Exception {
     docIdCounter = 0;
     config = segmentCreationSpec;
     this.indexCreationInfoMap = indexCreationInfoMap;
@@ -133,7 +136,13 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         _dictionaryCreatorMap.put(columnName, dictionaryCreator);
 
         // Create dictionary
-        dictionaryCreator.build();
+        try {
+          dictionaryCreator.build();
+        } catch (Exception e) {
+          LOGGER.error("Error building dictionary for field: {}, cardinality: {}, max length in bytes: {}",
+              fieldSpec.getName(), indexCreationInfo.getDistinctValueCount(), dictionaryCreator.getNumBytesPerEntry());
+          Utils.rethrowException(e);
+        }
 
         // Initialize forward index creator
         int cardinality = indexCreationInfo.getDistinctValueCount();
@@ -172,7 +181,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         Preconditions.checkState(!invertedIndexColumns.contains(columnName),
             "Cannot create inverted index for raw index column: %s", columnName);
 
-        ChunkCompressorFactory.CompressionType compressionType = segmentCreationSpec.getColumnCompressionType(columnName);
+        ChunkCompressorFactory.CompressionType compressionType =
+            segmentCreationSpec.getColumnCompressionType(columnName);
 
         // Initialize forward index creator
         _forwardIndexCreatorMap.put(columnName,
@@ -254,16 +264,14 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
   }
 
   @Override
-  public void seal()
-      throws ConfigurationException, IOException {
+  public void seal() throws ConfigurationException, IOException {
     for (InvertedIndexCreator invertedIndexCreator : _invertedIndexCreatorMap.values()) {
       invertedIndexCreator.seal();
     }
     writeMetadata();
   }
 
-  void writeMetadata()
-      throws ConfigurationException {
+  void writeMetadata() throws ConfigurationException {
     PropertiesConfiguration properties =
         new PropertiesConfiguration(new File(_indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME));
 
@@ -467,8 +475,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
    */
   public static SingleValueRawIndexCreator getRawIndexCreatorForColumn(File file,
       ChunkCompressorFactory.CompressionType compressionType, String column, FieldSpec.DataType dataType, int totalDocs,
-      int lengthOfLongestEntry)
-      throws IOException {
+      int lengthOfLongestEntry) throws IOException {
 
     SingleValueRawIndexCreator indexCreator;
     switch (dataType) {
@@ -506,8 +513,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public void close() throws IOException {
     for (SegmentDictionaryCreator dictionaryCreator : _dictionaryCreatorMap.values()) {
       dictionaryCreator.close();
     }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/segment/creator/impl/SegmentDictionaryCreator.java
@@ -69,7 +69,7 @@ public class SegmentDictionaryCreator implements Closeable {
         _intValueToIndexMap = new Int2IntOpenHashMap(numValues);
 
         try (PinotDataBuffer dataBuffer = PinotDataBuffer.fromFile(_dictionaryFile, 0,
-            numValues * V1Constants.Numbers.INTEGER_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
+            (long) numValues * V1Constants.Numbers.INTEGER_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
             _dictionaryFile.getName());
             FixedByteValueReaderWriter writer = new FixedByteValueReaderWriter(dataBuffer)) {
           for (int i = 0; i < numValues; i++) {
@@ -88,7 +88,7 @@ public class SegmentDictionaryCreator implements Closeable {
         _longValueToIndexMap = new Long2IntOpenHashMap(numValues);
 
         try (PinotDataBuffer dataBuffer = PinotDataBuffer.fromFile(_dictionaryFile, 0,
-            numValues * V1Constants.Numbers.LONG_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
+            (long) numValues * V1Constants.Numbers.LONG_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
             _dictionaryFile.getName());
             FixedByteValueReaderWriter writer = new FixedByteValueReaderWriter(dataBuffer)) {
           for (int i = 0; i < numValues; i++) {
@@ -107,7 +107,7 @@ public class SegmentDictionaryCreator implements Closeable {
         _floatValueToIndexMap = new Float2IntOpenHashMap(numValues);
 
         try (PinotDataBuffer dataBuffer = PinotDataBuffer.fromFile(_dictionaryFile, 0,
-            numValues * V1Constants.Numbers.FLOAT_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
+            (long) numValues * V1Constants.Numbers.FLOAT_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
             _dictionaryFile.getName());
             FixedByteValueReaderWriter writer = new FixedByteValueReaderWriter(dataBuffer)) {
           for (int i = 0; i < numValues; i++) {
@@ -126,7 +126,7 @@ public class SegmentDictionaryCreator implements Closeable {
         _doubleValueToIndexMap = new Double2IntOpenHashMap(numValues);
 
         try (PinotDataBuffer dataBuffer = PinotDataBuffer.fromFile(_dictionaryFile, 0,
-            numValues * V1Constants.Numbers.DOUBLE_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
+            (long) numValues * V1Constants.Numbers.DOUBLE_SIZE, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
             _dictionaryFile.getName());
             FixedByteValueReaderWriter writer = new FixedByteValueReaderWriter(dataBuffer)) {
           for (int i = 0; i < numValues; i++) {
@@ -154,8 +154,9 @@ public class SegmentDictionaryCreator implements Closeable {
           _numBytesPerEntry = Math.max(_numBytesPerEntry, valueBytes.length);
         }
 
-        try (PinotDataBuffer dataBuffer = PinotDataBuffer.fromFile(_dictionaryFile, 0, numValues * _numBytesPerEntry,
-            ReadMode.mmap, FileChannel.MapMode.READ_WRITE, _dictionaryFile.getName());
+        try (PinotDataBuffer dataBuffer = PinotDataBuffer.fromFile(_dictionaryFile, 0,
+            (long) numValues * _numBytesPerEntry, ReadMode.mmap, FileChannel.MapMode.READ_WRITE,
+            _dictionaryFile.getName());
             FixedByteValueReaderWriter writer = new FixedByteValueReaderWriter(dataBuffer)) {
           for (int i = 0; i < numValues; i++) {
             byte[] value = sortedStringBytes[i];


### PR DESCRIPTION
This PR adds log to track the field name when exception happens. 
Currently if some exceptions like `IndexOutOfBoundsException` are thrown, we don't know which field it is, which makes us hard to debug.
This PR also hot fixes the calculation of buffer length. Basically if two factors in the multiplication are of type integer, then the result is of type integer as well. Casting one of the factor to long will fix the problem.