### PR TITLE
Add a time buffer in retention manager when picking segments which are missing from ideal state for deletion

### DIFF
--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -237,6 +237,15 @@ public class RetentionManagerTest {
         segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
         idealState.setPartitionState(segName, serverName, "CONSUMING");
         allSegments.add(segmentMetadata);
+      } else if (seq == 1) {
+        // create IN_PROGRESS metadata absent from ideal state, older than 5 days
+        segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+        allSegments.add(segmentMetadata);
+        segmentsToBeDeleted.add(segmentMetadata.getSegmentName());
+      } else if (seq == nSegments - 1) {
+        // create IN_PROGRESS metadata absent from ideal state, younger than 5 days
+        segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+        allSegments.add(segmentMetadata);
       } else if (seq % 2 == 0) {
         // create ONLINE segment
         segmentMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);


### PR DESCRIPTION
Retention could end up prematurely selecting a segment for deletion because of the absense of any time buffer. If a new segment metadata is created (step 2) and the retention manager kicks in before the ideal state entry for the new segment is created (step 3), then the retention manager would mark the brand new segment for deletion due to absence in ideal state. Adding a time buffer of 5 days, so that we do not pick a segment for deletion unless it is old enough. That gives the segment enough time to complete its lifecycle in committing, or to get repaired by validation manager