### PR TITLE
Count scheduling time into query timeout, and also add early termination if scheduling takes too long

### DIFF
--- a/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/exception/QueryException.java
@@ -42,6 +42,7 @@ public class QueryException {
   // TODO: Handle these errors in broker
   public static final int SERVER_SHUTTING_DOWN_ERROR_CODE = 210;
   public static final int SERVER_OUT_OF_CAPACITY_ERROR_CODE = 211;
+  public static final int QUERY_SCHEDULING_TIMEOUT_ERROR_CODE = 240;
   public static final int EXECUTION_TIMEOUT_ERROR_CODE = 250;
   public static final int BROKER_GATHER_ERROR_CODE = 300;
   public static final int DATA_TABLE_DESERIALIZATION_ERROR_CODE = 310;
@@ -66,8 +67,12 @@ public class QueryException {
   public static final ProcessingException COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR =
       new ProcessingException(COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR_CODE);
   public static final ProcessingException QUERY_EXECUTION_ERROR = new ProcessingException(QUERY_EXECUTION_ERROR_CODE);
-  public static final ProcessingException SERVER_SCHEDULER_DOWN_ERROR = new ProcessingException(SERVER_SHUTTING_DOWN_ERROR_CODE);
-  public static final ProcessingException SERVER_OUT_OF_CAPACITY_ERROR = new ProcessingException(SERVER_OUT_OF_CAPACITY_ERROR_CODE);
+  public static final ProcessingException SERVER_SCHEDULER_DOWN_ERROR =
+      new ProcessingException(SERVER_SHUTTING_DOWN_ERROR_CODE);
+  public static final ProcessingException SERVER_OUT_OF_CAPACITY_ERROR =
+      new ProcessingException(SERVER_OUT_OF_CAPACITY_ERROR_CODE);
+  public static final ProcessingException QUERY_SCHEDULING_TIMEOUT_ERROR =
+      new ProcessingException(QUERY_SCHEDULING_TIMEOUT_ERROR_CODE);
   public static final ProcessingException EXECUTION_TIMEOUT_ERROR =
       new ProcessingException(EXECUTION_TIMEOUT_ERROR_CODE);
   public static final ProcessingException BROKER_GATHER_ERROR = new ProcessingException(BROKER_GATHER_ERROR_CODE);
@@ -98,6 +103,7 @@ public class QueryException {
     QUERY_EXECUTION_ERROR.setMessage("QueryExecutionError");
     SERVER_SCHEDULER_DOWN_ERROR.setMessage("ServerShuttingDown");
     SERVER_OUT_OF_CAPACITY_ERROR.setMessage("ServerOutOfCapacity");
+    QUERY_SCHEDULING_TIMEOUT_ERROR.setMessage("QuerySchedulingTimeoutError");
     EXECUTION_TIMEOUT_ERROR.setMessage("ExecutionTimeoutError");
     BROKER_GATHER_ERROR.setMessage("BrokerGatherError");
     DATA_TABLE_DESERIALIZATION_ERROR.setMessage("DataTableDeserializationError");

--- a/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/com/linkedin/pinot/common/metrics/ServerMeter.java
@@ -27,6 +27,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   UNCAUGHT_EXCEPTIONS("exceptions", true),
   REQUEST_DESERIALIZATION_EXCEPTIONS("exceptions", true),
   RESPONSE_SERIALIZATION_EXCEPTIONS("exceptions", true),
+  SCHEDULING_TIMEOUT_EXCEPTIONS("exceptions", true),
   QUERY_EXECUTION_EXCEPTIONS("exceptions", false),
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
   DELETED_SEGMENT_COUNT("segments", false),

--- a/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/com/linkedin/pinot/query/executor/QueryExecutorTest.java
@@ -118,9 +118,7 @@ public class QueryExecutorTest {
     String query = "SELECT COUNT(*) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest =
-        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
-    DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
+    DataTable instanceResponse = _queryExecutor.processQuery(getQueryRequest(instanceRequest), QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getLong(0, 0), 400002L);
   }
 
@@ -129,9 +127,7 @@ public class QueryExecutorTest {
     String query = "SELECT SUM(met) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest =
-        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
-    DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
+    DataTable instanceResponse = _queryExecutor.processQuery(getQueryRequest(instanceRequest), QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 40000200000.0);
   }
 
@@ -140,9 +136,7 @@ public class QueryExecutorTest {
     String query = "SELECT MAX(met) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest =
-        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
-    DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
+    DataTable instanceResponse = _queryExecutor.processQuery(getQueryRequest(instanceRequest), QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 200000.0);
   }
 
@@ -151,9 +145,7 @@ public class QueryExecutorTest {
     String query = "SELECT MIN(met) FROM " + TABLE_NAME;
     InstanceRequest instanceRequest = new InstanceRequest(0L, COMPILER.compileToBrokerRequest(query));
     instanceRequest.setSearchSegments(_segmentNames);
-    ServerQueryRequest queryRequest =
-        new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
-    DataTable instanceResponse = _queryExecutor.processQuery(queryRequest, QUERY_RUNNERS);
+    DataTable instanceResponse = _queryExecutor.processQuery(getQueryRequest(instanceRequest), QUERY_RUNNERS);
     Assert.assertEquals(instanceResponse.getDouble(0, 0), 0.0);
   }
 
@@ -163,5 +155,9 @@ public class QueryExecutorTest {
       segment.destroy();
     }
     FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  private ServerQueryRequest getQueryRequest(InstanceRequest instanceRequest) {
+    return new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
   }
 }


### PR DESCRIPTION
1. Count scheduling time into query timeout, use the remaining time as the timeout for query execution
2. If scheduling delay is longer than query timout, terly terminate the query with exception
3. Add a metric to track scheduling timeout