### PR TITLE
Remove declared exceptions that cannot be thrown

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/utils/SchemaUtils.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/utils/SchemaUtils.java
@@ -59,8 +59,7 @@ public class SchemaUtils {
   /**
    * Wrap {@link Schema} into a {@link ZNRecord}.
    */
-  public static ZNRecord toZNRecord(@Nonnull Schema schema)
-      throws IllegalArgumentException, IllegalAccessException {
+  public static ZNRecord toZNRecord(@Nonnull Schema schema) {
     ZNRecord record = new ZNRecord(schema.getSchemaName());
     record.setSimpleField("schemaJSON", schema.getJSONSchema());
     return record;

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -985,7 +985,7 @@ public class PinotHelixResourceManager {
   /**
    * Schema APIs
    */
-  public void addOrUpdateSchema(Schema schema) throws IllegalArgumentException, IllegalAccessException {
+  public void addOrUpdateSchema(Schema schema) {
     ZNRecord record = SchemaUtils.toZNRecord(schema);
     String name = schema.getSchemaName();
     PinotHelixPropertyStoreZnRecordProvider propertyStoreHelper =


### PR DESCRIPTION
Remove exceptions that cannot be thrown by the code in the
method (IllegalAccessException) and subclasses of RuntimeException
(IllegalArgumentException).