### PR TITLE
[TE] Advanced Dimension Analysis Table (3): static table improvements

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions/component.js
@@ -20,7 +20,6 @@
  */
 
 import Component from '@ember/component';
-import { once, later } from '@ember/runloop'
 import { isPresent, isEmpty } from '@ember/utils';
 import { task, timeout } from 'ember-concurrency';
 import { inject as service } from '@ember/service';

--- a/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/components/rootcause-dimensions/component.js
@@ -45,13 +45,16 @@ export default Component.extend({
   dimensionsApiService: service('services/api/dimensions'),
 
   /**
-   * Incoming cached state for rootcause view
-   * The context object is maintained by the RCA caching services. It defines the 'state' of the analysis view as
-   * the user modifies options. This object will always contain start/end ranges, and active metric settings, which
-   * this component needs to react to.
-   * @type {Object}
+   * Incoming start and end dates (context.analysisRange) for current metric or entity being analyzed
+   * @type {Array}
    */
-  context: {},
+  range: [],
+
+  /**
+   * The type of change used by the current metric (context.compareMode)
+   * @type {String}
+   */
+  mode: '',
 
   /**
    * Incoming collection of loaded entities cached in RCA services
@@ -96,6 +99,12 @@ export default Component.extend({
   dimensionsRawData: [],
 
   /**
+   * Single record cache for previous row's dimension names array
+   * @type {Array}
+   */
+  previousDimensionNames: [],
+
+  /**
    * Override for table classes
    * @type {Object}
    */
@@ -126,9 +135,9 @@ export default Component.extend({
     this._super(...arguments);
 
     // We're pulling in the entities list here because its the only way to extract the metric name and dataset
-    const { entities, metricUrn, context } = this.getProperties('entities', 'metricUrn', 'context');
+    const { entities, metricUrn, range, mode } = this.getProperties('entities', 'metricUrn', 'range', 'mode');
     // Baseline start/end is dependent on 'compareMode' (WoW, Wo2W, etc)
-    const baselineRange = toBaselineRange(context.analysisRange, context.compareMode);
+    const baselineRange = toBaselineRange(range, mode);
     // If metric URN is found in entity list, proceed. Otherwise, we have no metadata to construct the call.
     const metricEntity = entities[metricUrn];
 
@@ -138,8 +147,8 @@ export default Component.extend({
         get(this, 'fetchDimensionAnalysisData').perform({
           metric: parsedMetric[1],
           dataset: parsedMetric[0],
-          currentStart: context.analysisRange[0],
-          currentEnd: context.analysisRange[1],
+          currentStart: range[0],
+          currentEnd: range[1],
           baselineStart: baselineRange[0],
           baselineEnd: baselineRange[1],
           summarySize: 20,
@@ -151,7 +160,7 @@ export default Component.extend({
   },
 
   /**
-   * Data for dimensions table
+   * Data for each column of dimensions table
    * @type Array - array of objects, each corresponding to a row in the table
    */
   dimensionTableData: computed(
@@ -160,45 +169,35 @@ export default Component.extend({
     'metricUrn',
     function () {
       const { dimensionsRawData, selectedUrns, metricUrn } = this.getProperties('dimensionsRawData', 'selectedUrns', 'metricUrn');
+      const toFixedIfDecimal = (number) => (number % 1 !== 0) ? number.toFixed(2) : number;
       const dimensionNames = dimensionsRawData.dimensions || [];
       const dimensionRows = dimensionsRawData.responseRows || [];
-      const toFixedIfDecimal = (number) => (number % 1 !== 0) ? number.toFixed(2) : number;
-      let summaryRowIndex = 0; // row containing aggregated values
       let newDimensionRows = [];
 
-      // We are iterating over each row to make sure we have current-over-baseline and dimension data
+      // Build new dimension array for display as table rows
       if (dimensionRows.length) {
         dimensionRows.forEach((record, index) => {
-          // Generate URN for each record from dimension names/values
-          let { dimensionKeyVals, dimensionUrn } = this._buildDimensionalUrn(dimensionNames, record);
+          let {
+            dimensionArr, // Generate array of cell-specific objects for each dimension
+            dimensionUrn // Generate URN for each record from dimension names/values
+          } = this._generateDimensionUrn(dimensionNames, record);
           let overallContribution = record.contributionToOverallChange;
 
-          let newRow = {
-            id: index - 1,
+          // New records of template-ready data
+          newDimensionRows.push({
+            id: index + 1,
             dimensionUrn,
-            ...dimensionKeyVals, // add a new property to each row for each available dimension
+            dimensionArr,
             names: record.names,
             dimensions: dimensionNames,
+            isSelected: selectedUrns.has(dimensionUrn),
             percentageChange: record.percentageChange,
             contributionChange: record.contributionChange,
-            contributionToOverallChange: overallContribution,
-            isSelected: selectedUrns.has(dimensionUrn),
+            contributionToOverallChange: record.contributionToOverallChange,
             cob: `${toFixedIfDecimal(record.currentValue) || 0} / ${toFixedIfDecimal(record.baselineValue) || 0}`,
             elementWidth: this._calculateContributionBarWidth(dimensionRows, record)
-          };
-
-          // Append to new table data array
-          newDimensionRows.push(newRow);
-
-          // One row should contain the aggregate data with overall change contribution
-          if (record.names.every(name => name.includes('ALL'))) {
-            set(this, 'overallChange', overallContribution);
-            summaryRowIndex = index;
-          }
+          });
         });
-
-        // Remove the summary row from the array - not needed in table
-        newDimensionRows.splice(summaryRowIndex, 1);
       }
 
       return newDimensionRows;
@@ -238,7 +237,6 @@ export default Component.extend({
     }
   ),
 
-
   /**
    * Builds the headers array dynamically, based on availability of dimension records
    * @type {Array} Array of grouped headers
@@ -270,10 +268,9 @@ export default Component.extend({
     const widthAdditivePositive = allValuesPositive ? EXTRA_WIDTH : 0;
     const widthAdditiveNegative = allValuesNegative ? EXTRA_WIDTH : 0;
 
-    // Find the largest change value (excluding the first 'totals' row)
+    // Find the largest change value across all rows
     const maxChange = d3.max(dimensionRows.map((row) => {
-      let isIndexRow = row.names.every(name => name.includes('ALL'));
-      return isIndexRow ? 0 : Math.abs(toWidthNumber(row.contributionToOverallChange));
+      return Math.abs(toWidthNumber(row.contributionToOverallChange));
     }));
 
     // Generate a scale mapping the change value span to a specific range
@@ -293,26 +290,42 @@ export default Component.extend({
   },
 
   /**
-   * Builds a rich URN containing all the dimensions present in a record
-   * @method  _buildDimensionalUrn
+   * Builds an array of objects with enough data for the dynamic dimension table columns to
+   * know how to render each cell. Based on this object 'dimensionArr', we also build a  rich URN
+   * containing all the dimensions present in a record in a format that the RCA page understands.
+   * @method  _generateDimensionUrn
    * @param {Array} dimensionNames - array of dimension names from root of response object
    * @param {Array} record - single current record
-   * @returns {Object} name/value object for dimensions and the URN
+   * @returns {Object} name/value object for dimensions, plus the new URN
    * @private
    */
-  _buildDimensionalUrn(dimensionNames, record) {
-    // Object literal pulling in dimension names as keys
-    const dimensionKeyVals = Object.assign(...dimensionNames.map((name, index) => {
-      return { [name.camelize()]: record.names[index] || '-' };
-    }));
+  _generateDimensionUrn(dimensionNames, record) {
+    // We cache the value of the previous row's dimension values for row grouping
+    const previousDimensionNames = get(this, 'previousDimensionNames');
+    // We want to display excluded dimensions with value '(ALL)-' and having 'otherDimensionValues' prop
+    const otherValues = isPresent(record, 'otherDimensionValues') ? record.otherDimensionValues : null;
+
+    // Array to help dimension column component decide what to render in each cell
+    const dimensionArr = dimensionNames.map((name, index) => {
+      let dimensionValue = record.names[index];
+      return {
+        label: name.camelize(),
+        value: dimensionValue || '-',
+        isHidden: dimensionValue === previousDimensionNames[index], // if its a repeated value, hide it
+        otherValues: dimensionValue === '(ALL)-' ? otherValues : null
+      };
+    });
 
     // Create a string version of dimension name/value pairs
-    const encodedDimensions = isPresent(dimensionKeyVals) ? Object.keys(dimensionKeyVals).map((dName) => {
-      return encodeURIComponent(`${dName}=${dimensionKeyVals[dName]}`);
+    const encodedDimensions = isPresent(dimensionArr) ? dimensionArr.map((dObj) => {
+      return encodeURIComponent(`${dObj.label}=${dObj.value}`);
     }).join(':') : '';
-
+    // Append dimensions string to metricUrn. This will be sent to the graph legend for display
     const dimensionUrn = `${get(this, 'metricUrn')}:${encodedDimensions}`;
-    return { dimensionKeyVals, dimensionUrn };
+    // Now save the current record names as 'previous'
+    set(this, 'previousDimensionNames', record.names);
+
+    return { dimensionArr, dimensionUrn };
   },
 
   actions: {
@@ -348,12 +361,15 @@ export default Component.extend({
   fetchDimensionAnalysisData: task(function * (dimensionObj) {
     const dimensionsPayload = yield this.get('dimensionsApiService').queryDimensionsByMetric(dimensionObj);
     const dimensionNames = dimensionsPayload.dimensions || [];
+    const ratio = dimensionsPayload.globalRatio;
+    const convertedChangeRate = (ratio) => `${Math.abs((ratio -1) * 100).toFixed(2)}%`;
 
     this.setProperties({
       isLoading: false,
       dimensionsRawData: dimensionsPayload,
       cachedUrn: get(this, 'metricUrn'),
-      isDimensionDataPresent: true
+      isDimensionDataPresent: true,
+      overallChange: ratio ? convertedChangeRate(ratio) : 'N/A'
     });
 
   }).cancelOn('deactivate').drop()

--- a/thirdeye/thirdeye-frontend/app/pods/custom/dimensions-table/dimension/component.js
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/dimensions-table/dimension/component.js
@@ -1,6 +1,7 @@
 /**
  * Custom model table component
  * Constructs the dynamic dimension columns for the Advanced Dimension Analysis table
+ * This component will be rendered once for each dynamic dimension column
  * @module custom/dimensions-table/dimension
  *
  * @example for usage in models table columns definitions
@@ -15,44 +16,101 @@
  * }
  */
 import Component from "@ember/component";
-import { getWithDefault } from '@ember/object';
-import { get, set, setProperties } from '@ember/object';
+import { computed, get, set, setProperties, getWithDefault } from '@ember/object';
+import { isPresent } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import { once } from '@ember/runloop'
 
-const BLOCK_CLASS = 'rootcause-dimensions-table__dimension-cell';
+const CUSTOM_CLASS = 'rootcause-dimensions-table__dimension-cell';
 
 export default Component.extend({
 
-  dimensionLabel: null,
+  /**
+   * The column's cell content - dimension value
+   * @type {String}
+   */
+  dimensionValue: null,
+
+  /**
+   * The dimension group's list of excluded dimensions, typically present in a dimension of value '(ALL)-'
+   * @type {String}
+   */
+  excludedDimensions: null,
+
+  /**
+   * Visibility of content, based on whether its a dupe of the cell above it
+   * @type {Boolean}
+   */
+  isValueShown: true,
+
+  /**
+   * Determines whether the current cell will have the "blank" class applied
+   * @type {Boolean}
+   */
   isCellHidden: false,
-  isRowSelected: false,
-  onSelection: null,
-  inputId: null,
-  classNames: [BLOCK_CLASS],
-  classNameBindings: [`isCellHidden:${BLOCK_CLASS}--blank`],
 
-  didReceiveAttrs() {
+  /**
+   * Component classes
+   * @type {Array}
+   */
+  classNames: [CUSTOM_CLASS, `${CUSTOM_CLASS}--dynamic`],
+
+
+  init() {
     this._super(...arguments);
-    this._formatDimensionLabel();
-  },
-
-  _formatDimensionLabel() {
-    const isFirstColumn = this.column.isFirstColumn;
-    const dimNames = getWithDefault(this.record, 'names', []);
-    const label = this.record[this.column.propertyName];
-    const prevRecord = this.data[this.record.id - 1];
-    const prevLabel = prevRecord ? prevRecord[this.column.propertyName] : '';
-    const isThisLabelHidden = this.column.isGrouped && label === prevLabel;
-    const modifiedLabel = label.toLowerCase().includes('all') ? 'Total' : label;
 
     once(() => {
-      setProperties(this, {
-        isFirstColumn,
-        dimensionLabel: isThisLabelHidden ? '' : modifiedLabel,
-        isCellHidden: isThisLabelHidden,
-        inputId: `dimension-check${this.record.id}`
-      });
+      this._formatDimensionLabel(this.record.dimensionArr, this.column);
+    });
+  },
+
+  /**
+   * Sets value and visibility for each individual dimension cell. Allows us to group 'groupable' columns
+   * to give the table the appearance of a drill-down, or tree (basically hiding the current label
+   * if it is a duplicate of the previous one)
+   * @method  _formatDimensionLabel
+   * @param {Array} dimensionArr - array of dimension names from root of response object
+   * @param {Object} column - object containing current column properties
+   * @example of dimensionArr containing dimension properties from 'this.record'
+   *   [{
+   *     label: 'countryCode',
+   *     value: '(ALL)',
+   *     isHidden: true,
+   *     otherValues: null
+   *   },
+   *   {
+   *     label: 'interfaceLocale',
+   *     value: '(ALL)-',
+   *     isHidden: false
+   *     otherValues: 'dim1, dim2.subdim'
+   *   }]
+   * @returns {undefined}
+   * @private
+   */
+  _formatDimensionLabel(dimensionArr, column) {
+    // This is the cell data for this column component to render: find the index
+    const filteredDimensionIndex = dimensionArr.findIndex(dimObj => dimObj.label === column.propertyName);
+    // This is the cell data for this column component to render: find the object
+    const filteredDimensionObj = dimensionArr[filteredDimensionIndex];
+    // Look at the previous object.
+    const previousDimension = dimensionArr[filteredDimensionIndex - 1];
+    // Was it hidden? Does it meet the requirements to be hidden? The second through last -1 depends on visibility of its neighbor to the left.
+    const canThisCellBeHidden = filteredDimensionIndex > 0 ? isPresent(previousDimension) && previousDimension.isHidden : true;
+    // Roll up to the next requirements to be hidden
+    const isCellHidden = column.isGrouped && filteredDimensionObj.isHidden && canThisCellBeHidden;
+    // Locate the current cell's element
+    const cellEl = document.querySelector(`#${this.elementId}`);
+
+    // Add hide class to table cell (no jquery)
+    if (isCellHidden && cellEl) {
+      this.get('element').parentNode.classList.add(`${CUSTOM_CLASS}--blank`);
+    }
+
+    // Set required cell props
+    setProperties(this, {
+      isValueShown: !isCellHidden,
+      dimensionValue: filteredDimensionObj.value,
+      excludedDimensions: filteredDimensionObj.otherValues
     });
   }
 

--- a/thirdeye/thirdeye-frontend/app/pods/custom/dimensions-table/dimension/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/custom/dimensions-table/dimension/template.hbs
@@ -1,10 +1,21 @@
-{{#if isFirstColumn}}
+{{#if column.isFirstColumn}}
   {{input
     type="checkbox"
     class="rootcause-dimensions-table__checkbox-cell"
     checked=record.isSelected}}
 {{/if}}
 
-<div class="rootcause-dimensions-table__dimension-cell--dynamic {{if isFirstColumn "rootcause-dimensions-table__dimension-cell--first"}}" title="{{dimensionLabel}}">
-  {{dimensionLabel}}
+<div class="rootcause-dimensions-table__dimension-content {{if column.isFirstColumn "rootcause-dimensions-table__dimension-content--first"}}" title="{{dimensionValue}}">
+  {{#if isValueShown}}
+    {{#if excludedDimensions}}
+      <a class="te-anomaly-table__link" href="#">
+        {{dimensionValue}}
+        {{#tooltip-on-element}}
+          {{excludedDimensions}}
+        {{/tooltip-on-element}}
+      </a>
+    {{else}}
+      {{dimensionValue}}
+    {{/if}}
+  {{/if}}
 </div>

--- a/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/dimensions/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/dimensions/template.hbs
@@ -11,7 +11,7 @@
       range=context.analysisRange
       mode=context.compareMode
       selectedUrns=selectedUrns
-      isLoading=true
+      isLoading=isDimensionLoading
       onSelection=(action "onSelection")
     }}
   {{/subtab.tabpanel}}

--- a/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/dimensions/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/partials/rootcause/dimensions/template.hbs
@@ -1,23 +1,20 @@
 {{#shared/common-tabs selection=activeSubTabs.dimensions activeTab=activeSubTabs.dimensions as |subtab|}}
   {{#subtab.tablist as |subtablist|}}
-    {{#if model.isDevEnv}} {{!--  Remove conditional when table view is ready  --}}
-      {{#subtablist.tab name="table"}}Table{{/subtablist.tab}}
-    {{/if}}
+    {{#subtablist.tab name="table"}}Table{{/subtablist.tab}}
     {{#subtablist.tab name="heatmap"}}Heatmap{{/subtablist.tab}}
   {{/subtab.tablist}}
 
-  {{#if model.isDevEnv}} {{!--  Remove conditional when table view is ready --}}
-    {{#subtab.tabpanel name="table"}}
-      {{rootcause-dimensions
-        entities=entities
-        metricUrn=metricUrn
-        context=context
-        selectedUrns=selectedUrns
-        isLoading=true
-        onSelection=(action "onSelection")
-      }}
-    {{/subtab.tabpanel}}
-  {{/if}}
+  {{#subtab.tabpanel name="table"}}
+    {{rootcause-dimensions
+      entities=entities
+      metricUrn=metricUrn
+      range=context.analysisRange
+      mode=context.compareMode
+      selectedUrns=selectedUrns
+      isLoading=true
+      onSelection=(action "onSelection")
+    }}
+  {{/subtab.tabpanel}}
 
   {{#subtab.tabpanel name="heatmap"}}
     {{#if isLoadingBreakdowns}}

--- a/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/rootcause/controller.js
@@ -217,6 +217,12 @@ export default Controller.extend({
    */
   sessionOwner: null,
 
+  /**
+   * rootcause dimension table default loading state
+   * @type {boolean}
+   */
+  isDimensionLoading: true,
+
   //
   // static component config
   //
@@ -798,7 +804,8 @@ export default Controller.extend({
 
       this.setProperties({
         selectedUrns: new Set(selectedUrns),
-        sessionModified: true
+        sessionModified: true,
+        isDimensionLoading: false
       });
     },
 

--- a/thirdeye/thirdeye-frontend/app/styles/pods/custom/dimensions-table.scss
+++ b/thirdeye/thirdeye-frontend/app/styles/pods/custom/dimensions-table.scss
@@ -42,18 +42,17 @@
     white-space: nowrap;
 
     &--blank {
-      border: none;
+      border-top: none;
     }
+  }
+  &__dimension-content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 180px;
 
     &--first {
       margin-left: 10px;
       display: inline;
-    }
-
-    &--dynamic {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      max-width: 180px;
     }
   }
   &__header {

--- a/thirdeye/thirdeye-frontend/tests/integration/pods/components/rootcause-dimensions/component-test.js
+++ b/thirdeye/thirdeye-frontend/tests/integration/pods/components/rootcause-dimensions/component-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | rootcause-dimensions', function(hooks) {
   setupRenderingTest(hooks);
 
-  skip('it renders', async function(assert) {
+  test('it renders', async function(assert) {
     this.setProperties({
       metricUrn: 'dataset1:metric1:12345',
       entities: {
@@ -18,19 +18,25 @@ module('Integration | Component | rootcause-dimensions', function(hooks) {
         analysisRange: [ 1525806000000, 1526022000000 ],
         anomalyRange: [ 1525968000000, 1525978800000 ],
         compareMode: 'WoW'
-      }
+      },
+      selectedUrns: {},
+      onSelection: () => {}
     });
 
     await render(hbs`
       {{rootcause-dimensions
-        selectedUrn=metricUrn
         entities=entities
-        context=context
+        metricUrn=metricUrn
+        range=context.analysisRange
+        mode=context.compareMode
+        selectedUrns=selectedUrns
+        isLoading=true
+        onSelection=(action onSelection)
       }}
     `);
 
     const table = this.$('.rootcause-dimensions-table');
     assert.ok(table.length, 'It should render properly');
-    assert.ok(table.find('.table-header').length, 'It should have headers');
+    assert.ok(table.find('thead tr').length > 0, 'It should have headers');
   });
 });


### PR DESCRIPTION
Improving on the stability of the static table, responsive to changes in metric, analysis range, graph legend selections. This is after initial feedback from users:
- scalable spacing in change contribution visual column (bar width relative to max values)
- displaying first aggregate row (previously hidden)
- tooltips for excluded dimensions where available
- correction for `overall change` value

Sample data shown in screenshot:
![screen shot 2018-06-14 at 5 48 54 pm](https://user-images.githubusercontent.com/11814420/41444995-49fcc01c-6ffb-11e8-897e-e597d8f6a7ca.png)
