### PR TITLE
Fix the race condition when modifying the same segment file on pinot server

### DIFF
--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -29,6 +29,7 @@ import com.linkedin.pinot.core.segment.index.SegmentMetadataImpl;
 import com.linkedin.pinot.core.segment.index.loader.LoaderUtils;
 import com.linkedin.pinot.core.segment.index.loader.V3RemoveIndexException;
 import java.io.File;
+import java.util.concurrent.locks.Lock;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
@@ -56,29 +57,35 @@ public class SegmentFetcherAndLoader {
     SegmentFetcherFactory.getInstance().init(segmentFetcherFactoryConfig);
   }
 
-  public void addOrReplaceOfflineSegment(String tableName, String segmentId) {
+  public void addOrReplaceOfflineSegment(String tableNameWithType, String segmentName) {
     OfflineSegmentZKMetadata newSegmentZKMetadata =
-        ZKMetadataProvider.getOfflineSegmentZKMetadata(_propertyStore, tableName, segmentId);
+        ZKMetadataProvider.getOfflineSegmentZKMetadata(_propertyStore, tableNameWithType, segmentName);
     Preconditions.checkNotNull(newSegmentZKMetadata);
 
-    LOGGER.info("Adding or replacing segment {} for table {}, metadata {}", segmentId, tableName, newSegmentZKMetadata);
+    LOGGER.info("Adding or replacing segment {} for table {}, metadata {}", segmentName, tableNameWithType,
+        newSegmentZKMetadata);
+
+    // This method might modify the file on disk. Use segment lock to prevent race condition
+    Lock segmentLock = SegmentLocks.getSegmentLock(tableNameWithType, segmentName);
     try {
+      segmentLock.lock();
+
       // We lock the segment in order to get its metadata, and then release the lock, so it is possible
       // that the segment is dropped after we get its metadata.
-      SegmentMetadata localSegmentMetadata = _dataManager.getSegmentMetadata(tableName, segmentId);
+      SegmentMetadata localSegmentMetadata = _dataManager.getSegmentMetadata(tableNameWithType, segmentName);
 
       if (localSegmentMetadata == null) {
-        LOGGER.info("Segment {} of table {} is not loaded in memory, checking disk", segmentId, tableName);
-        File indexDir = new File(getSegmentLocalDirectory(tableName, segmentId));
+        LOGGER.info("Segment {} of table {} is not loaded in memory, checking disk", segmentName, tableNameWithType);
+        File indexDir = new File(getSegmentLocalDirectory(tableNameWithType, segmentName));
         // Restart during segment reload might leave segment in inconsistent state (index directory might not exist but
         // segment backup directory existed), need to first try to recover from reload failure before checking the
         // existence of the index directory and loading segment metadata from it
         LoaderUtils.reloadFailureRecovery(indexDir);
         if (indexDir.exists()) {
-          LOGGER.info("Segment {} of table {} found on disk, attempting to load it", segmentId, tableName);
+          LOGGER.info("Segment {} of table {} found on disk, attempting to load it", segmentName, tableNameWithType);
           try {
             localSegmentMetadata = new SegmentMetadataImpl(indexDir);
-            LOGGER.info("Found segment {} of table {} with crc {} on disk", segmentId, tableName,
+            LOGGER.info("Found segment {} of table {} with crc {} on disk", segmentName, tableNameWithType,
                 localSegmentMetadata.getCrc());
           } catch (Exception e) {
             // The localSegmentDir should help us get the table name,
@@ -88,21 +95,21 @@ public class SegmentFetcherAndLoader {
           }
           try {
             if (!isNewSegmentMetadata(newSegmentZKMetadata, localSegmentMetadata)) {
-              LOGGER.info("Segment metadata same as before, loading {} of table {} (crc {}) from disk", segmentId,
-                  tableName, localSegmentMetadata.getCrc());
-              _dataManager.addOfflineSegment(tableName, segmentId, indexDir);
+              LOGGER.info("Segment metadata same as before, loading {} of table {} (crc {}) from disk", segmentName,
+                  tableNameWithType, localSegmentMetadata.getCrc());
+              _dataManager.addOfflineSegment(tableNameWithType, segmentName, indexDir);
               // TODO Update zk metadata with CRC for this instance
               return;
             }
           } catch (V3RemoveIndexException e) {
             LOGGER.info(
                 "Unable to remove local index from V3 format segment: {}, table: {}, try to reload it from controller.",
-                segmentId, tableName, e);
+                segmentName, tableNameWithType, e);
             FileUtils.deleteQuietly(indexDir);
             localSegmentMetadata = null;
           } catch (Exception e) {
-            LOGGER.error("Failed to load {} of table {} from local, will try to reload it from controller!", segmentId,
-                tableName, e);
+            LOGGER.error("Failed to load {} of table {} from local, will try to reload it from controller!",
+                segmentName, tableNameWithType, e);
             FileUtils.deleteQuietly(indexDir);
             localSegmentMetadata = null;
           }
@@ -120,25 +127,27 @@ public class SegmentFetcherAndLoader {
       // that we have is different from that in zookeeper.
       if (isNewSegmentMetadata(newSegmentZKMetadata, localSegmentMetadata)) {
         if (localSegmentMetadata == null) {
-          LOGGER.info("Loading new segment {} of table {} from controller", segmentId, tableName);
+          LOGGER.info("Loading new segment {} of table {} from controller", segmentName, tableNameWithType);
         } else {
-          LOGGER.info("Trying to refresh segment {} of table {} with new data.", segmentId, tableName);
+          LOGGER.info("Trying to refresh segment {} of table {} with new data.", segmentName, tableNameWithType);
         }
         String uri = newSegmentZKMetadata.getDownloadUrl();
         // Retry will be done here.
-        String localSegmentDir = downloadSegmentToLocal(uri, tableName, segmentId);
+        String localSegmentDir = downloadSegmentToLocal(uri, tableNameWithType, segmentName);
         SegmentMetadata segmentMetadata = new SegmentMetadataImpl(new File(localSegmentDir));
-        _dataManager.addOfflineSegment(tableName, segmentId, new File(localSegmentDir));
-        LOGGER.info("Downloaded segment {} of table {} crc {} from controller", segmentId, tableName,
+        _dataManager.addOfflineSegment(tableNameWithType, segmentName, new File(localSegmentDir));
+        LOGGER.info("Downloaded segment {} of table {} crc {} from controller", segmentName, tableNameWithType,
             segmentMetadata.getCrc());
       } else {
-        LOGGER.info("Got already loaded segment {} of table {} crc {} again, will do nothing.", segmentId, tableName,
-            localSegmentMetadata.getCrc());
+        LOGGER.info("Got already loaded segment {} of table {} crc {} again, will do nothing.", segmentName,
+            tableNameWithType, localSegmentMetadata.getCrc());
       }
     } catch (final Exception e) {
-      LOGGER.error("Cannot load segment : " + segmentId + " for table " + tableName, e);
+      LOGGER.error("Cannot load segment : " + segmentName + " for table " + tableNameWithType, e);
       Utils.rethrowException(e);
       throw new AssertionError("Should not reach this");
+    } finally {
+      segmentLock.unlock();
     }
   }
 

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentLocks.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentLocks.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2014-2016 LinkedIn Corp. (pinot-core@linkedin.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.linkedin.pinot.server.starter.helix;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+public class SegmentLocks {
+  private static final int NUM_LOCKS = 10000;
+  private static final Lock[] LOCKS = new Lock[NUM_LOCKS];
+
+  static {
+    for (int i = 0; i < NUM_LOCKS; i++) {
+      LOCKS[i] = new ReentrantLock();
+    }
+  }
+
+  public static Lock getSegmentLock(String tableNameWithType, String segmentName) {
+    return LOCKS[Math.abs((31 * tableNameWithType.hashCode() + segmentName.hashCode()) % NUM_LOCKS)];
+  }
+}

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
@@ -96,14 +96,14 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
 
   private class SegmentRefreshMessageHandler extends MessageHandler {
     private final String _segmentName;
-    private final String _tableName;
+    private final String _tableNameWithType;
     private final Logger _logger;
 
     public SegmentRefreshMessageHandler(SegmentRefreshMessage refreshMessage, NotificationContext context) {
       super(refreshMessage, context);
       _segmentName = refreshMessage.getPartitionName();
-      _tableName = refreshMessage.getResourceName();
-      _logger = LoggerFactory.getLogger(_tableName + "-" + SegmentRefreshMessageHandler.class);
+      _tableNameWithType = refreshMessage.getResourceName();
+      _logger = LoggerFactory.getLogger(_tableNameWithType + "-" + SegmentRefreshMessageHandler.class);
     }
 
     @Override
@@ -113,7 +113,7 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
       try {
         acquireSema(_segmentName, LOGGER);
         // The number of retry times depends on the retry count in SegmentOperations.
-        _fetcherAndLoader.addOrReplaceOfflineSegment(_tableName, _segmentName);
+        _fetcherAndLoader.addOrReplaceOfflineSegment(_tableNameWithType, _segmentName);
         result.setSuccess(true);
       } finally {
         releaseSema();

--- a/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/com/linkedin/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -28,6 +28,7 @@ import com.linkedin.pinot.core.data.manager.SegmentDataManager;
 import com.linkedin.pinot.core.data.manager.TableDataManager;
 import com.linkedin.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
 import java.io.File;
+import java.util.concurrent.locks.Lock;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.ZNRecord;
@@ -189,17 +190,24 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     @Transition(from = "OFFLINE", to = "DROPPED")
     public void onBecomeDroppedFromOffline(Message message, NotificationContext context) {
       _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOffline() : " + message);
-      final String segmentId = message.getPartitionName();
-      final String tableName = message.getResourceName();
+      String tableNameWithType = message.getResourceName();
+      String segmentName = message.getPartitionName();
+
+      // This method might modify the file on disk. Use segment lock to prevent race condition
+      Lock segmentLock = SegmentLocks.getSegmentLock(tableNameWithType, segmentName);
       try {
-        final File segmentDir = new File(_fetcherAndLoader.getSegmentLocalDirectory(tableName, segmentId));
+        segmentLock.lock();
+
+        final File segmentDir = new File(_fetcherAndLoader.getSegmentLocalDirectory(tableNameWithType, segmentName));
         if (segmentDir.exists()) {
           FileUtils.deleteQuietly(segmentDir);
           _logger.info("Deleted segment directory {}", segmentDir);
         }
       } catch (final Exception e) {
-        _logger.error("Cannot delete the segment : " + segmentId + " from local directory!\n" + e.getMessage(), e);
+        _logger.error("Cannot delete the segment : " + segmentName + " from local directory!\n" + e.getMessage(), e);
         Utils.rethrowException(e);
+      } finally {
+        segmentLock.unlock();
       }
     }
 


### PR DESCRIPTION
Add/Delete/Refresh/Reload operations might modify the segment file. Prevent them running on the same segment.
Use a global lock array to lock the segment based on hash value of table name and segment name.

NOTE: This is a quick fix. The clean fix would be managing everything in TableDataManager