### PR TITLE
Handle a state created due to race condition between RetentionManager and segment commit, resulting in no consuming segments for the partition

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1110,7 +1110,8 @@ public class PinotLLCRealtimeSegmentManager {
           // step-2 was undone by retention manager (i.e. new IN_PROGRESS metadata got deleted)
           // step 3 was partially undone by retention manager (i.e. marking old segment ONLINE was done but new CONSUMING segment was deleted)
 
-          if (isAllInstancesInState(instanceStateMap, PinotHelixSegmentOnlineOfflineStateModelGenerator.OFFLINE_STATE) || !(isTooSoonToCorrect(tableNameWithType, segmentId, now))) {
+          if (isAllInstancesInState(instanceStateMap, PinotHelixSegmentOnlineOfflineStateModelGenerator.OFFLINE_STATE)
+              || !(isTooSoonToCorrect(tableNameWithType, segmentId, now))) {
             // No instances are consuming, so create a new consuming segment.
             int nextSeqNum = segmentName.getSequenceNumber() + 1;
             LOGGER.info("Creating CONSUMING segment for {} partition {} with seq {}", tableNameWithType, partition,

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1107,8 +1107,8 @@ public class PinotLLCRealtimeSegmentManager {
 
             // No instances are consuming, so create a new consuming segment.
             LLCSegmentName newLLCSegmentName = makeNextLLCSegmentName(segmentName, partition, now);
-            LOGGER.info("Creating CONSUMING segment for {} partition {} with seq {}", tableNameWithType, partition,
-                newLLCSegmentName.getSequenceNumber());
+            LOGGER.info("Creating CONSUMING segment {} for {} partition {}", newLLCSegmentName.getSegmentName(),
+                tableNameWithType, partition);
 
             // To begin with, set startOffset to the oldest available offset in kafka. Fix it to be the one we want,
             // depending on what the prev segment had.

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1085,7 +1085,9 @@ public class PinotLLCRealtimeSegmentManager {
                     + "Old segment metadata {} has status DONE, but segments are still in CONSUMING state in ideal STATE",
                 tableNameWithType, partition, segmentId);
 
-            LLCSegmentName newLLCSegmentName = getNextLLCSegment(tableNameWithType, segmentName, partition, now);
+            LLCSegmentName newLLCSegmentName = getNextLLCSegment(segmentName, partition, now);
+            LOGGER.info("{}: Creating new segment metadata for {}", tableNameWithType,
+                newLLCSegmentName.getSegmentName());
 
             CommittingSegmentDescriptor committingSegmentDescriptor =
                 new CommittingSegmentDescriptor(segmentId, latestMetadata.getEndOffset(), 0);
@@ -1132,7 +1134,9 @@ public class PinotLLCRealtimeSegmentManager {
                     + "Old segment metadata {} has status DONE, and segments in ONLINE state in ideal state, however new segment metadata and ideal state entries are missing",
                 tableNameWithType, partition, segmentId);
 
-            LLCSegmentName newLLCSegmentName = getNextLLCSegment(tableNameWithType, segmentName, partition, now);
+            LLCSegmentName newLLCSegmentName = getNextLLCSegment(segmentName, partition, now);
+            LOGGER.info("{}: Creating new segment metadata for {}", tableNameWithType,
+                newLLCSegmentName.getSegmentName());
 
             CommittingSegmentDescriptor committingSegmentDescriptor =
                 new CommittingSegmentDescriptor(segmentId, latestMetadata.getEndOffset(), 0);
@@ -1191,13 +1195,10 @@ public class PinotLLCRealtimeSegmentManager {
     return idealState;
   }
 
-  private LLCSegmentName getNextLLCSegment(String tableNameWithType, LLCSegmentName segmentName, int partition, long now) {
+  private LLCSegmentName getNextLLCSegment(LLCSegmentName segmentName, int partition, long now) {
     final int newSeqNum = segmentName.getSequenceNumber() + 1;
     LLCSegmentName newLLCSegmentName =
         new LLCSegmentName(segmentName.getTableName(), partition, newSeqNum, now);
-
-    LOGGER.info("{}: Creating new segment metadata for {}", tableNameWithType,
-        newLLCSegmentName.getSegmentName());
     return newLLCSegmentName;
   }
 

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -641,6 +641,12 @@ public class PinotLLCRealtimeSegmentManagerTest {
             IdealState idealStateCopy = new IdealState((ZNRecord) znRecordSerializer.deserialize(znRecordSerializer.serialize(idealState.getRecord())));
             Map<String, Map<String, String>> oldMapFields = idealStateCopy.getRecord().getMapFields();
 
+            if (tooSoonToCorrect) {
+              segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
+              // validate nothing changed and try again with disabled
+              verifyNoChangeToOldEntries(oldMapFields, idealState);
+              segmentManager.tooSoonToCorrect = false;
+            }
             segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
 
             verifyRepairs(tableConfig, idealState, expectedPartitionAssignment, segmentManager, oldMapFields);

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -627,7 +627,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
             // generate error scenario
             int randomlySelectedPartition = random.nextInt(nPartitions);
-            Map<String, LLCSegmentName> partitionToLatestSegments = segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
+            Map<String, LLCSegmentName> partitionToLatestSegments =
+                segmentManager._partitionAssignmentGenerator.getPartitionToLatestSegments(idealState);
             LLCSegmentName latestSegment = partitionToLatestSegments.get(String.valueOf(randomlySelectedPartition));
             LLCRealtimeSegmentZKMetadata latestMetadata =
                 segmentManager.getRealtimeSegmentZKMetadata(tableName, latestSegment.getSegmentName(), null);
@@ -639,13 +640,6 @@ public class PinotLLCRealtimeSegmentManagerTest {
             nPartitions = expectedPartitionAssignment.getNumPartitions();
             IdealState idealStateCopy = new IdealState((ZNRecord) znRecordSerializer.deserialize(znRecordSerializer.serialize(idealState.getRecord())));
             Map<String, Map<String, String>> oldMapFields = idealStateCopy.getRecord().getMapFields();
-
-            if (tooSoonToCorrect) {
-              segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
-              // validate nothing changed and try again with disabled
-              verifyNoChangeToOldEntries(oldMapFields, idealState);
-              segmentManager.tooSoonToCorrect = false;
-            }
 
             segmentManager.validateLLCSegments(tableConfig, idealState, nPartitions);
 


### PR DESCRIPTION
Segment commit takes place in 3 steps:
1. mark committing segment metadata to DONE
2. create new segment metadata to IN_PROGRESS
3. update ideal state with segment state to ONLINE and new segment state to CONSUMING

The RetentionManager checks for segments which have metadata present but no entry in ideal state. If the RetentionManager happens to check between steps 2 and 3 above, it will mark the newly created segment for deletion. 
The fix for this is to make retrntion manager not pick segments that are new (provided 5 days buffer: https://github.com/linkedin/pinot/pull/2890)
Additionally, the ValidationManager should be able to detect and recover from sucha a scenario

In this PR, a check is put in place to look for all segments ONLINE in ideal state for latest segment, and metadata being DONE. In such a scenario, a new metadata is created IN_PROGRESS and new segment is created in ideal state CONSUMING. We make sure that we don't correct segments that are too soon to correct