### PR TITLE
[TE] Fix for Alert Page graph dimension display

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/component.js
@@ -2,12 +2,14 @@
  * Wrapper component for the anomaly-graph component as used in the self-serve flow.
  * It handles presentation of the graph under various loading and error conditions.
  * @module components/self-serve-graph
- * @property {Boolean} isMetricDataLoading  - is primary metric data still loading
- * @property {Boolean} isMetricDataInvalid  - has the metric data been found to be not graphable
- * @property {Boolean} isDimensionFetchDone - are we done preparing dimension data
- * @property {Object} metricData            - primary metric data
- * @property {Array} topDimensions          - top x dimensions to load aside from primary metric
- * @property {String} componentId           - id for the graph wrapper element
+ * @property {Boolean} isMetricDataLoading    - is primary metric data still loading
+ * @property {Boolean} isMetricDataInvalid    - has the metric data been found to be not graphable
+ * @property {Boolean} isDimensionFetchDone   - are we done preparing dimension data
+ * @property {Boolean} isSecondaryDataLoading - loads spinner if peripheral data load is made
+ * @property {Boolean} removeGraphMargin      - render with or without extra margins
+ * @property {Object} metricData              - primary metric data
+ * @property {Array} topDimensions            - top x dimensions to load aside from primary metric
+ * @property {String} componentId             - id for the graph wrapper element
  * @example
     {{self-serve-graph
       isMetricDataLoading=false
@@ -25,18 +27,15 @@ import Component from '@ember/component';
 import { computed, set } from '@ember/object';
 
 export default Component.extend({
-
+  classNames: ['col-xs-12', 'te-graph-container'],
+  classNameBindings: ['removeGraphMargin:te-graph-container--marginless'],
   isMetricDataLoading: true,
   isMetricDataInvalid: false,
   isDimensionFetchDone: false,
+  isSecondaryDataLoading: false,
   metricData: {},
   topDimensions: [],
   componentId: '',
-
-  graphMessageText: {
-    loading: 'Graph will appear here when data is loaded...',
-    error: 'Could not load graph data for this metric...'
-  },
 
   /**
    * Standard legend settings for graph
@@ -60,6 +59,42 @@ export default Component.extend({
     function() {
       const topDimensions = this.get('topDimensions');
       return topDimensions ? this.get('topDimensions').filterBy('isSelected') : [];
+    }
+  ),
+
+  /**
+   * Determines pending state of graph
+   * @returns {Boolean}
+   */
+  isMetricDataPending: computed(
+    'isMetricSelected',
+    'isMetricDataLoading',
+    function() {
+      const {
+        isMetricSelected,
+        isMetricDataLoading
+      } = this.getProperties('isMetricSelected', 'isMetricDataLoading');
+      return !this.get('isMetricSelected') || this.get('isMetricDataLoading');
+    }
+  ),
+
+  /**
+   * Determines whether peripheral data for the graph is loading
+   * @returns {Boolean}
+   */
+  isAnythingLoading: computed.or('isMetricDataLoading', 'isSecondaryDataLoading'),
+
+  /**
+   * Sets the message text over the graph placeholder before data is loaded
+   * @method graphMessageText
+   * @return {String} the appropriate graph placeholder text
+   */
+  graphMessageText: computed(
+    'isMetricDataInvalid',
+    function() {
+      const defaultMsg = 'Graph will appear here when data is loaded...';
+      const invalidMsg = 'Sorry, metric has no current data';
+      return this.get('isMetricDataInvalid') ? invalidMsg : defaultMsg;
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
@@ -1,43 +1,36 @@
-<div class="col-xs-12 te-graph-container">
-  <div class="te-graph-alert {{if (or isMetricDataLoading isMetricDataInvalid) 'te-graph-alert--pending'}}">
-    {{#if (or isFetchingDimensions isDimensionFetchDone)}}
-      {{#if isDimensionError}}
-        <div class="te-form__super-label">... error loading subDimensions for <span class="stronger">{{selectedDimension}}</span></div>
-      {{else}}
-        <div class="te-form__super-label">...{{if isDimensionFetchDone 'Displaying' 'Loading'}} top {{topDimensions.length}} contributing subDimensions for <span class="stronger">{{selectedDimension}}</span></div>
-      {{/if}}
-    {{/if}}
-    {{#if isMetricDataLoading}}
-      <div class="spinner-wrapper-self-serve">{{ember-spinner}}</div>
-      <div class="te-graph-alert__content">
-        <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
-        <p class="te-graph-alert__pre-text">{{graphMessageText.loading}}</p>
-      </div>
+<div class="te-graph-alert {{if isMetricDataPending 'te-graph-alert--pending'}}">
+  {{#if (or isFetchingDimensions isDimensionFetchDone)}}
+    {{#if isDimensionError}}
+      <div class="te-form__super-label">... error loading subDimensions for <span class="stronger">{{selectedDimension}}</span></div>
     {{else}}
-      {{#if (not isMetricDataInvalid)}}
-        {{anomaly-graph
-          primaryMetric=metricData
-          selectedDimensions=selectedDimensions
-          dimensions=topDimensions
-          showDimensions=true
-          isLoading=loading
-          showSubchart=true
-          showLegend=true
-          enableZoom=true
-          legendText=legendText
-          componentId=componentId
-          showGraphLegend=false
-          onSelection=(action "onSelection")
-        }}
-      {{else}}
-        <div class="te-graph-alert__content">
-          <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
-          <p class="te-graph-alert__pre-text">{{graphMessageText.error}}</p>
-        </div>
-      {{/if}}
+      <div class="te-form__super-label">...{{if isDimensionFetchDone 'Displaying' 'Loading'}} top {{topDimensions.length}} contributing subDimensions for <span class="stronger">{{selectedDimension}}</span></div>
     {{/if}}
-  </div>
-    <div class="te-form__note">
-      NOTE: If you find the metric shown above is inconsistent, please email <a class="thirdeye-link-secondary" target="_blank" href="{{graphMailtoLink}}">ask_thirdeye</a>.
+  {{/if}}
+  {{#if isAnythingLoading}} <div class="spinner-wrapper-self-serve">{{ember-spinner}}</div> {{/if}}
+  {{#if isMetricDataPending}}
+    <div class="te-graph-alert__content">
+      <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
+      <p class="te-graph-alert__pre-text">{{graphMessageText}}</p>
     </div>
+  {{else}}
+    {{#if (not isMetricDataInvalid)}}
+      {{anomaly-graph
+        primaryMetric=metricData
+        selectedDimensions=selectedDimensions
+        dimensions=topDimensions
+        showDimensions=true
+        isLoading=loading
+        showSubchart=true
+        showLegend=true
+        enableZoom=true
+        legendText=legendText
+        componentId=componentId
+        showGraphLegend=false
+        onSelection=(action "onSelection")
+      }}
+    {{/if}}
+  {{/if}}
+</div>
+<div class="te-form__note">
+  NOTE: If you find the metric shown above is inconsistent, please email <a class="thirdeye-link-secondary" target="_blank" href="{{graphMailtoLink}}">ask_thirdeye</a>.
 </div>

--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-graph/template.hbs
@@ -17,7 +17,7 @@
       {{#if (not isMetricDataInvalid)}}
         {{anomaly-graph
           primaryMetric=metricData
-          selectedDimension=selectedDimension
+          selectedDimensions=selectedDimensions
           dimensions=topDimensions
           showDimensions=true
           isLoading=loading

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -88,7 +88,6 @@ export default Controller.extend({
       sortColumnStartUp: false,
       sortColumnScoreUp: false,
       sortColumnChangeUp: false,
-      isFetchingDimensions: false,
       isDimensionFetchDone: false,
       sortColumnResolutionUp: false,
       checkReplayInterval: 2000, // 2 seconds

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/controller.js
@@ -70,6 +70,7 @@ export default Controller.extend({
     this.setProperties({
       filters: {},
       loadedWowData: [],
+      topDimensions: [],
       predefinedRanges: {},
       missingAnomalyProps: {},
       selectedSortMode: '',
@@ -307,6 +308,18 @@ export default Controller.extend({
         });
       }
       return anomalies;
+    }
+  ),
+
+  /**
+   * All selected dimensions to be loaded into graph
+   * @returns {Array}
+   */
+  selectedDimensions: computed(
+    'topDimensions',
+    'topDimensions.@each.isSelected',
+    function() {
+      return this.get('topDimensions').filterBy('isSelected');
     }
   ),
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/route.js
@@ -367,7 +367,6 @@ export default Route.extend({
     this.controller.setProperties({
       metricData,
       alertDimension,
-      topDimensions: [],
       isMetricDataLoading: false
     });
     // If alert has dimensions set, load them into graph once replay is done.

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -132,6 +132,7 @@
         componentId='alert-page'
         topDimensions=topDimensions
         selectedDimension=alertDimension
+        selectedDimensions=selectedDimensions
         isMetricDataLoading=isMetricDataLoading
         isMetricDataInvalid=isMetricDataInvalid
         isDimensionFetchDone=isDimensionFetchDone

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/explore/template.hbs
@@ -115,7 +115,6 @@
             dimensionOptions=dimensionOptions
             timePickerIncrement=timePickerIncrement
             isDimensionFetchDone=isDimensionFetchDone
-            isFetchingDimensions=alertHasDimensions
             isMetricDataLoading=isMetricDataLoading
             isMetricDataInvalid=isMetricDataInvalid
             inputAction=(action "onInputMissingAnomaly")
@@ -127,12 +126,12 @@
 
       {{!-- Alert page graph --}}
       {{self-serve-graph
-        isMetricSelected=true
         metricData=metricData
         componentId='alert-page'
         topDimensions=topDimensions
         selectedDimension=alertDimension
         selectedDimensions=selectedDimensions
+        isMetricSelected=true
         isMetricDataLoading=isMetricDataLoading
         isMetricDataInvalid=isMetricDataInvalid
         isDimensionFetchDone=isDimensionFetchDone

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -44,7 +44,7 @@ export default Controller.extend({
   isMetricDataLoading: false,
   isGroupNameDuplicate: false,
   isAlertNameDuplicate: false,
-  isFetchingDimensions: false,
+  isSecondaryDataLoading: false,
   isDimensionFetchDone: false,
   isProcessingForm: false,
   isEmailError: false,
@@ -59,14 +59,6 @@ export default Controller.extend({
   graphEmailLinkProps: '',
   dimensionCount: 7,
   availableDimensions: 0,
-  legendText: {
-    dotted: {
-      text: 'WoW'
-    },
-    solid: {
-      text: 'Observed'
-    }
-  },
 
   /**
    * Component property initial settings
@@ -295,6 +287,7 @@ export default Controller.extend({
           metricId: metric.id,
           isMetricSelected: isDataGood,
           isMetricDataLoading: false,
+          isSecondaryDataLoading: false,
           showGraphLegend: true,
           selectedMetric: Object.assign(metricData, { color: 'blue' }),
           isMetricDataInvalid: !isDataGood
@@ -306,7 +299,6 @@ export default Controller.extend({
           // Update graph only if we have new dimension data
           if (orderedDimensions.length) {
             this.setProperties({
-              isFetchingDimensions: false,
               isDimensionFetchDone: true,
               topDimensions: orderedDimensions,
               availableDimensions: orderedDimensions.length
@@ -317,6 +309,7 @@ export default Controller.extend({
         this.setProperties({
           isMetricDataInvalid: true,
           isMetricDataLoading: false,
+          isSecondaryDataLoading: false,
           selectMetricErrMsg: error
         });
       });
@@ -585,20 +578,6 @@ export default Controller.extend({
   ),
 
   /**
-   * Sets the message text over the graph placeholder before data is loaded
-   * @method graphMessageText
-   * @return {String} the appropriate graph placeholder text
-   */
-  graphMessageText: computed(
-    'isMetricDataInvalid',
-    function() {
-      const defaultMsg = 'Once a metric is selected, the metric replay graph will show here';
-      const invalidMsg = 'Sorry, metric has no current data';
-      return this.get('isMetricDataInvalid') ? invalidMsg : defaultMsg;
-    }
-  ),
-
-  /**
    * Determines whether input fields in general are enabled. When metric data is 'invalid',
    * we will still enable alert creation.
    * @method generalFieldsEnabled
@@ -733,7 +712,7 @@ export default Controller.extend({
    */
   clearAll() {
     this.setProperties({
-      isFetchingDimensions: false,
+      isSecondaryDataLoading: false,
       isDimensionFetchDone: false,
       isEmailError: false,
       isEmptyEmail: false,
@@ -768,13 +747,6 @@ export default Controller.extend({
    * Actions for create alert form view
    */
   actions: {
-
-    /**
-     * Handles the primary metric selection in the alert creation
-     */
-    onPrimaryMetricToggle() {
-      return;
-    },
 
     /**
      * When a metric is selected, fetch its props, and send them to the graph builder
@@ -838,7 +810,7 @@ export default Controller.extend({
       // Update dimension options and loader
       this.setProperties({
         dimensions: [...dimensionNameSet],
-        isMetricDataLoading: true
+        isSecondaryDataLoading: true
       });
       // Do not allow selected dimension to match selected filter
       if (isSelectedDimensionEqualToSelectedFilter) {
@@ -863,13 +835,10 @@ export default Controller.extend({
       if (selectedDimension === 'All') {
         this.setProperties({
           topDimensions: [],
-          isFetchingDimensions: false
+          isSecondaryDataLoading: false
         });
       } else {
-        this.setProperties({
-          isMetricDataLoading: true,
-          isFetchingDimensions: true
-        });
+        this.set('isSecondaryDataLoading', true);
         this.modifyAlertFunctionName();
         this.triggerGraphFromMetric();
       }
@@ -884,7 +853,7 @@ export default Controller.extend({
     onSelectGranularity(selectedObj) {
       this.setProperties({
         selectedGranularity: selectedObj,
-        isMetricDataLoading: true
+        isSecondaryDataLoading: true
       });
       this.modifyAlertFunctionName();
       this.triggerGraphFromMetric();
@@ -1029,16 +998,6 @@ export default Controller.extend({
      */
     onResetForm() {
       this.clearAll();
-    },
-
-    /**
-     * Enable reaction to dimension toggling in graph legend component
-     * @method onSelection
-     * @return {undefined}
-     */
-    onSelection(selectedDimension) {
-      const { isSelected } = selectedDimension;
-      set(selectedDimension, 'isSelected', !isSelected);
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -90,44 +90,20 @@
       }}
     </div>
 
-    <div class="col-xs-12">
-      <div class="te-graph-alert {{if (not isMetricSelected) 'te-graph-alert--pending'}}">
-        {{#if (or isFetchingDimensions isDimensionFetchDone)}}
-          {{#if isDimensionError}}
-            <div class="te-form__super-label">... error loading subDimensions for <span class="stronger">{{selectedDimension}}</span></div>
-          {{else}}
-            <div class="te-form__super-label">...{{if isDimensionFetchDone 'Displaying' 'Loading'}} top {{availableDimensions}} contributing subDimensions for <span class="stronger">{{selectedDimension}}</span></div>
-          {{/if}}
-        {{/if}}
-        {{#if isMetricDataLoading}}{{ember-spinner}}{{/if}}
-        {{#if isMetricSelected}}
-          {{anomaly-graph
-            primaryMetric=selectedMetric
-            selectedDimensions=selectedDimensions
-            dimensions=topDimensions
-            showDimensions=true
-            isLoading=loading
-            showSubchart=true
-            showLegend=true
-            enableZoom=true
-            legendText=legendText
-            componentId='create-alert'
-            showGraphLegend=false
-            onSelection=(action "onSelection")
-            onPrimaryMetricToggle=(action "onPrimaryMetricToggle")
-            height=400
-          }}
-          <div class="te-form__note">
-            NOTE: If you find the metric shown above is inconsistent, please email <a class="thirdeye-link-secondary" target="_blank" href="{{graphMailtoLink}}">ask_thirdeye</a>.
-          </div>
-        {{else}}
-          <div class="te-graph-alert__content">
-            <div class="glyphicon glyphicon-{{if isMetricDataInvalid 'alert' 'equalizer'}} te-graph-alert__icon{{if isMetricDataInvalid '--warning'}}"></div>
-            <p class="te-graph-alert__pre-text">{{graphMessageText}}</p>
-          </div>
-        {{/if}}
-      </div>
-    </div>
+    {{!-- Render metric graph --}}
+    {{self-serve-graph
+      removeGraphMargin=true
+      metricData=selectedMetric
+      componentId='create-alert'
+      topDimensions=topDimensions
+      selectedDimension=selectedDimension
+      selectedDimensions=selectedDimensions
+      isMetricSelected=isMetricSelected
+      isMetricDataLoading=isMetricDataLoading
+      isMetricDataInvalid=isMetricDataInvalid
+      isSecondaryDataLoading=isSecondaryDataLoading
+      isDimensionFetchDone=isDimensionFetchDone
+    }}
 
   </fieldset>
 

--- a/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/shared/_styles.scss
@@ -410,6 +410,10 @@ body {
 
 .te-graph-container {
   margin: 10px 0 20px -15px;
+
+  &--marginless {
+    margin: 0;
+  }
 }
 
 .te-block-container {


### PR DESCRIPTION
Metric graph for Alert Page was not passing "contributing sub-dimension" data to its graph component `self-serve-graph`.

Also, for a more consistent implementation, allowing Create Alert page to leverage the shared graph component for self-serve, and send a common signal when peripheral data is loading (whether filters, dimensions, granularity changes).

All tests passing.