### PR TITLE
[TE] self-serve edit alert config group editing improvements

### DIFF
--- a/thirdeye/thirdeye-frontend/app/pods/components/self-serve-config-group-table/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/components/self-serve-config-group-table/template.hbs
@@ -15,6 +15,6 @@
       {{/accordion.item}}
     {{/bs-accordion}}
   {{else}}
-    <span class="alert-group-functions__item--id">No alerts are monitored by this group yet.</span>
+    <span class="alert-group-functions__item--id">No other alerts are monitored by this group yet.</span>
   {{/if}}
 </div>

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/route.js
@@ -25,13 +25,20 @@ export default Route.extend({
     }
   },
 
-  model(params, transition) {
-    const { id, alertData, allConfigGroups, allAppNames } = this.modelFor('manage.alert');
+  async model(params, transition) {
+    const {
+      id,
+      alertData,
+      allConfigGroups,
+      allAppNames
+    } = this.modelFor('manage.alert');
+
     if (!id) { return; }
+    const email = await fetch(selfServeApiCommon.configGroupByAlertId(id)).then(checkStatus);
 
     return RSVP.hash({
+      email,
       alertData,
-      email: fetch(selfServeApiCommon.configGroupByAlertId(id)).then(checkStatus),
       allConfigGroups,
       allAppNames
     });
@@ -126,7 +133,7 @@ export default Route.extend({
    * @return {RSVP.hash} A new list of functions (alerts)
    */
   fetchAlertDataById: task(function * (functionIds) {
-    const functionArray =  yield functionIds.map(id => fetch(selfServeApiCommon.alertById(id)).then(checkStatus));
+    const functionArray = yield functionIds.map(id => fetch(selfServeApiCommon.alertById(id)).then(checkStatus));
     return RSVP.hash(functionArray);
   }),
 

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/edit/template.hbs
@@ -26,6 +26,10 @@
     {{!-- Field: App Name --}}
     <div class="form-group col-xs-10">
       <label for="anomaly-form-app-name" class="control-label te-label required">Alert belongs to</label>
+      <span>
+        <i class="glyphicon glyphicon-question-sign"></i>
+        {{#tooltip-on-element}}Changing the application team will load the team's notification email groups below{{/tooltip-on-element}}
+      </span>
       {{#power-select
         options=allApplications
         selected=selectedApplication
@@ -83,6 +87,10 @@
     {{!--  Fields for new alert group creation --}}
     <div class="form-group te-form__new-sub col-sm-6">
       <label for="config-group-new-name" class="control-label te-label"><strong>Or</strong> create new subscription group</label>
+      <span>
+        <i class="glyphicon glyphicon-question-sign"></i>
+        {{#tooltip-on-element}}Before creating a new group, please check if you can simply add recipients to an existing one.{{/tooltip-on-element}}
+      </span>
       {{#if isGroupNameDuplicate}}
         <div class="te-form__alert--warning alert-warning">Warning: <strong>{{newConfigGroupName}}</strong> already exists. Please try another name.</div>
       {{/if}}
@@ -109,6 +117,10 @@
     <div class="form-group col-xs-12">
       <label for="config-group" class="control-label te-label">
         Recipients in subscription group:
+        <span>
+          <i class="glyphicon glyphicon-question-sign"></i>
+          {{#tooltip-on-element}}You may add recipients to this anomaly notification group. At this time we do not support removing recipients.{{/tooltip-on-element}}
+        </span>
         <div class="te-form__text-block te-form__text-block--faded">{{if selectedConfigGroupRecipients selectedConfigGroupRecipients "No recipients yet"}}</div>
       </label>
       {{#if isDuplicateEmail}}

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/route.js
@@ -11,6 +11,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import config from 'thirdeye-frontend/config/environment';
 import { checkStatus, buildDateEod } from 'thirdeye-frontend/utils/utils';
+import { selfServeApiCommon } from 'thirdeye-frontend/utils/api/self-serve';
 
 // Setup for query param behavior
 const queryParamsConfig = {
@@ -60,10 +61,10 @@ export default Route.extend({
       functionName: functionName || 'Unknown',
       isLoadError: Number(id) === -1,
       destination: transition.targetName,
-      alertData: fetch(`/onboard/function/${id}`).then(checkStatus),
-      email: fetch(`/thirdeye/email/function/${id}`).then(checkStatus),
-      allConfigGroups: fetch('/thirdeye/entity/ALERT_CONFIG').then(res => res.json()),
-      allAppNames: fetch('/thirdeye/entity/APPLICATION').then(res => res.json())
+      alertData: fetch(selfServeApiCommon.alertById(id)).then(checkStatus),
+      email: fetch(selfServeApiCommon.configGroupByAlertId(id)).then(checkStatus),
+      allConfigGroups: fetch(selfServeApiCommon.allConfigGroups).then(res => res.json()),
+      allAppNames: fetch(selfServeApiCommon.allApplications).then(res => res.json())
     });
   },
 
@@ -153,7 +154,7 @@ export default Route.extend({
         isOverViewModeActive: false,
         isEditModeActive: true
       });
-      this.transitionTo('manage.alert.edit', alertId);
+      this.transitionTo('manage.alert.edit', alertId, { queryParams: { refresh: true }});
     },
 
     /**

--- a/thirdeye/thirdeye-frontend/app/pods/manage/alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/manage/alert/template.hbs
@@ -107,7 +107,7 @@
       <div class="te-topcard-subnav">
         <div class="te-topcard-subnav__item">
           <span {{action "setEditModeActive"}}>
-            {{#link-to "manage.alert.edit" alertData.id class="thirdeye-link thirdeye-link--smaller thirdeye-link--nav" activeClass="thirdeye-link--active"}}
+            {{#link-to "manage.alert.edit" alertData.id (query-params refresh=true) class="thirdeye-link thirdeye-link--smaller thirdeye-link--nav" activeClass="thirdeye-link--active"}}
               Edit alert settings
             {{/link-to}}
           </span>

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/controller.js
@@ -679,7 +679,7 @@ export default Controller.extend({
 
       // Conditionally send recipients property
       if (alertGroupNewRecipient) {
-        Object.assign(newAlertObj, { alertRecipients: alertGroupNewRecipient });
+        Object.assign(newAlertObj, { alertRecipients: alertGroupNewRecipient.replace(/ /g, '') });
       }
 
       // Do we have custom sensitivity settings to add?

--- a/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
+++ b/thirdeye/thirdeye-frontend/app/pods/self-serve/create-alert/template.hbs
@@ -243,6 +243,10 @@
     {{!-- Field: App Name --}}
     <div class="col-xs-12">
       <label for="anomaly-form-app-name" class="control-label te-label te-label--taller required">Alert belongs to</label>
+      <span>
+        <i class="glyphicon glyphicon-question-sign"></i>
+        {{#tooltip-on-element}}Changing the application team will load the team's notification/subscription groups below{{/tooltip-on-element}}
+      </span>
        {{#power-select
           options=allApplicationNames
           selected=selectedAppName
@@ -308,6 +312,10 @@
     {{!--  Fields for new alert group creation --}}
     <div class="col-sm-6">
       <label for="config-group-new-name" class="control-label te-label te-label--taller"><strong>Or</strong> create new subscription group</label>
+      <span>
+        <i class="glyphicon glyphicon-question-sign"></i>
+        {{#tooltip-on-element}}Before creating a new group, please check if you can simply add recipients to an existing one.{{/tooltip-on-element}}
+      </span>
       {{#if isGroupNameDuplicate}}
         <div class="te-form__alert--warning alert-warning">Warning: <strong>{{newConfigGroupName}}</strong> already exists. Please try another name.</div>
       {{/if}}

--- a/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
+++ b/thirdeye/thirdeye-frontend/app/utils/api/self-serve.js
@@ -70,6 +70,13 @@ const alertFunctionByAppName = appName => `/data/autocomplete/functionByAppname?
 const alertById = functionId => `/onboard/function/${functionId}`;
 
 /**
+ * GET config group records containing functionId in emailConfig property
+ * @param {String} id: alert function id
+ * @see {@link https://tinyurl.com/yc36oo2c|class EmailResource}
+ */
+const configGroupByAlertId = functionId => `/thirdeye/email/function/${functionId}`;
+
+/**
  * GET the timestamp for the end of the time range of available data for a given metric
  * @param {Numer} metricId
  * @see {@link https://tinyurl.com/y8vxqvg7|class DataResource}
@@ -133,6 +140,7 @@ export const selfServeApiCommon = {
   allConfigGroups,
   allApplications,
   alertFunctionByName,
+  configGroupByAlertId,
   alertFunctionByAppName,
   metricAutoComplete
 };

--- a/thirdeye/thirdeye-frontend/tests/acceptance/edit-alert-test.js
+++ b/thirdeye/thirdeye-frontend/tests/acceptance/edit-alert-test.js
@@ -9,6 +9,8 @@ module('Acceptance | edit alert', function(hooks) {
 
   test(`visiting ${selfServeConst.EDIT_LINK} and checking that fields render correctly and edit is successful`, async (assert) => {
     const alert = server.create('alert');
+    const editSuccessMsg = `Edit Alert Success! You have successfully edited alert ${alert.id}`;
+
     await visit(`/manage/alert/${alert.id}/edit`);
 
     assert.equal(
@@ -33,19 +35,8 @@ module('Acceptance | edit alert', function(hooks) {
     await click(selfServeConst.STATUS_TOGGLER);
     await click(selfServeConst.SUBMIT_BUTTON);
 
-    assert.equal(
-      currentURL(),
-      '/manage/alerts',
-      'correctly redirects to manage alerts page after edit'
-    );
-
-    assert.equal(
-      $(`${selfServeConst.NEW_FUNC_RESULT}[title='${selfServeConst.NEW_FUNC_NAME}']`).get(0).innerText,
-      selfServeConst.NEW_FUNC_NAME,
-      'after edit, alert name is saved correctly');
-    assert.equal(
-      $(selfServeConst.STATUS_RESULT).get(0).innerText,
-      'Inactive',
-      'after edit, alert status is saved correctly');
+    assert.ok(
+      $(selfServeConst.IMPORT_SUCCESS).get(0).innerText.includes(editSuccessMsg),
+      'after edit, alert is saved successfully');
   });
 });


### PR DESCRIPTION
Making UX improvements to alert editing view (mainly related to managing notification groups):

- Group selection loads latest changes to email list
- Group selection loads list of "alerts monitored by" in table (same as in create alerts)
- Email list in POST payload is compatible with expected JSON format (no spaces)
- Edit view refreshes on internal navigation (vs displaying previously loaded alert data)
- Tooltips added for better understanding of how to use groups
- Removing 2 second redirect to Alert index page (gives user time to verify changes)