### PR TITLE
Refactor PinotResourceManagerResponse to make it immutable and provide a uniform way to construct

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -123,10 +123,8 @@ public class PinotInstanceRestletResource {
   })
   public SuccessResponse addInstance(Instance instance) {
     LOGGER.info("Instance creation request received for instance " + instance.toInstanceId());
-    final PinotResourceManagerResponse resp = pinotHelixResourceManager.addInstance(instance);
-    if (resp.status == PinotResourceManagerResponse.ResponseStatus.failure) {
-      throw new ControllerApplicationException(LOGGER, "Instance already exists",
-          Response.Status.CONFLICT);
+    if (!pinotHelixResourceManager.addInstance(instance).isSuccessful()) {
+      throw new ControllerApplicationException(LOGGER, "Instance already exists", Response.Status.CONFLICT);
     }
     return new SuccessResponse("Instance successfully created");
   }

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -420,6 +420,7 @@ public class PinotSegmentRestletResource {
    * @return
    * @throws JSONException
    */
+  // TODO: move this method into PinotHelixResourceManager
   private static PinotResourceManagerResponse toggleSegmentsForTable(@Nonnull List<String> segmentsToToggle,
       @Nonnull String tableName, String segmentName, @Nonnull StateType state,
       PinotHelixResourceManager helixResourceManager) {
@@ -429,9 +430,9 @@ public class PinotSegmentRestletResource {
       if (state == StateType.ENABLE) {
         int instanceCount = helixResourceManager.getAllInstances().size();
         if (instanceCount != 0) {
-          timeOutInSeconds = (long) ((_offlineToOnlineTimeoutInseconds * segmentsToToggle.size()) / instanceCount);
+          timeOutInSeconds = (_offlineToOnlineTimeoutInseconds * segmentsToToggle.size()) / instanceCount;
         } else {
-          return new PinotResourceManagerResponse("Error: could not find any instances in table " + tableName, false);
+          return PinotResourceManagerResponse.failure("No instance found for table " + tableName);
         }
       }
     }
@@ -447,7 +448,7 @@ public class PinotSegmentRestletResource {
       //
       // In jersey, API, if there are no segments in realtime (or in offline), we succeed the operation AND return 200
       // if we succeeded.
-      return new PinotResourceManagerResponse("No segments to toggle", true);
+      return PinotResourceManagerResponse.success("No segment to toggle");
     }
 
     switch (state) {

--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotResourceManagerResponse.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/PinotResourceManagerResponse.java
@@ -15,67 +15,40 @@
  */
 package com.linkedin.pinot.controller.helix.core;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 public class PinotResourceManagerResponse {
+  public static final PinotResourceManagerResponse SUCCESS = new PinotResourceManagerResponse(true, null);
+  public static final PinotResourceManagerResponse FAILURE = new PinotResourceManagerResponse(false, null);
 
-  public final static PinotResourceManagerResponse SUCCESS_RESPONSE = new PinotResourceManagerResponse(true);
-  public final static PinotResourceManagerResponse FAILURE_RESPONSE = new PinotResourceManagerResponse(false);
+  private final boolean _successful;
+  private final String _message;
 
-  public enum ResponseStatus {
-    success,
-    failure;
+  public static PinotResourceManagerResponse success(String message) {
+    return new PinotResourceManagerResponse(true, message);
   }
 
-  public String message = "";
-  public ResponseStatus status = ResponseStatus.failure;
-
-  public PinotResourceManagerResponse() {
+  public static PinotResourceManagerResponse failure(String message) {
+    return new PinotResourceManagerResponse(false, message);
   }
 
-  public PinotResourceManagerResponse(String message, boolean succeeded) {
-    this.message = message;
-    if (succeeded) {
-      status = ResponseStatus.success;
-    } else {
-      status = ResponseStatus.failure;
-    }
-  }
-
-  public PinotResourceManagerResponse(boolean isSucceed) {
-    if (isSucceed) {
-      status = ResponseStatus.success;
-    } else {
-      status = ResponseStatus.failure;
-    }
+  private PinotResourceManagerResponse(boolean successful, String message) {
+    _successful = successful;
+    _message = message;
   }
 
   public boolean isSuccessful() {
-    return status == ResponseStatus.success;
+    return _successful;
   }
 
-  public JSONObject toJSON() throws JSONException {
-    final JSONObject ret = new JSONObject();
-    ret.put("status", status.toString());
-    if (status == ResponseStatus.success) {
-      ret.put("message", message);
-    } else {
-      ret.put("errorMessage", message);
-    }
-    return ret;
+  public String getMessage() {
+    return _message;
   }
 
   @Override
   public String toString() {
-    if (status == ResponseStatus.success) {
-      return "status : " + status + ",\tmessage : " + message;
+    if (_successful) {
+      return _message == null ? "SUCCESS" : "SUCCESS: " + _message;
     } else {
-      return "status : " + status + ",\terrorMessage : " + message;
+      return _message == null ? "FAILURE" : "FAILURE: " + _message;
     }
-  }
-
-  public String getMessage() {
-    return message;
   }
 }


### PR DESCRIPTION
Make PinotResourceManagerResponse immutable, and always be constructed by static methods PinotResourceManagerResponse.success() and PinotResourceManagaerResponse.failure()
Currently all members in PinotResourceManagerResponse are public and mutable, and some pieces of code change them in multiple steps which is very confusing and not necessary
PinotResourceManagerResponse should be immutable and always with the state SUCCESS/FAILURE
With this PR, we uniform the way of constructing the response and make it easier to use