### PR TITLE
Print error log message when schema is null

### DIFF
--- a/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/com/linkedin/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -227,7 +227,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         return;
       }
       Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-      Preconditions.checkNotNull(schema);
+      if (schema == null) {
+        String errorMsg = "No schema for table: " + _tableNameWithType;
+        _logger.error(errorMsg);
+        throw new RuntimeException(errorMsg);
+      }
       if (!isValid(schema, tableConfig.getIndexingConfig())) {
         _logger.error("Not adding segment {}", segmentName);
         throw new RuntimeException("Mismatching schema/table config for " + _tableNameWithType);


### PR DESCRIPTION
This PR prints error log message when realtime segment is about to upload while schema is null. Previously it only throws NPE.