### PR TITLE
Return detailed error responses for Table API errors

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -114,7 +114,7 @@ public class PinotTableRestletResource {
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
       if (e instanceof PinotHelixResourceManager.InvalidTableConfigException) {
-        String errStr = "Invalid table config for table: " + tableName;
+        String errStr = String.format("Invalid table config for table %s: %s", tableName, e.getMessage());
         throw new ControllerApplicationException(LOGGER, errStr, Response.Status.BAD_REQUEST, e);
       } else if (e instanceof PinotHelixResourceManager.TableAlreadyExistsException) {
         throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
@@ -285,7 +285,7 @@ public class PinotTableRestletResource {
       ensureMinReplicas(tableConfig);
       _pinotHelixResourceManager.setExistingTableConfig(tableConfig, tableNameWithType, tableType);
     } catch (PinotHelixResourceManager.InvalidTableConfigException e) {
-      String errStr = "Failed to update configuration for table " + tableName;
+      String errStr = String.format("Failed to update configuration for %s due to: %s", tableName, e.getMessage());
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER, errStr, Response.Status.BAD_REQUEST, e);
     } catch (Exception e) {
@@ -315,7 +315,7 @@ public class PinotTableRestletResource {
       }
       return tableConfigValidateStr.toString();
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, "Invalid JSON", Response.Status.BAD_REQUEST);
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);
     }
   }
 
@@ -346,7 +346,8 @@ public class PinotTableRestletResource {
       try {
         streamMetadata = new StreamMetadata(config.getIndexingConfig().getStreamConfigs());
       } catch (Exception e) {
-        throw new PinotHelixResourceManager.InvalidTableConfigException("Invalid tableIndexConfig or streamConfigs", e);
+        String errorMsg = String.format("Invalid tableIndexConfig or streamConfig: %s", e.getMessage());
+        throw new PinotHelixResourceManager.InvalidTableConfigException(errorMsg, e);
       }
       verifyReplicasPerPartition = streamMetadata.hasSimpleKafkaConsumerType();
       verifyReplication = streamMetadata.hasHighLevelKafkaConsumerType();

--- a/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/com/linkedin/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -117,6 +117,17 @@ public class PinotTableRestletResourceTest extends ControllerTest {
       Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 409"));
     }
 
+    // Create an OFFLINE table with invalid replication config
+    offlineTableConfig.getValidationConfig().setReplication("abc");
+    offlineTableConfig.setTableName("invalid_replication_table");
+    try {
+      sendPostRequest(_createTableUrl, offlineTableConfig.toJSONConfigString());
+      Assert.fail("Creation of an invalid OFFLINE table does not fail");
+    } catch (IOException e) {
+      // Expected 400 Bad Request
+      Assert.assertTrue(e.getMessage().startsWith("Server returned HTTP response code: 400"));
+    }
+
     // Create a REALTIME table with an invalid name which should fail
     // NOTE: Set bad table name inside table config builder is not allowed, so have to explicitly set in table config
     TableConfig realtimeTableConfig = _realtimeBuilder.build();


### PR DESCRIPTION
Currently, when an invalid table config is posted, the message with the 400 error response does not indicate what the error is. This change provides the error message where applicable.

Testing done:
==========
Before this change, having a non-numeric value for the "replication" field resulted in this response for curl:
{"code":400,"error":"Invalid table config for table: audience_OFFLINE"}

With the change, we now see:
{"code":400,"error":"Invalid table config for table audience_OFFLINE: Invalid replication number"}

I updated a unit test for this scenario, but the response string in the unit tests don't capture the error detail.

TODO:
---------
Review the same for other APIs as well.