### PR TITLE
Support arbitrary percentile for percentile aggregation functions

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/DictionaryBasedAggregationOperator.java
@@ -23,7 +23,7 @@ import com.linkedin.pinot.core.query.aggregation.AggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.DoubleAggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
-import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionType;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.util.ArrayList;
@@ -69,8 +69,7 @@ public class DictionaryBasedAggregationOperator extends BaseOperator<Intermediat
 
     for (AggregationFunctionContext aggregationFunctionContext : _aggregationFunctionContexts) {
       AggregationFunction function = aggregationFunctionContext.getAggregationFunction();
-      AggregationFunctionFactory.AggregationFunctionType functionType =
-          AggregationFunctionFactory.AggregationFunctionType.valueOf(function.getName().toUpperCase());
+      AggregationFunctionType functionType = AggregationFunctionType.valueOf(function.getName().toUpperCase());
       String column = aggregationFunctionContext.getAggregationColumns()[0];
       Dictionary dictionary = _dictionaryMap.get(column);
       AggregationResultHolder resultHolder;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/operator/query/MetadataBasedAggregationOperator.java
@@ -26,6 +26,7 @@ import com.linkedin.pinot.core.query.aggregation.DoubleAggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionType;
 import com.linkedin.pinot.core.query.aggregation.function.customobject.MinMaxRangePair;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import java.util.ArrayList;
@@ -69,8 +70,7 @@ public class MetadataBasedAggregationOperator extends BaseOperator<IntermediateR
 
     for (AggregationFunctionContext aggregationFunctionContext : _aggregationFunctionContexts) {
       AggregationFunction function = aggregationFunctionContext.getAggregationFunction();
-      AggregationFunctionFactory.AggregationFunctionType functionType =
-          AggregationFunctionFactory.AggregationFunctionType.valueOf(function.getName().toUpperCase());
+      AggregationFunctionType functionType = AggregationFunctionType.valueOf(function.getName().toUpperCase());
       String column = aggregationFunctionContext.getAggregationColumns()[0];
 
       SegmentMetadataImpl segmentMetadata = (SegmentMetadataImpl) _segmentMetadata;

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/MetadataBasedAggregationPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/MetadataBasedAggregationPlanNode.java
@@ -22,7 +22,7 @@ import com.linkedin.pinot.core.common.Operator;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.query.MetadataBasedAggregationOperator;
 import com.linkedin.pinot.core.query.aggregation.AggregationFunctionContext;
-import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionType;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +61,7 @@ public class MetadataBasedAggregationPlanNode implements PlanNode {
     for (AggregationFunctionContext aggregationFunctionContext : aggregationFunctionContexts) {
       if (!aggregationFunctionContext.getAggregationFunction()
           .getName()
-          .equals(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+          .equals(AggregationFunctionType.COUNT.getName())) {
         for (String column : aggregationFunctionContext.getAggregationColumns()) {
           if (!dataSourceMap.containsKey(column)) {
             dataSourceMap.put(column, _indexSegment.getDataSource(column));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/TransformPlanNode.java
@@ -20,7 +20,7 @@ import com.linkedin.pinot.common.request.BrokerRequest;
 import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.operator.transform.TransformOperator;
-import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionType;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -60,8 +60,7 @@ public class TransformPlanNode implements PlanNode {
   private void extractColumnsAndTransforms(@Nonnull BrokerRequest brokerRequest) {
     if (brokerRequest.isSetAggregationsInfo()) {
       for (AggregationInfo aggregationInfo : brokerRequest.getAggregationsInfo()) {
-        if (!aggregationInfo.getAggregationType()
-            .equalsIgnoreCase(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+        if (!aggregationInfo.getAggregationType().equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
           String[] columns = aggregationInfo.getAggregationParams().get("column").split(",");
           for (String column : columns) {
             TransformExpressionTree transformExpressionTree = TransformExpressionTree.compileToExpressionTree(column);

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -17,7 +17,6 @@ package com.linkedin.pinot.core.plan.maker;
 
 import com.linkedin.pinot.common.request.AggregationInfo;
 import com.linkedin.pinot.common.request.BrokerRequest;
-import com.linkedin.pinot.core.common.DataSource;
 import com.linkedin.pinot.core.data.manager.SegmentDataManager;
 import com.linkedin.pinot.core.indexsegment.IndexSegment;
 import com.linkedin.pinot.core.plan.AggregationGroupByPlanNode;
@@ -30,10 +29,11 @@ import com.linkedin.pinot.core.plan.MetadataBasedAggregationPlanNode;
 import com.linkedin.pinot.core.plan.Plan;
 import com.linkedin.pinot.core.plan.PlanNode;
 import com.linkedin.pinot.core.plan.SelectionPlanNode;
-import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory.AggregationFunctionType;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionType;
 import com.linkedin.pinot.core.query.config.QueryExecutorConfig;
 import com.linkedin.pinot.core.segment.index.ColumnMetadata;
 import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
+import com.linkedin.pinot.core.segment.index.readers.Dictionary;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -85,8 +85,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     if (brokerRequest.isSetAggregationsInfo()) {
 
       if (brokerRequest.isSetGroupBy()) {
-        return new AggregationGroupByPlanNode(indexSegment, brokerRequest,
-            _maxInitialResultHolderCapacity, _numAggrGroupsLimit);
+        return new AggregationGroupByPlanNode(indexSegment, brokerRequest, _maxInitialResultHolderCapacity,
+            _numAggrGroupsLimit);
       } else {
         if (isFitForMetadataBasedPlan(brokerRequest, indexSegment)) {
           return new MetadataBasedAggregationPlanNode(indexSegment, brokerRequest.getAggregationsInfo());
@@ -151,8 +151,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
 
   private static boolean isMetadataBasedAggregationFunction(AggregationInfo aggregationInfo,
       IndexSegment indexSegment) {
-    AggregationFunctionType aggFuncType = AggregationFunctionType.valueOf(aggregationInfo.getAggregationType().toUpperCase());
-    if (aggFuncType.equals(AggregationFunctionType.COUNT)) {
+    String functionName = aggregationInfo.getAggregationType();
+    if (AggregationFunctionType.isOfType(functionName, AggregationFunctionType.COUNT)) {
       return true;
     }
 
@@ -164,16 +164,16 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
      * Keeping this code for reference, but not using it for now,
      * until all the edge cases are fixed
      */
-    //isMetadataBasedMinMax(aggFuncType, indexSegment, aggregationInfo);
+    //isMetadataBasedMinMax(functionName, indexSegment, aggregationInfo);
     return false;
   }
 
-  private static boolean isMetadataBasedMinMax(AggregationFunctionType aggFuncType,
-      IndexSegment indexSegment, AggregationInfo aggregationInfo) {
+  private static boolean isMetadataBasedMinMax(String functionName, IndexSegment indexSegment,
+      AggregationInfo aggregationInfo) {
     // Use minValue and maxValue from metadata, in non star tree cases
     // minValue and maxValue is generated from dictionary on segment load, so it won't be correct in case of star tree
-    if (aggFuncType.isOfType(AggregationFunctionType.MAX, AggregationFunctionType.MIN, AggregationFunctionType.MINMAXRANGE)
-        && !indexSegment.getSegmentMetadata().hasStarTree()) {
+    if (AggregationFunctionType.isOfType(functionName, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
+        AggregationFunctionType.MINMAXRANGE) && !indexSegment.getSegmentMetadata().hasStarTree()) {
       String column = aggregationInfo.getAggregationParams().get("column");
       SegmentMetadataImpl segmentMetadata = (SegmentMetadataImpl) indexSegment.getSegmentMetadata();
       if (segmentMetadata == null || segmentMetadata.getColumnMetadataMap() == null) {
@@ -195,12 +195,11 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
    * @param indexSegment
    * @return True if query can be served using dictionary, false otherwise.
    */
-  public static boolean isFitForDictionaryBasedPlan(BrokerRequest brokerRequest,
-      IndexSegment indexSegment) {
+  public static boolean isFitForDictionaryBasedPlan(BrokerRequest brokerRequest, IndexSegment indexSegment) {
     // Skipping dictionary in case of star tree. Results from dictionary won't be correct
     // because of aggregated values in metrics, and ALL value in dimension
-    if ((brokerRequest.getFilterQuery() != null) || brokerRequest.isSetGroupBy()
-        || indexSegment.getSegmentMetadata().hasStarTree()) {
+    if ((brokerRequest.getFilterQuery() != null) || brokerRequest.isSetGroupBy() || indexSegment.getSegmentMetadata()
+        .hasStarTree()) {
       return false;
     }
     List<AggregationInfo> aggregationsInfo = brokerRequest.getAggregationsInfo();
@@ -217,15 +216,12 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
 
   private static boolean isDictionaryBasedAggregationFunction(AggregationInfo aggregationInfo,
       IndexSegment indexSegment) {
-    AggregationFunctionType aggFuncType = AggregationFunctionType.valueOf(aggregationInfo.getAggregationType().toUpperCase());
-    if (aggFuncType.isOfType(AggregationFunctionType.MAX, AggregationFunctionType.MIN, AggregationFunctionType.MINMAXRANGE)) {
+    if (AggregationFunctionType.isOfType(aggregationInfo.getAggregationType(), AggregationFunctionType.MIN,
+        AggregationFunctionType.MAX, AggregationFunctionType.MINMAXRANGE)) {
       String column = aggregationInfo.getAggregationParams().get("column");
-      DataSource dataSource = indexSegment.getDataSource(column);
-      if (dataSource.getDataSourceMetadata().hasDictionary() && dataSource.getDictionary().isSorted()) {
-        return true;
-      }
+      Dictionary dictionary = indexSegment.getDataSource(column).getDictionary();
+      return dictionary != null && dictionary.isSorted();
     }
     return false;
   }
-
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/DefaultAggregationExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/DefaultAggregationExecutor.java
@@ -18,7 +18,7 @@ package com.linkedin.pinot.core.query.aggregation;
 import com.linkedin.pinot.common.request.transform.TransformExpressionTree;
 import com.linkedin.pinot.core.operator.blocks.TransformBlock;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
-import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionType;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -44,7 +44,7 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
       _functions[i] = function;
       _resultHolders[i] = _functions[i].createAggregationResultHolder();
       // TODO: currently only support single argument aggregation
-      if (!function.getName().equals(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+      if (!function.getName().equals(AggregationFunctionType.COUNT.getName())) {
         _expressions[i] =
             TransformExpressionTree.compileToExpressionTree(functionContexts[i].getAggregationColumns()[0]);
       }
@@ -58,7 +58,7 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
       AggregationFunction function = _functions[i];
       AggregationResultHolder resultHolder = _resultHolders[i];
 
-      if (function.getName().equals(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+      if (function.getName().equals(AggregationFunctionType.COUNT.getName())) {
         function.aggregate(length, resultHolder);
       } else {
         function.aggregate(length, resultHolder, transformBlock.getBlockValueSet(_expressions[i]));

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -15,6 +15,7 @@
  */
 package com.linkedin.pinot.core.query.aggregation.function;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.pinot.core.query.exception.BadQueryRequestException;
 import javax.annotation.Nonnull;
 
@@ -26,309 +27,85 @@ public class AggregationFunctionFactory {
   private AggregationFunctionFactory() {
   }
 
-  public enum AggregationFunctionType {
-    // Single-value aggregation functions.
-    COUNT("count"),
-    MIN("min"),
-    MAX("max"),
-    SUM("sum"),
-    AVG("avg"),
-    MINMAXRANGE("minMaxRange"),
-    DISTINCTCOUNT("distinctCount"),
-    DISTINCTCOUNTHLL("distinctCountHLL"),
-    FASTHLL("fastHLL"),
-    PERCENTILE5("percentile5"),
-    PERCENTILE10("percentile10"),
-    PERCENTILE20("percentile20"),
-    PERCENTILE25("percentile25"),
-    PERCENTILE30("percentile30"),
-    PERCENTILE40("percentile40"),
-    PERCENTILE50("percentile50"),
-    PERCENTILE60("percentile60"),
-    PERCENTILE70("percentile70"),
-    PERCENTILE75("percentile75"),
-    PERCENTILE80("percentile80"),
-    PERCENTILE90("percentile90"),
-    PERCENTILE95("percentile95"),
-    PERCENTILE99("percentile99"),
-    PERCENTILEEST5("percentileEst5"),
-    PERCENTILEEST10("percentileEst10"),
-    PERCENTILEEST20("percentileEst20"),
-    PERCENTILEEST25("percentileEst25"),
-    PERCENTILEEST30("percentileEst30"),
-    PERCENTILEEST40("percentileEst40"),
-    PERCENTILEEST50("percentileEst50"),
-    PERCENTILEEST60("percentileEst60"),
-    PERCENTILEEST70("percentileEst70"),
-    PERCENTILEEST75("percentileEst75"),
-    PERCENTILEEST80("percentileEst80"),
-    PERCENTILEEST90("percentileEst90"),
-    PERCENTILEEST95("percentileEst95"),
-    PERCENTILEEST99("percentileEst99"),
-    PERCENTILETDIGEST5("percentileTDigest5"),
-    PERCENTILETDIGEST10("percentileTDigest10"),
-    PERCENTILETDIGEST20("percentileTDigest20"),
-    PERCENTILETDIGEST25("percentileTDigest25"),
-    PERCENTILETDIGEST30("percentileTDigest30"),
-    PERCENTILETDIGEST40("percentileTDigest40"),
-    PERCENTILETDIGEST50("percentileTDigest50"),
-    PERCENTILETDIGEST60("percentileTDigest60"),
-    PERCENTILETDIGEST70("percentileTDigest70"),
-    PERCENTILETDIGEST75("percentileTDigest75"),
-    PERCENTILETDIGEST80("percentileTDigest80"),
-    PERCENTILETDIGEST90("percentileTDigest90"),
-    PERCENTILETDIGEST95("percentileTDigest95"),
-    PERCENTILETDIGEST99("percentileTDigest99"),
-    // Multi-value aggregation functions.
-    COUNTMV("countMV"),
-    MINMV("minMV"),
-    MAXMV("maxMV"),
-    SUMMV("sumMV"),
-    AVGMV("avgMV"),
-    MINMAXRANGEMV("minMaxRangeMV"),
-    DISTINCTCOUNTMV("distinctCountMV"),
-    DISTINCTCOUNTHLLMV("distinctCountHLLMV"),
-    FASTHLLMV("fastHLLMV"),
-    PERCENTILE5MV("percentile5MV"),
-    PERCENTILE10MV("percentile10MV"),
-    PERCENTILE20MV("percentile20MV"),
-    PERCENTILE25MV("percentile25MV"),
-    PERCENTILE30MV("percentile30MV"),
-    PERCENTILE40MV("percentile40MV"),
-    PERCENTILE50MV("percentile50MV"),
-    PERCENTILE60MV("percentile60MV"),
-    PERCENTILE70MV("percentile70MV"),
-    PERCENTILE75MV("percentile75MV"),
-    PERCENTILE80MV("percentile80MV"),
-    PERCENTILE90MV("percentile90MV"),
-    PERCENTILE95MV("percentile95MV"),
-    PERCENTILE99MV("percentile99MV"),
-    PERCENTILEEST5MV("percentileEst5MV"),
-    PERCENTILEEST10MV("percentileEst10MV"),
-    PERCENTILEEST20MV("percentileEst20MV"),
-    PERCENTILEEST25MV("percentileEst25MV"),
-    PERCENTILEEST30MV("percentileEst30MV"),
-    PERCENTILEEST40MV("percentileEst40MV"),
-    PERCENTILEEST50MV("percentileEst50MV"),
-    PERCENTILEEST60MV("percentileEst60MV"),
-    PERCENTILEEST70MV("percentileEst70MV"),
-    PERCENTILEEST75MV("percentileEst75MV"),
-    PERCENTILEEST80MV("percentileEst80MV"),
-    PERCENTILEEST90MV("percentileEst90MV"),
-    PERCENTILEEST95MV("percentileEst95MV"),
-    PERCENTILEEST99MV("percentileEst99MV");
-
-    private final String _name;
-
-    AggregationFunctionType(@Nonnull String name) {
-      _name = name;
-    }
-
-    @Nonnull
-    public String getName() {
-      return _name;
-    }
-
-    public boolean isOfType(AggregationFunctionType... aggregationFunctionTypes) {
-      for (AggregationFunctionType aggFuncType : aggregationFunctionTypes) {
-        if (this.equals(aggFuncType)) {
-          return true;
-        }
-      }
-      return false;
-    }
-  }
-
   /**
    * Given the name of aggregation function, create and return a new instance of the corresponding aggregation function.
    */
   @Nonnull
   public static AggregationFunction getAggregationFunction(@Nonnull String functionName) {
-    AggregationFunctionType aggregationFunctionType;
     try {
-      aggregationFunctionType = AggregationFunctionType.valueOf(functionName.toUpperCase());
+      String upperCaseFunctionName = functionName.toUpperCase();
+      if (upperCaseFunctionName.startsWith("PERCENTILE")) {
+        String remainingFunctionName = upperCaseFunctionName.substring(10);
+        if (remainingFunctionName.matches("\\d+")) {
+          // Percentile
+          return new PercentileAggregationFunction(parsePercentile(remainingFunctionName));
+        } else if (remainingFunctionName.matches("EST\\d+")) {
+          // PercentileEst
+          return new PercentileEstAggregationFunction(parsePercentile(remainingFunctionName.substring(3)));
+        } else if (remainingFunctionName.matches("TDIGEST\\d+")) {
+          // PercentileTDigest
+          return new PercentileTDigestAggregationFunction(parsePercentile(remainingFunctionName.substring(7)));
+        } else if (remainingFunctionName.matches("\\d+MV")) {
+          // PercentileMV
+          return new PercentileMVAggregationFunction(
+              parsePercentile(remainingFunctionName.substring(0, remainingFunctionName.length() - 2)));
+        } else if (remainingFunctionName.matches("EST\\d+MV")) {
+          // PercentileEstMV
+          return new PercentileEstMVAggregationFunction(
+              parsePercentile(remainingFunctionName.substring(3, remainingFunctionName.length() - 2)));
+        } else {
+          throw new UnsupportedOperationException();
+        }
+      } else {
+        switch (AggregationFunctionType.valueOf(upperCaseFunctionName)) {
+          case COUNT:
+            return new CountAggregationFunction();
+          case MIN:
+            return new MinAggregationFunction();
+          case MAX:
+            return new MaxAggregationFunction();
+          case SUM:
+            return new SumAggregationFunction();
+          case AVG:
+            return new AvgAggregationFunction();
+          case MINMAXRANGE:
+            return new MinMaxRangeAggregationFunction();
+          case DISTINCTCOUNT:
+            return new DistinctCountAggregationFunction();
+          case DISTINCTCOUNTHLL:
+            return new DistinctCountHLLAggregationFunction();
+          case FASTHLL:
+            return new FastHLLAggregationFunction();
+          case COUNTMV:
+            return new CountMVAggregationFunction();
+          case MINMV:
+            return new MinMVAggregationFunction();
+          case MAXMV:
+            return new MaxMVAggregationFunction();
+          case SUMMV:
+            return new SumMVAggregationFunction();
+          case AVGMV:
+            return new AvgMVAggregationFunction();
+          case MINMAXRANGEMV:
+            return new MinMaxRangeMVAggregationFunction();
+          case DISTINCTCOUNTMV:
+            return new DistinctCountMVAggregationFunction();
+          case DISTINCTCOUNTHLLMV:
+            return new DistinctCountHLLMVAggregationFunction();
+          case FASTHLLMV:
+            return new FastHLLMVAggregationFunction();
+          default:
+            throw new UnsupportedOperationException();
+        }
+      }
     } catch (Exception e) {
       throw new BadQueryRequestException("Invalid aggregation function name: " + functionName);
     }
-    switch (aggregationFunctionType) {
-      case COUNT:
-        return new CountAggregationFunction();
-      case MIN:
-        return new MinAggregationFunction();
-      case MAX:
-        return new MaxAggregationFunction();
-      case SUM:
-        return new SumAggregationFunction();
-      case AVG:
-        return new AvgAggregationFunction();
-      case MINMAXRANGE:
-        return new MinMaxRangeAggregationFunction();
-      case DISTINCTCOUNT:
-        return new DistinctCountAggregationFunction();
-      case DISTINCTCOUNTHLL:
-        return new DistinctCountHLLAggregationFunction();
-      case FASTHLL:
-        return new FastHLLAggregationFunction();
-      case PERCENTILE5:
-        return new PercentileAggregationFunction(5);
-      case PERCENTILE10:
-        return new PercentileAggregationFunction(10);
-      case PERCENTILE20:
-        return new PercentileAggregationFunction(20);
-      case PERCENTILE25:
-        return new PercentileAggregationFunction(25);
-      case PERCENTILE30:
-        return new PercentileAggregationFunction(30);
-      case PERCENTILE40:
-        return new PercentileAggregationFunction(40);
-      case PERCENTILE50:
-        return new PercentileAggregationFunction(50);
-      case PERCENTILE60:
-        return new PercentileAggregationFunction(60);
-      case PERCENTILE70:
-        return new PercentileAggregationFunction(70);
-      case PERCENTILE75:
-        return new PercentileAggregationFunction(75);
-      case PERCENTILE80:
-        return new PercentileAggregationFunction(80);
-      case PERCENTILE90:
-        return new PercentileAggregationFunction(90);
-      case PERCENTILE95:
-        return new PercentileAggregationFunction(95);
-      case PERCENTILE99:
-        return new PercentileAggregationFunction(99);
-      case PERCENTILEEST5:
-        return new PercentileEstAggregationFunction(5);
-      case PERCENTILEEST10:
-        return new PercentileEstAggregationFunction(10);
-      case PERCENTILEEST20:
-        return new PercentileEstAggregationFunction(20);
-      case PERCENTILEEST25:
-        return new PercentileEstAggregationFunction(25);
-      case PERCENTILEEST30:
-        return new PercentileEstAggregationFunction(30);
-      case PERCENTILEEST40:
-        return new PercentileEstAggregationFunction(40);
-      case PERCENTILEEST50:
-        return new PercentileEstAggregationFunction(50);
-      case PERCENTILEEST60:
-        return new PercentileEstAggregationFunction(60);
-      case PERCENTILEEST70:
-        return new PercentileEstAggregationFunction(70);
-      case PERCENTILEEST75:
-        return new PercentileEstAggregationFunction(75);
-      case PERCENTILEEST80:
-        return new PercentileEstAggregationFunction(80);
-      case PERCENTILEEST90:
-        return new PercentileEstAggregationFunction(90);
-      case PERCENTILEEST95:
-        return new PercentileEstAggregationFunction(95);
-      case PERCENTILEEST99:
-        return new PercentileEstAggregationFunction(99);
-      case PERCENTILETDIGEST5:
-        return new PercentileTDigestAggregationFunction(5);
-      case PERCENTILETDIGEST10:
-        return new PercentileTDigestAggregationFunction(10);
-      case PERCENTILETDIGEST20:
-        return new PercentileTDigestAggregationFunction(20);
-      case PERCENTILETDIGEST25:
-        return new PercentileTDigestAggregationFunction(25);
-      case PERCENTILETDIGEST30:
-        return new PercentileTDigestAggregationFunction(30);
-      case PERCENTILETDIGEST40:
-        return new PercentileTDigestAggregationFunction(40);
-      case PERCENTILETDIGEST50:
-        return new PercentileTDigestAggregationFunction(50);
-      case PERCENTILETDIGEST60:
-        return new PercentileTDigestAggregationFunction(60);
-      case PERCENTILETDIGEST70:
-        return new PercentileTDigestAggregationFunction(70);
-      case PERCENTILETDIGEST75:
-        return new PercentileTDigestAggregationFunction(75);
-      case PERCENTILETDIGEST80:
-        return new PercentileTDigestAggregationFunction(80);
-      case PERCENTILETDIGEST90:
-        return new PercentileTDigestAggregationFunction(90);
-      case PERCENTILETDIGEST95:
-        return new PercentileTDigestAggregationFunction(95);
-      case PERCENTILETDIGEST99:
-        return new PercentileTDigestAggregationFunction(99);
-      case COUNTMV:
-        return new CountMVAggregationFunction();
-      case MINMV:
-        return new MinMVAggregationFunction();
-      case MAXMV:
-        return new MaxMVAggregationFunction();
-      case SUMMV:
-        return new SumMVAggregationFunction();
-      case AVGMV:
-        return new AvgMVAggregationFunction();
-      case MINMAXRANGEMV:
-        return new MinMaxRangeMVAggregationFunction();
-      case DISTINCTCOUNTMV:
-        return new DistinctCountMVAggregationFunction();
-      case DISTINCTCOUNTHLLMV:
-        return new DistinctCountHLLMVAggregationFunction();
-      case FASTHLLMV:
-        return new FastHLLMVAggregationFunction();
-      case PERCENTILE5MV:
-        return new PercentileMVAggregationFunction(5);
-      case PERCENTILE10MV:
-        return new PercentileMVAggregationFunction(10);
-      case PERCENTILE20MV:
-        return new PercentileMVAggregationFunction(20);
-      case PERCENTILE25MV:
-        return new PercentileMVAggregationFunction(25);
-      case PERCENTILE30MV:
-        return new PercentileMVAggregationFunction(30);
-      case PERCENTILE40MV:
-        return new PercentileMVAggregationFunction(40);
-      case PERCENTILE50MV:
-        return new PercentileMVAggregationFunction(50);
-      case PERCENTILE60MV:
-        return new PercentileMVAggregationFunction(60);
-      case PERCENTILE70MV:
-        return new PercentileMVAggregationFunction(70);
-      case PERCENTILE75MV:
-        return new PercentileMVAggregationFunction(75);
-      case PERCENTILE80MV:
-        return new PercentileMVAggregationFunction(80);
-      case PERCENTILE90MV:
-        return new PercentileMVAggregationFunction(90);
-      case PERCENTILE95MV:
-        return new PercentileMVAggregationFunction(95);
-      case PERCENTILE99MV:
-        return new PercentileMVAggregationFunction(99);
-      case PERCENTILEEST5MV:
-        return new PercentileEstMVAggregationFunction(5);
-      case PERCENTILEEST10MV:
-        return new PercentileEstMVAggregationFunction(10);
-      case PERCENTILEEST20MV:
-        return new PercentileEstMVAggregationFunction(20);
-      case PERCENTILEEST25MV:
-        return new PercentileEstMVAggregationFunction(25);
-      case PERCENTILEEST30MV:
-        return new PercentileEstMVAggregationFunction(30);
-      case PERCENTILEEST40MV:
-        return new PercentileEstMVAggregationFunction(40);
-      case PERCENTILEEST50MV:
-        return new PercentileEstMVAggregationFunction(50);
-      case PERCENTILEEST60MV:
-        return new PercentileEstMVAggregationFunction(60);
-      case PERCENTILEEST70MV:
-        return new PercentileEstMVAggregationFunction(70);
-      case PERCENTILEEST75MV:
-        return new PercentileEstMVAggregationFunction(75);
-      case PERCENTILEEST80MV:
-        return new PercentileEstMVAggregationFunction(80);
-      case PERCENTILEEST90MV:
-        return new PercentileEstMVAggregationFunction(90);
-      case PERCENTILEEST95MV:
-        return new PercentileEstMVAggregationFunction(95);
-      case PERCENTILEEST99MV:
-        return new PercentileEstMVAggregationFunction(99);
-      default:
-        throw new UnsupportedOperationException();
-    }
+  }
+
+  private static int parsePercentile(String percentileString) {
+    int percentile = Integer.parseInt(percentileString);
+    Preconditions.checkState(percentile >= 0 && percentile <= 100);
+    return percentile;
   }
 }

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionType.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AggregationFunctionType.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.core.query.aggregation.function;
+
+import javax.annotation.Nonnull;
+
+
+public enum AggregationFunctionType {
+  // Aggregation functions for single-valued columns
+  COUNT("count"),
+  MIN("min"),
+  MAX("max"),
+  SUM("sum"),
+  AVG("avg"),
+  MINMAXRANGE("minMaxRange"),
+  DISTINCTCOUNT("distinctCount"),
+  DISTINCTCOUNTHLL("distinctCountHLL"),
+  FASTHLL("fastHLL"),
+  // Aggregation functions for multi-valued columns
+  COUNTMV("countMV"),
+  MINMV("minMV"),
+  MAXMV("maxMV"),
+  SUMMV("sumMV"),
+  AVGMV("avgMV"),
+  MINMAXRANGEMV("minMaxRangeMV"),
+  DISTINCTCOUNTMV("distinctCountMV"),
+  DISTINCTCOUNTHLLMV("distinctCountHLLMV"),
+  FASTHLLMV("fastHLLMV");
+
+  private final String _name;
+
+  AggregationFunctionType(@Nonnull String name) {
+    _name = name;
+  }
+
+  @Nonnull
+  public String getName() {
+    return _name;
+  }
+
+  public static boolean isOfType(@Nonnull String functionName,
+      @Nonnull AggregationFunctionType... aggregationFunctionTypes) {
+    String upperCaseFunctionName = functionName.toUpperCase();
+    for (AggregationFunctionType aggregationFunctionType : aggregationFunctionTypes) {
+      if (upperCaseFunctionName.equals(aggregationFunctionType.name())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
 
 
 public class AvgAggregationFunction implements AggregationFunction<AvgPair, Double> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.AVG.getName();
+  private static final String NAME = AggregationFunctionType.AVG.getName();
   private static final double DEFAULT_FINAL_RESULT = Double.NEGATIVE_INFINITY;
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 
 
 public class AvgMVAggregationFunction extends AvgAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.AVGMV.getName();
+  private static final String NAME = AggregationFunctionType.AVGMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 
 
 public class CountAggregationFunction implements AggregationFunction<Long, Long> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.COUNT.getName();
+  private static final String NAME = AggregationFunctionType.COUNT.getName();
   private static final double DEFAULT_INITIAL_VALUE = 0.0;
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 
 
 public class CountMVAggregationFunction extends CountAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.COUNTMV.getName();
+  private static final String NAME = AggregationFunctionType.COUNTMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountAggregationFunction implements AggregationFunction<IntOpenHashSet, Integer> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNT.getName();
+  private static final String NAME = AggregationFunctionType.DISTINCTCOUNT.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountHLLAggregationFunction implements AggregationFunction<HyperLogLog, Long> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNTHLL.getName();
+  private static final String NAME = AggregationFunctionType.DISTINCTCOUNTHLL.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountHLLMVAggregationFunction.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountHLLMVAggregationFunction extends DistinctCountHLLAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNTHLLMV.getName();
+  private static final String NAME = AggregationFunctionType.DISTINCTCOUNTHLLMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 
 
 public class DistinctCountMVAggregationFunction extends DistinctCountAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.DISTINCTCOUNTMV.getName();
+  private static final String NAME = AggregationFunctionType.DISTINCTCOUNTMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLAggregationFunction.java
@@ -29,7 +29,7 @@ import javax.annotation.Nonnull;
 
 
 public class FastHLLAggregationFunction implements AggregationFunction<HyperLogLog, Long> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.FASTHLL.getName();
+  private static final String NAME = AggregationFunctionType.FASTHLL.getName();
 
   protected int _log2m = HllConstants.DEFAULT_LOG2M;
 

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/FastHLLMVAggregationFunction.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 
 
 public class FastHLLMVAggregationFunction extends FastHLLAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.FASTHLLMV.getName();
+  private static final String NAME = AggregationFunctionType.FASTHLLMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 
 
 public class MaxAggregationFunction implements AggregationFunction<Double, Double> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MAX.getName();
+  private static final String NAME = AggregationFunctionType.MAX.getName();
   private static final double DEFAULT_INITIAL_VALUE = Double.NEGATIVE_INFINITY;
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 
 
 public class MaxMVAggregationFunction extends MaxAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MAXMV.getName();
+  private static final String NAME = AggregationFunctionType.MAXMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 
 
 public class MinAggregationFunction implements AggregationFunction<Double, Double> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MIN.getName();
+  private static final String NAME = AggregationFunctionType.MIN.getName();
   private static final double DEFAULT_VALUE = Double.POSITIVE_INFINITY;
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 
 
 public class MinMVAggregationFunction extends MinAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MINMV.getName();
+  private static final String NAME = AggregationFunctionType.MINMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeAggregationFunction.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
 
 
 public class MinMaxRangeAggregationFunction implements AggregationFunction<MinMaxRangePair, Double> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MINMAXRANGE.getName();
+  private static final String NAME = AggregationFunctionType.MINMAXRANGE.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/MinMaxRangeMVAggregationFunction.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 
 
 public class MinMaxRangeMVAggregationFunction extends MinMaxRangeAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.MINMAXRANGEMV.getName();
+  private static final String NAME = AggregationFunctionType.MINMAXRANGEMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 
 
 public class SumAggregationFunction implements AggregationFunction<Double, Double> {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.SUM.getName();
+  private static final String NAME = AggregationFunctionType.SUM.getName();
   private static final double DEFAULT_VALUE = 0.0;
 
   @Nonnull

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -22,7 +22,7 @@ import javax.annotation.Nonnull;
 
 
 public class SumMVAggregationFunction extends SumAggregationFunction {
-  private static final String NAME = AggregationFunctionFactory.AggregationFunctionType.SUMMV.getName();
+  private static final String NAME = AggregationFunctionType.SUMMV.getName();
 
   @Nonnull
   @Override

--- a/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -25,6 +25,7 @@ import com.linkedin.pinot.core.plan.DocIdSetPlanNode;
 import com.linkedin.pinot.core.query.aggregation.AggregationFunctionContext;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunction;
 import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import com.linkedin.pinot.core.query.aggregation.function.AggregationFunctionType;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -82,7 +83,7 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
       AggregationFunction function = functionContexts[i].getAggregationFunction();
       _functions[i] = function;
       // TODO: currently only support single argument aggregation
-      if (!function.getName().equals(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+      if (!function.getName().equals(AggregationFunctionType.COUNT.getName())) {
         _aggregationExpressions[i] =
             TransformExpressionTree.compileToExpressionTree(functionContexts[i].getAggregationColumns()[0]);
       }
@@ -149,7 +150,7 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
       GroupByResultHolder resultHolder = _resultHolders[i];
 
       resultHolder.ensureCapacity(capacityNeeded);
-      if (function.getName().equals(AggregationFunctionFactory.AggregationFunctionType.COUNT.getName())) {
+      if (function.getName().equals(AggregationFunctionType.COUNT.getName())) {
         if (_hasMVGroupByExpression) {
           function.aggregateGroupByMV(length, _mvGroupKeys, resultHolder);
         } else {


### PR DESCRIPTION
1. Use regex matching to automatically figure out the percentile
2. Remove redundant aggregation function types
3. Change the AggregationFunctionType.isOfType() so that it won't throw exception when function name is not a valid aggregation function type. When matching function name with specific types, it should not throw any exception