### PR TITLE
Dynamic rate limit for pinot brokers

### DIFF
--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/ClusterChangeMediator.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/ClusterChangeMediator.java
@@ -93,7 +93,7 @@ public class ClusterChangeMediator implements LiveInstanceChangeListener, Extern
             if (externalViewUpdated) {
               try {
                 _helixExternalViewBasedRouting.processExternalViewChange();
-                // TODO: call processQueryQuotaChange
+                _tableQueryQuotaManager.processQueryQuotaChange();
               } catch (Exception e) {
                 LOGGER.warn("Caught exception while updating external view", e);
               }

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/ClusterChangeMediator.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/broker/helix/ClusterChangeMediator.java
@@ -132,6 +132,7 @@ public class ClusterChangeMediator implements LiveInstanceChangeListener, Extern
     } else {
       LOGGER.warn("Deferred cluster updater thread is null or stopped, not deferring external view routing table rebuild");
       _helixExternalViewBasedRouting.processExternalViewChange();
+      _tableQueryQuotaManager.processQueryQuotaChange();
     }
   }
 

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManager.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManager.java
@@ -267,7 +267,7 @@ public class TableQueryQuotaManager {
       String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
 
-      // Get quota config for table.
+      // Get latest quota config for table.
       QuotaConfig quotaConfig = getQuotaConfigFromPropertyStore(rawTableName, tableType);
       if (quotaConfig == null || quotaConfig.getMaxQueriesPerSecond() == null || !quotaConfig.isMaxQueriesPerSecondValid()) {
         removeRateLimiter(tableNameWithType);

--- a/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/com/linkedin/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -172,7 +172,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Validate QPS quota
     if (!_tableQueryQuotaManager.acquire(tableName)) {
-      String errorMessage = String.format("Request %d exceeds query quota for table: %s", requestId, tableName);
+      String errorMessage =
+          String.format("Request %d exceeds query quota for table:%s, query:%s", requestId, tableName, query);
       LOGGER.info(errorMessage);
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.QUERY_QUOTA_EXCEEDED, 1);
       return new BrokerResponseNative(QueryException.getException(QueryException.QUOTA_EXCEEDED_ERROR, errorMessage));

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
@@ -50,6 +50,7 @@ public class TableQueryQuotaManagerTest {
   private static String RAW_TABLE_NAME = "testTable";
   private static String OFFLINE_TABLE_NAME = RAW_TABLE_NAME + "_OFFLINE";
   private static String REALTIME_TABLE_NAME = RAW_TABLE_NAME + "_REALTIME";
+  private static final String BROKER_INSTANCE_ID = "broker_instance_1";
 
 
   @BeforeTest
@@ -64,7 +65,7 @@ public class TableQueryQuotaManagerTest {
   }
 
   private HelixManager initHelixManager(String helixClusterName) {
-    return new FakeHelixManager(helixClusterName, helixClusterName + "_1", InstanceType.CONTROLLER, ZkStarter.DEFAULT_ZK_STR);
+    return new FakeHelixManager(helixClusterName, BROKER_INSTANCE_ID, InstanceType.PARTICIPANT, ZkStarter.DEFAULT_ZK_STR);
   }
 
   public class FakeHelixManager extends ZKHelixManager {
@@ -184,7 +185,7 @@ public class TableQueryQuotaManagerTest {
   @Test
   public void testBothTableHaveQpsQuotaConfig() throws Exception {
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
-    brokerResource.setState(REALTIME_TABLE_NAME, "broker_instance_1", "ONLINE");
+    brokerResource.setState(REALTIME_TABLE_NAME, BROKER_INSTANCE_ID, "ONLINE");
     brokerResource.setState(REALTIME_TABLE_NAME, "broker_instance_2", "OFFLINE");
 
     QuotaConfig quotaConfig = new QuotaConfig();
@@ -369,7 +370,7 @@ public class TableQueryQuotaManagerTest {
 
   private ExternalView generateBrokerResource(String tableName) {
     ExternalView brokerResource = new ExternalView(BROKER_RESOURCE_INSTANCE);
-    brokerResource.setState(tableName, "broker_instance_1", "ONLINE");
+    brokerResource.setState(tableName, BROKER_INSTANCE_ID, "ONLINE");
     brokerResource.setState(tableName, "broker_instance_2", "OFFLINE");
     return brokerResource;
   }

--- a/pinot-broker/src/test/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/com/linkedin/pinot/broker/queryquota/TableQueryQuotaManagerTest.java
@@ -216,6 +216,7 @@ public class TableQueryQuotaManagerTest {
     ZKMetadataProvider.setRealtimeTableConfig(_testPropertyStore, REALTIME_TABLE_NAME, TableConfig.toZnRecord(realtimeTableConfig));
     ZKMetadataProvider.setOfflineTableConfig(_testPropertyStore, OFFLINE_TABLE_NAME, TableConfig.toZnRecord(offlineTableConfig));
 
+    // Since each table has 2 online brokers, per broker rate becomes 100.0 / 2 = 50.0
     _tableQueryQuotaManager.initTableQueryQuota(offlineTableConfig, brokerResource);
     Assert.assertEquals(_tableQueryQuotaManager.getRateLimiterMapSize(), 1);
     _tableQueryQuotaManager.initTableQueryQuota(realtimeTableConfig, brokerResource);

--- a/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
+++ b/pinot-common/src/test/java/com/linkedin/pinot/common/config/QuotaConfigTest.java
@@ -65,11 +65,21 @@ public class QuotaConfigTest {
 
       Assert.assertNotNull(quotaConfig.getMaxQueriesPerSecond());
       Assert.assertEquals(quotaConfig.getMaxQueriesPerSecond(), "100.00");
+      Assert.assertTrue(quotaConfig.isMaxQueriesPerSecondValid());
+    }
+    {
+      String quotaConfigStr = "{\"maxQueriesPerSecond\" : \"0.5\"}";
+      QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
+
+      Assert.assertNotNull(quotaConfig.getMaxQueriesPerSecond());
+      Assert.assertEquals(quotaConfig.getMaxQueriesPerSecond(), "0.5");
+      Assert.assertTrue(quotaConfig.isMaxQueriesPerSecondValid());
     }
     {
       String quotaConfigStr = "{}";
       QuotaConfig quotaConfig = new ObjectMapper().readValue(quotaConfigStr, QuotaConfig.class);
       Assert.assertNull(quotaConfig.getMaxQueriesPerSecond());
+      Assert.assertTrue(quotaConfig.isMaxQueriesPerSecondValid());
     }
   }
 


### PR DESCRIPTION
This PR uses dynamic rate limit for pinot brokers.
Basically dynamic per broker rate  = overall rate / number of online brokers.
If # of online brokers is changed, BrokerResourceOnlineOfflineStateModelFactory will update rate for a particular table.
If overall rate is modified, ClusterChangeMediator will capture the broker resourceEV change, and then update all the per broker rates with the latest qps quotas.
If overall rate is newly added for an existing table, since TableQueryQuotaManager only keeps track of the existing quotas, pinot brokers need to be restarted in order to fetch the newly added quota from table config in property store.
