### PR TITLE
Fix the percentile aggregation functions

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -37,24 +37,30 @@ public class AggregationFunctionFactory {
     DISTINCTCOUNT("distinctCount"),
     DISTINCTCOUNTHLL("distinctCountHLL"),
     FASTHLL("fastHLL"),
+    PERCENTILE5("percentile5"),
     PERCENTILE10("percentile10"),
     PERCENTILE20("percentile20"),
+    PERCENTILE25("percentile25"),
     PERCENTILE30("percentile30"),
     PERCENTILE40("percentile40"),
     PERCENTILE50("percentile50"),
     PERCENTILE60("percentile60"),
     PERCENTILE70("percentile70"),
+    PERCENTILE75("percentile75"),
     PERCENTILE80("percentile80"),
     PERCENTILE90("percentile90"),
     PERCENTILE95("percentile95"),
     PERCENTILE99("percentile99"),
+    PERCENTILEEST5("percentileEst5"),
     PERCENTILEEST10("percentileEst10"),
     PERCENTILEEST20("percentileEst20"),
+    PERCENTILEEST25("percentileEst25"),
     PERCENTILEEST30("percentileEst30"),
     PERCENTILEEST40("percentileEst40"),
     PERCENTILEEST50("percentileEst50"),
     PERCENTILEEST60("percentileEst60"),
     PERCENTILEEST70("percentileEst70"),
+    PERCENTILEEST75("percentileEst75"),
     PERCENTILEEST80("percentileEst80"),
     PERCENTILEEST90("percentileEst90"),
     PERCENTILEEST95("percentileEst95"),
@@ -83,24 +89,30 @@ public class AggregationFunctionFactory {
     DISTINCTCOUNTMV("distinctCountMV"),
     DISTINCTCOUNTHLLMV("distinctCountHLLMV"),
     FASTHLLMV("fastHLLMV"),
+    PERCENTILE5MV("percentile5MV"),
     PERCENTILE10MV("percentile10MV"),
     PERCENTILE20MV("percentile20MV"),
+    PERCENTILE25MV("percentile25MV"),
     PERCENTILE30MV("percentile30MV"),
     PERCENTILE40MV("percentile40MV"),
     PERCENTILE50MV("percentile50MV"),
     PERCENTILE60MV("percentile60MV"),
     PERCENTILE70MV("percentile70MV"),
+    PERCENTILE75MV("percentile75MV"),
     PERCENTILE80MV("percentile80MV"),
     PERCENTILE90MV("percentile90MV"),
     PERCENTILE95MV("percentile95MV"),
     PERCENTILE99MV("percentile99MV"),
+    PERCENTILEEST5MV("percentileEst5MV"),
     PERCENTILEEST10MV("percentileEst10MV"),
     PERCENTILEEST20MV("percentileEst20MV"),
+    PERCENTILEEST25MV("percentileEst25MV"),
     PERCENTILEEST30MV("percentileEst30MV"),
     PERCENTILEEST40MV("percentileEst40MV"),
     PERCENTILEEST50MV("percentileEst50MV"),
     PERCENTILEEST60MV("percentileEst60MV"),
     PERCENTILEEST70MV("percentileEst70MV"),
+    PERCENTILEEST75MV("percentileEst75MV"),
     PERCENTILEEST80MV("percentileEst80MV"),
     PERCENTILEEST90MV("percentileEst90MV"),
     PERCENTILEEST95MV("percentileEst95MV"),
@@ -157,10 +169,14 @@ public class AggregationFunctionFactory {
         return new DistinctCountHLLAggregationFunction();
       case FASTHLL:
         return new FastHLLAggregationFunction();
+      case PERCENTILE5:
+        return new PercentileAggregationFunction(5);
       case PERCENTILE10:
         return new PercentileAggregationFunction(10);
       case PERCENTILE20:
         return new PercentileAggregationFunction(20);
+      case PERCENTILE25:
+        return new PercentileAggregationFunction(25);
       case PERCENTILE30:
         return new PercentileAggregationFunction(30);
       case PERCENTILE40:
@@ -171,6 +187,8 @@ public class AggregationFunctionFactory {
         return new PercentileAggregationFunction(60);
       case PERCENTILE70:
         return new PercentileAggregationFunction(70);
+      case PERCENTILE75:
+        return new PercentileAggregationFunction(75);
       case PERCENTILE80:
         return new PercentileAggregationFunction(80);
       case PERCENTILE90:
@@ -179,10 +197,14 @@ public class AggregationFunctionFactory {
         return new PercentileAggregationFunction(95);
       case PERCENTILE99:
         return new PercentileAggregationFunction(99);
+      case PERCENTILEEST5:
+        return new PercentileEstAggregationFunction(5);
       case PERCENTILEEST10:
         return new PercentileEstAggregationFunction(10);
       case PERCENTILEEST20:
         return new PercentileEstAggregationFunction(20);
+      case PERCENTILEEST25:
+        return new PercentileEstAggregationFunction(25);
       case PERCENTILEEST30:
         return new PercentileEstAggregationFunction(30);
       case PERCENTILEEST40:
@@ -193,6 +215,8 @@ public class AggregationFunctionFactory {
         return new PercentileEstAggregationFunction(60);
       case PERCENTILEEST70:
         return new PercentileEstAggregationFunction(70);
+      case PERCENTILEEST75:
+        return new PercentileEstAggregationFunction(75);
       case PERCENTILEEST80:
         return new PercentileEstAggregationFunction(80);
       case PERCENTILEEST90:
@@ -247,10 +271,14 @@ public class AggregationFunctionFactory {
         return new DistinctCountHLLMVAggregationFunction();
       case FASTHLLMV:
         return new FastHLLMVAggregationFunction();
+      case PERCENTILE5MV:
+        return new PercentileMVAggregationFunction(5);
       case PERCENTILE10MV:
         return new PercentileMVAggregationFunction(10);
       case PERCENTILE20MV:
         return new PercentileMVAggregationFunction(20);
+      case PERCENTILE25MV:
+        return new PercentileMVAggregationFunction(25);
       case PERCENTILE30MV:
         return new PercentileMVAggregationFunction(30);
       case PERCENTILE40MV:
@@ -261,6 +289,8 @@ public class AggregationFunctionFactory {
         return new PercentileMVAggregationFunction(60);
       case PERCENTILE70MV:
         return new PercentileMVAggregationFunction(70);
+      case PERCENTILE75MV:
+        return new PercentileMVAggregationFunction(75);
       case PERCENTILE80MV:
         return new PercentileMVAggregationFunction(80);
       case PERCENTILE90MV:
@@ -269,10 +299,14 @@ public class AggregationFunctionFactory {
         return new PercentileMVAggregationFunction(95);
       case PERCENTILE99MV:
         return new PercentileMVAggregationFunction(99);
+      case PERCENTILEEST5MV:
+        return new PercentileEstMVAggregationFunction(5);
       case PERCENTILEEST10MV:
         return new PercentileEstMVAggregationFunction(10);
       case PERCENTILEEST20MV:
         return new PercentileEstMVAggregationFunction(20);
+      case PERCENTILEEST25MV:
+        return new PercentileEstMVAggregationFunction(25);
       case PERCENTILEEST30MV:
         return new PercentileEstMVAggregationFunction(30);
       case PERCENTILEEST40MV:
@@ -283,6 +317,8 @@ public class AggregationFunctionFactory {
         return new PercentileEstMVAggregationFunction(60);
       case PERCENTILEEST70MV:
         return new PercentileEstMVAggregationFunction(70);
+      case PERCENTILEEST75MV:
+        return new PercentileEstMVAggregationFunction(75);
       case PERCENTILEEST80MV:
         return new PercentileEstMVAggregationFunction(80);
       case PERCENTILEEST90MV:

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -33,23 +33,11 @@ public class PercentileAggregationFunction implements AggregationFunction<Double
   private final int _percentile;
 
   public PercentileAggregationFunction(int percentile) {
-    switch (percentile) {
-      case 50:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE50.getName();
-        break;
-      case 90:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE90.getName();
-        break;
-      case 95:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE95.getName();
-        break;
-      case 99:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE99.getName();
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported percentile for PercentileAggregationFunction: " + percentile);
-    }
+    this("percentile" + percentile, percentile);
+  }
+
+  protected PercentileAggregationFunction(String name, int percentile) {
+    _name = name;
     _percentile = percentile;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -32,23 +32,11 @@ public class PercentileEstAggregationFunction implements AggregationFunction<Qua
   private final int _percentile;
 
   public PercentileEstAggregationFunction(int percentile) {
-    switch (percentile) {
-      case 50:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST50.getName();
-        break;
-      case 90:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST90.getName();
-        break;
-      case 95:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST95.getName();
-        break;
-      case 99:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST99.getName();
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported percentile for PercentileEstAggregationFunction: " + percentile);
-    }
+    this("percentileEst" + percentile, percentile);
+  }
+
+  protected PercentileEstAggregationFunction(String name, int percentile) {
+    _name = name;
     _percentile = percentile;
   }
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -24,60 +24,9 @@ import javax.annotation.Nonnull;
 
 public class PercentileEstMVAggregationFunction extends PercentileEstAggregationFunction {
   private static final double DEFAULT_MAX_ERROR = 0.01;
-  private final String _name;
 
   public PercentileEstMVAggregationFunction(int percentile) {
-    super(percentile);
-    switch (percentile) {
-      case 10:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST10MV.getName();
-        break;
-      case 20:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST20MV.getName();
-        break;
-      case 30:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST30MV.getName();
-        break;
-      case 40:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST40MV.getName();
-        break;
-      case 50:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST50MV.getName();
-        break;
-      case 60:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST60MV.getName();
-        break;
-      case 70:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST70MV.getName();
-        break;
-      case 80:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST80MV.getName();
-        break;
-      case 90:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST90MV.getName();
-        break;
-      case 95:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST95MV.getName();
-        break;
-      case 99:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILEEST99MV.getName();
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported percentile for PercentileEstMVAggregationFunction: " + percentile);
-    }
-  }
-
-  @Nonnull
-  @Override
-  public String getName() {
-    return _name;
-  }
-
-  @Nonnull
-  @Override
-  public String getColumnName(@Nonnull String[] columns) {
-    return _name + "_" + columns[0];
+    super("percentileEst" + percentile + "MV", percentile);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -23,39 +23,9 @@ import javax.annotation.Nonnull;
 
 
 public class PercentileMVAggregationFunction extends PercentileAggregationFunction {
-  private final String _name;
 
   public PercentileMVAggregationFunction(int percentile) {
-    super(percentile);
-    switch (percentile) {
-      case 50:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE50MV.getName();
-        break;
-      case 90:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE90MV.getName();
-        break;
-      case 95:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE95MV.getName();
-        break;
-      case 99:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILE99MV.getName();
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported percentile for PercentileAggregationFunction: " + percentile);
-    }
-  }
-
-  @Nonnull
-  @Override
-  public String getName() {
-    return _name;
-  }
-
-  @Nonnull
-  @Override
-  public String getColumnName(@Nonnull String[] columns) {
-    return _name + "_" + columns[0];
+    super("percentile" + percentile + "MV", percentile);
   }
 
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -33,62 +33,15 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   public static final int DEFAULT_TDIGEST_COMPRESSION = 100;
 
   private final String _name;
-  private final double _percentile;
+  private final int _percentile;
 
-  /**
-   * Constructor for the class.
-   *
-   * @param percentile Percentile to compute.
-   */
   public PercentileTDigestAggregationFunction(int percentile) {
-    switch (percentile) {
-      case 5:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST5.getName();
-        break;
-      case 10:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST10.getName();
-        break;
-      case 20:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST20.getName();
-        break;
-      case 25:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST25.getName();
-        break;
-      case 30:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST30.getName();
-        break;
-      case 40:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST40.getName();
-        break;
-      case 50:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST50.getName();
-        break;
-      case 60:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST60.getName();
-        break;
-      case 70:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST70.getName();
-        break;
-      case 75:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST75.getName();
-        break;
-      case 80:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST80.getName();
-        break;
-      case 90:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST90.getName();
-        break;
-      case 95:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST95.getName();
-        break;
-      case 99:
-        _name = AggregationFunctionFactory.AggregationFunctionType.PERCENTILETDIGEST99.getName();
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported percentile for PercentileTDigestAggregationFunction: " + percentile);
-    }
-    _percentile = percentile / 100.0;
+    this("percentileTDigest" + percentile, percentile);
+  }
+
+  protected PercentileTDigestAggregationFunction(String name, int percentile) {
+    _name = name;
+    _percentile = percentile;
   }
 
   @Nonnull
@@ -216,6 +169,6 @@ public class PercentileTDigestAggregationFunction implements AggregationFunction
   @Nonnull
   @Override
   public Double extractFinalResult(@Nonnull TDigest intermediateResult) {
-    return intermediateResult.quantile(_percentile);
+    return intermediateResult.quantile(_percentile / 100.0);
   }
 }


### PR DESCRIPTION
After the fix, for all percentile aggregation functions (PERCENTILE, PERCENTILEEST, PERCENTILETDIGEST, PERCENTILEMV, PERCENTILEESTMV), support the following percentiles:
5, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 95, 99